### PR TITLE
test(agent-setup): harden disabled-skills.test.ts against cross-file mock pollution

### DIFF
--- a/packages/agent-setup/src/disabled-skills.test.ts
+++ b/packages/agent-setup/src/disabled-skills.test.ts
@@ -20,6 +20,13 @@ beforeEach(() => {
 	testHome = fs.mkdtempSync(path.join(os.tmpdir(), "superset-skills-"));
 	process.env.SUPERSET_HOME_DIR = testHome;
 	delete process.env.SUPERSET_DISABLED_SKILLS;
+	// Some sibling test file in this suite mock.module()s "./paths" for the
+	// whole process without restoring it, which can point this file's own
+	// resolveSupersetHomeDir() at a directory another test already wrote to.
+	// Every test writes before it reads today, so that's currently harmless,
+	// but clear it here too so a future test that reads first doesn't
+	// silently inherit foreign state.
+	fs.rmSync(getDisabledSkillsStateFilePath(), { force: true });
 });
 
 afterEach(() => {
@@ -42,11 +49,6 @@ describe("shared disabled-skills state", () => {
 	});
 
 	it("treats a missing or corrupt file as nothing disabled", () => {
-		// Some sibling test file in this suite mock.module()s "./paths" for the
-		// whole process without restoring it, which can point this file's own
-		// resolveSupersetHomeDir() at a directory another test already wrote
-		// to — start this test by clearing whatever's there, wherever "there" is.
-		fs.rmSync(getDisabledSkillsStateFilePath(), { force: true });
 		expect(readSharedDisabledSkillIds()).toEqual([]);
 
 		fs.writeFileSync(getDisabledSkillsStateFilePath(), "{not json");


### PR DESCRIPTION
## Summary
Small follow-on to #6833. Post-merge code review (my own `/code-review` plus CodeRabbit) flagged a handful of simplification/reuse suggestions on top of the correctness/accessibility fixes already merged. Most turned out not to be clean wins once checked against the actual code (redundant-looking UI controls were intentional per the original request; the "reusable" hooks it suggested don't actually fit — one needs workspace context we don't have, the other has different fallback semantics that would regress UX; the "duplicated" disabled-skill check is already about as DRY as it can be). This PR does the one that was a genuine, low-risk win.

- `packages/agent-setup/src/disabled-skills.test.ts`: `agent-wrappers.test.ts` calls `mock.module()` on `"./paths"` for the whole test process without ever restoring it, which can point this file's own `resolveSupersetHomeDir()` at a directory a sibling test already wrote to. Every test here currently writes before it reads, so this was harmless in practice, but moved the defensive clear from one test into `beforeEach` so a future test that reads first can't silently inherit foreign state and fail nondeterministically (or mask a real regression).

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` in `packages/agent-setup` — 255 pass
- [x] `bun test src/agent-wrappers.test.ts src/disabled-skills.test.ts` (the specific contamination scenario) — 63 pass

https://claude.ai/code/session_011Nvw5AnhY9tfUkA1Mo1Lgt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-file test pollution by clearing the disabled-skills state file in `beforeEach` of `packages/agent-setup/src/disabled-skills.test.ts`. Previously only one test cleared it; now all tests start clean, avoiding nondeterministic reads when another file’s persistent `mock.module("./paths")` redirects `resolveSupersetHomeDir()`.

- Only changes `packages/agent-setup/src/disabled-skills.test.ts`; no runtime code touched.
- Moves `fs.rmSync(getDisabledSkillsStateFilePath(), { force: true })` from a single test into `beforeEach` to ensure isolation across the suite.

<sup>Written for commit cf31a249be138e2e7d0b79547d858b0a9d427dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by resetting disabled-skill state before each test.
  * Removed redundant cleanup from an individual test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->