### PR TITLE
feat(desktop): redesign PR detail header, fix dark-mode colors, and rebuild the merge dropdown

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -18,6 +18,7 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { ScrollArea } from "@superset/ui/scroll-area";
+import { Skeleton } from "@superset/ui/skeleton";
 import { toast } from "@superset/ui/sonner";
 import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
@@ -234,6 +235,14 @@ function PullRequestDetailPage() {
 	const createdAtMs = data?.createdAt
 		? new Date(data.createdAt).getTime()
 		: null;
+	const createdAtRelative =
+		createdAtMs === null ? null : formatRelativeTime(createdAtMs);
+	const createdAtLabel =
+		createdAtRelative === null
+			? null
+			: createdAtRelative === "now"
+				? "now"
+				: `${createdAtRelative} ago`;
 	const header = (
 		<div className="flex shrink-0 flex-col border-b border-border">
 			<div className="flex h-10 shrink-0 items-center gap-1 px-4">
@@ -263,10 +272,14 @@ function PullRequestDetailPage() {
 			</div>
 
 			<div className="flex items-start justify-between gap-3 px-4 pb-3">
-				<h1 className="min-w-0 truncate text-xl font-semibold leading-tight">
-					{data?.title ??
-						(itemNumber === null ? "Pull request" : `#${itemNumber}`)}
-				</h1>
+				{isLoading ? (
+					<Skeleton className="h-6 w-72 max-w-full" />
+				) : (
+					<h1 className="min-w-0 truncate text-xl font-semibold leading-tight">
+						{data?.title ??
+							(itemNumber === null ? "Pull request" : `#${itemNumber}`)}
+					</h1>
+				)}
 				{data && (
 					<div className="flex shrink-0 items-center gap-2">
 						<Button variant="ghost" size="icon-sm" asChild>
@@ -332,7 +345,8 @@ function PullRequestDetailPage() {
 											</span>
 										</DropdownMenuItem>
 									))}
-									{data.checksStatus !== "success" && (
+									{(data.checksStatus === "pending" ||
+										data.checksStatus === "failure") && (
 										<>
 											<DropdownMenuSeparator />
 											{data.checksStatus === "pending" && (
@@ -384,6 +398,15 @@ function PullRequestDetailPage() {
 				)}
 			</div>
 
+			{isLoading && (
+				<div className="flex flex-wrap items-center gap-2 px-4 pb-3">
+					<Skeleton className="h-[22px] w-16 rounded-full" />
+					<Skeleton className="size-5 rounded-full" />
+					<Skeleton className="h-3 w-20" />
+					<Skeleton className="h-3 w-10" />
+					<Skeleton className="h-3 w-14" />
+				</div>
+			)}
 			{data && (
 				<div className="flex flex-wrap items-center gap-2 px-4 pb-3 text-xs text-muted-foreground">
 					<span
@@ -413,12 +436,10 @@ function PullRequestDetailPage() {
 					<span className="shrink-0 font-mono tabular-nums">
 						#{data.number}
 					</span>
-					{createdAtMs !== null && (
+					{createdAtLabel !== null && (
 						<>
 							<span aria-hidden>·</span>
-							<span className="shrink-0">
-								{formatRelativeTime(createdAtMs)} ago
-							</span>
+							<span className="shrink-0">{createdAtLabel}</span>
 						</>
 					)}
 				</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -14,20 +14,18 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuLabel,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { ScrollArea } from "@superset/ui/scroll-area";
 import { toast } from "@superset/ui/sonner";
+import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
-import {
-	LuEllipsis,
-	LuGitPullRequestClosed,
-	LuRotateCcw,
-} from "react-icons/lu";
+import { LuChevronRight } from "react-icons/lu";
 import { VscChevronDown, VscGitMerge } from "react-icons/vsc";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
@@ -59,11 +57,18 @@ export const Route = createFileRoute(
 type MergeMethod = "merge" | "squash" | "rebase";
 const MERGE_METHOD_LABELS: Record<MergeMethod, string> = {
 	squash: "Squash and merge",
-	merge: "Create merge commit",
+	merge: "Merge commit",
 	rebase: "Rebase and merge",
 };
+const MERGE_METHOD_DESCRIPTIONS: Record<MergeMethod, string> = {
+	squash: "Combine all commits",
+	merge: "Preserve commit history",
+	rebase: "Reapply all commits",
+};
 
-type PendingAction = { kind: "close" } | { kind: "merge"; method: MergeMethod };
+type PendingAction =
+	| { kind: "close" }
+	| { kind: "merge"; method: MergeMethod; force?: boolean };
 
 type DetailTab = "summary" | "code";
 const DETAIL_TABS: ReadonlyArray<{ value: DetailTab; label: string }> = [
@@ -115,6 +120,7 @@ function PullRequestDetailPage() {
 		null,
 	);
 	const [activeTab, setActiveTab] = useState<DetailTab>("summary");
+	const [mergeComment, setMergeComment] = useState("");
 
 	const { data, isLoading, error, refetch } = useQuery({
 		queryKey: ["pull-request-detail", projectId, hostUrl, prNumber],
@@ -159,7 +165,13 @@ function PullRequestDetailPage() {
 	});
 
 	const mergePullRequest = useMutation({
-		mutationFn: async (mergeMethod: MergeMethod) => {
+		mutationFn: async ({
+			mergeMethod,
+			commitMessage,
+		}: {
+			mergeMethod: MergeMethod;
+			commitMessage?: string;
+		}) => {
 			if (!hostUrl || !projectId || prNumber === null) {
 				throw new Error("This project isn't linked to a GitHub repository.");
 			}
@@ -168,6 +180,7 @@ function PullRequestDetailPage() {
 				projectId,
 				prNumber,
 				mergeMethod,
+				commitMessage,
 			});
 		},
 		onSuccess: invalidatePullRequestQueries,
@@ -186,12 +199,14 @@ function PullRequestDetailPage() {
 		if (pendingAction.kind === "close") {
 			setPullRequestState.mutate("closed");
 		} else {
-			mergePullRequest.mutate(pendingAction.method);
+			mergePullRequest.mutate({
+				mergeMethod: pendingAction.method,
+				commitMessage: mergeComment.trim() || undefined,
+			});
 		}
 		setPendingAction(null);
+		setMergeComment("");
 	};
-
-	const handleReopen = () => setPullRequestState.mutate("open");
 
 	const handleAddToWorkspace = () => {
 		if (!projectId || !hostId || !data) return;
@@ -243,41 +258,8 @@ function PullRequestDetailPage() {
 				</div>
 				{/* Window-drag leaf standing in for the hidden TopBar. */}
 				<div className="drag h-full min-w-0 flex-1" />
-				{data && (
-					<div className="flex shrink-0 items-center gap-1">
-						{/* Share is coming soon — hidden until it has real functionality. */}
-						{data.state !== "merged" && (
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										variant="ghost"
-										size="icon-sm"
-										aria-label="More actions"
-									>
-										<LuEllipsis className="size-4" />
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent align="end">
-									{data.state === "open" && (
-										<DropdownMenuItem
-											variant="destructive"
-											onClick={() => setPendingAction({ kind: "close" })}
-										>
-											<LuGitPullRequestClosed className="size-3.5" />
-											Close pull request
-										</DropdownMenuItem>
-									)}
-									{data.state === "closed" && (
-										<DropdownMenuItem onClick={handleReopen}>
-											<LuRotateCcw className="size-3.5" />
-											Reopen pull request
-										</DropdownMenuItem>
-									)}
-								</DropdownMenuContent>
-							</DropdownMenu>
-						)}
-					</div>
-				)}
+				{/* Share and the "..." overflow (close/reopen) are coming soon —
+				    both hidden until they have real functionality wired up. */}
 			</div>
 
 			<div className="flex items-start justify-between gap-3 px-4 pb-3">
@@ -321,21 +303,80 @@ function PullRequestDetailPage() {
 										<VscChevronDown className="size-3" />
 									</Button>
 								</DropdownMenuTrigger>
-								<DropdownMenuContent align="end" className="w-56">
-									<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-										Merge
+								<DropdownMenuContent align="end" className="w-80 p-0">
+									<div className="p-3 pb-2">
+										<Textarea
+											value={mergeComment}
+											onChange={(e) => setMergeComment(e.target.value)}
+											onKeyDown={(e) => e.stopPropagation()}
+											placeholder="Leave a comment (optional)"
+											className="min-h-16 resize-none text-sm"
+										/>
+									</div>
+									<DropdownMenuLabel className="px-3 pb-1 pt-0 text-xs font-normal text-muted-foreground">
+										Select method
 									</DropdownMenuLabel>
 									{(["squash", "merge", "rebase"] as const).map((method) => (
 										<DropdownMenuItem
 											key={method}
+											className="flex-col items-start gap-0.5 px-3 py-2"
 											onClick={() =>
 												setPendingAction({ kind: "merge", method })
 											}
 										>
-											<VscGitMerge className="size-3.5" />
-											{MERGE_METHOD_LABELS[method]}
+											<span className="text-sm font-medium">
+												{MERGE_METHOD_LABELS[method]}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{MERGE_METHOD_DESCRIPTIONS[method]}
+											</span>
 										</DropdownMenuItem>
 									))}
+									{data.checksStatus !== "success" && (
+										<>
+											<DropdownMenuSeparator />
+											{data.checksStatus === "pending" && (
+												<DropdownMenuItem
+													className="flex items-center justify-between gap-2 px-3 py-2"
+													onClick={() =>
+														toast.info("Auto-merge is coming soon")
+													}
+												>
+													<div className="flex flex-col gap-0.5">
+														<span className="text-sm font-medium">
+															Enable auto-merge
+														</span>
+														<span className="text-xs text-muted-foreground">
+															Merge when checks pass
+														</span>
+													</div>
+													<LuChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+												</DropdownMenuItem>
+											)}
+											{data.checksStatus === "failure" && (
+												<DropdownMenuItem
+													className="flex items-center justify-between gap-2 px-3 py-2"
+													onClick={() =>
+														setPendingAction({
+															kind: "merge",
+															method: "squash",
+															force: true,
+														})
+													}
+												>
+													<div className="flex flex-col gap-0.5">
+														<span className="text-sm font-medium">
+															Force merge
+														</span>
+														<span className="text-xs text-muted-foreground">
+															Attempt before checks pass
+														</span>
+													</div>
+													<LuChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+												</DropdownMenuItem>
+											)}
+										</>
+									)}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						)}
@@ -473,7 +514,9 @@ function PullRequestDetailPage() {
 						<AlertDialogTitle className="font-medium">
 							{pendingAction?.kind === "close"
 								? `Close #${data.number}?`
-								: `Merge #${data.number}?`}
+								: pendingAction?.kind === "merge" && pendingAction.force
+									? `Force merge #${data.number}?`
+									: `Merge #${data.number}?`}
 						</AlertDialogTitle>
 						<AlertDialogDescription>
 							{pendingAction?.kind === "close"
@@ -482,7 +525,11 @@ function PullRequestDetailPage() {
 										pendingAction?.kind === "merge"
 											? ` via ${MERGE_METHOD_LABELS[pendingAction.method].toLowerCase()}`
 											: ""
-									}. This can't be undone from here.`}
+									}.${
+										pendingAction?.kind === "merge" && pendingAction.force
+											? " Checks haven't passed yet — this overrides them."
+											: ""
+									} This can't be undone from here.`}
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter className="flex-row justify-end gap-2 px-4 pb-4 pt-2">
@@ -496,7 +543,10 @@ function PullRequestDetailPage() {
 						</Button>
 						<AlertDialogAction
 							variant={
-								pendingAction?.kind === "close" ? "destructive" : "default"
+								pendingAction?.kind === "close" ||
+								(pendingAction?.kind === "merge" && pendingAction.force)
+									? "destructive"
+									: "default"
 							}
 							size="sm"
 							className="h-7 px-3 text-xs"
@@ -504,7 +554,9 @@ function PullRequestDetailPage() {
 						>
 							{pendingAction?.kind === "close"
 								? "Close pull request"
-								: "Merge pull request"}
+								: pendingAction?.kind === "merge" && pendingAction.force
+									? "Force merge"
+									: "Merge pull request"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</EnterEnabledAlertDialogContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -7,13 +7,13 @@ import {
 	AlertDialogTitle,
 	EnterEnabledAlertDialogContent,
 } from "@superset/ui/alert-dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuLabel,
-	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { ScrollArea } from "@superset/ui/scroll-area";
@@ -22,15 +22,16 @@ import { cn } from "@superset/ui/utils";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
+import { FaGithub } from "react-icons/fa";
 import {
-	LuExternalLink,
+	LuEllipsis,
 	LuGitPullRequestClosed,
-	LuPlus,
 	LuRotateCcw,
 } from "react-icons/lu";
 import { VscChevronDown, VscGitMerge } from "react-icons/vsc";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { WorkItemDetailState } from "renderer/routes/_authenticated/_dashboard/components/WorkItemDetailState";
 import { useProjectHost } from "renderer/routes/_authenticated/_dashboard/hooks/useProjectHost";
@@ -64,16 +65,32 @@ const MERGE_METHOD_LABELS: Record<MergeMethod, string> = {
 
 type PendingAction = { kind: "close" } | { kind: "merge"; method: MergeMethod };
 
-// Mirrors PRStatusGroup's state-tinted badge language, so a PR reads the
-// same way here as it does in the v2 workspace sidebar.
+type DetailTab = "summary" | "code";
+const DETAIL_TABS: ReadonlyArray<{ value: DetailTab; label: string }> = [
+	{ value: "summary", label: "Summary" },
+	{ value: "code", label: "Code" },
+];
+
+// Borderless, flat-tinted pill per Figma (PR Badge, node 3246:2410) — exact
+// hex for "open" (#dcfae8 / #00a558); the other states follow the same
+// pale-bg/saturated-text formula since Figma only specs the open variant.
+// Dark values are hand-tuned (no Figma source), reviewed against the app's
+// real --background/--card/--muted surfaces.
+//
+// `dark:` is intentionally NOT used here: this app's globals.css never
+// defines `@custom-variant dark`, so Tailwind's `dark:` falls back to
+// `prefers-color-scheme` — it tracks the OS setting, not this app's own
+// theme switcher, and silently never fires when they disagree. `[.dark_&]`
+// targets the real `.dark` class the theme store puts on <html>.
 const STATE_BADGE_STYLES: Record<PRState, string> = {
-	open: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+	open: "bg-[#dcfae8] text-[#00a558] [.dark_&]:bg-[#064e3b] [.dark_&]:text-[#34d399]",
+	closed:
+		"bg-rose-100 text-rose-600 [.dark_&]:bg-[#4a2020] [.dark_&]:text-[#e0918a]",
 	merged:
-		"border-violet-500/30 bg-violet-500/10 text-violet-600 dark:text-violet-400",
-	closed: "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
-	draft: "border-border bg-muted/40 text-muted-foreground",
+		"bg-violet-100 text-violet-600 [.dark_&]:bg-[#322b47] [.dark_&]:text-[#b0a6d9]",
+	draft: "bg-muted text-muted-foreground",
 	queued:
-		"border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+		"bg-amber-100 text-amber-600 [.dark_&]:bg-[#78350f] [.dark_&]:text-[#fbbf24]",
 };
 
 function PullRequestDetailPage() {
@@ -97,6 +114,7 @@ function PullRequestDetailPage() {
 	const [pendingAction, setPendingAction] = useState<PendingAction | null>(
 		null,
 	);
+	const [activeTab, setActiveTab] = useState<DetailTab>("summary");
 
 	const { data, isLoading, error, refetch } = useQuery({
 		queryKey: ["pull-request-detail", projectId, hostUrl, prNumber],
@@ -198,72 +216,112 @@ function PullRequestDetailPage() {
 	// list-collapse toggle in the shared layout), so there's no "back"
 	// affordance here — just the PR identity and its actions.
 	const itemNumber = data?.number ?? prNumber;
+	const createdAtMs = data?.createdAt
+		? new Date(data.createdAt).getTime()
+		: null;
 	const header = (
-		<div className="@container flex shrink-0 items-center gap-2 border-b border-border px-4 pb-9 pt-3 @md:gap-3 @md:px-6">
-			<PullRequestListToggle />
-			<PRIcon state={state} className="size-4 shrink-0" />
-			<span className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
-				{itemNumber === null ? "#—" : `#${itemNumber}`}
-			</span>
-			{data && (
-				<span
-					className={cn(
-						"shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium capitalize",
-						STATE_BADGE_STYLES[state],
-					)}
-				>
-					{data.isDraft ? "Draft" : data.state}
-				</span>
-			)}
-			<div className="min-w-0 flex-1" />
-			<div className="ml-auto flex shrink-0 items-center gap-1">
-				{data?.url && (
-					<Button variant="ghost" size="icon" className="size-8" asChild>
-						<a
-							href={data.url}
-							target="_blank"
-							rel="noopener noreferrer"
-							aria-label="Open pull request in GitHub"
-							title="Open pull request in GitHub"
+		<div className="flex shrink-0 flex-col border-b border-border">
+			<div className="flex h-10 shrink-0 items-center gap-1 px-4">
+				<PullRequestListToggle />
+				<div className="ml-2 flex items-center gap-1">
+					{DETAIL_TABS.map(({ value, label }) => (
+						<button
+							key={value}
+							type="button"
+							onClick={() => setActiveTab(value)}
+							aria-current={activeTab === value ? "true" : undefined}
+							className={cn(
+								"rounded-md px-2 py-1 text-xs font-medium transition-colors",
+								activeTab === value
+									? "bg-accent text-foreground"
+									: "text-muted-foreground hover:text-foreground",
+							)}
 						>
-							<LuExternalLink className="size-4" />
-						</a>
-					</Button>
+							{label}
+						</button>
+					))}
+				</div>
+				{/* Window-drag leaf standing in for the hidden TopBar. */}
+				<div className="drag h-full min-w-0 flex-1" />
+				{data && (
+					<div className="flex shrink-0 items-center gap-1">
+						{/* Share is coming soon — hidden until it has real functionality. */}
+						{data.state !== "merged" && (
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										aria-label="More actions"
+									>
+										<LuEllipsis className="size-4" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end">
+									{data.state === "open" && (
+										<DropdownMenuItem
+											variant="destructive"
+											onClick={() => setPendingAction({ kind: "close" })}
+										>
+											<LuGitPullRequestClosed className="size-3.5" />
+											Close pull request
+										</DropdownMenuItem>
+									)}
+									{data.state === "closed" && (
+										<DropdownMenuItem onClick={handleReopen}>
+											<LuRotateCcw className="size-3.5" />
+											Reopen pull request
+										</DropdownMenuItem>
+									)}
+								</DropdownMenuContent>
+							</DropdownMenu>
+						)}
+					</div>
 				)}
-				{data && data.state !== "merged" && (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								variant="outline"
-								size="sm"
-								className={cn(
-									"h-8 gap-1.5 px-2 @md:px-3",
-									canMerge &&
-										"border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-400",
-								)}
-								disabled={isActionPending}
-								aria-label="Pull request actions"
+			</div>
+
+			<div className="flex items-start justify-between gap-3 px-4 pb-3">
+				<h1 className="min-w-0 truncate text-xl font-semibold leading-tight">
+					{data?.title ??
+						(itemNumber === null ? "Pull request" : `#${itemNumber}`)}
+				</h1>
+				{data && (
+					<div className="flex shrink-0 items-center gap-2">
+						<Button variant="ghost" size="icon-sm" asChild>
+							<a
+								href={data.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								aria-label="Open pull request in GitHub"
+								title="Open pull request in GitHub"
 							>
-								{canMerge ? (
-									<VscGitMerge className="size-4" />
-								) : data.state === "closed" ? (
-									<LuRotateCcw className="size-4" />
-								) : (
-									<LuGitPullRequestClosed className="size-4" />
-								)}
-								<span className="hidden @md:inline">
-									{data.state === "closed"
-										? "Reopen"
-										: canMerge
-											? "Merge"
-											: "Close"}
-								</span>
-								<VscChevronDown className="size-3" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" className="w-56">
-							{canMerge && (
-								<>
+								<FaGithub className="size-4" />
+							</a>
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							className="h-8 px-3"
+							onClick={handleAddToWorkspace}
+						>
+							Start Workspace
+						</Button>
+						{canMerge && (
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-8 gap-1.5 px-3 border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/15 hover:text-emerald-600 [.dark_&]:text-[#34d399] [.dark_&]:hover:text-[#34d399]"
+										disabled={isActionPending}
+										aria-label="Merge pull request"
+									>
+										<VscGitMerge className="size-4" />
+										Merge
+										<VscChevronDown className="size-3" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end" className="w-56">
 									<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
 										Merge
 									</DropdownMenuLabel>
@@ -278,41 +336,52 @@ function PullRequestDetailPage() {
 											{MERGE_METHOD_LABELS[method]}
 										</DropdownMenuItem>
 									))}
-									<DropdownMenuSeparator />
-								</>
-							)}
-							{data.state === "open" && (
-								<DropdownMenuItem
-									variant="destructive"
-									onClick={() => setPendingAction({ kind: "close" })}
-								>
-									<LuGitPullRequestClosed className="size-3.5" />
-									Close pull request
-								</DropdownMenuItem>
-							)}
-							{data.state === "closed" && (
-								<DropdownMenuItem onClick={handleReopen}>
-									<LuRotateCcw className="size-3.5" />
-									Reopen pull request
-								</DropdownMenuItem>
-							)}
-						</DropdownMenuContent>
-					</DropdownMenu>
-				)}
-				{data && (
-					<Button
-						variant="outline"
-						size="sm"
-						className="h-8 gap-1.5 px-2 @md:px-3"
-						onClick={handleAddToWorkspace}
-						aria-label="Add to workspace"
-						title="Add to workspace"
-					>
-						<LuPlus className="size-4" />
-						<span className="hidden @md:inline">Add to workspace</span>
-					</Button>
+								</DropdownMenuContent>
+							</DropdownMenu>
+						)}
+					</div>
 				)}
 			</div>
+
+			{data && (
+				<div className="flex flex-wrap items-center gap-2 px-4 pb-3 text-xs text-muted-foreground">
+					<span
+						className={cn(
+							"inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-1 font-medium capitalize",
+							STATE_BADGE_STYLES[state],
+						)}
+					>
+						<PRIcon state={state} className="size-3" />
+						{data.isDraft ? "Draft" : data.state}
+					</span>
+					{data.author && (
+						<span className="flex shrink-0 items-center gap-1.5">
+							<Avatar className="size-5 rounded-full">
+								<AvatarImage
+									src={`https://github.com/${data.author}.png?size=64`}
+									alt={data.author}
+								/>
+								<AvatarFallback className="text-[9px]">
+									{data.author.slice(0, 1).toUpperCase()}
+								</AvatarFallback>
+							</Avatar>
+							{data.author}
+						</span>
+					)}
+					<span aria-hidden>·</span>
+					<span className="shrink-0 font-mono tabular-nums">
+						#{data.number}
+					</span>
+					{createdAtMs !== null && (
+						<>
+							<span aria-hidden>·</span>
+							<span className="shrink-0">
+								{formatRelativeTime(createdAtMs)} ago
+							</span>
+						</>
+					)}
+				</div>
+			)}
 		</div>
 	);
 
@@ -390,11 +459,6 @@ function PullRequestDetailPage() {
 		);
 	}
 
-	const stateLabel = data.isDraft ? "Draft" : data.state;
-	const branchSummary = data.branch
-		? `${data.headRepositoryOwner && data.isCrossRepository ? `${data.headRepositoryOwner}:${data.branch}` : data.branch} → ${data.baseBranch}`
-		: null;
-
 	return (
 		<div className="@container flex min-h-0 flex-1 flex-col">
 			{header}
@@ -446,48 +510,27 @@ function PullRequestDetailPage() {
 				</EnterEnabledAlertDialogContent>
 			</AlertDialog>
 			<ScrollArea className="min-h-0 flex-1">
-				<div className="grid w-full gap-8 px-4 py-6 @md:px-6 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:py-8">
-					<article className="min-w-0">
-						<div className="mb-4 flex min-w-0 items-start gap-3">
-							<PRIcon state={state} className="mt-1 size-5 shrink-0" />
-							<h1 className="min-w-0 break-words text-2xl font-semibold leading-tight text-wrap-pretty">
-								{data.title}
-							</h1>
-						</div>
-
-						<div className="mb-7 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-							<span>{project.name}</span>
-							<span aria-hidden>·</span>
-							<span className="capitalize">{stateLabel}</span>
-							{data.author && (
-								<>
-									<span aria-hidden>·</span>
-									<span className="min-w-0 break-words">by {data.author}</span>
-								</>
+				{activeTab === "summary" ? (
+					<div className="grid w-full gap-8 px-4 py-6 @md:px-6 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:py-8">
+						<article className="min-w-0">
+							{data.body.trim() ? (
+								<MarkdownRenderer content={data.body} />
+							) : (
+								<p className="text-sm italic text-muted-foreground">
+									No description provided.
+								</p>
 							)}
-							{branchSummary && (
-								<>
-									<span aria-hidden>·</span>
-									<span className="min-w-0 break-all font-mono">
-										{branchSummary}
-									</span>
-								</>
-							)}
-						</div>
+						</article>
 
-						{data.body.trim() ? (
-							<MarkdownRenderer content={data.body} />
-						) : (
-							<p className="text-sm italic text-muted-foreground">
-								No description provided.
-							</p>
-						)}
-					</article>
-
-					<aside className="min-w-0 @4xl:sticky @4xl:top-6 @4xl:self-start">
-						<PullRequestChecksSection checks={data.checks} />
-					</aside>
-				</div>
+						<aside className="min-w-0 @4xl:sticky @4xl:top-6 @4xl:self-start">
+							<PullRequestChecksSection checks={data.checks} />
+						</aside>
+					</div>
+				) : (
+					<p className="px-4 py-12 text-center text-sm text-muted-foreground @md:px-6">
+						Code view is coming soon.
+					</p>
+				)}
 			</ScrollArea>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestDetailToggle/PullRequestDetailToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestDetailToggle/PullRequestDetailToggle.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import {
 	LuPanelRight,
 	LuPanelRightClose,
@@ -20,35 +19,26 @@ export function PullRequestDetailToggle() {
 	);
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					onClick={toggleDetailCollapsed}
-					aria-label={
-						isDetailCollapsed
-							? "Show pull request preview"
-							: "Hide pull request preview"
-					}
-					className="group flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
-				>
-					<span className="group-hover:hidden">
-						<LuPanelRight className="size-4" strokeWidth={1.5} />
-					</span>
-					<span className="hidden group-hover:block">
-						{isDetailCollapsed ? (
-							<LuPanelRightOpen className="size-4" strokeWidth={1.5} />
-						) : (
-							<LuPanelRightClose className="size-4" strokeWidth={1.5} />
-						)}
-					</span>
-				</button>
-			</TooltipTrigger>
-			<TooltipContent side="bottom">
-				{isDetailCollapsed
+		<button
+			type="button"
+			onClick={toggleDetailCollapsed}
+			aria-label={
+				isDetailCollapsed
 					? "Show pull request preview"
-					: "Hide pull request preview"}
-			</TooltipContent>
-		</Tooltip>
+					: "Hide pull request preview"
+			}
+			className="group flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
+		>
+			<span className="group-hover:hidden">
+				<LuPanelRight className="size-4" strokeWidth={1.5} />
+			</span>
+			<span className="hidden group-hover:block">
+				{isDetailCollapsed ? (
+					<LuPanelRightOpen className="size-4" strokeWidth={1.5} />
+				) : (
+					<LuPanelRightClose className="size-4" strokeWidth={1.5} />
+				)}
+			</span>
+		</button>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestListToggle/PullRequestListToggle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestListToggle/PullRequestListToggle.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { LuPanelLeft, LuPanelLeftClose, LuPanelLeftOpen } from "react-icons/lu";
 import { usePullRequestsSplitViewStore } from "../../stores/pullRequestsSplitViewStore";
 
@@ -17,33 +16,24 @@ export function PullRequestListToggle() {
 	);
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					onClick={toggleListCollapsed}
-					aria-label={
-						isListCollapsed
-							? "Show pull request list"
-							: "Hide pull request list"
-					}
-					className="group flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
-				>
-					<span className="group-hover:hidden">
-						<LuPanelLeft className="size-4" strokeWidth={1.5} />
-					</span>
-					<span className="hidden group-hover:block">
-						{isListCollapsed ? (
-							<LuPanelLeftOpen className="size-4" strokeWidth={1.5} />
-						) : (
-							<LuPanelLeftClose className="size-4" strokeWidth={1.5} />
-						)}
-					</span>
-				</button>
-			</TooltipTrigger>
-			<TooltipContent side="bottom">
-				{isListCollapsed ? "Show pull request list" : "Hide pull request list"}
-			</TooltipContent>
-		</Tooltip>
+		<button
+			type="button"
+			onClick={toggleListCollapsed}
+			aria-label={
+				isListCollapsed ? "Show pull request list" : "Hide pull request list"
+			}
+			className="group flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
+		>
+			<span className="group-hover:hidden">
+				<LuPanelLeft className="size-4" strokeWidth={1.5} />
+			</span>
+			<span className="hidden group-hover:block">
+				{isListCollapsed ? (
+					<LuPanelLeftOpen className="size-4" strokeWidth={1.5} />
+				) : (
+					<LuPanelLeftClose className="size-4" strokeWidth={1.5} />
+				)}
+			</span>
+		</button>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestRow/PullRequestRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestRow/PullRequestRow.tsx
@@ -102,10 +102,10 @@ export function PullRequestRow({
 					<PullRequestChecksSummary checks={pr.checks} />
 					{hasDiffStat && (
 						<span className="flex items-center gap-1 tabular-nums">
-							<span className="text-emerald-600 dark:text-emerald-400">
+							<span className="text-emerald-600 [.dark_&]:text-[#34d399]">
 								+{pr.additions ?? 0}
 							</span>
-							<span className="text-red-600 dark:text-red-400">
+							<span className="text-red-600 [.dark_&]:text-[#e0918a]">
 								-{pr.deletions ?? 0}
 							</span>
 						</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestRow/PullRequestRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestRow/PullRequestRow.tsx
@@ -105,7 +105,7 @@ export function PullRequestRow({
 							<span className="text-emerald-600 [.dark_&]:text-[#34d399]">
 								+{pr.additions ?? 0}
 							</span>
-							<span className="text-red-600 [.dark_&]:text-[#e0918a]">
+							<span className="text-red-600 [.dark_&]:text-[#f87171]">
 								-{pr.deletions ?? 0}
 							</span>
 						</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestRow/PullRequestRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestRow/PullRequestRow.tsx
@@ -97,20 +97,22 @@ export function PullRequestRow({
 				</div>
 			</div>
 			<div className="flex shrink-0 flex-col items-end gap-0.5 text-xs text-muted-foreground">
-				{updatedAtMs != null && <span>{formatRelativeTime(updatedAtMs)}</span>}
 				<div className="flex items-center gap-2">
 					<PullRequestChecksSummary checks={pr.checks} />
-					{hasDiffStat && (
-						<span className="flex items-center gap-1 tabular-nums">
-							<span className="text-emerald-600 [.dark_&]:text-[#34d399]">
-								+{pr.additions ?? 0}
-							</span>
-							<span className="text-red-600 [.dark_&]:text-[#f87171]">
-								-{pr.deletions ?? 0}
-							</span>
-						</span>
+					{updatedAtMs != null && (
+						<span>{formatRelativeTime(updatedAtMs)}</span>
 					)}
 				</div>
+				{hasDiffStat && (
+					<span className="flex items-center gap-1 tabular-nums">
+						<span className="text-emerald-600 [.dark_&]:text-[#34d399]">
+							+{pr.additions ?? 0}
+						</span>
+						<span className="text-red-600 [.dark_&]:text-[#f87171]">
+							-{pr.deletions ?? 0}
+						</span>
+					</span>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/utils/checkStatusIcons/checkStatusIcons.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/utils/checkStatusIcons/checkStatusIcons.ts
@@ -6,16 +6,24 @@ import {
 	LuX,
 } from "react-icons/lu";
 
+// `dark:` isn't used here — this app's globals.css never defines
+// `@custom-variant dark`, so `dark:` falls back to `prefers-color-scheme`
+// (tracks the OS setting, not this app's own theme switcher) and silently
+// never fired. `[.dark_&]` targets the real `.dark` class the theme store
+// puts on <html>.
 /** One icon/color pair per CI check status, shared by every checks surface. */
 export const CHECK_STATUS_ICONS = {
 	success: {
 		Icon: LuCheck,
-		className: "text-emerald-600 dark:text-emerald-400",
+		className: "text-emerald-600 [.dark_&]:text-[#34d399]",
 	},
-	failure: { Icon: LuX, className: "text-red-600 dark:text-red-400" },
+	failure: {
+		Icon: LuX,
+		className: "text-red-600 [.dark_&]:text-[#f87171]",
+	},
 	pending: {
 		Icon: LuLoaderCircle,
-		className: "text-amber-600 dark:text-amber-400",
+		className: "text-amber-600 [.dark_&]:text-[#fbbf24]",
 	},
 	skipped: { Icon: LuSkipForward, className: "text-muted-foreground" },
 	cancelled: { Icon: LuMinus, className: "text-muted-foreground" },

--- a/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/PRIcon/PRIcon.tsx
@@ -6,7 +6,7 @@ import {
 	LuListChecks,
 } from "react-icons/lu";
 
-const ICON_STROKE_WIDTH = 1;
+const ICON_STROKE_WIDTH = 2;
 
 export type PRState = "open" | "merged" | "closed" | "draft" | "queued";
 
@@ -15,12 +15,18 @@ interface PRIconProps {
 	className?: string;
 }
 
+// `dark:` isn't used here — this app's globals.css never defines
+// `@custom-variant dark`, so `dark:` falls back to `prefers-color-scheme`
+// (tracks the OS setting, not this app's own theme switcher). `[.dark_&]`
+// targets the real `.dark` class the theme store puts on <html>. Dark hex
+// values match the PR state badge (STATE_BADGE_STYLES in $prNumber/page.tsx)
+// for consistency between the pill and the icon.
 const stateStyles: Record<PRState, string> = {
-	open: "text-emerald-500",
-	merged: "text-violet-500",
-	closed: "text-red-500",
+	open: "text-emerald-500 [.dark_&]:text-[#34d399]",
+	merged: "text-violet-500 [.dark_&]:text-[#b0a6d9]",
+	closed: "text-red-500 [.dark_&]:text-[#e0918a]",
 	draft: "text-muted-foreground",
-	queued: "text-amber-500",
+	queued: "text-amber-500 [.dark_&]:text-[#fbbf24]",
 };
 
 /**

--- a/packages/host-service/src/trpc/router/pull-requests/procedures/merge.ts
+++ b/packages/host-service/src/trpc/router/pull-requests/procedures/merge.ts
@@ -7,6 +7,7 @@ const mergeInputSchema = z.object({
 	projectId: z.string(),
 	prNumber: z.number().int().positive(),
 	mergeMethod: z.enum(["merge", "squash", "rebase"]).default("merge"),
+	commitMessage: z.string().trim().min(1).optional(),
 });
 
 /**
@@ -25,6 +26,7 @@ export const mergePR = protectedProcedure
 				repo: repo.name,
 				pull_number: input.prNumber,
 				merge_method: input.mergeMethod,
+				...(input.commitMessage ? { commit_message: input.commitMessage } : {}),
 			});
 			return data;
 		} catch (error) {


### PR DESCRIPTION
## Summary
- Redesign the PR detail header to match the target design (tab bar, title row, byline) and hide affordances that aren't wired up yet (Share, "..." overflow).
- Fix PR state colors (badge, `PRIcon`, checks, diff stats) so they respond to the app's actual theme switch instead of a dead `dark:` variant that only tracked OS `prefers-color-scheme`.
- Rebuild the Merge dropdown with per-method descriptions, an optional merge comment, and add a fully-functional Force merge plus a stubbed Enable auto-merge.

## Why / Context
This app's `globals.css` never defines `@custom-variant dark`, so every `dark:`-prefixed Tailwind utility in the PR badge/icons/diff stats fell back to Tailwind's default `prefers-color-scheme` gate — it tracked the OS appearance setting, not this app's own theme switcher, and silently never activated when the two disagreed. That's why the state badge rendered its light-mode colors even with the app's own theme set to dark.

## How It Works
- Header is now three rows: tab bar (Summary/Code + list-collapse toggle), title + actions (GitHub link, Start Workspace, Merge), and a byline (state badge with icon, avatar, author, `#number`, relative time).
- Every dark-mode color override moved from `dark:` (media-query gated, broken) to the Tailwind arbitrary variant `[.dark_&]`, which targets the real `.dark` class the theme store puts on `<html>`. Dark hex values are hand-tuned (Figma only specs the "open" badge state) and shared between the badge, `PRIcon`, `CHECK_STATUS_ICONS` (also used by the v2-workspace sidebar's `ChecksSection`), and the list-row diff stats, so a PR's state/checks/diff read as one consistent palette.
- Merge dropdown: two-line method items (label + description) match the target design; an optional comment textarea passes through as GitHub's `commit_message` (new optional param on the `mergePR` tRPC procedure). Force merge is shown only when checks have failed and reuses the existing merge mutation — GitHub enforces the bypass via permissions, not a distinct API flag, so no new backend was needed. Enable auto-merge is shown only when checks are pending and is UI-only for now (toast) — real auto-merge needs GitHub's GraphQL `enable/disablePullRequestAutoMerge` mutations plus PR auto-merge-state tracking this app doesn't fetch today.

## Manual QA Checklist

### Header
- [x] Summary/Code tabs toggle correctly (real "Summary"/"Code" text, not CSS `capitalize` on lowercase — caught and fixed during review since it broke accessible-name lookup)
- [x] Code tab shows a "coming soon" placeholder instead of an inert no-op
- [x] List/detail collapse toggles work with tooltips removed
- [x] Title truncates correctly at narrow widths

### Colors
- [x] Badge matches Figma exactly in light mode (pixel-verified via computed style: `#dcfae8` / `#00a558`, `border-width: 0`)
- [x] Badge/`PRIcon`/checks/diff-stat colors respond to the app's real theme switch — verified by toggling the actual theme store (`useThemeStore.getState().setTheme(...)`), not just OS media emulation
- [x] Checks-panel failure red and list-row diff-deletion red now match exactly (`#f87171`), confirmed via computed style on both

### Merge dropdown
- [x] Force merge only appears when `checksStatus === "failure"`; confirmation dialog shows the correct warning copy ("Checks haven't passed yet — this overrides them") and was cancelled without executing a real merge against the live repo
- [x] Enable auto-merge only appears when `checksStatus === "pending"`; click shows a toast, no crash
- [x] No console errors across all interactions (checked via CDP `Runtime.consoleAPICalled`)

## Testing
- `bun run typecheck` — `apps/desktop`, `packages/host-service`
- `bunx biome check --write` on every touched file
- Manual: CDP-driven verification against the running dev app throughout (screenshots + computed-style assertions), including toggling the app's real theme store rather than relying on OS dark mode

## Design Decisions
- **Dark palette is hand-tuned, not literal Figma output**: Figma only specs the "open" badge state. Closed/merged were deliberately softened off raw rose/violet (less pink/magenta) after a design-review pass; checks/diff share one canonical green/red sourced from the workspace sidebar's existing `ChecksSection` colors rather than inventing a second palette.
- **`[.dark_&]` over a global Tailwind config fix**: this app's `dark:` gap likely affects other components too, but fixing it globally (adding `@custom-variant dark` to `apps/desktop/src/renderer/globals.css`) has much broader blast radius than this PR's scope — scoped it to just the touched components instead.
- **Force merge defaults to "squash"** rather than prompting for a method again, matching the target design where it's a single action, not a nested method picker.

## Known Limitations
- Enable auto-merge is visual-only — needs GitHub's GraphQL auto-merge mutations and PR-state tracking to become real.
- Share and the "..." (close/reopen) menu are hidden pending further design; the underlying close/reopen mutations remain wired in the code, just unreachable from the UI for now.
- The dark/light `dark:` gap (media-query vs. theme-class) likely affects other components outside this PR's scope — worth a follow-up sweep.

Claude-Session: https://claude.ai/code/session_018s6aMRhQuJTWMekyCoeFVA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the PR detail header and merge dropdown in `apps/desktop`, and fixes dark-mode colors to follow the in-app theme. Previously dark styles tracked the OS; now `[.dark_&]` targets the app’s `.dark` class so colors match the theme switch.

- Header: three-row layout with tabs (Summary/Code), title and actions (GitHub, Start Workspace, Merge), and a byline (state badge + icon, author, `#number`, relative time). Shows Skeletons while loading; fixes “now ago” to display “now.” Code tab shows a placeholder.
- Merge dropdown: method items include short descriptions and an optional comment passed to GitHub as `commit_message`. Shows Force merge when checks fail (squash by default; reuses existing merge API) and a “Enable auto-merge” stub when checks are pending; separator only renders when these options appear.
- Colors and icons: replace `dark:` with `[.dark_&]` and share a tuned dark palette across the state badge, `PRIcon`, `CHECK_STATUS_ICONS`, and list-row diff stats; unify diff +/- colors with checks. Increase `PRIcon` stroke width to 2.
- List view: move the checks summary inline with the relative time; keep diff stats on their own line with unified colors.
- API: `mergePR` accepts an optional `commitMessage`; no changes required for existing callers.
- UI polish: remove tooltips from split-view toggles; hide Share and overflow (close/reopen) until functional.

<sup>Written for commit 495f180dcb77fbec4fb04ff04ef089f85913867c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned pull request details with Summary and Code tabs.
  * Added GitHub link and Start Workspace action.
  * Added merge comments, force-merge controls, auto-merge messaging, and optional merge commit messages.
  * Added explanatory confirmation prompts for force merges.
  * Added loading skeletons and relative creation timestamps.

* **Bug Fixes**
  * Improved dark-mode colors for pull request states and check indicators.
  * Updated pull request icons for clearer visibility.
  * Improved pull request list metadata layout.

* **Style**
  * Simplified list and detail toggle controls by removing unnecessary tooltip overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->