### PR TITLE
fix(desktop): stop one WebGL failure from latching all terminals onto the DOM renderer

### DIFF
--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -99,9 +99,17 @@ const forceRepaint = (win: BrowserWindow) => {
 };
 
 // GPU process restarts don't repaint existing compositor layers automatically.
+// Rate-limited: each repaint resizes the window, which runs a full fit +
+// refresh on every attached terminal, so a crash-looping GPU process must not
+// turn into an unbounded resize storm (GH #6822).
+const GPU_GONE_REPAINT_COOLDOWN_MS = 10_000;
+let lastGpuGoneRepaintAt = 0;
 app.on("child-process-gone", (_event, details) => {
 	if (details.type === "GPU") {
 		console.warn("[main-window] GPU process gone:", details.reason);
+		const now = Date.now();
+		if (now - lastGpuGoneRepaintAt < GPU_GONE_REPAINT_COOLDOWN_MS) return;
+		lastGpuGoneRepaintAt = now;
 		const win = getWindow();
 		if (win) forceRepaint(win);
 	}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -70,8 +70,9 @@ export function loadAddons(
 	setLigaturesEnabled(options.ligatures);
 
 	// Every terminal attempts WebGL on its own. A failure here degrades THIS
-	// terminal to xterm's DOM renderer, which costs roughly an order of
-	// magnitude more per frame — so it must never be latched for the session.
+	// terminal to xterm's DOM renderer, which costs 1.2x (a TUI redrawing a few
+	// dirty rows) to 13.7x (bulk scrolling output) more renderer CPU — so it
+	// must never be latched for the session.
 	// Losses are routinely transient (a driver reset after an OS update) or
 	// routine (browsers cap live WebGL contexts, so opening enough terminals
 	// evicts the oldest), and latching turned either into a permanently

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -16,9 +16,6 @@ export interface LoadAddonsResult {
 	dispose: () => void;
 }
 
-// Once WebGL fails, skip it for all subsequent runtimes (VS Code pattern).
-let suggestedRendererType: "webgl" | "dom" | undefined;
-
 // Truecolor-heavy TUIs mint unbounded glyph variants, growing the WebGL glyph
 // atlas without bound (SUPER-1793); reset it after this many page adds.
 const ATLAS_PAGE_ADDS_BEFORE_RESET = 32;
@@ -72,15 +69,24 @@ export function loadAddons(
 	};
 	setLigaturesEnabled(options.ligatures);
 
+	// Every terminal attempts WebGL on its own. A failure here degrades THIS
+	// terminal to xterm's DOM renderer, which costs roughly an order of
+	// magnitude more per frame — so it must never be latched for the session.
+	// Losses are routinely transient (a driver reset after an OS update) or
+	// routine (browsers cap live WebGL contexts, so opening enough terminals
+	// evicts the oldest), and latching turned either into a permanently
+	// degraded session recoverable only by restarting the app (GH #6822).
 	const rafId = requestAnimationFrame(() => {
-		if (disposed || suggestedRendererType === "dom") return;
+		if (disposed) return;
 
 		try {
 			webglAddon = new WebglAddon();
 			webglAddon.onContextLoss(() => {
 				webglAddon?.dispose();
 				webglAddon = null;
-				suggestedRendererType = "dom";
+				console.warn(
+					"[terminal] WebGL context lost — this terminal falls back to the DOM renderer",
+				);
 				terminal.refresh(0, terminal.rows - 1);
 			});
 			// Subscribe before loadAddon: the first page-add fires during activation.
@@ -94,8 +100,11 @@ export function loadAddons(
 				}
 			});
 			terminal.loadAddon(webglAddon);
-		} catch {
-			suggestedRendererType = "dom";
+		} catch (err) {
+			console.warn(
+				"[terminal] WebGL renderer unavailable — this terminal falls back to the DOM renderer",
+				err,
+			);
 			webglAddon = null;
 		}
 	});

--- a/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-addons.ts
@@ -105,6 +105,13 @@ export function loadAddons(
 				"[terminal] WebGL renderer unavailable — this terminal falls back to the DOM renderer",
 				err,
 			);
+			// xterm's AddonManager pushes the addon and wraps its dispose
+			// BEFORE calling activate(), and does not roll back when activate
+			// throws. Dropping the reference alone would strand the instance in
+			// the manager for the terminal's lifetime, so dispose it explicitly.
+			try {
+				webglAddon?.dispose();
+			} catch {}
 			webglAddon = null;
 		}
 	});


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/6822

## Summary
- Delete the session-wide WebGL→DOM renderer latch in `loadAddons`. One transient GPU context loss used to switch **every terminal created afterwards** onto xterm's DOM renderer for the rest of the app session, silently, with no recovery short of restarting the app.
- Log both fallback paths so a degraded session is visible in bug reports instead of invisible.
- Rate-limit the GPU-process-gone `forceRepaint` so a crash-looping GPU process can't drive a resize storm through every terminal.

## Why / Context

Reported as "Massive CPU consumption due to rendering" on macOS, right after the reporter updated macOS over the weekend — a GPU driver/blocklist change is exactly the trigger class for a first context loss.

`suggestedRendererType` lived at module scope, so the first failure anywhere in the window latched `"dom"` and every later terminal skipped WebGL entirely.

**The latch is the bug, not its threshold.** Falling back costs one failed `WebglAddon.activate()` per terminal creation. Latching costs every frame of every terminal for the rest of the session (1.2x-13.7x depending on workload, measured below). It also mishandles a routine case: browsers cap live WebGL contexts, so opening enough terminals evicts the oldest — and the latch turned that ordinary eviction into a permanently degraded session.

