### PR TITLE
PR view follow-ups: markdown, checks, and responsive layout

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
@@ -32,7 +32,7 @@ export function CodeBlock({ children, className, node }: CodeBlockProps) {
 
 	if (isInline) {
 		return (
-			<code className="px-1.5 py-0.5 rounded-md bg-fill-selected font-mono text-sm">
+			<code className="px-1.5 py-0.5 rounded-md bg-fill-selected font-mono text-xs">
 				{children}
 			</code>
 		);

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
@@ -32,7 +32,7 @@ export function CodeBlock({ children, className, node }: CodeBlockProps) {
 
 	if (isInline) {
 		return (
-			<code className="px-1.5 py-0.5 rounded bg-muted font-mono text-sm">
+			<code className="px-1.5 py-0.5 rounded-md bg-fill-selected font-mono text-sm">
 				{children}
 			</code>
 		);

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx
@@ -5,7 +5,7 @@ import "./default.css";
 
 export const defaultConfig: MarkdownStyleConfig = {
 	wrapperClass: "default-markdown",
-	articleClass: "px-8 py-6 max-w-none",
+	articleClass: "px-8 pt-2 pb-6 max-w-none",
 	components: {
 		code: ({ className, children, node }) => (
 			<CodeBlock className={className} node={node}>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/config.tsx
@@ -5,7 +5,7 @@ import "./default.css";
 
 export const defaultConfig: MarkdownStyleConfig = {
 	wrapperClass: "default-markdown",
-	articleClass: "px-8 pt-2 pb-6 max-w-none",
+	articleClass: "px-8 pt-2 pb-6",
 	components: {
 		code: ({ className, children, node }) => (
 			<CodeBlock className={className} node={node}>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
@@ -1,6 +1,7 @@
 .default-markdown {
 	color: var(--foreground);
 	background: var(--background);
+	font-size: 0.875rem;
 }
 
 .default-markdown article {
@@ -8,8 +9,15 @@
 	margin: 0 auto;
 }
 
+/* Headings carry their own margin-top for spacing between blocks, but that
+ * still applies to the very first block too, stacking on top of the
+ * article's own padding for a much bigger gap than intended. */
+.default-markdown article > *:first-child {
+	margin-top: 0;
+}
+
 .default-markdown h1 {
-	font-size: 2.25rem;
+	font-size: 1.875rem;
 	font-weight: 700;
 	line-height: 1.2;
 	margin-top: 0;
@@ -18,7 +26,7 @@
 }
 
 .default-markdown h2 {
-	font-size: 1.5rem;
+	font-size: 1.25rem;
 	font-weight: 600;
 	line-height: 1.3;
 	margin-top: 2rem;
@@ -26,7 +34,7 @@
 }
 
 .default-markdown h3 {
-	font-size: 1.25rem;
+	font-size: 1.125rem;
 	font-weight: 600;
 	line-height: 1.4;
 	margin-top: 1.5rem;
@@ -36,7 +44,7 @@
 .default-markdown h4,
 .default-markdown h5,
 .default-markdown h6 {
-	font-size: 1rem;
+	font-size: 0.875rem;
 	font-weight: 600;
 	line-height: 1.5;
 	margin-top: 1.25rem;
@@ -84,7 +92,6 @@
 .default-markdown table {
 	width: 100%;
 	border-collapse: collapse;
-	font-size: 0.95rem;
 	margin: 1rem 0;
 }
 

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
@@ -13,8 +13,13 @@
 
 /* Headings carry their own margin-top for spacing between blocks, but that
  * still applies to the very first block too, stacking on top of the
- * article's own padding for a much bigger gap than intended. */
-.default-markdown article > *:first-child {
+ * article's own padding for a much bigger gap than intended. Two levels
+ * deep: react-markdown (MarkdownRenderer) puts the first block directly
+ * under <article>, but TipTapMarkdownRenderer wraps its editor content in
+ * its own root div (EditorContent's ProseMirror mount point) between
+ * <article> and the first real block — both share this stylesheet. */
+.default-markdown article > *:first-child,
+.default-markdown article > *:first-child > *:first-child {
 	margin-top: 0;
 }
 

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
@@ -6,7 +6,9 @@
 
 .default-markdown article {
 	width: 100%;
+	max-width: 56rem;
 	margin: 0 auto;
+	overflow-wrap: break-word;
 }
 
 /* Headings carry their own margin-top for spacing between blocks, but that
@@ -23,6 +25,8 @@
 	margin-top: 0;
 	margin-bottom: 1rem;
 	letter-spacing: -0.025em;
+	padding-bottom: 0.3rem;
+	border-bottom: 1px solid var(--border);
 }
 
 .default-markdown h2 {
@@ -31,6 +35,8 @@
 	line-height: 1.3;
 	margin-top: 2rem;
 	margin-bottom: 0.75rem;
+	padding-bottom: 0.3rem;
+	border-bottom: 1px solid var(--border);
 }
 
 .default-markdown h3 {

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/styles/default/default.css
@@ -23,8 +23,6 @@
 	line-height: 1.3;
 	margin-top: 2rem;
 	margin-bottom: 0.75rem;
-	padding-bottom: 0.5rem;
-	border-bottom: 1px solid var(--border);
 }
 
 .default-markdown h3 {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -280,7 +280,7 @@ function formatDiffStats(additions: number, deletions: number): string {
 // (data-title); the filename-first look (name in the foreground color, then
 // the containing directory trailing off in the muted color) is built by
 // hiding that native title and rendering our own split via
-// renderHeaderFilenameSuffix instead — see PR_CODE_TAB_CARD_UNSAFE_CSS's
+// renderHeaderFilenameSuffix instead — see prCodeTabCardUnsafeCss's
 // `[data-title] { display: none }` rule.
 function splitPath(path: string): { dir: string; name: string } {
 	const slashIndex = path.lastIndexOf("/");
@@ -846,7 +846,7 @@ export function PullRequestCodeTab({
 			({
 				...options,
 				// A visible gap between files is what makes the rounded
-				// header/diff pair (PR_CODE_TAB_CARD_UNSAFE_CSS) read as
+				// header/diff pair (prCodeTabCardUnsafeCss) read as
 				// separate cards rather than one continuous, oddly-cornered
 				// block — DiffPane's own gap: 0 doesn't need this since it
 				// has no such per-file card styling.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -276,11 +276,11 @@ function PullRequestDetailPage() {
 				    both hidden until they have real functionality wired up. */}
 			</div>
 
-			<div className="flex items-start justify-between gap-3 px-4 pb-3">
+			<div className="flex flex-wrap items-start justify-between gap-3 px-4 pb-3">
 				{isLoading ? (
 					<Skeleton className="h-6 w-72 max-w-full" />
 				) : (
-					<h1 className="min-w-0 select-text truncate text-xl font-semibold leading-tight">
+					<h1 className="min-w-[12rem] flex-1 select-text truncate text-xl font-semibold leading-tight">
 						{data?.title ??
 							(itemNumber === null ? "Pull request" : `#${itemNumber}`)}
 					</h1>
@@ -437,49 +437,53 @@ function PullRequestDetailPage() {
 							{data.author}
 						</span>
 					)}
-					<span aria-hidden>·</span>
-					<span className="shrink-0 font-mono tabular-nums">
-						#{data.number}
+					<span className="inline-flex shrink-0 items-center gap-2">
+						<span aria-hidden>·</span>
+						<span className="font-mono tabular-nums">#{data.number}</span>
 					</span>
-					<span aria-hidden>·</span>
-					<Tooltip delayDuration={1000}>
-						<TooltipTrigger asChild>
-							<button
-								type="button"
-								onClick={() => {
-									copyBranch(data.branch)
-										.then(() => {
-											toast.success("Branch copied", {
-												description: data.branch,
-												icon: (
-													<span className="flex size-4 items-center justify-center rounded-full bg-emerald-500">
-														<LuCheck
-															className="size-2.5 text-white"
-															strokeWidth={3}
-														/>
-													</span>
-												),
+					<span className="inline-flex min-w-0 shrink items-center gap-2">
+						<span aria-hidden>·</span>
+						<Tooltip delayDuration={1000}>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={() => {
+										copyBranch(data.branch)
+											.then(() => {
+												toast.success("Branch copied", {
+													description: data.branch,
+													icon: (
+														<span className="flex size-4 items-center justify-center rounded-full bg-emerald-500">
+															<LuCheck
+																className="size-2.5 text-white"
+																strokeWidth={3}
+															/>
+														</span>
+													),
+												});
+											})
+											.catch(() => {
+												toast.error("Couldn't copy branch name");
 											});
-										})
-										.catch(() => {
-											toast.error("Couldn't copy branch name");
-										});
-								}}
-								className="flex min-w-0 shrink items-center gap-1 font-mono text-muted-foreground hover:text-foreground"
-							>
-								<LuGitBranch className="size-3 shrink-0" />
-								<span className="truncate hover:underline">{data.branch}</span>
-							</button>
-						</TooltipTrigger>
-						<TooltipContent side="bottom">
-							{branchCopied ? "Copied" : "Click to copy"}
-						</TooltipContent>
-					</Tooltip>
+									}}
+									className="flex min-w-0 shrink items-center gap-1 font-mono text-muted-foreground hover:text-foreground"
+								>
+									<LuGitBranch className="size-3 shrink-0" />
+									<span className="truncate hover:underline">
+										{data.branch}
+									</span>
+								</button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								{branchCopied ? "Copied" : "Click to copy"}
+							</TooltipContent>
+						</Tooltip>
+					</span>
 					{createdAtLabel !== null && (
-						<>
+						<span className="inline-flex shrink-0 items-center gap-2">
 							<span aria-hidden>·</span>
-							<span className="shrink-0">{createdAtLabel}</span>
-						</>
+							<span>{createdAtLabel}</span>
+						</span>
 					)}
 				</div>
 			)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -633,7 +633,7 @@ function PullRequestDetailPage() {
 				className={cn("min-h-0 flex-1", activeTab !== "summary" && "hidden")}
 			>
 				<ScrollArea className="h-full">
-					<div className="grid w-full gap-8 px-4 pt-3 pb-6 @md:px-6 @md:pt-4 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:pb-8">
+					<div className="grid w-full gap-8 px-4 pt-3 pb-6 @md:px-6 @md:pt-4 @3xl:grid-cols-[minmax(0,1fr)_20rem] @3xl:pb-8">
 						<article className="group/description relative min-w-0">
 							<a
 								href={data.url}
@@ -653,7 +653,7 @@ function PullRequestDetailPage() {
 							)}
 						</article>
 
-						<aside className="min-w-0 @4xl:sticky @4xl:top-4 @4xl:self-start">
+						<aside className="min-w-0 @3xl:sticky @3xl:top-4 @3xl:self-start">
 							<PullRequestChecksSection checks={data.checks} />
 						</aside>
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -27,13 +27,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
-import {
-	LuCheck,
-	LuChevronDown,
-	LuChevronRight,
-	LuGitBranch,
-	LuPencil,
-} from "react-icons/lu";
+import { LuCheck, LuChevronRight, LuGitBranch, LuPencil } from "react-icons/lu";
 import { VscChevronDown, VscGitMerge } from "react-icons/vsc";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
@@ -131,7 +125,6 @@ function PullRequestDetailPage() {
 	);
 	const [activeTab, setActiveTab] = useState<DetailTab>("summary");
 	const [mergeComment, setMergeComment] = useState("");
-	const [isDescriptionCollapsed, setIsDescriptionCollapsed] = useState(false);
 	const { copyToClipboard: copyBranch, copied: branchCopied } =
 		useCopyToClipboard();
 
@@ -640,46 +633,27 @@ function PullRequestDetailPage() {
 				className={cn("min-h-0 flex-1", activeTab !== "summary" && "hidden")}
 			>
 				<ScrollArea className="h-full">
-					<div className="grid w-full gap-8 px-4 py-6 @md:px-6 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:py-8">
-						<article className="group/description flex min-w-0 flex-col gap-1">
-							<div className="flex items-center gap-1">
-								<button
-									type="button"
-									onClick={() =>
-										setIsDescriptionCollapsed((collapsed) => !collapsed)
-									}
-									className="-ml-2 flex w-fit items-center gap-1.5 rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
-								>
-									Description
-									<LuChevronDown
-										className={cn(
-											"size-3.5 shrink-0 transition-transform",
-											isDescriptionCollapsed && "-rotate-90",
-										)}
-									/>
-								</button>
-								<span className="min-w-0 flex-1" />
-								<a
-									href={data.url}
-									target="_blank"
-									rel="noopener noreferrer"
-									aria-label="Edit description"
-									className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-fill-hover hover:text-foreground focus-visible:opacity-100 group-hover/description:opacity-100"
-								>
-									<LuPencil className="size-3.5" />
-								</a>
-							</div>
-							{!isDescriptionCollapsed &&
-								(data.body.trim() ? (
-									<MarkdownRenderer content={data.body} />
-								) : (
-									<p className="text-sm italic text-muted-foreground">
-										No description provided.
-									</p>
-								))}
+					<div className="grid w-full gap-8 px-4 pt-3 pb-6 @md:px-6 @md:pt-4 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:pb-8">
+						<article className="group/description relative min-w-0">
+							<a
+								href={data.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								aria-label="Edit description"
+								className="absolute right-0 top-0 flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-fill-hover hover:text-foreground focus-visible:opacity-100 group-hover/description:opacity-100"
+							>
+								<LuPencil className="size-3.5" />
+							</a>
+							{data.body.trim() ? (
+								<MarkdownRenderer content={data.body} />
+							) : (
+								<p className="text-sm italic text-muted-foreground">
+									No description provided.
+								</p>
+							)}
 						</article>
 
-						<aside className="min-w-0 @4xl:sticky @4xl:top-6 @4xl:self-start">
+						<aside className="min-w-0 @4xl:sticky @4xl:top-4 @4xl:self-start">
 							<PullRequestChecksSection checks={data.checks} />
 						</aside>
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/page.tsx
@@ -27,7 +27,13 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
 import { FaGithub } from "react-icons/fa";
-import { LuCheck, LuChevronRight, LuGitBranch } from "react-icons/lu";
+import {
+	LuCheck,
+	LuChevronDown,
+	LuChevronRight,
+	LuGitBranch,
+	LuPencil,
+} from "react-icons/lu";
 import { VscChevronDown, VscGitMerge } from "react-icons/vsc";
 import { MarkdownRenderer } from "renderer/components/MarkdownRenderer";
 import { useHostUrl } from "renderer/hooks/host-service/useHostTargetUrl";
@@ -125,6 +131,7 @@ function PullRequestDetailPage() {
 	);
 	const [activeTab, setActiveTab] = useState<DetailTab>("summary");
 	const [mergeComment, setMergeComment] = useState("");
+	const [isDescriptionCollapsed, setIsDescriptionCollapsed] = useState(false);
 	const { copyToClipboard: copyBranch, copied: branchCopied } =
 		useCopyToClipboard();
 
@@ -634,14 +641,42 @@ function PullRequestDetailPage() {
 			>
 				<ScrollArea className="h-full">
 					<div className="grid w-full gap-8 px-4 py-6 @md:px-6 @4xl:grid-cols-[minmax(0,1fr)_20rem] @4xl:py-8">
-						<article className="min-w-0">
-							{data.body.trim() ? (
-								<MarkdownRenderer content={data.body} />
-							) : (
-								<p className="text-sm italic text-muted-foreground">
-									No description provided.
-								</p>
-							)}
+						<article className="group/description flex min-w-0 flex-col gap-1">
+							<div className="flex items-center gap-1">
+								<button
+									type="button"
+									onClick={() =>
+										setIsDescriptionCollapsed((collapsed) => !collapsed)
+									}
+									className="-ml-2 flex w-fit items-center gap-1.5 rounded px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
+								>
+									Description
+									<LuChevronDown
+										className={cn(
+											"size-3.5 shrink-0 transition-transform",
+											isDescriptionCollapsed && "-rotate-90",
+										)}
+									/>
+								</button>
+								<span className="min-w-0 flex-1" />
+								<a
+									href={data.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									aria-label="Edit description"
+									className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-fill-hover hover:text-foreground focus-visible:opacity-100 group-hover/description:opacity-100"
+								>
+									<LuPencil className="size-3.5" />
+								</a>
+							</div>
+							{!isDescriptionCollapsed &&
+								(data.body.trim() ? (
+									<MarkdownRenderer content={data.body} />
+								) : (
+									<p className="text-sm italic text-muted-foreground">
+										No description provided.
+									</p>
+								))}
 						</article>
 
 						<aside className="min-w-0 @4xl:sticky @4xl:top-6 @4xl:self-start">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestChecksSection/PullRequestChecksSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestChecksSection/PullRequestChecksSection.tsx
@@ -74,7 +74,7 @@ export function PullRequestChecksSection({
 							</>
 						);
 						const rowClassName =
-							"flex min-w-0 items-center gap-2 rounded-md px-2 py-2.5 -mx-2 hover:bg-fill-hover";
+							"flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 -mx-2 hover:bg-fill-hover";
 						return check.url ? (
 							<a
 								key={`${check.name}-${index}`}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestChecksSection/PullRequestChecksSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestChecksSection/PullRequestChecksSection.tsx
@@ -6,6 +6,16 @@ import {
 	summarizePullRequestChecks,
 } from "../pull-request-checks";
 
+// Capy's checks list states each row's outcome as a word next to the
+// external-link icon, not just an icon color — matches that.
+const CHECK_STATUS_LABELS: Record<PullRequestCheck["status"], string> = {
+	success: "Passed",
+	failure: "Failed",
+	pending: "Running",
+	skipped: "Skipped",
+	cancelled: "Cancelled",
+};
+
 interface PullRequestChecksSectionProps {
 	checks: PullRequestCheck[];
 }
@@ -33,9 +43,9 @@ export function PullRequestChecksSection({
 				</h2>
 				<span className="text-xs text-muted-foreground">{summaryLabel}</span>
 			</div>
-			<div className="overflow-hidden rounded-lg border border-border/70 bg-muted/15">
+			<div>
 				{checks.length === 0 ? (
-					<div className="flex items-center gap-2 px-3 py-3 text-xs text-muted-foreground">
+					<div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
 						<LuCircleMinus className="size-3.5" />
 						No checks reported for the latest commit.
 					</div>
@@ -55,13 +65,16 @@ export function PullRequestChecksSection({
 								<span className="min-w-0 flex-1 truncate text-xs">
 									{check.name}
 								</span>
+								<span className="shrink-0 text-xs text-muted-foreground">
+									{CHECK_STATUS_LABELS[check.status]}
+								</span>
 								{check.url && (
 									<LuArrowUpRight className="size-3.5 shrink-0 text-muted-foreground" />
 								)}
 							</>
 						);
 						const rowClassName =
-							"flex min-w-0 items-center gap-2 border-b border-border/50 px-3 py-2.5 last:border-b-0 hover:bg-accent/40";
+							"flex min-w-0 items-center gap-2 rounded-md px-2 py-2.5 -mx-2 hover:bg-fill-hover";
 						return check.url ? (
 							<a
 								key={`${check.name}-${index}`}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/layout.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@superset/ui/utils";
 import { createFileRoute, Outlet, useParams } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { resolveProjectFilterParams } from "renderer/routes/_authenticated/_dashboard/components/ProjectFilter/project-filter-utils";
 import { parsePositiveIntegerParam } from "renderer/routes/_authenticated/_dashboard/utils/parsePositiveIntegerParam";
 import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel";
@@ -13,6 +13,15 @@ import {
 	MIN_PULL_REQUESTS_LIST_WIDTH,
 	usePullRequestsSplitViewStore,
 } from "./stores/pullRequestsSplitViewStore";
+
+// The list panel keeps its own persisted width regardless of window size, so
+// on a narrower window it can eat a disproportionate share and leave the
+// detail pane too cramped to render its own header row (title, GitHub link,
+// Start Workspace, Merge) without truncating or clipping. Below this, the
+// list gets clamped down (display only — the user's stored preference is
+// left untouched, so it's back at its real width the moment the window
+// grows again).
+const MIN_DETAIL_PANE_WIDTH = 420;
 
 export type PullRequestsSearch = {
 	search?: string;
@@ -76,6 +85,30 @@ function PullRequestsLayout() {
 		[projects, project],
 	);
 
+	const rootRef = useRef<HTMLDivElement>(null);
+	const [containerWidth, setContainerWidth] = useState<number | null>(null);
+	useEffect(() => {
+		const el = rootRef.current;
+		if (!el) return;
+		const update = () => setContainerWidth(el.getBoundingClientRect().width);
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
+	// Display-only clamp: never call setListWidth here, or a narrow window
+	// would permanently overwrite the user's actual preferred width.
+	const displayListWidth =
+		containerWidth == null
+			? listWidth
+			: Math.min(
+					listWidth,
+					Math.max(
+						MIN_PULL_REQUESTS_LIST_WIDTH,
+						containerWidth - MIN_DETAIL_PANE_WIDTH,
+					),
+				);
+
 	const listContent = (
 		<PullRequestsView
 			initialSearch={search}
@@ -90,6 +123,7 @@ function PullRequestsLayout() {
 
 	return (
 		<div
+			ref={rootRef}
 			className={cn(
 				"flex h-full min-h-0 min-w-0 flex-1 overflow-hidden",
 				isAppSidebarCollapsed && "rounded-tl-[8px] bg-sidebar dark:bg-muted/35",
@@ -98,7 +132,7 @@ function PullRequestsLayout() {
 			{!isListCollapsed && (
 				<ResizablePanel
 					disabled={isDetailCollapsed}
-					width={listWidth}
+					width={displayListWidth}
 					onWidthChange={setListWidth}
 					isResizing={isResizingList}
 					onResizingChange={setIsResizingList}


### PR DESCRIPTION
## Summary
- Restyled the PR body's inline code pills and section headers to read closer to a native GitHub PR description (visible pill background, no stray divider clutter, then h1/h2 dividers restored once the target reference became GitHub itself)
- Restyled the Checks list to a flat, bordered-free row layout with each check's outcome spelled out (Passed/Failed/Running/Skipped/Cancelled), tightened row padding
- Added a hover-revealed "Edit description" affordance that opens the PR on GitHub
- Stepped every markdown font size down a tier and tightened the excess top padding above the description
- Fixed the checks sidebar disappearing below the fold on realistic window widths (was gated behind an 896px container query that a typical laptop window rarely reaches with the PR list panel open)
- Fixed a set of layout bugs found by comparing screenshots across four window widths (800/1024/1440/1979px) against GitHub's own PR page: the PR-list column could starve the detail pane down to an unusable width, the header row had no wrap so the title crushed to a few characters and the Merge button could be pushed fully off-screen, inline code could scissor mid-word, and the "· " separators in the metadata row could wrap orphaned

## Test plan
- [x] `bunx tsc --noEmit -p apps/desktop`
- [x] `bunx biome check` on touched files
- [x] Verified live in the dev app via CDP across light/dark mode and window widths 800/1024/1440/1979px

https://claude.ai/code/session_018s6aMRhQuJTWMekyCoeFVA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an edit-description link to pull request details.
  - Added clear status labels for checks, including Passed, Failed, Running, Skipped, and Cancelled.
- **Improvements**
  - Improved responsive pull request layouts and split-view space allocation.
  - Refined Markdown spacing, typography, wrapping, and readability.
  - Updated code blocks and headings for a cleaner appearance.
  - Refined check-list styling with compact hover states and clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->