### PR TITLE
feat(desktop): add a PDF viewer to the file pane

### DIFF
--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -395,6 +395,8 @@ export async function createPlatformWindow({
 		webPreferences: {
 			preload: join(__dirname, "../preload/index.js"),
 			webviewTag: true,
+			// Chromium's built-in PDF viewer, used by the file pane's PDF view
+			plugins: true,
 			// Isolate Electron session from system browser cookies
 			// This ensures desktop uses bearer token auth, not web cookies
 			partition: "persist:superset",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/allViews.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/allViews.ts
@@ -3,6 +3,7 @@ import { binaryWarningView } from "./views/BinaryWarningView";
 import { codeView } from "./views/CodeView";
 import { imageView } from "./views/ImageView";
 import { markdownPreviewView } from "./views/MarkdownPreviewView";
+import { pdfView } from "./views/PdfView";
 import { videoView } from "./views/VideoView";
 
 // Order is preserved as a stable tiebreaker for equal-priority views.
@@ -10,6 +11,7 @@ import { videoView } from "./views/VideoView";
 export const ALL_VIEWS: FileView[] = [
 	imageView,
 	videoView,
+	pdfView,
 	binaryWarningView,
 	markdownPreviewView,
 	codeView,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/PdfView/PdfView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/PdfView/PdfView.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { getBaseName } from "renderer/lib/pathBasename";
+import type { ViewProps } from "../../types";
+
+export function PdfView({ document, filePath }: ViewProps) {
+	const [source, setSource] = useState<{
+		key: string;
+		url: string;
+	} | null>(null);
+
+	const sourceKey =
+		document.content.kind === "bytes"
+			? `${filePath}\0${document.content.revision}`
+			: null;
+
+	useEffect(() => {
+		if (document.content.kind !== "bytes") {
+			setSource(null);
+			return;
+		}
+		const url = URL.createObjectURL(
+			new Blob([document.content.value as BlobPart], {
+				type: "application/pdf",
+			}),
+		);
+		setSource({ key: `${filePath}\0${document.content.revision}`, url });
+		return () => URL.revokeObjectURL(url);
+	}, [document.content, filePath]);
+
+	if (!source || source.key !== sourceKey) {
+		return null;
+	}
+
+	return (
+		<iframe
+			src={source.url}
+			title={getBaseName(filePath)}
+			className="h-full w-full border-0 bg-background"
+		/>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/PdfView/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/registry/views/PdfView/index.ts
@@ -1,0 +1,12 @@
+import { isPdfFile } from "shared/file-types";
+import type { FileView } from "../../types";
+import { PdfView } from "./PdfView";
+
+export const pdfView: FileView = {
+	id: "pdf",
+	label: "PDF",
+	match: (filePath) => isPdfFile(filePath),
+	priority: "exclusive",
+	documentKind: "bytes",
+	Renderer: PdfView,
+};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.ts
@@ -1,6 +1,6 @@
 import type { workspaceTrpc } from "@superset/workspace-client";
 import type { FsWatchEvent } from "@superset/workspace-fs/client";
-import { isImageFile, isVideoFile } from "shared/file-types";
+import { isImageFile, isPdfFile, isVideoFile } from "shared/file-types";
 import type {
 	ConflictResolution,
 	ConflictState,
@@ -92,7 +92,9 @@ async function loadEntry(
 ): Promise<void> {
 	const client = entry.trpcClient;
 	const readAsBinary =
-		isImageFile(entry.absolutePath) || isVideoFile(entry.absolutePath);
+		isImageFile(entry.absolutePath) ||
+		isVideoFile(entry.absolutePath) ||
+		isPdfFile(entry.absolutePath);
 	const maxBytes = options.unlimited ? undefined : DEFAULT_MAX_BYTES;
 	try {
 		const result = await client.filesystem.readFile.query({

--- a/apps/desktop/src/shared/file-types.test.ts
+++ b/apps/desktop/src/shared/file-types.test.ts
@@ -4,6 +4,7 @@ import {
 	getImageMimeType,
 	getVideoMimeType,
 	isImageFile,
+	isPdfFile,
 	isPreviewableVideoFile,
 	isVideoFile,
 	parseBase64DataUrl,
@@ -55,6 +56,13 @@ describe("file-types", () => {
 		expect(getVideoMimeType("demo.webm")).toBe("video/webm");
 		expect(getVideoMimeType("demo.mov")).toBe("video/quicktime");
 		expect(getVideoMimeType("demo.avi")).toBeNull();
+	});
+
+	test("detects PDF file paths", () => {
+		expect(isPdfFile("report.pdf")).toBe(true);
+		expect(isPdfFile("docs/REPORT.PDF")).toBe(true);
+		expect(isPdfFile("report.pdf.txt")).toBe(false);
+		expect(isPdfFile("report")).toBe(false);
 	});
 
 	test("parses base64 data URLs with extra MIME parameters", () => {

--- a/apps/desktop/src/shared/file-types.ts
+++ b/apps/desktop/src/shared/file-types.ts
@@ -73,6 +73,13 @@ const IMAGE_MIME_TYPE_EXTENSIONS: Record<string, string> = {
 const MARKDOWN_EXTENSIONS = new Set(["md", "markdown", "mdx"]);
 
 /**
+ * Checks if a file is a PDF based on extension
+ */
+export function isPdfFile(filePath: string): boolean {
+	return getFileExtension(filePath) === "pdf";
+}
+
+/**
  * Checks if a file is an image based on extension
  */
 export function isImageFile(filePath: string): boolean {


### PR DESCRIPTION
## Summary
- Opening a `.pdf` in the file pane now renders it in a real PDF viewer (page thumbnails, zoom, search, print) instead of the "binary file — Open Anyway" warning.

## Why / Context
The file pane's view registry already handles images, video, and markdown, but PDFs fell through to `BinaryWarningView`: the document store read them as UTF-8, NUL-sniffed them as binary, and no view matched.

## How It Works
- New `PdfView` in the FilePane view registry (`priority: "exclusive"`, matching the ImageView/VideoView pattern). It builds an `application/pdf` blob URL from the document bytes and renders it in an `<iframe>`, with VideoView's `filePath\0revision` staleness guard so a reloaded document never shows a stale blob.
- `fileDocumentStore` now reads `.pdf` files as bytes (`isPdfFile` added to `shared/file-types`), same as images/video.
- `plugins: true` on the main window's webPreferences enables Chromium's built-in PDF viewer, which is what renders inside the iframe. No CSP change needed — `frame-src` already allows `blob:`, and no new dependency (no pdf.js).

## Manual QA Checklist
Verified end-to-end over CDP against the dev app with a real two-page PDF:
- [x] Opening a `.pdf` via file search renders the Chromium PDF viewer in the pane (toolbar, thumbnails, page counter)
- [x] Page navigation works with real mouse input (thumbnail click → viewer follows to page 2)
- [x] Close pane → reopen file remounts cleanly with a fresh blob URL
- [x] `console.error` hooked across the whole cycle — stayed empty
- [x] Changes pane / file watcher treat the PDF as a binary file (no diff attempt)

## Testing
- `bun run typecheck` (desktop)
- `bun run lint`
- `bun test src/shared/file-types.test.ts` (new `isPdfFile` cases)

## Design Decisions
- **Chromium's built-in viewer instead of pdf.js**: one line of main-process config vs. a new dependency plus custom toolbar/zoom/search UI. The built-in viewer gives all of that for free and stays in sync with Electron upgrades.

## Known Limitations
- The viewer's own toolbar shows the blob UUID rather than the filename (blob URLs carry no name); the pane header directly above shows the real filename.
- PDFs over the store's 10 MiB cap show the existing "too large" state with the load-anyway escape hatch, same as video.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders `.pdf` files in the file pane with Chromium's built-in PDF viewer (thumbnails, zoom, search, print) instead of the previous "binary file — Open Anyway" warning.

- Registers a new exclusive `PdfView` in the FilePane registry and reads `.pdf` files as bytes in the file document store via new `isPdfFile` in `shared/file-types`.
- Enables `plugins: true` on the main window webPreferences so the viewer runs inside an iframe over a blob URL, with no new dependency or CSP change.
- Uses a `filePath\0revision` staleness guard so a reloaded document never shows a stale blob URL.
- The viewer's own toolbar shows the blob UUID instead of the filename; PDFs over the 10 MiB cap keep the existing "too large" state with the load-anyway escape hatch.

<sup>Written for commit aac750ddf761ef77f8c7171a8da0a724350030cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF preview support in the desktop file pane.
  * PDF files now open in the built-in viewer with proper document titles.
  * PDF detection works consistently regardless of filename capitalization.

* **Bug Fixes**
  * Improved PDF loading and cleanup to prevent stale previews and resource leaks.

* **Tests**
  * Added coverage for identifying PDF files and rejecting non-PDF paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->