### PR TITLE
fix(api): write the subscription row when granting a YC deal

### DIFF
--- a/apps/api/src/app/api/integrations/yc-deals/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/yc-deals/webhook/route.ts
@@ -106,9 +106,6 @@ async function grantSubscription(
 		eq(members.organizationId, org.id),
 	);
 
-	// The subscription syncs into our subscriptions table through the existing
-	// better-auth Stripe webhook (customer.subscription.created), which
-	// resolves the org by stripeCustomerId. Nothing to write here.
 	const subscription = await stripeClient.subscriptions.create({
 		customer: customerId,
 		items: [
@@ -123,6 +120,25 @@ async function grantSubscription(
 			organizationId: org.id,
 			ycRedemptionId: String(payload.id),
 		},
+	});
+
+	// The better-auth Stripe plugin's customer.subscription.created handler
+	// cannot resolve an org from a customer id (it only does that when the
+	// plugin is configured with `organization.enabled`, which we don't set), so
+	// a subscription created through the API never reaches our table. Write the
+	// row here. Later updates and cancels do reconcile through the plugin,
+	// which finds this row by stripeSubscriptionId.
+	const item = subscription.items.data[0];
+	await db.insert(subscriptions).values({
+		plan: "pro",
+		referenceId: org.id,
+		stripeCustomerId: customerId,
+		stripeSubscriptionId: subscription.id,
+		status: subscription.status,
+		periodStart: item ? new Date(item.current_period_start * 1000) : null,
+		periodEnd: item ? new Date(item.current_period_end * 1000) : null,
+		seats: item?.quantity ?? Math.max(seatCount, 1),
+		billingInterval: item?.price.recurring?.interval ?? "month",
 	});
 
 	return {


### PR DESCRIPTION
## The bug

#6859 assumed a Stripe subscription created through the API would sync into our `subscriptions` table via the better-auth Stripe webhook. It does not.

The plugin's `customer.subscription.created` handler resolves the reference through `findReferenceByStripeCustomerId`, which only looks up organizations when the plugin is configured with `organization.enabled`. We never set that (`packages/auth/src/server.ts:992`), so it falls through to a `user.stripeCustomerId` lookup, finds nothing, logs a warning, and returns without creating the row.

The normal checkout flow is unaffected: `checkout.session.completed` uses `client_reference_id`, not the customer lookup.

Consequences of the grant path as shipped:

- A granted redemption created a Stripe subscription that never became a plan in the product. The founder was charged nothing and got nothing.
- Eligibility is decided by looking for an active subscription, so with no row a second redemption by the same founder granted a *second* Stripe subscription.

Confirmed against production: redemption 999901 has `status=granted` with a Stripe subscription id, and `subscriptions` has zero rows for that org.

## The fix

Write the row in the grant path, mirroring the shape the plugin would have inserted (`billing_interval` uses the raw Stripe interval, `month`/`year`, which is what the other 1,067 rows use). Updates and cancels still reconcile through the plugin, which finds the row by `stripeSubscriptionId` rather than by customer.

Scoped to this route deliberately, rather than flipping `organization.enabled` on the shared plugin config, which would change webhook resolution for all billing.

## Testing

On a throwaway Neon branch (deleted after):

- grant writes `plan=pro`, `status=active`, `seats=1`, `billing_interval=month`, correct period bounds
- replayed delivery stays idempotent
- second redemption by the same owner is now rejected as already subscribed (this was the double-grant hole)

lint, typecheck, and the test suite pass.

https://claude.ai/code/session_018XTDNZ8ZasyZ7TkQdJPLGk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for redeeming eligible YC Bookface deals through a secure webhook.
  * Eligible organizations can receive discounted Superset subscriptions automatically.
  * When automatic matching isn’t possible, a single-use promotion code is emailed to the redeemer.
  * Added duplicate redemption handling and clear responses for invalid or already-subscribed accounts.
  * Added a branded email template with redemption instructions and download details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->