So this removes it rather than tuning it. Each terminal attempts WebGL independently; a failure degrades only that terminal.

## How It Works

`loadAddons` no longer consults or writes any cross-terminal state. The rAF block attempts `new WebglAddon()` + `loadAddon` per terminal; `onContextLoss` disposes that addon and refreshes that terminal only. Both the loss path and the construction-failure path `console.warn`, which reaches `main.log` as `[renderer-console]`.

## Manual QA — CDP verified end-to-end

Driven over CDP against the dev app **from this worktree** (verified target: CDP port owner's executable path is `…/issue-6822-renderer-cpu/…`, page target on this worktree's `DESKTOP_VITE_PORT=6745`). Real user journey: click workspace in sidebar → `Open Terminal` → **trusted** `Cmd+T` (`Input.dispatchKeyEvent`) per new tab → real `WEBGL_lose_context.loseContext()` on the terminal's own canvas. Identical script both sides; only `terminal-addons.ts` differed.

Renderer oracle established empirically: `Le` = WebGL renderer (class name matches the addon-webgl bundle; 3 canvases, 0 row divs), `mt` = DOM renderer (0 canvases, 53 row divs).

| | T1 created | T1 after its own context loss | **T2 created AFTER the loss** |
|---|---|---|---|
| **before** (`04976b33c`) | `Le` WebGL | `mt` DOM | **`mt` DOM — 0 canvases, 53 rows** |
| **after** (this branch) | `Le` WebGL | `mt` DOM | **`Le` WebGL — 2 canvases, 0 rows** |

- [x] Bug reproduces on the parent commit: a brand-new terminal opened after one context loss comes up on the DOM renderer
- [x] Fixed: a brand-new terminal opened after the same loss gets WebGL
- [x] The terminal that actually lost its context still degrades (the fix does not resurrect a lost context — it stops the loss spreading)
- [x] Fallback warning reaches `main.log`: `[renderer-console] [terminal] WebGL context lost — this terminal falls back to the DOM renderer`
- [x] App launches, terminals spawn, workspace switching works

**Cost of the regression, measured.** Renderer main-thread CPU (CDP `Performance.TaskDuration`), same terminal, before vs after its own context loss. **The cost depends heavily on the workload, so both patterns are reported:**

| workload | WebGL | DOM | ratio |
|---|---|---|---|
| scroll-heavy truecolor (600 lines streamed) | 4,663 ms stream / 8.6 ms avg frame | 64,009 ms / 74.1 ms avg frame | **13.7x** |
| Claude-Code-style shimmer, one line rewritten in place @10Hz | 16.5% of one core | 19.6% of one core | **1.19x** |

Read the second row for the reporter, who runs several Claude CLI sessions: that TUI is dirty-row-bounded, not scrolling, and there the gap is modest. The dramatic number applies to bulk output (build logs, test runs, `git log`) — common, but not what the original report describes.

**Caveat on the metric:** `TaskDuration` is renderer main-thread only and excludes the GPU process. A separate Electron-harness run of the shimmer workload using whole-process `ps %CPU` measured WebGL *higher* than DOM (glyph-atlas churn: WebGL mints a new atlas entry per distinct RGB, SUPER-1793, and the 32-page reset forces re-rasterization). Those two measurements are not directly comparable and I have not reconciled them. What both agree on: **DOM is never cheaper on the renderer main thread**, so removing the latch never pushes anyone onto a more expensive path there. Whether truecolor shimmer is net cheaper on DOM once GPU-process cost is counted is still open, belongs to the atlas-churn work, and is explicitly not what this PR claims to fix.

## Testing
- `bun run typecheck` (root + desktop)
- `bun run lint`
- `bun test src/renderer/lib/terminal src/main/windows` — 318 pass

## Design Decisions
- **Delete the latch instead of raising its threshold.** I first wrote a failure-budget policy module (3 distinct failures, 5s coalescing window) and deleted it: it still degrades the session permanently, just later, and it still mis-fires on routine WebGL context eviction. The latch buys a try/catch per terminal creation and costs between 1.2x and 13.7x per frame depending on workload — it is not worth keeping in any form.
- **No replacement unit test.** Testing this needs `@xterm/addon-webgl` mocked, and `mock.module` is process-global in this repo and has destabilized unrelated test files before. Guarding a deletion with a flaky test is a bad trade; the CDP A/B above is the evidence.

## Known Limitations
- The `main.ts` repaint cooldown is **defensive and unverified** — there is no evidence the reporter's GPU process was crash-looping. It bounds an externally-triggered unbounded operation (each repaint resizes the window, running a full fit + refresh through every attached terminal's `ResizeObserver`). Happy to drop it if a reviewer prefers this PR as a pure deletion.
- Only the renderer half was A/B'd over CDP; the `main.ts` change is main-process and would need a full relaunch to exercise.
- Terminals that lose their context still stay on DOM until they are recreated. Recovering a live terminal in place is out of scope here.

## Risks / Rollout
- Risk: low. Net deletion of cross-terminal state; per-terminal behavior on failure is unchanged.
- On a machine where WebGL is genuinely unavailable, every terminal now attempts and fails once instead of only the first — one failed `activate()` per terminal creation, not per frame.
- Rollback: revert the commit; no persisted state, no schema, no config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated graphics crashes from causing continuous window resizing and repainting.
  * Improved terminal rendering reliability by allowing each terminal to independently use WebGL.
  * Terminals now fall back to standard rendering if WebGL initialization fails or the graphics context is lost.
  * Improved cleanup after failed WebGL initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
