### PR TITLE
feat(marketing): surface SOC 2 Type II across the site

### DIFF
--- a/apps/marketing/content/changelog/2026-08-27-soc-2-type-ii.mdx
+++ b/apps/marketing/content/changelog/2026-08-27-soc-2-type-ii.mdx
@@ -1,0 +1,11 @@
+---
+title: SOC 2 Type II
+date: 2026-08-27
+description: Superset has completed its SOC 2 Type II audit. The report is available through our trust center.
+---
+
+Superset has completed its SOC 2 Type II audit. An independent auditor examined our security controls operating over a multi-month period, not just their design at a point in time, and issued the final report this week. It builds on the [penetration test we passed earlier this year](/changelog/2026-03-30-mobile-agents-themes-editor).
+
+Security has shaped Superset from the start. Your repos, terminal output, and agent sessions stay on your machine, cloud sync carries account and organization metadata only, and the full source is available to audit on GitHub. The Type II report adds independent, ongoing verification of the controls behind all of that, from access reviews to change management and monitoring.
+
+Request the report and review our security documentation at [trust.superset.sh](https://trust.superset.sh). If your security team is evaluating Superset, [talk to us](/enterprise).

--- a/apps/marketing/src/app/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/components/Footer/Footer.tsx
@@ -5,6 +5,7 @@ import { m } from "framer-motion";
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Soc2Badge } from "../Soc2Badge";
 import { SocialLinks } from "../SocialLinks";
 
 function SupersetLogo() {
@@ -89,6 +90,14 @@ export function Footer() {
 							<SupersetLogo />
 						</Link>
 						<SocialLinks className="-ml-2" />
+						<a
+							href={COMPANY.TRUST_URL}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="w-max text-muted-foreground transition-colors hover:text-foreground"
+						>
+							<Soc2Badge size={80} />
+						</a>
 						<p className="text-sm text-muted-foreground">
 							© {new Date().getFullYear()} Superset Inc.
 						</p>

--- a/apps/marketing/src/app/components/SecuritySection/SecuritySection.tsx
+++ b/apps/marketing/src/app/components/SecuritySection/SecuritySection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { COMPANY } from "@superset/shared/constants";
 import { m } from "framer-motion";
 import type { ReactNode } from "react";
 import {
@@ -7,6 +8,7 @@ import {
 	HiOutlineServerStack,
 	HiOutlineSignal,
 } from "react-icons/hi2";
+import { Soc2Badge } from "../Soc2Badge";
 
 const SECURITY_FEATURES: {
 	icon: ReactNode;
@@ -39,24 +41,35 @@ export function SecuritySection() {
 			<div className="max-w-7xl mx-auto px-6 sm:px-8">
 				{/* Heading */}
 				<m.div
-					className="mb-16 space-y-4"
+					className="mb-16 flex items-start justify-between gap-8"
 					initial={{ opacity: 0, y: 20 }}
 					whileInView={{ opacity: 1, y: 0 }}
 					viewport={{ once: true }}
 					transition={{ duration: 0.5 }}
 				>
-					<span className="text-sm font-mono uppercase tracking-widest text-brand">
-						Security
-					</span>
-					<h2 className="text-3xl sm:text-4xl lg:text-5xl font-medium tracking-tight leading-[1.1] text-foreground">
-						Private by default.
-						<br />
-						You&apos;re in control.
-					</h2>
-					<p className="text-base sm:text-lg font-light text-muted-foreground max-w-[700px]">
-						Your code stays local by default, with explicit control over
-						connected services.
-					</p>
+					<div className="space-y-4">
+						<span className="text-sm font-mono uppercase tracking-widest text-brand">
+							Security
+						</span>
+						<h2 className="text-3xl sm:text-4xl lg:text-5xl font-medium tracking-tight leading-[1.1] text-foreground">
+							Private by default.
+							<br />
+							You&apos;re in control.
+						</h2>
+						<p className="text-base sm:text-lg font-light text-muted-foreground max-w-[700px]">
+							Your code stays local by default, with explicit control over
+							connected services.
+						</p>
+					</div>
+					<a
+						href={COMPANY.TRUST_URL}
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="SOC 2 Type II compliant. Request our report."
+						className="hidden sm:block shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+					>
+						<Soc2Badge size={128} />
+					</a>
 				</m.div>
 
 				{/* Features Grid */}

--- a/apps/marketing/src/app/components/Soc2Badge/Soc2Badge.tsx
+++ b/apps/marketing/src/app/components/Soc2Badge/Soc2Badge.tsx
@@ -1,0 +1,94 @@
+import { useId } from "react";
+
+interface Soc2BadgeProps {
+	size?: number;
+	className?: string;
+}
+
+export function Soc2Badge({ size = 96, className }: Soc2BadgeProps) {
+	const ringId = useId();
+
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 120 120"
+			fill="none"
+			role="img"
+			aria-label="SOC 2 Type II compliant"
+			className={className}
+		>
+			<title>SOC 2 Type II compliant</title>
+			<circle
+				cx="60"
+				cy="60"
+				r="58.5"
+				stroke="currentColor"
+				strokeOpacity="0.25"
+			/>
+			<circle
+				cx="60"
+				cy="60"
+				r="41.5"
+				stroke="currentColor"
+				strokeOpacity="0.25"
+			/>
+			<defs>
+				{/* Top arc runs clockwise, bottom arc counterclockwise on a wider
+				    radius, so both halves read upright inside the same band */}
+				<path id={`${ringId}-top`} d="M 10,60 A 50,50 0 0 1 110,60" />
+				<path id={`${ringId}-bottom`} d="M 4,60 A 56,56 0 0 0 116,60" />
+			</defs>
+			<text
+				textAnchor="middle"
+				fontSize="6.5"
+				letterSpacing="1.1"
+				fill="currentColor"
+				fillOpacity="0.7"
+				style={{ fontFamily: "var(--font-ibm-plex-mono), monospace" }}
+			>
+				<textPath href={`#${ringId}-top`} startOffset="50%">
+					SERVICE ORGANIZATION CONTROLS
+				</textPath>
+			</text>
+			<text
+				textAnchor="middle"
+				fontSize="6.5"
+				letterSpacing="1.1"
+				fill="currentColor"
+				fillOpacity="0.7"
+				style={{ fontFamily: "var(--font-ibm-plex-mono), monospace" }}
+			>
+				<textPath href={`#${ringId}-bottom`} startOffset="50%">
+					INDEPENDENTLY AUDITED
+				</textPath>
+			</text>
+			<circle cx="10" cy="60" r="1" fill="currentColor" fillOpacity="0.5" />
+			<circle cx="110" cy="60" r="1" fill="currentColor" fillOpacity="0.5" />
+			<circle cx="60" cy="44" r="2.5" fill="var(--color-brand)" />
+			<text
+				x="60"
+				y="66"
+				textAnchor="middle"
+				fontSize="17"
+				fontWeight="500"
+				fill="currentColor"
+				style={{ fontFamily: "var(--font-inter), sans-serif" }}
+			>
+				SOC 2
+			</text>
+			<text
+				x="60"
+				y="80"
+				textAnchor="middle"
+				fontSize="7"
+				letterSpacing="2"
+				fill="currentColor"
+				fillOpacity="0.7"
+				style={{ fontFamily: "var(--font-ibm-plex-mono), monospace" }}
+			>
+				TYPE II
+			</text>
+		</svg>
+	);
+}

--- a/apps/marketing/src/app/components/Soc2Badge/index.ts
+++ b/apps/marketing/src/app/components/Soc2Badge/index.ts
@@ -1,0 +1,1 @@
+export { Soc2Badge } from "./Soc2Badge";

--- a/apps/marketing/src/app/enterprise/components/EnterpriseFAQ/constants.ts
+++ b/apps/marketing/src/app/enterprise/components/EnterpriseFAQ/constants.ts
@@ -19,6 +19,6 @@ export const ENTERPRISE_FAQ_ITEMS: FAQItem[] = [
 	{
 		question: "Is my data secure?",
 		answer:
-			"Superset runs locally on your developers' machines. We don't store your code or AI conversations. Contact us to learn more about our security practices.",
+			"Superset runs locally on your developers' machines. We don't store your code or AI conversations, and Superset has completed a SOC 2 Type II audit with an independent auditor. Request the report and review our security documentation at trust.superset.sh.",
 	},
 ];

--- a/apps/marketing/src/app/enterprise/page.tsx
+++ b/apps/marketing/src/app/enterprise/page.tsx
@@ -1,6 +1,7 @@
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { Soc2Badge } from "@/app/components/Soc2Badge";
 import { EnterpriseContactForm } from "./components/EnterpriseContactForm";
 import { EnterpriseFAQ } from "./components/EnterpriseFAQ";
 
@@ -31,16 +32,30 @@ export default function EnterprisePage() {
 					<GridCross className="top-0 left-0" />
 					<GridCross className="top-0 right-0" />
 
-					<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
-						Enterprise
-					</span>
-					<h1 className="text-3xl md:text-4xl font-medium tracking-tight text-foreground mt-4">
-						Superset for your team
-					</h1>
-					<p className="text-muted-foreground mt-3 max-w-lg">
-						Interested in bringing Superset to your organization? Reach out and
-						we&apos;ll work with you to find the right setup for your team.
-					</p>
+					<div className="flex items-start justify-between gap-8">
+						<div>
+							<span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">
+								Enterprise
+							</span>
+							<h1 className="text-3xl md:text-4xl font-medium tracking-tight text-foreground mt-4">
+								Superset for your team
+							</h1>
+							<p className="text-muted-foreground mt-3 max-w-lg">
+								Interested in bringing Superset to your organization? Reach out
+								and we&apos;ll work with you to find the right setup for your
+								team.
+							</p>
+						</div>
+						<a
+							href={COMPANY.TRUST_URL}
+							target="_blank"
+							rel="noopener noreferrer"
+							aria-label="SOC 2 Type II compliant. Request our report."
+							className="hidden md:block shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+						>
+							<Soc2Badge size={104} />
+						</a>
+					</div>
 
 					<GridCross className="bottom-0 left-0" />
 					<GridCross className="bottom-0 right-0" />

--- a/apps/marketing/src/app/pricing/constants.ts
+++ b/apps/marketing/src/app/pricing/constants.ts
@@ -92,6 +92,7 @@ export const PRICING_TIERS: PricingTier[] = [
 			"Everything in Pro",
 			"SAML SSO & SCIM provisioning",
 			"Audit logs",
+			"SOC 2 Type II report",
 			"Uptime SLA & dedicated support",
 			"Custom integrations",
 		],
@@ -168,6 +169,7 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
 			{ label: "IP restrictions", values: [null, null, true] },
 			{ label: "SCIM provisioning", values: [null, null, true] },
 			{ label: "Audit log", values: [null, null, true] },
+			{ label: "SOC 2 Type II report", values: [null, null, true] },
 		],
 	},
 ];
@@ -192,6 +194,11 @@ export const PRICING_FAQ_ITEMS: FAQItem[] = [
 		question: "What's included in Enterprise?",
 		answer:
 			"Everything in Pro plus SSO & SAML, SCIM provisioning, IP restrictions, audit logs, a custom SLA, dedicated support, and custom contracts. Pricing is tailored to your organization. Get in touch and we'll scope something that fits.",
+	},
+	{
+		question: "Is Superset SOC 2 compliant?",
+		answer:
+			"Yes. Superset has completed a SOC 2 Type II audit with an independent auditor, covering our security controls in operation over time. Request the report and review our security documentation at trust.superset.sh.",
 	},
 	{
 		question: "Where does my code run?",


### PR DESCRIPTION
## Summary
- Superset's SOC 2 Type II report was issued 2026-08-25 (Oneleet audit, trust.superset.sh live). This PR surfaces it everywhere an enterprise buyer looks: a house-drawn SOC 2 seal on the footer, homepage security section, and enterprise page, plus pricing mentions and a changelog announcement.

## Why / Context
Enterprise prospects have been asking for our SOC 2 status by email (bridge-letter thread in July). Competitors present it as a pricing/enterprise bullet plus a security-page badge linking to a trust portal (Cursor, Linear, Vercel, Warp all follow this shape). We had zero mentions on the site.

## How It Works
- New `Soc2Badge` component (`src/app/components/Soc2Badge/`): an inline SVG seal, no external assets. Ring text on two arcs so both halves read upright, brand-orange accents, `currentColor` so it inherits theme. Every placement links to trust.superset.sh.
- Placements: footer (80px, under social links), homepage `SecuritySection` heading (128px, hidden on mobile), enterprise page header (104px, `md+`).
- Pricing (`pricing/constants.ts`): "SOC 2 Type II report" bullet on the Enterprise tier, a Security comparison row, and a new FAQ item.
- Enterprise FAQ: "Is my data secure?" now cites the Type II audit and the trust center.
- Changelog: `2026-08-27-soc-2-type-ii.mdx`, short Linear-style announcement linking the March pen-test entry and the trust center.

Wording is deliberately "completed a SOC 2 Type II audit" / "SOC 2 Type II report", not "certified", since SOC 2 is an attestation and security teams read the difference.

## Manual QA Checklist
Verified in a real browser against the dev server (screenshots taken at each spot):
- [x] Homepage security section shows the seal right of the heading; links out to trust.superset.sh
- [x] Enterprise page header shows the seal next to the title above the contact form
- [x] Footer seal renders on every page under the social icons
- [x] Pricing Enterprise card shows the new bullet; comparison table has the SOC 2 row; FAQ entry renders
- [x] Changelog entry renders correctly (no hero image, list + detail pages)
- [ ] Seal on mobile widths (hidden on homepage/enterprise by design; footer only)

## Testing
- `bun run typecheck` (apps/marketing)
- `bunx biome check` on touched files
- `bun run lint:prose` (Vale): 0 errors, 0 warnings

## Design Decisions
- **House-drawn seal instead of the Oneleet dynamic badge**: Oneleet's auto-updating badge img URL only exists in the Oneleet dashboard (Frameworks -> Compliance Badges). Swapping it in later is a small change; meanwhile the SVG is self-contained and on-brand.
- **No dedicated /security page**: the homepage section plus trust.superset.sh already cover it; a page felt like scope creep for this PR.

## Known Limitations
- Changelog dates render one day early in negative-UTC-offset dev environments (pre-existing: `formatContentDate` parses date-only strings as UTC midnight, formats in local time). Prod on Vercel runs UTC and is unaffected. Left out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Superset's SOC 2 Type II audit across the marketing site. Previously the site had no SOC 2 mentions; now a new `Soc2Badge` links to the trust center from the footer, homepage security section, and enterprise page header, with pricing and changelog additions.

- The badge is an inline SVG seal that inherits the theme's colors and needs no external assets, so it renders on all pages.
- The Enterprise tier gains a "SOC 2 Type II report" bullet, a comparison row, and a new FAQ; the enterprise FAQ answer now cites the audit.
- Adds a changelog announcement linking the earlier penetration test and the trust center.
- Wording uses "completed a SOC 2 Type II audit" / "report" rather than "certified", since SOC 2 is an attestation.

<sup>Written for commit 9c800f8d9c846a9af287b272861cb49c9edde601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SOC 2 Type II compliance badges across the marketing, security, and enterprise pages, linking to the trust center.
  * Added an announcement explaining the completed independent SOC 2 Type II audit and how to request the report.
  * Added SOC 2 Type II reporting to Enterprise plan features and security comparisons.
* **Documentation**
  * Updated enterprise security FAQs with audit and trust center information.
  * Added details about Superset’s security practices and available compliance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->