### PR TITLE
feat(mobile): replace the empty no-host home with a Connect a device guide

### DIFF
--- a/apps/mobile/app/(authenticated)/(home)/index.tsx
+++ b/apps/mobile/app/(authenticated)/(home)/index.tsx
@@ -1,11 +1,35 @@
+import { useOrgHostsQuery } from "@/hooks/useOrgHosts";
 import { useSession } from "@/lib/auth/client";
 import { HomeScreen } from "@/screens/(authenticated)/(home)/home";
+import { useWorkspacesFilterStore } from "@/screens/(authenticated)/(home)/home/stores/workspacesFilterStore";
+import { HomeConnectHostScreen } from "@/screens/(authenticated)/(home)/home-connect-host";
 import { HomePaywallScreen } from "@/screens/(authenticated)/(home)/home-paywall";
+import { useWorkspaceScope } from "@/screens/(authenticated)/(home)/hooks/useWorkspaceScope";
 
 export default function HomeIndex() {
 	const { data: session } = useSession();
+	const hosts = useOrgHostsQuery();
+	const scope = useWorkspaceScope();
+	const hasHydrated = useWorkspacesFilterStore((store) => store.hasHydrated);
+
 	if (session && !session.session.plan) {
 		return <HomePaywallScreen />;
 	}
+
+	// An organization with no device of yours has no workspaces to list and
+	// nowhere for the composer to send: the home screen renders as an empty
+	// list under a dead composer. Setup happens on a desktop, so say so there.
+	// Only once the query has actually answered — an empty list while it is
+	// still pending is not an answer. Cloud is exempt: its workspaces exist
+	// without a machine of yours behind them.
+	if (
+		hasHydrated &&
+		scope === "host" &&
+		hosts.isSuccess &&
+		hosts.data.length === 0
+	) {
+		return <HomeConnectHostScreen />;
+	}
+
 	return <HomeScreen />;
 }

