### PR TITLE
fix(desktop): back-pressure PTY writes on the terminal parser's drain signal

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.test.ts
@@ -158,6 +158,25 @@ describe("runWhenParserIdle", () => {
 		expect(ran).toBe(false);
 	});
 
+	test("a throwing write still releases the gate", async () => {
+		const gate = createParserIdleGate();
+		// xterm throws out of write() past its own pending-data ceiling and
+		// never calls back; the gate must not stay armed on that path.
+		const write = wrapWrite(gate, () => {
+			throw new Error("write data discarded, use flow control");
+		});
+
+		expect(() => write("burst")).toThrow("write data discarded");
+
+		let ran = false;
+		runWhenParserIdle(gate, () => {
+			ran = true;
+		});
+		await flushMicrotasks();
+		expect(gate.pending).toBe(0);
+		expect(ran).toBe(true);
+	});
+
 	test("preserves the caller's own write callback", () => {
 		const gate = createParserIdleGate();
 		const fake = fakeWrite();

--- a/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
+++ b/apps/desktop/src/renderer/lib/terminal/parser-idle-gate.ts
@@ -27,16 +27,30 @@ function flushQueued(gate: ParserIdleGate): void {
 export function wrapWrite(gate: ParserIdleGate, write: WriteFn): WriteFn {
 	return (data, callback) => {
 		gate.pending++;
-		write(data, () => {
-			try {
-				callback?.();
-			} finally {
-				gate.pending--;
-				if (gate.pending === 0 && gate.queued) {
-					queueMicrotask(() => flushQueued(gate));
-				}
+		let released = false;
+		const release = () => {
+			if (released) return;
+			released = true;
+			gate.pending--;
+			if (gate.pending === 0 && gate.queued) {
+				queueMicrotask(() => flushQueued(gate));
 			}
-		});
+		};
+		try {
+			write(data, () => {
+				try {
+					callback?.();
+				} finally {
+					release();
+				}
+			});
+		} catch (error) {
+			// xterm throws out of write() when its own pending-data ceiling is
+			// passed, and then never calls back. Release here or pending never
+			// returns to zero and queued work waits forever.
+			release();
+			throw error;
+		}
 	};
 }
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -143,7 +143,12 @@ function createMockTerminal(
 		emitData(data: string) {
 			onDataListener?.(data);
 		},
-		write() {},
+		// xterm invokes the completion callback once the batch has parsed; the
+		// coalescer holds the next batch until it does, so a double that never
+		// calls back would model a permanently stalled parser.
+		write(_data: string | Uint8Array, callback?: () => void) {
+			callback?.();
+		},
 		writeln() {},
 	} as unknown as XTerm & { emitData(data: string): void };
 }
@@ -216,12 +221,15 @@ describe("PTY output write coalescing", () => {
 		const terminal = createMockTerminal();
 		const writes: string[] = [];
 		const events: string[] = [];
-		(terminal as unknown as { write: (d: Uint8Array) => void }).write = (
-			data: Uint8Array,
-		) => {
+		(
+			terminal as unknown as {
+				write: (d: Uint8Array, cb?: () => void) => void;
+			}
+		).write = (data: Uint8Array, callback?: () => void) => {
 			const text = new TextDecoder().decode(data);
 			writes.push(text);
 			events.push(`write:${text}`);
+			callback?.();
 		};
 		(terminal as unknown as { writeln: (s: string) => void }).writeln = (
 			line: string,

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -574,8 +574,8 @@ export function connect(
 	// Recreate per connect so the coalescer always targets the current terminal;
 	// dispose flushes anything the previous socket left pending.
 	transport._writeCoalescer?.dispose();
-	transport._writeCoalescer = createWriteCoalescer((data) =>
-		terminal.write(data),
+	transport._writeCoalescer = createWriteCoalescer((data, done) =>
+		terminal.write(data, done),
 	);
 	setupLiveness(transport);
 	setConnectionState(transport, "connecting");
@@ -661,11 +661,12 @@ function attachSocketListeners(
 		// channel; renderer treats them identically). Pipe straight into xterm.
 		if (data instanceof ArrayBuffer) {
 			// Queue PTY bytes; the coalescer batches them into one xterm.write per
-			// animation frame. There's no output ACK back to host-service:
-			// back-pressure lives entirely on the host side, which bounds this
-			// socket's send buffer and drops us (we reconnect and catch up by
-			// seq) if we fall hopelessly behind. A slow renderer can never wedge
-			// the shell.
+			// animation frame and holds the next batch until xterm reports the
+			// last one parsed. There's no output ACK back to host-service:
+			// socket-level back-pressure lives entirely on the host side, which
+			// bounds this socket's send buffer and drops us (we reconnect and
+			// catch up by seq) if we fall hopelessly behind. A slow renderer can
+			// never wedge the shell.
 			if (transport._seqCounting && transport.seqAnchor) {
 				transport.seqAnchor.seq += data.byteLength;
 			}

--- a/apps/desktop/src/renderer/lib/terminal/write-coalescer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/write-coalescer.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { createWriteCoalescer, MAX_PENDING_BYTES } from "./write-coalescer";
+import {
+	createWriteCoalescer,
+	MAX_BACKLOG_BYTES,
+	MAX_PENDING_BYTES,
+} from "./write-coalescer";
 
 // Capture rAF callbacks so tests control frame timing deterministically.
 let frameCallbacks: Map<number, FrameRequestCallback>;
@@ -200,6 +204,76 @@ describe("createWriteCoalescer", () => {
 		// the previous batch has not parsed yet.
 		coalescer.flushSync();
 		expect(term.text()).toEqual(["first", "second"]);
+	});
+
+	test("bounds its own queue when the parser never reports a parse", async () => {
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
+
+		coalescer.push(bytes("head"));
+		fireFrame();
+		expect(term.writes).toHaveLength(1);
+
+		// The parser has not called back and never will (a throttled background
+		// renderer parses in ~12ms slices per second; a hung async parser
+		// handler never resumes at all). Everything below piles into the
+		// coalescer's own queue, which is where the emulator's bounded pile
+		// moved to when back-pressure was added.
+		coalescer.push(bytes("OLDEST"));
+		for (let i = 0; i < 24; i++) {
+			coalescer.push(new Uint8Array(1024 * 1024));
+		}
+		coalescer.push(bytes("NEWEST"));
+
+		await term.drain();
+		const batch = term.writes[1] as Uint8Array;
+
+		// 25 MB went in; the queue held its ceiling, plus the notice it prepends.
+		expect(batch.length).toBeLessThanOrEqual(MAX_BACKLOG_BYTES + 256);
+
+		// Dropped from the head, so the newest bytes — the ones that decide what
+		// the pane ends up showing — survived.
+		const tail = new TextDecoder().decode(batch.subarray(batch.length - 6));
+		expect(tail).toBe("NEWEST");
+
+		// ...and the pane is told it happened, at the point it happened.
+		const head = new TextDecoder().decode(batch.subarray(0, 96));
+		expect(head).toContain("[terminal] dropped output");
+	});
+
+	test("reports an overflow episode once, not once per flush", async () => {
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
+
+		coalescer.push(bytes("head"));
+		fireFrame();
+
+		const notices = () =>
+			term.writes.filter((w) =>
+				new TextDecoder()
+					.decode(w.subarray(0, 96))
+					.includes("[terminal] dropped output"),
+			).length;
+
+		// Three separate drains, all while the backlog stays over the ceiling.
+		for (let round = 0; round < 3; round++) {
+			for (let i = 0; i < 12; i++) {
+				coalescer.push(new Uint8Array(1024 * 1024));
+			}
+			await term.drain();
+		}
+		expect(notices()).toBe(1);
+
+		// The burst ends and the queue drains; a later one is a new episode.
+		await term.drain();
+		coalescer.push(bytes("quiet"));
+		fireFrame();
+		await term.drain();
+		for (let i = 0; i < 12; i++) {
+			coalescer.push(new Uint8Array(1024 * 1024));
+		}
+		await term.drain();
+		expect(notices()).toBe(2);
 	});
 
 	test("a throwing write does not wedge the coalescer", () => {

--- a/apps/desktop/src/renderer/lib/terminal/write-coalescer.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/write-coalescer.test.ts
@@ -38,86 +38,104 @@ function bytes(text: string): Uint8Array {
 	return new TextEncoder().encode(text);
 }
 
+// Stands in for xterm: records each batch and holds its completion callback
+// until the test says the parser caught up, the way xterm holds it until the
+// chunk has parsed.
+function fakeTerminal() {
+	const writes: Uint8Array[] = [];
+	const callbacks: Array<() => void> = [];
+	return {
+		writes,
+		write(data: Uint8Array, done: () => void) {
+			writes.push(data);
+			callbacks.push(done);
+		},
+		text: () => writes.map((w) => new TextDecoder().decode(w)),
+		/** Report every outstanding batch parsed, then settle the microtasks. */
+		async drain() {
+			for (const done of callbacks.splice(0, callbacks.length)) done();
+			await Promise.resolve();
+		},
+	};
+}
+
 describe("createWriteCoalescer", () => {
 	test("coalesces chunks arriving in the same frame into one write", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		coalescer.push(bytes("foo"));
 		coalescer.push(bytes("bar"));
 		coalescer.push(bytes("baz"));
-		expect(writes).toHaveLength(0);
+		expect(term.writes).toHaveLength(0);
 
 		fireFrame();
-		expect(writes).toHaveLength(1);
-		expect(new TextDecoder().decode(writes[0])).toBe("foobarbaz");
+		expect(term.text()).toEqual(["foobarbaz"]);
 	});
 
-	test("schedules a new frame for data arriving after a flush", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+	test("schedules a new frame for data arriving after a flush", async () => {
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		coalescer.push(bytes("first"));
 		fireFrame();
+		await term.drain();
 		coalescer.push(bytes("second"));
 		fireFrame();
 
-		expect(writes).toHaveLength(2);
-		expect(new TextDecoder().decode(writes[1])).toBe("second");
+		expect(term.text()).toEqual(["first", "second"]);
 	});
 
 	test("flushSync writes pending bytes immediately and cancels the scheduled frame", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		coalescer.push(bytes("pending"));
 		coalescer.flushSync();
-		expect(writes).toHaveLength(1);
-		expect(new TextDecoder().decode(writes[0])).toBe("pending");
+		expect(term.text()).toEqual(["pending"]);
 
 		// The previously scheduled frame must not produce a second write.
 		fireFrame();
-		expect(writes).toHaveLength(1);
+		expect(term.writes).toHaveLength(1);
 	});
 
 	test("flushSync with nothing pending writes nothing", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		coalescer.flushSync();
-		expect(writes).toHaveLength(0);
+		expect(term.writes).toHaveLength(0);
 	});
 
 	test("flushes immediately when pending bytes exceed the cap", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		coalescer.push(new Uint8Array(MAX_PENDING_BYTES + 1));
-		expect(writes).toHaveLength(1);
-		expect(writes[0]).toHaveLength(MAX_PENDING_BYTES + 1);
+		expect(term.writes).toHaveLength(1);
+		expect(term.writes[0]).toHaveLength(MAX_PENDING_BYTES + 1);
 
 		// Nothing left for the frame to write.
 		fireFrame();
-		expect(writes).toHaveLength(1);
+		expect(term.writes).toHaveLength(1);
 	});
 
 	test("dispose flushes pending bytes and ignores later pushes", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		coalescer.push(bytes("tail"));
 		coalescer.dispose();
-		expect(writes).toHaveLength(1);
-		expect(new TextDecoder().decode(writes[0])).toBe("tail");
+		expect(term.text()).toEqual(["tail"]);
 
 		coalescer.push(bytes("ignored"));
 		fireFrame();
-		expect(writes).toHaveLength(1);
+		expect(term.writes).toHaveLength(1);
 	});
 
 	test("preserves byte order across many small chunks", () => {
-		const writes: Uint8Array[] = [];
-		const coalescer = createWriteCoalescer((data) => writes.push(data));
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
 
 		const parts = Array.from({ length: 100 }, (_, i) => `${i},`);
 		for (const part of parts) {
@@ -125,7 +143,81 @@ describe("createWriteCoalescer", () => {
 		}
 		fireFrame();
 
-		expect(writes).toHaveLength(1);
-		expect(new TextDecoder().decode(writes[0])).toBe(parts.join(""));
+		expect(term.text()).toEqual([parts.join("")]);
+	});
+
+	test("holds the next batch until the terminal reports the last one parsed", async () => {
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
+
+		coalescer.push(bytes("first"));
+		fireFrame();
+		expect(term.text()).toEqual(["first"]);
+
+		// Terminal has not called back yet: frames keep passing, nothing more
+		// is handed over, and nothing is dropped.
+		coalescer.push(bytes("second"));
+		fireFrame();
+		fireFrame();
+		expect(term.text()).toEqual(["first"]);
+
+		await term.drain();
+		fireFrame();
+		expect(term.text()).toEqual(["first", "second"]);
+	});
+
+	test("never exceeds the cap in the terminal while it is behind", async () => {
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
+
+		coalescer.push(bytes("first"));
+		fireFrame();
+
+		// A burst far past the cap arrives while the terminal is still parsing.
+		// Pre-back-pressure this flushed on every cap crossing, piling unparsed
+		// data up inside the terminal until it threw the batch away.
+		for (let i = 0; i < 8; i++) {
+			coalescer.push(new Uint8Array(MAX_PENDING_BYTES));
+		}
+		expect(term.writes).toHaveLength(1);
+
+		// Draining hands the whole backlog over at once, without waiting for a
+		// frame — the terminal is behind, so idling would only widen the gap.
+		await term.drain();
+		expect(term.writes).toHaveLength(2);
+		expect(term.writes[1]).toHaveLength(8 * MAX_PENDING_BYTES);
+	});
+
+	test("flushSync still orders other writers behind pending bytes mid-parse", () => {
+		const term = fakeTerminal();
+		const coalescer = createWriteCoalescer(term.write);
+
+		coalescer.push(bytes("first"));
+		fireFrame();
+		coalescer.push(bytes("second"));
+
+		// An exit notice needs the PTY bytes in the terminal first, even though
+		// the previous batch has not parsed yet.
+		coalescer.flushSync();
+		expect(term.text()).toEqual(["first", "second"]);
+	});
+
+	test("a throwing write does not wedge the coalescer", () => {
+		const writes: string[] = [];
+		let fail = true;
+		const coalescer = createWriteCoalescer((data) => {
+			if (fail) throw new Error("write data discarded, use flow control");
+			writes.push(new TextDecoder().decode(data));
+		});
+
+		coalescer.push(bytes("discarded"));
+		expect(() => coalescer.flushSync()).toThrow("write data discarded");
+
+		// The failed write must not leave the coalescer believing a batch is
+		// still in flight, or the pane would never render again.
+		fail = false;
+		coalescer.push(bytes("after"));
+		fireFrame();
+		expect(writes).toEqual(["after"]);
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
@@ -6,13 +6,20 @@
  * cycle per chunk, which overwhelms the renderer during streaming output.
  * Batching to the display refresh rate makes the cost per frame constant
  * regardless of chunk count. See issues #2241 / #2244.
+ *
+ * Frame batching alone still lets a sustained burst outrun the emulator: it
+ * keeps its own queue of unparsed data and throws the batch away once that
+ * queue passes its ceiling. So a batch is only handed over while the emulator
+ * reports itself drained — its write-completion callback is the signal.
  */
 
 /**
  * Pending-byte ceiling. requestAnimationFrame stalls while the window is
  * hidden (Electron throttles backgrounded renderers), so without a cap the
  * buffer could grow unboundedly during a background firehose. Exceeding the
- * cap flushes synchronously, bounding memory at the cost of one early write.
+ * cap writes early instead of waiting for a frame that may be far off. It
+ * doubles as the "we are behind" mark: past it, a drained emulator is handed
+ * the next batch straight away rather than idling until the next frame.
  */
 export const MAX_PENDING_BYTES = 1024 * 1024;
 
@@ -29,12 +36,33 @@ export interface WriteCoalescer {
 }
 
 export function createWriteCoalescer(
-	write: (data: Uint8Array) => void,
+	/** `done` is the emulator's write-completion callback: it has parsed the batch. */
+	write: (data: Uint8Array, done: () => void) => void,
 ): WriteCoalescer {
 	let pending: Uint8Array[] = [];
 	let pendingBytes = 0;
 	let frameId: number | null = null;
+	let inFlight = 0;
 	let disposed = false;
+
+	function scheduleFrame() {
+		if (frameId !== null) return;
+		frameId = requestAnimationFrame(() => {
+			frameId = null;
+			// Emulator still parsing: onDrained schedules the next batch.
+			if (inFlight > 0) return;
+			flushSync();
+		});
+	}
+
+	function onDrained() {
+		inFlight--;
+		if (disposed || inFlight > 0 || pendingBytes === 0) return;
+		// Same rule push uses: a full cap's worth banked means we are behind,
+		// so hand the next batch over now rather than idle until the frame.
+		if (pendingBytes > MAX_PENDING_BYTES) flushSync();
+		else scheduleFrame();
+	}
 
 	function flushSync() {
 		if (frameId !== null) {
@@ -55,23 +83,43 @@ export function createWriteCoalescer(
 		}
 		pending = [];
 		pendingBytes = 0;
-		write(batch);
+		inFlight++;
+		let drained = false;
+		try {
+			write(batch, () => {
+				if (drained) return;
+				drained = true;
+				// Deferred, not immediate: the emulator invokes this from inside
+				// its parse loop and before it drops the batch from its own
+				// pending count, so writing here would both re-enter that loop
+				// and be measured against a count that still includes this batch.
+				queueMicrotask(onDrained);
+			});
+		} catch (error) {
+			// The emulator throws instead of buffering once its own ceiling is
+			// passed, and then never calls back. Release here or nothing is ever
+			// written to this terminal again.
+			if (!drained) {
+				drained = true;
+				inFlight--;
+			}
+			throw error;
+		}
 	}
 
 	function push(chunk: Uint8Array) {
 		if (disposed) return;
 		pending.push(chunk);
 		pendingBytes += chunk.length;
+		// Back-pressure. While the emulator is still parsing the last batch,
+		// hold everything: another write only grows the queue it discards when
+		// it overflows. onDrained picks these bytes up the moment it catches up.
+		if (inFlight > 0) return;
 		if (pendingBytes > MAX_PENDING_BYTES) {
 			flushSync();
 			return;
 		}
-		if (frameId === null) {
-			frameId = requestAnimationFrame(() => {
-				frameId = null;
-				flushSync();
-			});
-		}
+		scheduleFrame();
 	}
 
 	return {

--- a/apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
+++ b/apps/desktop/src/renderer/lib/terminal/write-coalescer.ts
@@ -11,6 +11,10 @@
  * keeps its own queue of unparsed data and throws the batch away once that
  * queue passes its ceiling. So a batch is only handed over while the emulator
  * reports itself drained — its write-completion callback is the signal.
+ *
+ * That moves a burst's backlog out of the emulator and into `pending`, so the
+ * ceiling has to move here with it: MAX_BACKLOG_BYTES bounds the queue, and
+ * the pane is told when it is hit.
  */
 
 /**
@@ -22,6 +26,35 @@
  * the next batch straight away rather than idling until the next frame.
  */
 export const MAX_PENDING_BYTES = 1024 * 1024;
+
+/**
+ * Hard ceiling on the coalescer's own queue.
+ *
+ * Waiting for the emulator's drain signal is what keeps it from discarding
+ * data, but it also means a slow parser's backlog accumulates here instead of
+ * there — and unlike the emulator's queue, `pending` has no ceiling of its
+ * own. A backgrounded renderer is the case that matters: Electron throttles
+ * it, so the parser advances in ~12ms slices per second while PTY bytes keep
+ * arriving at full rate. Left unbounded that ends in a renderer OOM, which
+ * kills every pane in the window rather than corrupting one of them.
+ *
+ * 8 MB because host-service already treats exactly that much un-consumed
+ * output on this stream as hopelessly behind (WS_SEND_BUFFER_CAP_BYTES, which
+ * drops the socket), and because at 8x the flush cap an ordinary heavy burst
+ * never comes near it.
+ */
+export const MAX_BACKLOG_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Written into the stream at the point bytes went missing. Silent loss is what
+ * this whole path exists to remove, so an overflow has to be visible in the
+ * pane it happened to.
+ */
+const DROP_NOTICE = new TextEncoder().encode(
+	`\r\n[terminal] dropped output — renderer fell more than ${
+		MAX_BACKLOG_BYTES / (1024 * 1024)
+	} MB behind\r\n`,
+);
 
 export interface WriteCoalescer {
 	/** Queue PTY bytes for the next frame's write. */
@@ -44,6 +77,34 @@ export function createWriteCoalescer(
 	let frameId: number | null = null;
 	let inFlight = 0;
 	let disposed = false;
+	// One notice per overflow episode, not per flush: a firehose that drops for
+	// a minute would otherwise bury the pane under its own notices. `dropping`
+	// holds the episode open while `droppedSinceFlush` keeps confirming it.
+	let dropping = false;
+	let dropNoticeOwed = false;
+	let droppedSinceFlush = false;
+
+	/**
+	 * Drop from the head, never the tail. A terminal's worth is the screen it
+	 * ends up showing, and the bytes that decide that are the newest ones —
+	 * agent CLIs repaint constantly, so a pane that keeps the tail resyncs on
+	 * the next repaint. Dropping the tail instead would leave it permanently
+	 * behind and permanently wrong.
+	 */
+	function dropOldest() {
+		let cut = 0;
+		let dropped = 0;
+		while (cut < pending.length && pendingBytes - dropped > MAX_BACKLOG_BYTES) {
+			dropped += (pending[cut] as Uint8Array).length;
+			cut++;
+		}
+		pending.splice(0, cut);
+		pendingBytes -= dropped;
+		droppedSinceFlush = true;
+		if (dropping) return;
+		dropping = true;
+		dropNoticeOwed = true;
+	}
 
 	function scheduleFrame() {
 		if (frameId !== null) return;
@@ -70,6 +131,15 @@ export function createWriteCoalescer(
 			frameId = null;
 		}
 		if (pendingBytes === 0) return;
+		if (dropNoticeOwed) {
+			dropNoticeOwed = false;
+			// Prepended at flush rather than queued at the drop, because a
+			// later drop takes from the head and would eat the notice itself.
+			pending.unshift(DROP_NOTICE);
+			pendingBytes += DROP_NOTICE.length;
+		}
+		if (!droppedSinceFlush) dropping = false;
+		droppedSinceFlush = false;
 		let batch: Uint8Array;
 		if (pending.length === 1) {
 			batch = pending[0] as Uint8Array;
@@ -114,7 +184,12 @@ export function createWriteCoalescer(
 		// Back-pressure. While the emulator is still parsing the last batch,
 		// hold everything: another write only grows the queue it discards when
 		// it overflows. onDrained picks these bytes up the moment it catches up.
-		if (inFlight > 0) return;
+		if (inFlight > 0) {
+			// The only path that can grow `pending` without bound: below, a
+			// queue past MAX_PENDING_BYTES is always written out instead.
+			if (pendingBytes > MAX_BACKLOG_BYTES) dropOldest();
+			return;
+		}
 		if (pendingBytes > MAX_PENDING_BYTES) {
 			flushSync();
 			return;


### PR DESCRIPTION
## Problem

During a sustained burst of terminal output, the pane loses output: chunks of
the stream are silently thrown away by the emulator, so the visible terminal
is corrupted — mangled repaints, truncated command output — and a resize of
that pane stops working for the rest of the session. One session produced 25
of these inside about four minutes, all on 1.24.2.

## Root cause

`write-coalescer.ts` batches PTY bytes into one `xterm.write()` per animation
frame and bounds its own queue at 1 MB, but it never waited for the emulator
to finish parsing what it had already been handed. xterm keeps its own queue
of unparsed data and, past a 50 MB ceiling, throws straight out of `write()`
and discards that batch:

```js
write(e,t){ if(!this._store.isDisposed){
  if(this._pendingData>5e7) throw new Error("write data discarded, use flow control to avoid losing data");
```

When output arrived faster than the parser drained, that count climbed until
every subsequent batch was discarded. The throw unwound through the coalescer
into the WebSocket message handler, where nothing catches it.

Second-order damage: `parser-idle-gate.ts` incremented `gate.pending` *before*
calling write and decremented it only inside the completion callback. A
synchronous throw skipped the decrement, so the counter stayed above zero
forever and `runWhenParserIdle` never ran its queued work again for that
terminal — that queue is the resize path the gate exists to protect.

## Fix

Use the write-completion callback the emulator already accepts (and that
`wrapWrite` already threads through) as a drain signal:

- The coalescer hands over a batch only while nothing is in flight. Bytes
  arriving mid-parse accumulate in the coalescer's own queue instead of the
  emulator's, and the completion callback releases the next batch.
- The drain flush is deferred by a microtask rather than run inline. The
  emulator invokes the callback from inside its parse loop and *before* it
  subtracts the batch from `_pendingData`, so writing inline would both
  re-enter that loop and be measured against a count that still includes the
  batch just parsed.
- Past the existing 1 MB cap the drain flushes immediately instead of waiting
  for a frame. The cap now doubles as the "we are behind" mark, so a backlog
  is worked off at the parser's full rate rather than one frame at a time.
- `wrapWrite` releases its counter if `write` throws synchronously.

No ceiling was raised or removed, on either side.

**Does this remove the throw entirely?** Not quite, so the counter guard
stays. Our writes can no longer trip it — each starts from a drained parser,
and the emulator's check runs before it adds the batch, so a drained parser
accepts a single batch of any size — but `flushSync()` is called from outside
the coalescer (exit notice, `synced`, socket close, detach/park) and writes
unconditionally to keep ordering. In an extreme backlog that one write can
leave `_pendingData` above the ceiling for whatever writes next. That is now a
bounded, one-off case instead of the steady state, and it can no longer
corrupt the resize gate.

## Bounding the backlog

Back-pressure moves a burst's backlog out of the emulator and into the
coalescer. The emulator enforced a 50 MB ceiling on that pile; the coalescer
enforced none, and `push()` returned before the 1 MB cap check whenever a
write was in flight. The path where that matters most is the one
`MAX_PENDING_BYTES` was originally written for — a backgrounded renderer,
which Electron throttles to ~12 ms of parsing per second, so the completion
callback is late and every byte arriving meanwhile accumulated without limit.

Renderer OOM is not hypothetical in this app, and trading one pane's lost
output for a crash that takes every pane in the window with it is the wrong
trade at the extreme. So the ceiling moves here with the backlog:

- **`MAX_BACKLOG_BYTES = 8 MB`.** Chosen because host-service already treats
  exactly that much un-consumed output on this same stream as hopelessly
  behind (`WS_SEND_BUFFER_CAP_BYTES`, where it drops the socket) — the same
  judgement about the same bytes, applied one hop later — and because at 8x
  the flush cap an ordinary heavy burst never approaches it. It is reachable:
  the burst in DESKTOP-12M banked tens of MB, so it would have hit this.
- **Drop from the head, never the tail.** The newest bytes are the ones that
  decide what the pane ends up showing, and agent CLIs repaint constantly, so
  a pane that keeps the tail resyncs on the next repaint. Dropping the tail
  would leave it permanently behind and permanently wrong.
- **What the user sees:** a line written into the stream at the point bytes
  went missing — `[terminal] dropped output — renderer fell more than 8 MB
  behind`. Once per overflow episode, not once per flush, or a firehose that
  drops for a minute would bury the pane under its own notices. It is
  prepended at flush rather than queued at the drop, since a later drop takes
  from the head and would otherwise eat the notice itself.

So the loss is bounded, attributed, and visible. No Sentry capture for it.

One honest limitation: the notice is ordinary bytes through the parser, so if
the previous batch happened to end mid-escape-sequence the notice can be
swallowed by it — the same way the resumed stream is. The drop boundary is
already a corruption point; this does not add a new one.

### Effect on the ordinary case, where the emulator keeps up

Unchanged: at most one write per frame, same as today, no extra copying per
push (the bound costs one integer comparison on the in-flight path), and the
drain-flush-past-the-cap fast path is untouched.

The one case that shifts is when a batch is still parsing at a frame boundary:
that frame is skipped and the batch goes out on the next one, up to ~16 ms
later. Those pixels could not have appeared sooner anyway — the emulator had
not finished the previous batch. In the other direction, once more than 1 MB
has banked the coalescer stops waiting for frames entirely and writes on every
drain, which is faster than the old frame-paced behaviour.

A hung async parser handler (inline image decode) now holds output in our
queue rather than the emulator's; neither rendered before, and the queue is
now bounded, so it degrades to a drop notice instead of unbounded growth.

### Ordering guarantee

`flushSync()` still writes everything pending immediately, even mid-parse, so
other writers (exit notices, error lines) stay ordered behind pending PTY
bytes. Covered by a test.

No typed cause added — nothing throws a `TRPCError` on this path; this is a
renderer-side scheduling fix.

## Verification

`bunx biome check` on the changed files (one formatting fix applied with
`--write`, then re-checked clean):

```
Checked 2 files in 13ms. Fixed 1 file.
=== recheck ===
Checked 2 files in 8ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck` — exit 0:

```
$ tsc --noEmit
typecheck exit: 0
```

Both new behaviours were tested by writing the test first and confirming it
failed before the change.

The gate test, run against the unfixed `parser-idle-gate.ts`, reproducing the
stuck counter:

```
176 | 		expect(gate.pending).toBe(0);
                             ^
error: expect(received).toBe(expected)
Expected: 0
Received: 1
(fail) runWhenParserIdle > a throwing write still releases the gate [0.15ms]
 8 pass
 1 fail
```

The backlog-bound tests, run against the head of this branch before the bound
existed (`MAX_BACKLOG_BYTES` added as a bare constant so the failure was
behavioural, not a resolution error) — 25 MB pushed into a parser that never
calls back, and no notice:

```
error: expect(received).toBeLessThanOrEqual(expected)
Expected: <= 8388864
Received: 25165836
(fail) createWriteCoalescer > bounds its own queue when the parser never reports a parse [4.33ms]
error: expect(received).toBe(expected)
Expected: 1
Received: 0
(fail) createWriteCoalescer > reports an overflow episode once, not once per flush [5.45ms]
 11 pass
 2 fail
```

With the fix in place, `bun test src/renderer/lib/terminal/write-coalescer.test.ts`:

```
 13 pass
 0 fail
```

Full desktop suite, `bun run test` (includes
`src/no-main-process-blocking.test.ts`; no git code was touched):

```
 2894 pass
 0 fail
 2 snapshots, 57699 expect() calls
Ran 2894 tests across 311 files. [24.13s]
```

New coverage: the coalescer holds the next batch until the terminal reports
the previous one parsed; a burst far past the cap produces no write while the
terminal is behind, then goes out whole on drain; a stalled parser that never
calls back cannot grow the queue past the bound, keeps the newest bytes, and
gets the drop notice; the notice appears once per episode across repeated
drops and again for a later episode; `flushSync` still orders a later writer
behind pending bytes mid-parse; a throwing write leaves neither the coalescer
nor the gate wedged. The terminal doubles in the transport tests now invoke
the write callback, as real xterm does — previously they modelled a
permanently stalled parser.

Refs DESKTOP-12M

https://claude.ai/code/session_01Bd7bCdb333XcBU4eYoct3q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented terminal output from becoming stuck after write failures.
  * Coordinated incoming output with parsing completion to preserve ordering and reduce overload.
  * Limited oversized backlogs while preserving the newest output and displaying an overflow notice.
  * Improved recovery and continued processing during sustained output bursts.

* **Tests**
  * Added coverage for delayed parsing, backlog limits, write ordering, overflow handling, and recovery after failed writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->