### PR TITLE
feat(desktop): plain-click terminal links open in-app, shift-click external

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.test.ts
@@ -5,6 +5,7 @@ import { TerminalLinkManager } from "./terminal-link-manager";
 function createMockTerminal() {
 	const registeredProviders: ILinkProvider[] = [];
 	const disposedProviders: ILinkProvider[] = [];
+	const selectionState = { hasSelection: false };
 	const terminal = {
 		options: {
 			linkHandler: null,
@@ -23,9 +24,10 @@ function createMockTerminal() {
 			},
 		},
 		cols: 80,
+		hasSelection: () => selectionState.hasSelection,
 	} as unknown as XTerm;
 
-	return { terminal, registeredProviders, disposedProviders };
+	return { terminal, registeredProviders, disposedProviders, selectionState };
 }
 
 describe("TerminalLinkManager", () => {
@@ -64,6 +66,39 @@ describe("TerminalLinkManager", () => {
 		expect(onUrlClick).toHaveBeenCalledWith(event, "https://example.com");
 		expect(onLinkHover).toHaveBeenCalledWith(event, { kind: "url" });
 		expect(onLinkLeave).toHaveBeenCalled();
+	});
+
+	it("skips plain-click activation while text is selected, but not modifier clicks", () => {
+		const { terminal, selectionState } = createMockTerminal();
+		const manager = new TerminalLinkManager(terminal);
+		const onUrlClick = mock();
+
+		manager.setHandlers({
+			stat: async () => null,
+			onUrlClick,
+		});
+
+		const linkHandler = terminal.options.linkHandler;
+		const range = { start: { x: 1, y: 1 }, end: { x: 20, y: 1 } };
+
+		// Tail of a double-click word-select / intra-link drag: suppressed.
+		selectionState.hasSelection = true;
+		linkHandler?.activate({} as MouseEvent, "https://example.com", range);
+		expect(onUrlClick).not.toHaveBeenCalled();
+
+		// Shift-click extends the selection as a side effect but must still
+		// activate, else the shift binding would be unreachable.
+		linkHandler?.activate(
+			{ shiftKey: true } as MouseEvent,
+			"https://example.com",
+			range,
+		);
+		expect(onUrlClick).toHaveBeenCalledTimes(1);
+
+		// Plain click without a selection activates.
+		selectionState.hasSelection = false;
+		linkHandler?.activate({} as MouseEvent, "https://example.com", range);
+		expect(onUrlClick).toHaveBeenCalledTimes(2);
 	});
 
 	it("clears only the OSC link handler it installed", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-link-manager.ts
@@ -97,6 +97,24 @@ export class TerminalLinkManager {
 		this._oscLinkHandler = null;
 	}
 
+	/**
+	 * xterm activates a link whenever mousedown and mouseup hit the same link,
+	 * which includes the tail of a double-click word-select or a drag within
+	 * the link's own text. When an unmodified click ends with text selected,
+	 * the gesture was selection — not navigation — so activation is skipped
+	 * (also prevents double-click from activating twice). Modifier clicks
+	 * always activate: shift-click extends a selection as a side effect, and
+	 * suppressing it would make the binding unreachable.
+	 */
+	private _isSelectionGesture(event: MouseEvent): boolean {
+		return (
+			!event.metaKey &&
+			!event.ctrlKey &&
+			!event.shiftKey &&
+			this._terminal.hasSelection()
+		);
+	}
+
 	private _register(): void {
 		const handlers = this._handlers;
 		if (!handlers?.stat) return;
@@ -114,12 +132,20 @@ export class TerminalLinkManager {
 		const onLinkHover = handlers.onLinkHover;
 		const onLinkLeave = handlers.onLinkLeave;
 
+		const rawFileClick = handlers.onFileLinkClick;
+		const onFileClick = rawFileClick
+			? (event: MouseEvent, link: DetectedLink) => {
+					if (this._isSelectionGesture(event)) return;
+					rawFileClick(event, link);
+				}
+			: undefined;
+
 		// 1. File path detector (highest priority)
 		const detector = new LocalLinkDetector(this._resolver);
 		const adapter = new LinkDetectorAdapter(
 			this._terminal,
 			detector,
-			handlers.onFileLinkClick,
+			onFileClick,
 			onLinkHover
 				? (event, link) =>
 						onLinkHover(event, {
@@ -138,6 +164,7 @@ export class TerminalLinkManager {
 			const urlProvider = new UrlLinkProvider(
 				this._terminal,
 				(event, uri) => {
+					if (this._isSelectionGesture(event)) return;
 					onUrlClick(event, uri);
 				},
 				onLinkHover
@@ -153,6 +180,7 @@ export class TerminalLinkManager {
 			this._oscLinkHandler = {
 				allowNonHttpProtocols: false,
 				activate: (event, uri) => {
+					if (this._isSelectionGesture(event)) return;
 					onUrlClick(event, uri);
 				},
 				hover: onLinkHover
@@ -169,8 +197,7 @@ export class TerminalLinkManager {
 		// exists (validated via stat). Catches bare filenames like
 		// "AGENTS.md" that have no path separator or line suffix.
 		// To disable: remove or comment out this block.
-		if (handlers.onFileLinkClick) {
-			const onFileClick = handlers.onFileLinkClick;
+		if (onFileClick) {
 			const wordDetector = new WordLinkDetector(
 				this._terminal,
 				this._resolver,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -91,7 +91,7 @@ describe("healV2UserPreferences", () => {
 		);
 	});
 
-	it("migrates the legacy url link default to the current default", () => {
+	it("migrates the original url link default to the current default", () => {
 		const healed = healV2UserPreferences({
 			urlLinks: {
 				plain: null,
@@ -102,7 +102,23 @@ describe("healV2UserPreferences", () => {
 		});
 
 		expect(healed.urlLinks).toEqual(DEFAULT_V2_USER_PREFERENCES.urlLinks);
-		expect(healed.urlLinks.shift).toBe("newTab");
+		expect(healed.urlLinks.plain).toBe("pane");
+		expect(healed.urlLinks.shift).toBe("external");
+	});
+
+	it("migrates the second-generation url link default to the current default", () => {
+		const healed = healV2UserPreferences({
+			urlLinks: {
+				plain: null,
+				shift: "newTab",
+				meta: "pane",
+				metaShift: "external",
+			},
+		});
+
+		expect(healed.urlLinks).toEqual(DEFAULT_V2_USER_PREFERENCES.urlLinks);
+		expect(healed.urlLinks.plain).toBe("pane");
+		expect(healed.urlLinks.shift).toBe("external");
 	});
 
 	it("keeps a customized url link map untouched", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -307,10 +307,19 @@ const DEFAULT_LINK_TIER_MAP: LinkTierMap = {
 	metaShift: "external",
 };
 
-const DEFAULT_URL_LINKS: LinkTierMap = {
+// Retired urlLinks default (plain unbound, shift → new tab). Kept so heal can
+// migrate never-customized stored rows to the current default.
+const LEGACY_URL_LINKS: LinkTierMap = {
 	plain: null,
 	shift: "newTab",
 	meta: "pane",
+	metaShift: "external",
+};
+
+const DEFAULT_URL_LINKS: LinkTierMap = {
+	plain: "pane",
+	shift: "external",
+	meta: "newTab",
 	metaShift: "external",
 };
 
@@ -489,12 +498,15 @@ export function healV2UserPreferences(raw: unknown): V2UserPreferencesRow {
 		r.sidebarFileLinks &&
 		isCompleteLinkTierMap(r.sidebarFileLinks) &&
 		isSameLinkTierMap(r.sidebarFileLinks, LEGACY_SIDEBAR_FILE_LINKS);
-	// A stored map identical to the retired default was never customized —
-	// swap it for the current default (shift gained "newTab").
+	// A stored map identical to a retired default was never customized — swap
+	// it for the current default (plain-click now opens the in-app browser,
+	// shift-click the system browser). Two retired generations: the original
+	// shared map, then LEGACY_URL_LINKS.
 	const shouldMigrateLegacyUrlLinks =
 		r.urlLinks &&
 		isCompleteLinkTierMap(r.urlLinks) &&
-		isSameLinkTierMap(r.urlLinks, DEFAULT_LINK_TIER_MAP);
+		(isSameLinkTierMap(r.urlLinks, DEFAULT_LINK_TIER_MAP) ||
+			isSameLinkTierMap(r.urlLinks, LEGACY_URL_LINKS));
 	return {
 		...DEFAULT_V2_USER_PREFERENCES,
 		...r,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/helpers.ts
@@ -206,9 +206,11 @@ export function createTerminalInWrapper(options: CreateTerminalOptions = {}): {
 				});
 		},
 		onUrlClick: (event, uri) => {
-			if (!event.metaKey && !event.ctrlKey) return;
 			event.preventDefault();
-			const handler = urlClickRef?.current;
+			// Shift-click always opens the system browser. Any other click uses
+			// the in-app browser handler when one is installed (openLinksInApp
+			// setting), falling back to the system browser.
+			const handler = event.shiftKey ? undefined : urlClickRef?.current;
 			if (handler) {
 				handler(uri);
 				return;


### PR DESCRIPTION
## Summary

URL links in the terminal now open on **plain click** in the in-app browser, and **shift-click** opens the system browser.

- **v2 terminal**: new default `urlLinks` tier map — plain → in-app browser, shift → default browser, ⌘ → new in-app tab, ⌘⇧ → default browser. `healV2UserPreferences` migrates stored rows still on either retired default (original shared map, or the plain-unbound/shift-newTab generation); customized maps are untouched. Hover tooltips, click hints, and Settings → Links all follow the map, so no copy changes needed.
- **v1 terminal**: drops the cmd/ctrl-only gate. Plain click uses the in-app handler when the "Open links in the in-app browser" setting is on (system browser otherwise); shift-click always opens the system browser.
- **Selection guard** (`TerminalLinkManager`, shared by v1 + v2, covers URL, file, OSC 8, and word links): xterm activates a link whenever mousedown and mouseup hit the same link, so with plain click bound, double-clicking a URL to select it would have opened it — twice. Unmodified clicks that end with text selected (double-click word-select, intra-link drag) no longer activate. Modifier clicks still activate, since shift-click extends a selection as a side effect and would otherwise be unreachable.

## Test Plan

- [x] `bun test` on schema, withReadHeal, terminal-link-manager, and clickPolicy tiers — 46 pass, including new tests for the two-generation urlLinks migration and the selection-gesture guard
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on touched files
- [ ] Manual: plain click a URL in a v2 terminal → opens in-app browser pane; shift-click → system browser; ⌘-click → new in-app tab; double-click a URL → selects without opening

https://claude.ai/code/session_01W1jBRSrUHFuSnmtS7VjVRh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal links now open with a regular click, without requiring Ctrl/Meta.
  - Shift-click opens links in the system browser.
  - Other clicks use the configured in-app handler when available.

- **Bug Fixes**
  - Plain link activation is prevented while terminal text is selected, while modifier-click behavior remains available.
  - Updated link preferences are automatically migrated to the current actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->