### PR TITLE
fix(marketing): ignore WebMCP tool registrations the browser rejects async

### DIFF
--- a/apps/marketing/src/app/components/WebMcpTools/WebMcpTools.tsx
+++ b/apps/marketing/src/app/components/WebMcpTools/WebMcpTools.tsx
@@ -112,25 +112,28 @@ function buildTools(): ModelContextTool[] {
 	];
 }
 
+// A registration or unregistration the browser refuses is ignored; there is
+// nothing to recover. Refusal is signalled either by throwing synchronously or
+// by returning a rejected promise, so both have to be swallowed.
+function ignoreRefusal(call: () => unknown) {
+	try {
+		Promise.resolve(call()).catch(() => {});
+	} catch {
+		// Refused synchronously.
+	}
+}
+
 export function WebMcpTools() {
 	useEffect(() => {
 		const context = getModelContext();
 		if (!context) return;
 		const tools = buildTools();
 		for (const tool of tools) {
-			try {
-				context.registerTool(tool);
-			} catch {
-				// Browser rejected the registration; nothing to recover.
-			}
+			ignoreRefusal(() => context.registerTool(tool));
 		}
 		return () => {
 			for (const tool of tools) {
-				try {
-					context.unregisterTool?.(tool.name);
-				} catch {
-					// Already gone.
-				}
+				ignoreRefusal(() => context.unregisterTool?.(tool.name));
 			}
 		};
 	}, []);


### PR DESCRIPTION
## Problem

The marketing homepage registers three read-only WebMCP tools in a mount effect.
On the current marketing deploy, a visitor on a browser that implements the API
gets an uncaught page-level error — `InvalidStateError: Duplicate tool name`
(`DOMException.code: 11`, mechanism `onunhandledrejection`, `handled: no`) — when
the browser refuses a registration. The page keeps working; the defect is that
the refusal is not ignored the way the code says it is.

## Root cause

`document.modelContext.registerTool()` returns a promise. A browser that refuses
signals it by rejecting, not by throwing. The loop wrapped each call in a
synchronous `try/catch` and discarded the returned value, so the `catch` never
ran and the rejection went unhandled — despite the comment beside it stating that
a refused registration is deliberately ignored.

## Fix

One helper used by both loops: run the call, ignore a synchronous throw *and*
attach a rejection handler to a returned promise. Same three tools, same schemas,
same mount and cleanup timing. Non-promise returns (an implementation returning
`undefined`, or the `unregisterTool?.()` optional call on a browser that does not
expose it) pass through unchanged.

No typed `cause` was added — nothing branches on this; it is swallowed at the
call site.

## Why this is only noise removal, and not silencing a real failure

Reviewer question worth recording, because the answer was not obvious: since the
cleanup discards its `unregisterTool` result too, could a remount register while
the previous unmount's unregistration is still in flight — registration refused,
late unregistration then removing the tool, leaving the page with no tools and
now no error to show for it?

No. **`unregisterTool` does not exist.** It was removed from the WebMCP draft in
`webmachinelearning/webmcp` PR #147 (merged 2026-03-26) in favour of passing an
`AbortSignal` to `registerTool`. Verified against Chrome 151.0.7922.174 — the same
major version as the browser in the report — with WebMCP enabled
(`--enable-blink-features=WebMCP,WebMCPTesting`):

```
surfaces: {"doc":true,"nav":true,"testing":true}
modelContext proto methods: ["ontoolchange","executeTool","getTools","registerTool","constructor"]
typeof unregisterTool: undefined
registerTool returns: [object Promise] | thenable=true
duplicate registration: REJECTED InvalidStateError code=11: Duplicate tool name
```

and in the shipped binary: `unregisterTool` occurs **0** times, `registerTool` 4,
`Duplicate tool name` 4. So `context.unregisterTool?.(name)` short-circuits on
every shipping build — the cleanup is inert, nothing is ever in flight, and there
is no race to lose. A refusal also leaves the existing registration intact:

```
state after a refused duplicate: {"refusal":"InvalidStateError: Duplicate tool name","stillRegisteredCount":1}
```

What actually happens on home -> pricing -> home is: mount 1 registers three
tools; the cleanup no-ops; mount 2 re-registers the same three names and is
refused three times. The tools from mount 1 are still registered and still
execute. The rejection reports a benign duplicate, not a broken feature.

## Verification

```
$ bunx biome check apps/marketing/src/app/components/WebMcpTools/WebMcpTools.tsx
Checked 1 file in 14ms. No fixes applied.

$ cd apps/marketing && bun run typecheck
$ tsc --noEmit
typecheck exit=0

$ bun test src/app/components/WebMcpTools
bun test v1.3.14 (0d9b296a)
The following filters did not match any test files in --cwd=".../apps/marketing":
 src/app/components/WebMcpTools
949 files were searched [15.00ms]
```

`apps/marketing` contains no test files (`find apps/marketing/src -name "*.test.*"`
is empty), so behaviour was verified in a real browser instead of in stubs.

**End-to-end remount, real Chrome 151, real component.** The actual
`WebMcpTools.tsx` (pre-change and post-change) bundled into a page served over
localhost, rendered with React, then unmounted and remounted **in a single commit
via a key swap** — the tightest possible cleanup-then-register ordering, tighter
than a real route change — with `document.modelContext.getTools()` read at each
step and `window.unhandledrejection` counted:

```
BEFORE {"afterMount":["superset_install_command","superset_open_page","superset_product_facts"],
        "afterRemount":["superset_install_command","superset_open_page","superset_product_facts"],
        "unhandledRejections":3,"sampleRejection":"InvalidStateError: Duplicate tool name",
        "executesAfterRemount":"{\"surface\":\"cli\",\"command\":\"brew install superset-sh/tap/superset (or: curl -fsSL https://superset.sh/cli/install.sh | s"}

AFTER  {"afterMount":["superset_install_command","superset_open_page","superset_product_facts"],
        "afterRemount":["superset_install_command","superset_open_page","superset_product_facts"],
        "unhandledRejections":0,"sampleRejection":null,
        "executesAfterRemount":"{\"surface\":\"cli\",\"command\":\"brew install superset-sh/tap/superset (or: curl -fsSL https://superset.sh/cli/install.sh | s"}
```

All three tools are registered **and still execute** after the remount in both
builds. The only difference the change makes is 3 unhandled rejections -> 0. The
pre-change run reproduces MARKETING-65 exactly (same error name, same message).

Harness files were temporary and are not part of this diff; the working tree is
the one-file change shown.

## Follow-up worth its own change (deliberately not done here)

The cleanup is dead code against every shipping implementation: `unregisterTool`
is gone from the spec and absent from the browser, so tools registered on the
homepage persist for the life of the document, and each remount produces refusals
that this PR now swallows. The spec's replacement is
`registerTool(tool, { signal })` plus `controller.abort()` on cleanup, and abort
frees the name synchronously — verified same-tick:

```
abort semantics: {"toolsBeforeAbort":["abort_probe"],"reRegister":"SUCCEEDED same-tick after abort()","toolsAfter":["abort_probe"]}
```

That would remove the duplicate refusal at the root and make cleanup actually
work, with no sequencing machinery and no race. It changes the unregistration
mechanism, so it is a separate, deliberate change rather than a rider on a
noise fix.

Refs MARKETING-65

https://claude.ai/code/session_01QUohWQsTNDZcGLo3dqhtHT
