### PR TITLE
fix(host-service): pin git's message locale so environmental failures classify

### DIFF
--- a/packages/host-service/src/runtime/git/git-message-locale.test.ts
+++ b/packages/host-service/src/runtime/git/git-message-locale.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TRPCError } from "@trpc/server";
+import { rethrowEnvironmentalGitError } from "../../trpc/router/git/utils/classify-git-error";
+import { getGitStatusSnapshot } from "../../trpc/router/git/utils/git-status";
+import { createGitEnvResolver } from "./git";
+import { createUserSimpleGit } from "./simple-git";
+import type { GitCredentialProvider } from "./types";
+
+// Git translates its diagnostics, and classify-git-error.ts recognises git's
+// own English wording — so the classifier only works if the subprocess speaks
+// English. These tests drive the real status path against a `git` that has
+// translations installed, which the machines in HOST-SERVICE-3Q do and CI does
+// not: the stub resolves the message locale exactly the way GNU gettext does
+// (LC_ALL over LC_MESSAGES over LANG; LANGUAGE consulted only when the
+// resolved locale is not "C") and answers in that language.
+const GIT_TRANSLATING_STUB = `#!/bin/sh
+locale="\${LC_ALL:-\${LC_MESSAGES:-\${LANG:-C}}}"
+if [ "$locale" = "C" ]; then
+	language="C"
+else
+	language="\${LANGUAGE:-$locale}"
+fi
+case "$language" in
+	fr*) echo "fatal: ce n'est pas un dépôt git (ni aucun des répertoires parents) : .git" >&2 ;;
+	*) echo "fatal: not a git repository (or any of the parent directories): .git" >&2 ;;
+esac
+exit 128
+`;
+
+// A French desktop: every locale variable set, including the one gettext reads
+// ahead of all of them.
+const FRENCH_USER_ENV = {
+	LANG: "fr_FR.UTF-8",
+	LANGUAGE: "fr",
+	LC_ALL: "fr_FR.UTF-8",
+	LC_MESSAGES: "fr_FR.UTF-8",
+};
+
+const tempDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function providerWithEnv(env: Record<string, string>): GitCredentialProvider {
+	return {
+		getCredentials: async () => ({ env: { ...env } }),
+		getToken: async () => null,
+	};
+}
+
+/** A PATH holding nothing but a `git` that translates its diagnostics. */
+function translatingGitPath(): string {
+	const dir = tempDir("superset-git-stub-");
+	const stub = join(dir, "git");
+	writeFileSync(stub, GIT_TRANSLATING_STUB);
+	chmodSync(stub, 0o755);
+	return dir;
+}
+
+/** The error that escapes the status snapshot — what getStatus's catch sees. */
+async function statusSnapshotFailure(
+	worktreePath: string,
+	env: Record<string, string>,
+): Promise<Error> {
+	try {
+		await getGitStatusSnapshot({
+			git: createUserSimpleGit(worktreePath).env(env),
+			worktreePath,
+		});
+	} catch (error) {
+		return error as Error;
+	}
+	throw new Error("expected the status snapshot to fail");
+}
+
+function classify(error: unknown): TRPCError | null {
+	try {
+		rethrowEnvironmentalGitError(error);
+		return null;
+	} catch (thrown) {
+		return thrown as TRPCError;
+	}
+}
+
+describe("git message locale", () => {
+	test("pins the message locale over every locale variable the user set", async () => {
+		const repo = tempDir("superset-git-locale-");
+
+		const env = await createGitEnvResolver(providerWithEnv(FRENCH_USER_ENV))(
+			repo,
+		);
+
+		// "C" exactly, not "POSIX": gettext ignores LANGUAGE only for "C", and
+		// LC_ALL is the only variable a user's own LC_ALL cannot outrank.
+		expect(env.LC_ALL).toBe("C");
+	});
+
+	test("a localized 'not a git repository' failure classifies as a non-500", async () => {
+		const notARepo = tempDir("superset-git-locale-");
+		const provider = providerWithEnv({
+			...FRENCH_USER_ENV,
+			PATH: translatingGitPath(),
+		});
+
+		const env = await createGitEnvResolver(provider)(notARepo);
+		const error = await statusSnapshotFailure(notARepo, env);
+
+		expect(error.message).toContain("not a git repository");
+		const thrown = classify(error);
+		expect(thrown?.code).toBe("BAD_REQUEST");
+		expect((thrown?.cause as { kind?: string } | undefined)?.kind).toBe(
+			"NOT_GIT_REPO",
+		);
+	});
+
+	test("the same failure in the user's own locale falls through unclassified", async () => {
+		// The pre-pin env, kept as the reason this is fixed in the environment
+		// rather than by adding a French pattern: nothing in the classifier
+		// matches git's French wording, so the condition reports as a 500.
+		const notARepo = tempDir("superset-git-locale-");
+		const unpinnedEnv = {
+			...FRENCH_USER_ENV,
+			PATH: translatingGitPath(),
+			GIT_OPTIONAL_LOCKS: "0",
+		};
+
+		const error = await statusSnapshotFailure(notARepo, unpinnedEnv);
+
+		expect(error.message).toContain("dépôt git");
+		expect(classify(error)).toBeNull();
+	});
+
+	test("non-ASCII paths still round-trip through status parsing", async () => {
+		// LC_ALL pins LC_CTYPE too. Git reports paths as bytes and quotes them by
+		// core.quotePath rather than by locale, and the snapshot reads them
+		// through `-z`, which disables quoting outright — so the pin must not
+		// disturb a worktree whose filenames are not ASCII.
+		const repo = tempDir("superset-git-locale-");
+		const setup = createUserSimpleGit(repo);
+		await setup.init();
+		await setup.raw(["config", "user.email", "test@example.com"]);
+		await setup.raw(["config", "user.name", "test"]);
+		await setup.raw(["config", "commit.gpgsign", "false"]);
+		await writeFile(join(repo, "café.txt"), "un\n");
+		await setup.raw(["add", "--", "café.txt"]);
+		await setup.raw(["commit", "-m", "initial"]);
+		await writeFile(join(repo, "café.txt"), "un\ndeux\n");
+		await mkdir(join(repo, "日本語"), { recursive: true });
+		await writeFile(join(repo, "日本語", "файл.txt"), "три\n");
+
+		const env = await createGitEnvResolver(
+			providerWithEnv(process.env as Record<string, string>),
+		)(repo);
+		const { snapshot } = await getGitStatusSnapshot({
+			git: createUserSimpleGit(repo).env(env),
+			worktreePath: repo,
+		});
+
+		expect(env.LC_ALL).toBe("C");
+		const paths = snapshot.unstaged.map((file) => file.path);
+		expect(paths).toContain("café.txt");
+		expect(paths).toContain("日本語/файл.txt");
+	});
+});

