### PR TITLE
Add email privacy toggle to usage view

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx
@@ -14,6 +14,8 @@ import {
 	LuCircleCheck,
 	LuCopy,
 	LuEllipsis,
+	LuEye,
+	LuEyeOff,
 	LuPlus,
 	LuRefreshCw,
 } from "react-icons/lu";
@@ -98,6 +100,7 @@ function AccountCard({
 	onRemove,
 	isSwitching,
 	selectable,
+	hideEmails,
 }: {
 	account: UsageAccount;
 	onMakeDefault: () => void;
@@ -109,6 +112,8 @@ function AccountCard({
 	 * radio group: the default gets a check + accent border, the rest get a
 	 * selectable circle. */
 	selectable: boolean;
+	/** Replaces account emails so screenshots do not retain identifying pixels. */
+	hideEmails: boolean;
 }) {
 	const credits = creditsLine(account);
 	const { copyToClipboard, copied } = useCopyToClipboard();
@@ -140,8 +145,15 @@ function AccountCard({
 							<LuCircle className="size-3.5" />
 						</button>
 					))}
-				<span className="truncate text-xs font-medium">
-					{account.email ?? PROVIDER_LABELS[account.provider]}
+				<span
+					className={cn(
+						"truncate text-xs font-medium transition-[filter]",
+						hideEmails && account.email && "select-none blur-[5px]",
+					)}
+				>
+					{hideEmails && account.email
+						? "Email hidden"
+						: (account.email ?? PROVIDER_LABELS[account.provider])}
 				</span>
 				{account.plan && (
 					<span className="rounded bg-muted px-1 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -260,6 +272,7 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 	const removeAccount = useRemoveUsageAccount(hostUrl);
 	const isDark = useIsDarkTheme();
 	const [isRefreshing, setIsRefreshing] = useState(false);
+	const [hideEmails, setHideEmails] = useState(false);
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
 	const [dialogProvider, setDialogProvider] = useState<Provider>("claude");
 	const [switchTarget, setSwitchTarget] = useState<SwitchSignInTarget | null>(
@@ -312,6 +325,20 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 				<span className="ml-auto text-[10px] text-muted-foreground">
 					Official quota · refreshes every 5 min
 				</span>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-6 gap-1 px-1.5 text-[10px] text-muted-foreground"
+					aria-pressed={hideEmails}
+					onClick={() => setHideEmails((hidden) => !hidden)}
+				>
+					{hideEmails ? (
+						<LuEye className="size-3" />
+					) : (
+						<LuEyeOff className="size-3" />
+					)}
+					{hideEmails ? "Show emails" : "Hide emails"}
+				</Button>
 				<Button
 					variant="ghost"
 					size="icon"
@@ -378,6 +405,7 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 											}
 											isSwitching={setDefault.isPending}
 											selectable={providerAccounts.length > 1}
+											hideEmails={hideEmails}
 										/>
 									))}
 								</div>


### PR DESCRIPTION
## Summary
- add a Hide emails control to the Usage view
- replace account emails with a neutral placeholder before applying blur
- keep the privacy state ephemeral for quick screenshot sharing

## Testing
- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/_dashboard/usage/components/UsageView/UsageView.tsx`
- `bun run --filter=@superset/desktop typecheck`
- CDP verification in the authenticated desktop Usage view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle to show or hide email addresses on account cards.
  * Hidden emails are displayed as “Email hidden” with a blur effect.
  * Eye icons indicate whether email visibility is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->