### PR TITLE
Polish the PR Code tab diff viewer

### DIFF
--- a/apps/desktop/src/main/lib/window-state/bounds-validation.test.ts
+++ b/apps/desktop/src/main/lib/window-state/bounds-validation.test.ts
@@ -8,17 +8,23 @@ import {
 	mock,
 } from "bun:test";
 
+const getPrimaryDisplayMock = mock(() => ({
+	workAreaSize: { width: 1920, height: 1080 },
+	bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+}));
+
 const mockScreen = {
-	getPrimaryDisplay: mock(() => ({
-		workAreaSize: { width: 1920, height: 1080 },
-		bounds: { x: 0, y: 0, width: 1920, height: 1080 },
-	})),
+	getPrimaryDisplay: getPrimaryDisplayMock,
 	getAllDisplays: mock(() => [
 		{
 			bounds: { x: 0, y: 0, width: 1920, height: 1080 },
 			workAreaSize: { width: 1920, height: 1080 },
 		},
 	]),
+	// Defaults to the primary display, matching real Electron in a
+	// single-display setup — multi-display tests override this to point at
+	// whichever display the saved position actually lands on.
+	getDisplayMatching: mock(() => getPrimaryDisplayMock()),
 };
 
 const { getInitialWindowBounds, isVisibleOnAnyDisplay, setScreenForTesting } =
@@ -218,6 +224,14 @@ describe("getInitialWindowBounds", () => {
 		(screen.getAllDisplays as ReturnType<typeof MockType>).mockReturnValue([
 			{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } },
 		]);
+		// Reset to the (possibly just-reassigned) primary display so a test
+		// further down that overrides getDisplayMatching for a secondary
+		// monitor doesn't leak into the next one.
+		(
+			screen.getDisplayMatching as ReturnType<typeof MockType>
+		).mockImplementation(() =>
+			(screen.getPrimaryDisplay as ReturnType<typeof MockType>)(),
+		);
 	});
 
 	describe("no saved state", () => {
@@ -407,6 +421,33 @@ describe("getInitialWindowBounds", () => {
 			expect(result.x).toBe(2000);
 			expect(result.y).toBe(100);
 			expect(result.center).toBe(false);
+		});
+
+		it("should clamp to the work area of the display the saved position is on, not always the primary", () => {
+			// Primary (first) display is the usual 1920x1080; the window was
+			// last on a larger secondary display and saved at a size that
+			// would get shrunk if clamped against the primary instead.
+			(screen.getAllDisplays as ReturnType<typeof MockType>).mockReturnValue([
+				{ bounds: { x: 0, y: 0, width: 1920, height: 1080 } },
+				{ bounds: { x: 1920, y: 0, width: 3840, height: 2160 } },
+			]);
+			(
+				screen.getDisplayMatching as ReturnType<typeof MockType>
+			).mockReturnValue({
+				workAreaSize: { width: 3840, height: 2160 },
+			});
+
+			const result = getInitialWindowBounds({
+				x: 2000,
+				y: 100,
+				width: 3800,
+				height: 2100,
+				isMaximized: false,
+			});
+
+			// Would be 1920x1080 under the old always-clamp-to-primary bug.
+			expect(result.width).toBe(3800);
+			expect(result.height).toBe(2100);
 		});
 	});
 });

--- a/apps/desktop/src/main/lib/window-state/bounds-validation.ts
+++ b/apps/desktop/src/main/lib/window-state/bounds-validation.ts
@@ -3,11 +3,8 @@ import type { WindowState } from "./window-state";
 
 const MIN_VISIBLE_OVERLAP = 50;
 const MIN_WINDOW_SIZE = 400;
