### PR TITLE
feat(marketing): add Factory 2026 forecast page

### DIFF
--- a/apps/marketing/src/app/factory-2026/components/AttentionChart/AttentionChart.tsx
+++ b/apps/marketing/src/app/factory-2026/components/AttentionChart/AttentionChart.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { ATTENTION_CURVE } from "../../constants";
+
+const W = 560;
+const H = 220;
+const PAD = { top: 20, right: 20, bottom: 28, left: 40 };
+
+const plotW = W - PAD.left - PAD.right;
+const plotH = H - PAD.top - PAD.bottom;
+
+const x = (index: number) =>
+	PAD.left + (index / (ATTENTION_CURVE.length - 1)) * plotW;
+const y = (share: number) => PAD.top + (1 - share / 100) * plotH;
+
+const LABELED_LEVELS = new Set(["F0", "F3", "F5"]);
+
+export function AttentionChart() {
+	const [hovered, setHovered] = useState<number | null>(null);
+
+	const path = ATTENTION_CURVE.map(
+		(point, index) => `${index === 0 ? "M" : "L"}${x(index)},${y(point.share)}`,
+	).join(" ");
+
+	const onMove = (event: React.PointerEvent<SVGSVGElement>) => {
+		const rect = event.currentTarget.getBoundingClientRect();
+		const px = ((event.clientX - rect.left) / rect.width) * W;
+		const index = Math.round(
+			((px - PAD.left) / plotW) * (ATTENTION_CURVE.length - 1),
+		);
+		setHovered(Math.max(0, Math.min(ATTENTION_CURVE.length - 1, index)));
+	};
+
+	const hoveredPoint = hovered === null ? null : ATTENTION_CURVE[hovered];
+
+	return (
+		<figure className="border border-border p-4 md:p-6">
+			<figcaption>
+				<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+					Fig. 1 · Human share of the effort behind a merged change
+				</span>
+				<span className="block text-xs text-muted-foreground mt-1">
+					Schematic, by autonomy level. Hover for values.
+				</span>
+			</figcaption>
+			<div className="relative mt-4">
+				<svg
+					viewBox={`0 0 ${W} ${H}`}
+					className="w-full h-auto touch-none"
+					role="img"
+					aria-label="Line chart: the human share of effort per merged change falls from 100 percent at F0 to about 2 percent at F5"
+					onPointerMove={onMove}
+					onPointerLeave={() => setHovered(null)}
+				>
+					{/* Gridlines */}
+					{[0, 50, 100].map((tick) => (
+						<g key={tick}>
+							<line
+								x1={PAD.left}
+								x2={W - PAD.right}
+								y1={y(tick)}
+								y2={y(tick)}
+								className="stroke-border"
+								strokeWidth={1}
+							/>
+							<text
+								x={PAD.left - 8}
+								y={y(tick) + 3}
+								textAnchor="end"
+								className="fill-muted-foreground font-mono"
+								fontSize={10}
+							>
+								{tick}%
+							</text>
+						</g>
+					))}
+
+					<path d={path} fill="none" className="stroke-brand" strokeWidth={2} />
+
+					{ATTENTION_CURVE.map((point, index) => (
+						<g key={point.level}>
+							<circle
+								cx={x(index)}
+								cy={y(point.share)}
+								r={hovered === index ? 5 : 4}
+								className="fill-brand"
+								stroke="var(--background)"
+								strokeWidth={2}
+							/>
+							{LABELED_LEVELS.has(point.level) && hovered !== index && (
+								<text
+									x={x(index)}
+									y={y(point.share) - 10}
+									textAnchor="middle"
+									className="fill-foreground font-mono"
+									fontSize={10}
+								>
+									{point.share}%
+								</text>
+							)}
+							<text
+								x={x(index)}
+								y={H - 8}
+								textAnchor="middle"
+								className={`font-mono ${point.level === "F3" ? "fill-foreground" : "fill-muted-foreground"}`}
+								fontSize={10}
+							>
+								{point.level}
+							</text>
+						</g>
+					))}
+
+					{/* You are here marker at F3 */}
+					<line
+						x1={x(3)}
+						x2={x(3)}
+						y1={y(ATTENTION_CURVE[3]?.share ?? 0) + 8}
+						y2={H - PAD.bottom}
+						className="stroke-foreground/30"
+						strokeWidth={1}
+						strokeDasharray="3 3"
+					/>
+				</svg>
+
+				{hoveredPoint && hovered !== null && (
+					<div
+						className="pointer-events-none absolute -translate-x-1/2 border border-border bg-background px-2 py-1 text-[11px] font-mono whitespace-nowrap"
+						style={{
+							left: `${(x(hovered) / W) * 100}%`,
+							top: `${(Math.max(0, y(hoveredPoint.share) - 34) / H) * 100}%`,
+						}}
+					>
+						<span className="text-muted-foreground">{hoveredPoint.level}</span>{" "}
+						<span className="text-foreground">{hoveredPoint.share}% human</span>
+					</div>
+				)}
+			</div>
+			<p className="text-xs font-mono text-muted-foreground mt-2">
+				<span className="text-foreground">F3</span> · you are here
+			</p>
+		</figure>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/AttentionChart/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/AttentionChart/index.ts
@@ -1,0 +1,1 @@
+export { AttentionChart } from "./AttentionChart";

--- a/apps/marketing/src/app/factory-2026/components/ForecastChart/ForecastChart.tsx
+++ b/apps/marketing/src/app/factory-2026/components/ForecastChart/ForecastChart.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { AGENT_SHARE_SERIES, F4_GATE_SHARE, TODAY_T } from "../../constants";
+
+const W = 560;
+const H = 250;
+const PAD = { top: 24, right: 20, bottom: 28, left: 40 };
+
+const plotW = W - PAD.left - PAD.right;
+const plotH = H - PAD.top - PAD.bottom;
+
+const T_MIN = 2024;
+const T_MAX = 2028;
+const Y_MAX = 60;
+
+const x = (t: number) => PAD.left + ((t - T_MIN) / (T_MAX - T_MIN)) * plotW;
+const y = (share: number) => PAD.top + (1 - share / Y_MAX) * plotH;
+
+const history = AGENT_SHARE_SERIES.filter((point) => !point.forecast);
+const forecast = AGENT_SHARE_SERIES.filter((point) => point.forecast);
+const forecastWithAnchor = history.length
+	? [...history.slice(-1), ...forecast]
+	: forecast;
+
+const toPath = (points: typeof AGENT_SHARE_SERIES) =>
+	points
+		.map((p, i) => `${i === 0 ? "M" : "L"}${x(p.t)},${y(p.share)}`)
+		.join(" ");
+
+export function ForecastChart() {
+	const [hovered, setHovered] = useState<number | null>(null);
+
+	const onMove = (event: React.PointerEvent<SVGSVGElement>) => {
+		const rect = event.currentTarget.getBoundingClientRect();
+		const px = ((event.clientX - rect.left) / rect.width) * W;
+		let best = 0;
+		let bestDist = Number.POSITIVE_INFINITY;
+		AGENT_SHARE_SERIES.forEach((point, index) => {
+			const dist = Math.abs(x(point.t) - px);
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = index;
+			}
+		});
+		setHovered(best);
+	};
+
+	const hoveredPoint = hovered === null ? null : AGENT_SHARE_SERIES[hovered];
+
+	return (
+		<figure className="border border-border p-4 md:p-6">
+			<figcaption>
+				<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+					Fig. 2 · Merged changes written by agents, zero human edits
+				</span>
+				<span className="block text-xs text-muted-foreground mt-1">
+					Industry median, our estimate. Dashed is forecast. The first F4 teams
+					cross the gate earlier.
+				</span>
+			</figcaption>
+			<div className="relative mt-4">
+				<svg
+					viewBox={`0 0 ${W} ${H}`}
+					className="w-full h-auto touch-none"
+					role="img"
+					aria-label="Line chart: the share of merged changes written by agents with zero human edits rises from about 1 percent in 2024 to an estimated 27 percent today, with a forecast crossing the 50 percent F4 gate during 2027"
+					onPointerMove={onMove}
+					onPointerLeave={() => setHovered(null)}
+				>
+					{/* Gridlines */}
+					{[0, 25, 50].map((tick) => (
+						<g key={tick}>
+							<line
+								x1={PAD.left}
+								x2={W - PAD.right}
+								y1={y(tick)}
+								y2={y(tick)}
+								className="stroke-border"
+								strokeWidth={1}
+							/>
+							<text
+								x={PAD.left - 8}
+								y={y(tick) + 3}
+								textAnchor="end"
+								className="fill-muted-foreground font-mono"
+								fontSize={10}
+							>
+								{tick}%
+							</text>
+						</g>
+					))}
+
+					{/* Year ticks */}
+					{[2024, 2025, 2026, 2027, 2028].map((year) => (
+						<text
+							key={year}
+							x={x(year)}
+							y={H - 8}
+							textAnchor="middle"
+							className="fill-muted-foreground font-mono"
+							fontSize={10}
+						>
+							{year}
+						</text>
+					))}
+
+					{/* F4 gate line */}
+					<line
+						x1={PAD.left}
+						x2={W - PAD.right}
+						y1={y(F4_GATE_SHARE)}
+						y2={y(F4_GATE_SHARE)}
+						className="stroke-foreground/40"
+						strokeWidth={1}
+						strokeDasharray="5 4"
+					/>
+					<text
+						x={W - PAD.right}
+						y={y(F4_GATE_SHARE) - 6}
+						textAnchor="end"
+						className="fill-foreground/70 font-mono"
+						fontSize={10}
+					>
+						F4 gate · {F4_GATE_SHARE}%
+					</text>
+
+					{/* Today marker */}
+					<line
+						x1={x(TODAY_T)}
+						x2={x(TODAY_T)}
+						y1={PAD.top}
+						y2={H - PAD.bottom}
+						className="stroke-brand/40"
+						strokeWidth={1}
+						strokeDasharray="3 3"
+					/>
+					<text
+						x={x(TODAY_T)}
+						y={PAD.top - 8}
+						textAnchor="middle"
+						className="fill-brand font-mono"
+						fontSize={10}
+					>
+						TODAY
+					</text>
+
+					<path
+						d={toPath(history)}
+						fill="none"
+						className="stroke-brand"
+						strokeWidth={2}
+					/>
+					<path
+						d={toPath(forecastWithAnchor)}
+						fill="none"
+						className="stroke-brand"
+						strokeWidth={2}
+						strokeDasharray="5 4"
+					/>
+
+					{AGENT_SHARE_SERIES.map((point, index) => (
+						<circle
+							key={point.t}
+							cx={x(point.t)}
+							cy={y(point.share)}
+							r={hovered === index ? 5 : 4}
+							className={
+								point.forecast ? "fill-background stroke-brand" : "fill-brand"
+							}
+							strokeWidth={point.forecast ? 2 : 2}
+							stroke={point.forecast ? undefined : "var(--background)"}
+						/>
+					))}
+				</svg>
+
+				{hoveredPoint && hovered !== null && (
+					<div
+						className="pointer-events-none absolute -translate-x-1/2 border border-border bg-background px-2 py-1 text-[11px] font-mono whitespace-nowrap"
+						style={{
+							left: `${(x(hoveredPoint.t) / W) * 100}%`,
+							top: `${(Math.max(0, y(hoveredPoint.share) - 34) / H) * 100}%`,
+						}}
+					>
+						<span className="text-muted-foreground">{hoveredPoint.label}</span>{" "}
+						<span className="text-foreground">{hoveredPoint.share}%</span>
+						{hoveredPoint.forecast && (
+							<span className="text-brand"> · forecast</span>
+						)}
+					</div>
+				)}
+			</div>
+		</figure>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/ForecastChart/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/ForecastChart/index.ts
@@ -1,0 +1,1 @@
+export { ForecastChart } from "./ForecastChart";

--- a/apps/marketing/src/app/factory-2026/components/ForecastEntry/ForecastEntry.tsx
+++ b/apps/marketing/src/app/factory-2026/components/ForecastEntry/ForecastEntry.tsx
@@ -1,0 +1,67 @@
+import { type ForecastPeriod, PERIOD_IDS } from "../../constants";
+
+interface ForecastEntryProps {
+	entry: ForecastPeriod;
+}
+
+const STATUS_LABELS: Record<ForecastPeriod["status"], string> = {
+	happened: "Happened",
+	underway: "Underway",
+	forecast: "Forecast",
+};
+
+export function ForecastEntry({ entry }: ForecastEntryProps) {
+	return (
+		<article
+			id={PERIOD_IDS[entry.period]}
+			className="relative scroll-mt-24 border-b border-border pb-16 last:border-b-0 last:pb-0"
+		>
+			{/* Sticky period label positioned to the left of the gridline */}
+			<div
+				className="hidden lg:flex absolute top-0 bottom-0 items-start"
+				style={{ right: "calc(100% + 24px)" }}
+			>
+				<div className="sticky top-24 flex items-center gap-3 pt-1">
+					<span className="text-sm font-mono text-muted-foreground whitespace-nowrap">
+						{entry.period}
+					</span>
+					<div
+						className={`w-0.5 h-5 ${entry.status === "forecast" ? "bg-border" : "bg-brand"}`}
+					/>
+				</div>
+			</div>
+
+			{/* Mobile period label */}
+			<span className="lg:hidden block text-sm font-mono text-muted-foreground mb-4">
+				{entry.period}
+			</span>
+
+			<div className="flex flex-wrap items-baseline gap-x-3 gap-y-2 mb-4">
+				<h3 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground">
+					{entry.title}
+				</h3>
+				<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+					{STATUS_LABELS[entry.status]}
+				</span>
+			</div>
+
+			{entry.paragraphs.map((paragraph) => (
+				<p
+					key={paragraph}
+					className="text-muted-foreground leading-relaxed mb-4 last:mb-0"
+				>
+					{paragraph}
+				</p>
+			))}
+
+			<div className="mt-6 border-l-2 border-brand/40 pl-4">
+				<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+					What has to become true
+				</span>
+				<p className="text-sm text-foreground/80 mt-1.5 leading-relaxed">
+					{entry.becomesTrue}
+				</p>
+			</div>
+		</article>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/ForecastEntry/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/ForecastEntry/index.ts
@@ -1,0 +1,1 @@
+export { ForecastEntry } from "./ForecastEntry";

--- a/apps/marketing/src/app/factory-2026/components/GateJumpLink/GateJumpLink.tsx
+++ b/apps/marketing/src/app/factory-2026/components/GateJumpLink/GateJumpLink.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { scrollToElement } from "../../utils/scrollToElement";
+
+interface GateJumpLinkProps {
+	targetId: string;
+	className?: string;
+	title?: string;
+	children: ReactNode;
+}
+
+/** Anchor that smooth-scrolls to a gate row and flashes it. */
+export function GateJumpLink({
+	targetId,
+	className,
+	title,
+	children,
+}: GateJumpLinkProps) {
+	const jump = (event: React.MouseEvent) => {
+		const el = document.getElementById(targetId);
+		if (!el) return;
+		event.preventDefault();
+		scrollToElement(el, { center: true });
+		el.classList.add("bg-brand/10");
+		window.setTimeout(() => el.classList.remove("bg-brand/10"), 1600);
+	};
+
+	return (
+		<a href={`#${targetId}`} onClick={jump} className={className} title={title}>
+			{children}
+		</a>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/GateJumpLink/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/GateJumpLink/index.ts
@@ -1,0 +1,1 @@
+export { GateJumpLink } from "./GateJumpLink";

--- a/apps/marketing/src/app/factory-2026/components/GateScorecard/GateScorecard.tsx
+++ b/apps/marketing/src/app/factory-2026/components/GateScorecard/GateScorecard.tsx
@@ -1,0 +1,49 @@
+import type { GateScore, GateStatus } from "../../constants";
+
+interface GateScorecardProps {
+	scores: GateScore[];
+}
+
+const STATUS_META: Record<
+	GateStatus,
+	{ glyph: string; label: string; className: string }
+> = {
+	open: { glyph: "●", label: "Open", className: "text-brand" },
+	partial: { glyph: "◐", label: "Partial", className: "text-foreground/70" },
+	closed: { glyph: "○", label: "Closed", className: "text-muted-foreground" },
+};
+
+export function GateScorecard({ scores }: GateScorecardProps) {
+	return (
+		<div className="border border-border">
+			{scores.map((score) => {
+				const status = STATUS_META[score.status];
+				return (
+					<div
+						key={score.gateId}
+						id={`gate-${score.gateId}`}
+						className="grid scroll-mt-24 grid-cols-[auto_1fr] md:grid-cols-[3rem_1fr_7rem] gap-x-4 gap-y-1 items-baseline border-b border-border last:border-b-0 px-4 py-3 md:px-6 md:py-4 transition-colors duration-700"
+					>
+						<span className="text-sm font-mono text-muted-foreground">
+							{score.level}
+						</span>
+						<div>
+							<p className="text-sm text-foreground leading-relaxed">
+								{score.gate}
+							</p>
+							<p className="text-sm text-muted-foreground leading-relaxed mt-0.5">
+								{score.note}
+							</p>
+						</div>
+						<span
+							className={`col-start-2 md:col-start-3 inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-wider ${status.className}`}
+						>
+							<span aria-hidden="true">{status.glyph}</span>
+							{status.label}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/GateScorecard/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/GateScorecard/index.ts
@@ -1,0 +1,1 @@
+export { GateScorecard } from "./GateScorecard";

--- a/apps/marketing/src/app/factory-2026/components/GatesSummary/GatesSummary.tsx
+++ b/apps/marketing/src/app/factory-2026/components/GatesSummary/GatesSummary.tsx
@@ -1,0 +1,65 @@
+import type { GateScore, GateStatus } from "../../constants";
+import { GateJumpLink } from "../GateJumpLink";
+
+interface GatesSummaryProps {
+	scores: GateScore[];
+}
+
+const SEGMENT_CLASSES: Record<GateStatus, string> = {
+	open: "bg-brand",
+	partial:
+		"bg-[repeating-linear-gradient(135deg,var(--brand)_0,var(--brand)_3px,transparent_3px,transparent_6px)]",
+	closed: "bg-foreground/10",
+};
+
+const GLYPHS: Record<GateStatus, string> = {
+	open: "●",
+	partial: "◐",
+	closed: "○",
+};
+
+export function GatesSummary({ scores }: GatesSummaryProps) {
+	const counts: Record<GateStatus, number> = {
+		open: 0,
+		partial: 0,
+		closed: 0,
+	};
+	for (const score of scores) {
+		counts[score.status] += 1;
+	}
+
+	return (
+		<div>
+			<div className="flex gap-0.5">
+				{scores.map((score) => (
+					<GateJumpLink
+						key={score.gateId}
+						targetId={`gate-${score.gateId}`}
+						title={`${score.level} · ${score.gate} · ${score.status}`}
+						className={`h-3 flex-1 hover:outline hover:outline-1 hover:outline-brand ${SEGMENT_CLASSES[score.status]}`}
+					>
+						<span className="sr-only">
+							{score.level} {score.gate}: {score.status}
+						</span>
+					</GateJumpLink>
+				))}
+			</div>
+			<p className="flex flex-wrap gap-x-4 gap-y-1 text-xs font-mono mt-2">
+				{(Object.keys(counts) as GateStatus[]).map((status) => (
+					<span key={status} className="text-muted-foreground">
+						<span
+							className={status === "closed" ? "" : "text-brand"}
+							aria-hidden="true"
+						>
+							{GLYPHS[status]}
+						</span>{" "}
+						{counts[status]} {status}
+					</span>
+				))}
+				<span className="text-muted-foreground">
+					of {scores.length} F3 and F4 gates
+				</span>
+			</p>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/GatesSummary/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/GatesSummary/index.ts
@@ -1,0 +1,1 @@
+export { GatesSummary } from "./GatesSummary";

--- a/apps/marketing/src/app/factory-2026/components/HeroStats/HeroStats.tsx
+++ b/apps/marketing/src/app/factory-2026/components/HeroStats/HeroStats.tsx
@@ -1,0 +1,61 @@
+import { formatTally, GATE_SCORECARD, tallyGates } from "../../constants";
+import { GateJumpLink } from "../GateJumpLink";
+
+const SEGMENT_CLASSES = {
+	open: "bg-brand",
+	partial:
+		"bg-[repeating-linear-gradient(135deg,var(--brand)_0,var(--brand)_3px,transparent_3px,transparent_6px)]",
+	closed: "bg-foreground/10",
+};
+
+export function HeroStats() {
+	const f3 = tallyGates("F3");
+	const f4 = tallyGates("F4");
+
+	return (
+		<div className="mt-8 grid grid-cols-1 sm:grid-cols-3 border border-border divide-y sm:divide-y-0 sm:divide-x divide-border">
+			<div className="px-4 py-3 md:px-5">
+				<span className="text-[10px] font-mono text-muted-foreground uppercase tracking-wider">
+					Current level
+				</span>
+				<p className="text-lg font-mono text-foreground mt-1">
+					F3 <span className="text-muted-foreground text-sm">· Delegated</span>
+				</p>
+			</div>
+			<div className="px-4 py-3 md:px-5">
+				<span className="text-[10px] font-mono text-muted-foreground uppercase tracking-wider">
+					Gates open
+				</span>
+				<p className="text-lg font-mono text-foreground mt-1">
+					{formatTally(f3)}{" "}
+					<span className="text-muted-foreground text-sm">F3</span>
+					<span className="text-muted-foreground text-sm"> · </span>
+					{formatTally(f4)}{" "}
+					<span className="text-muted-foreground text-sm">F4</span>
+				</p>
+				<div className="flex gap-0.5 mt-2">
+					{GATE_SCORECARD.map((score) => (
+						<GateJumpLink
+							key={score.gateId}
+							targetId={`gate-${score.gateId}`}
+							title={`${score.level} · ${score.gate} · ${score.status}`}
+							className={`h-1.5 flex-1 hover:outline hover:outline-1 hover:outline-brand ${SEGMENT_CLASSES[score.status]}`}
+						>
+							<span className="sr-only">
+								{score.level} {score.gate}: {score.status}
+							</span>
+						</GateJumpLink>
+					))}
+				</div>
+			</div>
+			<div className="px-4 py-3 md:px-5">
+				<span className="text-[10px] font-mono text-muted-foreground uppercase tracking-wider">
+					F4 gate crossed
+				</span>
+				<p className="text-lg font-mono text-foreground mt-1">
+					2027 <span className="text-muted-foreground text-sm">· forecast</span>
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/HeroStats/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/HeroStats/index.ts
@@ -1,0 +1,1 @@
+export { HeroStats } from "./HeroStats";

--- a/apps/marketing/src/app/factory-2026/components/LevelCard/LevelCard.tsx
+++ b/apps/marketing/src/app/factory-2026/components/LevelCard/LevelCard.tsx
@@ -1,0 +1,120 @@
+import {
+	type FactoryLevel,
+	formatTally,
+	GATE_GLYPHS,
+	GATE_STATUS_BY_ID,
+	tallyGates,
+} from "../../constants";
+import { GateJumpLink } from "../GateJumpLink";
+
+interface LevelCardProps {
+	level: FactoryLevel;
+}
+
+const STATUS_TEXT_CLASSES = {
+	open: "text-brand",
+	partial: "text-brand",
+	closed: "text-muted-foreground",
+};
+
+export function LevelCard({ level }: LevelCardProps) {
+	const highlighted = level.id === "F4";
+	const tracked = level.gates.some((gate) => gate.id);
+	const tally = tracked ? tallyGates(level.id) : null;
+
+	return (
+		<article
+			id={level.id}
+			className={`relative scroll-mt-24 border p-6 md:p-8 ${
+				highlighted ? "border-brand/40 bg-brand/[0.04]" : "border-border"
+			}`}
+		>
+			<div className="flex flex-wrap items-baseline gap-x-3 gap-y-2">
+				<span
+					className={`text-sm font-mono ${highlighted ? "text-brand" : "text-muted-foreground"}`}
+				>
+					{level.id}
+				</span>
+				<h3 className="text-xl md:text-2xl font-medium tracking-tight text-foreground">
+					{level.name}
+				</h3>
+				<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+					{level.era}
+				</span>
+				{level.badge && (
+					<span
+						className={`inline-flex items-center gap-1.5 text-xs font-mono uppercase tracking-wider border rounded-[2px] px-2 py-0.5 ${
+							highlighted
+								? "border-brand/40 text-brand"
+								: "border-border text-muted-foreground"
+						}`}
+					>
+						{level.badge}
+					</span>
+				)}
+			</div>
+
+			<p className="text-muted-foreground mt-3 leading-relaxed">
+				{level.description}
+			</p>
+
+			<div className="mt-5">
+				<div className="flex items-baseline gap-3">
+					<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+						Gates
+					</span>
+					{tally && (
+						<span className="text-xs font-mono text-brand">
+							{formatTally(tally)} open
+						</span>
+					)}
+				</div>
+				<ul className="mt-2 flex flex-col gap-1.5">
+					{level.gates.map((gate) => {
+						const status = gate.id ? GATE_STATUS_BY_ID[gate.id] : undefined;
+
+						if (gate.id && status) {
+							return (
+								<li key={gate.text}>
+									<GateJumpLink
+										targetId={`gate-${gate.id}`}
+										title="See this gate on the scorecard"
+										className="group flex gap-2.5 text-sm text-muted-foreground leading-relaxed hover:text-foreground transition-colors"
+									>
+										<span
+											className={`shrink-0 font-mono ${STATUS_TEXT_CLASSES[status]}`}
+											aria-hidden="true"
+										>
+											{GATE_GLYPHS[status]}
+										</span>
+										<span>
+											{gate.text}{" "}
+											<span className="whitespace-nowrap font-mono text-[10px] uppercase tracking-wider text-muted-foreground/70 group-hover:text-brand transition-colors">
+												{status} →
+											</span>
+										</span>
+									</GateJumpLink>
+								</li>
+							);
+						}
+
+						return (
+							<li
+								key={gate.text}
+								className="flex gap-2.5 text-sm text-muted-foreground leading-relaxed"
+							>
+								<span
+									className={`shrink-0 font-mono ${highlighted ? "text-brand" : "text-foreground/40"}`}
+									aria-hidden="true"
+								>
+									{level.id === "F5" ? GATE_GLYPHS.closed : "▸"}
+								</span>
+								{gate.text}
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+		</article>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/LevelCard/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/LevelCard/index.ts
@@ -1,0 +1,1 @@
+export { LevelCard } from "./LevelCard";

--- a/apps/marketing/src/app/factory-2026/components/ProgressSidebar/ProgressSidebar.tsx
+++ b/apps/marketing/src/app/factory-2026/components/ProgressSidebar/ProgressSidebar.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+	FACTORY_LEVELS,
+	FORECAST_PERIODS,
+	GATE_SCORECARD,
+	PERIOD_IDS,
+	PERIOD_T,
+	TIMELINE_END,
+	TIMELINE_START,
+	TODAY_T,
+} from "../../constants";
+import { scrollToElement } from "../../utils/scrollToElement";
+import { GateJumpLink } from "../GateJumpLink";
+import { GateMeter } from "./components/GateMeter";
+
+interface Waypoint {
+	id: string;
+	label: string;
+	group: boolean;
+}
+
+const WAYPOINTS: Waypoint[] = [
+	{ id: "rubric", label: "The rubric", group: true },
+	...FACTORY_LEVELS.map((level) => ({
+		id: level.id,
+		label: `${level.id} · ${level.name}`,
+		group: false,
+	})),
+	{ id: "forecast", label: "The forecast", group: true },
+	...FORECAST_PERIODS.map((period) => ({
+		id: PERIOD_IDS[period.period] ?? period.period,
+		label: `${period.period} · ${period.title}`,
+		group: false,
+	})),
+	{ id: "scorecard", label: "The scorecard", group: true },
+];
+
+const MARKER_T: Record<string, number> = PERIOD_T;
+
+const NEXT_GATE = GATE_SCORECARD.find(
+	(score) => score.level === "F4" && score.status === "partial",
+);
+
+export function ProgressSidebar() {
+	const [activeId, setActiveId] = useState<string | null>(null);
+	const [progress, setProgress] = useState(0);
+	const ticking = useRef(false);
+
+	useEffect(() => {
+		const update = () => {
+			ticking.current = false;
+			const doc = document.documentElement;
+			const max = doc.scrollHeight - window.innerHeight;
+			setProgress(max > 0 ? Math.min(1, window.scrollY / max) : 0);
+
+			const cutoff = window.innerHeight * 0.4;
+			let current: string | null = null;
+			for (const waypoint of WAYPOINTS) {
+				const el = document.getElementById(waypoint.id);
+				if (el && el.getBoundingClientRect().top <= cutoff) {
+					current = waypoint.id;
+				}
+			}
+			setActiveId(current);
+		};
+		const onScroll = () => {
+			if (!ticking.current) {
+				ticking.current = true;
+				requestAnimationFrame(update);
+			}
+		};
+		update();
+		window.addEventListener("scroll", onScroll, { passive: true });
+		window.addEventListener("resize", onScroll);
+		return () => {
+			window.removeEventListener("scroll", onScroll);
+			window.removeEventListener("resize", onScroll);
+		};
+	}, []);
+
+	const active = WAYPOINTS.find((waypoint) => waypoint.id === activeId);
+	const markerT = (activeId && MARKER_T[activeId]) || TODAY_T;
+	const markerLeft =
+		((markerT - TIMELINE_START) / (TIMELINE_END - TIMELINE_START)) * 100;
+	const todayLeft =
+		((TODAY_T - TIMELINE_START) / (TIMELINE_END - TIMELINE_START)) * 100;
+	const inFuture = markerT > TODAY_T + 0.01;
+
+	const jumpTo = (id: string) => {
+		const el = document.getElementById(id);
+		if (!el) return;
+		scrollToElement(el);
+	};
+
+	return (
+		<nav
+			aria-label="Prediction progress"
+			className="hidden xl:block fixed right-6 top-1/2 -translate-y-1/2 z-40 w-56"
+		>
+			<div className="border border-border bg-background/80 backdrop-blur-sm px-4 py-3">
+				<div className="flex items-baseline justify-between">
+					<span className="text-[10px] font-mono text-muted-foreground uppercase tracking-wider">
+						Factory 2026
+					</span>
+					<span className="text-[10px] font-mono text-muted-foreground tabular-nums">
+						{Math.round(progress * 100)}% read
+					</span>
+				</div>
+				<p className="text-xs font-mono text-foreground mt-1.5 leading-snug min-h-8">
+					{active ? active.label : "The self-driving software factory"}
+				</p>
+
+				{/* Scenario timeline: where the section you are reading sits in time */}
+				<div className="relative mt-2 h-8">
+					<div className="absolute left-0 right-0 top-3 h-px bg-border" />
+					{/* Today tick */}
+					<div
+						className="absolute top-1.5 h-3 w-px bg-brand/60"
+						style={{ left: `${todayLeft}%` }}
+					/>
+					{/* Moving scenario marker */}
+					<div
+						className={`absolute top-3 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full transition-[left] duration-500 ${
+							inFuture ? "border border-brand bg-background" : "bg-brand"
+						}`}
+						style={{ left: `${markerLeft}%` }}
+					/>
+					<span className="absolute left-0 top-5 text-[9px] font-mono text-muted-foreground">
+						{TIMELINE_START}
+					</span>
+					<span className="absolute right-0 top-5 text-[9px] font-mono text-muted-foreground">
+						{TIMELINE_END}
+					</span>
+					<span
+						className="absolute top-[-3px] -translate-x-1/2 text-[9px] font-mono text-brand/80"
+						style={{ left: `${todayLeft}%` }}
+					>
+						now
+					</span>
+				</div>
+
+				{/* Gate meters: the prediction's actual progress */}
+				<div className="mt-2 flex flex-col gap-1.5 border-t border-border pt-2.5">
+					<span className="text-[10px] font-mono text-muted-foreground uppercase tracking-wider">
+						Gates open
+					</span>
+					<GateMeter level="F3" />
+					<GateMeter level="F4" />
+					{NEXT_GATE && (
+						<p className="text-[10px] font-mono text-muted-foreground leading-snug mt-0.5">
+							Next:{" "}
+							<GateJumpLink
+								targetId={`gate-${NEXT_GATE.gateId}`}
+								className="text-foreground/80 hover:text-brand transition-colors"
+							>
+								{NEXT_GATE.gate.toLowerCase()} →
+							</GateJumpLink>
+						</p>
+					)}
+				</div>
+			</div>
+
+			<div className="relative mt-3 pl-4">
+				{/* Rail with progress fill */}
+				<div className="absolute left-0 top-1 bottom-1 w-px bg-border" />
+				<div
+					className="absolute left-0 top-1 w-px bg-brand"
+					style={{
+						height: `${progress * 100}%`,
+						maxHeight: "calc(100% - 8px)",
+					}}
+				/>
+				<ul className="flex flex-col gap-1">
+					{WAYPOINTS.map((waypoint) => {
+						const isActive = waypoint.id === activeId;
+						return (
+							<li key={waypoint.id}>
+								<button
+									type="button"
+									onClick={() => jumpTo(waypoint.id)}
+									className={`group flex w-full items-center gap-2 text-left text-[11px] font-mono transition-colors ${
+										waypoint.group ? "uppercase tracking-wider mt-2" : "pl-3"
+									} ${
+										isActive
+											? "text-foreground"
+											: "text-muted-foreground hover:text-foreground"
+									}`}
+								>
+									<span
+										className={`shrink-0 transition-colors ${isActive ? "text-brand" : "text-border group-hover:text-muted-foreground"}`}
+										aria-hidden="true"
+									>
+										●
+									</span>
+									<span className="truncate">{waypoint.label}</span>
+								</button>
+							</li>
+						);
+					})}
+				</ul>
+			</div>
+		</nav>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/ProgressSidebar/components/GateMeter/GateMeter.tsx
+++ b/apps/marketing/src/app/factory-2026/components/ProgressSidebar/components/GateMeter/GateMeter.tsx
@@ -1,0 +1,42 @@
+import { formatTally, GATE_SCORECARD, tallyGates } from "../../../../constants";
+import { GateJumpLink } from "../../../GateJumpLink";
+
+const CELL_CLASSES = {
+	open: "bg-brand",
+	partial:
+		"bg-[linear-gradient(90deg,var(--brand)_50%,transparent_50%)] border border-brand/50",
+	closed: "bg-foreground/10",
+};
+
+interface GateMeterProps {
+	level: string;
+}
+
+export function GateMeter({ level }: GateMeterProps) {
+	const scores = GATE_SCORECARD.filter((score) => score.level === level);
+	const tally = tallyGates(level);
+	return (
+		<div className="flex items-center gap-2">
+			<span className="w-5 text-[10px] font-mono text-muted-foreground">
+				{level}
+			</span>
+			<div className="flex gap-0.5">
+				{scores.map((score) => (
+					<GateJumpLink
+						key={score.gateId}
+						targetId={`gate-${score.gateId}`}
+						title={`${score.gate} · ${score.status}`}
+						className={`h-2.5 w-2.5 hover:outline hover:outline-1 hover:outline-brand ${CELL_CLASSES[score.status]}`}
+					>
+						<span className="sr-only">
+							{score.gate}: {score.status}
+						</span>
+					</GateJumpLink>
+				))}
+			</div>
+			<span className="text-[10px] font-mono text-brand tabular-nums">
+				{formatTally(tally)}
+			</span>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/components/ProgressSidebar/components/GateMeter/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/ProgressSidebar/components/GateMeter/index.ts
@@ -1,0 +1,1 @@
+export { GateMeter } from "./GateMeter";

--- a/apps/marketing/src/app/factory-2026/components/ProgressSidebar/index.ts
+++ b/apps/marketing/src/app/factory-2026/components/ProgressSidebar/index.ts
@@ -1,0 +1,1 @@
+export { ProgressSidebar } from "./ProgressSidebar";

--- a/apps/marketing/src/app/factory-2026/constants.ts
+++ b/apps/marketing/src/app/factory-2026/constants.ts
@@ -1,0 +1,331 @@
+export type GateStatus = "open" | "partial" | "closed";
+
+export interface FactoryGate {
+	/** Set when the gate is tracked on the scorecard; enables status + jump links. */
+	id?: string;
+	text: string;
+}
+
+export interface FactoryLevel {
+	id: string;
+	name: string;
+	era: string;
+	description: string;
+	gates: FactoryGate[];
+	badge?: string;
+}
+
+export interface ForecastPeriod {
+	period: string;
+	title: string;
+	status: "happened" | "underway" | "forecast";
+	paragraphs: string[];
+	becomesTrue: string;
+}
+
+export interface GateScore {
+	gateId: string;
+	level: string;
+	gate: string;
+	status: GateStatus;
+	note: string;
+}
+
+export const FACTORY_LEVELS: FactoryLevel[] = [
+	{
+		id: "F0",
+		name: "Manual",
+		era: "Most of software history",
+		description:
+			"Humans write every line. Tools compile, lint, and complain. The keyboard is the factory.",
+		gates: [{ text: "None. This is the floor." }],
+	},
+	{
+		id: "F1",
+		name: "Assisted",
+		era: "2021 to 2023",
+		description:
+			"Autocomplete gets good. A model suggests the next few tokens, but nothing ships without a human typing most of it.",
+		gates: [
+			{ text: "Model-suggested code appears in a majority of new files." },
+			{ text: "Nobody reviews differently because of it." },
+		],
+	},
+	{
+		id: "F2",
+		name: "Supervised",
+		era: "2024",
+		description:
+			"An agent writes whole functions and files while a human watches every step and approves every command. One agent, one human. Faster, but still serial.",
+		gates: [
+			{ text: "An agent completes multi-file changes end to end." },
+			{ text: "The human reads every line before it merges." },
+			{ text: "One human drives at most one agent at a time." },
+		],
+	},
+	{
+		id: "F3",
+		name: "Delegated",
+		era: "2025 to now",
+		badge: "Where serious teams are",
+		description:
+			"The agent owns a task from ticket to diff. The human reviews the result, not the keystrokes. Attention shifts from writing code to specifying work and judging it. One engineer runs several agents at once in isolated workspaces.",
+		gates: [
+			{
+				id: "f3-routine",
+				text: "Agents complete routine tickets with no mid-task intervention.",
+			},
+			{
+				id: "f3-parallel",
+				text: "One engineer sustains 3 or more agent workstreams through a workday.",
+			},
+			{
+				id: "f3-zero-edit",
+				text: "The majority of merged agent PRs need review only, with zero human edits.",
+			},
+		],
+	},
+	{
+		id: "F4",
+		name: "Orchestrated",
+		era: "The 2026 bet",
+		badge: "The factory",
+		description:
+			"Fleets of agents plan, implement, review, and test each other's work. Humans set direction, arbitrate exceptions, and own taste. The unit of human attention is no longer the pull request. It is the decision.",
+		gates: [
+			{
+				id: "f4-majority",
+				text: "More than half of merged changes are written by agents with zero human edits.",
+			},
+			{
+				id: "f4-review",
+				text: "Agent review catches regressions at parity with human review on the same diffs.",
+			},
+			{
+				id: "f4-parallel",
+				text: "One engineer sustains 10 or more concurrent workstreams without dropped state.",
+			},
+			{
+				id: "f4-overnight",
+				text: "Overnight and weekend runs complete unattended and are mergeable in the morning.",
+			},
+			{
+				id: "f4-latency",
+				text: "Median ticket-to-production time under one day for routine work.",
+			},
+		],
+	},
+	{
+		id: "F5",
+		name: "Autonomous",
+		era: "Not a 2026 claim",
+		badge: "Full self-driving",
+		description:
+			"Outcome in, software out. Humans specify intent, constraints, and budget. The factory schedules itself, ships continuously, monitors what it shipped, and rolls itself back. Most changes merge with no human in the loop, and the incident rate does not rise.",
+		gates: [
+			{
+				text: "A majority of production changes merge without any human reading the diff.",
+			},
+			{
+				text: "Change-failure rate at or below the human-era baseline for two consecutive quarters.",
+			},
+			{
+				text: "The factory reverts its own bad deploys faster than a human on-call did.",
+			},
+			{
+				text: "Humans in the loop are there for judgment calls, not throughput.",
+			},
+		],
+	},
+];
+
+export const FORECAST_PERIODS: ForecastPeriod[] = [
+	{
+		period: "Early 2026",
+		title: "Review becomes the bottleneck",
+		status: "happened",
+		paragraphs: [
+			"Writing code is no longer where engineer hours go. Reading it is. Teams that adopted parallel agents in 2025 hit the wall first: ten agents can produce more diffs before lunch than a team can honestly review by Friday.",
+			"The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff.",
+		],
+		becomesTrue:
+			"Agent reviewers catch planted regressions at parity with median human reviewers in blind tests.",
+	},
+	{
+		period: "Mid 2026",
+		title: "The dispatcher appears",
+		status: "underway",
+		paragraphs: [
+			"The job description shifts. Engineers stop being typists with taste and become dispatchers with taste: decomposing work, routing it to fleets, arbitrating conflicts between agents that both touched the same module.",
+			"Tools that treat agents as a fleet, not a chat window, become the default interface to the codebase.",
+		],
+		becomesTrue:
+			"One engineer sustains 10 or more concurrent workstreams, and merge-conflict resolution between agent branches is itself mostly automated.",
+	},
+	{
+		period: "Late 2026",
+		title: "The overnight shift",
+		status: "forecast",
+		paragraphs: [
+			"Long-horizon reliability crosses a threshold. Work assigned at 6pm is mergeable at 9am often enough that not scheduling the overnight shift feels like leaving a factory idle.",
+			"Environment setup, flaky tests, and credential plumbing, the boring failure modes that killed unattended runs in 2025, are mostly engineered away rather than modeled away.",
+		],
+		becomesTrue:
+			"Unattended runs of 8 hours or more succeed on a majority of routine tickets without a human unblocking them.",
+	},
+	{
+		period: "2027",
+		title: "The first F4 teams",
+		status: "forecast",
+		paragraphs: [
+			"The first teams, small ones, ship majority-agent code without reading every line, and their defect rates hold. Nothing mystical behind it: review layers, canaries, fast rollback, and a habit of writing specifications instead of code.",
+			"Everyone argues about whether this generalizes. That argument is the sign the level was reached.",
+		],
+		becomesTrue:
+			"At least one team we can name, ours included, passes every F4 gate for a full quarter and publishes the numbers.",
+	},
+];
+
+export const GATE_SCORECARD: GateScore[] = [
+	{
+		gateId: "f3-routine",
+		level: "F3",
+		gate: "Routine tickets with no mid-task intervention",
+		status: "open",
+		note: "Standard for well-scoped work in isolated workspaces.",
+	},
+	{
+		gateId: "f3-parallel",
+		level: "F3",
+		gate: "3+ concurrent workstreams per engineer",
+		status: "open",
+		note: "Daily practice for our team and our heaviest users.",
+	},
+	{
+		gateId: "f3-zero-edit",
+		level: "F3",
+		gate: "Zero-edit majority on merged agent PRs",
+		status: "partial",
+		note: "True for routine work, not yet for gnarly refactors.",
+	},
+	{
+		gateId: "f4-majority",
+		level: "F4",
+		gate: "Half of merged changes are zero-edit agent code",
+		status: "closed",
+		note: "Humans still edit or heavily steer most merged diffs.",
+	},
+	{
+		gateId: "f4-review",
+		level: "F4",
+		gate: "Agent review at parity with human review",
+		status: "closed",
+		note: "Agent review catches real bugs but is not yet trusted alone.",
+	},
+	{
+		gateId: "f4-parallel",
+		level: "F4",
+		gate: "10+ concurrent workstreams without dropped state",
+		status: "partial",
+		note: "Possible on good days. Supervision cost still grows too fast.",
+	},
+	{
+		gateId: "f4-overnight",
+		level: "F4",
+		gate: "Unattended overnight runs, mergeable by morning",
+		status: "partial",
+		note: "Works when environments are clean. Environments are rarely clean.",
+	},
+	{
+		gateId: "f4-latency",
+		level: "F4",
+		gate: "Ticket to production under one day, median",
+		status: "closed",
+		note: "Review and CI queues eat the gains agents create.",
+	},
+];
+
+export const GATE_STATUS_BY_ID: Record<string, GateStatus> = Object.fromEntries(
+	GATE_SCORECARD.map((score) => [score.gateId, score.status]),
+);
+
+export const GATE_GLYPHS: Record<GateStatus, string> = {
+	open: "●",
+	partial: "◐",
+	closed: "○",
+};
+
+export interface GateTally {
+	score: number;
+	total: number;
+}
+
+/** Open counts 1, partial counts 0.5. */
+export function tallyGates(level: string): GateTally {
+	const scores = GATE_SCORECARD.filter((score) => score.level === level);
+	const score = scores.reduce(
+		(sum, entry) =>
+			sum +
+			(entry.status === "open" ? 1 : entry.status === "partial" ? 0.5 : 0),
+		0,
+	);
+	return { score, total: scores.length };
+}
+
+export const formatTally = (tally: GateTally) =>
+	`${tally.score % 1 === 0 ? tally.score : tally.score.toFixed(1)}/${tally.total}`;
+
+export interface AttentionPoint {
+	level: string;
+	share: number;
+}
+
+/** Human share of the effort behind a merged change, schematic. */
+export const ATTENTION_CURVE: AttentionPoint[] = [
+	{ level: "F0", share: 100 },
+	{ level: "F1", share: 90 },
+	{ level: "F2", share: 70 },
+	{ level: "F3", share: 35 },
+	{ level: "F4", share: 10 },
+	{ level: "F5", share: 2 },
+];
+
+export interface AgentSharePoint {
+	t: number;
+	label: string;
+	share: number;
+	forecast: boolean;
+}
+
+/** Share of merged changes written by agents with zero human edits, our estimate. */
+export const AGENT_SHARE_SERIES: AgentSharePoint[] = [
+	{ t: 2024.0, label: "Early 2024", share: 1, forecast: false },
+	{ t: 2024.5, label: "Mid 2024", share: 2, forecast: false },
+	{ t: 2025.0, label: "Early 2025", share: 5, forecast: false },
+	{ t: 2025.5, label: "Mid 2025", share: 9, forecast: false },
+	{ t: 2026.0, label: "Early 2026", share: 16, forecast: false },
+	{ t: 2026.6, label: "Aug 2026", share: 27, forecast: false },
+	{ t: 2027.0, label: "Early 2027", share: 38, forecast: true },
+	{ t: 2027.5, label: "Mid 2027", share: 47, forecast: true },
+	{ t: 2028.0, label: "Early 2028", share: 56, forecast: true },
+];
+
+export const F4_GATE_SHARE = 50;
+export const TODAY_T = 2026.6;
+export const TIMELINE_START = 2024;
+export const TIMELINE_END = 2028;
+
+export const PERIOD_IDS: Record<string, string> = {
+	"Early 2026": "early-2026",
+	"Mid 2026": "mid-2026",
+	"Late 2026": "late-2026",
+	"2027": "first-f4-teams",
+};
+
+/** Where each forecast period sits on the 2024 to 2028 timeline. */
+export const PERIOD_T: Record<string, number> = {
+	"early-2026": 2026.1,
+	"mid-2026": 2026.5,
+	"late-2026": 2026.85,
+	"first-f4-teams": 2027.3,
+};

--- a/apps/marketing/src/app/factory-2026/page.tsx
+++ b/apps/marketing/src/app/factory-2026/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { GridCross } from "@/app/blog/components/GridCross";
+import { AttentionChart } from "./components/AttentionChart";
+import { ForecastChart } from "./components/ForecastChart";
+import { ForecastEntry } from "./components/ForecastEntry";
+import { GateScorecard } from "./components/GateScorecard";
+import { GatesSummary } from "./components/GatesSummary";
+import { HeroStats } from "./components/HeroStats";
+import { LevelCard } from "./components/LevelCard";
+import { ProgressSidebar } from "./components/ProgressSidebar";
+import { FACTORY_LEVELS, FORECAST_PERIODS, GATE_SCORECARD } from "./constants";
+
+const DESCRIPTION =
+	"A falsifiable rubric for the self-driving software factory: six levels of autonomy, the measurable gates between them, and a forecast for how far 2026 gets us.";
+
+export const metadata: Metadata = {
+	title: "Factory 2026",
+	description: DESCRIPTION,
+	alternates: {
+		canonical: "/factory-2026",
+	},
+	openGraph: {
+		title: "Factory 2026 | Superset",
+		description: DESCRIPTION,
+		url: "/factory-2026",
+		images: ["/opengraph-image"],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "Factory 2026 | Superset",
+		description: DESCRIPTION,
+		images: ["/opengraph-image"],
+	},
+};
+
+export default function Factory2026Page() {
+	return (
+		<main className="relative min-h-screen">
+			{/* Vertical guide lines */}
+			<div
+				className="absolute inset-0 pointer-events-none"
+				style={{
+					backgroundImage: `
+						linear-gradient(to right, transparent 0%, transparent calc(50% - 384px), rgba(255,255,255,0.06) calc(50% - 384px), rgba(255,255,255,0.06) calc(50% - 383px), transparent calc(50% - 383px), transparent calc(50% + 383px), rgba(255,255,255,0.06) calc(50% + 383px), rgba(255,255,255,0.06) calc(50% + 384px), transparent calc(50% + 384px))
+					`,
+				}}
+			/>
+
+			{/* Hero */}
+			<header className="relative border-b border-border">
+				<div className="max-w-3xl mx-auto px-6 pt-16 pb-10 md:pt-20 md:pb-12 relative">
+					<GridCross className="top-0 left-0" />
+					<GridCross className="top-0 right-0" />
+
+					<span className="inline-flex items-center gap-2 text-xs font-mono text-muted-foreground border border-border rounded-[2px] px-3 py-1.5 bg-foreground/[0.03]">
+						<span className="text-brand shrink-0">●</span>
+						Forecast · Published August 2026
+					</span>
+					<h1 className="text-3xl md:text-4xl lg:text-5xl font-medium tracking-tight text-foreground mt-6">
+						The self-driving software factory
+					</h1>
+					<p className="text-muted-foreground mt-4 leading-relaxed">
+						Six levels of factory autonomy, the gates between them, and our
+						forecast for how far 2026 gets us. Written down now so you can grade
+						us later.
+					</p>
+					<p className="text-muted-foreground mt-4 leading-relaxed">
+						Predictions about AI are cheap because nobody checks them. This page
+						is a rubric, not a vibe: every gate below is either true or false of
+						a real team shipping real software. We update it as gates open, and
+						we do not move the goalposts.
+					</p>
+
+					<HeroStats />
+
+					<GridCross className="bottom-0 left-0" />
+					<GridCross className="bottom-0 right-0" />
+				</div>
+			</header>
+
+			<ProgressSidebar />
+
+			{/* Levels */}
+			<section
+				id="rubric"
+				className="relative scroll-mt-24 border-b border-border"
+			>
+				<div className="max-w-3xl mx-auto px-6 py-16 relative">
+					<GridCross className="bottom-0 left-0" />
+					<GridCross className="bottom-0 right-0" />
+
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						The rubric
+					</span>
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground mt-4">
+						Six levels of factory autonomy
+					</h2>
+					<p className="text-muted-foreground mt-3 max-w-lg leading-relaxed">
+						Borrowed from how self-driving cars are graded, applied to how
+						software gets built. The interesting jump is F3 to F4: from agents
+						you delegate to, to a factory you direct.
+					</p>
+
+					<div className="mt-10">
+						<AttentionChart />
+					</div>
+
+					<div className="mt-10 flex flex-col gap-4">
+						{FACTORY_LEVELS.map((level) => (
+							<LevelCard key={level.id} level={level} />
+						))}
+					</div>
+				</div>
+			</section>
+
+			{/* Forecast timeline */}
+			<section
+				id="forecast"
+				className="relative scroll-mt-24 border-b border-border"
+			>
+				<div className="max-w-3xl mx-auto px-6 py-16 relative">
+					<GridCross className="bottom-0 left-0" />
+					<GridCross className="bottom-0 right-0" />
+
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						The forecast
+					</span>
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground mt-4">
+						How 2026 plays out
+					</h2>
+					<p className="text-muted-foreground mt-3 max-w-lg leading-relaxed">
+						Part record, part bet. The first two entries are already happening.
+						The rest is stated concretely enough to be wrong about.
+					</p>
+
+					<div className="mt-10">
+						<ForecastChart />
+					</div>
+
+					<div className="mt-12 flex flex-col gap-16">
+						{FORECAST_PERIODS.map((entry) => (
+							<ForecastEntry key={entry.period} entry={entry} />
+						))}
+					</div>
+
+					<div className="mt-16 border border-border p-6 md:p-8">
+						<span className="text-xs font-mono text-muted-foreground uppercase tracking-wider">
+							Beyond: F5 is not a near-term claim
+						</span>
+						<p className="text-muted-foreground mt-3 leading-relaxed">
+							We do not forecast full self-driving in 2026 or 2027. The honest
+							unknowns: whether agent review holds up against adversarial
+							complexity, whether specification can replace code reading as the
+							trust anchor at scale, and whether compute economics keep the
+							overnight shift cheaper than the humans it augments. F5 is a
+							rubric entry so we recognize it when we see it, not a promise.
+						</p>
+					</div>
+				</div>
+			</section>
+
+			{/* Scorecard */}
+			<section
+				id="scorecard"
+				className="relative scroll-mt-24 border-b border-border"
+			>
+				<div className="max-w-3xl mx-auto px-6 py-16 relative">
+					<GridCross className="bottom-0 left-0" />
+					<GridCross className="bottom-0 right-0" />
+
+					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+						The scorecard
+					</span>
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground mt-4">
+						Where the industry is, honestly
+					</h2>
+					<p className="text-muted-foreground mt-3 max-w-lg leading-relaxed">
+						Our read as of August 2026, based on our own team and the teams we
+						watch closely. F3 is mostly open. F4 is mostly closed. That gap is
+						the work.
+					</p>
+
+					<div className="mt-10">
+						<GatesSummary scores={GATE_SCORECARD} />
+					</div>
+
+					<div className="mt-8">
+						<GateScorecard scores={GATE_SCORECARD} />
+					</div>
+				</div>
+			</section>
+
+			{/* CTA */}
+			<section className="relative">
+				<div className="max-w-3xl mx-auto px-6 py-16 md:py-20 relative text-center">
+					<h2 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground">
+						The factory needs a floor
+					</h2>
+					<p className="text-muted-foreground mt-3 max-w-lg mx-auto leading-relaxed">
+						Superset is the workbench for the F3 to F4 transition: parallel
+						agents in isolated workspaces, fleets you can actually supervise,
+						and a review surface for code you did not write.
+					</p>
+					<div className="mt-8 flex items-center justify-center gap-4">
+						<Link
+							href="/download"
+							className="bg-foreground text-background px-6 py-3 text-sm font-normal transition-colors hover:bg-brand hover:text-white"
+						>
+							Download Superset
+						</Link>
+						<Link
+							href="/changelog"
+							className="group inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+						>
+							Read the changelog
+							<span className="transition-transform group-hover:translate-x-0.5">
+								→
+							</span>
+						</Link>
+					</div>
+				</div>
+			</section>
+		</main>
+	);
+}

--- a/apps/marketing/src/app/factory-2026/utils/scrollToElement/index.ts
+++ b/apps/marketing/src/app/factory-2026/utils/scrollToElement/index.ts
@@ -1,0 +1,1 @@
+export { scrollToElement } from "./scrollToElement";

--- a/apps/marketing/src/app/factory-2026/utils/scrollToElement/scrollToElement.ts
+++ b/apps/marketing/src/app/factory-2026/utils/scrollToElement/scrollToElement.ts
@@ -1,0 +1,55 @@
+interface ScrollToElementOptions {
+	/** Center the element in the viewport instead of aligning to the top offset. */
+	center?: boolean;
+}
+
+/**
+ * Animated scroll driven by rAF. Native behavior:"smooth" silently no-ops in
+ * some environments (e.g. Chrome with smooth scrolling disabled), so we
+ * animate ourselves and jump instantly under prefers-reduced-motion.
+ */
+export function scrollToElement(
+	el: HTMLElement,
+	options?: ScrollToElementOptions,
+) {
+	const rect = el.getBoundingClientRect();
+	const offset = options?.center
+		? Math.max(24, (window.innerHeight - rect.height) / 2)
+		: 96; // matches scroll-mt-24 on the anchor targets
+	const max = document.documentElement.scrollHeight - window.innerHeight;
+	const target = Math.min(max, Math.max(0, window.scrollY + rect.top - offset));
+
+	const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+	if (reduced) {
+		window.scrollTo(0, target);
+		return;
+	}
+
+	const start = window.scrollY;
+	const distance = target - start;
+	if (Math.abs(distance) < 1) return;
+
+	const duration = Math.min(700, 250 + Math.abs(distance) * 0.06);
+	const startedAt = performance.now();
+	const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
+
+	let cancelled = false;
+	const cancel = () => {
+		cancelled = true;
+	};
+	window.addEventListener("wheel", cancel, { once: true, passive: true });
+	window.addEventListener("touchstart", cancel, { once: true, passive: true });
+
+	const step = (now: number) => {
+		if (cancelled) return;
+		const t = Math.min(1, (now - startedAt) / duration);
+		window.scrollTo(0, start + distance * easeOutCubic(t));
+		if (t < 1) {
+			requestAnimationFrame(step);
+		} else {
+			window.removeEventListener("wheel", cancel);
+			window.removeEventListener("touchstart", cancel);
+		}
+	};
+	requestAnimationFrame(step);
+}

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -97,6 +97,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 			priority: 0.8,
 		},
 		{
+			url: `${baseUrl}/factory-2026`,
+			lastModified: new Date(),
+			changeFrequency: "monthly",
+			priority: 0.8,
+		},
+		{
 			url: `${baseUrl}/roadmap`,
 			lastModified: new Date(),
 			changeFrequency: "weekly",


### PR DESCRIPTION
## Summary
- New marketing page at `/factory-2026`: a falsifiable rubric for when software engineering reaches the "full self-driving factory", in the spirit of ai-2027.com.
- Six autonomy levels (F0 Manual through F5 Autonomous) with measurable gates, a period-by-period forecast through 2027, and an honest scorecard of which gates are open as of August 2026.
- Interactive layer: a fixed prediction-dashboard sidebar (xl+), two hover-enabled SVG charts, a hero stat strip, and gate jump links connecting the rubric, meters, and scorecard.

## Why / Context
Kiet wants a Factory 2026 page: a public, gradeable rubric for the self-driving software factory rather than a vague vision post. Every claim is stated as a gate that is either true or false of a real team, so we can update the page as gates open without moving goalposts. It also gives the Factory concept a public anchor.

## How It Works
- All copy and data live in `constants.ts`: levels, gates (with ids), forecast periods, the scorecard, and chart series. Gate statuses are stored once and joined by `gateId`, so the level cards, hero strip, sidebar meters, summary bar, and scorecard can never disagree.
- `ProgressSidebar` (client) tracks scroll via a rAF-throttled listener: waypoint nav with reading progress, a 2024 to 2028 timeline whose marker moves to the period being read (hollow dot when it is a forecast), F3/F4 per-gate meters, and a "next gate" pointer.
- `AttentionChart` and `ForecastChart` are hand-rolled responsive SVGs with hover tooltips; the forecast chart draws solid history to a TODAY marker, then a dashed projection crossing the 50% F4 gate line.
- `GateJumpLink` + `utils/scrollToElement` implement gate cross-links: rAF-driven eased scrolling (native `behavior: "smooth"` silently no-ops in some Chrome configs), instant under `prefers-reduced-motion`, cancelled by user scroll, with a brief highlight flash on the target row.
- Page follows the marketing conventions: static `metadata` export, guide-rail gradient + `GridCross` section shells, mono eyebrow typography, hero pill, sticky left-rail timeline labels; added to `sitemap.ts`.

## Manual QA Checklist
Verified in Chrome against `bun run dev`:
- [x] All sections render: hero + stat strip, six level cards, both charts, forecast timeline, scorecard, CTA
- [x] Sidebar readout, reading %, and active waypoint update while scrolling; waypoint clicks jump to the right section (96px header offset)
- [x] Chart tooltips appear on hover with correct values
- [x] Gate links scroll the matching scorecard row to viewport center and flash it
- [x] Copy passes the Vale prose rules (0 errors, 0 warnings via `bunx vale --config=vale.ini`)
- [ ] Final end-to-end visual pass of the sidebar timeline marker moving into forecast periods (my Chrome window stopped rendering near the end; jump targets and marker math verified programmatically instead)

## Testing
- `bun run typecheck`
- `bunx biome check` on the new files
- No automated tests: the page is static content plus DOM-driven scroll behavior; the marketing app has no test infra today

## Known Limitations
- The forecast chart's series is a labeled estimate, not measured data; the page says so in the caption.
- Sidebar is hidden below `xl` (no gutter); the hero stat strip carries the prediction progress on smaller viewports.
- Page is not linked from the header nav yet; it is in the sitemap. Easy follow-up in `Header/constants.ts` if we want it under Resources.

https://claude.ai/code/session_018zZwTL7PSLoibzfcyfQiLi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public Factory 2026 forecast page at /factory-2026 with a falsifiable autonomy rubric (F0–F5), interactive charts, and a prediction sidebar. This gives marketing a single, gradeable source for the “self‑driving factory” concept and keeps all copy/data consistent across the page.

- **Review notes**
  - All copy, gates, levels, scorecard entries, chart series, and IDs live in `apps/marketing/src/app/factory-2026/constants.ts`; UI components read from this source so level cards, hero stats, sidebar meters, and scorecard stay in sync.
  - Client behaviors: `ProgressSidebar` tracks scroll (rAF-throttled) to show reading progress and a 2024–2028 timeline marker; `GateJumpLink` uses `utils/scrollToElement` for eased scrolling, respects `prefers-reduced-motion`, and cancels on user input.
  - Charts: `AttentionChart` and `ForecastChart` are responsive SVGs with hover tooltips; the forecast shows a dashed projection and an F4 gate line with a TODAY marker.
  - Routing/SEO: static `metadata` export is included; `/factory-2026` is added to `apps/marketing/src/app/sitemap.ts`. The page is not linked in the header nav yet.
  - Layout: sidebar shows on `xl+`; smaller viewports use the hero stat strip. No test infra; page is static content with DOM-driven interactions.

<sup>Written for commit d1a44a687976f94633fff2d7fb1bc41f899ab037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Factory 2026 marketing page with autonomy levels, forecast timeline, gate scorecard, and call-to-action links.
  * Added interactive charts showing human effort and agent-written merge share over time.
  * Added progress navigation, gate summaries, status indicators, and smooth section jumping.
  * Added responsive forecast entries, level cards, and detailed gate information.
  * Added the page to the marketing sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->