### PR TITLE
fix(host-service): pre-trust session folders so agent CLIs skip the trust dialog

### DIFF
--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -24,6 +24,7 @@ import { protectedProcedure, router } from "../../index";
 import { resolveAttachmentPath } from "../attachments/storage";
 import { toTerminalSessionError } from "../terminal/errors";
 import { resolveDefaultAccountEnv } from "../usage/default-account";
+import { seedAgentFolderTrust } from "../workspace-creation/shared/seed-agent-trust";
 
 interface ResolvedHostAgentConfig {
 	id: string;
@@ -397,6 +398,17 @@ export async function runAgentInWorkspace(
 			code: "NOT_FOUND",
 			message: `Workspace ${input.workspaceId} not found on this host — it may have been deleted.`,
 		});
+	}
+	// Session workspaces are standalone repos the host itself scaffolded, so
+	// agent CLIs can't inherit folder trust from anywhere — pre-trust the
+	// folder in the launching agent's own trust store so its first
+	// interactive boot skips the trust dialog. Worktree workspaces inherit
+	// trust from the main checkout and need nothing.
+	if (workspace.projectId === null) {
+		const config = resolveHostAgentConfig(ctx.db, input.agent);
+		if (config) {
+			await seedAgentFolderTrust(ctx.db, workspace.worktreePath, config);
+		}
 	}
 	return runTerminalAgent(ctx, input);
 }

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -107,6 +114,20 @@ describe("seedClaudeFolderTrust", () => {
 		await seedClaudeFolderTrust(file, "/tmp/session-e");
 		expect(() => readFileSync(file, "utf-8")).toThrow();
 	});
