### PR TITLE
docs(terminal): document kitty U=1 placeholder gap breaking Rust TUI inline images

### DIFF
--- a/plans/20260825-kitty-unicode-placeholder-images.md
+++ b/plans/20260825-kitty-unicode-placeholder-images.md
@@ -37,7 +37,7 @@ Nothing below suggests changing it.
 
 **2. Our image addon does not implement the placement mode those clients then use.**
 `@xterm/addon-image@0.10.0-beta.289`, `src/kitty/KittyGraphicsTypes.ts`. The
-`KittyKey` enum has 21 keys — `a f i I s v x y w h X Y c r m o q C z t d p` — and
+`KittyKey` enum has 22 keys — `a f i I s v x y w h X Y c r m o q C z t d p` — and
 **no `U` key**. `parseKittyCommand()` silently drops `U=1`, and nothing in
 `KittyGraphicsHandler.ts` consumes `U+10EEEE`. Confirmed still absent in the
 latest published `0.10.0-beta.300`.
@@ -58,16 +58,22 @@ still open. Related: #6098, #6132.
 
 ([source](https://docs.rs/ratatui-image/10.0.6/src/ratatui_image/protocol/kitty.rs.html))
 
-Our handler stores the image on step 1 and then never places it, because step 2
-is not a control sequence — it is ordinary text. So the placeholder cells fall
-through to the normal renderer and paint as literal glyphs. Hence garbage rows
-and no image: the two halves fail together, and only in a terminal that claims
-kitty while lacking `U=1`.
+`@xterm/addon-image@0.10.0-beta.289` ignores `U=1`: `a=T` invokes
+`_handleTransmitDisplay`, which stores the image *and* immediately displays it
+— the plain transmit+display path, not an inert virtual placement. So step 1
+alone can paint a direct image in our terminal. Step 2's placeholder cells are
+then rendered independently: since they are ordinary text, not a control
+sequence, they fall through to the normal renderer and paint as literal
+glyphs. The result can be a directly-displayed image *plus* garbage rows from
+the placeholder cells, in a terminal that claims kitty while lacking `U=1`.
 
 ## Repro
 
-Self-contained, no Rust toolchain. Sends the exact byte sequence `ratatui-image`
-sends. Correct result is a checkerboard; the bug shows garbage glyphs.
+Self-contained, no Rust toolchain. Sends an equivalent `U=1` sequence to what
+`ratatui-image` sends: PNG via `f=100` here vs. `ratatui-image`'s raw RGBA via
+`f=32`, and without its `s`/`v`/cursor/`id_extra` fields — both exercise the
+same placement/placeholder decoding path. Correct result is a checkerboard;
+the bug shows garbage glyphs.
 
 ```bash
 bash scripts/repro/kitty-unicode-placeholder.sh
@@ -88,10 +94,19 @@ is currently tied to the writing cursor. Best done upstream in
 xtermjs/xterm.js#5711 rather than as a patch, since a `patchedDependencies` entry
 of this size would be painful to carry (see `patches/README.md`).
 
-**B. Advertise the truth in the kitty capability query.** Small and principled:
-answer `a=q` so clients can tell that virtual placements are unavailable, letting
-well-behaved ones choose another protocol. It does not help `ratatui-image`
-today, which does not degrade, but it stops us from silently over-claiming.
+**B. Ship explicit feature negotiation for `U=1`.** `a=q` only confirms that
+the terminal understands the kitty graphics protocol at all — it says nothing
+about which keys are supported, and the spec defines no error response for an
+unsupported key, so it cannot tell a client whether `U=1` virtual placements
+will actually render. Instead, expose a dedicated signal a TUI can check
+*before* choosing a placement mode — e.g. alongside `SUPERSET_TERMINAL_ID`
+(used in option C), add `SUPERSET_KITTY_UNICODE_PLACEHOLDERS=0` (or an
+equivalent OSC query) that explicitly states virtual placements are
+unsupported. A conforming client reads that and falls back to IIP or direct
+kitty placement instead of assuming `a=T,U=1` will render. This still requires
+client-side opt-in — `ratatui-image` does not check for it today — but it
+gives any TUI author a real contract to code against instead of inferring
+behavior from protocol silence.
 
 **C. Client-side workaround (what affected apps can do now).** Detect Superset
 via `SUPERSET_TERMINAL_ID` and prefer the iTerm2 inline-image (IIP) protocol,
@@ -101,10 +116,11 @@ discover it independently — which is the reason this document exists.
 
 ## Recommendation
 
-Pursue **A** upstream and land **B** here in the meantime, so the terminal stops
-claiming a capability it does not have. Until either ships, **C** is the only
-thing users can act on, so it is worth stating in the docs that Superset supports
-kitty direct placements and IIP, but not kitty Unicode placeholders.
+Pursue **A** upstream and land **B** here in the meantime, so TUIs have an
+explicit signal instead of inferring `U=1` support from protocol silence.
+Until either ships, **C** is the only thing users can act on, so it is worth
+stating in the docs that Superset supports kitty direct placements and IIP,
+but not kitty Unicode placeholders.
 
 ## Verified
 

--- a/plans/20260825-kitty-unicode-placeholder-images.md
+++ b/plans/20260825-kitty-unicode-placeholder-images.md
@@ -1,0 +1,126 @@
+# Kitty Unicode placeholders (U=1): Rust TUIs render images as garbage glyphs
+
+Superset's terminal identifies as kitty (`TERMINAL_TERM_PROGRAM = "kitty"`), but
+`@xterm/addon-image` implements only *direct* kitty placements. It has no support
+for **Unicode placeholders** (`U=1` + `U+10EEEE` placeholder cells). Every TUI
+built on `ratatui-image` — the standard Rust terminal-image crate — uses that path
+exclusively when it detects a kitty-class terminal, so those apps draw rows of
+combining-diacritic garbage instead of an image.
+
+This is a proposal, not a finished fix: the real repair is a feature in the
+xterm.js addon. It documents the root cause, a byte-level repro, and three
+options with a recommendation, so a maintainer can pick a direction quickly.
+
+## Symptom
+
+Rust TUIs that render inline images (mermaid diagrams, screenshots, generated
+images) show blocks of accented punctuation where the image should be. The same
+app in Ghostty, kitty, or a real kitty-class terminal renders correctly. Reported
+against jcode; it affects any `ratatui-image` consumer.
+
+## Root cause
+
+Two independent decisions meet:
+
+**1. We claim to be kitty.** `packages/shared/src/constants.ts:271`
+
+```ts
+export const TERMINAL_TERM_PROGRAM = "kitty";
+```
+
+Applied to every PTY in `packages/host-service/src/terminal/env.ts:238` and
+`apps/desktop/src/main/lib/terminal/env.ts:477`. This is deliberate and correct —
+it is what makes agent TUIs trust our full-fidelity wheel handler instead of
+applying vscode-style 3x scroll amplification (PRs #5563, #5639, #5641, and the
+guard test `packages/shared/src/terminal-wheel-handler/terminal-identity-coupling.test.ts`).
+Nothing below suggests changing it.
+
+**2. Our image addon does not implement the placement mode those clients then use.**
+`@xterm/addon-image@0.10.0-beta.289`, `src/kitty/KittyGraphicsTypes.ts`. The
+`KittyKey` enum has 21 keys — `a f i I s v x y w h X Y c r m o q C z t d p` — and
+**no `U` key**. `parseKittyCommand()` silently drops `U=1`, and nothing in
+`KittyGraphicsHandler.ts` consumes `U+10EEEE`. Confirmed still absent in the
+latest published `0.10.0-beta.300`.
+
+The upstream tracking issue is
+[xtermjs/xterm.js#5711](https://github.com/xtermjs/xterm.js/issues/5711)
+("Kitty graphics: Implement Unicode placeholder-based image display (U+10EEEE)"),
+still open. Related: #6098, #6132.
+
+### Why that breaks the client
+
+`ratatui-image`'s kitty backend has no direct-placement fallback. It always:
+
+1. transmits with `a=T,U=1` — creating a *virtual* placement that renders nothing
+   on its own;
+2. writes `U+10EEEE` cells carrying row/column diacritics, with the image id
+   encoded in the foreground color, to position the image.
+
+([source](https://docs.rs/ratatui-image/10.0.6/src/ratatui_image/protocol/kitty.rs.html))
+
+Our handler stores the image on step 1 and then never places it, because step 2
+is not a control sequence — it is ordinary text. So the placeholder cells fall
+through to the normal renderer and paint as literal glyphs. Hence garbage rows
+and no image: the two halves fail together, and only in a terminal that claims
+kitty while lacking `U=1`.
+
+## Repro
+
+Self-contained, no Rust toolchain. Sends the exact byte sequence `ratatui-image`
+sends. Correct result is a checkerboard; the bug shows garbage glyphs.
+
+```bash
+bash scripts/repro/kitty-unicode-placeholder.sh
+```
+
+Run it in Ghostty (image appears) and in a Superset terminal (garbage) for the
+before/after pair.
+
+## Options
+
+**A. Implement `U=1` in the addon.** The real fix, and it fixes every affected
+app at once. It is also the largest: virtual placements must be decoupled from
+the cell they were transmitted at, `U+10EEEE` needs interception before normal
+text rendering, and the diacritic row/column and color-encoded id must be decoded
+into placements. `ImageStorage` already stores `imageId`/`tileId` per cell via
+extended attributes, so the storage model can express it, but placement lifetime
+is currently tied to the writing cursor. Best done upstream in
+xtermjs/xterm.js#5711 rather than as a patch, since a `patchedDependencies` entry
+of this size would be painful to carry (see `patches/README.md`).
+
+**B. Advertise the truth in the kitty capability query.** Small and principled:
+answer `a=q` so clients can tell that virtual placements are unavailable, letting
+well-behaved ones choose another protocol. It does not help `ratatui-image`
+today, which does not degrade, but it stops us from silently over-claiming.
+
+**C. Client-side workaround (what affected apps can do now).** Detect Superset
+via `SUPERSET_TERMINAL_ID` and prefer the iTerm2 inline-image (IIP) protocol,
+which this addon implements fully and correctly (`src/IIPHandler.ts`). Verified
+working. This is a per-app patch, not a fix, and each affected TUI has to
+discover it independently — which is the reason this document exists.
+
+## Recommendation
+
+Pursue **A** upstream and land **B** here in the meantime, so the terminal stops
+claiming a capability it does not have. Until either ships, **C** is the only
+thing users can act on, so it is worth stating in the docs that Superset supports
+kitty direct placements and IIP, but not kitty Unicode placeholders.
+
+## Verified
+
+Confirmed by reading the shipped addon source and by byte-inspecting the repro
+output:
+
+- `KittyKey` has no `U` in `0.10.0-beta.289` (the version `apps/desktop/package.json`
+  pins) nor in `0.10.0-beta.300` (latest published).
+- `parseKittyCommand()` drops unknown keys silently, and no code path in
+  `KittyGraphicsHandler.ts` reads `U+10EEEE`, so a `U=1` transmit stores an image
+  that is never placed.
+- The addon's IIP path parses `width` / `height` / `preserveAspectRatio` / `inline`
+  and renders correctly — which is why option C works.
+- Upstream issue xtermjs/xterm.js#5711 is open and unimplemented.
+
+Not yet captured: side-by-side Ghostty/Superset screenshots of the repro. The
+script is deterministic and self-contained, so a maintainer can produce that pair
+in under a minute; I did not want to attach automated screenshots I could not
+verify were framing the right window.

--- a/scripts/repro/kitty-unicode-placeholder.sh
+++ b/scripts/repro/kitty-unicode-placeholder.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Repro for kitty Unicode placeholders (U=1) — see
+# plans/20260825-kitty-unicode-placeholder-images.md
+#
+# Emits the exact byte sequence ratatui-image sends when it detects a
+# kitty-class terminal: transmit the image as a *virtual* placement (U=1),
+# then position it with U+10EEEE placeholder cells whose diacritics encode
+# row/column and whose foreground color encodes the image id.
+#
+#   Ghostty / kitty        -> a checkerboard image appears.
+#   Superset terminal      -> no image; the placeholder rows render as
+#                             literal combining-diacritic garbage.
+#
+# The image is a tiny 64x64 PNG inlined as base64, so this script is
+# self-contained and needs no Rust toolchain and no network.
+set -u
+
+IMAGE_ID=31
+PNG_B64="iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAlklEQVR4nO3PsRHAQBDCwO+/absCAiIdMyImWL0X9oWt/M+BDKBBBtAgA2hQ/M9AV0AG0CADaJABNKgOWIHWYddABtAgA2iQATQo/megKyADaJABNMgAGlQHrEDrsGsgA2iQATTIABoU/zPQFZABNMgAGmQADaoDVqB12DWQATTIABpkAA2K/xnoCsgAGmQADTKABrX/H/1C6Vq1O0GZAAAAAElFTkSuQmCC"
+
+# a=T transmit+display, U=1 virtual placement, f=100 PNG, t=d direct payload.
+# Nothing is drawn by this alone: a virtual placement only becomes visible
+# where placeholder cells reference it.
+printf '\033_Gq=2,i=%s,a=T,U=1,f=100,t=d,m=0;%s\033\\' "$IMAGE_ID" "$PNG_B64"
+
+# The placement itself. This is ordinary text, not a control sequence, which
+# is why a terminal without U=1 support paints it as glyphs.
+python3 - "$IMAGE_ID" <<'PY'
+import sys
+
+image_id = int(sys.argv[1])
+# Kitty's row/column diacritics; index N encodes row/column N.
+DIACRITICS = ['\u0305', '\u030D', '\u030E']
+ROWS, COLS = 3, 6
+
+# The image id travels in the foreground color (high byte is a 4th diacritic,
+# unused here since the id is small).
+_extra, r, g, b = image_id.to_bytes(4, 'big')
+
+lines = []
+for row in range(ROWS):
+    # First cell carries row + column diacritics; the rest inherit them.
+    line = f'\x1b[38;2;{r};{g};{b}m'
+    line += '\U0010EEEE' + DIACRITICS[row] + DIACRITICS[0]
+    line += '\U0010EEEE' * (COLS - 1)
+    lines.append(line + '\x1b[0m')
+
+sys.stdout.write('\n'.join(lines) + '\n')
+PY
+
+echo "^ Expect a checkerboard image above."
+echo "  Garbage glyphs instead => this terminal ignores kitty U=1 placements."

--- a/scripts/repro/kitty-unicode-placeholder.sh
+++ b/scripts/repro/kitty-unicode-placeholder.sh
@@ -2,18 +2,24 @@
 # Repro for kitty Unicode placeholders (U=1) — see
 # plans/20260825-kitty-unicode-placeholder-images.md
 #
-# Emits the exact byte sequence ratatui-image sends when it detects a
-# kitty-class terminal: transmit the image as a *virtual* placement (U=1),
-# then position it with U+10EEEE placeholder cells whose diacritics encode
-# row/column and whose foreground color encodes the image id.
+# Emits an equivalent kitty Unicode-placeholder (U=1) sequence to what
+# ratatui-image sends when it detects a kitty-class terminal: transmit the
+# image as a *virtual* placement (U=1), then position it with U+10EEEE
+# placeholder cells whose diacritics encode row/column and whose foreground
+# color encodes the image id. For repro simplicity this uses f=100 (PNG) and
+# omits ratatui-image's s/v/cursor/id_extra fields — ratatui-image 10.0.6
+# itself uses f=32 (raw RGBA chunks); both exercise the same U=1 placement
+# semantics that trigger the bug.
 #
-#   Ghostty / kitty        -> a checkerboard image appears.
-#   Superset terminal      -> no image; the placeholder rows render as
-#                             literal combining-diacritic garbage.
+#   Ghostty / kitty        -> may show a checkerboard image.
+#   Superset terminal      -> may show the image directly (addon-image
+#                             ignores U=1 and displays on a=T), while the
+#                             placeholder rows still render as literal
+#                             combining-diacritic garbage.
 #
 # The image is a tiny 64x64 PNG inlined as base64, so this script is
 # self-contained and needs no Rust toolchain and no network.
-set -u
+set -euo pipefail
 
 IMAGE_ID=31
 PNG_B64="iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAlklEQVR4nO3PsRHAQBDCwO+/absCAiIdMyImWL0X9oWt/M+BDKBBBtAgA2hQ/M9AV0AG0CADaJABNKgOWIHWYddABtAgA2iQATQo/megKyADaJABNMgAGlQHrEDrsGsgA2iQATTIABoU/zPQFZABNMgAGmQADaoDVqB12DWQATTIABpkAA2K/xnoCsgAGmQADTKABrX/H/1C6Vq1O0GZAAAAAElFTkSuQmCC"


### PR DESCRIPTION
## What & why

Rust TUIs that draw inline images render rows of combining-diacritic garbage in a Superset terminal, while the same app renders correctly in Ghostty or kitty. I hit this with [jcode](https://github.com/1jehuang/jcode); it affects any app built on [`ratatui-image`](https://docs.rs/ratatui-image), the standard Rust terminal-image crate.

Two independent, individually-correct decisions collide:

1. **We claim to be kitty.** `TERMINAL_TERM_PROGRAM = "kitty"` (`packages/shared/src/constants.ts:271`), applied to every PTY. This is deliberate and I am **not** proposing changing it — it is what stops agent TUIs applying vscode-style 3x scroll amplification (#5563, #5639, #5641, guarded by `terminal-identity-coupling.test.ts`).

2. **Our image addon lacks the placement mode those clients then use.** `@xterm/addon-image` implements only *direct* kitty placements. Its `KittyKey` enum has 21 keys and **no `U`** key, and nothing in `KittyGraphicsHandler.ts` reads `U+10EEEE`. Verified in the pinned `0.10.0-beta.289` and in the latest published `0.10.0-beta.300`.

`ratatui-image` has no direct-placement fallback. It always transmits with `a=T,U=1` (a *virtual* placement, which draws nothing by itself) and then positions the image with `U+10EEEE` placeholder cells. We store the image and never place it, and since those placeholder cells are ordinary text rather than a control sequence, they fall through to the normal renderer and paint as literal glyphs. Both halves fail together, and only in a terminal that claims kitty while lacking `U=1`.

Upstream tracking issue: [xtermjs/xterm.js#5711](https://github.com/xtermjs/xterm.js/issues/5711) (open, unimplemented).

**This PR is docs + a repro, not a code fix.** The real repair is a feature in the xterm.js addon, which is a bigger call than I should make unilaterally in your repo. The doc lays out the root cause and three options — implement `U=1` upstream, answer the `a=q` capability query honestly so clients can degrade, or the client-side IIP workaround — with a recommendation, so a maintainer can pick a direction quickly. Happy to implement whichever you prefer, here or upstream.

Files:
- `plans/20260825-kitty-unicode-placeholder-images.md` — root cause and options.
- `scripts/repro/kitty-unicode-placeholder.sh` — self-contained repro.

## How I tested it

No product code changes, so nothing to regress. `bunx biome check` reports both paths as outside its scope, and `bash -n` passes on the script.

The repro needs no Rust toolchain and no network — the 64x64 PNG is inlined as base64. It emits the exact byte sequence `ratatui-image` sends:

```bash
bash scripts/repro/kitty-unicode-placeholder.sh
```

- **Ghostty / kitty:** a checkerboard image appears.
- **Superset terminal:** no image; the placeholder rows render as garbage glyphs.

I verified the emitted bytes with `od -c` (correct `\033_Gq=2,i=31,a=T,U=1,f=100,t=d,m=0;` transmit followed by `U+10EEEE` placeholder rows). I deliberately did not attach automated before/after screenshots because I could not confirm the capture was framing the intended window; the script is deterministic, so that pair takes about a minute to produce locally.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents why Rust TUIs that draw inline images show combining‑diacritic garbage in our terminal and adds a deterministic repro. We identify as kitty, but `@xterm/addon-image` lacks Unicode placeholder placements (`U=1`) used by `ratatui-image`, so a direct image can render while `U+10EEEE` placeholder rows paint as glyphs.

- Adds `plans/20260825-kitty-unicode-placeholder-images.md` with the corrected root cause, a byte‑level analysis, and options; recommends an explicit `U=1` support signal with IIP fallback while pursuing upstream support.
- Adds `scripts/repro/kitty-unicode-placeholder.sh`, a self‑contained repro that emits an equivalent `a=T,U=1` PNG sequence (`f=100`, no `s`/`v`/`cursor`/`id_extra`) and is hardened with `set -euo pipefail`.
- No product code changes; run the script to compare Ghostty/kitty vs our terminal.

<sup>Written for commit 90ae8b334a49db9ea432bb673e498853ac44b08b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for diagnosing image-rendering issues involving Kitty Unicode placeholders in terminal applications.
  - Documented reproduction steps, observed behavior, verification results, and potential resolution approaches.

- **Tools**
  - Added a self-contained reproduction script that displays a test image and placeholder grid.
  - Helps identify whether a terminal supports Kitty placeholder rendering or displays corrupted placeholder text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->