### PR TITLE
fix(themes): readable syntax comments when brightBlack is a surface tone

### DIFF
--- a/apps/marketing/public/marketplace/themes/atlas.json
+++ b/apps/marketing/public/marketplace/themes/atlas.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#8770ad",
 		"brightCyan": "#7aa6a0",
 		"brightWhite": "#f3eadb"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6a5e48"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/brutalist.json
+++ b/apps/marketing/public/marketplace/themes/brutalist.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#e8e8e8",
 		"brightCyan": "#bdbdbd",
 		"brightWhite": "#ffffff"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#7a7a7a"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/catppuccin-frappe.json
+++ b/apps/marketing/public/marketplace/themes/catppuccin-frappe.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#f4b8e4",
 		"brightCyan": "#99d1db",
 		"brightWhite": "#c6d0f5"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#626880"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/catppuccin-latte.json
+++ b/apps/marketing/public/marketplace/themes/catppuccin-latte.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#ea76cb",
 		"brightCyan": "#04a5e5",
 		"brightWhite": "#4c4f69"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#acb0be"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/catppuccin-macchiato.json
+++ b/apps/marketing/public/marketplace/themes/catppuccin-macchiato.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#f5bde6",
 		"brightCyan": "#91d7e3",
 		"brightWhite": "#cad3f5"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#5b6078"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/catppuccin-mocha.json
+++ b/apps/marketing/public/marketplace/themes/catppuccin-mocha.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#f5c2e7",
 		"brightCyan": "#89dceb",
 		"brightWhite": "#cdd6f4"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#585b70"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/console.json
+++ b/apps/marketing/public/marketplace/themes/console.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#bdffce",
 		"brightCyan": "#9affae",
 		"brightWhite": "#d6ffdf"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#1a8c40"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/dracula.json
+++ b/apps/marketing/public/marketplace/themes/dracula.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#ff92df",
 		"brightCyan": "#a4ffff",
 		"brightWhite": "#ffffff"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6272a4"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/ember.json
+++ b/apps/marketing/public/marketplace/themes/ember.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#d494e6",
 		"brightCyan": "#73c7d3",
 		"brightWhite": "#ffffff"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#5c5856"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/ferro.json
+++ b/apps/marketing/public/marketplace/themes/ferro.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#c87a5a",
 		"brightCyan": "#a3c4c9",
 		"brightWhite": "#f0e8d8"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#857d70"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/github-dark-colorblind.json
+++ b/apps/marketing/public/marketplace/themes/github-dark-colorblind.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#d2a8ff",
 		"brightCyan": "#56d4dd",
 		"brightWhite": "#ffffff"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6e7681"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/gruvbox-dark.json
+++ b/apps/marketing/public/marketplace/themes/gruvbox-dark.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#d3869b",
 		"brightCyan": "#8ec07c",
 		"brightWhite": "#ebdbb2"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#928374"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/hangar.json
+++ b/apps/marketing/public/marketplace/themes/hangar.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#c87a5a",
 		"brightCyan": "#a3c4c9",
 		"brightWhite": "#f5f3ec"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#8c8d92"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/inkwell.json
+++ b/apps/marketing/public/marketplace/themes/inkwell.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#785588",
 		"brightCyan": "#578799",
 		"brightWhite": "#fcf8ee"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#5b6a85"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/kintsugi.json
+++ b/apps/marketing/public/marketplace/themes/kintsugi.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#bd9264",
 		"brightCyan": "#a3c4ba",
 		"brightWhite": "#f5e9d6"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#857762"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/monokai-classic.json
+++ b/apps/marketing/public/marketplace/themes/monokai-classic.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#ae81ff",
 		"brightCyan": "#a1efe4",
 		"brightWhite": "#f9f8f5"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#75715e"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/nord.json
+++ b/apps/marketing/public/marketplace/themes/nord.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#b48ead",
 		"brightCyan": "#8fbcbb",
 		"brightWhite": "#eceff4"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#7b88a1"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/obsidian.json
+++ b/apps/marketing/public/marketplace/themes/obsidian.json
@@ -69,5 +69,10 @@
 		"brightMagenta": "oklch(0.82 0.17 315)",
 		"brightCyan": "oklch(0.84 0.15 205)",
 		"brightWhite": "oklch(1 0 0)"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "oklch(0.58 0.012 265)"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/one-dark-pro.json
+++ b/apps/marketing/public/marketplace/themes/one-dark-pro.json
@@ -66,5 +66,10 @@
 		"brightMagenta": "#c678dd",
 		"brightCyan": "#56b6c2",
 		"brightWhite": "#ffffff"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#5c6370"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/reactor.json
+++ b/apps/marketing/public/marketplace/themes/reactor.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#b890d0",
 		"brightCyan": "#80ddee",
 		"brightWhite": "#dcefff"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#7188a3"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/riso.json
+++ b/apps/marketing/public/marketplace/themes/riso.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#ff7aae",
 		"brightCyan": "#7da9b8",
 		"brightWhite": "#fbf4dc"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6e6850"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/rose-pine.json
+++ b/apps/marketing/public/marketplace/themes/rose-pine.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#c4a7e7",
 		"brightCyan": "#ebbcba",
 		"brightWhite": "#e0def4"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6e6a86"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/solarized-dark.json
+++ b/apps/marketing/public/marketplace/themes/solarized-dark.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#6c71c4",
 		"brightCyan": "#93a1a1",
 		"brightWhite": "#fdf6e3"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#586e75"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/solarized-light.json
+++ b/apps/marketing/public/marketplace/themes/solarized-light.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#6c71c4",
 		"brightCyan": "#93a1a1",
 		"brightWhite": "#fdf6e3"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#002b36"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/supernova.json