--- a/apps/mobile/screens/(authenticated)/(home)/home-connect-host/HomeConnectHostScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home-connect-host/HomeConnectHostScreen.tsx
@@ -1,0 +1,122 @@
+import { COMPANY } from "@superset/shared/constants";
+import * as Haptics from "expo-haptics";
+import { useRouter } from "expo-router";
+import { MonitorSmartphone } from "lucide-react-native";
+import { useEffect, useState } from "react";
+import { ScrollView, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+import { useOrgHostsQuery } from "@/hooks/useOrgHosts";
+import { openUrl } from "@/lib/open-url";
+import { posthog } from "@/lib/posthog";
+import { useOrganizations } from "@/screens/(authenticated)/hooks/useOrganizations";
+import { OrganizationHeaderButton } from "../home/components/OrganizationHeaderButton";
+import { SetupStep } from "./components/SetupStep";
+
+const SETUP_DOCS_URL = `${COMPANY.DOCS_URL}/remote-workspaces`;
+
+/**
+ * Home for an organization with no device of yours in it. Every list on this
+ * tab is served by a machine running Superset, and a machine only reaches the
+ * relay once someone opts it in on a desktop — so with none connected the
+ * normal home is an empty list above a composer that can't send anywhere,
+ * which reads as a broken app rather than an unfinished setup.
+ *
+ * The steps are the setup itself, not a teaser for the docs: the work happens
+ * on a computer this screen can't reach, so the phone's job is to say exactly
+ * what to do there. The org name is in step 2 because signing the desktop into
+ * a different organization is the failure that looks identical to this one.
+ * The hosts query polls, so the screen gives way on its own once a device
+ * lands.
+ */
+export function HomeConnectHostScreen() {
+	const router = useRouter();
+	const { isLoadingOrganizations, activeOrganization } = useOrganizations();
+	const hosts = useOrgHostsQuery();
+
+	// Only a tap of Check again shows as checking: the hosts query polls on its
+	// own, and borrowing its isFetching would blink the button every 30s.
+	const [checking, setChecking] = useState(false);
+
+	useEffect(() => {
+		posthog.capture("host_setup_prompt_shown");
+	}, []);
+
+	return (
+		<>
+			<OrganizationHeaderButton
+				isLoading={isLoadingOrganizations}
+				name={activeOrganization?.name}
+				logo={activeOrganization?.logo}
+				onPress={() => {
+					void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+					router.push("/(authenticated)/(home)/organizations");
+				}}
+			/>
+			<ScrollView
+				className="bg-background flex-1"
+				contentContainerClassName="justify-center gap-6 px-6 py-8"
+				contentContainerStyle={{ flexGrow: 1 }}
+				contentInsetAdjustmentBehavior="automatic"
+			>
+				<View className="items-center gap-3">
+					<View className="bg-muted size-14 items-center justify-center rounded-full">
+						<Icon
+							as={MonitorSmartphone}
+							className="text-foreground size-7"
+							strokeWidth={1.5}
+						/>
+					</View>
+					<View className="items-center gap-2">
+						<Text className="text-2xl font-semibold text-foreground">
+							Connect a device
+						</Text>
+						<Text className="text-muted-foreground text-center text-base">
+							Superset Mobile runs agents on the computers you connect.
+						</Text>
+					</View>
+				</View>
+
+				<View className="gap-4">
+					<SetupStep step={1} title="Install the desktop app">
+						Download Superset at{" "}
+						<Text className="text-foreground text-sm font-medium">
+							{COMPANY.DOMAIN}/download
+						</Text>
+						.
+					</SetupStep>
+					<SetupStep
+						step={2}
+						title={`Sign in to ${activeOrganization?.name ?? "this organization"}`}
+					/>
+					<SetupStep step={3} title="Allow access through the relay">
+						Settings → Security → “Allow remote workspaces to access this device
+						via relay”.
+					</SetupStep>
+				</View>
+
+				<View className="gap-2">
+					<Button
+						size="lg"
+						disabled={checking}
+						onPress={() => {
+							void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+							setChecking(true);
+							void hosts.refetch().finally(() => setChecking(false));
+						}}
+					>
+						<Text>{checking ? "Checking…" : "Check again"}</Text>
+					</Button>
+					<Button
+						size="lg"
+						variant="outline"
+						onPress={() => openUrl(SETUP_DOCS_URL)}
+					>
+						<Text>Read the setup guide</Text>
+					</Button>
+				</View>
+			</ScrollView>
+		</>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/home-connect-host/components/SetupStep/SetupStep.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home-connect-host/components/SetupStep/SetupStep.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { View } from "react-native";
+import { Text } from "@/components/ui/text";
+
+export function SetupStep({
+	step,
+	title,
+	children,
+}: {
+	step: number;
+	title: string;
+	children?: ReactNode;
+}) {
+	return (
+		<View className="flex-row gap-3">
+			<View className="bg-muted size-6 items-center justify-center rounded-full">
+				<Text className="text-muted-foreground text-xs font-semibold">
+					{step}
+				</Text>
+			</View>
+			<View className="flex-1 gap-0.5">
+				<Text className="text-base font-medium text-foreground">{title}</Text>
+				{children ? (
+					<Text className="text-muted-foreground text-sm leading-5">
+						{children}
+					</Text>
+				) : null}
+			</View>
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/home-connect-host/components/SetupStep/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home-connect-host/components/SetupStep/index.ts
@@ -1,0 +1,1 @@
+export { SetupStep } from "./SetupStep";

--- a/apps/mobile/screens/(authenticated)/(home)/home-connect-host/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home-connect-host/index.ts
@@ -1,0 +1,1 @@
+export { HomeConnectHostScreen } from "./HomeConnectHostScreen";

--- a/apps/mobile/screens/(authenticated)/settings/hosts/HostsSettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/settings/hosts/HostsSettingsScreen.tsx
@@ -1,8 +1,12 @@
+import { COMPANY } from "@superset/shared/constants";
 import { useMemo } from "react";
-import { ScrollView, Text } from "react-native";
+import { ScrollView, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
 import { useHostsPresence } from "@/hooks/useHostsPresence";
 import { useOrgHosts } from "@/hooks/useOrgHosts";
 import { useTheme } from "@/hooks/useTheme";
+import { openUrl } from "@/lib/open-url";
 import { HostStatusDot } from "@/screens/(authenticated)/components/HostStatusDot";
 import { ListRow } from "@/screens/(authenticated)/components/ListRow";
 
@@ -27,6 +31,29 @@ export function HostsSettingsScreen() {
 			className="bg-background flex-1"
 			contentContainerClassName="px-6 pb-12"
 		>
+			{hostRows.length === 0 ? (
+				// Same dead end as the home screen's: a device only reaches the
+				// relay once someone opts it in on a desktop, so an empty list here
+				// is a setup step nobody has been told about.
+				<View className="items-center gap-4 py-16">
+					<Text className="text-base font-medium text-foreground">
+						No devices yet
+					</Text>
+					<Text
+						className="text-center text-sm leading-5"
+						style={{ color: theme.mutedForeground }}
+					>
+						In the Superset desktop app, open Settings → Security and turn on
+						“Allow remote workspaces to access this device via relay”.
+					</Text>
+					<Button
+						variant="secondary"
+						onPress={() => openUrl(`${COMPANY.DOCS_URL}/remote-workspaces`)}
+					>
+						<Text>Read the setup guide</Text>
+					</Button>
+				</View>
+			) : null}
 			{hostRows.map((host, index) => (
 				<ListRow
 					key={host.machineId}

--- a/apps/mobile/screens/(authenticated)/settings/hosts/HostsSettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/settings/hosts/HostsSettingsScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useHostsPresence } from "@/hooks/useHostsPresence";
-import { useOrgHosts } from "@/hooks/useOrgHosts";
+import { NO_HOSTS, useOrgHostsQuery } from "@/hooks/useOrgHosts";
 import { useTheme } from "@/hooks/useTheme";
 import { openUrl } from "@/lib/open-url";
 import { HostStatusDot } from "@/screens/(authenticated)/components/HostStatusDot";
@@ -12,7 +12,8 @@ import { ListRow } from "@/screens/(authenticated)/components/ListRow";
 
 export function HostsSettingsScreen() {
 	const theme = useTheme();
-	const hosts = useOrgHosts();
+	const hostsQuery = useOrgHostsQuery();
+	const hosts = hostsQuery.data ?? NO_HOSTS;
 	const presence = useHostsPresence(hosts);
 
 	const hostRows = useMemo(
@@ -31,10 +32,11 @@ export function HostsSettingsScreen() {
 			className="bg-background flex-1"
 			contentContainerClassName="px-6 pb-12"
 		>
-			{hostRows.length === 0 ? (
+			{hostsQuery.isSuccess && hostRows.length === 0 ? (
 				// Same dead end as the home screen's: a device only reaches the
 				// relay once someone opts it in on a desktop, so an empty list here
-				// is a setup step nobody has been told about.
+				// is a setup step nobody has been told about. Only once the query
+				// has answered — an empty list while it is pending is not an answer.
 				<View className="items-center gap-4 py-16">
 					<Text className="text-base font-medium text-foreground">
 						No devices yet


### PR DESCRIPTION
## Summary

A host only becomes visible to mobile once someone turns on **Settings → Security → "Allow remote workspaces to access this device via relay"** on a desktop. That toggle defaults to off, and it is what sets `RELAY_URL` for the host service — the only thing that calls `host.ensure` and registers the machine. No toggle, no host row, so `v2Host.list` comes back empty.

With an empty list the home screen renders nothing useful: no scope chip (it is hidden when there is no host name), an empty list claiming **"No projects on this host yet"** — there is no host — and a composer with zero targets that cannot send anywhere. Every user who installs mobile before connecting a desktop lands there.

This replaces that state with `HomeConnectHostScreen`, gated at the home route the same way the paywall is:

- Org switcher header kept — signing the desktop into a *different organization* is the failure that looks identical to this one, and step 2 names the active org.
- Three setup steps: install from `superset.sh/download`, sign in to the org, then the relay toggle quoted verbatim from the desktop copy.
- **Check again** (refetches hosts) and **Read the setup guide** → `docs/remote-workspaces`. The hosts query already polls every 30s, so the screen gives way on its own once the device lands.
- `host_setup_prompt_shown` PostHog event, to size how many installs hit this.

The gate only fires once the hosts query has *answered* — pending or errored falls through to the normal screen, so a network blip never tells someone to go install a desktop app. Cloud scope is exempt: its workspaces exist without a machine of yours behind them.

**Settings → Hosts** rendered a blank page in the same situation; it now carries a short version of the same guidance.

## Test Plan

- [x] Verified on the iOS simulator with the hosts query stubbed empty — screen renders, fits without scrolling, "Read the setup guide" lands on the docs' *Option 1: Desktop* section, `host_setup_prompt_shown` fires
- [x] Settings → Hosts empty state verified on the simulator
- [x] `bun run lint` clean (6375 files)
- [x] `bun run test` in apps/mobile — 47 pass, 0 fail
- [x] `bun run typecheck` in apps/mobile — no errors in mobile (only the known local-only `.ts`-import/`unref` noise from port-scanner, pty-daemon, workspace-fs)
- [ ] With a real host connected, home still renders the normal workspace list

https://claude.ai/code/session_01JxoyBif1eipREWXtjX5CKY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided setup screen for organizations without connected hosts, including desktop setup instructions, relay permissions, documentation, and a “Check again” action.
  * The home screen now directs users to host setup when no hosts are configured.
  * Added an empty state in Host Settings with setup guidance and a documentation link.
* **UI Improvements**
  * Added reusable numbered setup steps for clearer onboarding instructions.
* **Bug Fixes**
  * Host setup guidance no longer appears while host information is still loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->