--- a/packages/host-service/src/runtime/git/git.test.ts
+++ b/packages/host-service/src/runtime/git/git.test.ts
@@ -83,7 +83,7 @@ describe("createGitEnvResolver", () => {
 		]);
 	});
 
-	test("sets GIT_OPTIONAL_LOCKS and merges provider env", async () => {
+	test("sets the git-invocation env and merges provider env", async () => {
 		const repo = await initRepoWithOrigin("https://github.com/acme/env.git");
 		const provider: GitCredentialProvider = {
 			getCredentials: async (remoteUrl: string | null) => {
@@ -101,6 +101,7 @@ describe("createGitEnvResolver", () => {
 			BASE: "1",
 			GIT_ASKPASS: "/tmp/askpass",
 			GIT_OPTIONAL_LOCKS: "0",
+			LC_ALL: "C",
 		});
 	});
 });

--- a/packages/host-service/src/runtime/git/git.ts
+++ b/packages/host-service/src/runtime/git/git.ts
@@ -57,6 +57,18 @@ export function createGitEnvResolver(provider: GitCredentialProvider) {
 			...initialCredentials.env,
 			...credentials.env,
 			GIT_OPTIONAL_LOCKS: "0",
+			// Git translates its diagnostics, and the classifier that keeps
+			// environmental failures off the 500 path recognises git's own
+			// English wording (trpc/router/git/utils/classify-git-error.ts). Pin
+			// the locale so every machine produces the wording those patterns
+			// were written against, instead of growing a per-language table.
+			// LC_ALL rather than LC_MESSAGES: POSIX resolves LC_ALL first, so a
+			// user's own LC_ALL would outrank an LC_MESSAGES we set here, and
+			// gettext ignores LANGUAGE — which outranks both — only when the
+			// resolved locale is exactly "C". It costs nothing in the output we
+			// parse: git reports paths as bytes and quotes them by
+			// core.quotePath, not by locale.
+			LC_ALL: "C",
 		};
 	};
 }