-interface DisplayBoundsLike {
+interface DisplayLike {
 	bounds: Rectangle;
-}
-
-interface PrimaryDisplayLike {
 	workAreaSize: {
 		width: number;
 		height: number;
@@ -15,8 +12,12 @@ interface PrimaryDisplayLike {
 }
 
 interface ScreenLike {
-	getAllDisplays(): DisplayBoundsLike[];
-	getPrimaryDisplay(): PrimaryDisplayLike;
+	getAllDisplays(): DisplayLike[];
+	getPrimaryDisplay(): DisplayLike;
+	/** The display whose bounds most closely match the given rect — used to
+	 *  clamp saved dimensions against the display the window actually last
+	 *  sat on, not always the primary one (see clampToWorkArea). */
+	getDisplayMatching(rect: Rectangle): DisplayLike;
 }
 
 let screenOverride: ScreenLike | null = null;
@@ -54,17 +55,27 @@ export function isVisibleOnAnyDisplay(bounds: Rectangle): boolean {
 }
 
 /**
- * Clamps dimensions to not exceed the primary display work area.
- * Handles DPI/resolution changes since last save.
+ * Clamps saved dimensions to not exceed the work area of the display the
+ * saved position (x/y) actually sits on — not always the primary display.
+ * A window last closed maximized/full-height on a secondary monitor larger
+ * than the primary one would otherwise get its saved width/height shrunk
+ * down to the primary's work area on relaunch, while x/y still point at the
+ * secondary monitor: the window ends up correctly positioned but sized far
+ * smaller than the screen it's on. getDisplayMatching finds the display
+ * nearest the saved rect (falls back sanely if the saved rect covers none),
+ * so this also still handles DPI/resolution changes on that same display.
  */
-function clampToWorkArea(
-	width: number,
-	height: number,
-): { width: number; height: number } {
-	const { workAreaSize } = getScreen().getPrimaryDisplay();
+function clampToWorkArea(bounds: Rectangle): { width: number; height: number } {
+	const { workAreaSize } = getScreen().getDisplayMatching(bounds);
 	return {
-		width: Math.min(Math.max(width, MIN_WINDOW_SIZE), workAreaSize.width),
-		height: Math.min(Math.max(height, MIN_WINDOW_SIZE), workAreaSize.height),
+		width: Math.min(
+			Math.max(bounds.width, MIN_WINDOW_SIZE),
+			workAreaSize.width,
+		),
+		height: Math.min(
+			Math.max(bounds.height, MIN_WINDOW_SIZE),
+			workAreaSize.height,
+		),
 	};
 }
 
@@ -99,10 +110,12 @@ export function getInitialWindowBounds(
 		};
 	}
 
-	const { width, height } = clampToWorkArea(
-		savedState.width,
-		savedState.height,
-	);
+	const { width, height } = clampToWorkArea({
+		x: savedState.x,
+		y: savedState.y,
+		width: savedState.width,
+		height: savedState.height,
+	});
 
 	const savedBounds: Rectangle = {
 		x: savedState.x,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -174,6 +174,10 @@ function prCodeTabCardUnsafeCss(
 		 * PR list row's own diff-stat placement. Overrides the shared
 		 * hook's flex-start (same selector, appended later so it wins). */
 		justify-content: space-between;
+		/* Pierre's own padding (0 16px) sits the collapse chevron well right
+		 * of the Files pill above it (px-2 on the toolbar row, 8px) — cut to
+		 * match so the two rows read as left-aligned. */
+		padding-left: 8px;
 	}
 	/* Every header carries data-sticky from first render (confirmed live —
 	 * it's there even scrolled to the very top), since position: sticky

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	LuChevronDown,
+	LuChevronRight,
 	LuChevronUp,
 	LuColumns2,
 	LuPanelLeft,
@@ -332,6 +333,27 @@ export function PullRequestCodeTab({
 		updateComposer(null);
 		codeViewRef.current?.clearSelectedLines();
 	}, [updateComposer]);
+	// Per-file collapse — Pierre's CodeViewDiffItem has a native `collapsed`
+	// field it uses to hide a file's body while keeping its header rendered,
+	// so this only needs to track *which* items are collapsed and bump their
+	// version (same reasoning as composerVersionRef above: Pierre skips an
+	// item whose version didn't change, and toggling collapsed doesn't touch
+	// threadsUpdatedAt on its own).
+	const [collapsedFileIds, setCollapsedFileIds] = useState<ReadonlySet<string>>(
+		new Set(),
+	);
+	const collapseVersionRef = useRef(0);
+	const collapseAffectedIdRef = useRef<string | null>(null);
+	const toggleFileCollapsed = useCallback((itemId: string) => {
+		collapseVersionRef.current += 1;
+		collapseAffectedIdRef.current = itemId;
+		setCollapsedFileIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(itemId)) next.delete(itemId);
+			else next.add(itemId);
+			return next;
+		});
+	}, []);
 	const queryClient = useQueryClient();
 
 	const { data, isLoading, error, refetch } = useQuery({
@@ -626,31 +648,44 @@ export function PullRequestCodeTab({
 					composerAnnotation && composer?.path === f.path
 						? [...threadAnnotations, composerAnnotation]
 						: threadAnnotations;
+				const isVersionAffected =
+					composerAffectedPathsRef.current.has(f.path) ||
+					collapseAffectedIdRef.current === f.item.id;
 				return {
 					...f.item,
 					annotations: annotations.length > 0 ? annotations : undefined,
+					collapsed: collapsedFileIds.has(f.item.id),
 					// Pierre's controlled `items` prop diffs items by id and, per
 					// its own docs ("bump the version when also changing the
 					// value"), needs an explicit version bump to know an
 					// already-rendered item's content changed — otherwise a
 					// same-id item with new annotations (a reply landing, a
-					// resolve toggling, a composer opening/closing) can go stale
-					// in the live view even though the query cache/state is
-					// correct. Only the file(s) actually losing or gaining the
-					// composer annotation get the extra bump, so a composer
-					// transition elsewhere doesn't force Pierre to reprocess
-					// every file in the diff.
-					version: composerAffectedPathsRef.current.has(f.path)
-						? threadsUpdatedAt + composerVersionRef.current
+					// resolve toggling, a composer opening/closing) or a
+					// collapsed toggle can go stale in the live view even though
+					// the query cache/state is correct. Only the file(s) actually
+					// affected get the extra bump, so a transition elsewhere
+					// doesn't force Pierre to reprocess every file in the diff.
+					version: isVersionAffected
+						? threadsUpdatedAt +
+							composerVersionRef.current +
+							collapseVersionRef.current
 						: threadsUpdatedAt,
 				};
 			}),
-		// composerVersionRef.current and composerAffectedPathsRef.current
-		// are read directly, not listed as dependencies — both are written
-		// synchronously in updateComposer before setComposer, so they're
-		// already current by the time this recomputes off the `composer`
-		// change below.
-		[files, annotationsByPath, composer, composerAnnotation, threadsUpdatedAt],
+		// composerVersionRef.current, composerAffectedPathsRef.current,
+		// collapseVersionRef.current, and collapseAffectedIdRef.current are
+		// read directly, not listed as dependencies — all are written
+		// synchronously in their respective update callbacks before the
+		// state setter, so they're already current by the time this
+		// recomputes off the `composer`/`collapsedFileIds` change below.
+		[
+			files,
+			annotationsByPath,
+			composer,
+			composerAnnotation,
+			threadsUpdatedAt,
+			collapsedFileIds,
+		],
 	);
 	// Flattened in diff order (file order, then line number within a file)
 	// so next/prev walks the pane top-to-bottom instead of thread-creation
@@ -1019,6 +1054,28 @@ export function PullRequestCodeTab({
 						style={codeViewStyle}
 						items={items}
 						options={codeViewOptions}
+						renderHeaderPrefix={(item) => {
+							const isCollapsed = collapsedFileIds.has(item.id);
+							return (
+								<button
+									type="button"
+									onClick={(e) => {
+										e.stopPropagation();
+										toggleFileCollapsed(item.id);
+									}}
+									aria-label={isCollapsed ? "Expand file" : "Collapse file"}
+									className="flex size-4 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+								>
+									<LuChevronRight
+										className={cn(
+											"size-3 shrink-0 transition-transform",
+											!isCollapsed && "rotate-90",
+										)}
+										strokeWidth={1.5}
+									/>
+								</button>
+							);
+						}}
 						renderAnnotation={(annotation) => {
 							const metadata = annotation.metadata;
 							if (!metadata) return null;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -187,6 +187,13 @@ function prCodeTabCardUnsafeCss(
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 	}
+	/* Pierre renders the full relative path as one plain-text node here;
+	 * replaced by our own filename/directory split rendered through
+	 * renderHeaderFilenameSuffix, which sits right after this in the DOM so
+	 * hiding it (rather than removing/reordering) keeps the same slot order. */
+	[data-diffs-header='default'] [data-title] {
+		display: none;
+	}
 	/* Match PullRequestRow's diff-stat colors (the PR list view) instead of
 	 * the shared hook's own green/red, which use a different palette. */
 	[data-diffs-header='default'] [data-additions-count] {
@@ -255,6 +262,21 @@ function formatDiffStats(additions: number, deletions: number): string {
 	if (additions === 0) return `−${deletions}`;
 	if (deletions === 0) return `+${additions}`;
 	return `+${additions} −${deletions}`;
+}
+
+// Pierre's own header renders the full relative path as one string
+// (data-title); the filename-first look (name in the foreground color, then
+// the containing directory trailing off in the muted color) is built by
+// hiding that native title and rendering our own split via
+// renderHeaderFilenameSuffix instead — see PR_CODE_TAB_CARD_UNSAFE_CSS's
+// `[data-title] { display: none }` rule.
+function splitPath(path: string): { dir: string; name: string } {
+	const slashIndex = path.lastIndexOf("/");
+	if (slashIndex === -1) return { dir: "", name: path };
+	return {
+		dir: path.slice(0, slashIndex + 1),
+		name: path.slice(slashIndex + 1),
+	};
 }
 
 // Matches DiffPane's useDiffCommentComposer: a range spanning both an
@@ -1144,6 +1166,21 @@ export function PullRequestCodeTab({
 										strokeWidth={1.5}
 									/>
 								</button>
+							);
+						}}
+						renderHeaderFilenameSuffix={(item) => {
+							const path = pathByItemId.get(item.id);
+							if (!path) return null;
+							const { dir, name } = splitPath(path);
+							return (
+								<span className="flex min-w-0 items-center gap-1.5">
+									<span className="shrink-0 text-foreground">{name}</span>
+									{dir && (
+										<span className="min-w-0 truncate text-muted-foreground/70">
+											{dir}
+										</span>
+									)}
+								</span>
 							);
 						}}
 						renderAnnotation={(annotation) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -158,6 +158,18 @@ const PR_CODE_TAB_CARD_UNSAFE_CSS = `
 		border-top-right-radius: 0.75rem;
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 	}
+	/* Every header carries data-sticky from first render (confirmed live —
+	 * it's there even scrolled to the very top), since position: sticky
+	 * pins it while the code column scrolls behind it, not clipped away.
+	 * Rounded top corners cut a notch out of the header's own background,
+	 * and whatever's scrolled behind shows through that notch as a stray
+	 * border/text sliver. Squaring the top only (the diff body below,
+	 * [data-diff], keeps its rounded bottom) removes the notch entirely —
+	 * reads as a flat toolbar cap on a rounded card, not a broken corner. */
+	[data-diffs-header='default'][data-sticky] {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
 	[data-diff] {
 		--diffs-light-bg: var(--background) !important;
 		--diffs-dark-bg: var(--background) !important;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -215,6 +215,14 @@ function prCodeTabCardUnsafeCss(
 		border-bottom-right-radius: 0.75rem;
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 	}
+	/* The shared hook zeroes this strip's own inline padding to sit flush
+	 * with DiffPane's edge-to-edge pane — appropriate there, but it leaves
+	 * "N unmodified lines" text touching this card's left border with no
+	 * breathing room. Restored (higher specificity: same selector, later in
+	 * the concatenated string, so this !important wins over that one). */
+	[data-separator^='line-info'] [data-separator-content] {
+		padding-inline: 8px !important;
+	}
 `;
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -118,12 +118,41 @@ const TREE_STYLE = createPierreTreeStyle({
 // pane's own width — a fully reactive re-collapse on resize would need a
 // bulk collapse-all the tree model doesn't expose.
 const NARROW_WINDOW_WIDTH_THRESHOLD = 1400;
-// Below this (stricter) width, even a collapsed-folders tree panel is more
-// than the split can spare — hide the whole panel by default rather than
-// just defaulting its folders closed. Same one-time, mount-only read as
-// NARROW_WINDOW_WIDTH_THRESHOLD, for the same reason (isTreeCollapsed is a
-// plain default here, not a continuously-tracked breakpoint).
-const NARROW_WINDOW_WIDTH_HIDE_TREE_THRESHOLD = 1150;
+// Below this (stricter) *pane* width — this tab's own rendered width, via
+// ResizeObserver, not the window's — even a collapsed-folders tree panel is
+// more than the split can spare, so the whole panel hides by default. Unlike
+// NARROW_WINDOW_WIDTH_THRESHOLD this one does stay reactive after mount:
+// isTreeCollapsed is plain component state (no Pierre store tied to it), so
+// nothing stops it tracking width for the tab's whole lifetime.
+const NARROW_PANE_WIDTH_HIDE_TREE_THRESHOLD = 1150;
+
+// Extra unsafeCSS appended to (not replacing) useDiffCodeViewTheme's own —
+// that hook is shared with the v2-workspace DiffPane, so styling specific to
+// this tab's card-per-file look lives here instead of there. Pierre has no
+// single wrapping element around one file's header+content (confirmed live:
+// [data-diffs-header]'s parentElement is the shadow root itself), so the
+// "card" is an illusion built from two adjacent elements — the header gets
+// rounded top corners, the diff body gets rounded bottom corners, matching
+// borders on both meet with no gap between them, and layout.gap (set where
+// this is used) puts real space before the *next* file's header. Mirrors
+// packages/ui's shared Card component's own recipe (rounded-xl border
+// shadow-sm) rather than inventing a new one.
+const PR_CODE_TAB_CARD_UNSAFE_CSS = `
+	[data-diffs-header='default'] {
+		border: 1px solid var(--border);
+		border-bottom: none;
+		border-top-left-radius: 0.75rem;
+		border-top-right-radius: 0.75rem;
+		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+	}
+	[data-diff] {
+		border: 1px solid var(--border);
+		border-top: none;
+		border-bottom-left-radius: 0.75rem;
+		border-bottom-right-radius: 0.75rem;
+		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+	}
+`;
 
 // GitHub's diff-file-type vocabulary (from parsePatchFiles) mapped onto
 // Pierre's tree git-status vocabulary — a distinct mapping from
@@ -203,9 +232,32 @@ export function PullRequestCodeTab({
 	const [initialTreeExpansion] = useState<"open" | "closed">(() =>
 		window.innerWidth < NARROW_WINDOW_WIDTH_THRESHOLD ? "closed" : "open",
 	);
-	const [isTreeCollapsed, setIsTreeCollapsed] = useState(
-		() => window.innerWidth < NARROW_WINDOW_WIDTH_HIDE_TREE_THRESHOLD,
-	);
+	// Tracks this tab's own rendered width, not the window's — the PR list
+	// pane, an app sidebar, or a split view can all make the detail pane
+	// (where this tab lives) far narrower than the window, and window width
+	// alone missed that entirely.
+	const rootRef = useRef<HTMLDivElement>(null);
+	const [containerWidth, setContainerWidth] = useState<number | null>(null);
+	useEffect(() => {
+		const el = rootRef.current;
+		if (!el) return;
+		const update = () => setContainerWidth(el.getBoundingClientRect().width);
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
+	// null = no explicit user choice yet, so the panel auto-collapses/expands
+	// as the pane crosses the width threshold. Once the reviewer clicks the
+	// toggle, their choice sticks regardless of further resizing — auto
+	// behavior only ever supplies a default, never fights a deliberate click.
+	const [manualTreeCollapsed, setManualTreeCollapsed] = useState<
+		boolean | null
+	>(null);
+	const isTreeCollapsed =
+		manualTreeCollapsed ??
+		(containerWidth != null &&
+			containerWidth < NARROW_PANE_WIDTH_HIDE_TREE_THRESHOLD);
 	const [treeWidth, setTreeWidth] = useState(DEFAULT_TREE_WIDTH);
 	const [isResizingTree, setIsResizingTree] = useState(false);
 	const [composer, setComposer] = useState<ComposerState | null>(null);
@@ -635,6 +687,13 @@ export function PullRequestCodeTab({
 		() =>
 			({
 				...options,
+				// A visible gap between files is what makes the rounded
+				// header/diff pair (PR_CODE_TAB_CARD_UNSAFE_CSS) read as
+				// separate cards rather than one continuous, oddly-cornered
+				// block — DiffPane's own gap: 0 doesn't need this since it
+				// has no such per-file card styling.
+				layout: { ...options.layout, gap: 16 },
+				unsafeCSS: `${options.unsafeCSS ?? ""}\n${PR_CODE_TAB_CARD_UNSAFE_CSS}`,
 				enableLineSelection: true,
 				enableGutterUtility: true,
 				// Pierre gates the gutter "+" button's pointer flow behind a
@@ -729,40 +788,48 @@ export function PullRequestCodeTab({
 
 	if (isLoading) {
 		return (
-			<div className="flex flex-1 items-center justify-center">
-				<WorkItemDetailState message="Loading diff…" isLoading />
+			<div ref={rootRef} className="flex min-h-0 flex-1 flex-col">
+				<div className="flex flex-1 items-center justify-center">
+					<WorkItemDetailState message="Loading diff…" isLoading />
+				</div>
 			</div>
 		);
 	}
 
 	if (error instanceof Error) {
 		return (
-			<div className="flex flex-1 items-center justify-center">
-				<WorkItemDetailState
-					message={error.message}
-					isError
-					onRetry={() => void refetch()}
-				/>
+			<div ref={rootRef} className="flex min-h-0 flex-1 flex-col">
+				<div className="flex flex-1 items-center justify-center">
+					<WorkItemDetailState
+						message={error.message}
+						isError
+						onRetry={() => void refetch()}
+					/>
+				</div>
 			</div>
 		);
 	}
 
 	if (patchParseError) {
 		return (
-			<div className="flex flex-1 items-center justify-center">
-				<WorkItemDetailState
-					message={`Couldn't parse this diff: ${patchParseError}`}
-					isError
-					onRetry={() => void refetch()}
-				/>
+			<div ref={rootRef} className="flex min-h-0 flex-1 flex-col">
+				<div className="flex flex-1 items-center justify-center">
+					<WorkItemDetailState
+						message={`Couldn't parse this diff: ${patchParseError}`}
+						isError
+						onRetry={() => void refetch()}
+					/>
+				</div>
 			</div>
 		);
 	}
 
 	if (items.length === 0) {
 		return (
-			<div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-sm text-muted-foreground">
-				No changes to display.
+			<div ref={rootRef} className="flex min-h-0 flex-1 flex-col">
+				<div className="flex flex-1 items-center justify-center px-6 py-10 text-center text-sm text-muted-foreground">
+					No changes to display.
+				</div>
 			</div>
 		);
 	}
@@ -776,7 +843,10 @@ export function PullRequestCodeTab({
 		);
 
 	return (
-		<div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3 @md:px-6">
+		<div
+			ref={rootRef}
+			className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3 @md:px-6"
+		>
 			<div className="flex min-h-0 flex-1 overflow-hidden">
 				{!isTreeCollapsed && (
 					<ResizablePanel
@@ -802,7 +872,7 @@ export function PullRequestCodeTab({
 							<TooltipTrigger asChild>
 								<button
 									type="button"
-									onClick={() => setIsTreeCollapsed((prev) => !prev)}
+									onClick={() => setManualTreeCollapsed(!isTreeCollapsed)}
 									aria-label={
 										isTreeCollapsed ? "Show file tree" : "Hide file tree"
 									}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -948,7 +948,7 @@ export function PullRequestCodeTab({
 									aria-label={
 										isTreeCollapsed ? "Show file tree" : "Hide file tree"
 									}
-									className="flex items-center gap-1.5 rounded px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+									className="flex items-center gap-1.5 rounded-md bg-muted/50 px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 								>
 									<LuFiles className="size-3.5 shrink-0" strokeWidth={1.5} />
 									<span className="text-[11px] font-medium">Files</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -128,15 +128,28 @@ const NARROW_PANE_WIDTH_HIDE_TREE_THRESHOLD = 1150;
 
 // Extra unsafeCSS appended to (not replacing) useDiffCodeViewTheme's own —
 // that hook is shared with the v2-workspace DiffPane, so styling specific to
-// this tab's card-per-file look lives here instead of there. Pierre has no
-// single wrapping element around one file's header+content (confirmed live:
-// [data-diffs-header]'s parentElement is the shadow root itself), so the
-// "card" is an illusion built from two adjacent elements — the header gets
-// rounded top corners, the diff body gets rounded bottom corners, matching
-// borders on both meet with no gap between them, and layout.gap (set where
-// this is used) puts real space before the *next* file's header. Mirrors
-// packages/ui's shared Card component's own recipe (rounded-xl border
-// shadow-sm) rather than inventing a new one.
+// this tab lives here instead of there.
+//
+// [data-diff]'s --diffs-light-bg/--diffs-dark-bg override: the shared hook
+// sources its background from the *terminal* theme
+// (terminalTheme?.background ?? var(--background)), which makes sense for
+// DiffPane sitting next to terminal panes, but this tab has no terminal
+// nearby and the terminal theme's default background doesn't match this
+// app's own var(--background) — re-overridden here (both are !important, so
+// this wins by appearing later in the concatenated string) back to the
+// token the rest of the tab actually uses. The CodeView root's own
+// `style.backgroundColor` gets the equivalent fix directly as a prop
+// (see codeViewStyle) since that one isn't reachable through unsafeCSS.
+//
+// Card-per-file look: Pierre has no single wrapping element around one
+// file's header+content (confirmed live: [data-diffs-header]'s
+// parentElement is the shadow root itself), so the "card" is an illusion
+// built from two adjacent elements — the header gets rounded top corners,
+// the diff body gets rounded bottom corners, matching borders on both meet
+// with no gap between them, and layout.gap (set where this is used) puts
+// real space before the *next* file's header. Mirrors packages/ui's shared
+// Card component's own recipe (rounded-xl border shadow-sm) rather than
+// inventing a new one.
 const PR_CODE_TAB_CARD_UNSAFE_CSS = `
 	[data-diffs-header='default'] {
 		border: 1px solid var(--border);
@@ -146,6 +159,8 @@ const PR_CODE_TAB_CARD_UNSAFE_CSS = `
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 	}
 	[data-diff] {
+		--diffs-light-bg: var(--background) !important;
+		--diffs-dark-bg: var(--background) !important;
 		border: 1px solid var(--border);
 		border-top: none;
 		border-bottom-left-radius: 0.75rem;
@@ -222,6 +237,18 @@ export function PullRequestCodeTab({
 	hostId,
 }: PullRequestCodeTabProps) {
 	const { options, style } = useDiffCodeViewTheme();
+	// useDiffCodeViewTheme sources its background from the *terminal* theme
+	// (terminalTheme?.background ?? var(--background)) — sensible for
+	// DiffPane, which sits next to terminal panes in the workspace view, but
+	// this tab has no terminal nearby and the terminal theme's default
+	// background doesn't match the app's own var(--background) (e.g. a flat
+	// white terminal background against this app's slightly-off-white
+	// #f9f9fa page). Most visible on the CodeView root's own native
+	// scrollbar, which paints against whatever background that element has.
+	const codeViewStyle = useMemo(
+		() => ({ ...style, backgroundColor: "var(--background)" }),
+		[style],
+	);
 	const codeViewRef = useRef<CodeViewHandle<PrAnnotationMetadata>>(null);
 	// Sourced from the same persisted setting DiffPane's toggle reads/writes
 	// (options.diffStyle already carries it via useDiffCodeViewTheme) — a
@@ -977,7 +1004,7 @@ export function PullRequestCodeTab({
 					<CodeView
 						ref={codeViewRef}
 						className="min-h-0 flex-1 overflow-y-auto overflow-x-clip overscroll-contain [overflow-anchor:none]"
-						style={style}
+						style={codeViewStyle}
 						items={items}
 						options={codeViewOptions}
 						renderAnnotation={(annotation) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -39,6 +39,7 @@ import type { AgentTarget } from "renderer/routes/_authenticated/_dashboard/v2-w
 import { useDiffCodeViewTheme } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
 import { useSettings } from "renderer/stores/settings";
+import { useResolvedTheme } from "renderer/stores/theme";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates/useWorkspaceCreates";
 import { PullRequestCommentComposer } from "../PullRequestCommentComposer";
 import { PullRequestCommentThread } from "../PullRequestCommentThread";
@@ -151,13 +152,28 @@ const NARROW_PANE_WIDTH_HIDE_TREE_THRESHOLD = 1150;
 // real space before the *next* file's header. Mirrors packages/ui's shared
 // Card component's own recipe (rounded-xl border shadow-sm) rather than
 // inventing a new one.
-const PR_CODE_TAB_CARD_UNSAFE_CSS = `
+//
+// A function (not a static string) because the additions/deletions colors
+// are theme-branched in JS — mirroring useDiffCodeViewTheme's own
+// additionColor/deletionColor — rather than relying on a `.dark` selector,
+// which can't reach in from outside the shadow root the way a CSS custom
+// property can.
+function prCodeTabCardUnsafeCss(
+	additionsColor: string,
+	deletionsColor: string,
+): string {
+	return `
 	[data-diffs-header='default'] {
 		border: 1px solid var(--border);
 		border-bottom: none;
 		border-top-left-radius: 0.75rem;
 		border-top-right-radius: 0.75rem;
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+		/* Pushes [data-metadata] (the +/- count) to the card's right edge
+		 * instead of leaving it flush against the filename — matches the
+		 * PR list row's own diff-stat placement. Overrides the shared
+		 * hook's flex-start (same selector, appended later so it wins). */
+		justify-content: space-between;
 	}
 	/* Every header carries data-sticky from first render (confirmed live —
 	 * it's there even scrolled to the very top), since position: sticky
@@ -171,6 +187,14 @@ const PR_CODE_TAB_CARD_UNSAFE_CSS = `
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 	}
+	/* Match PullRequestRow's diff-stat colors (the PR list view) instead of
+	 * the shared hook's own green/red, which use a different palette. */
+	[data-diffs-header='default'] [data-additions-count] {
+		color: ${additionsColor};
+	}
+	[data-diffs-header='default'] [data-deletions-count] {
+		color: ${deletionsColor};
+	}
 	[data-diff] {
 		--diffs-light-bg: var(--background) !important;
 		--diffs-dark-bg: var(--background) !important;
@@ -181,6 +205,7 @@ const PR_CODE_TAB_CARD_UNSAFE_CSS = `
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 	}
 `;
+}
 
 // GitHub's diff-file-type vocabulary (from parsePatchFiles) mapped onto
 // Pierre's tree git-status vocabulary — a distinct mapping from
@@ -250,6 +275,19 @@ export function PullRequestCodeTab({
 	hostId,
 }: PullRequestCodeTabProps) {
 	const { options, style } = useDiffCodeViewTheme();
+	// Matches PullRequestRow's diff-stat colors exactly (text-emerald-600 /
+	// [.dark_&]:text-[#34d399], text-red-600 / [.dark_&]:text-[#f87171]) so
+	// the same PR reads with the same additions/deletions colors in both the
+	// list and the diff viewer. Branched in JS rather than a `.dark`
+	// selector in unsafeCSS — `.dark` lives on an ancestor outside Pierre's
+	// shadow root, which a shadow-scoped stylesheet's descendant combinator
+	// can't reach (see additionColor/deletionColor in useDiffCodeViewTheme
+	// for the same pattern).
+	const activeTheme = useResolvedTheme();
+	const prAdditionsColor =
+		activeTheme.type === "dark" ? "#34d399" : "var(--color-emerald-600)";
+	const prDeletionsColor =
+		activeTheme.type === "dark" ? "#f87171" : "var(--color-red-600)";
 	// useDiffCodeViewTheme sources its background from the *terminal* theme
 	// (terminalTheme?.background ?? var(--background)) — sensible for
 	// DiffPane, which sits next to terminal panes in the workspace view, but
@@ -779,7 +817,7 @@ export function PullRequestCodeTab({
 				// block — DiffPane's own gap: 0 doesn't need this since it
 				// has no such per-file card styling.
 				layout: { ...options.layout, gap: 16 },
-				unsafeCSS: `${options.unsafeCSS ?? ""}\n${PR_CODE_TAB_CARD_UNSAFE_CSS}`,
+				unsafeCSS: `${options.unsafeCSS ?? ""}\n${prCodeTabCardUnsafeCss(prAdditionsColor, prDeletionsColor)}`,
 				enableLineSelection: true,
 				enableGutterUtility: true,
 				// Pierre gates the gutter "+" button's pointer flow behind a
@@ -802,7 +840,7 @@ export function PullRequestCodeTab({
 					updateComposer({ itemId: context.item.id, path, range });
 				},
 			}) as CodeViewOptions<PrAnnotationMetadata>,
-		[options, pathByItemId, updateComposer],
+		[options, pathByItemId, updateComposer, prAdditionsColor, prDeletionsColor],
 	);
 
 	const treePaths = useMemo(() => files.map((f) => f.path), [files]);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -18,9 +18,7 @@ import {
 	LuChevronRight,
 	LuChevronUp,
 	LuColumns2,
-	LuPanelLeft,
-	LuPanelLeftClose,
-	LuPanelLeftOpen,
+	LuFiles,
 	LuRows2,
 } from "react-icons/lu";
 import {
@@ -950,20 +948,12 @@ export function PullRequestCodeTab({
 									aria-label={
 										isTreeCollapsed ? "Show file tree" : "Hide file tree"
 									}
-									className="group flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
+									className="flex items-center gap-1.5 rounded px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
 								>
-									<span className="group-hover:hidden">
-										<LuPanelLeft className="size-3.5" strokeWidth={1.5} />
-									</span>
-									<span className="hidden group-hover:block">
-										{isTreeCollapsed ? (
-											<LuPanelLeftOpen className="size-3.5" strokeWidth={1.5} />
-										) : (
-											<LuPanelLeftClose
-												className="size-3.5"
-												strokeWidth={1.5}
-											/>
-										)}
+									<LuFiles className="size-3.5 shrink-0" strokeWidth={1.5} />
+									<span className="text-[11px] font-medium">Files</span>
+									<span className="text-[11px] tabular-nums text-muted-foreground/70">
+										{files.length}
 									</span>
 								</button>
 							</TooltipTrigger>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -118,6 +118,12 @@ const TREE_STYLE = createPierreTreeStyle({
 // pane's own width — a fully reactive re-collapse on resize would need a
 // bulk collapse-all the tree model doesn't expose.
 const NARROW_WINDOW_WIDTH_THRESHOLD = 1400;
+// Below this (stricter) width, even a collapsed-folders tree panel is more
+// than the split can spare — hide the whole panel by default rather than
+// just defaulting its folders closed. Same one-time, mount-only read as
+// NARROW_WINDOW_WIDTH_THRESHOLD, for the same reason (isTreeCollapsed is a
+// plain default here, not a continuously-tracked breakpoint).
+const NARROW_WINDOW_WIDTH_HIDE_TREE_THRESHOLD = 1150;
 
 // GitHub's diff-file-type vocabulary (from parsePatchFiles) mapped onto
 // Pierre's tree git-status vocabulary — a distinct mapping from
@@ -197,7 +203,9 @@ export function PullRequestCodeTab({
 	const [initialTreeExpansion] = useState<"open" | "closed">(() =>
 		window.innerWidth < NARROW_WINDOW_WIDTH_THRESHOLD ? "closed" : "open",
 	);
-	const [isTreeCollapsed, setIsTreeCollapsed] = useState(false);
+	const [isTreeCollapsed, setIsTreeCollapsed] = useState(
+		() => window.innerWidth < NARROW_WINDOW_WIDTH_HIDE_TREE_THRESHOLD,
+	);
 	const [treeWidth, setTreeWidth] = useState(DEFAULT_TREE_WIDTH);
 	const [isResizingTree, setIsResizingTree] = useState(false);
 	const [composer, setComposer] = useState<ComposerState | null>(null);
@@ -769,7 +777,7 @@ export function PullRequestCodeTab({
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-3 @md:px-6">
-			<div className="flex min-h-0 flex-1 overflow-hidden rounded-lg border border-border">
+			<div className="flex min-h-0 flex-1 overflow-hidden">
 				{!isTreeCollapsed && (
 					<ResizablePanel
 						width={treeWidth}
@@ -789,7 +797,7 @@ export function PullRequestCodeTab({
 					</ResizablePanel>
 				)}
 				<div className="flex min-h-0 flex-1 flex-col">
-					<div className="flex shrink-0 items-center justify-between gap-1 border-b border-border/50 px-2 py-1.5">
+					<div className="flex shrink-0 items-center justify-between gap-1 border-b border-border/20 px-2 py-1.5">
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<button
@@ -822,7 +830,7 @@ export function PullRequestCodeTab({
 						<div className="flex items-center gap-1">
 							{orderedThreads.length > 0 && (
 								<>
-									<div className="flex items-center gap-0.5 rounded-md border border-border/60 px-1 py-0.5">
+									<div className="flex items-center gap-0.5 rounded-md bg-muted/50 px-1 py-0.5">
 										<Tooltip>
 											<TooltipTrigger asChild>
 												<button

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -1188,7 +1188,10 @@ export function PullRequestCodeTab({
 								<span className="flex min-w-0 items-center gap-1.5">
 									<span className="shrink-0 text-foreground">{name}</span>
 									{dir && (
-										<span className="min-w-0 truncate text-muted-foreground/70">
+										<span
+											className="min-w-0 truncate text-muted-foreground/70"
+											title={dir}
+										>
 											{dir}
 										</span>
 									)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -19,7 +19,9 @@ import {
 	LuChevronUp,
 	LuColumns2,
 	LuFiles,
+	LuFoldVertical,
 	LuRows2,
+	LuUnfoldVertical,
 } from "react-icons/lu";
 import {
 	type AgentPromptFileSide,
@@ -341,10 +343,12 @@ export function PullRequestCodeTab({
 		new Set(),
 	);
 	const collapseVersionRef = useRef(0);
-	const collapseAffectedIdRef = useRef<string | null>(null);
+	// A single id for a per-file toggle, every id for collapse/expand-all —
+	// either way, every item this set names gets the version bump below.
+	const collapseAffectedIdsRef = useRef<ReadonlySet<string>>(new Set());
 	const toggleFileCollapsed = useCallback((itemId: string) => {
 		collapseVersionRef.current += 1;
-		collapseAffectedIdRef.current = itemId;
+		collapseAffectedIdsRef.current = new Set([itemId]);
 		setCollapsedFileIds((prev) => {
 			const next = new Set(prev);
 			if (next.has(itemId)) next.delete(itemId);
@@ -352,6 +356,14 @@ export function PullRequestCodeTab({
 			return next;
 		});
 	}, []);
+	const setAllFilesCollapsed = useCallback(
+		(collapsed: boolean, allItemIds: readonly string[]) => {
+			collapseVersionRef.current += 1;
+			collapseAffectedIdsRef.current = new Set(allItemIds);
+			setCollapsedFileIds(collapsed ? new Set(allItemIds) : new Set());
+		},
+		[],
+	);
 	const queryClient = useQueryClient();
 
 	const { data, isLoading, error, refetch } = useQuery({
@@ -615,6 +627,8 @@ export function PullRequestCodeTab({
 	}, [data?.patch]);
 	const files = parsedPatch.files;
 	const patchParseError = parsedPatch.error;
+	const areAllFilesCollapsed =
+		files.length > 0 && files.every((f) => collapsedFileIds.has(f.item.id));
 	const pathByItemId = useMemo(
 		() => new Map(files.map((f) => [f.item.id, f.path])),
 		[files],
@@ -648,7 +662,7 @@ export function PullRequestCodeTab({
 						: threadAnnotations;
 				const isVersionAffected =
 					composerAffectedPathsRef.current.has(f.path) ||
-					collapseAffectedIdRef.current === f.item.id;
+					collapseAffectedIdsRef.current.has(f.item.id);
 				return {
 					...f.item,
 					annotations: annotations.length > 0 ? annotations : undefined,
@@ -671,7 +685,7 @@ export function PullRequestCodeTab({
 				};
 			}),
 		// composerVersionRef.current, composerAffectedPathsRef.current,
-		// collapseVersionRef.current, and collapseAffectedIdRef.current are
+		// collapseVersionRef.current, and collapseAffectedIdsRef.current are
 		// read directly, not listed as dependencies — all are written
 		// synchronously in their respective update callbacks before the
 		// state setter, so they're already current by the time this
@@ -940,27 +954,55 @@ export function PullRequestCodeTab({
 				)}
 				<div className="flex min-h-0 flex-1 flex-col">
 					<div className="flex shrink-0 items-center justify-between gap-1 border-b border-border/20 px-2 py-1.5">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<button
-									type="button"
-									onClick={() => setManualTreeCollapsed(!isTreeCollapsed)}
-									aria-label={
-										isTreeCollapsed ? "Show file tree" : "Hide file tree"
-									}
-									className="flex items-center gap-1.5 rounded-md bg-muted/50 px-1.5 py-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-								>
-									<LuFiles className="size-3.5 shrink-0" strokeWidth={1.5} />
-									<span className="text-[11px] font-medium">Files</span>
-									<span className="text-[11px] tabular-nums text-muted-foreground/70">
-										{files.length}
-									</span>
-								</button>
-							</TooltipTrigger>
-							<TooltipContent side="bottom">
-								{isTreeCollapsed ? "Show file tree" : "Hide file tree"}
-							</TooltipContent>
-						</Tooltip>
+						<div className="flex items-center gap-1">
+							<button
+								type="button"
+								onClick={() => setManualTreeCollapsed(!isTreeCollapsed)}
+								aria-label={
+									isTreeCollapsed ? "Show file tree" : "Hide file tree"
+								}
+								className="flex items-center gap-1.5 rounded-md bg-fill-hover px-1.5 py-1 text-muted-foreground transition-colors hover:bg-fill-selected hover:text-foreground"
+							>
+								<LuFiles className="size-3.5 shrink-0" strokeWidth={1.5} />
+								<span className="text-[11px] font-medium">Files</span>
+								<span className="text-[11px] tabular-nums text-muted-foreground/70">
+									{files.length}
+								</span>
+							</button>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<button
+										type="button"
+										onClick={() =>
+											setAllFilesCollapsed(
+												!areAllFilesCollapsed,
+												files.map((f) => f.item.id),
+											)
+										}
+										aria-label={
+											areAllFilesCollapsed
+												? "Expand all files"
+												: "Collapse all files"
+										}
+										className="flex items-center justify-center rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
+									>
+										{areAllFilesCollapsed ? (
+											<LuUnfoldVertical
+												className="size-3.5"
+												strokeWidth={1.5}
+											/>
+										) : (
+											<LuFoldVertical className="size-3.5" strokeWidth={1.5} />
+										)}
+									</button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom">
+									{areAllFilesCollapsed
+										? "Expand all files"
+										: "Collapse all files"}
+								</TooltipContent>
+							</Tooltip>
+						</div>
 						<div className="flex items-center gap-1">
 							{orderedThreads.length > 0 && (
 								<>


### PR DESCRIPTION
## Summary
- Collapsible per-file cards (individually and via a collapse/expand-all toggle), styled as bordered cards with rounded corners and a sticky header that no longer leaks scrolled content
- Redesigned the file-tree toggle into a labeled "Files" pill with a file count, given a persistent (theme-aware) background
- File headers now show the filename first, then its directory path in muted gray, right-aligned diff stats using the same green/red as the PR list view, and left padding matched to the toolbar above
- Diff viewer background/scrollbar now matches the app's own background instead of the terminal theme's
- Fixed window bounds restoring at the wrong size when last closed on a secondary monitor larger than the primary

## Test plan
- [x] `bunx tsc --noEmit -p apps/desktop`
- [x] `bunx biome check` on touched files
- [x] `bun test apps/desktop/src/main/lib/window-state/bounds-validation.test.ts`
- [x] Verified live in the dev app via CDP (light and dark mode) — collapse/expand, header alignment, colors, scrolling

https://claude.ai/code/session_018s6aMRhQuJTWMekyCoeFVA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive file-tree behavior that adapts to available panel width.
  * Added file count, collapse-all, and individual file expand/collapse controls.
  * Improved code diff headers with clearer filenames, paths, and theme-aware styling.

* **Bug Fixes**
  * Window restoration now correctly constrains saved dimensions to the monitor containing the window, including multi-monitor setups.
  * Improved loading, error, and empty-state rendering in the pull request code view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->