### PR TITLE
feat(marketing): tier icons and factory backdrop for leaderboard pages

### DIFF
--- a/apps/marketing/src/app/components/FactoryBackdrop/FactoryBackdrop.tsx
+++ b/apps/marketing/src/app/components/FactoryBackdrop/FactoryBackdrop.tsx
@@ -1,0 +1,53 @@
+const FLOOR_GRID =
+	"linear-gradient(to right, rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.04) 1px, transparent 1px)";
+
+const FLOOR_FADE = "linear-gradient(to bottom, black, transparent 62%)";
+
+const BRAND_RGB = "210,86,17";
+
+const guideLines = (halfWidth: number) =>
+	`linear-gradient(to right, transparent calc(50% - ${halfWidth}px), rgba(255,255,255,0.07) calc(50% - ${halfWidth}px), rgba(255,255,255,0.07) calc(50% - ${halfWidth - 1}px), transparent calc(50% - ${halfWidth - 1}px), transparent calc(50% + ${halfWidth - 1}px), rgba(255,255,255,0.07) calc(50% + ${halfWidth - 1}px), rgba(255,255,255,0.07) calc(50% + ${halfWidth}px), transparent calc(50% + ${halfWidth}px))`;
+
+const furnaceGlow = (rgb: string) =>
+	`radial-gradient(ellipse 62% 100% at 50% 0%, rgba(${rgb},0.14), rgba(${rgb},0.035) 45%, transparent 72%)`;
+
+interface FactoryBackdropProps {
+	tint?: string;
+	halfWidth?: number;
+}
+
+export function FactoryBackdrop({
+	tint = BRAND_RGB,
+	halfWidth = 448,
+}: FactoryBackdropProps) {
+	return (
+		<div
+			aria-hidden="true"
+			className="pointer-events-none absolute inset-0 overflow-hidden"
+		>
+			<div
+				className="absolute inset-0"
+				style={{
+					backgroundImage: FLOOR_GRID,
+					backgroundSize: "32px 32px",
+					maskImage: FLOOR_FADE,
+					WebkitMaskImage: FLOOR_FADE,
+				}}
+			/>
+			<div
+				className="absolute inset-x-0 top-0 h-[620px]"
+				style={{ backgroundImage: furnaceGlow(tint) }}
+			/>
+			<div
+				className="absolute inset-0"
+				style={{ backgroundImage: guideLines(halfWidth) }}
+			/>
+			<div
+				className="absolute inset-x-0 top-0 h-px"
+				style={{
+					backgroundImage: `linear-gradient(to right, transparent, rgba(${tint},0.55), transparent)`,
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/marketing/src/app/components/FactoryBackdrop/FactoryBackdrop.tsx
+++ b/apps/marketing/src/app/components/FactoryBackdrop/FactoryBackdrop.tsx
@@ -5,9 +5,14 @@ const FLOOR_FADE = "linear-gradient(to bottom, black, transparent 62%)";
 
 const BRAND_RGB = "210,86,17";
 
+/**
+ * The pair of hairlines marking the content column's edges. Takes the container's
+ * half-width because the pages that use this are not all the same measure.
+ */
 const guideLines = (halfWidth: number) =>
 	`linear-gradient(to right, transparent calc(50% - ${halfWidth}px), rgba(255,255,255,0.07) calc(50% - ${halfWidth}px), rgba(255,255,255,0.07) calc(50% - ${halfWidth - 1}px), transparent calc(50% - ${halfWidth - 1}px), transparent calc(50% + ${halfWidth - 1}px), rgba(255,255,255,0.07) calc(50% + ${halfWidth - 1}px), rgba(255,255,255,0.07) calc(50% + ${halfWidth}px), transparent calc(50% + ${halfWidth}px))`;
 
+/** Warm cast at the top of the page, tinted to whatever the page is about. */
 const furnaceGlow = (rgb: string) =>
 	`radial-gradient(ellipse 62% 100% at 50% 0%, rgba(${rgb},0.14), rgba(${rgb},0.035) 45%, transparent 72%)`;
 
@@ -16,6 +21,13 @@ interface FactoryBackdropProps {
 	halfWidth?: number;
 }
 
+/**
+ * Factory-floor grid, furnace glow and column guides behind a page.
+ *
+ * `tint` colours the glow and hairline: the leaderboard and stats pass nothing and
+ * get the brand orange, while a profile passes that developer's tier colour.
+ * `halfWidth` must match the content container or the guides miss its edges.
+ */
 export function FactoryBackdrop({
 	tint = BRAND_RGB,
 	halfWidth = 448,

--- a/apps/marketing/src/app/components/FactoryBackdrop/FactoryBackdrop.tsx
+++ b/apps/marketing/src/app/components/FactoryBackdrop/FactoryBackdrop.tsx
@@ -5,14 +5,9 @@ const FLOOR_FADE = "linear-gradient(to bottom, black, transparent 62%)";
 
 const BRAND_RGB = "210,86,17";
 
-/**
- * The pair of hairlines marking the content column's edges. Takes the container's
- * half-width because the pages that use this are not all the same measure.
- */
 const guideLines = (halfWidth: number) =>
 	`linear-gradient(to right, transparent calc(50% - ${halfWidth}px), rgba(255,255,255,0.07) calc(50% - ${halfWidth}px), rgba(255,255,255,0.07) calc(50% - ${halfWidth - 1}px), transparent calc(50% - ${halfWidth - 1}px), transparent calc(50% + ${halfWidth - 1}px), rgba(255,255,255,0.07) calc(50% + ${halfWidth - 1}px), rgba(255,255,255,0.07) calc(50% + ${halfWidth}px), transparent calc(50% + ${halfWidth}px))`;
 
-/** Warm cast at the top of the page, tinted to whatever the page is about. */
 const furnaceGlow = (rgb: string) =>
 	`radial-gradient(ellipse 62% 100% at 50% 0%, rgba(${rgb},0.14), rgba(${rgb},0.035) 45%, transparent 72%)`;
 
@@ -21,13 +16,6 @@ interface FactoryBackdropProps {
 	halfWidth?: number;
 }
 
-/**
- * Factory-floor grid, furnace glow and column guides behind a page.
- *
- * `tint` colours the glow and hairline: the leaderboard and stats pass nothing and
- * get the brand orange, while a profile passes that developer's tier colour.
- * `halfWidth` must match the content container or the guides miss its edges.
- */
 export function FactoryBackdrop({
 	tint = BRAND_RGB,
 	halfWidth = 448,

--- a/apps/marketing/src/app/components/FactoryBackdrop/index.ts
+++ b/apps/marketing/src/app/components/FactoryBackdrop/index.ts
@@ -1,0 +1,1 @@
+export { FactoryBackdrop } from "./FactoryBackdrop";

--- a/apps/marketing/src/app/components/TierBadge/TierBadge.tsx
+++ b/apps/marketing/src/app/components/TierBadge/TierBadge.tsx
@@ -1,3 +1,5 @@
+import { TierIcon } from "@/app/components/TierIcon";
+
 export const TIER_NAMES = [
 	"Button pusher",
 	"Operator",
@@ -5,12 +7,17 @@ export const TIER_NAMES = [
 	"Henry Ford",
 ] as const;
 
-const TIER_STYLES = [
-	"text-muted-foreground border-border",
-	"text-sky-400 border-sky-400/30",
-	"text-emerald-400 border-emerald-400/30",
-	"text-brand border-brand/40",
+export const TIER_RGB = [
+	"147,157,171",
+	"91,157,251",
+	"49,176,108",
+	"219,135,34",
 ] as const;
+
+const LOCKED_RGB = "255,255,255";
+
+export const tierRgb = (tier: number): string =>
+	TIER_RGB[tier - 1] ?? TIER_RGB[1];
 
 export const tierLabel = (tier: number): string =>
 	tier >= 1 && tier <= 4 ? (TIER_NAMES[tier - 1] ?? "Unranked") : "Unranked";
@@ -29,14 +36,22 @@ export function TierBadge({
 }: TierBadgeProps) {
 	const ranked = tier >= 1 && tier <= 4;
 	const style = ranked
-		? (TIER_STYLES[tier - 1] ?? TIER_STYLES[0])
-		: "text-muted-foreground/60 border-border/60";
+		? {
+				color: `rgb(${tierRgb(tier)})`,
+				borderColor: `rgba(${tierRgb(tier)},0.4)`,
+			}
+		: {
+				color: `rgba(${LOCKED_RGB},0.4)`,
+				borderColor: `rgba(${LOCKED_RGB},0.14)`,
+			};
 
 	if (size === "hero") {
 		return (
 			<div
-				className={`inline-flex flex-col items-center border px-8 py-4 ${style} ${className}`}
+				className={`inline-flex flex-col items-center border px-8 py-4 ${className}`}
+				style={style}
 			>
+				<TierIcon tier={tier} size={36} hollow={!ranked} className="mb-3" />
 				<span className="font-mono text-[0.58rem] uppercase tracking-[0.2em] opacity-60">
 					{ranked ? `Factory tier ${tier}` : "Unranked"}
 				</span>
@@ -49,8 +64,10 @@ export function TierBadge({
 
 	return (
 		<span
-			className={`inline-block border px-2 py-0.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] whitespace-nowrap ${style} ${className}`}
+			className={`inline-flex items-center gap-1.5 border px-2 py-0.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] whitespace-nowrap ${className}`}
+			style={style}
 		>
+			<TierIcon tier={tier} size={9} hollow={!ranked} />
 			{tierLabel(tier)}
 		</span>
 	);

--- a/apps/marketing/src/app/components/TierBadge/TierBadge.tsx
+++ b/apps/marketing/src/app/components/TierBadge/TierBadge.tsx
@@ -16,11 +16,9 @@ export const TIER_RGB = [
 
 const LOCKED_RGB = "255,255,255";
 
-/** Tier colour as an `r,g,b` triple, for interpolating into rgba(). */
 export const tierRgb = (tier: number): string =>
 	TIER_RGB[tier - 1] ?? TIER_RGB[1];
 
-/** Display name for a tier, falling back to "Unranked" outside 1-4. */
 export const tierLabel = (tier: number): string =>
 	tier >= 1 && tier <= 4 ? (TIER_NAMES[tier - 1] ?? "Unranked") : "Unranked";
 
@@ -31,12 +29,6 @@ interface TierBadgeProps {
 	className?: string;
 }
 
-/**
- * A developer's tier as an inline chip, or as the hero block on a profile.
- *
- * Colour comes from the tier palette rather than utility classes because the tiers
- * are tuned to a fixed luminance that Tailwind's scale does not have a step for.
- */
 export function TierBadge({
 	tier,
 	size = "sm",

--- a/apps/marketing/src/app/components/TierBadge/TierBadge.tsx
+++ b/apps/marketing/src/app/components/TierBadge/TierBadge.tsx
@@ -16,9 +16,11 @@ export const TIER_RGB = [
 
 const LOCKED_RGB = "255,255,255";
 
+/** Tier colour as an `r,g,b` triple, for interpolating into rgba(). */
 export const tierRgb = (tier: number): string =>
 	TIER_RGB[tier - 1] ?? TIER_RGB[1];
 
+/** Display name for a tier, falling back to "Unranked" outside 1-4. */
 export const tierLabel = (tier: number): string =>
 	tier >= 1 && tier <= 4 ? (TIER_NAMES[tier - 1] ?? "Unranked") : "Unranked";
 
@@ -29,6 +31,12 @@ interface TierBadgeProps {
 	className?: string;
 }
 
+/**
+ * A developer's tier as an inline chip, or as the hero block on a profile.
+ *
+ * Colour comes from the tier palette rather than utility classes because the tiers
+ * are tuned to a fixed luminance that Tailwind's scale does not have a step for.
+ */
 export function TierBadge({
 	tier,
 	size = "sm",

--- a/apps/marketing/src/app/components/TierBadge/index.ts
+++ b/apps/marketing/src/app/components/TierBadge/index.ts
@@ -1,1 +1,7 @@
-export { TIER_NAMES, TierBadge, tierLabel } from "./TierBadge";
+export {
+	TIER_NAMES,
+	TIER_RGB,
+	TierBadge,
+	tierLabel,
+	tierRgb,
+} from "./TierBadge";

--- a/apps/marketing/src/app/components/TierIcon/TierIcon.tsx
+++ b/apps/marketing/src/app/components/TierIcon/TierIcon.tsx
@@ -2,63 +2,68 @@ const GRID = 9;
 
 const ART = [
 	[
-		"##.....##",
+		"#########",
 		"#.......#",
-		".........",
-		".........",
-		".........",
-		".........",
-		"..#####..",
 		"#.......#",
-		"##.....##",
+		"#.......#",
+		"#.......#",
+		"#.......#",
+		"#.......#",
+		"#.#####.#",
+		"#########",
 	],
 	[
-		"##.....##",
+		"#########",
 		"#.......#",
-		".........",
-		".........",
-		".........",
-		"..#####..",
-		"..#####..",
 		"#.......#",
-		"##.....##",
+		"#.......#",
+		"#.......#",
+		"#.......#",
+		"#.#####.#",
+		"#.#####.#",
+		"#########",
 	],
 	[
-		"##.....##",
+		"#########",
 		"#.......#",
-		".........",
-		".........",
-		"..#####..",
-		"..#####..",
-		"..#####..",
 		"#.......#",
-		"##.....##",
+		"#.......#",
+		"#.......#",
+		"#.#####.#",
+		"#.#####.#",
+		"#.#####.#",
+		"#########",
 	],
 	[
-		"##.....##",
+		"#########",
 		"#.......#",
-		"..#####..",
-		"..#####..",
-		"..#####..",
-		"..#####..",
-		"..#####..",
-		"#.......#",
-		"##.....##",
+		"#.#####.#",
+		"#.#####.#",
+		"#.#####.#",
+		"#.#####.#",
+		"#.#####.#",
+		"#.#####.#",
+		"#########",
 	],
 ] as const;
 
 const FRAME = [
-	"##.....##",
+	"#########",
 	"#.......#",
-	".........",
-	".........",
-	".........",
-	".........",
-	".........",
 	"#.......#",
-	"##.....##",
+	"#.......#",
+	"#.......#",
+	"#.......#",
+	"#.......#",
+	"#.......#",
+	"#########",
 ] as const;
 
+/**
+ * Collapses a row of the grid into `[x, width]` spans of set cells. One rect per
+ * span rather than per cell keeps the emitted SVG small enough to inline at every
+ * call site without a sprite sheet.
+ */
 function rowRuns(row: string): Array<[number, number]> {
 	const runs: Array<[number, number]> = [];
 	let start = -1;
@@ -81,6 +86,13 @@ interface TierIconProps {
 	className?: string;
 }
 
+/**
+ * The factory tier drawn as a gauge filling up, on a 9x9 grid so the same art is
+ * pixel-exact at every size it ships at (9px in a table badge, 36px in the hero).
+ * Fills with `currentColor`, so the tier palette drives it with no per-icon colour.
+ *
+ * `hollow` renders the empty vessel, used for developers with no tier yet.
+ */
 export function TierIcon({
 	tier,
 	size = 18,

--- a/apps/marketing/src/app/components/TierIcon/TierIcon.tsx
+++ b/apps/marketing/src/app/components/TierIcon/TierIcon.tsx
@@ -59,11 +59,6 @@ const FRAME = [
 	"#########",
 ] as const;
 
-/**
- * Collapses a row of the grid into `[x, width]` spans of set cells. One rect per
- * span rather than per cell keeps the emitted SVG small enough to inline at every
- * call site without a sprite sheet.
- */
 function rowRuns(row: string): Array<[number, number]> {
 	const runs: Array<[number, number]> = [];
 	let start = -1;
@@ -86,13 +81,6 @@ interface TierIconProps {
 	className?: string;
 }
 
-/**
- * The factory tier drawn as a gauge filling up, on a 9x9 grid so the same art is
- * pixel-exact at every size it ships at (9px in a table badge, 36px in the hero).
- * Fills with `currentColor`, so the tier palette drives it with no per-icon colour.
- *
- * `hollow` renders the empty vessel, used for developers with no tier yet.
- */
 export function TierIcon({
 	tier,
 	size = 18,

--- a/apps/marketing/src/app/components/TierIcon/TierIcon.tsx
+++ b/apps/marketing/src/app/components/TierIcon/TierIcon.tsx
@@ -1,0 +1,116 @@
+const GRID = 9;
+
+const ART = [
+	[
+		"##.....##",
+		"#.......#",
+		".........",
+		".........",
+		".........",
+		".........",
+		"..#####..",
+		"#.......#",
+		"##.....##",
+	],
+	[
+		"##.....##",
+		"#.......#",
+		".........",
+		".........",
+		".........",
+		"..#####..",
+		"..#####..",
+		"#.......#",
+		"##.....##",
+	],
+	[
+		"##.....##",
+		"#.......#",
+		".........",
+		".........",
+		"..#####..",
+		"..#####..",
+		"..#####..",
+		"#.......#",
+		"##.....##",
+	],
+	[
+		"##.....##",
+		"#.......#",
+		"..#####..",
+		"..#####..",
+		"..#####..",
+		"..#####..",
+		"..#####..",
+		"#.......#",
+		"##.....##",
+	],
+] as const;
+
+const FRAME = [
+	"##.....##",
+	"#.......#",
+	".........",
+	".........",
+	".........",
+	".........",
+	".........",
+	"#.......#",
+	"##.....##",
+] as const;
+
+function rowRuns(row: string): Array<[number, number]> {
+	const runs: Array<[number, number]> = [];
+	let start = -1;
+	for (let x = 0; x <= row.length; x++) {
+		if (row[x] === "#") {
+			if (start < 0) start = x;
+		} else if (start >= 0) {
+			runs.push([start, x - start]);
+			start = -1;
+		}
+	}
+	return runs;
+}
+
+interface TierIconProps {
+	tier: number;
+
+	size?: number;
+	hollow?: boolean;
+	className?: string;
+}
+
+export function TierIcon({
+	tier,
+	size = 18,
+	hollow = false,
+	className = "",
+}: TierIconProps) {
+	const art = hollow ? FRAME : ART[tier - 1];
+	if (!art) return null;
+
+	return (
+		<svg
+			aria-hidden="true"
+			width={size}
+			height={size}
+			viewBox={`0 0 ${GRID} ${GRID}`}
+			shapeRendering="crispEdges"
+			className={`shrink-0 ${className}`}
+		>
+			{art.flatMap((row, y) =>
+				rowRuns(row).map(([x, width]) => (
+					<rect
+						key={`${y}:${x}`}
+						x={x}
+						y={y}
+						width={width}
+						height={1}
+						fill="currentColor"
+					/>
+				)),
+			)}
+		</svg>
+	);
+}

--- a/apps/marketing/src/app/components/TierIcon/index.ts
+++ b/apps/marketing/src/app/components/TierIcon/index.ts
@@ -1,0 +1,1 @@
+export { TierIcon } from "./TierIcon";

--- a/apps/marketing/src/app/components/TierTube/TierTube.tsx
+++ b/apps/marketing/src/app/components/TierTube/TierTube.tsx
@@ -1,11 +1,7 @@
-import { TIER_NAMES } from "@/app/components/TierBadge";
+import { TIER_NAMES, TIER_RGB } from "@/app/components/TierBadge";
+import { TierIcon } from "@/app/components/TierIcon";
 
-const ZONES = [
-	{ tier: 1, rgb: "138,144,153" },
-	{ tier: 2, rgb: "91,157,251" },
-	{ tier: 3, rgb: "63,207,127" },
-	{ tier: 4, rgb: "242,163,60" },
-] as const;
+const ZONES = TIER_RGB.map((rgb, index) => ({ tier: index + 1, rgb }));
 
 const railLeft = (position: number) =>
 	position <= 0 ? 0 : ((position - 0.5) / ZONES.length) * 100;
@@ -121,9 +117,7 @@ export function TierTube({
 									isActive ? "animate-station-pulse" : ""
 								}`}
 								style={{
-									borderColor: reached
-										? `rgb(${rgb})`
-										: "rgba(255,255,255,0.16)",
+									borderColor: reached ? `rgb(${rgb})` : `rgba(${rgb},0.4)`,
 									background: reached ? `rgb(${rgb})` : "transparent",
 									boxShadow: isActive
 										? `0 0 0 4px rgba(${rgb},0.16)`
@@ -160,15 +154,19 @@ export function TierTube({
 								/>
 							)}
 							<div
-								className={`text-xl leading-none ${
-									pixelClassName || "font-mono tracking-tight"
-								}`}
+								className="flex items-center gap-3"
 								style={{
-									color: reached ? `rgb(${rgb})` : undefined,
-									opacity: reached ? 1 : 0.35,
+									color: reached ? `rgb(${rgb})` : `rgba(${rgb},0.38)`,
 								}}
 							>
-								{value}
+								<TierIcon tier={tier} size={27} />
+								<span
+									className={`text-xl leading-none ${
+										pixelClassName || "font-mono tracking-tight"
+									}`}
+								>
+									{value}
+								</span>
 							</div>
 							<div className="font-mono text-[0.65rem] uppercase tracking-[0.12em] text-muted-foreground mt-2">
 								{TIER_NAMES[tier - 1]}

--- a/apps/marketing/src/app/leaderboard/page.tsx
+++ b/apps/marketing/src/app/leaderboard/page.tsx
@@ -2,6 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { Silkscreen } from "next/font/google";
 import Link from "next/link";
+import { FactoryBackdrop } from "@/app/components/FactoryBackdrop";
 import { fetchStandings, fetchStats } from "@/app/utils/fetchLeaderboard";
 import { LeaderboardBoard } from "./components/LeaderboardBoard";
 
@@ -45,6 +46,8 @@ export default async function LeaderboardPage() {
 
 	return (
 		<main className="relative min-h-screen">
+			<FactoryBackdrop />
+
 			<div className="relative max-w-4xl mx-auto px-6 py-10 md:py-14">
 				<header className="text-center pt-6 md:pt-10">
 					<h1

--- a/apps/marketing/src/app/stats/page.tsx
+++ b/apps/marketing/src/app/stats/page.tsx
@@ -2,6 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { Silkscreen } from "next/font/google";
 import Link from "next/link";
+import { FactoryBackdrop } from "@/app/components/FactoryBackdrop";
 import { fetchStats } from "@/app/utils/fetchLeaderboard";
 import { formatDayRange } from "@/app/utils/formatUsage";
 import { StatsBody } from "./components/StatsBody";
@@ -42,7 +43,9 @@ export default async function StatsPage() {
 
 	return (
 		<main className="relative min-h-screen">
-			<div className="max-w-4xl mx-auto px-6 py-10 md:py-14">
+			<FactoryBackdrop />
+
+			<div className="relative max-w-4xl mx-auto px-6 py-10 md:py-14">
 				<header className="text-center pt-6 md:pt-10">
 					<h1
 						className={`${pixel.className} text-3xl md:text-4xl text-foreground`}

--- a/apps/marketing/src/app/user/[handle]/page.tsx
+++ b/apps/marketing/src/app/user/[handle]/page.tsx
@@ -4,12 +4,15 @@ import { Silkscreen } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { FactoryBackdrop } from "@/app/components/FactoryBackdrop";
 import {
 	buildModelColors,
 	ModelBars,
 	toTokenRows,
 } from "@/app/components/ModelBars";
 import { StatStrip } from "@/app/components/StatStrip";
+import { tierRgb } from "@/app/components/TierBadge";
+import { TierIcon } from "@/app/components/TierIcon";
 import { TierTube } from "@/app/components/TierTube";
 import { TokenSplitBar } from "@/app/components/TokenSplitBar";
 import { avatarUrl } from "@/app/utils/avatarUrl";
@@ -86,8 +89,13 @@ export default async function UserProfilePage({ params }: PageProps) {
 		profile.allTime.tokens,
 	)} tokens of agent usage.`;
 
+	const tier = profile.factory?.tier ?? 0;
+	const tint = tier >= 1 ? tierRgb(tier) : undefined;
+
 	return (
 		<main className="relative min-h-screen">
+			<FactoryBackdrop tint={tint} halfWidth={384} />
+
 			<div className="relative max-w-3xl mx-auto px-6 py-10 md:py-14">
 				<Link
 					href="/leaderboard"
@@ -97,14 +105,31 @@ export default async function UserProfilePage({ params }: PageProps) {
 				</Link>
 
 				<header className="text-center pt-8 md:pt-10">
-					<Image
-						src={avatarUrl(profile.handle)}
-						alt=""
-						width={72}
-						height={72}
-						unoptimized
-						className="size-18 mx-auto rounded-[3px] bg-foreground/[0.04]"
-					/>
+					<div className="relative mx-auto w-fit">
+						<Image
+							src={avatarUrl(profile.handle)}
+							alt=""
+							width={72}
+							height={72}
+							unoptimized
+							className="size-18 rounded-[3px] bg-foreground/[0.04]"
+							style={
+								tint
+									? {
+											boxShadow: `0 0 0 1px rgba(${tint},0.45), 0 0 28px rgba(${tint},0.22)`,
+										}
+									: undefined
+							}
+						/>
+						{tier >= 1 && (
+							<span
+								className="absolute -bottom-2 -right-2 flex size-7 items-center justify-center border border-border bg-background"
+								style={{ color: `rgb(${tint})` }}
+							>
+								<TierIcon tier={tier} size={18} />
+							</span>
+						)}
+					</div>
 					<h1
 						className={`${pixel.className} text-2xl md:text-3xl text-foreground mt-5`}
 					>


### PR DESCRIPTION
## What & why

The leaderboard, stats and profile pages were flat: a plain background, and a tier
strip that was hard to read at a glance. Three changes.

**Tier icons.** A shared `TierIcon` draws each factory tier as a gauge filling up,
on a 9x9 grid rendered as `<rect>` runs with `shape-rendering: crispEdges`. The same
art is pixel-exact at every size it ships at — 9px in a table badge, 27px in the tier
tube, 36px in the profile hero. It fills with `currentColor`, so the tier palette
drives it with no per-icon colour.

**Page backdrop.** A shared `FactoryBackdrop` puts a factory-floor grid, a furnace
glow and the content-column guides behind a page. Leaderboard and stats take the
brand tint; a profile is tinted by that developer's own tier, and the avatar picks up
a matching crest and glow. It is parameterised by tint and container half-width,
which is a small step toward the same gradient that is currently hardcoded inline in
twelve other pages.

**Tier palette.** `brand-light` — the colour of every stat number on these pages —
sits at relative luminance 0.331, but emerald was at 0.47 and amber at 0.45. Those
two read brighter than everything around them, which is what made the tier strip look
uneven. All four tiers now land at ~0.33 and about 7:1 against the background:

| Tier | Before | After | Luminance | Contrast |
|---|---|---|---|---|
| Button pusher | `#8a9099` | `#939dab` | 0.333 | 7.21:1 |
| Operator | `#5b9dfb` | `#5b9dfb` | 0.333 | 7.22:1 |
| Plant Manager | `#3fcf7f` | `#31b06c` | 0.328 | 7.12:1 |
| Henry Ford | `#f2a33c` | `#db8722` | 0.325 | 7.07:1 |

Unreached tiers keep their own icon and hue at 38% alpha instead of collapsing to
grey, so you can see the whole ladder before you have climbed it.

No API, data or caching changes — this is presentation only.

## How I tested it

Drove the dev app at 1440x1000 over CDP and captured `/leaderboard`, `/stats` and
`/user/<handle>`, checking the tier strip, the badges in the table, the tier tube
cards and the profile avatar crest.

That pass caught a real defect. The first version of the gauge used corner brackets,
which at 27px collapse into 2px stubs and read as scattered fragments rather than a
gauge — worst on the avatar crest, where it looked like a rendering artifact. The
frame is now continuous, so it reads as a vessel filling. Screenshots below.

Also verified:

- `bun run lint` — clean, no warnings
- `bun run typecheck` — clean across all packages
- `bun test` in `apps/marketing` — 11/11 pass

The 192 failures in a full-repo `bun test` are git/PTY/worktree integration tests in
desktop and host-service. None are in `apps/marketing`, and this diff touches nothing
outside it. I did not diff them against a clean tree.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a factory-inspired decorative backdrop to leaderboard, stats, and profile pages.
  - Added crisp tier artwork with filled and hollow icon styles.
  - Enhanced profile avatars with tier-colored glows and conditional tier badges.
- **Improvements**
  - Updated tier badges and leaderboard summaries with consistent tier colors.
  - Improved visual distinction for locked and unreached tiers.
  - Refined tier visuals for clearer, more consistent presentation across pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->