### PR TITLE
fix(web): stop set-active hijacking the OAuth consent navigation

### DIFF
--- a/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
+++ b/apps/web/src/app/oauth/consent/components/ConsentForm/ConsentForm.tsx
@@ -19,6 +19,8 @@ import {
 	LuUser,
 } from "react-icons/lu";
 
+import { env } from "@/env";
+
 interface Organization {
 	id: string;
 	name: string;
@@ -83,14 +85,21 @@ export function ConsentForm({
 
 		try {
 			if (accept) {
-				const { error: setActiveError } =
-					await authClient.organization.setActive({
-						organizationId: selectedOrgId,
-					});
-				if (setActiveError) {
-					throw new Error(
-						setActiveError.message ?? "Failed to set organization",
-					);
+				// Deliberately not authClient: here the API answers set-active with a
+				// redirect back to this page, and better-auth's client navigates on
+				// it, cancelling the consent call below before the CLI ever gets its
+				// code (#6609).
+				const response = await fetch(
+					`${env.NEXT_PUBLIC_API_URL}/api/auth/organization/set-active`,
+					{
+						method: "POST",
+						credentials: "include",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ organizationId: selectedOrgId }),
+					},
+				);
+				if (!response.ok) {
+					throw new Error("Failed to set organization");
 				}
 			}
 


### PR DESCRIPTION
Fixes #6609

## Summary
- `superset auth login` can hang forever on "Authorizing..." because the consent page fires two requests that both want to own the browser's location, and only one of them should.
- `organization.setActive()` is now called with a plain `fetch` instead of `authClient`, so `handleConsent` is the only thing that can navigate.

## Why / Context

The issue proposed that `authClient.oauth2.consent()` resolves 2xx without `data.url`, falling off the end of `handleConsent` without `setIsLoading(false)`. **That is not what happens** — I traced `@better-auth/oauth-provider@1.6.22` and probed the live endpoint under 9 conditions:

```
A. no oauth_query           400  {"error_description":"missing oauth query","error":"invalid_request"}
B. tampered sig             400  {"error":"invalid_signature"}
C. sig removed              400  {"error":"invalid_signature"}
D. expired exp              400  {"error":"invalid_signature"}
E. scope never requested    400  {"error_description":"Scope not originally requested",...}
F. empty scope              400  {"error_description":"Scope not originally requested",...}
G. deny                     200  {"redirect":true,"url":"...callback?error=access_denied..."}
H. valid accept             200  {"redirect":true,"url":"...callback?code=OMjnI4Rkffdd..."}
I. accept, already consented 200 {"redirect":true,"url":"...callback?code=RrvCjUIo7Hiz..."}
```

Every 2xx carries `url`; every failure is a 400 with `error`, which the existing `catch` already surfaces. The `data?.url`-falsy branch is unreachable dead code, and the field is `url`, not `redirectURI`.

**The actual cause is a redirect race.** `packages/auth/src/server.ts:141` enables `session.cookieCache`, so `set-active` re-sets the session cookie. That trips the oauth-provider's `after` hook (`dist/index.mjs:3019`), which re-runs `/oauth2/authorize` — and the signed query still carries `prompt=consent`, so it returns a redirect straight back to the consent page. better-auth's client `redirectPlugin` (`better-auth/dist/client/fetch-plugins.mjs:3`) navigates on any `{redirect:true,url}` response.

So `setActive` starts a full-page navigation, and the consent POST is fired into a document being torn down:

```
organization/set-active -> 200   {"redirect":true,"url":"http://localhost:4800/oauth/consent?..."}
oauth2/consent          -> CANCELLED
>>> CLI RECEIVED NOTHING
```

The page silently reloads, the button returns to an enabled "Authorize", no error is shown, and no code is minted. **`redirect:true` appeared on 12/12 measured runs** — the race is armed on every login; only timing decides whether it hurts. That is why this reproduces for some users and not for the team: on a warm, fast path the consent call wins.

## How It Works

The fix closes it at two independent levels:

1. No `authClient` call, so `redirectPlugin` never sees the response and cannot navigate.
2. The `oauthProviderClient` fetch plugin only injects `oauth_query` into `authClient` calls. Without it the server's `before` hook never populates `oAuthState`, so the `after` hook bails at `if (!_query) return` and **never emits a redirect at all**. Observed: `set-active` now returns the organization object.

This matches existing convention — `AcceptInvitationButton.tsx:52` already calls a better-auth endpoint with a plain `credentials: "include"` fetch.

## Manual QA Checklist

Driven over CDP against local `@superset/web` (:4800) and `@superset/api` (:4801) with real mouse input, plus the real CLI.

- [x] Forced race (consent POST held 2500ms so the navigation commits first) — **before:** `oauth2/consent -> CANCELLED`, loopback got nothing; **after:** `oauth2/consent -> 200`, browser reached `127.0.0.1:51789/callback?code=...`
- [x] `set-active` response shape — **before:** `{"redirect":true,"url":".../oauth/consent?..."}`; **after:** `{"name":"Local Admin's Team",...,"id":"1b8bd46c-..."}`
- [x] 10 consecutive logins: `setActive redirect=false` 10/10, SUCCESS 10/10
- [x] Real `superset auth login` end-to-end: `Logged in successfully.`
- [x] Multi-org: 2 orgs, picked the non-active one through the dropdown — `set-active` returned "Second Test Org" and the CLI reported `Organization: Second Test Org` / `72d07788-...`
- [x] Deny path unchanged (`accept=false` returns `access_denied`, no `setActive` call)

## Testing
- `bun run --cwd apps/web typecheck`
- `bunx @biomejs/biome check` on the changed file — no fixes needed
- No automated test: `apps/web` has no React test infrastructure today (`bun test src`, one route test, no testing-library or jsdom). See follow-ups.

## Design Decisions

- **Why not just add the missing `else`**: it is unreachable, so it would have changed nothing about this bug. Left out so the diff is only the lines that were actually wrong.
- **Why not `disableDefaultFetchPlugins`**: it is a `createAuthClient` construction option (`better-auth/dist/client/config.mjs:50`), so disabling it would kill auto-redirect for social sign-in too.
- **Why not a per-call `onSuccess`**: it does not suppress a plugin hook. In `@better-fetch/fetch@1.3.1`, `hooks.onSuccess` is an array with the per-call handler at index 0 and plugin hooks pushed after (`dist/index.js:41,60`); `dist/index.js:675` awaits every entry.
- **Why not skip `setActive` when the org is already active**: that narrows the race window without closing it, and still leaves org-switchers exposed.

## Known Limitations

The reported wording is a button stuck on "Authorizing..." *forever*. This wedge resets the button rather than freezing it. A permanent freeze additionally requires the navigation to `127.0.0.1:<port>/callback` to never complete — reproducible by pointing that port at a listener that accepts and never responds (a local firewall swallowing rather than refusing loopback traffic). I could not confirm that is the reporter's environment. It is unaffected either way by the `else` branch, since `data.url` is present and correct on that path.

## Follow-ups

- **CLI hardening** (both points from the issue still stand): surface the swallowed `waitForCallback` timeout (`packages/cli/src/lib/auth.ts:365-369`) instead of sitting silently, and give `login()` an overall deadline so a wedged attempt stops holding one of the five loopback ports forever. These are what turned a failed consent into five minutes of no feedback.
- **Add the `else` branch** as insurance so any future redirect-less response becomes an actionable error rather than a silent hang.
- **Regression test** once `apps/web` has React test infra: mock `setActive` to resolve with `{redirect:true,url}` and assert `window.location.href` ends at the *consent* response's URL, not the set-active one.
- **Consider removing the round trip entirely**: the plugin already resolves the org via `postLogin.consentReferenceId` (`packages/auth/src/server.ts:357`). If the selected org could be threaded through there, `setActive` leaves this path altogether.

## Risks / Rollout
- **Risk:** low. One call site, one page. Error detail from `setActive` is slightly coarser (`"Failed to set organization"` instead of better-auth's message); the response body is not parsed for a message.
- **Rollback:** revert the commit — no schema, config, or API changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth consent redirect race that caused `superset auth login` to hang indefinitely. Replaces `authClient.organization.setActive()` with a plain `fetch` so only `handleConsent` can navigate the browser, preventing the consent POST from being cancelled by a competing full-page redirect. Resolves issue #6609.

<sup>Written for commit b01d4c9e7ebe1b29a3929dde61aef41ed9fa47ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization activation during consent setup to prevent unexpected navigation.
  * Added more consistent error handling when organization activation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->