### PR TITLE
fix(host-service): stop a busy pty-daemon from being orphaned by a fresh spawn

### DIFF
--- a/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.node-test.ts
@@ -22,7 +22,7 @@ import {
 	encodeFrame,
 	FrameDecoder,
 } from "@superset/pty-daemon/protocol";
-import { DaemonSupervisor } from "./DaemonSupervisor.ts";
+import { DaemonSupervisor, ptyDaemonSocketPath } from "./DaemonSupervisor.ts";
 import { EXPECTED_DAEMON_VERSION } from "./expected-version.ts";
 import {
 	type PtyDaemonManifest,
@@ -1233,3 +1233,90 @@ async function waitForSocket(
 	}
 	return false;
 }
+
+describe("manifest-less adoption of a slow daemon (GH #6822)", () => {
+	// With no manifest, `tryAdopt` falls through to `tryAdoptFromSocket`. If
+	// that concedes, `spawn` runs `Server.listen`, which unlinks the socket
+	// path unconditionally — POSIX keeps the incumbent listener bound to an
+	// unreachable inode, so it survives with every PTY it owns and no way
+	// back. A daemon starved of CPU is exactly the one that misses the probe
+	// budget, so slowness must not be read as death.
+	test("adopts a live daemon that answers hello slower than one attempt", async () => {
+		const orgId = "org-slow-hello";
+		const socketPath = ptyDaemonSocketPath(orgId);
+		try {
+			fs.unlinkSync(socketPath);
+		} catch {
+			// no leftover
+		}
+		// Longer than VERSION_PROBE_TIMEOUT_MS (1.5s), so raising only the
+		// total budget cannot rescue it — the per-attempt cap has to rise too.
+		const HELLO_DELAY_MS = 2_500;
+		const placeholder = childProcess.spawn("sleep", ["60"], {
+			stdio: "ignore",
+		});
+		const server = net.createServer((sock) => {
+			const decoder = new FrameDecoder();
+			sock.on("error", () => {});
+			sock.on("data", (chunk: Buffer) => {
+				decoder.push(chunk);
+				for (const { message } of decoder.drain()) {
+					if ((message as { type?: string }).type !== "hello") continue;
+					setTimeout(() => {
+						if (sock.destroyed) return;
+						sock.write(
+							encodeFrame({
+								type: "hello-ack",
+								protocol: CURRENT_PROTOCOL_VERSION,
+								daemonVersion: EXPECTED_DAEMON_VERSION,
+								daemonPid: placeholder.pid,
+							}),
+						);
+					}, HELLO_DELAY_MS);
+				}
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+		try {
+			// Deliberately NO manifest — that is what forces the socket path.
+			assert.equal(
+				fs.existsSync(
+					path.join(ptyDaemonManifestDir(orgId), "pty-daemon-manifest.json"),
+				),
+				false,
+				"test must start with no manifest",
+			);
+			const sup = new DaemonSupervisor({
+				scriptPath: DAEMON_BUNDLE,
+				autoUpdate: false,
+			});
+			supervisorsToCleanup.push({ sup, orgId });
+			const instance = await sup.ensure(orgId);
+
+			assert.equal(
+				instance.pid,
+				placeholder.pid,
+				"must adopt the slow daemon, not spawn over (and orphan) it",
+			);
+			assert.equal(
+				server.listening,
+				true,
+				"incumbent listener must not have been unlinked out from under",
+			);
+			assert.equal(
+				isAlive(placeholder.pid as number),
+				true,
+				"adoption must never kill the incumbent",
+			);
+		} finally {
+			server.close();
+			placeholder.kill("SIGKILL");
+			try {
+				fs.unlinkSync(socketPath);
+			} catch {
+				// best-effort
+			}
+		}
+	});
+});

--- a/packages/host-service/src/daemon/DaemonSupervisor.test.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@superset/pty-daemon/protocol";
 import {
 	DaemonSupervisor,
+	probeDaemonHelloWithRetry,
 	probeDaemonVersion,
 	ptyDaemonSocketPath,
 	shouldKillStaleDaemonForDev,
@@ -204,6 +205,96 @@ describe("probeDaemonVersion", () => {
 			}
 		} finally {
 			await fake.close();
+		}
+	});
+});
+
+describe("probeDaemonHelloWithRetry stopWhenNoListener", () => {
+	const deadSocket = () =>
+		path.join(
+			os.tmpdir(),
+			`nonexistent-${process.pid}-${Math.random().toString(36).slice(2, 8)}.sock`,
+		);
+
+	test("without the flag, retries through refused connects for the whole budget", async () => {
+		// The handoff path depends on this: probes must survive the brief
+		// predecessor-exit → successor-bind gap where every connect is refused.
+		const started = Date.now();
+		const probe = await probeDaemonHelloWithRetry(deadSocket(), 400);
+		expect(probe).toBeNull();
+		expect(Date.now() - started).toBeGreaterThanOrEqual(350);
+	});
+
+	test("with the flag, a refused connect ends the retry loop immediately", async () => {
+		// The adoption-escalation path depends on this: a daemon that died
+		// mid-probe must cost ~one attempt, not the whole escalated budget.
+		const started = Date.now();
+		const probe = await probeDaemonHelloWithRetry(deadSocket(), 5_000, {
+			stopWhenNoListener: true,
+		});
+		expect(probe).toBeNull();
+		expect(Date.now() - started).toBeLessThan(1_000);
+	});
+
+	test("with the flag, a silent-but-accepting listener still gets the whole budget", async () => {
+		const fake = await startFakeDaemon({ silent: true });
+		const started = Date.now();
+		try {
+			const probe = await probeDaemonHelloWithRetry(fake.socketPath, 600, {
+				perAttemptTimeoutMs: 200,
+				stopWhenNoListener: true,
+			});
+			expect(probe).toBeNull();
+			expect(Date.now() - started).toBeGreaterThanOrEqual(550);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	test("honors the per-attempt cap: adopts a hello slower than the default attempt", async () => {
+		// A CPU-starved daemon can need more than VERSION_PROBE_TIMEOUT_MS to
+		// answer one hello; only a raised per-attempt cap can ever adopt it.
+		const socketPath = deadSocket();
+		const server = net.createServer((sock) => {
+			const decoder = new FrameDecoder();
+			sock.on("error", () => {});
+			sock.on("data", (chunk: Buffer) => {
+				decoder.push(chunk);
+				for (const decoded of decoder.drain()) {
+					if ((decoded.message as ClientMessage).type !== "hello") continue;
+					setTimeout(() => {
+						if (sock.destroyed) return;
+						sock.write(
+							encodeFrame({
+								type: "hello-ack",
+								protocol: 1,
+								daemonVersion: "0.1.0",
+								daemonPid: process.pid,
+							}),
+						);
+					}, 400);
+				}
+			});
+		});
+		await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+		try {
+			// One 200ms attempt can never catch a 400ms hello…
+			expect(
+				await probeDaemonHelloWithRetry(socketPath, 300, {
+					perAttemptTimeoutMs: 200,
+					stopWhenNoListener: true,
+				}),
+			).toBeNull();
+			// …a 600ms attempt does.
+			const probe = await probeDaemonHelloWithRetry(socketPath, 1_000, {
+				perAttemptTimeoutMs: 600,
+				stopWhenNoListener: true,
+			});
+			expect(probe?.daemonVersion).toBe("0.1.0");
+		} finally {
+			await new Promise<void>((resolve) => {
+				server.close(() => resolve());
+			});
 		}
 	});
 });

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -1551,11 +1551,15 @@ export async function probeDaemonHelloWithRetry(
 	options: {
 		perAttemptTimeoutMs?: number;
 		/**
-		 * End the retry loop as soon as an attempt fails without ever
-		 * connecting. The default keeps retrying through refused connects
-		 * because the handoff path needs it (brief predecessor-exit →
-		 * successor-bind gap); the adoption-escalation path sets this so a
-		 * daemon that dies mid-probe costs one attempt, not the whole budget.
+		 * End the retry loop as soon as an attempt is DEFINITIVELY refused —
+		 * ECONNREFUSED/ENOENT prove no listener holds the path. The default
+		 * keeps retrying through refused connects because the handoff path
+		 * needs it (brief predecessor-exit → successor-bind gap); the
+		 * adoption-escalation path sets this so a daemon that dies mid-probe
+		 * costs one attempt, not the whole budget. An attempt that times out
+		 * with the connect still pending is NOT treated as no-listener: a
+		 * flooded daemon whose accept backlog is full hangs connects, and it
+		 * is exactly the live daemon the escalation exists to protect.
 		 */
 		stopWhenNoListener?: boolean;
 	} = {},
@@ -1565,12 +1569,10 @@ export async function probeDaemonHelloWithRetry(
 	while (Date.now() < deadline) {
 		const remaining = deadline - Date.now();
 		const perAttempt = Math.min(remaining, perAttemptCap);
-		let connected = false;
-		const probe = await probeDaemonHello(socketPath, perAttempt, () => {
-			connected = true;
-		});
+		const outcome: ProbeAttemptOutcome = {};
+		const probe = await probeDaemonHello(socketPath, perAttempt, outcome);
 		if (probe !== null) return probe;
-		if (options.stopWhenNoListener && !connected) return null;
+		if (options.stopWhenNoListener && outcome.noListener) return null;
 		await new Promise((r) => setTimeout(r, 50));
 	}
 	return null;
@@ -1647,12 +1649,22 @@ export async function probeDaemonVersion(
 	return (await probeDaemonHello(socketPath, timeoutMs))?.daemonVersion ?? null;
 }
 
+/**
+ * How a failed probe attempt failed, for the retry wrapper's stop decision.
+ * `connected` = the connect succeeded (a silent listener holds the path).
+ * `noListener` = the connect was definitively refused (ECONNREFUSED/ENOENT).
+ * Neither set = indeterminate — most notably a timeout with the connect still
+ * pending, which is how a flooded listener with a full accept backlog looks.
+ */
+interface ProbeAttemptOutcome {
+	connected?: boolean;
+	noListener?: boolean;
+}
+
 function probeDaemonHello(
 	socketPath: string,
 	timeoutMs: number,
-	/** Fired when the connect succeeds, even if the hello never comes back —
-	 * lets the retry wrapper tell a silent listener from no listener. */
-	onConnect?: () => void,
+	outcome?: ProbeAttemptOutcome,
 ): Promise<DaemonProbeResult | null> {
 	return new Promise<DaemonProbeResult | null>((resolve) => {
 		const sock = net.createConnection({ path: socketPath });
@@ -1679,11 +1691,20 @@ function probeDaemonHello(
 
 		const timer = setTimeout(() => cleanup(null), timeoutMs);
 
-		sock.once("error", () => cleanup(null));
+		sock.once("error", (err: NodeJS.ErrnoException) => {
+			if (
+				outcome &&
+				!outcome.connected &&
+				(err.code === "ECONNREFUSED" || err.code === "ENOENT")
+			) {
+				outcome.noListener = true;
+			}
+			cleanup(null);
+		});
 		sock.once("close", () => cleanup(null));
 
 		sock.once("connect", () => {
-			onConnect?.();
+			if (outcome) outcome.connected = true;
 			try {
 				sock.write(
 					encodeFrame({

--- a/packages/host-service/src/daemon/DaemonSupervisor.ts
+++ b/packages/host-service/src/daemon/DaemonSupervisor.ts
@@ -97,6 +97,23 @@ const HANDOFF_PREDECESSOR_EXIT_TIMEOUT_MS = 3_000;
 const HANDOFF_PROBE_TOTAL_TIMEOUT_MS = 3_000;
 const DAEMON_TERMINATE_TIMEOUT_MS = 1_000;
 const ADOPTION_PROBE_TOTAL_TIMEOUT_MS = 3_000;
+/**
+ * Escalated budget for a socket whose listener keeps accepting but whose
+ * hello never came back within the ordinary budget. Spawning instead would
+ * unlink that listener's path and orphan its PTYs forever, so it is worth
+ * waiting longer — a daemon starved of CPU (the exact condition in GH #6822)
+ * can miss a 3s budget and still be perfectly healthy. The per-attempt cap
+ * matters as much as the total: retrying a 1.5s attempt can never adopt a
+ * daemon that uniformly needs longer than 1.5s per connection.
+ *
+ * The budget bounds how long terminal readiness can stall behind a daemon
+ * that is wedged-but-accepting (the one case where waiting is wasted): the
+ * ordinary 3s probe plus this escalation is the worst case, and the
+ * escalated retry loop stops early the moment connects are refused — so a
+ * daemon that dies mid-probe costs ~one attempt, not the whole budget.
+ */
+const ADOPTION_PROBE_LIVE_SOCKET_TIMEOUT_MS = 8_000;
+const ADOPTION_PROBE_LIVE_SOCKET_ATTEMPT_TIMEOUT_MS = 4_000;
 
 /**
  * Crash supervision parameters. If the daemon for an organization crashes
@@ -447,15 +464,19 @@ export class DaemonSupervisor {
 		this.stopping.delete(organizationId);
 		this.lastUpdatePendingPair.delete(organizationId);
 
-		if (existingManifest) {
-			writePtyDaemonManifest({
-				pid: result.successorPid,
-				socketPath: instance.socketPath,
-				protocolVersions: existingManifest.protocolVersions,
-				startedAt: successorStartedAt,
-				organizationId,
-			});
-		}
+		// Always write, even when the predecessor had no manifest (it was
+		// adopted from its socket). Skipping it left the successor invisible to
+		// the next boot's `tryAdopt`, forcing the socket-adopt path whose
+		// probe failure orphans a live daemon (GH #6822).
+		writePtyDaemonManifest({
+			pid: result.successorPid,
+			socketPath: instance.socketPath,
+			protocolVersions: existingManifest?.protocolVersions ?? [
+				CURRENT_PROTOCOL_VERSION,
+			],
+			startedAt: successorStartedAt,
+			organizationId,
+		});
 
 		// Successor wasn't spawned as our child — start liveness polling.
 		this.startAdoptedLivenessCheck(organizationId, result.successorPid);
@@ -1050,10 +1071,40 @@ export class DaemonSupervisor {
 		const reachable = await isSocketConnectable(socketPath, 1000);
 		if (!reachable) return null;
 
-		const probe = await probeDaemonHelloWithRetry(
+		let probe = await probeDaemonHelloWithRetry(
 			socketPath,
 			ADOPTION_PROBE_TOTAL_TIMEOUT_MS,
 		);
+		if (!probe) {
+			// The listener was accepting a moment ago, so a silent probe most
+			// likely means a live daemon too busy to answer — not a stale
+			// socket file. Conceding now sends us to `spawn`, whose
+			// `Server.listen` unlinks this path unconditionally: POSIX leaves
+			// the old listener bound to an unreachable inode, so it keeps
+			// every PTY (agents, dev servers, watchers) running and burning
+			// CPU with no way back (GH #6822). No EADDRINUSE is raised, so
+			// nothing downstream notices.
+			logEvent("pty_daemon_socket_adopt_escalated", {
+				organizationId,
+				socketPath,
+				sourceReason: context.reason,
+				timeoutMs: ADOPTION_PROBE_LIVE_SOCKET_TIMEOUT_MS,
+			});
+			// Raise the PER-ATTEMPT cap too, not just the total: retrying a
+			// 1.5s attempt can never adopt a daemon that uniformly needs
+			// longer than 1.5s to answer, which is the starved daemon we are
+			// trying not to orphan. stopWhenNoListener bounds the wasted wait:
+			// if the daemon died since the probe above, the first refused
+			// connect ends the escalation instead of spinning out the budget.
+			probe = await probeDaemonHelloWithRetry(
+				socketPath,
+				ADOPTION_PROBE_LIVE_SOCKET_TIMEOUT_MS,
+				{
+					perAttemptTimeoutMs: ADOPTION_PROBE_LIVE_SOCKET_ATTEMPT_TIMEOUT_MS,
+					stopWhenNoListener: true,
+				},
+			);
+		}
 		if (!probe) {
 			logEvent("pty_daemon_socket_adopt_rejected", {
 				organizationId,
@@ -1137,6 +1188,23 @@ export class DaemonSupervisor {
 		}
 		const socketPath = ptyDaemonSocketPath(organizationId);
 		const logPath = path.join(dir, "pty-daemon.log");
+
+		// Adoption has already given up by the time we get here, yet a listener
+		// is STILL accepting on this path. Today the spawned daemon unlinks it
+		// and takes the name — the incumbent stays alive, bound to an
+		// unreachable inode, holding its whole PTY tree, visible only in `ps`
+		// days later (GH #6822). The event names the hazardous *condition*
+		// (spawning over a live socket), not that outcome: once the daemon-side
+		// bind refusal lands, the same condition ends with the child standing
+		// down instead of orphaning, and the event keeps marking the residual
+		// adopt-then-spawn disagreement worth investigating.
+		if (await isSocketConnectable(socketPath, 1000)) {
+			logEvent("pty_daemon_spawn_over_live_socket", {
+				organizationId,
+				socketPath,
+				reason: "adoption conceded but the socket is still accepting",
+			});
+		}
 
 		if (!fs.existsSync(this.opts.scriptPath)) {
 			throw new Error(
@@ -1477,16 +1545,32 @@ export async function listDaemonSessions(
  * `probeDaemonVersion` resolves to null on the first connect-error;
  * we have to actively retry.
  */
-async function probeDaemonHelloWithRetry(
+export async function probeDaemonHelloWithRetry(
 	socketPath: string,
 	totalTimeoutMs: number,
+	options: {
+		perAttemptTimeoutMs?: number;
+		/**
+		 * End the retry loop as soon as an attempt fails without ever
+		 * connecting. The default keeps retrying through refused connects
+		 * because the handoff path needs it (brief predecessor-exit →
+		 * successor-bind gap); the adoption-escalation path sets this so a
+		 * daemon that dies mid-probe costs one attempt, not the whole budget.
+		 */
+		stopWhenNoListener?: boolean;
+	} = {},
 ): Promise<DaemonProbeResult | null> {
+	const perAttemptCap = options.perAttemptTimeoutMs ?? VERSION_PROBE_TIMEOUT_MS;
 	const deadline = Date.now() + totalTimeoutMs;
 	while (Date.now() < deadline) {
 		const remaining = deadline - Date.now();
-		const perAttempt = Math.min(remaining, VERSION_PROBE_TIMEOUT_MS);
-		const probe = await probeDaemonHello(socketPath, perAttempt);
+		const perAttempt = Math.min(remaining, perAttemptCap);
+		let connected = false;
+		const probe = await probeDaemonHello(socketPath, perAttempt, () => {
+			connected = true;
+		});
 		if (probe !== null) return probe;
+		if (options.stopWhenNoListener && !connected) return null;
 		await new Promise((r) => setTimeout(r, 50));
 	}
 	return null;
@@ -1566,6 +1650,9 @@ export async function probeDaemonVersion(
 function probeDaemonHello(
 	socketPath: string,
 	timeoutMs: number,
+	/** Fired when the connect succeeds, even if the hello never comes back —
+	 * lets the retry wrapper tell a silent listener from no listener. */
+	onConnect?: () => void,
 ): Promise<DaemonProbeResult | null> {
 	return new Promise<DaemonProbeResult | null>((resolve) => {
 		const sock = net.createConnection({ path: socketPath });
@@ -1596,6 +1683,7 @@ function probeDaemonHello(
 		sock.once("close", () => cleanup(null));
 
 		sock.once("connect", () => {
+			onConnect?.();
 			try {
 				sock.write(
 					encodeFrame({


### PR DESCRIPTION
Ships the parked orphaned-daemon fix (was sitting unpushed on `fix/ptyd-orphaned-by-unlink-spawn`) now that SUPER-2043 gives it field evidence: Clinton's `ps` shows a v1.23.0 `pty-daemon.js` + `terminal-host.js` still running days later alongside the v1.24.2 app. Companion to #6895 (the renderer-side freeze fix) — this one is the machine-wide CPU-leak half of that report.

## The bug

`Server.listen()` in pty-daemon unlinks the socket path unconditionally before binding. POSIX does not close the incumbent listener on unlink: it stays bound to a now-unreachable inode, keeps its entire PTY tree (agents, dev servers, watchers) alive and burning CPU, and raises no `EADDRINUSE` — so nothing downstream ever notices. The only guard is adoption, and `tryAdoptFromSocket` conceded whenever the hello probe failed, even though it had just proven the socket connectable one line earlier. A CPU-starved daemon is exactly the one that misses the 3s probe budget, making the leak self-reinforcing: high CPU → probe timeout → spawn over the live daemon → one more tree burning CPU → the next probe is likelier to time out.

## The fix

- **`tryAdoptFromSocket`**: when the ordinary 3s probe comes back silent on a socket that was accepting, escalate — 8s total, 4s per attempt — before conceding. The per-attempt cap matters as much as the total: retrying a 1.5s attempt can never adopt a daemon that uniformly needs longer than 1.5s per connection.
- **`runUpdate`**: always write the successor manifest. Skipping it when the predecessor had none (socket-adopted) left the successor invisible to the next boot's `tryAdopt`, forcing the very socket-adopt path that orphans.
- **`spawn`**: log `pty_daemon_spawn_over_live_socket` when spawning while a still-accepting socket holds the path. The event names the hazardous *condition*, not the orphaning outcome — once the daemon-side bind-refusal fix (in flight separately) lands, the same condition ends with the child standing down, and the event keeps marking the adopt-then-spawn disagreement worth investigating.

## What changed vs. the first cut (the reason it was parked)

The original version added a ~17s worst-case stall to terminal readiness when a daemon is wedged-but-accepting (1s connect check + 3s probe + 1s re-check + 12s escalation). This version bounds that at **~11s**:

- escalated budget 12s → **8s** (still two full 4s attempts);
- the serial `isSocketConnectable` re-check is gone — the escalated retry loop itself observes per-attempt connects and **stops immediately when connects are refused** (`stopWhenNoListener`), so a daemon that dies mid-probe costs ~50ms of escalation instead of the whole budget;
- the handoff path keeps the old retry-through-refused behavior it depends on (predecessor-exit → successor-bind gap).

The stall only ever applies to the wedged-daemon case, where the pre-fix behavior was strictly worse: instant spawn-over, orphaning the incumbent and all its sessions forever. Boot is unaffected (`ensure()` is fire-and-track); terminal attaches surface the wait as the existing "Terminal not ready — retrying" state.

## Tests

- node-test regression (from the original commit): a manifest-less listener answering hello after 2.5s is adopted, not spawned over — asserted by pid + incumbent still listening. Mutation-checked (fails with escalation disabled).
- New unit tests for `stopWhenNoListener`: refused connects end the escalated loop immediately; silent-but-accepting listeners still get the whole budget; without the flag the handoff behavior (retry through refused) is preserved; per-attempt cap adopts a hello slower than the default attempt. Mutation-checked.
- Full `DaemonSupervisor.test.ts` 57/57; `DaemonSupervisor.node-test.ts` 18/19 — the one failure ("auto-update defers when live sessions exist") reproduces identically on pristine origin/main (stale since #5833, deliberately changed behavior) and is untouched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a busy pty-daemon being orphaned by a fresh spawn. Old behavior: when the hello probe timed out, adoption conceded and `Server.listen()` unlinked the socket path, leaving the incumbent daemon bound to an unreachable inode with its whole PTY tree alive and burning CPU. New behavior: adoption escalates to an 8s budget with a 4s per-attempt cap before conceding, and the successor manifest is written even when the predecessor had none.

**Behavior and testing**
- Escalation logs `pty_daemon_socket_adopt_escalated` and stops only when a connect is definitively refused (ECONNREFUSED/ENOENT), so a daemon that dies mid-probe costs about one attempt instead of the whole budget; a timed-out connect still pending is treated as a flooded-but-live daemon and keeps the remaining budget.
- Worst-case terminal readiness stall behind a wedged-but-accepting daemon is ~11s; boot is unaffected and terminal attaches surface the wait as "Terminal not ready — retrying".
- Spawning over a still-accepting socket logs `pty_daemon_spawn_over_live_socket`.
- The pre-existing `auto-update defers when live sessions exist` node-test failure reproduces identically on `main` and is untouched.

<sup>Written for commit ddbd06705040df786d38e9d4bc554a07f096c711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daemon recovery when responses are delayed, helping healthy background processes remain available instead of being unnecessarily replaced.
  - Prevented active daemon sockets from being overwritten without recording the event.
  - Ensured successor daemon state is consistently written during updates.
  - Improved handling of unavailable sockets by stopping recovery attempts promptly when no daemon is listening.
- **Tests**
  - Added coverage for delayed responses, unavailable sockets, and adopting existing daemons under degraded conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Relationship to the daemon-side structural fix (in flight)

A structural version — `Server.listen()` connect-probing and refusing to unlink a live socket, plus spawn-time socket-ownership verification — is being prepared separately and supersedes the escalation as the root-cause fix. This PR still earns its keep alongside it: the daemon-side refusal only runs in the newly bundled binary, so the supervisor-side guard here is what covers an older installed app version that launches later against the shared socket, and any path where a new host-service meets a socket it cannot identify. The rebase plan is agreed with that work's author (escalation trims to one 4s attempt once the structural guard lands).
