### PR TITLE
fix(desktop): API key revoke via org-scoped tRPC mutation with optimistic updates

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/api-keys/components/ApiKeysSettings/ApiKeysSettings.tsx
@@ -23,7 +23,6 @@ import {
 } from "react-icons/hi2";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
-import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
 import { useSettingsSearchQuery } from "renderer/stores/settings-state";
@@ -83,6 +82,25 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 		}
 	};
 
+	const revokeMutation = cloudTrpc.apiKey.revoke.useMutation({
+		onMutate: async ({ id }) => {
+			await utils.apiKey.list.cancel();
+			const previousKeys = utils.apiKey.list.getData();
+			utils.apiKey.list.setData(undefined, (keys) =>
+				keys?.filter((key) => key.id !== id),
+			);
+			return { previousKeys };
+		},
+		onError: (error, _input, context) => {
+			utils.apiKey.list.setData(undefined, context?.previousKeys);
+			toast.error(error.message || "Failed to revoke API key");
+		},
+		onSuccess: () => {
+			toast.success("API key revoked");
+		},
+		onSettled: () => utils.apiKey.list.invalidate(),
+	});
+
 	const handleRevokeKey = (id: string, name: string | null) => {
 		alert({
 			title: "Revoke API key",
@@ -92,10 +110,8 @@ export function ApiKeysSettings({ visibleItems }: ApiKeysSettingsProps) {
 				{
 					label: "Revoke",
 					variant: "destructive",
-					onClick: async () => {
-						await authClient.apiKey.delete({ keyId: id });
-						await utils.apiKey.list.invalidate();
-						toast.success("API key revoked");
+					onClick: () => {
+						revokeMutation.mutate({ id });
 					},
 				},
 			],

--- a/packages/trpc/src/router/api-key/api-key.ts
+++ b/packages/trpc/src/router/api-key/api-key.ts
@@ -5,11 +5,12 @@ import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { protectedProcedure } from "../../trpc";
-import { requireActiveOrgMembership } from "../utils/active-org";
 
 export const apiKeyRouter = {
+	// API keys mint a session as their creator, so they are personal
+	// credentials: list and revoke are scoped to the session user, never
+	// the organization.
 	list: protectedProcedure.query(async ({ ctx }) => {
-		const organizationId = await requireActiveOrgMembership(ctx);
 		return db
 			.select({
 				id: apikeys.id,
@@ -19,7 +20,7 @@ export const apiKeyRouter = {
 				lastRequest: apikeys.lastRequest,
 			})
 			.from(apikeys)
-			.where(eq(apikeys.organizationId, organizationId))
+			.where(eq(apikeys.referenceId, ctx.session.user.id))
 			.orderBy(desc(apikeys.createdAt));
 	}),
 
@@ -48,13 +49,12 @@ export const apiKeyRouter = {
 	revoke: protectedProcedure
 		.input(z.object({ id: z.uuid() }))
 		.mutation(async ({ ctx, input }) => {
-			const organizationId = await requireActiveOrgMembership(ctx);
 			const deleted = await db
 				.delete(apikeys)
 				.where(
 					and(
 						eq(apikeys.id, input.id),
-						eq(apikeys.organizationId, organizationId),
+						eq(apikeys.referenceId, ctx.session.user.id),
 					),
 				)
 				.returning({ id: apikeys.id });

--- a/packages/trpc/src/router/api-key/api-key.ts
+++ b/packages/trpc/src/router/api-key/api-key.ts
@@ -1,7 +1,7 @@
 import { db } from "@superset/db/client";
 import { apikeys } from "@superset/db/schema";
 import { TRPCError } from "@trpc/server";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { protectedProcedure } from "../../trpc";
@@ -43,5 +43,27 @@ export const apiKeyRouter = {
 			});
 
 			return { key: result.key };
+		}),
+
+	revoke: protectedProcedure
+		.input(z.object({ id: z.uuid() }))
+		.mutation(async ({ ctx, input }) => {
+			const organizationId = await requireActiveOrgMembership(ctx);
+			const deleted = await db
+				.delete(apikeys)
+				.where(
+					and(
+						eq(apikeys.id, input.id),
+						eq(apikeys.organizationId, organizationId),
+					),
+				)
+				.returning({ id: apikeys.id });
+
+			if (deleted.length === 0) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "API key not found",
+				});
+			}
 		}),
 };

--- a/packages/trpc/src/router/api-key/api-key.ts
+++ b/packages/trpc/src/router/api-key/api-key.ts
@@ -1,7 +1,7 @@
 import { db } from "@superset/db/client";
 import { apikeys } from "@superset/db/schema";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { protectedProcedure } from "../../trpc";
@@ -49,21 +49,9 @@ export const apiKeyRouter = {
 	revoke: protectedProcedure
 		.input(z.object({ id: z.uuid() }))
 		.mutation(async ({ ctx, input }) => {
-			const deleted = await db
-				.delete(apikeys)
-				.where(
-					and(
-						eq(apikeys.id, input.id),
-						eq(apikeys.referenceId, ctx.session.user.id),
-					),
-				)
-				.returning({ id: apikeys.id });
-
-			if (deleted.length === 0) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "API key not found",
-				});
-			}
+			await ctx.auth.api.deleteApiKey({
+				headers: ctx.headers,
+				body: { keyId: input.id },
+			});
 		}),
 };


### PR DESCRIPTION
## Problem

Revoking an API key from desktop Settings → API keys appeared to do nothing, with no error shown.

Root cause: the list was org-scoped (every key in the active organization), but revoke went through better-auth's client `apiKey.delete`, which only deletes keys whose `referenceId` matches the session user. Revoking any key created by another org member failed with NOT_FOUND — and since the better-auth client returns `{ error }` instead of throwing, the component ignored the failure, toasted "API key revoked", and refetched the unchanged list.

The org-wide list was itself the deeper bug: an API key mints a session **as its creator** (`enableSessionForAPIKeys`), so keys are personal credentials, not org resources — the org id stamped in key metadata is provenance only and doesn't constrain usage. Teammates' key metadata (name/prefix/last-used) shouldn't be visible on your settings screen at all.

## Fix

- **`packages/trpc`**:
  - `apiKey.list` now returns only the session user's keys (`reference_id = user.id`) instead of every key in the active org.
  - New `apiKey.revoke` mutation that calls `ctx.auth.api.deleteApiKey`, mirroring how `create` goes through better-auth. Better-auth's own ownership check is the authorization: with the list user-scoped, every id the UI can pass is the user's own key.
- **`apps/desktop`**: revoke now uses `cloudTrpc.apiKey.revoke.useMutation` with an optimistic update on the list (`onMutate` filter + snapshot), rollback and an error toast on failure, success toast only on success, and invalidation on settle. Server errors now surface in the toast instead of being silently ignored.

No admin permissioning added deliberately: since a key just impersonates its creator, removing a member from the org already cuts the key's org access — admin key revocation would solve a problem membership removal already covers.

## Testing

- `packages/trpc`: typecheck ✓, `bun run test` 50/50 ✓
- `apps/desktop`: typecheck ✓, `bun run test` 2896/2896 ✓
- biome check on changed files ✓

https://claude.ai/code/session_016owhMV2wiiG6Syua3BwcUk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to revoke API keys from the settings page.
  * API key management is now scoped to the signed-in account rather than the active organization.
  * Revoked keys are removed from the list immediately for a more responsive experience.

* **Bug Fixes**
  * Failed revocations now restore the previous key list and display an error.
  * Successful revocations show a confirmation message and refresh the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->