+
+	test("preserves a tightened file mode across the rewrite", async () => {
+		const file = join(dir, ".claude.json");
+		writeFileSync(file, "{}");
+		chmodSync(file, 0o600);
+		await seedClaudeFolderTrust(file, "/tmp/session-f");
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+	});
+
+	test("creates a brand-new store owner-only", async () => {
+		const file = join(dir, ".claude.json");
+		await seedClaudeFolderTrust(file, "/tmp/session-g");
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+	});
 });
 
 describe("seedCodexFolderTrust", () => {
@@ -150,5 +171,49 @@ describe("seedCodexFolderTrust", () => {
 		const file = join(dir, "missing-home", "config.toml");
 		await seedCodexFolderTrust(file, "/tmp/session-d");
 		expect(() => readFileSync(file, "utf-8")).toThrow();
+	});
+
+	test("detects an equivalent header with different spacing", async () => {
+		const file = join(dir, "config.toml");
+		const content =
+			'[ projects . "/tmp/session-e" ]\ntrust_level = "untrusted"\n';
+		writeFileSync(file, content);
+		await seedCodexFolderTrust(file, "/tmp/session-e");
+		expect(readFileSync(file, "utf-8")).toBe(content);
+	});
+
+	test("detects a literal-string header", async () => {
+		const file = join(dir, "config.toml");
+		const content =
+			"[projects.'/tmp/session-f']\ntrust_level = \"untrusted\"\n";
+		writeFileSync(file, content);
+		await seedCodexFolderTrust(file, "/tmp/session-f");
+		expect(readFileSync(file, "utf-8")).toBe(content);
+	});
+
+	test("detects a top-level dotted key", async () => {
+		const file = join(dir, "config.toml");
+		const content = 'projects."/tmp/session-g".trust_level = "untrusted"\n';
+		writeFileSync(file, content);
+		await seedCodexFolderTrust(file, "/tmp/session-g");
+		expect(readFileSync(file, "utf-8")).toBe(content);
+	});
+
+	test("matches an escaped header against the raw path", async () => {
+		const file = join(dir, "config.toml");
+		const content =
+			'[projects."/tmp/we\\"ird\\\\path"]\ntrust_level = "untrusted"\n';
+		writeFileSync(file, content);
+		await seedCodexFolderTrust(file, '/tmp/we"ird\\path');
+		expect(readFileSync(file, "utf-8")).toBe(content);
+	});
+
+	test("still appends when only a different path is defined", async () => {
+		const file = join(dir, "config.toml");
+		writeFileSync(file, '[ projects . "/other" ]\ntrust_level = "trusted"\n');
+		await seedCodexFolderTrust(file, "/tmp/session-h");
+		expect(readFileSync(file, "utf-8")).toContain(
+			'[projects."/tmp/session-h"]\ntrust_level = "trusted"\n',
+		);
 	});
 });

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	resolveTrustFamily,
+	seedClaudeFolderTrust,
+	seedCodexFolderTrust,
+} from "./seed-agent-trust";
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "seed-agent-trust-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("resolveTrustFamily", () => {
+	test("matches by preset id", () => {
+		expect(resolveTrustFamily({ presetId: "claude", command: "claude" })).toBe(
+			"claude",
+		);
+		expect(resolveTrustFamily({ presetId: "codex", command: "codex" })).toBe(
+			"codex",
+		);
+	});
+
+	test("matches custom presets by launch executable", () => {
+		expect(
+			resolveTrustFamily({
+				presetId: "custom-abc",
+				command: "/usr/local/bin/claude --verbose",
+			}),
+		).toBe("claude");
+		expect(
+			resolveTrustFamily({
+				presetId: "custom-def",
+				command: "C:\\tools\\codex.exe",
+			}),
+		).toBe("codex");
+	});
+
+	test("returns null for providers without a known trust store", () => {
+		expect(resolveTrustFamily({ presetId: "gemini", command: "gemini" })).toBe(
+			null,
+		);
+		expect(
+			resolveTrustFamily({ presetId: "custom-xyz", command: "my-agent" }),
+		).toBe(null);
+	});
+});
+
+describe("seedClaudeFolderTrust", () => {
+	test("creates the state file with the trusted entry", async () => {
+		const file = join(dir, ".claude.json");
+		await seedClaudeFolderTrust(file, "/tmp/session-a");
+		const state = JSON.parse(readFileSync(file, "utf-8"));
+		expect(state.projects["/tmp/session-a"].hasTrustDialogAccepted).toBe(true);
+	});
+
+	test("merges into existing state, preserving other keys", async () => {
+		const file = join(dir, ".claude.json");
+		writeFileSync(
+			file,
+			JSON.stringify({
+				oauthAccount: { emailAddress: "x@y.z" },
+				projects: {
+					"/existing": { hasTrustDialogAccepted: true, allowedTools: ["Bash"] },
+					"/tmp/session-b": { allowedTools: ["Edit"] },
+				},
+			}),
+		);
+		await seedClaudeFolderTrust(file, "/tmp/session-b");
+		const state = JSON.parse(readFileSync(file, "utf-8"));
+		expect(state.oauthAccount.emailAddress).toBe("x@y.z");
+		expect(state.projects["/existing"].allowedTools).toEqual(["Bash"]);
+		expect(state.projects["/tmp/session-b"]).toEqual({
+			allowedTools: ["Edit"],
+			hasTrustDialogAccepted: true,
+		});
+	});
+
+	test("no-ops when the entry is already trusted", async () => {
+		const file = join(dir, ".claude.json");
+		const content = JSON.stringify({
+			projects: { "/tmp/session-c": { hasTrustDialogAccepted: true } },
+		});
+		writeFileSync(file, content);
+		await seedClaudeFolderTrust(file, "/tmp/session-c");
+		expect(readFileSync(file, "utf-8")).toBe(content);
+	});
+
+	test("throws on a corrupt state file without clobbering it", async () => {
+		const file = join(dir, ".claude.json");
+		writeFileSync(file, "{not json");
+		await expect(
+			seedClaudeFolderTrust(file, "/tmp/session-d"),
+		).rejects.toThrow();
+		expect(readFileSync(file, "utf-8")).toBe("{not json");
+	});
+
+	test("skips when the config dir itself does not exist", async () => {
+		const file = join(dir, "missing-profile", ".claude.json");
+		await seedClaudeFolderTrust(file, "/tmp/session-e");
+		expect(() => readFileSync(file, "utf-8")).toThrow();
+	});
+});
+
+describe("seedCodexFolderTrust", () => {
+	test("creates config.toml with the trusted table", async () => {
+		const file = join(dir, "config.toml");
+		await seedCodexFolderTrust(file, "/tmp/session-a");
+		expect(readFileSync(file, "utf-8")).toBe(
+			'[projects."/tmp/session-a"]\ntrust_level = "trusted"\n',
+		);
+	});
+
+	test("appends after existing content, preserving it", async () => {
+		const file = join(dir, "config.toml");
+		writeFileSync(
+			file,
+			'model = "gpt-5"\n\n[projects."/other"]\ntrust_level = "trusted"\n',
+		);
+		await seedCodexFolderTrust(file, "/tmp/session-b");
+		expect(readFileSync(file, "utf-8")).toBe(
+			'model = "gpt-5"\n\n[projects."/other"]\ntrust_level = "trusted"\n\n[projects."/tmp/session-b"]\ntrust_level = "trusted"\n',
+		);
+	});
+
+	test("leaves an existing table for the path untouched", async () => {
+		const file = join(dir, "config.toml");
+		const content = '[projects."/tmp/session-c"]\ntrust_level = "untrusted"\n';
+		writeFileSync(file, content);
+		await seedCodexFolderTrust(file, "/tmp/session-c");
+		expect(readFileSync(file, "utf-8")).toBe(content);
+	});
+
+	test("escapes quotes and backslashes in the path key", async () => {
+		const file = join(dir, "config.toml");
+		await seedCodexFolderTrust(file, '/tmp/we"ird\\path');
+		expect(readFileSync(file, "utf-8")).toBe(
+			'[projects."/tmp/we\\"ird\\\\path"]\ntrust_level = "trusted"\n',
+		);
+	});
+
+	test("skips when the codex home does not exist", async () => {
+		const file = join(dir, "missing-home", "config.toml");
+		await seedCodexFolderTrust(file, "/tmp/session-d");
+		expect(() => readFileSync(file, "utf-8")).toThrow();
+	});
+});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.ts
@@ -1,0 +1,182 @@
+/**
+ * Pre-trusts a host-created folder in the launching agent CLIs' trust
+ * stores, so their first interactive launch skips the "do you trust this
+ * folder?" dialog. Session folders need this because they are standalone
+ * repos: agent CLIs treat a git repo root as its own trust domain (worktrees
+ * inherit from the main checkout, plain dirs from trusted ancestors, but a
+ * fresh standalone repo inherits nothing), so every new session would
+ * otherwise prompt. Auto-trusting is sound only because the host itself just
+ * created the folder as an empty scaffold — never seed a folder with
+ * pre-existing user content.
+ *
+ * Each store is the CLI's own sanctioned escape hatch: Claude's untrusted-
+ * folder error says to set `projects[<path>].hasTrustDialogAccepted: true`
+ * in its state file, and Codex persists `trust_level = "trusted"` in
+ * config.toml the same way. Everything here is best-effort — a failed seed
+ * just means the dialog shows once.
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { HostDb } from "../../../../db";
+import { resolveDefaultAccountEnv } from "../../usage/default-account";
+
+type TrustFamily = "claude" | "codex";
+
+interface TrustTarget {
+	family: TrustFamily;
+	file: string;
+}
+
+/**
+ * Provider family of an agent config, from its preset id or launch
+ * executable. The executable check covers custom presets that still run the
+ * stock `claude`/`codex` binaries (possibly via absolute paths or wrappers
+ * named after them).
+ */
+export function resolveTrustFamily(config: {
+	presetId: string;
+	command: string;
+}): TrustFamily | null {
+	const [token = ""] = config.command.trim().split(/\s+/);
+	const executable = (token.split(/[\\/]/).pop() ?? "")
+		.toLowerCase()
+		.replace(/\.exe$/, "");
+	for (const family of ["claude", "codex"] as const) {
+		if (config.presetId === family || executable === family) return family;
+	}
+	return null;
+}
+
+/**
+ * Trust-store file for one agent config, mirroring launch-time resolution:
+ * per-agent env wins over the host-default account selection
+ * (`{...accountEnv, ...config.env}` in buildTerminalAgentLaunch, and the
+ * agent wrapper's pointer-file fallback reads the same DB-backed selection).
+ * Claude keeps state inside a custom CLAUDE_CONFIG_DIR but next door at
+ * `~/.claude.json` for the default home; Codex always uses
+ * `$CODEX_HOME/config.toml`.
+ */
+function resolveTrustTarget(
+	db: HostDb,
+	config: { presetId: string; command: string; env: Record<string, string> },
+): TrustTarget | null {
+	const family = resolveTrustFamily(config);
+	if (family === null) return null;
+	const env = { ...resolveDefaultAccountEnv(db, family), ...config.env };
+	if (family === "claude") {
+		const configDir = env.CLAUDE_CONFIG_DIR;
+		return {
+			family,
+			file: configDir
+				? join(configDir, ".claude.json")
+				: join(homedir(), ".claude.json"),
+		};
+	}
+	const codexHome = env.CODEX_HOME || join(homedir(), ".codex");
+	return { family, file: join(codexHome, "config.toml") };
+}
+
+/** Same-directory tmp write + rename, so a crash never truncates the store. */
+async function atomicWrite(file: string, content: string): Promise<void> {
+	const tmpDir = await mkdtemp(join(dirname(file), ".superset-trust-"));
+	const tmpFile = join(tmpDir, "next");
+	try {
+		await writeFile(tmpFile, content);
+		await rename(tmpFile, file);
+	} finally {
+		await rm(tmpDir, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Merge `projects[<path>].hasTrustDialogAccepted: true` into a Claude state
+ * file, preserving every other key. A corrupt file throws instead of being
+ * clobbered. No-op when the entry is already trusted.
+ */
+export async function seedClaudeFolderTrust(
+	stateFile: string,
+	folderPath: string,
+): Promise<void> {
+	let state: Record<string, unknown> = {};
+	if (existsSync(stateFile)) {
+		state = JSON.parse(await readFile(stateFile, "utf-8"));
+	} else if (!existsSync(dirname(stateFile))) {
+		// A missing config dir means this login was never set up — the CLI's
+		// own onboarding (which includes trust) will run anyway.
+		return;
+	}
+	const projects = (state.projects ?? {}) as Record<
+		string,
+		Record<string, unknown> | undefined
+	>;
+	const existing = projects[folderPath];
+	if (existing?.hasTrustDialogAccepted === true) return;
+	state.projects = {
+		...projects,
+		[folderPath]: { ...existing, hasTrustDialogAccepted: true },
+	};
+	await atomicWrite(stateFile, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Append a `[projects."<path>"]` table with `trust_level = "trusted"` to a
+ * Codex config.toml. An existing table for the path is left untouched — a
+ * user's explicit "untrusted" must not be overridden.
+ */
+export async function seedCodexFolderTrust(
+	configFile: string,
+	folderPath: string,
+): Promise<void> {
+	const escaped = folderPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	const header = `[projects."${escaped}"]`;
+	let content = "";
+	if (existsSync(configFile)) {
+		content = await readFile(configFile, "utf-8");
+		if (content.split(/\r?\n/).some((line) => line.trim() === header)) return;
+	} else if (!existsSync(dirname(configFile))) {
+		return;
+	}
+	const block = `${header}\ntrust_level = "trusted"\n`;
+	const next =
+		content.length === 0 ? block : `${content.replace(/\n*$/, "\n\n")}${block}`;
+	await atomicWrite(configFile, next);
+}
+
+function normalizeFolderPath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
+	}
+}
+
+/**
+ * Seed trust for `folderPath` in the launching agent's trust store, if it
+ * has a known one. `config` is the already-resolved host agent config of the
+ * agent about to launch. Best-effort: failures log and the dialog shows
+ * once.
+ */
+export async function seedAgentFolderTrust(
+	db: HostDb,
+	folderPath: string,
+	config: { presetId: string; command: string; env: Record<string, string> },
+): Promise<void> {
+	try {
+		const target = resolveTrustTarget(db, config);
+		if (target === null) return;
+		const normalized = normalizeFolderPath(folderPath);
+		if (target.family === "claude") {
+			await seedClaudeFolderTrust(target.file, normalized);
+		} else {
+			await seedCodexFolderTrust(target.file, normalized);
+		}
+	} catch (err) {
+		console.warn(
+			`[agents.run] failed to pre-trust session folder '${folderPath}' for agent '${config.presetId}':`,
+			err,
+		);
+	}
+}

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/seed-agent-trust.ts
@@ -17,7 +17,15 @@
  */
 
 import { existsSync, realpathSync } from "node:fs";
-import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+	chmod,
+	mkdtemp,
+	readFile,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { HostDb } from "../../../../db";
@@ -79,12 +87,22 @@ function resolveTrustTarget(
 	return { family, file: join(codexHome, "config.toml") };
 }
 
-/** Same-directory tmp write + rename, so a crash never truncates the store. */
+/**
+ * Same-directory tmp write + rename, so a crash never truncates the store.
+ * The replacement keeps the store's existing mode — these files can sit next
+ * to credentials, so a user-tightened mode must survive the rewrite — and a
+ * brand-new store starts owner-only.
+ */
 async function atomicWrite(file: string, content: string): Promise<void> {
+	const mode = await stat(file).then(
+		(info) => info.mode & 0o777,
+		() => 0o600,
+	);
 	const tmpDir = await mkdtemp(join(dirname(file), ".superset-trust-"));
 	const tmpFile = join(tmpDir, "next");
 	try {
 		await writeFile(tmpFile, content);
+		await chmod(tmpFile, mode);
 		await rename(tmpFile, file);
 	} finally {
 		await rm(tmpDir, { recursive: true, force: true });
@@ -112,6 +130,10 @@ export async function seedClaudeFolderTrust(
 		string,
 		Record<string, unknown> | undefined
 	>;
+	// `false` is Claude's default scaffold value ("dialog never accepted"),
+	// not a recorded decline — the CLI persists no decline state (declining
+	// just exits). So overwriting false → true is the intended seed, unlike
+	// Codex's explicit "untrusted", which is preserved below.
 	const existing = projects[folderPath];
 	if (existing?.hasTrustDialogAccepted === true) return;
 	state.projects = {
@@ -122,24 +144,43 @@ export async function seedClaudeFolderTrust(
 }
 
 /**
+ * True when the config already defines a `projects` entry for `folderPath`,
+ * tolerating header spacing and both TOML string styles (plus top-level
+ * dotted keys). Appending a duplicate table would make the whole file
+ * unparseable for Codex, so detection must be broader than the exact header
+ * Codex itself writes.
+ */
+function codexProjectEntryExists(content: string, folderPath: string): boolean {
+	const entry =
+		/^\s*\[?\s*projects\s*\.\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)')\s*[\].]/;
+	for (const line of content.split(/\r?\n/)) {
+		const match = entry.exec(line);
+		if (!match) continue;
+		const key =
+			match[1] !== undefined ? match[1].replace(/\\(["\\])/g, "$1") : match[2];
+		if (key === folderPath) return true;
+	}
+	return false;
+}
+
+/**
  * Append a `[projects."<path>"]` table with `trust_level = "trusted"` to a
- * Codex config.toml. An existing table for the path is left untouched — a
+ * Codex config.toml. An existing entry for the path is left untouched — a
  * user's explicit "untrusted" must not be overridden.
  */
 export async function seedCodexFolderTrust(
 	configFile: string,
 	folderPath: string,
 ): Promise<void> {
-	const escaped = folderPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-	const header = `[projects."${escaped}"]`;
 	let content = "";
 	if (existsSync(configFile)) {
 		content = await readFile(configFile, "utf-8");
-		if (content.split(/\r?\n/).some((line) => line.trim() === header)) return;
+		if (codexProjectEntryExists(content, folderPath)) return;
 	} else if (!existsSync(dirname(configFile))) {
 		return;
 	}
-	const block = `${header}\ntrust_level = "trusted"\n`;
+	const escaped = folderPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	const block = `[projects."${escaped}"]\ntrust_level = "trusted"\n`;
 	const next =
 		content.length === 0 ? block : `${content.replace(/\n*$/, "\n\n")}${block}`;
 	await atomicWrite(configFile, next);


### PR DESCRIPTION
## Summary
- Session workspaces no longer hit the agent CLI trust dialog ("Do you trust the files in this folder?") on every create — the host pre-trusts the session folder in the launching agent's own trust store before the launch.
- Covers Claude and Codex (and custom presets that run either binary); other providers are no-ops until their store format is added.

## Why / Context
Sessions are standalone git repos under `~/.superset/sessions` (`create-session.ts`), and agent CLI trust never crosses a git repo boundary from above: worktree workspaces inherit trust from the main checkout, plain directories inherit from trusted ancestors, but a fresh standalone repo inherits nothing — verified against Claude Code 2.1.245's trust-check logic and live pty probes (a trusted `~/.superset/sessions` parent does **not** cover a `git init`'d child; codex behaves the same). So every session agent launch blocked on the dialog until the user pressed Enter, and every session folder prompted again.

Auto-trusting is sound only because the host itself just created the folder as an empty scaffold. Both writes are the CLIs' own sanctioned escape hatches — Claude's untrusted-folder error literally says to set `projects[<path>].hasTrustDialogAccepted: true`, and Codex persists `trust_level = "trusted"` the same way.

## How It Works
- New `workspace-creation/shared/seed-agent-trust.ts`: resolves the provider family from the agent config's preset id **or** launch executable (covers custom presets), resolves the trust-store file mirroring launch env precedence (`{...resolveDefaultAccountEnv(family), ...config.env}` — per-agent `CLAUDE_CONFIG_DIR`/`CODEX_HOME` wins over the host-default account selection), then merges the entry: JSON read-modify-write for Claude's state file, TOML table append for Codex's `config.toml`. Writes are atomic (same-dir tmp + rename), merge-only (a corrupt file throws instead of being clobbered; an existing codex entry — including an explicit `"untrusted"` — is never overridden), and skip providers that were never onboarded.
- Hooked in `runAgentInWorkspace` gated on `workspace.projectId === null`, so one call site covers create-time dispatch (`dispatchSugarAgents` funnels through it), the agent strip, automations, and a different provider launched later into an existing session. Best-effort: a failed seed logs and the dialog just shows once.

## Manual QA Checklist
CDP A/B in the real dev desktop app (patch-file revert of the hook per side, full stack relaunch each side since host-service is main-process code):
- [x] **Pre-fix baseline:** `workspaces.createSession` with a claude agent → agent blocked on the in-app trust dialog in the session's terminal pane; no trust entry written; `terminal_agent_bindings` row never appeared.
- [x] **Post-fix:** same journey → claude booted straight into `~/.superset/sessions/<name>`, answered the test prompt, binding reached `Stop`; seed landed in the host-default account's profile (`~/.claude-work/.claude.json` in the dev snapshot — the exact file the launched claude read, which then merged its own runtime keys into the entry).
- [x] **Later launch into an existing session:** `agents.run` with codex on the same workspace → `trust_level = "trusted"` appended to `~/.codex/config.toml`, codex completed a full turn (binding `Stop`), no directory prompt. (Follow-up probe closed the YOLO caveat: codex launched with the app's exact flags — `--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust` — in an unseeded session repo still shows the directory-trust prompt, and the identical launch goes straight to the composer after seeding the folder through the real module. YOLO mode does not bypass folder trust, so this leg is a decisive A/B too.)
- [x] Standalone pty probes: fresh session repos prompted both bare CLIs before seeding and neither after seeding through the real module; a 1.5MB real `~/.claude.json` round-tripped intact (all prior projects + oauth preserved).
- [x] Test sessions destroyed cleanly afterwards (`workspaceCleanup.destroy` removed dirs + rows).

## Testing
- `bun test src/trpc/router/workspace-creation` (180 pass, includes 13 new tests for family resolution, JSON merge, TOML append, idempotency, corrupt-file and missing-config-dir handling; the codex idempotency guard was mutation-tested to confirm the suite catches regressions)
- `bun run typecheck` (host-service)
- `bunx biome check` on changed files

## Design Decisions
- **Seed at agent launch, not at session create:** `runAgentInWorkspace` is the single funnel for create-time dispatch, agent-strip launches, and automations — seeding only in `createSession` would miss any agent launched later into an existing session (including a different provider).
- **Why not trust the sessions root once:** there is no federation mechanism to inherit — trust is keyed per exact path and the ancestor walk stops at the enclosing git repo root by design (each repo is its own trust domain). Making sessions worktrees of a hidden shared repo would get worktree-style inheritance but breaks the standalone-repo semantics sessions were built on.

## Known Limitations
- `hasTrustDialogAccepted` is the mechanism Claude's dialog itself uses (and its error message recommends), but not a documented stable API — if a future CLI version changes it, the failure mode is the dialog returning, not breakage.
- A session created with **no** agent, where the user then types `claude` manually in a terminal, still prompts — nothing in the launch path knows about that folder.
- Concurrent CLI rewrites of the same state file can race the seed (both sides write whole-file via tmp+rename); the window is milliseconds at session create and the cost of losing is one dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New standalone agent session folders are automatically trusted for supported Claude and Codex configurations.
  * Existing trust settings are preserved, and repeated launches avoid duplicate entries.
  * Trust setup handles custom configuration locations and safely skips unsupported or unavailable configurations.

* **Bug Fixes**
  * Trust setup failures no longer prevent agent sessions from launching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
