### PR TITLE
fix(desktop): make New Window reachable without the native menu bar

### DIFF
--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -157,9 +157,17 @@ const config: Configuration = {
 		// Chrome/VS Code approach) is always shown. A plain relaunch hits the
 		// single-instance lock, which opens a new window.
 		desktop: {
+			// electron-builder appends [Desktop Action] groups but never writes
+			// the Actions= key that exposes them, so declare it explicitly —
+			// launchers ignore action groups not listed under Actions.
+			entry: {
+				Actions: "new-window;",
+			},
 			desktopActions: {
 				"new-window": {
 					Name: "New Window",
+					// Must mirror the generated main Exec (AppImage default when
+					// linux.executableArgs is unset); update both together.
 					Exec: "AppRun --no-sandbox",
 				},
 			},

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -166,9 +166,12 @@ const config: Configuration = {
 			desktopActions: {
 				"new-window": {
 					Name: "New Window",
-					// Must mirror the generated main Exec (AppImage default when
-					// linux.executableArgs is unset); update both together.
-					Exec: "AppRun --no-sandbox",
+					// Args must stay in sync with linux.executableArgs (the
+					// AppImage default is --no-sandbox when unset); %U is
+					// intentionally omitted. --new-window is what the
+					// second-instance handler keys on to open a window instead
+					// of focusing the running app.
+					Exec: "AppRun --no-sandbox --new-window",
 				},
 			},
 		},

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -154,8 +154,9 @@ const config: Configuration = {
 		artifactName: `superset-\${version}-\${arch}.\${ext}`,
 		// GNOME's app menus only show their heuristic "New Window" item
 		// intermittently for running apps; an explicit desktop action (the
-		// Chrome/VS Code approach) is always shown. A plain relaunch hits the
-		// single-instance lock, which opens a new window.
+		// Chrome/VS Code approach) is always shown. The action relaunches with
+		// --new-window, which the second-instance handler answers by opening a
+		// window; a plain relaunch focuses the running app.
 		desktop: {
 			// electron-builder appends [Desktop Action] groups but never writes
 			// the Actions= key that exposes them, so declare it explicitly —

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -152,6 +152,18 @@ const config: Configuration = {
 		synopsis: pkg.description,
 		target: ["AppImage"],
 		artifactName: `superset-\${version}-\${arch}.\${ext}`,
+		// GNOME's app menus only show their heuristic "New Window" item
+		// intermittently for running apps; an explicit desktop action (the
+		// Chrome/VS Code approach) is always shown. A plain relaunch hits the
+		// single-instance lock, which opens a new window.
+		desktop: {
+			desktopActions: {
+				"new-window": {
+					Name: "New Window",
+					Exec: "AppRun --no-sandbox",
+				},
+			},
+		},
 	},
 
 	// Windows

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,6 +32,7 @@ import { loadWebviewBrowserExtension } from "./lib/extensions";
 import { getHostServiceCoordinator } from "./lib/host-service-coordinator";
 import { localDb } from "./lib/local-db";
 import { requestLocalNetworkAccess } from "./lib/local-network-permission";
+import { menuEmitter } from "./lib/menu-events";
 import { PAGE_SCHEME, pageProtocolHandler } from "./lib/pageContent";
 import {
 	initTanstackDbPersistence,
@@ -356,11 +357,18 @@ if (!gotTheLock) {
 } else {
 	// Windows/Linux: protocol URL arrives as argv on the second instance
 	app.on("second-instance", async (_event, argv) => {
-		focusMainWindow();
 		const url = findDeepLinkInArgv(argv);
 		if (url) {
+			focusMainWindow();
 			await processDeepLink(url);
+			return;
 		}
+		// A plain relaunch with no deep link is the OS asking for a window: the
+		// shell's "New Window" (GNOME top-bar/dock app menus) and a second click
+		// on the launcher both re-run the executable, and the single-instance
+		// lock lands them here. Focusing alone made those clicks a silent no-op.
+		console.log("[main] Second instance launched; opening a new window");
+		menuEmitter.emit("new-window");
 	});
 
 	(async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -357,18 +357,32 @@ if (!gotTheLock) {
 } else {
 	// Windows/Linux: protocol URL arrives as argv on the second instance
 	app.on("second-instance", async (_event, argv) => {
+		// An auto-update restart spawns the replacement while this process
+		// still holds the single-instance lock; don't build windows mid-quit.
+		if (isQuitting) return;
 		const url = findDeepLinkInArgv(argv);
 		if (url) {
-			focusMainWindow();
+			// processDeepLink focuses the window on every one of its paths.
 			await processDeepLink(url);
 			return;
 		}
-		// A plain relaunch with no deep link is the OS asking for a window: the
-		// shell's "New Window" (GNOME top-bar/dock app menus) and a second click
-		// on the launcher both re-run the executable, and the single-instance
-		// lock lands them here. Focusing alone made those clicks a silent no-op.
-		console.log("[main] Second instance launched; opening a new window");
-		menuEmitter.emit("new-window");
+		// The desktop entry's "New Window" action (GNOME top-bar/dock app
+		// menus) relaunches the executable with --new-window, and the
+		// single-instance lock lands it here. A plain relaunch keeps the
+		// Electron-standard behavior of focusing the running app, so a
+		// Start-menu or launcher re-click never stacks extra windows. The
+		// listener-count check covers the boot window before initAppServices
+		// registers the handler; falling back to focus matches pre-ready
+		// behavior instead of dropping the event silently.
+		if (
+			argv.includes("--new-window") &&
+			menuEmitter.listenerCount("new-window") > 0
+		) {
+			console.log("[main] Second instance requested a new window");
+			menuEmitter.emit("new-window");
+			return;
+		}
+		focusMainWindow();
 	});
 
 	(async () => {

--- a/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
@@ -183,7 +183,7 @@ export const actionsProvider: CommandProvider = {
 			},
 			{
 				id: "actions.newWindow",
-				title: "New Window",
+				title: "New window",
 				section: "actions",
 				icon: AppWindowIcon,
 				keywords: ["window", "open", "multi"],

--- a/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
@@ -186,7 +186,7 @@ export const actionsProvider: CommandProvider = {
 				title: "New window",
 				section: "actions",
 				icon: AppWindowIcon,
-				keywords: ["window", "open", "multi"],
+				keywords: ["open", "multi"],
 				run: async () => {
 					try {
 						await electronTrpcClient.window.openNew.mutate();

--- a/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/actions/commands.tsx
@@ -1,6 +1,7 @@
 import type { DesktopNotice } from "@superset/shared/desktop-notices";
 import { toast } from "@superset/ui/sonner";
 import {
+	AppWindowIcon,
 	BellIcon,
 	BellOffIcon,
 	CircleCheckIcon,
@@ -177,6 +178,22 @@ export const actionsProvider: CommandProvider = {
 						const message =
 							error instanceof Error ? error.message : String(error);
 						toast.error(`Failed to check for updates: ${message}`);
+					}
+				},
+			},
+			{
+				id: "actions.newWindow",
+				title: "New Window",
+				section: "actions",
+				icon: AppWindowIcon,
+				keywords: ["window", "open", "multi"],
+				run: async () => {
+					try {
+						await electronTrpcClient.window.openNew.mutate();
+					} catch (error) {
+						const message =
+							error instanceof Error ? error.message : String(error);
+						toast.error(`Failed to open new window: ${message}`);
 					}
 				},
 			},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -195,7 +195,7 @@ export function OrganizationDropdown({
 
 					<DropdownMenuItem onSelect={() => openNewWindow.mutate()}>
 						<HiOutlineWindow className="h-4 w-4" />
-						<span>New Window</span>
+						<span>New window</span>
 					</DropdownMenuItem>
 
 					<HelpSubMenu onSubmitPrompt={() => setSubmitPromptOpen(true)} />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -43,9 +43,8 @@ export function OrganizationDropdown({
 	const navigate = useNavigate();
 	const [submitPromptOpen, setSubmitPromptOpen] = useState(false);
 	const openNewWindow = electronTrpc.window.openNew.useMutation({
-		onError: (error) => {
-			toast.error(`Failed to open new window: ${error.message}`);
-		},
+		onError: (error) =>
+			toast.error(`Failed to open new window: ${error.message}`),
 	});
 
 	// Per-window active org (from CollectionsProvider), not the shared session —

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/TopBar/components/OrganizationDropdown/OrganizationDropdown.tsx
@@ -11,6 +11,7 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { FiUsers } from "react-icons/fi";
@@ -20,11 +21,13 @@ import {
 	HiOutlineArrowRightOnRectangle,
 	HiOutlineArrowsRightLeft,
 	HiOutlinePlus,
+	HiOutlineWindow,
 } from "react-icons/hi2";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { useSignOut } from "renderer/hooks/useSignOut";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { HelpSubMenu } from "./components/HelpSubMenu";
 import { SubmitPromptDialog } from "./components/SubmitPromptDialog";
@@ -39,6 +42,11 @@ export function OrganizationDropdown({
 	const signOut = useSignOut();
 	const navigate = useNavigate();
 	const [submitPromptOpen, setSubmitPromptOpen] = useState(false);
+	const openNewWindow = electronTrpc.window.openNew.useMutation({
+		onError: (error) => {
+			toast.error(`Failed to open new window: ${error.message}`);
+		},
+	});
 
 	// Per-window active org (from CollectionsProvider), not the shared session —
 	// so the checkmark reflects what THIS window is showing.
@@ -184,6 +192,11 @@ export function OrganizationDropdown({
 							</DropdownMenuSubContent>
 						</DropdownMenuSub>
 					)}
+
+					<DropdownMenuItem onSelect={() => openNewWindow.mutate()}>
+						<HiOutlineWindow className="h-4 w-4" />
+						<span>New Window</span>
+					</DropdownMenuItem>
 
 					<HelpSubMenu onSubmitPrompt={() => setSubmitPromptOpen(true)} />
 


### PR DESCRIPTION
## What & why

New Window is now reachable on Linux and Windows, where multi-window (#5337) previously had no working trigger. Three entry points:

- a **New window** item in the organization dropdown and a **New window** command in the command palette — both call the existing `window.openNew` tRPC mutation, so every trigger funnels through the same main-process path as the native menu item, and the new window inherits the calling window's organization;
- the **OS shell's own "New Window"** (GNOME top-bar/dock app menus): the packaged desktop action relaunches the executable with `--new-window`, and the single-instance handler opens a window when it sees that flag. A plain relaunch keeps the Electron-standard focus-the-running-app behavior, so a Start-menu or launcher re-click never stacks extra windows; deep-link relaunches are unchanged (focus + process the link), and the handler bails during quit so auto-update restarts can't spawn a phantom window. The AppImage's desktop file declares that action explicitly (`Actions=new-window;` plus the action group — electron-builder emits the group but omits the exposing `Actions=` key, so it is set via `desktop.entry`), since GNOME only shows its own heuristic "New Window" item intermittently for running apps — a declared action is always shown.

Previously the native File → New Window menu was the feature's only trigger. On macOS that menu lives in the system menu bar, but Linux and Windows run a frameless window (`frame: false`), and Electron never renders a menu bar for frameless windows — Alt does nothing and even `setMenuBarVisibility(true)` is a no-op (verified on Electron 41.10.3 with the app's exact window flags). The `Ctrl+Alt+N` accelerator still fires, but there was nothing to click — and GNOME's shell-level "New Window" silently did nothing because the second instance only focused the first window.

macOS impact: the native menu path is untouched (`menu.ts` and the window-creation code are unchanged), the two renderer surfaces are additive, and the one main-process change is an additive branch in the `second-instance` handler — on macOS a second instance only spawns on an explicit `open -n`/CLI relaunch, where opening a window matches what was asked for. One scope note: the error toast covers a failed renderer-to-main call; a failure inside main-process window creation stays console-logged as before (surfacing it would need wider main-process changes — left as follow-up).

Related: #5337

## How I tested it

Drove the running Linux dev app over CDP per CONTRIBUTING's flow, with real clicks:

- Organization dropdown → **New window**: a second app window opened, showing the same organization as the caller. Verified from the first window, from a newly-opened window, and from the collapsed-sidebar avatar variant.
- Command palette → search "new window" → run: another window opened.
- OS shell path: relaunched the running app with `--new-window` (what the packaged desktop action does) — the primary logged the request and opened a new window (count 1 → 2); a plain relaunch left the count unchanged and focused the running app.
- No console errors; window restore-on-relaunch still works (all open windows came back after the dev main-process restart).

Before/after screenshots were captured from the CDP session (menu open showing the new item; the second window). I can attach them on request — the capturing agent could not upload images from its environment.

Checks: `bun run lint` and `bun run typecheck` pass; the desktop `bun test` suite is green apart from one failure that exists on the base branch and is unrelated to this change (`terminal-ws-transport` sleep/wake test; `jest.advanceTimersByTime` unsupported under `bun test`).

Platform coverage, stated honestly: verified end-to-end on Linux (GNOME/Wayland). Windows shares the identical frameless setup and code paths but was not exercised on a Windows machine. On macOS the changed second-instance branch is reachable only via explicit second-launch, and the menu/window-creation code is untouched.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “New window” action to the command palette.
  - Added a “New window” option to the organization dropdown menu.
  - Added a “New Window” desktop shortcut on Linux.
  - Relaunching with the “New Window” shortcut opens a separate window.
  - Displays an error notification if a new window cannot be opened.
- **Bug Fixes**
  - Relaunching normally now focuses the existing app window instead of opening an unintended duplicate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

