### PR TITLE
feat(mobile): add mark as unread to the workspace row menu

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/WorkspaceRow.tsx
@@ -63,8 +63,17 @@ export function WorkspaceRow({
 		workspace.hostReachable &&
 		workspace.worktreeExists !== false &&
 		(cloudStatus === undefined || cloudStatus === "ready");
-	const { renameWorkspace, deleteWorkspace, copyId, shareWorkspace } =
-		useWorkspaceRowActions(workspace, cache, cloudStatus);
+	const {
+		renameWorkspace,
+		deleteWorkspace,
+		copyId,
+		shareWorkspace,
+		isUnread,
+		toggleUnread,
+	} = useWorkspaceRowActions(workspace, cache, sessions, cloudStatus);
+	// A manual mark reads as `review` — desktop's rollup ranks it lowest, so
+	// any live status the sessions are reporting keeps the slot.
+	const rowAttention = attention ?? (isUnread ? "review" : null);
 
 	return (
 		<WorkspaceRowMenu
@@ -78,6 +87,8 @@ export function WorkspaceRow({
 					? workspace.type !== "main"
 					: cloudStatus !== "provisioning"
 			}
+			isUnread={isUnread}
+			onToggleUnread={toggleUnread}
 			onRename={() => void renameWorkspace()}
 			onDelete={deleteWorkspace}
 			onCopyId={copyId}
@@ -98,7 +109,7 @@ export function WorkspaceRow({
 				{/* Desktop WorkspaceIcon semantics: working replaces the icon with
 				    the braille spinner; other statuses overlay a corner ping on the
 				    base icon (PR state when one exists, else the workspace mark). */}
-				{attention === "working" || cloudStatus === "provisioning" ? (
+				{rowAttention === "working" || cloudStatus === "provisioning" ? (
 					<View className="size-6 items-center justify-center">
 						<AsciiSpinner />
 					</View>
@@ -131,15 +142,15 @@ export function WorkspaceRow({
 								strokeWidth={1.75}
 							/>
 						)}
-						{attention === "permission" ? (
+						{rowAttention === "permission" ? (
 							<View className="absolute -right-0.5 -top-0.5">
 								<PingDot color="#eab308" size={7} />
 							</View>
-						) : attention === "failed" || cloudStatus === "failed" ? (
+						) : rowAttention === "failed" || cloudStatus === "failed" ? (
 							<View className="absolute -right-0.5 -top-0.5">
 								<PingDot color="#ef4444" size={7} />
 							</View>
-						) : attention === "review" ? (
+						) : rowAttention === "review" ? (
 							<View className="bg-green-500 absolute -right-0.5 -top-0.5 size-2 rounded-full" />
 						) : null}
 					</View>

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/components/WorkspaceRowMenu/WorkspaceRowMenu.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/components/WorkspaceRowMenu/WorkspaceRowMenu.tsx
@@ -4,6 +4,8 @@ import type { ReactNode } from "react";
 export function WorkspaceRowMenu({
 	canRename,
 	canDelete,
+	isUnread,
+	onToggleUnread,
 	onRename,
 	onDelete,
 	onCopyId,
@@ -12,6 +14,8 @@ export function WorkspaceRowMenu({
 }: {
 	canRename: boolean;
 	canDelete: boolean;
+	isUnread: boolean;
+	onToggleUnread: () => void;
 	onRename: () => void;
 	onDelete: () => void;
 	onCopyId: () => void;
@@ -30,6 +34,12 @@ export function WorkspaceRowMenu({
 			<Link.Menu>
 				{/* Each action is its own direct child: Link.Menu drops anything
 				    wrapped in a Fragment. */}
+				<Link.MenuAction
+					icon={isUnread ? "envelope.open" : "envelope.badge"}
+					onPress={onToggleUnread}
+				>
+					{isUnread ? "Mark as Read" : "Mark as Unread"}
+				</Link.MenuAction>
 				{canRename ? (
 					<Link.MenuAction icon="pencil" onPress={onRename}>
 						Rename

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/useWorkspaceRowActions.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/WorkspaceRow/hooks/useWorkspaceRowActions/useWorkspaceRowActions.ts
@@ -10,16 +10,56 @@ import type {
 } from "@/hooks/useHostWorkspaces";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { workspaceShareUrl } from "@/lib/web-links";
+import { useTerminalSeenStore } from "@/screens/(authenticated)/stores/terminalSeenStore";
+import { useUnreadWorkspacesStore } from "@/screens/(authenticated)/stores/unreadWorkspacesStore";
+import type { TerminalRowData } from "../../../../hooks/useHostTerminals";
 
 export function useWorkspaceRowActions(
 	workspace: HostWorkspaceItem,
 	cache: HostWorkspacesCacheOps,
+	/** The workspace's live sessions — marked seen when the row is read. */
+	sessions: TerminalRowData[],
 	/** Set for a cloud workspace, whose name and lifetime the API owns. */
 	cloudStatus?: CloudWorkspaceStatus,
 ) {
 	const cloud = useCloudWorkspaceActions();
 	const remove = useDeleteWorkspace();
 	const isCloud = cloudStatus !== undefined;
+	const manuallyUnread = useUnreadWorkspacesStore(
+		(state) => workspace.id in state.manualUnread,
+	);
+	const setManualUnread = useUnreadWorkspacesStore(
+		(state) => state.setManualUnread,
+	);
+	const clearManualUnread = useUnreadWorkspacesStore(
+		(state) => state.clearManualUnread,
+	);
+	const markTerminalSeen = useTerminalSeenStore(
+		(state) => state.markTerminalSeen,
+	);
+
+	// Desktop's isUnread: the manual mark, or any session still wanting a
+	// look — reading the row has to clear both, or the dot survives it.
+	const isUnread =
+		manuallyUnread ||
+		sessions.some(
+			(session) =>
+				session.attention === "review" || session.attention === "failed",
+		);
+
+	const toggleUnread = () => {
+		if (!isUnread) {
+			setManualUnread(workspace.id);
+			return;
+		}
+		clearManualUnread(workspace.id);
+		for (const session of sessions) {
+			// Host clock only: "seen through this session's last agent event".
+			if (session.lastEventAt !== null) {
+				markTerminalSeen(session.terminalId, session.lastEventAt);
+			}
+		}
+	};
 
 	const renameWorkspace = async () => {
 		const hostUrl = isCloud ? null : cache.resolveHostUrl(workspace.hostId);
@@ -72,5 +112,7 @@ export function useWorkspaceRowActions(
 		deleteWorkspace,
 		copyId,
 		shareWorkspace,
+		isUnread,
+		toggleUnread,
 	};
 }

--- a/apps/mobile/screens/(authenticated)/stores/unreadWorkspacesStore/index.ts
+++ b/apps/mobile/screens/(authenticated)/stores/unreadWorkspacesStore/index.ts
@@ -1,0 +1,1 @@
+export { useUnreadWorkspacesStore } from "./unreadWorkspacesStore";

--- a/apps/mobile/screens/(authenticated)/stores/unreadWorkspacesStore/unreadWorkspacesStore.ts
+++ b/apps/mobile/screens/(authenticated)/stores/unreadWorkspacesStore/unreadWorkspacesStore.ts
@@ -1,0 +1,39 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+/**
+ * Device-local manual unread marks, like desktop's v2-notifications
+ * manualUnread: a marked workspace wears `review` attention on home until it
+ * is opened or marked read again.
+ */
+interface UnreadWorkspacesStore {
+	manualUnread: Record<string, true>;
+	setManualUnread: (workspaceId: string) => void;
+	clearManualUnread: (workspaceId: string) => void;
+}
+
+export const useUnreadWorkspacesStore = create<UnreadWorkspacesStore>()(
+	persist(
+		(set) => ({
+			manualUnread: {},
+			setManualUnread: (workspaceId) => {
+				set((state) => ({
+					manualUnread: { ...state.manualUnread, [workspaceId]: true },
+				}));
+			},
+			clearManualUnread: (workspaceId) => {
+				set((state) => {
+					if (!(workspaceId in state.manualUnread)) return state;
+					const { [workspaceId]: _removed, ...manualUnread } =
+						state.manualUnread;
+					return { manualUnread };
+				});
+			},
+		}),
+		{
+			name: "unread-workspaces-v1",
+			storage: createJSONStorage(() => AsyncStorage),
+		},
+	),
+);

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -36,6 +36,7 @@ import { useCreateTerminalWorkspace } from "@/screens/(authenticated)/hooks/useC
 import { usePendingWorkspaceCreatesStore } from "@/screens/(authenticated)/stores/pendingWorkspaceCreatesStore";
 import { useTerminalSeenStore } from "@/screens/(authenticated)/stores/terminalSeenStore";
 import { useTerminalTabOrderStore } from "@/screens/(authenticated)/stores/terminalTabOrderStore";
+import { useUnreadWorkspacesStore } from "@/screens/(authenticated)/stores/unreadWorkspacesStore";
 import { CloudWorkspaceProvisioningState } from "../components/CloudWorkspaceProvisioningState";
 import { HeaderNotice } from "../components/HeaderNotice";
 import { PullRequestsButton } from "../components/PullRequestsButton";
@@ -274,6 +275,15 @@ export function WorkspaceScreen() {
 		}
 		if (activeTerminalId) setPickedTerminalId(activeTerminalId);
 	}, [params.tab, rows, activeTerminalId]);
+
+	// Opening the workspace reads it, the way clicking a desktop sidebar row
+	// does — the mark is only there to bring you back here.
+	const clearManualUnread = useUnreadWorkspacesStore(
+		(state) => state.clearManualUnread,
+	);
+	useEffect(() => {
+		if (id) clearManualUnread(id);
+	}, [id, clearManualUnread]);
 
 	// Port of desktop's useClearActivePaneAttention: viewing the tab clears
 	// its `review` state by advancing the seen mark to the binding's last


### PR DESCRIPTION
Desktop's sidebar context menu can mark a workspace unread — the way you park a session you want to come back to. Mobile had no equivalent: once you'd looked at a row, the dot was gone and the only record was your memory.

## How it works

- `unreadWorkspacesStore` is the mobile twin of desktop's v2-notifications `manualUnread`: a device-local `Record<workspaceId, true>` persisted to AsyncStorage, alongside `pinnedWorkspacesStore` and `terminalSeenStore`.
- The home row's long-press menu gains **Mark as Unread** / **Mark as Read** (`envelope.badge` / `envelope.open`), sitting above Rename.
- A marked row wears the same green `review` dot a finished agent leaves. Live status wins the icon slot: `attention ?? (isUnread ? "review" : null)` reproduces desktop's rollup exactly, where `review` ranks below `working`/`permission`/`failed`, so marking a busy workspace unread doesn't hide its spinner — the dot surfaces when the agent stops.
- `isUnread` is desktop's definition — the manual mark **or** any session sitting in `review`/`failed` — so the menu offers "Mark as Read" for a row that's unread because an agent finished. Reading it clears the manual mark *and* advances each session's seen mark to its binding's `lastEventAt` (host clock, never the device clock — same rule as the existing seen store), which is what desktop's `clearWorkspaceAttention` does.
- Opening the workspace clears the mark, the way clicking a desktop sidebar row does. It's in `WorkspaceScreen` rather than the row's `onPress`, so deep links and the composer's targets clear it too.

## Verification

Static only — no simulator run:

- `bun run typecheck` in `apps/mobile`: 18 errors, all pre-existing and all in `../../packages/*` (`port-scanner`, `pty-daemon`, `workspace-fs`); none in `apps/mobile`.
- `bun run test` in `apps/mobile`: 47 pass, 0 fail.
- biome clean on the touched files.

The SF Symbol names typecheck against expo-router's `SFSymbol` union, so both icons are real. Say the word if you want the menu driven on a sim before this lands.

## Notes

- Marks are per-device, like pins — desktop's are per-install too.
- Nothing prunes marks for deleted workspaces; `pinnedWorkspacesStore` doesn't either, and the entry is a dead key nothing reads.

https://claude.ai/code/session_01S1TtWQev7GuqrheU7uxzhZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Mark as Unread/Read to the mobile workspace row menu so users can park a workspace to revisit. Previously mobile had no manual unread; now rows can show the green review dot, which clears when you open the workspace or mark it read.

- Device-local `unreadWorkspacesStore` persists manual unread marks per device.
- A manual unread renders as `review`; live `working`/`permission`/`failed` still take precedence.
- Mark as Read clears the manual mark and advances each session’s seen state to its host-clock `lastEventAt`; opening a workspace also clears the mark.
- Marks are not pruned for deleted workspaces (same behavior as pins).

<sup>Written for commit ac6aaaeb100a9fec83809fff2db29f393d488ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unread indicators for workspaces based on pending reviews, failures, or manually marked status.
  * Added menu actions to mark workspaces as read or unread.
  * Opening a workspace now clears its manual unread indicator.
  * Unread workspace status persists locally between sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->