### PR TITLE
fix(desktop): stop 'Host unreachable' lingering after host-service restart

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -192,6 +192,48 @@ describe("HostServiceCoordinator preferred ports", () => {
 	});
 });
 
+interface StableSecretInternals {
+	getOrCreateSecret(organizationId: string): string;
+}
+
+describe("HostServiceCoordinator stable secret", () => {
+	let coordinator: InstanceType<typeof HostServiceCoordinator>;
+	let internals: StableSecretInternals;
+
+	beforeEach(() => {
+		resetMocks();
+		testManifestRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hsc-test-"));
+		coordinator = new HostServiceCoordinator();
+		internals = coordinator as unknown as StableSecretInternals;
+	});
+
+	afterEach(() => {
+		coordinator.stopAll();
+		if (testManifestRoot) {
+			fs.rmSync(testManifestRoot, { recursive: true, force: true });
+			testManifestRoot = "";
+		}
+	});
+
+	test("hands respawns the same secret clients already hold", () => {
+		const first = internals.getOrCreateSecret("org-1");
+
+		expect(internals.getOrCreateSecret("org-1")).toBe(first);
+		expect(internals.getOrCreateSecret("org-2")).not.toBe(first);
+	});
+
+	test("seeds the secret from a surviving manifest, then keeps it", () => {
+		manifestStore.current = baseManifest(1234);
+
+		expect(internals.getOrCreateSecret("org-1")).toBe("manifest-secret");
+
+		// Sticky once seeded: losing the manifest (crash cleanup) must not
+		// rotate the credential out from under connected clients.
+		manifestStore.current = null;
+		expect(internals.getOrCreateSecret("org-1")).toBe("manifest-secret");
+	});
+});
+
 interface ReconcileInternals {
 	instances: Map<
 		string,

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -171,6 +171,7 @@ export class HostServiceCoordinator extends EventEmitter {
 	private instances = new Map<string, HostServiceProcess>();
 	private pendingStarts = new Map<string, PendingStart>();
 	private lastKnownPorts = new Map<string, number>();
+	private stableSecrets = new Map<string, string>();
 	private scriptPath = path.join(__dirname, "host-service.js");
 	private machineId = getHostId();
 	private devReloadWatcher: fs.FSWatcher | null = null;
@@ -291,6 +292,26 @@ export class HostServiceCoordinator extends EventEmitter {
 	private rememberPort(organizationId: string, port: number): void {
 		if (!isValidPort(port)) return;
 		this.lastKnownPorts.set(organizationId, port);
+	}
+
+	/**
+	 * One PSK per org for the coordinator's lifetime, seeded from a surviving
+	 * manifest when there is one. Respawns and restarts must reuse it: every
+	 * live client (renderer windows, the CLI, peer app instances) caches this
+	 * secret against the host URL, and rotating it per spawn strands them all
+	 * on auth-rejected redials until their next connection poll — which showed
+	 * up as multi-second "Host unreachable" screens after a restarted service
+	 * was already serving. Stability gives up nothing: the current secret
+	 * already sits on disk in the manifest for adoption, so per-spawn rotation
+	 * never narrowed its exposure.
+	 */
+	private getOrCreateSecret(organizationId: string): string {
+		const existing =
+			this.stableSecrets.get(organizationId) ??
+			readManifest(organizationId)?.authToken;
+		const secret = existing ?? randomBytes(32).toString("hex");
+		this.stableSecrets.set(organizationId, secret);
+		return secret;
 	}
 
 	stop(organizationId: string): void {
@@ -674,6 +695,9 @@ export class HostServiceCoordinator extends EventEmitter {
 			owned: false,
 		});
 		this.rememberPort(organizationId, port);
+		// A later respawn must keep honoring credentials clients cached against
+		// the adopted instance.
+		this.stableSecrets.set(organizationId, manifest.authToken);
 		this.emitStatus(organizationId, "running", previous?.status ?? null);
 
 		log.info(
@@ -694,7 +718,7 @@ export class HostServiceCoordinator extends EventEmitter {
 		const port = await findFreePort(preferredPorts);
 		if (!isStartAllowed()) throw new Error("Host service start cancelled");
 		this.rememberPort(organizationId, port);
-		const secret = randomBytes(32).toString("hex");
+		const secret = this.getOrCreateSecret(organizationId);
 
 		const instance: HostServiceProcess = {
 			pid: 0,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
@@ -6,6 +6,7 @@ import { useLocalHostService } from "renderer/routes/_authenticated/providers/Lo
 import { StateScreenShell } from "../../../../components/StateScreenShell";
 import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceHostUnreachableState";
 import { useHostReachability } from "../../../../hooks/useHostReachability";
+import { LOCAL_HOST_SERVICE_DETAIL } from "../../utils/localHostServiceDetail";
 
 const HOST_LIST_STALE_MS = 30_000;
 
@@ -66,7 +67,7 @@ export function WorkspaceHostGate({
 							hostName={hostName}
 							detail={
 								isLocalRestartInFlight
-									? "The local host service is restarting. It should be back in a few seconds."
+									? LOCAL_HOST_SERVICE_DETAIL.starting
 									: detail
 							}
 							isReconnecting={isReconnecting || isLocalRestartInFlight}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
@@ -25,7 +25,15 @@ export function WorkspaceHostGate({
 	const hostUrl = useWorkspaceHostUrl();
 	const { isUnreachable, isReconnecting, detail, retry } =
 		useHostReachability(hostUrl);
-	const { machineId } = useLocalHostService();
+	const { machineId, hostServiceStatus } = useLocalHostService();
+
+	// A local host that dropped because the coordinator is mid-restart is not
+	// "unreachable, go restart it from the tray" — that advises the user to do
+	// what is already happening. Only "starting" is overridden: a service the
+	// coordinator believes is running yet stays unreachable is a real wedge,
+	// and for that the default advice stands.
+	const isLocalRestartInFlight =
+		workspace.hostId === machineId && hostServiceStatus === "starting";
 	const { data: hostRows = [] } = cloudTrpc.v2Host.list.useQuery(undefined, {
 		staleTime: HOST_LIST_STALE_MS,
 	});
@@ -56,8 +64,12 @@ export function WorkspaceHostGate({
 						<WorkspaceHostUnreachableState
 							hostId={workspace.hostId}
 							hostName={hostName}
-							detail={detail}
-							isReconnecting={isReconnecting}
+							detail={
+								isLocalRestartInFlight
+									? "The local host service is restarting. It should be back in a few seconds."
+									: detail
+							}
+							isReconnecting={isReconnecting || isLocalRestartInFlight}
 							onRetry={retry}
 						/>
 					</StateScreenShell>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/WorkspaceLocalHostPendingState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceLocalHostPendingState/WorkspaceLocalHostPendingState.tsx
@@ -1,10 +1,10 @@
 import { toast } from "@superset/ui/sonner";
-import { useEffect } from "react";
 import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { StateScreenShell } from "../../../../components/StateScreenShell";
 import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceHostUnreachableState";
+import { LOCAL_HOST_SERVICE_DETAIL } from "../../utils/localHostServiceDetail";
 
 /**
  * The workspace lives on this device but the local host service has no port
@@ -13,31 +13,9 @@ import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceH
  */
 const LOCAL_HOST_GRACE_MS = 10_000;
 
-const DETAIL_BY_STATUS = {
-	starting:
-		"The local host service is still starting up. It should be ready in a few seconds.",
-	stopped:
-		"The local host service isn't running, so nothing on this device can serve the workspace. Restarting it reattaches your terminals and files — nothing on disk is lost.",
-	// The process is up but its port hasn't reached us yet: getProcessStatus
-	// polls every second, the connection every five. Never advise a restart
-	// here — the service is healthy and this clears itself.
-	running: "The local host service just came up. Reconnecting to it now.",
-	unknown:
-		"The local host service isn't responding. Restarting it usually clears this; if it keeps happening, restart Superset.",
-} as const;
-
 export function WorkspaceLocalHostPendingState({ hostId }: { hostId: string }) {
 	const { hostServiceStatus, activeOrganizationId } = useLocalHostService();
 	const showState = useDelayElapsed(true, LOCAL_HOST_GRACE_MS);
-	const utils = electronTrpc.useUtils();
-
-	// The process reports running before the 5s connection poll hands us its
-	// port. Ask for the port now rather than leaving this screen up over a
-	// host service that is already serving.
-	useEffect(() => {
-		if (hostServiceStatus !== "running") return;
-		void utils.hostServiceCoordinator.getConnection.invalidate();
-	}, [hostServiceStatus, utils]);
 
 	const restart = electronTrpc.hostServiceCoordinator.restart.useMutation({
 		onError: (error) => {
@@ -62,7 +40,7 @@ export function WorkspaceLocalHostPendingState({ hostId }: { hostId: string }) {
 			<WorkspaceHostUnreachableState
 				hostId={hostId}
 				hostName="This device"
-				detail={DETAIL_BY_STATUS[hostServiceStatus]}
+				detail={LOCAL_HOST_SERVICE_DETAIL[hostServiceStatus]}
 				isReconnecting={isStarting}
 				retryLabel="Restart host service"
 				retryBusyLabel="Starting…"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/utils/localHostServiceDetail/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/utils/localHostServiceDetail/index.ts
@@ -1,0 +1,1 @@
+export { LOCAL_HOST_SERVICE_DETAIL } from "./localHostServiceDetail";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/utils/localHostServiceDetail/localHostServiceDetail.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/utils/localHostServiceDetail/localHostServiceDetail.ts
@@ -1,0 +1,23 @@
+import type { HostServiceAvailabilityStatus } from "renderer/lib/host-service-unavailable";
+
+/**
+ * What the takeover screens say about the local host service, by coordinator
+ * status. Shared by WorkspaceLocalHostPendingState (no port ever reported) and
+ * WorkspaceHostGate (connection dropped) so the two screens can't drift into
+ * telling different stories about the same service.
+ */
+export const LOCAL_HOST_SERVICE_DETAIL: Record<
+	HostServiceAvailabilityStatus,
+	string
+> = {
+	starting:
+		"The local host service is still starting up. It should be ready in a few seconds.",
+	stopped:
+		"The local host service isn't running, so nothing on this device can serve the workspace. Restarting it reattaches your terminals and files — nothing on disk is lost.",
+	// The process is up but its port hasn't reached us yet: getProcessStatus
+	// polls every second, the connection every five. Never advise a restart
+	// here — the service is healthy and this clears itself.
+	running: "The local host service just came up. Reconnecting to it now.",
+	unknown:
+		"The local host service isn't responding. Restarting it usually clears this; if it keeps happening, restart Superset.",
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -191,16 +191,13 @@ export function LocalHostServiceProvider({
 	// Fires on the null → connection edge after a restart (during downtime
 	// getConnection reports null, and react-query's structural sharing keeps an
 	// unchanged connection referentially stable). The event bus for this URL is
-	// on its own backoff and its last dial may have lost the race against this
-	// very update and been auth-rejected — without a nudge the workspace sits
-	// under "Host unreachable" for seconds after the service is back.
+	// on its own backoff and its next scheduled dial is seconds out — without a
+	// nudge the workspace sits under "Host unreachable" after the service is
+	// back. The secret is already in place: the context memo below stores it
+	// during the same render, before any effect runs.
 	useEffect(() => {
 		if (!activeConnection?.port) return;
-		const hostUrl = `http://127.0.0.1:${activeConnection.port}`;
-		if (activeConnection.secret) {
-			setHostServiceSecret(hostUrl, activeConnection.secret);
-		}
-		reconnectEventBusIfDown(hostUrl);
+		reconnectEventBusIfDown(`http://127.0.0.1:${activeConnection.port}`);
 	}, [activeConnection]);
 
 	const waitForHostReady = useCallback(

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/LocalHostServiceProvider/LocalHostServiceProvider.tsx
@@ -1,3 +1,4 @@
+import { reconnectEventBusIfDown } from "@superset/workspace-client";
 import {
 	createContext,
 	type ReactNode,
@@ -186,6 +187,21 @@ export function LocalHostServiceProvider({
 			},
 		},
 	);
+
+	// Fires on the null → connection edge after a restart (during downtime
+	// getConnection reports null, and react-query's structural sharing keeps an
+	// unchanged connection referentially stable). The event bus for this URL is
+	// on its own backoff and its last dial may have lost the race against this
+	// very update and been auth-rejected — without a nudge the workspace sits
+	// under "Host unreachable" for seconds after the service is back.
+	useEffect(() => {
+		if (!activeConnection?.port) return;
+		const hostUrl = `http://127.0.0.1:${activeConnection.port}`;
+		if (activeConnection.secret) {
+			setHostServiceSecret(hostUrl, activeConnection.secret);
+		}
+		reconnectEventBusIfDown(hostUrl);
+	}, [activeConnection]);
 
 	const waitForHostReady = useCallback(
 		async (timeoutMs = 20_000): Promise<string | null> => {

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -11,6 +11,7 @@ export {
 	type PortChangedPayload,
 	type ProjectChangedPayload,
 	type ProjectSnapshotPayload,
+	reconnectEventBusIfDown,
 	type TerminalLifecyclePayload,
 	type WorkspaceChangedPayload,
 	type WorkspaceCreateSettledPayload,

--- a/packages/workspace-client/src/lib/eventBus.test.ts
+++ b/packages/workspace-client/src/lib/eventBus.test.ts
@@ -140,6 +140,9 @@ describe("eventBus", () => {
 		const port = host.server.port;
 		const bus = getEventBus(host.hostUrl, () => "tok");
 		cleanups.push(bus.on("git:changed", "*", () => {}));
+		// stop() is idempotent, so registering it up front keeps a mid-test
+		// failure from leaking the server into later tests.
+		cleanups.push(() => host.server.stop(true));
 		await waitFor(() => host.clientCount() === 1);
 
 		host.server.stop(true);

--- a/packages/workspace-client/src/lib/eventBus.test.ts
+++ b/packages/workspace-client/src/lib/eventBus.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { getEventBus } from "./eventBus";
+import { getEventBus, reconnectEventBusIfDown } from "./eventBus";
 
 // Real WS server standing in for a host-service event bus. Records upgrades
 // and client commands; `push` broadcasts a server event to connected clients.
-function makeHostServer() {
+function makeHostServer(port = 0) {
 	const upgrades: string[] = [];
 	const commands: Array<Record<string, unknown>> = [];
 	const clients = new Set<Bun.ServerWebSocket<unknown>>();
 	const server = Bun.serve({
-		port: 0,
+		port,
 		fetch(req, srv) {
 			upgrades.push(new URL(req.url).pathname);
 			if (srv.upgrade(req)) return;
@@ -133,6 +133,40 @@ describe("eventBus", () => {
 		// every active watch from state.
 		await waitFor(() => host.commands.length === 2, 8_000);
 		expect(host.commands[1]).toEqual({ type: "fs:watch", workspaceId: "ws-1" });
+	});
+
+	it("reconnectEventBusIfDown dials a downed connection without waiting out the backoff", async () => {
+		const host = makeHostServer();
+		const port = host.server.port;
+		const bus = getEventBus(host.hostUrl, () => "tok");
+		cleanups.push(bus.on("git:changed", "*", () => {}));
+		await waitFor(() => host.clientCount() === 1);
+
+		host.server.stop(true);
+		await waitFor(() => bus.getConnectionStatus().state !== "open");
+		// Let the first automatic redial fail so the socket is sitting out a
+		// grown backoff when the "service is back" signal arrives.
+		await Bun.sleep(1_200);
+
+		const revived = makeHostServer(port);
+		cleanups.push(() => revived.server.stop(true));
+
+		reconnectEventBusIfDown(host.hostUrl);
+		await waitFor(() => revived.clientCount() === 1, 2_000);
+		expect(bus.getConnectionStatus().state).toBe("open");
+	});
+
+	it("reconnectEventBusIfDown leaves an open connection alone", async () => {
+		const host = makeHostServer();
+		const bus = getEventBus(host.hostUrl, () => "tok");
+		cleanups.push(bus.on("git:changed", "*", () => {}));
+		cleanups.push(() => host.server.stop(true));
+		await waitFor(() => host.clientCount() === 1);
+
+		reconnectEventBusIfDown(host.hostUrl);
+		await Bun.sleep(200);
+		expect(host.upgrades.length).toBe(1);
+		expect(bus.getConnectionStatus().state).toBe("open");
 	});
 
 	it("closes the connection when the last listener unsubscribes", async () => {

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -373,6 +373,23 @@ function getOrCreateConnection(
 	return state;
 }
 
+/**
+ * Dial the existing connection for `hostUrl` now, if there is one and it
+ * isn't open. For the moment a client learns the host's endpoint or
+ * credentials changed (a host-service restart handing out a fresh port or
+ * secret): the socket may be mid-backoff, or its last dial may have lost the
+ * race against the credential update and been auth-rejected — either way the
+ * next scheduled attempt is seconds out, and this collapses that wait.
+ * Deliberately never creates a connection: with no established consumers
+ * there is nothing to recover.
+ */
+export function reconnectEventBusIfDown(hostUrl: string): void {
+	const state = connections.get(hostUrl);
+	if (!state || state.status.state === "open") return;
+	state.socket.reconnect(1000, "endpoint or credentials refreshed");
+	setConnectionStatus(state, { state: "connecting" });
+}
+
 function maybeCleanupConnection(hostUrl: string): void {
 	const key = hostUrl;
 	const state = connections.get(key);


### PR DESCRIPTION
## Summary

When the host service restarts (update, crash respawn, tray restart), the "Host unreachable" takeover could stay on screen for up to ~9 seconds *after* the service was already serving again — the flash you see "for a second when the host service first turns on". CDP-instrumented repro attributed it to a race: every spawn minted a fresh PSK, so the gate's 5s redial could dial with the old secret just before the renderer's connection poll delivered the new one, get auth-rejected, and sit out another full backoff cycle.

Three layers, each fixing an independent piece:

- **Coordinator: stable per-org secret.** Respawns and restarts reuse the org's PSK (seeded from a surviving manifest) instead of rotating per spawn. Every client's cached credential — renderer windows, CLI, peer app instances — stays valid across restarts. Rotation bought nothing: the current secret already persists on disk in the manifest for adoption.
- **Renderer: event-driven reconnect.** New `reconnectEventBusIfDown` in workspace-client; `LocalHostServiceProvider` nudges the host's event bus on the null→connection edge after a restart, instead of leaving recovery to the gate's 5s redial timer and partysocket's grown backoff.
- **Gate: honest copy mid-restart.** While the coordinator reports the local service "starting", the takeover says "The local host service is restarting…" with the reconnecting badge, instead of advising a manual tray restart of a service that is already restarting.

Measured before/after (SIGKILL + respawn suppressed 13s, dev app over CDP, 200ms sampling): overlay cleared **0.7–9.2s** after the port was listening before; **0.6–1.5s** across all runs after, with the renderer's token never invalidated. A restart that completes inside the 10s unreachable grace still shows nothing.

## Test Plan

- [x] `bun test` — coordinator suite (42 pass, incl. new stable-secret tests), eventBus suite (7 pass, incl. reconnect-nudge tests)
- [x] `turbo typecheck` on desktop + workspace-client; biome clean on touched files
- [x] CDP end-to-end: kill host service with respawns suppressed past the grace — overlay appears at 10s, clears ≤1.5s after the service listens, secret identical across restart (3 runs)
- [x] CDP end-to-end: single kill with fast respawn — no overlay (grace path unchanged)
- [x] CDP end-to-end: spawn frozen with SIGSTOP past the grace — takeover shows "is restarting" copy with reconnecting badge, recovers after SIGCONT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Host unreachable" overlay lingering up to ~9 seconds after the host service restarts and is already serving again.

- The coordinator now reuses one per-org secret, seeded from a surviving manifest, instead of rotating per spawn, so every client's cached credential (renderer windows, CLI, peer app instances) stays valid across respawns and restarts.
- The renderer now reconnects the host event bus the moment the connection returns, instead of waiting out the gate's 5s redial and the socket's grown backoff.
- While the coordinator reports the local service "starting", the takeover shows "The local host service is restarting…" with the reconnecting badge instead of advising a manual tray restart.
- Shared the local host-service copy between the two takeover screens so they can't drift, and dropped the redundant connection-poll invalidation.
- Measured with a SIGKILL respawn (dev app, 200ms sampling): the overlay clears 0.6–1.5s after the port listens, down from 0.7–9.2s; a restart inside the 10s grace still shows nothing.

<sup>Written for commit 359892bc864170a9cc5a7ad43de50dce5337d56f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace recovery when the local host service restarts.
  * Event updates now reconnect promptly after temporary host-service downtime.
  * Preserved host-service authentication across restarts, respawns, and service handoffs.

* **User Experience**
  * Added clear, consistent status messages while the local host service starts, stops, or restarts.
  * Reconnection state now accurately reflects recovery activity instead of displaying misleading unavailable details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->