### PR TITLE
fix(panes): keep resize handles from painting above dialogs

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/Tab.tsx
@@ -292,7 +292,9 @@ export function Tab<TData>({
 	}
 
 	return (
-		<div className="flex h-full w-full min-h-0 min-w-0 flex-1 overflow-auto">
+		// isolate contains the resize handles' z-indexes so they never paint
+		// above body-portalled overlays (dialogs, menus).
+		<div className="isolate flex h-full w-full min-h-0 min-w-0 flex-1 overflow-auto">
 			<LayoutNodeView
 				store={store}
 				tab={tab}

--- a/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
+++ b/packages/panes/src/react/components/Workspace/components/Tab/constants.ts
@@ -11,5 +11,7 @@ export const RESIZE_HANDLE_CLICK_MAX_MOVEMENT_PX = 4;
 
 // At a T-junction, a nested perpendicular handle can overlap its ancestor's
 // hit area. Shallower handles stay above deeper ones so the border under the
-// pointer does not change identity after that border is dragged.
+// pointer does not change identity after that border is dragged. The pane
+// tree root isolates, so these values only order elements within the tree —
+// they never lift a handle above portalled overlays like dialogs.
 export const RESIZE_HANDLE_BASE_Z_INDEX = 100;


### PR DESCRIPTION
## Summary

#6834 (border double-click equalize) hoisted pane resize handles to `z-index: 100 - depth` so their hit areas cover the active pane's 2px border. Nothing between the handles and `<body>` created a stacking context, so the sash competed with body-portalled overlays directly — dialogs render at `z-50`, and the divider painted a line straight through them (e.g. the delete-session confirm).

Fix: add `isolate` to the pane-tree root in `Tab.tsx`. The handle z-indexes keep their internal ordering (hit area above pane borders, shallower sash above deeper at T-junctions) but can no longer outrank portalled overlays, whatever values the pane code uses.

## Verification (CDP, real dev app)

A/B/A on the same open delete-session dialog spanning a split divider, toggling `isolate` via HMR:

- without `isolate` (main): 8x magnified clip shows the sash slicing through the dialog text — reproduces the report exactly
- with the fix: identical clip, line gone

Also re-verified the #6834 feature end-to-end with real input: drag to 354/753, double-click 2px off the line on the pane border → 554/554; drag the other way, double-click on the line → 554/554. `console.error` hooked and empty throughout.

Note: `elementFromPoint` is not valid evidence here — a modal dialog makes the rest of the page `pointer-events: none`, so it returns the dialog even when the sash paints on top. Paint-level screenshots were used instead.

## Test Plan

- [x] `bun run typecheck` + 101 pane store tests pass
- [x] CDP: dialog over split divider is not sliced by the sash (fail-before/pass-after)
- [x] CDP: double-click equalize still works on the line and on the adjacent pane border

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pane resize handles painting above dialogs. After the border double-click fix (#6834) raised handle z-indexes, the sash sliced through body-portalled overlays like the delete-session confirm. The pane tree root is now isolated, so handle z-indexes only order elements inside the tree and dialogs paint above them as before. Double-click equalize still works on the divider and adjacent pane border.

<sup>Written for commit c001e8385ca4758494903a42fc9d5cc1efd519c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resize handles appearing above dialogs, menus, and other overlays.
  * Improved layering behavior so overlays consistently appear in front of workspace tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->