### PR TITLE
fix(desktop): park terminal transports on detach — close the socket, resume by seq

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.ts
@@ -34,6 +34,7 @@ import {
 	createTransport,
 	disposeTransport,
 	getPersistableSeqAnchor,
+	park,
 	reconnect,
 	sendDispose,
 	sendInput,
@@ -360,6 +361,10 @@ class TerminalRuntimeRegistryImpl {
 		if (entry.transport.sessionEnded) {
 			clearPersistedRuntimeState(terminalId);
 		}
+		// Snapshot and anchor are on disk — close the socket. A parked pane no
+		// longer parses hidden output or joins reconnect storms; remount's
+		// connect() re-dials and the host replays from the anchor.
+		park(entry.transport);
 		this.scheduleParkedEviction();
 	}
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -117,7 +117,7 @@ mock.module("@superset/workspace-client/relay-socket", () => ({
 		new FakeRelaySocket(options),
 }));
 
-const { connect, createTransport, disconnect, reconnect } = await import(
+const { connect, createTransport, disconnect, park, reconnect } = await import(
 	"./terminal-ws-transport"
 );
 
@@ -165,6 +165,13 @@ function connectAttached(url = "ws://host/terminal/t1") {
 	return { transport, terminal, socket };
 }
 
+// The park tests feed binary frames into the write coalescer outside the
+// coalescing describe's rAF harness; bun's test runtime has no
+// requestAnimationFrame, so give it an inert one (those tests never fire a
+// frame — pending bytes are flushed by park's coalescer dispose).
+const originalRaf = globalThis.requestAnimationFrame;
+const originalCancelRaf = globalThis.cancelAnimationFrame;
+
 beforeEach(() => {
 	FakeRelaySocket.instances = [];
 	if (win && typeof win.addEventListener !== "function") {
@@ -173,6 +180,10 @@ beforeEach(() => {
 	if (win && typeof win.removeEventListener !== "function") {
 		win.removeEventListener = () => {};
 	}
+	if (typeof globalThis.requestAnimationFrame !== "function") {
+		globalThis.requestAnimationFrame = () => 0;
+		globalThis.cancelAnimationFrame = () => {};
+	}
 });
 
 afterEach(() => {
@@ -180,6 +191,8 @@ afterEach(() => {
 		win.addEventListener = originalAddEventListener;
 		win.removeEventListener = originalRemoveEventListener;
 	}
+	globalThis.requestAnimationFrame = originalRaf;
+	globalThis.cancelAnimationFrame = originalCancelRaf;
 	setSystemTime();
 	jest.useRealTimers();
 });
@@ -645,6 +658,74 @@ describe("terminal-ws-transport", () => {
 		socket.open();
 		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
 		expect(transport.sessionEnded).toBe(false);
+	});
+
+	test("park closes the socket silently, keeping title and stream position", () => {
+		const { transport, socket } = connectAttached();
+		socket.message(JSON.stringify({ type: "title", title: "agent" }));
+		socket.message(
+			JSON.stringify({ type: "synced", epoch: "e1", seq: 40, mode: "exact" }),
+		);
+		const bytes = new TextEncoder().encode("hello");
+		socket.message(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		);
+
+		park(transport);
+
+		expect(socket.closed).toBe(true);
+		expect(transport.connectionState).toBe("disconnected");
+		// A park is not a failure: no reconnect logs, no diagnosis, no counted
+		// attempt — and the resume state survives for the next connect().
+		expect(transport.logs).toHaveLength(0);
+		expect(transport.lastDiagnosis).toBeNull();
+		expect(transport.title).toBe("agent");
+		expect(transport.seqAnchor).toEqual({ epoch: "e1", seq: 45 });
+	});
+
+	test("park stops the liveness watchdog and ignores late socket events", () => {
+		jest.useFakeTimers();
+		setSystemTime(new Date("2026-01-01T00:00:00Z"));
+		const { transport, socket } = connectAttached();
+
+		park(transport);
+
+		// Sleep/wake after a park must not resurrect the closed socket.
+		setSystemTime(new Date("2026-01-01T00:02:00Z"));
+		jest.advanceTimersByTime(120_000);
+		expect(socket.reconnectCount).toBe(0);
+
+		// A trailing close/message from the closed socket is dropped.
+		socket.drop(1006, "late");
+		socket.message(JSON.stringify({ type: "title", title: "late" }));
+		expect(transport.connectionState).toBe("disconnected");
+		expect(transport.logs).toHaveLength(0);
+	});
+
+	test("connect() after park dials a fresh socket anchored at the parked position", () => {
+		const { transport, terminal, socket } = connectAttached();
+		socket.message(
+			JSON.stringify({ type: "synced", epoch: "e1", seq: 10, mode: "exact" }),
+		);
+		const bytes = new TextEncoder().encode("abc");
+		socket.message(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		);
+		park(transport);
+		expect(FakeRelaySocket.instances).toHaveLength(1);
+
+		connect(transport, terminal, "ws://host/terminal/t1");
+
+		// The parked socket is gone for good; the remount dials a new one whose
+		// URL asks the host for exactly the bytes missed while parked.
+		expect(FakeRelaySocket.instances).toHaveLength(2);
+		const redial = FakeRelaySocket.instances.at(-1);
+		if (!redial) throw new Error("expected relay socket instance");
+		const buildUrl = redial.options.buildUrl as () => string;
+		expect(buildUrl()).toContain("seq=e1%3A13");
+		redial.open();
+		redial.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		expect(transport.connectionState).toBe("open");
 	});
 
 	test("ignores late events from a socket detached during teardown", () => {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -745,6 +745,27 @@ describe("terminal-ws-transport", () => {
 		expect(transport.seqAnchor).toBeNull();
 	});
 
+	test("park keeps a counted anchor when the connection closed before the park", () => {
+		// Counted connection ends (close consumed its per-connection flags),
+		// THEN the pane parks while the socket is between dials. The anchor is
+		// valid — dropping it would downgrade the next attach to seq=none and
+		// lose the replay of everything produced while parked.
+		const { transport, socket } = connectAttached();
+		socket.message(
+			JSON.stringify({ type: "synced", epoch: "e1", seq: 10, mode: "exact" }),
+		);
+		const bytes = new TextEncoder().encode("counted");
+		socket.message(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		);
+		socket.drop(1006, "host restart");
+		expect(transport.seqAnchor).toEqual({ epoch: "e1", seq: 17 });
+
+		park(transport);
+
+		expect(transport.seqAnchor).toEqual({ epoch: "e1", seq: 17 });
+	});
+
 	test("a failed connection after park is counted toward the diagnosis", () => {
 		const { transport, terminal } = connectAttached();
 		park(transport);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -789,6 +789,30 @@ describe("terminal-ws-transport", () => {
 		expect(transport.seqAnchor).toEqual({ epoch: "e1", seq: 17 });
 	});
 
+	test("an endpoint re-point resets seq capability so a legacy host is not parked", () => {
+		// Seq capability belongs to the endpoint. After re-pointing (e.g. the
+		// local host-service restarted on a new port running an older build),
+		// a latched _seqEverSynced from the old endpoint would let park()
+		// close a socket the legacy host cannot replay a gap for.
+		const { transport, terminal, socket } = connectAttached();
+		socket.message(
+			JSON.stringify({ type: "synced", epoch: "e1", seq: 10, mode: "exact" }),
+		);
+
+		connect(transport, terminal, "ws://host2/terminal/t1");
+		socket.open();
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
+		const bytes = new TextEncoder().encode("legacy output, no synced");
+		socket.message(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		);
+
+		park(transport);
+
+		expect(socket.closed).toBe(false);
+		expect(transport.connectionState).toBe("open");
+	});
+
 	test("a failed connection after park is counted toward the diagnosis", () => {
 		const { transport, terminal } = connectAttached();
 		park(transport);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -728,6 +728,23 @@ describe("terminal-ws-transport", () => {
 		expect(transport.connectionState).toBe("open");
 	});
 
+	test("park drops an anchor poisoned by uncounted bytes, keeps a counted one", () => {
+		// Pre-seq host (or bytes before this attach's `synced`): the xterm
+		// advanced but the anchor didn't. Parking must apply the same anchor
+		// hygiene the bypassed close handler would have — otherwise the next
+		// dial's exact catch-up re-delivers bytes already painted.
+		const { transport, socket } = connectAttached();
+		transport.seqAnchor = { epoch: "old", seq: 5 };
+		const bytes = new TextEncoder().encode("uncounted");
+		socket.message(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		);
+
+		park(transport);
+
+		expect(transport.seqAnchor).toBeNull();
+	});
+
 	test("a failed connection after park is counted toward the diagnosis", () => {
 		const { transport, terminal } = connectAttached();
 		park(transport);

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -728,6 +728,23 @@ describe("terminal-ws-transport", () => {
 		expect(transport.connectionState).toBe("open");
 	});
 
+	test("a failed connection after park is counted toward the diagnosis", () => {
+		const { transport, terminal } = connectAttached();
+		park(transport);
+
+		// Remount: fresh socket. Every post-park connection that dies before
+		// attaching must count as a failed attempt — a stale _connAttached
+		// carried over from the parked (attached) session would skip the first
+		// one and delay the outage diagnosis by a dial.
+		connect(transport, terminal, "ws://host/terminal/t1");
+		const redial = FakeRelaySocket.instances.at(-1);
+		if (!redial) throw new Error("expected relay socket instance");
+		redial.open();
+		redial.drop(1006, "host went away before attach");
+
+		expect(transport._attachRetry.consecutiveFailures).toBe(1);
+	});
+
 	test("ignores late events from a socket detached during teardown", () => {
 		const { transport, socket } = connectAttached();
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -728,13 +728,35 @@ describe("terminal-ws-transport", () => {
 		expect(transport.connectionState).toBe("open");
 	});
 
-	test("park drops an anchor poisoned by uncounted bytes, keeps a counted one", () => {
-		// Pre-seq host (or bytes before this attach's `synced`): the xterm
-		// advanced but the anchor didn't. Parking must apply the same anchor
-		// hygiene the bypassed close handler would have — otherwise the next
-		// dial's exact catch-up re-delivers bytes already painted.
+	test("park refuses to disconnect a pre-seq host", () => {
+		// A pre-seq host ignores `?seq=` and `replay=0` suppresses its legacy
+		// FIFO replay, so a closed socket means the parked gap is silently
+		// lost. Such transports keep the legacy always-connected behavior.
 		const { transport, socket } = connectAttached();
-		transport.seqAnchor = { epoch: "old", seq: 5 };
+		const bytes = new TextEncoder().encode("pre-seq output");
+		socket.message(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+		);
+
+		park(transport);
+
+		expect(socket.closed).toBe(false);
+		expect(transport.connectionState).toBe("open");
+	});
+
+	test("park drops an anchor poisoned by uncounted bytes on a seq-aware host", () => {
+		// A seq-aware transport (synced seen on an earlier connection) parked
+		// between a reattach and its `synced`: the current connection's bytes
+		// advanced the xterm without advancing the anchor. Parking must apply
+		// the same anchor hygiene the bypassed close handler would have —
+		// otherwise the next dial's exact catch-up re-delivers painted bytes.
+		const { transport, socket } = connectAttached();
+		socket.message(
+			JSON.stringify({ type: "synced", epoch: "e1", seq: 10, mode: "exact" }),
+		);
+		socket.drop(1006, "host restart");
+		socket.open();
+		socket.message(JSON.stringify({ type: "attached", terminalId: "t1" }));
 		const bytes = new TextEncoder().encode("uncounted");
 		socket.message(
 			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
@@ -742,6 +764,7 @@ describe("terminal-ws-transport", () => {
 
 		park(transport);
 
+		expect(socket.closed).toBe(true);
 		expect(transport.seqAnchor).toBeNull();
 	});
 

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -899,6 +899,40 @@ function attachSocketListeners(
 }
 
 /**
+ * Park the transport while its pane is hidden: close the socket and stop the
+ * liveness/reconnect machinery, keeping everything needed to resume — stream
+ * position (seqAnchor), replay flags, title, logs, session-ended state.
+ *
+ * A parked pane must cost nothing. Before this, every parked terminal kept a
+ * live socket that (a) received and parsed the full output stream of hidden
+ * agents, and (b) on any endpoint failure re-dialed forever on capped backoff.
+ * N parked panes retrying together feed Chromium's per-renderer WebSocket
+ * handshake throttle, which then delays every NEW handshake by seconds — the
+ * visible pane's reconnect (typing dead until re-attach) and create-on-attach
+ * terminal opens (SUPER-2043).
+ *
+ * The next connect() dials fresh; a seq-aware host replays exactly the missed
+ * bytes (or reanchors past the 2 MB ring), so parking loses nothing.
+ */
+export function park(transport: TerminalTransport) {
+	teardownLiveness(transport);
+	const socket = transport._socket;
+	if (socket) {
+		// Null before close() so the close listener's stale-socket guard drops
+		// the event — a park must not count as a failed attempt or push a log.
+		transport._socket = null;
+		socket.close();
+	}
+	transport._onDataDisposable?.dispose();
+	transport._onDataDisposable = null;
+	transport._writeCoalescer?.dispose();
+	transport._writeCoalescer = null;
+	if (transport.connectionState !== "disconnected") {
+		setConnectionState(transport, "disconnected");
+	}
+}
+
+/**
  * Manually re-dial after the transport stopped trying (access denied, fatal
  * server error, PTY exit) or to force an immediate reconnect. Clears the
  * terminated flag and resets the attempt budget.

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -923,6 +923,12 @@ export function park(transport: TerminalTransport) {
 		transport._socket = null;
 		socket.close();
 	}
+	// The skipped close handler is also what consumes these per-connection
+	// flags. Left latched from an attached session, a post-remount connection
+	// that dies before attaching would read the stale `_connAttached` and skip
+	// the failed-attempt accounting, delaying the outage diagnosis by a dial.
+	transport._connAttached = false;
+	transport._connHadRetryableError = false;
 	transport._onDataDisposable?.dispose();
 	transport._onDataDisposable = null;
 	transport._writeCoalescer?.dispose();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -820,6 +820,10 @@ function attachSocketListeners(
 		// Otherwise the anchor keeps its last-counted position and the next
 		// attach's `synced` re-arms counting.
 		transport._seqCounting = false;
+		// Consumed: the flag describes the connection that just ended. Leaving
+		// it set would make a later park() misread the ended connection's
+		// counted bytes as uncounted and drop a valid anchor.
+		transport._bytesSinceAttach = false;
 		setConnectionState(transport, "closed");
 		// Per-connection outcome flags; consumed once per close.
 		const connAttached = transport._connAttached;

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -919,6 +919,14 @@ function attachSocketListeners(
  * bytes (or reanchors past the 2 MB ring), so parking loses nothing.
  */
 export function park(transport: TerminalTransport) {
+	// A pre-seq host (bytes delivered, `synced` never seen) cannot replay a
+	// parked gap: it ignores `?seq=` and `replay=0` suppresses its legacy
+	// FIFO replay, so closing this socket would silently drop everything
+	// produced while parked. Keep the legacy always-connected behavior for
+	// those hosts — a local host is always version-matched with the app, so
+	// this only preserves output on version-skewed remote hosts. Also covers
+	// a first-ever connection parked before its `synced` arrived.
+	if (transport._hasReceivedBytes && !transport._seqEverSynced) return;
 	teardownLiveness(transport);
 	const socket = transport._socket;
 	if (socket) {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -929,6 +929,17 @@ export function park(transport: TerminalTransport) {
 	// the failed-attempt accounting, delaying the outage diagnosis by a dial.
 	transport._connAttached = false;
 	transport._connHadRetryableError = false;
+	// Mirror the close handler's anchor hygiene too: bytes without a `synced`
+	// came from a pre-seq host (or landed before this attach's sync) and
+	// advanced the xterm without advancing the anchor — a stale anchor kept
+	// across the park would let a later exact catch-up re-deliver painted
+	// bytes. Anchored-and-counted state survives untouched.
+	if (transport._bytesSinceAttach && !transport._seqCounting) {
+		transport.seqAnchor = null;
+	}
+	transport._seqCounting = false;
+	transport._bytesSinceAttach = false;
+
 	transport._onDataDisposable?.dispose();
 	transport._onDataDisposable = null;
 	transport._writeCoalescer?.dispose();

--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -559,6 +559,15 @@ export function connect(
 		return;
 	}
 
+	// Seq capability is a property of the endpoint, not the transport: a
+	// re-point can land on a different host-service generation, and a
+	// `_seqEverSynced` latched from the old endpoint would let park() close a
+	// socket the new (legacy) host cannot replay. The next `synced` re-latches
+	// it. `_hasReceivedBytes` deliberately stays: it guards a legacy host from
+	// double-painting its whole FIFO into an xterm that already has content.
+	if (transport.currentUrl && stripToken(transport.currentUrl) !== base) {
+		transport._seqEverSynced = false;
+	}
 	transport.currentUrl = wsUrl;
 	transport._localToken = extractToken(wsUrl);
 	transport._terminal = terminal;


### PR DESCRIPTION
Fixes SUPER-2043 (consolidates SUPER-1808, SUPER-2015 — same report from Clinton: multi-second UI hangs when typing in a Claude Code TUI or opening a new Terminal tab, only workspace navigation responsive, worsening since 1.17.0).

## Mechanism

A parked (hidden) terminal pane kept its WebSocket open for the life of the session:

1. **Hidden output parsing.** Every parked pane kept receiving and parsing the full output stream of its (often chatty, agent-driven) terminal — invisible renderer work that scales linearly with visited workspaces.
2. **Reconnect storms.** On any endpoint failure (host-service restart, sleep/wake half-open sockets, port change), every parked transport re-dialed forever on 500ms→10s backoff. N parked panes × infinite retries inflate **Chromium's per-renderer WebSocket handshake throttle**, which then delays every *new* handshake by seconds.

Measured in the real app (CDP, this branch): a fresh handshake to host-service takes **2 ms**; the same handshake right after a 50-dial burst takes **3,974 ms / 4,255 ms**. Since #6299 terminal creation rides the WS handshake (create-on-attach), and a visible pane's reconnect does too — so an inflated throttle is exactly "new tab hangs for seconds" and "typing dead for seconds until re-attach" (keystrokes are dropped while the socket is down, `terminal.onData` gates on `open`).

The stale pty-daemon hypothesis in the original tickets is a real but separate bug (orphaned old-version daemon burning CPU, fix parked on `fix/ptyd-orphaned-by-unlink-spawn`); it runs in a separate process and cannot block the renderer.

## Fix

`detach()` now **parks the transport**: tears down the liveness watchdog + resume listeners and closes the socket, keeping everything needed to resume (seq anchor, replay flags, title, logs, session-ended state). Remount's `connect()` dials a fresh socket carrying `?seq=<epoch>:<n>`, so a seq-aware host replays exactly the bytes missed while parked (reanchor + repaint past the 2 MB ring). This is plan item 9 of `plans/pty-lifecycle-cleanup.md` ("park = disconnect"), now lossless thanks to the seq-catch-up work.

Parked panes cost nothing: no hidden parsing, no dials feeding the throttle, and the host stops broadcasting to them entirely.

## Verification (CDP against the dev desktop app, real journey)

**Before (park call disabled):** enter workspace → run a 20s ticker → navigate away. Socket stays open (no `webSocketClosed`), **88 data frames** delivered to the hidden pane in 45 s.

**After:** same journey. `webSocketClosed` fires the instant the pane parks; **zero** dials/frames while parked; on return the redial carries `seq=887d7796818d3a3d:3143` and `LATE-LINE-WHILE-PARKED` (emitted while the socket was closed) appears exactly once — scrollback intact, no double-paint.

**Throttle repro:** in-renderer A/B above (2 ms → ~4 s) reproduces the user-visible hang and is the load the parked retry storms generate.

## Tests

- `park` closes the socket silently (no failure count, no logs, no diagnosis), keeps title + stream position
- `park` stops the liveness watchdog; late socket events ignored
- `connect()` after park dials a fresh socket anchored at the parked position; re-attach works
- Full transport + registry suites pass (34 tests), desktop typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SUPER-2043 — multi-second UI hangs when typing in a Claude Code TUI or opening a Terminal tab — by closing parked terminal sockets instead of keeping them alive. `detach()` now parks the transport: it tears down liveness/reconnect machinery and closes the socket, keeping the sequence anchor, title, logs, and session-ended state. Remount's `connect()` dials a fresh socket carrying the anchor, so a seq-aware host replays exactly the bytes missed while parked.

- Parked terminals no longer parse hidden output or retry dials, which was inflating Chromium's WebSocket handshake throttle and delaying every new handshake by seconds.
- Pre-seq hosts (bytes delivered, `synced` never seen) are not parked; they keep the always-connected behavior because they can't replay a parked gap.
- Parking applies the close handler's anchor hygiene: an anchor advanced by uncounted bytes is dropped, while a valid counted anchor survives.
- Parking resets per-connection flags so a redial that fails before attaching still counts toward the outage diagnosis.
- A re-point to a new endpoint resets seq capability, so a legacy host on a new port isn't parked.
- Adds tests for silent socket close, watchdog shutdown, anchored redial, pre-seq host exemption, poisoned-anchor drop, counted-anchor keep, endpoint re-point, and post-park failure accounting.

<sup>Written for commit 7003a1ee9bde13a4811d39d6bc0ecaea785fc301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hidden terminal panes now close their WebSocket connections, preventing unnecessary reconnection activity.
  - Terminal state, titles, and stream position are preserved while a pane is hidden.
  - Returning to a parked terminal automatically reconnects and resumes output from the correct position.
  - Improved handling of delayed connection events during pane transitions.
  - Connection failures after returning to a hidden terminal are now detected more reliably.
  - Improved recovery when connection sequence information is unavailable or outdated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Revert plan (labeled `revert-candidate`)

If field regressions appear (missing scrollback after workspace switches, terminals stuck "connecting" on remount, double-painted output), **revert first and diagnose after** — this PR is built to revert cleanly:

- Renderer-only; no protocol, host, or schema change. Old and new renderers speak the same terminal WS protocol, so a revert ships in any patch release with no ordering constraints.
- No persisted-state migration: it writes the same snapshot + seq-anchor keys the pre-PR code already wrote, so profiles roll backward with no cleanup.
- Two commits on one branch (`522c1a5d5` park + tests, `5a78cf043` per-connection flag reset); `git revert` of the squash-merge commit restores exact pre-PR behavior (parked panes hold sockets again).
- Watch after release: `terminal_connect_failed` telemetry and any report matching SUPER-2043's fingerprint; regressions specific to this PR would instead look like replay gaps or remount attach failures.