+++ b/apps/marketing/public/marketplace/themes/supernova.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#e87aff",
 		"brightCyan": "#80e0f0",
 		"brightWhite": "#e8eefd"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6478a8"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/tokyo-night-blackout.json
+++ b/apps/marketing/public/marketplace/themes/tokyo-night-blackout.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#c8a4ff",
 		"brightCyan": "#a4dfff",
 		"brightWhite": "#c0caf5"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#414868"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/twilight-run.json
+++ b/apps/marketing/public/marketplace/themes/twilight-run.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#bb96e3",
 		"brightCyan": "#a0d8e6",
 		"brightWhite": "#eaf0fa"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6e83a3"
+		}
 	}
 }

--- a/apps/marketing/public/marketplace/themes/vellum.json
+++ b/apps/marketing/public/marketplace/themes/vellum.json
@@ -68,5 +68,10 @@
 		"brightMagenta": "#785588",
 		"brightCyan": "#7a9694",
 		"brightWhite": "#fcf6e3"
+	},
+	"editor": {
+		"syntax": {
+			"comment": "#6b5d3c"
+		}
 	}
 }

--- a/packages/shared/src/themes/editor-theme.ts
+++ b/packages/shared/src/themes/editor-theme.ts
@@ -13,7 +13,10 @@ function deriveCommentColor(theme: Theme): string {
 	if (!brightBlack) {
 		return theme.ui.mutedForeground;
 	}
-	const background = theme.terminal?.background ?? theme.ui.background;
+	const background =
+		theme.editor?.colors?.background ??
+		theme.terminal?.background ??
+		theme.ui.background;
 	const brightBlackContrast = wcagContrast(brightBlack, background);
 	if (brightBlackContrast >= MIN_COMMENT_CONTRAST) {
 		return brightBlack;

--- a/packages/shared/src/themes/editor-theme.ts
+++ b/packages/shared/src/themes/editor-theme.ts
@@ -1,5 +1,28 @@
+import { wcagContrast } from "culori";
 import { type EditorTheme, getTerminalColors, type Theme } from "./types";
 import { withAlpha } from "./utils";
+
+/* Some themes use terminal brightBlack as a surface tone (kintsugi #2a221a on
+ * #0d0a08 is 1.26:1), not a dim-text tone. Below this ratio comments are
+ * illegible, so fall back to mutedForeground. Authentic low-contrast comment
+ * palettes (tokyo-night 1.91, one-dark 2.32, solarized 2.79) stay untouched. */
+const MIN_COMMENT_CONTRAST = 1.8;
+
+function deriveCommentColor(theme: Theme): string {
+	const brightBlack = theme.terminal?.brightBlack;
+	if (!brightBlack) {
+		return theme.ui.mutedForeground;
+	}
+	const background = theme.terminal?.background ?? theme.ui.background;
+	const brightBlackContrast = wcagContrast(brightBlack, background);
+	if (brightBlackContrast >= MIN_COMMENT_CONTRAST) {
+		return brightBlack;
+	}
+	const muted = theme.ui.mutedForeground;
+	return wcagContrast(muted, background) > brightBlackContrast
+		? muted
+		: brightBlack;
+}
 
 /**
  * Get editor colors from a theme, falling back to a derived palette if not defined.
@@ -53,7 +76,7 @@ export function getEditorTheme(theme: Theme): EditorTheme {
 		},
 		syntax: {
 			plainText: theme.ui.foreground,
-			comment: terminal?.brightBlack ?? theme.ui.mutedForeground,
+			comment: deriveCommentColor(theme),
 			keyword: terminal?.magenta ?? theme.ui.primary,
 			string: terminal?.green ?? theme.ui.chart2,
 			number: terminal?.yellow ?? theme.ui.chart4,


### PR DESCRIPTION
## Problem

Syntax comments in the PR diff viewer (and code editor) are derived from the theme's ANSI `terminal.brightBlack`. Themes that use `brightBlack` as a surface tone instead of a dim-text tone render comments near-invisibly — kintsugi's `#2a221a` on `#0d0a08` is a 1.26:1 contrast ratio. Same class of failure in console (1.17), supernova (1.27), reactor, brutalist, twilight-run, hangar, ferro, and nord.

## Fix

Two layers:

1. **Runtime guard** (`packages/shared`): `getEditorTheme` keeps `brightBlack` only when it clears a 1.8:1 contrast floor against the resolved editor background; below that, comments fall back to `ui.mutedForeground` (kintsugi: `#857762`, 4.52:1). The 1.8 threshold sits in a natural gap: broken surface-tone themes are all ≤1.69, while deliberately-dim authentic comment palettes start at 1.91 (tokyo-night), so solarized, one-dark, catppuccin, dracula, monokai, and gruvbox keep their exact original colors. This fixes already-installed theme snapshots and externally imported themes on the next app update, with no user action.

2. **Explicit tokens** (`apps/marketing`): every marketplace theme now pins `editor.syntax.comment` (tokyo-night already did — its precedent). Values are generated from the post-fix derivation so rendering is unchanged; new installs no longer depend on derivation for the one slot where ANSI mapping misfires.

## Verification

- All 814 `packages/shared` tests pass; typecheck and lint clean.
- Simulated across all 29 marketplace themes: the 8 broken ones land at 3.5–5.2:1, the other 21 keep their current comment color; tokyo-night's JSON round-trips byte-identical.

https://claude.ai/code/session_01FJjJhj2xgHJRj5by85m1jw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tailored comment syntax colors across marketplace themes for clearer, theme-consistent code readability.
  - Improved comment color contrast by adapting colors to the editor background and falling back to more readable muted tones when needed.
- **Bug Fixes**
  - Resolved low-contrast comment colors that could be difficult to read in certain themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->