### PR TITLE
feat(desktop): Cmd+K opens the command palette on macOS

### DIFF
--- a/apps/desktop/src/renderer/hotkeys/registry.ts
+++ b/apps/desktop/src/renderer/hotkeys/registry.ts
@@ -439,7 +439,10 @@ export const HOTKEYS_REGISTRY = {
 	},
 	CLEAR_TERMINAL: {
 		key: {
-			mac: L("meta+k"),
+			// meta+k belongs to OPEN_COMMAND_PALETTE; a shared chord would fire
+			// both handlers when a terminal is focused (react-hotkeys-hook has no
+			// precedence between scoped and global registrations).
+			mac: L("meta+shift+k"),
 			windows: L("ctrl+shift+k"),
 			linux: L("ctrl+shift+k"),
 		},
@@ -704,7 +707,7 @@ export const HOTKEYS_REGISTRY = {
 	},
 	OPEN_COMMAND_PALETTE: {
 		key: {
-			mac: L("meta+shift+k"),
+			mac: L("meta+k"),
 			windows: L("ctrl+shift+k"),
 			linux: L("ctrl+shift+k"),
 		},


### PR DESCRIPTION
## Summary

- `OPEN_COMMAND_PALETTE` mac default: `meta+shift+k` → `meta+k`, matching the Cmd+K convention (Linear, Slack, Raycast).
- `CLEAR_TERMINAL` mac default moves to `meta+shift+k` (mirroring the existing `ctrl+shift+k` on Windows/Linux). react-hotkeys-hook has no precedence between the terminal-scoped Clear handler and the global palette handler, so leaving both on `meta+k` would clear the terminal *and* open the palette on a single keypress in a focused terminal.

Windows/Linux palette stays on `ctrl+shift+k`: `ctrl+k` is readline kill-line, and registering it as an app chord would bubble it away from the shell.

No other surfaces hardcode these chords — no native menu accelerators, the sidebar hint derives from the registry, and user overrides in Settings > Keyboard are unaffected.

## Test Plan

- [x] `bun test src/renderer/hotkeys src/renderer/lib/terminal` — 447 pass
- [ ] On macOS: Cmd+K opens the palette (including with a terminal focused); Cmd+Shift+K clears a focused terminal

https://claude.ai/code/session_01TDNcHm7ttpccSwvRxeouzn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS keyboard shortcuts to prevent conflicts between clearing the terminal and opening the command palette.
  * Clear Terminal now uses `⌘⇧K`; Open Command Palette now uses `⌘K`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->