### PR TITLE
fix(trpc): raise leaderboard publish row caps so heavy days can publish

### DIFF
--- a/packages/trpc/src/router/leaderboard/schema.ts
+++ b/packages/trpc/src/router/leaderboard/schema.ts
@@ -3,10 +3,12 @@ import { isDayKey, LEADERBOARD_PERIODS } from "./periods";
 
 const dayKey = z.string().refine(isDayKey, "Expected a real YYYY-MM-DD date");
 
-// Per field, per (day, provider, model, host) row. Generous next to real usage,
-// but low enough that a full payload cannot overflow the bigint rollup on
-// leaderboard_participants.
-export const MAX_TOKENS_PER_ROW_FIELD = 50_000_000_000;
+// Per field, per (day, provider, model, host) row. Cache reads dominate the
+// count and scale with session concurrency, so one model on one day of heavily
+// parallel work clears 100B. The rollup on leaderboard_participants is read
+// back as a JS number, so the ceiling that matters is 2^53: this leaves room
+// for ~9k rows at the cap.
+export const MAX_TOKENS_PER_ROW_FIELD = 1_000_000_000_000;
 
 const tokenCount = z.number().int().min(0).max(MAX_TOKENS_PER_ROW_FIELD);
 
@@ -30,8 +32,9 @@ export const joinSchema = z.object({
 	visibility: visibilitySchema.default("public"),
 });
 
-// Same reasoning as the token cap, against the numeric(14,6) usd rollup.
-export const MAX_USD_PER_ROW = 10_000;
+// Same reasoning as the token cap. Two orders of magnitude under the
+// numeric(14,6) column the per-row value lands in.
+export const MAX_USD_PER_ROW = 1_000_000;
 
 export const publishDaySchema = z.object({
 	day: dayKey,


### PR DESCRIPTION
## What & why

A single oversized row rejects an entire leaderboard publish, so heavy users stop publishing without noticing.

The caps in `publishSchema` sit on the procedure input, which means zod fails the whole `days` array when one element is out of range and the mutation never reaches the handler. Every other day in that payload is dropped with it:

```
[leaderboard] auto-publish failed (will retry): TRPCClientError:
  days[4].cachedInput   Too big: expected number to be <=50000000000
  days[32].usdEstimate  Too big: expected number to be <=10000
```

They are also below real usage. `cachedInput` counts cache reads, which scale with session concurrency, so one model on one day of heavily parallel agent work clears the token cap and the $10,000 estimate together. `usdEstimate` is notional list price, not billed spend.

This raises the two caps so those days validate. 1T per field per row leaves about an order of magnitude over the largest row I have observed in practice, and $1M stays two orders of magnitude under the `numeric(14,6)` column the per-row value lands in.

Worth flagging for review, since I do not think the cap can carry the guarantee its comment claims: the rollup on `leaderboard_participants` is read back through `bigint({ mode: "number" })`, so the real ceiling is 2^53, and rows accumulate without bound across days, models and hosts. 1T x 9,007 rows reaches 2^53; the old 50B allowed 180,143. Neither is an invariant. If you want one it belongs in the rollup read path rather than in an input cap, and I am happy to do that instead if you would rather go that way.

Two related problems are out of scope here, but they are what turns this from an error into silent data loss, so they are worth their own fix:

- The rejection is console-only after the join toast, so an account can sit broken indefinitely with no signal.
- Days already rejected cannot be repaired. Once `publishWindowDays` shrinks the window back to 2 days nothing revisits them, and leaving and rejoining re-backfills only 30 days. Raising the caps fixes new publishes, not history.

Reported in Discord: https://discord.com/channels/1446776342577283114/1446776344204677132/1542510608828862515

## How I tested it

- Replayed a real 30-day payload from my own host against both versions of the schema, importing `packages/trpc/src/router/leaderboard/schema.ts` unmodified from `main` and from this branch. On `main`, 7 of 80 rows fail and `publishSchema.safeParse` rejects the whole payload with the same `Too big` messages as the console error above. On this branch all 80 rows parse and the payload is accepted.
- `bun run lint` passes repo-wide: 6,615 files checked, no diagnostics.
- `bun run typecheck` passes: 37 of 37 turbo tasks successful. Run locally with bun 1.4.0 rather than the pinned 1.3.14, so treat it as a strong signal rather than a CI-equivalent one.
- I have not run `bun run test`. The change is two numeric literals and a comment, and neither constant is referenced anywhere else in the repo.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs
