### PR TITLE
fix(desktop): gate the Superset chat agent choice behind the chat-v3 flag

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
+++ b/apps/desktop/src/renderer/hooks/useV2AgentChoices/useV2AgentChoices.ts
@@ -1,3 +1,5 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo } from "react";
 import type { AgentSelectAgent } from "renderer/components/AgentSelect";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
@@ -14,12 +16,14 @@ const SUPERSET_AGENT: AgentSelectAgent = {
 };
 
 // Superset chat isn't in the host's `host_agent_configs` table — it's
-// routed by id inside `runAgentInWorkspace`. Append after the host's
-// terminal rows so the user's preferred terminal agents stay on top.
+// chat-v3's entry point, so it rides the same flag as the rest of chat-v3.
+// Append after the host's terminal rows so the user's preferred terminal
+// agents stay on top.
 export function useV2AgentChoices(
 	hostUrl: string | null,
 ): UseV2AgentChoicesResult {
 	const query = useV2AgentConfigs(hostUrl);
+	const isChatV3Enabled = useFeatureFlagEnabled(FEATURE_FLAGS.CHAT_V3) ?? false;
 	const agents = useMemo<AgentSelectAgent[]>(() => {
 		const terminalAgents: AgentSelectAgent[] = (query.data ?? []).map(
 			(config) => ({
@@ -31,8 +35,10 @@ export function useV2AgentChoices(
 				presetId: config.presetId,
 			}),
 		);
-		return [...terminalAgents, SUPERSET_AGENT];
-	}, [query.data]);
+		return isChatV3Enabled
+			? [...terminalAgents, SUPERSET_AGENT]
+			: terminalAgents;
+	}, [query.data, isChatV3Enabled]);
 
 	return { agents, isFetched: query.isFetched };
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBody/AutomationBody.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBody/AutomationBody.tsx
@@ -90,12 +90,15 @@ export function AutomationBody({
 	const { localHostId } = useWorkspaceHostOptions();
 	const hostId = automation.targetHostId ?? localHostId ?? null;
 	const hostUrl = useHostUrl(hostId);
-	const { agents: hostAgents } = useV2AgentChoices(hostUrl);
-	// Only warn once the host's terminal configs have loaded — the list always
-	// contains the built-in Superset chat entry, so length 1 means "not loaded
-	// yet / host unreachable", not "agent missing".
+	const { agents: hostAgents, isFetched: hostAgentsFetched } =
+		useV2AgentChoices(hostUrl);
+	// Only warn once the host's terminal configs have loaded — the Superset
+	// chat entry is flag-gated, so list length alone can't tell "not loaded
+	// yet / host unreachable" apart from "agent missing".
 	const agentMissing =
-		hostAgents.length > 1 && !matchAgentChoice(hostAgents, automation.agent);
+		hostAgentsFetched &&
+		hostAgents.length > 0 &&
+		!matchAgentChoice(hostAgents, automation.agent);
 
 	return (
 		<div className="flex-1 overflow-y-auto px-8 py-8">


### PR DESCRIPTION
## What

Shows the built-in **Superset** chat entry in workspace/automation agent pickers only when the `chat-v3` PostHog flag is on, matching how the ChatV3 pane is gated. Everyone else no longer sees an entry that errors on launch.

## Why

Selecting Superset has failed at dispatch with `No host agent config matching 'superset'` since #6461 deleted the chat branch from `agents.run` (a known consequence of that removal). Rather than deleting the entry outright, it now rides the same flag as the rest of chat-v3, since that audience is its eventual consumer.

## How

- `useV2AgentChoices` appends `SUPERSET_AGENT` only when `useFeatureFlagEnabled(FEATURE_FLAGS.CHAT_V3)` — the hook is the single place the entry is injected; every desktop picker consumes it. Mobile and the CLI build their lists from host `agentConfigs.list`, which never seeds superset.
- `AutomationBody`'s "agent missing" warning used `hostAgents.length > 1` as a loading sentinel, which relied on the entry always being present. It now uses the hook's `isFetched` plus a non-empty list.

Note: the flag gates visibility only — selecting the entry still errors at dispatch until it's wired to open a ChatV3 pane (follow-up).

Verified: desktop typecheck, full desktop test suite (2842 pass), repo lint.

https://claude.ai/code/session_01BU6ydkrZ2vYKKR9HQhryyf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the Superset chat agent in desktop pickers behind the `chat-v3` flag to match ChatV3 gating and avoid showing an option that currently errors on launch.

- `useV2AgentChoices` appends `SUPERSET_AGENT` only when `useFeatureFlagEnabled(FEATURE_FLAGS.CHAT_V3)` from `posthog-js/react` and `@superset/shared/constants`.
- Updates AutomationBody: "agent missing" now checks the hook’s `isFetched` plus a non-empty list, instead of relying on a always-present Superset entry.
- Scope: desktop only; mobile and CLI build from host `agentConfigs.list` and never include Superset.
- Known limitation: this gates visibility only; selecting Superset still errors until wired to open the ChatV3 pane.

<sup>Written for commit cb625fcdb5ce271318826806c0a3da49c3524fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Superset agent options now appear only when Chat V3 is enabled.

* **Bug Fixes**
  * Improved automation agent validation after the available agent list finishes loading.
  * Corrected missing-agent warnings to accurately identify when an automation’s configured agent is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->