### PR TITLE
fix(desktop): keep Sessions expanded when Projects collapses

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -298,7 +298,6 @@ export function DashboardSidebar({
 										<DashboardSidebarSessionsSection
 											sessionWorkspaces={sessionWorkspaces}
 											isCollapsed={isCollapsed}
-											rowsHidden={!isCollapsed && workspacesListCollapsed}
 											workspaceShortcutLabels={workspaceShortcutLabels}
 											onWorkspaceHover={refreshWorkspacePullRequest}
 										/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx
@@ -21,8 +21,6 @@ import { SortableWorkspaceItem } from "../SortableWorkspaceItem";
 interface DashboardSidebarSessionsSectionProps {
 	sessionWorkspaces: DashboardSidebarWorkspace[];
 	isCollapsed?: boolean;
-	/** The workspaces-list collapse toggle hides rows; the header stays. */
-	rowsHidden?: boolean;
 	workspaceShortcutLabels?: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 }
@@ -40,7 +38,6 @@ interface DashboardSidebarSessionsSectionProps {
 export function DashboardSidebarSessionsSection({
 	sessionWorkspaces,
 	isCollapsed = false,
-	rowsHidden = false,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 }: DashboardSidebarSessionsSectionProps) {
@@ -55,7 +52,6 @@ export function DashboardSidebarSessionsSection({
 	// zone renders regardless of the section collapse.
 	const dropZoneEligible =
 		!isCollapsed &&
-		!rowsHidden &&
 		sessionItems.length === 0 &&
 		activeWorkspaceHome === SESSIONS_CONTAINER;
 
@@ -98,7 +94,7 @@ export function DashboardSidebarSessionsSection({
 					<TooltipContent side="bottom">New session</TooltipContent>
 				</Tooltip>
 			</DashboardSidebarSectionHeader>
-			{!rowsHidden && !isSectionCollapsed && (
+			{!isSectionCollapsed && (
 				<SortableContext
 					items={sessionItems}
 					strategy={verticalListSortingStrategy}


### PR DESCRIPTION
## Summary

- remove the Projects collapse flag from the Sessions section
- make session rows and the empty-session drop zone depend only on Sessions collapse state

## Verification

- `bun run --cwd apps/desktop typecheck`
- `bunx @biomejs/biome@2.4.2 check apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarSessionsSection/DashboardSidebarSessionsSection.tsx`

## UI verification

Not run: no desktop renderer for this worktree was running; the available CDP target belonged to another workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session visibility and drop-zone behavior in the dashboard sidebar.
  * Session rows now consistently reflect the section’s collapsed state and available session content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->