### PR TITLE
fix(desktop): contain wide markdown tables

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -309,6 +309,7 @@ export function MarkdownEditor({
 			TableKit.configure({
 				table: {
 					resizable: false,
+					renderWrapper: true,
 					cellMinWidth: 192,
 					HTMLAttributes: {
 						class: "markdown-table my-4 min-w-full border-collapse",

--- a/apps/desktop/src/renderer/components/MarkdownEditor/markdown-editor.css
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/markdown-editor.css
@@ -94,6 +94,12 @@ ul[data-type="taskList"]
 	border-radius: 0.375rem;
 }
 
+.ProseMirror .tableWrapper {
+	max-width: 100%;
+	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+}
+
 .markdown-table th,
 .markdown-table td {
 	border: 1px solid hsl(var(--border));

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.test.ts
@@ -85,3 +85,19 @@ describe("image attribute parsing", () => {
 		);
 	});
 });
+
+describe("table rendering", () => {
+	it("wraps tables in a dedicated horizontal scroll container", () => {
+		const editor = createEditor("| Name | Value |\n| --- | --- |\n| A | B |");
+		try {
+			const element = document.createElement("div");
+			element.innerHTML = editor.getHTML();
+			const wrapper = element.querySelector(".tableWrapper");
+
+			expect(wrapper).not.toBeNull();
+			expect(wrapper?.firstElementChild?.tagName).toBe("TABLE");
+		} finally {
+			editor.destroy();
+		}
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -265,6 +265,7 @@ export function createMarkdownExtensions({
 			},
 		}).configure({
 			resizable: false,
+			renderWrapper: true,
 			cellMinWidth: 192,
 			HTMLAttributes: {
 				class: "markdown-table my-4 min-w-full border-collapse",

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
@@ -90,6 +90,12 @@
 	margin: 1rem 0;
 }
 
+.default-markdown .tableWrapper {
+	max-width: 100%;
+	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+}
+
 .default-markdown th {
 	text-align: left;
 	padding: 0.5rem 1rem;

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/tufte/tufte.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/tufte/tufte.css
@@ -146,6 +146,12 @@
 }
 
 /* Tables */
+.tufte-markdown .tableWrapper {
+	max-width: 100%;
+	overflow-x: auto;
+	overscroll-behavior-inline: contain;
+}
+
 .tufte-markdown table {
 	border-collapse: collapse;
 	width: 100%;


### PR DESCRIPTION
## What & why

Wide Markdown tables could expand beyond their automation instructions card or Markdown preview. Enable TipTap's supported table wrapper in both shared Markdown rendering paths and make that wrapper the horizontal scroll boundary while preserving natural column widths.

This covers automation instructions, task descriptions, workspace prompts, and Default/Tufte Markdown file previews.

## How I tested it

- `bun run lint`
- `bun run --cwd apps/desktop typecheck`
- `bun test src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.test.ts` (from `apps/desktop`)
- CDP against the real Daily Comms Triage automation at a 1728px viewport: 734px wrapper containing a 1266px table; horizontal input moved `scrollLeft` 0 → 420 → 0 without widening the 768px instruction card

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is checked on fork PRs (not applicable; same-repo branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown table display on narrow screens.
  * Tables now stay within the available width and can scroll horizontally when needed.
  * Prevented table scrolling from affecting surrounding page content.
  * Applied the improved behavior across supported editor and renderer styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->