### PR TITLE
refactor(desktop): quit-flag consolidation + desktop-action Exec composition (follow-up to #6894)

### DIFF
--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -22,6 +22,9 @@ const dmgBackgroundPath = join(
 	pkg.resources,
 	"build/installer/background.tiff",
 );
+// Also the AppImage default when unset; declared so the desktop action's Exec
+// below is composed from the same args instead of drifting.
+const linuxExecutableArgs = ["--no-sandbox"];
 
 const config: Configuration = {
 	appId: "com.superset.desktop",
@@ -152,6 +155,7 @@ const config: Configuration = {
 		synopsis: pkg.description,
 		target: ["AppImage"],
 		artifactName: `superset-\${version}-\${arch}.\${ext}`,
+		executableArgs: linuxExecutableArgs,
 		// GNOME's app menus only show their heuristic "New Window" item
 		// intermittently for running apps; an explicit desktop action (the
 		// Chrome/VS Code approach) is always shown. The action relaunches with
@@ -167,12 +171,10 @@ const config: Configuration = {
 			desktopActions: {
 				"new-window": {
 					Name: "New Window",
-					// Args must stay in sync with linux.executableArgs (the
-					// AppImage default is --no-sandbox when unset); %U is
-					// intentionally omitted. --new-window is what the
+					// %U is intentionally omitted. --new-window is what the
 					// second-instance handler keys on to open a window instead
 					// of focusing the running app.
-					Exec: "AppRun --no-sandbox --new-window",
+					Exec: ["AppRun", ...linuxExecutableArgs, "--new-window"].join(" "),
 				},
 			},
 		},

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -43,6 +43,7 @@ import {
 import { syncInstalledPluginMcpServers } from "./lib/plugin-installs";
 import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { runQuitCleanup } from "./lib/quit-sequence";
+import { isAppQuitting, markAppQuitting } from "./lib/quit-state";
 import { initSentry } from "./lib/sentry";
 import {
 	prewarmTerminalRuntime,
@@ -58,7 +59,6 @@ import { sweepNetworkLogs } from "./network-logger-sweep";
 import {
 	createPlatformWindow,
 	initAppServices,
-	markAppQuitting,
 	persistOpenWindows,
 	restoreWindows,
 } from "./windows/main";
@@ -185,7 +185,6 @@ app.on("open-url", async (event, url) => {
 	}
 });
 
-let isQuitting = false;
 let skipQuitConfirmation = false;
 let forceFullCleanup = false;
 
@@ -220,7 +219,7 @@ function getConfirmOnQuitSetting(): boolean {
 }
 
 app.on("before-quit", async (event) => {
-	if (isQuitting) return;
+	if (isAppQuitting()) return;
 
 	const isDev = process.env.NODE_ENV === "development";
 	if (!skipQuitConfirmation && !isDev && getConfirmOnQuitSetting()) {
@@ -244,7 +243,6 @@ app.on("before-quit", async (event) => {
 		}
 	}
 
-	isQuitting = true;
 	// Snapshot all open windows (bounds + org) before they close, so relaunch
 	// restores them. markAppQuitting() stops per-window close handlers from
 	// shrinking the set as windows close one-by-one.
@@ -278,12 +276,12 @@ async function teardownTerminalHost(): Promise<void> {
 }
 
 process.on("uncaughtException", (error) => {
-	if (isQuitting) return;
+	if (isAppQuitting()) return;
 	console.error("[main] Uncaught exception:", error);
 });
 
 process.on("unhandledRejection", (reason) => {
-	if (isQuitting) return;
+	if (isAppQuitting()) return;
 	console.error("[main] Unhandled rejection:", reason);
 });
 
@@ -361,7 +359,7 @@ if (!gotTheLock) {
 	app.on("second-instance", async (_event, argv) => {
 		// An auto-update restart spawns the replacement while this process
 		// still holds the single-instance lock; don't build windows mid-quit.
-		if (isQuitting) return;
+		if (isAppQuitting()) return;
 		const url = findDeepLinkInArgv(argv);
 		if (url) {
 			// processDeepLink focuses the window on every one of its paths.

--- a/apps/desktop/src/main/lib/quit-state.ts
+++ b/apps/desktop/src/main/lib/quit-state.ts
@@ -1,0 +1,12 @@
+// Single "app is quitting" flag, set once from before-quit. Lives in its own
+// module (like menu-events) so index.ts and windows/main.ts share one flag
+// instead of each keeping a parallel boolean set at the same moment.
+let appQuitting = false;
+
+export function markAppQuitting(): void {
+	appQuitting = true;
+}
+
+export function isAppQuitting(): boolean {
+	return appQuitting;
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -34,6 +34,7 @@ import {
 	getWorkspaceName,
 } from "../lib/notifications/utils";
 import { recordV1TerminalExit } from "../lib/notifications/v1-agent-sessions";
+import { isAppQuitting } from "../lib/quit-state";
 import {
 	getAllWindows,
 	getFocusedOrLastWindow,
@@ -275,13 +276,6 @@ function stopSharedServices(): void {
 // ---------------------------------------------------------------------------
 // Multi-window restore
 // ---------------------------------------------------------------------------
-
-// Set during app quit so per-window close handlers don't shrink the persisted
-// set as windows close one-by-one — the full set is snapshotted in before-quit.
-let appQuitting = false;
-export function markAppQuitting(): void {
-	appQuitting = true;
-}
 
 function snapshotWindowState(window: BrowserWindow): WindowState {
 	const isMaximized = window.isMaximized();
@@ -578,7 +572,7 @@ export async function createPlatformWindow({
 		// A user closing one window (app keeps running) updates the restore set.
 		// During app quit we skip this — before-quit snapshots the full set so
 		// closing windows one-by-one doesn't shrink it.
-		if (!appQuitting) {
+		if (!isAppQuitting()) {
 			persistOpenWindows();
 		}
 


### PR DESCRIPTION
## What & why

Follow-up cleanups from the review of #6894 (now merged):

- **Consolidate the two app-quitting flags.** `main/index.ts` kept `isQuitting` and `windows/main.ts` kept `appQuitting`, both set at the same moment in `before-quit` but read by different guards (crash-log suppression, the second-instance handler, per-window close). They now share one flag in `main/lib/quit-state.ts` (`markAppQuitting()` / `isAppQuitting()`), so the guards can't drift apart. No behavior change.
- **Compose the desktop action's `Exec` from `linux.executableArgs`.** Declares `executableArgs: ["--no-sandbox"]` explicitly (identical to the AppImage default when unset, so the built artifact is unchanged) and builds the New Window action's `Exec` from it — replacing the keep-in-sync comment with actual sharing.

## Test plan

- [x] `tsc --noEmit` passes in apps/desktop (re-run post-rebase onto main)
- [x] `biome check` clean on the four touched files
- [x] No tests reference the consolidated flags
- [x] CDP-verified on macOS with this branch running: org-dropdown New window, command-palette New window, native File → New Window, per-window close (×3), and a real Cmd+Q quit — all through the consolidated quit-state path; no console errors, clean exit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling to prevent unnecessary window-state persistence and duplicate quit-related behavior, resulting in a more reliable exit experience.
  * Preserved Linux desktop “New Window” launch behavior while keeping its startup options consistent across application launches and desktop shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->