### PR DESCRIPTION
## Problem

A workspace status poll runs git in a directory that is not a git repository. We already decided that is a user-environment condition, not a bug: `getStatus` catches the failure and rethrows it as a typed non-500 whenever it recognises git's own wording. The recognition is a set of anchored English regular expressions.

Git translates its diagnostics into the user's locale. For anyone not running an English environment the text never matches, the failure falls through unclassified, and the same condition that is silent for an English user reports as a 500. The captured message in HOST-SERVICE-3Q is the French rendering of git's "not a git repository" text — 2,166 events over 7 days from three machines, none of them English-locale.

This is not specific to that one pattern. Every pattern in the classifier is English-only, so the gap applies to all of them, and to every pattern added later.

**Reality check** (asked of every fix on this path):

1. **User-visible harm.** Not in the UI — the Changes tab renders the same empty state either way, and the client's retry policy does not branch on the code. The harm is that a deliberate, already-shipped classification silently works for some users and not others: for a non-English user, *every* environmental git condition lands in the same unclassified bucket as a genuine host-service bug, so we cannot tell the two apart for exactly those users. A real regression affecting a French or Japanese machine is indistinguishable from their worktree having been deleted.
2. **Reach.** The events come from `git.getStatus` on 1.23.0; that path is unchanged on main at 1.24.2. `getStatus` → `runStatusSnapshot` → `resolveGitTaskEnv` → `createGitEnvResolver` is the only env the status subprocesses get, and `rethrowEnvironmentalGitError` has exactly one host-service call site (`git.ts:246`), on that path. The change ships in the next host-service/desktop release and reaches every host on it.
3. **Why code.** A Sentry-side filter is forbidden by repo law (PR #6164) and would also hide genuine bugs from these users. Translated patterns are unbounded, wrong the moment a locale is missing, and every entry is a fresh chance to over-match. Archiving leaves the classifier locale-dependent and re-fires. The code path is core and not being restructured. Fixing what git *says* is one variable and makes every existing pattern correct for everyone.
4. **Smallest change.** One environment variable on the env resolver. No new patterns, no new matcher, no new typed cause, no new capture.
5. **New matcher?** None. The classifier is untouched, so there is no new over-match surface; the existing negative tests still bound it.

## Root cause

`createGitEnvResolver` builds the env every git invocation is handed. It spreads the user's own environment through the credential provider, so the user's `LANG`/`LC_ALL`/`LANGUAGE` reach git and git answers in that language. Nothing pins the locale.

## Fix

Add `LC_ALL: "C"` alongside `GIT_OPTIONAL_LOCKS` in the env `createGitEnvResolver` returns, after the credential spreads so it wins over the user's own value.

**`LC_ALL` rather than `LC_MESSAGES`.** Both were live options; this is why the whole-locale one is right here:

- **`LC_MESSAGES` loses to the user.** POSIX resolves `LC_ALL` ahead of `LC_MESSAGES`, so on a machine that exports `LC_ALL=fr_FR.UTF-8` an `LC_MESSAGES` we set is simply ignored — the fix would silently not work for a subset of the very users it targets. Making it work would mean deleting the user's `LC_ALL` from the child env, which changes the effective value of every *other* category as a side effect: a strictly larger behaviour change than pinning one variable.
- **`LANGUAGE` outranks both**, and glibc's gettext ignores it only when the resolved locale is exactly `"C"` (`guess_category_value` compares `strcmp(locale, "C")`). `LC_ALL=C` therefore neutralises `LANGUAGE` too; `LC_ALL=POSIX` would not, which is why the value is `C`.
- **The cost usually charged against `LC_ALL` is not real for git.** Pinning `LC_CTYPE` sounds like it should change how non-ASCII path names are decoded and quoted in the output we parse. It does not: git reports paths as bytes and quotes them by `core.quotePath`, not by locale, and the snapshot reads status, numstat and untracked expansion through `-z`/`--null`, which disables quoting outright. Verified byte-for-byte on a repo with accented, CJK and Cyrillic filenames — `git status --porcelain --null`, `git diff --numstat -z` and `git ls-files` produce identical output under `LC_ALL=C` and `LC_ALL=fr_FR.UTF-8`. There is a test pinning this.

**No typed cause added.** The change adds no new throw, so no new `cause.kind`. (The existing kinds on this classifier are read by nothing but its own tests; that is pre-existing and out of scope here.)

**Behaviour change worth naming:** git's own prose in error surfaces is now English for non-English users rather than their language. The app UI is English-only, so this is a consistency gain, but it is a real user-visible difference.

### Which git failures on this path still report as 500s

Everything the classifier does not name — now reliably in English, so the boundary is the same on every machine. From the classifier's own negative tests: `index.lock` contention, dubious ownership, bad revisions and pathspecs, `cannot chdir to work tree`, installed filters that ran and failed (`external filter ... failed`), `unable to read` for non-tree objects, spawn syscall failures (`spawn git EAGAIN`), and our own simple-git misconfiguration other than a missing base directory. Those are bugs or conditions we have not yet decided about, and they keep reporting.

Also unchanged: host-service builds a few git clients with no env override at all (project import, repo resolution, git identity). They still inherit the user's locale — nothing classifies their messages, so pinning them would be machinery for a hypothetical. They are named, not touched.

## Verification

Every new test was written first and confirmed failing before the fix. The status-path test reproduces the Sentry message end-to-end — before the change:

```
121 |     expect(error.message).toContain("not a git repository");
error: expect(received).toContain(expected)
Expected to contain: "not a git repository"
Received: "fatal: ce n'est pas un dépôt git (ni aucun des répertoires parents) : .git\n"
(fail) git message locale > a localized 'not a git repository' failure classifies as a non-500
 1 pass
 3 fail
```

The one test that passed before and after is the negative control: it asserts that the *unpinned* env still produces the French wording and that the classifier does **not** match it. That is the standing record of why this is fixed in the environment rather than with a French pattern.

CI runs on machines whose git has no translation catalogs, so the localized case is driven against a `git` stub that resolves the message locale exactly the way GNU gettext does (`LC_ALL` over `LC_MESSAGES` over `LANG`; `LANGUAGE` consulted only when the resolved locale is not `"C"`) and answers in that language. The stub is reached the way a real git is — through the child environment's `PATH` — so the resolver, `createUserSimpleGit`, the real `getGitStatusSnapshot` and the real classifier are all exercised.

After the change:

```
$ bunx biome check packages/host-service/src/runtime/git/git.ts \
    packages/host-service/src/runtime/git/git.test.ts \
    packages/host-service/src/runtime/git/git-message-locale.test.ts
Checked 3 files in 18ms. No fixes applied.
```

```
$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false
(exit 0)
```

```
$ bun test src/runtime/git/git-message-locale.test.ts
 4 pass
 0 fail
 9 expect() calls
Ran 4 tests across 1 file. [1334.00ms]
```

```
$ bun test src/runtime/git/ src/trpc/router/git/ src/workers/
 179 pass
 0 fail
 400 expect() calls
Ran 179 tests across 18 files. [45.80s]
```

Full package suite, since the env resolver feeds every git worker task:

```
$ cd packages/host-service && bun run test
 1227 pass
 8 todo
 0 fail
 2864 expect() calls
Ran 1235 tests across 117 files. [196.83s]
```

No desktop git code was touched, so `apps/desktop/src/no-main-process-blocking.test.ts` is not in scope. `packages/host-service/src/no-main-loop-blocking.test.ts` passes unchanged — the change is inside `runtime/git/`, and no git client was added.

## Adjacent, deliberately not touched

`apps/desktop/src/lib/trpc/routers/workspaces/utils/git-errors.ts` carries a second copy of the same English-only patterns for the desktop process, with its own git clients and its own env. It has the same locale gap and is left alone here.

Refs HOST-SERVICE-3Q

https://claude.ai/code/session_018RT6cwVgxwCJ2MpnZaVpJz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git error handling by ensuring diagnostic messages are consistently interpreted across system locales.
  * Preserved non-ASCII filenames when reading Git status information.
  * Git repository errors are now classified reliably even when the operating system uses a non-English locale.

* **Tests**
  * Added coverage for localized Git diagnostics and Unicode file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->