### PR TITLE
fix(host-service): say which GitHub credential was rejected on the PR list

### DIFF
--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -100,8 +100,10 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 				// this classification.
 				throw new TRPCError({
 					code: "PRECONDITION_FAILED",
-					message:
-						"No GitHub token available. Set GITHUB_TOKEN/GH_TOKEN or authenticate via git credential manager.",
+					message: providers.credentials.credentialRemedy(
+						"github.com",
+						"missing",
+					),
 					cause: { kind: "NO_GITHUB_TOKEN" },
 				});
 			}

--- a/packages/host-service/src/providers/git/CloudGitCredentialProvider/CloudGitCredentialProvider.ts
+++ b/packages/host-service/src/providers/git/CloudGitCredentialProvider/CloudGitCredentialProvider.ts
@@ -1,5 +1,8 @@
 import { unlink } from "node:fs/promises";
-import type { GitCredentialProvider } from "../../../runtime/git/types";
+import type {
+	CredentialProblem,
+	GitCredentialProvider,
+} from "../../../runtime/git/types";
 import { writeTempAskpass } from "../askpass";
 
 interface CachedCredential {
@@ -53,6 +56,12 @@ export class CloudGitCredentialProvider implements GitCredentialProvider {
 				GIT_TERMINAL_PROMPT: "0",
 			},
 		};
+	}
+
+	credentialRemedy(_host: string, problem: CredentialProblem): string {
+		return problem === "missing"
+			? "No GitHub token for this workspace. Reconnect the GitHub integration."
+			: "GitHub rejected this workspace's token. Reconnect the GitHub integration.";
 	}
 
 	async getToken(_host: string): Promise<string | null> {

--- a/packages/host-service/src/providers/git/LocalGitCredentialProvider/LocalGitCredentialProvider.test.ts
+++ b/packages/host-service/src/providers/git/LocalGitCredentialProvider/LocalGitCredentialProvider.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalGitCredentialProvider } from "./LocalGitCredentialProvider";
+
+/**
+ * `gh auth token` echoes the environment ahead of its stored login, GH_TOKEN
+ * before GITHUB_TOKEN, matching the real CLI's precedence.
+ */
+const GH_STUB = `#!/bin/sh
+if [ -n "$GH_TOKEN" ]; then printf '%s\\n' "$GH_TOKEN"; exit 0; fi
+if [ -n "$GITHUB_TOKEN" ]; then printf '%s\\n' "$GITHUB_TOKEN"; exit 0; fi
+printf 'stored-gh-login\\n'
+`;
+
+/** A `git` that never resolves a credential, so lookup reaches the gh CLI. */
+const GIT_STUB = `#!/bin/sh
+exit 1
+`;
+
+/**
+ * `credential.helper = gh auth git-credential`, which replays the exported
+ * token instead of anything stored. Set up by \`gh auth setup-git\`.
+ */
+const GIT_HELPER_REPLAYS_ENV_STUB = `#!/bin/sh
+cat > /dev/null
+if [ -n "$GITHUB_TOKEN" ]; then printf 'password=%s\\n' "$GITHUB_TOKEN"; exit 0; fi
+printf 'password=stored-credential\\n'
+`;
+
+const tempDirs: string[] = [];
+
+function stubPath(gitStub: string): string {
+	const dir = mkdtempSync(join(tmpdir(), "superset-cred-stub-"));
+	tempDirs.push(dir);
+	for (const [name, body] of [
+		["gh", GH_STUB],
+		["git", gitStub],
+	]) {
+		const path = join(dir, name as string);
+		writeFileSync(path, body as string);
+		chmodSync(path, 0o755);
+	}
+	return dir;
+}
+
+function providerWith(env: Record<string, string>, gitStub = GIT_STUB) {
+	const dir = stubPath(gitStub);
+	return new LocalGitCredentialProvider(async () => ({
+		PATH: dir,
+		...env,
+	}));
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("LocalGitCredentialProvider token sources", () => {
+	// The app's own env is checked before anything is spawned; these tests
+	// exercise the login-shell path, so it must be clear.
+	const withoutProcessTokens = async (run: () => Promise<void>) => {
+		const saved = {
+			GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+			GH_TOKEN: process.env.GH_TOKEN,
+		};
+		process.env.GITHUB_TOKEN = undefined;
+		process.env.GH_TOKEN = undefined;
+		delete process.env.GITHUB_TOKEN;
+		delete process.env.GH_TOKEN;
+		try {
+			await run();
+		} finally {
+			if (saved.GITHUB_TOKEN !== undefined)
+				process.env.GITHUB_TOKEN = saved.GITHUB_TOKEN;
+			if (saved.GH_TOKEN !== undefined) process.env.GH_TOKEN = saved.GH_TOKEN;
+		}
+	};
+
+	test("a GITHUB_TOKEN exported by the login shell is not blamed on the gh CLI", async () => {
+		await withoutProcessTokens(async () => {
+			const provider = providerWith({ GITHUB_TOKEN: "shell-token" });
+			expect(await provider.getToken("github.com")).toBe("shell-token");
+			// `gh auth login` would not displace the variable, so the remedy
+			// has to name the variable instead.
+			const remedy = provider.credentialRemedy("github.com", "rejected");
+			expect(remedy).toContain("GITHUB_TOKEN");
+			expect(remedy).not.toContain("gh auth login");
+		});
+	});
+
+	test("GH_TOKEN from the login shell is named too", async () => {
+		await withoutProcessTokens(async () => {
+			const provider = providerWith({ GH_TOKEN: "shell-gh-token" });
+			expect(await provider.getToken("github.com")).toBe("shell-gh-token");
+			expect(provider.credentialRemedy("github.com", "rejected")).toContain(
+				"GH_TOKEN",
+			);
+		});
+	});
+
+	test("GH_TOKEN wins when both variables are set, as it does for gh", async () => {
+		await withoutProcessTokens(async () => {
+			const provider = providerWith({
+				GH_TOKEN: "gh-token-value",
+				GITHUB_TOKEN: "github-token-value",
+			});
+			expect(await provider.getToken("github.com")).toBe("gh-token-value");
+			const remedy = provider.credentialRemedy("github.com", "rejected");
+			expect(remedy).toContain("GH_TOKEN");
+			expect(remedy).not.toContain("GITHUB_TOKEN");
+		});
+	});
+
+	test("a credential helper replaying the exported token names the variable", async () => {
+		await withoutProcessTokens(async () => {
+			const provider = providerWith(
+				{ GITHUB_TOKEN: "shell-token" },
+				GIT_HELPER_REPLAYS_ENV_STUB,
+			);
+			expect(await provider.getToken("github.com")).toBe("shell-token");
+			const remedy = provider.credentialRemedy("github.com", "rejected");
+			expect(remedy).toContain("GITHUB_TOKEN");
+			expect(remedy).not.toContain("saved github.com credential");
+		});
+	});
+
+	test("a genuinely stored credential is still reported as saved", async () => {
+		await withoutProcessTokens(async () => {
+			const provider = providerWith({}, GIT_HELPER_REPLAYS_ENV_STUB);
+			expect(await provider.getToken("github.com")).toBe("stored-credential");
+			expect(provider.credentialRemedy("github.com", "rejected")).toContain(
+				"saved github.com credential",
+			);
+		});
+	});
+
+	test("a real gh login is still reported as the gh CLI", async () => {
+		await withoutProcessTokens(async () => {
+			const provider = providerWith({});
+			expect(await provider.getToken("github.com")).toBe("stored-gh-login");
+			expect(provider.credentialRemedy("github.com", "rejected")).toContain(
+				"gh auth login",
+			);
+		});
+	});
+});

--- a/packages/host-service/src/providers/git/LocalGitCredentialProvider/LocalGitCredentialProvider.ts
+++ b/packages/host-service/src/providers/git/LocalGitCredentialProvider/LocalGitCredentialProvider.ts
@@ -1,22 +1,29 @@
 import { execFile } from "node:child_process";
 import { unlink } from "node:fs/promises";
-import type { GitCredentialProvider } from "../../../runtime/git/types";
+import type {
+	CredentialProblem,
+	GitCredentialProvider,
+} from "../../../runtime/git/types";
+import { getToolEnvironment } from "../../../terminal/clean-shell-env";
 import { writeTempAskpass } from "../askpass";
+import { localCredentialRemedy, type TokenSource } from "./credential-remedy";
 
 const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000;
 
+interface ResolvedToken {
+	token: string;
+	source: TokenSource;
+	expiresAt: number;
+}
+
 export class LocalGitCredentialProvider implements GitCredentialProvider {
 	private envResolver: () => Promise<Record<string, string>>;
-	private cachedTokenByHost = new Map<
-		string,
-		{ token: string; expiresAt: number }
-	>();
-	private inflightByHost = new Map<string, Promise<string | null>>();
+	private cachedTokenByHost = new Map<string, ResolvedToken>();
+	private inflightByHost = new Map<string, Promise<ResolvedToken | null>>();
 	private cachedAskpass: { token: string; path: string } | null = null;
 
 	constructor(
-		envResolver: () => Promise<Record<string, string>> = async () =>
-			process.env as Record<string, string>,
+		envResolver: () => Promise<Record<string, string>> = getToolEnvironment,
 	) {
 		this.envResolver = envResolver;
 	}
@@ -38,36 +45,65 @@ export class LocalGitCredentialProvider implements GitCredentialProvider {
 	}
 
 	async getToken(host: string): Promise<string | null> {
-		// GITHUB_TOKEN/GH_TOKEN are GitHub-specific; never replay them to another host.
-		if (host === "github.com") {
-			const envToken = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
-			if (envToken) return envToken;
-		}
-
 		const cached = this.cachedTokenByHost.get(host);
 		if (cached && cached.expiresAt > Date.now()) return cached.token;
 
 		const inflight = this.inflightByHost.get(host);
-		if (inflight) return inflight;
+		if (inflight) return (await inflight)?.token ?? null;
 
 		const promise = this.fetchToken(host).finally(() => {
 			this.inflightByHost.delete(host);
 		});
 		this.inflightByHost.set(host, promise);
-		return promise;
+		return (await promise)?.token ?? null;
 	}
 
-	private async fetchToken(host: string): Promise<string | null> {
-		const token =
-			(await this.fetchTokenViaGitCredential(host)) ??
-			(host === "github.com" ? await this.fetchTokenViaGhCli() : null);
-		if (token) {
-			this.cachedTokenByHost.set(host, {
-				token,
-				expiresAt: Date.now() + TOKEN_CACHE_TTL_MS,
-			});
+	/**
+	 * Names the source of the token last resolved for `host`, ignoring its
+	 * TTL — the caller is explaining a failure, not authenticating.
+	 */
+	credentialRemedy(host: string, problem: CredentialProblem): string {
+		return localCredentialRemedy(
+			problem,
+			this.cachedTokenByHost.get(host)?.source ?? null,
+		);
+	}
+
+	private async fetchToken(host: string): Promise<ResolvedToken | null> {
+		const resolved = await this.lookupToken(host);
+		// A failed lookup leaves the expired entry in place for
+		// credentialRemedy, but must never hand that token back.
+		if (!resolved) return null;
+		const entry = { ...resolved, expiresAt: Date.now() + TOKEN_CACHE_TTL_MS };
+		this.cachedTokenByHost.set(host, entry);
+		return entry;
+	}
+
+	private async lookupToken(
+		host: string,
+	): Promise<Omit<ResolvedToken, "expiresAt"> | null> {
+		// GITHUB_TOKEN/GH_TOKEN are GitHub-specific; never replay them to
+		// another host. Read from this process's env, not the login shell's:
+		// the shell's tokens belong to the tools we spawn, not to us.
+		// GH_TOKEN before GITHUB_TOKEN, the gh CLI's own precedence, so both
+		// backends pick the same one when both variables are set.
+		if (host === "github.com") {
+			const { GITHUB_TOKEN, GH_TOKEN } = process.env;
+			if (GH_TOKEN) return { token: GH_TOKEN, source: "env:GH_TOKEN" };
+			if (GITHUB_TOKEN)
+				return { token: GITHUB_TOKEN, source: "env:GITHUB_TOKEN" };
 		}
-		return token;
+
+		const env = await this.envResolver();
+
+		const viaGit = await this.fetchTokenViaGitCredential(host);
+		if (viaGit)
+			return { token: viaGit, source: sourceOf(viaGit, env, "git-credential") };
+		if (host !== "github.com") return null;
+
+		const viaGh = await this.fetchTokenViaGhCli();
+		if (!viaGh) return null;
+		return { token: viaGh, source: sourceOf(viaGh, env, "gh-cli") };
 	}
 
 	private async askpassFor(token: string): Promise<string> {
@@ -116,6 +152,23 @@ export class LocalGitCredentialProvider implements GitCredentialProvider {
 			);
 		});
 	}
+}
+
+/**
+ * Both lookups run with the user's shell environment, and either can hand
+ * back a token that came from GH_TOKEN/GITHUB_TOKEN rather than from
+ * storage: `gh auth token` prefers those variables over its stored login,
+ * and `credential.helper = gh auth git-credential` replays them. Blaming
+ * storage would send the user to fix something the variable overrides.
+ */
+function sourceOf(
+	token: string,
+	env: Record<string, string>,
+	storedSource: TokenSource,
+): TokenSource {
+	if (token === env.GH_TOKEN) return "env:GH_TOKEN";
+	if (token === env.GITHUB_TOKEN) return "env:GITHUB_TOKEN";
+	return storedSource;
 }
 
 function httpsHost(remoteUrl: string | null): string | null {

--- a/packages/host-service/src/providers/git/LocalGitCredentialProvider/credential-remedy.ts
+++ b/packages/host-service/src/providers/git/LocalGitCredentialProvider/credential-remedy.ts
@@ -1,0 +1,50 @@
+import type { CredentialProblem } from "../../../runtime/git/types";
+
+/** Where LocalGitCredentialProvider found a token, in lookup order. */
+export type TokenSource =
+	| "env:GITHUB_TOKEN"
+	| "env:GH_TOKEN"
+	| "git-credential"
+	| "gh-cli";
+
+/** What GitHub rejected, and the one action that replaces it. */
+const REJECTED: Record<TokenSource, { credential: string; fix: string }> = {
+	"env:GITHUB_TOKEN": {
+		credential: "this machine's GITHUB_TOKEN",
+		fix: "Update or unset it, then restart Superset.",
+	},
+	"env:GH_TOKEN": {
+		credential: "this machine's GH_TOKEN",
+		fix: "Update or unset it, then restart Superset.",
+	},
+	"git-credential": {
+		// `git credential fill` wins over the gh CLI, so `gh auth login` can
+		// leave the rejected entry selected.
+		credential: "this machine's saved github.com credential",
+		fix: "Remove or update that credential, then restart Superset.",
+	},
+	"gh-cli": {
+		// The resolved token is cached for five minutes, so an immediate
+		// retry would reuse the rejected one.
+		credential: "this machine's gh CLI login",
+		fix: "Run `gh auth login`, then restart Superset.",
+	},
+};
+
+/**
+ * Name the credential and the fix in one line. The parenthetical matters:
+ * these are the machine's own credentials, and users otherwise reconnect
+ * the org's GitHub App integration forever (#6832).
+ */
+export function localCredentialRemedy(
+	problem: CredentialProblem,
+	source: TokenSource | null,
+): string {
+	if (problem === "missing") {
+		return "No GitHub login on this machine (the Superset integration doesn't cover this). Run `gh auth login`.";
+	}
+	const rejected = source && REJECTED[source];
+	return rejected
+		? `GitHub rejected ${rejected.credential} (not the Superset integration). ${rejected.fix}`
+		: "GitHub rejected this machine's GitHub login (not the Superset integration). Run `gh auth login`.";
+}

--- a/packages/host-service/src/runtime/git/git-message-locale.test.ts
+++ b/packages/host-service/src/runtime/git/git-message-locale.test.ts
@@ -58,6 +58,7 @@ function providerWithEnv(env: Record<string, string>): GitCredentialProvider {
 	return {
 		getCredentials: async () => ({ env: { ...env } }),
 		getToken: async () => null,
+		credentialRemedy: () => "no credentials",
 	};
 }
 

--- a/packages/host-service/src/runtime/git/git.test.ts
+++ b/packages/host-service/src/runtime/git/git.test.ts
@@ -28,6 +28,7 @@ function createRecordingProvider(): GitCredentialProvider & {
 			return { env: {} };
 		},
 		getToken: async () => null,
+		credentialRemedy: () => "no credentials",
 	};
 }
 
@@ -93,6 +94,7 @@ describe("createGitEnvResolver", () => {
 				return { env };
 			},
 			getToken: async () => null,
+			credentialRemedy: () => "no credentials",
 		};
 
 		const env = await createGitEnvResolver(provider)(repo);

--- a/packages/host-service/src/runtime/git/types.ts
+++ b/packages/host-service/src/runtime/git/types.ts
@@ -1,11 +1,20 @@
 import type { SimpleGit } from "simple-git";
 
+/** Whether `host` had no credential at all, or one GitHub refused. */
+export type CredentialProblem = "missing" | "rejected";
+
 export interface GitCredentialProvider {
 	getCredentials(
 		remoteUrl: string | null,
 	): Promise<{ env: Record<string, string> }>;
 
 	getToken(host: string): Promise<string | null>;
+
+	/**
+	 * What the user must change when `host` has no usable credential. Only
+	 * the provider knows where its tokens come from, so only it can say.
+	 */
+	credentialRemedy(host: string, problem: CredentialProblem): string;
 }
 
 export type GitFactory = (path: string) => Promise<SimpleGit>;

--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -237,6 +237,20 @@ export async function getStrictShellEnvironment(): Promise<
 	return { ...cache };
 }
 
+/**
+ * Env for spawning the user's own tools (`git`, `gh`) — their login shell's,
+ * so the app resolves the same binaries and auth the terminal does. Falls
+ * back to this process's env with the macOS PATH repaired: a GUI-launched
+ * app inherits launchd's bare PATH, which has no Homebrew.
+ */
+export async function getToolEnvironment(): Promise<Record<string, string>> {
+	return getStrictShellEnvironment().catch(() => {
+		const env = { ...process.env } as Record<string, string>;
+		augmentPathForMacOS(env);
+		return env;
+	});
+}
+
 export function clearStrictShellEnvCache(): void {
 	cache = null;
 	cacheTime = 0;

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-github-issues.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-github-issues.ts
@@ -8,6 +8,7 @@ import {
 	chunkProjectRepos,
 	formatRepoList,
 	githubRateLimitError,
+	githubRequestError,
 	isGithubNotFoundError,
 	isGithubRateLimitError,
 	mergeByUpdatedAtDesc,
@@ -386,11 +387,10 @@ export const searchGitHubIssues = protectedProcedure
 				page,
 			};
 		} catch (err) {
-			if (isGithubRateLimitError(err)) throw githubRateLimitError(err);
 			console.warn(
 				"[workspaceCreation.searchGitHubIssues] octokit fallback failed",
 				err,
 			);
-			throw err;
+			throw githubRequestError(err, ctx.credentials);
 		}
 	});

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
@@ -22,6 +22,7 @@ import {
 	collectChunkResults,
 	formatRepoList,
 	githubRateLimitError,
+	githubRequestError,
 	isGithubNotFoundError,
 	isGithubRateLimitError,
 	mergeByUpdatedAtDesc,
@@ -1230,13 +1231,12 @@ export const searchPullRequests = protectedProcedure
 				page,
 			};
 		} catch (err) {
-			if (isGithubRateLimitError(err)) throw githubRateLimitError(err);
 			// Both gh and Octokit failed — rethrow so the renderer's toast
 			// fires instead of the dropdown silently rendering "no results".
 			console.warn(
 				"[workspaceCreation.searchPullRequests] octokit fallback failed",
 				err,
 			);
-			throw err;
+			throw githubRequestError(err, ctx.credentials);
 		}
 	});

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.test.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import type { TRPCError } from "@trpc/server";
+import type { GitCredentialProvider } from "../../../../runtime/git/types";
 import {
 	buildSearchQuery,
 	chunkProjectRepos,
 	collectChunkResults,
 	GITHUB_SEARCH_QUERY_MAX_LENGTH,
 	githubRateLimitError,
+	githubRequestError,
+	isGithubAuthError,
 	isGithubNotFoundError,
 	isGithubRateLimitError,
 	mergeByUpdatedAtDesc,
@@ -254,6 +258,63 @@ describe("collectChunkResults", () => {
 			Promise.reject(rateLimited()),
 		]);
 		expect(() => collectChunkResults(settled)).toThrow("rate limit exceeded");
+	});
+});
+
+describe("auth error detection", () => {
+	test("matches Octokit 401s and gh bad-credentials text", () => {
+		expect(
+			isGithubAuthError(
+				Object.assign(
+					new Error("Bad credentials - https://docs.github.com/rest"),
+					{ status: 401 },
+				),
+			),
+		).toBe(true);
+		expect(
+			isGithubAuthError(
+				Object.assign(new Error("Command failed: gh api search/issues"), {
+					stderr: "gh: Bad credentials (HTTP 401)",
+				}),
+			),
+		).toBe(true);
+		expect(isGithubAuthError(new Error("HTTP 401: Unauthorized"))).toBe(true);
+		expect(isGithubAuthError(new Error("Validation Failed"))).toBe(false);
+		expect(
+			isGithubAuthError(
+				Object.assign(new Error("rate limit exceeded"), { status: 403 }),
+			),
+		).toBe(false);
+	});
+});
+
+describe("githubRequestError", () => {
+	const credentials: GitCredentialProvider = {
+		getCredentials: async () => ({ env: {} }),
+		getToken: async () => null,
+		credentialRemedy: () => "REMEDY",
+	};
+
+	test("a 401 carries the provider's remedy", () => {
+		const error = githubRequestError(
+			Object.assign(new Error("Bad credentials"), { status: 401 }),
+			credentials,
+		) as TRPCError;
+		expect(error.code).toBe("UNAUTHORIZED");
+		expect(error.message).toBe("REMEDY");
+	});
+
+	test("a rate limit stays a rate limit", () => {
+		const error = githubRequestError(
+			Object.assign(new Error("API rate limit exceeded"), { status: 403 }),
+			credentials,
+		) as TRPCError;
+		expect(error.code).toBe("TOO_MANY_REQUESTS");
+	});
+
+	test("anything else passes through untouched", () => {
+		const original = new Error("Validation Failed");
+		expect(githubRequestError(original, credentials)).toBe(original);
 	});
 });
 

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/github-search.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server";
+import type { GitCredentialProvider } from "../../../../runtime/git/types";
 import type { ResolvedGithubRepo } from "./project-helpers";
 
 /** A requested project paired with the repo its local remote points at. */
@@ -220,6 +221,37 @@ export function githubRateLimitError(error: unknown): TRPCError {
 		message: `GitHub API rate limit exceeded. Try again in a few minutes.${resetSuffix}`,
 		cause: error,
 	});
+}
+
+/**
+ * Rejected-credential failures: Octokit throws a 401 RequestError ("Bad
+ * credentials"); the gh CLI prints the same text (or "HTTP 401") with no
+ * status field.
+ */
+export function isGithubAuthError(error: unknown): boolean {
+	if (isRecord(error) && error.status === 401) return true;
+	return /bad credentials|\bHTTP 401\b/i.test(errorText(error));
+}
+
+/**
+ * Classify a search failure for the client. A raw "Bad credentials" reads
+ * like a broken GitHub App integration, so a 401 has to say which
+ * credential GitHub refused and where that credential lives (#6832).
+ * Anything unrecognized passes through untouched.
+ */
+export function githubRequestError(
+	error: unknown,
+	credentials: GitCredentialProvider,
+): unknown {
+	if (isGithubRateLimitError(error)) return githubRateLimitError(error);
+	if (isGithubAuthError(error)) {
+		return new TRPCError({
+			code: "UNAUTHORIZED",
+			message: credentials.credentialRemedy("github.com", "rejected"),
+			cause: error,
+		});
+	}
+	return error;
 }
 
 /**

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/exec-gh.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { getStrictShellEnvironment } from "../../../../terminal/clean-shell-env";
+import { getToolEnvironment } from "../../../../terminal/clean-shell-env";
 
 const execFileAsync = promisify(execFile);
 
@@ -21,9 +21,7 @@ export type ExecGh = (
 ) => Promise<unknown>;
 
 export const execGh: ExecGh = async (args, options) => {
-	const env = await getStrictShellEnvironment().catch(
-		() => process.env as Record<string, string>,
-	);
+	const env = await getToolEnvironment();
 	const { stdout } = await execFileAsync("gh", args, {
 		encoding: "utf8",
 		timeout: options?.timeout ?? 10_000,

--- a/packages/host-service/test/helpers/createTestHost.ts
+++ b/packages/host-service/test/helpers/createTestHost.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/app";
 import type { HostDb } from "../../src/db";
 import * as schema from "../../src/db/schema";
+import type { TokenSource } from "../../src/providers/git/LocalGitCredentialProvider/credential-remedy";
 import type { AppRouter as HostAppRouter } from "../../src/trpc/router";
 import {
 	createFakeApiClient,
@@ -31,6 +32,7 @@ export interface TestHostOptions {
 	psk?: string;
 	apiOverrides?: FakeApiOverrides;
 	githubToken?: string | null;
+	githubTokenSource?: TokenSource | null;
 	/**
 	 * Fake-runtime overrides typed as `unknown` so tests only need to
 	 * implement the methods they exercise — the real surfaces (Octokit,
@@ -112,7 +114,10 @@ export async function createTestHost(
 		providers: {
 			auth: new FakeApiAuthProvider(),
 			hostAuth: new FakeHostAuthProvider(psk),
-			credentials: new MemoryGitCredentialProvider(options.githubToken ?? null),
+			credentials: new MemoryGitCredentialProvider(
+				options.githubToken ?? null,
+				options.githubTokenSource ?? null,
+			),
 		},
 		db: db as unknown as HostDb,
 		api: fakeApi.client,

--- a/packages/host-service/test/helpers/fakes.ts
+++ b/packages/host-service/test/helpers/fakes.ts
@@ -1,6 +1,13 @@
 import type { ApiAuthProvider } from "../../src/providers/auth";
+import {
+	localCredentialRemedy,
+	type TokenSource,
+} from "../../src/providers/git/LocalGitCredentialProvider/credential-remedy";
 import type { HostAuthProvider } from "../../src/providers/host-auth";
-import type { GitCredentialProvider } from "../../src/runtime/git/types";
+import type {
+	CredentialProblem,
+	GitCredentialProvider,
+} from "../../src/runtime/git/types";
 import type { ApiClient } from "../../src/types";
 
 export class FakeApiAuthProvider implements ApiAuthProvider {
@@ -23,12 +30,18 @@ export class FakeHostAuthProvider implements HostAuthProvider {
 }
 
 export class MemoryGitCredentialProvider implements GitCredentialProvider {
-	constructor(private readonly token: string | null = null) {}
+	constructor(
+		private readonly token: string | null = null,
+		private readonly tokenSource: TokenSource | null = null,
+	) {}
 	async getCredentials(): Promise<{ env: Record<string, string> }> {
 		return { env: {} };
 	}
 	async getToken(): Promise<string | null> {
 		return this.token;
+	}
+	credentialRemedy(_host: string, problem: CredentialProblem): string {
+		return localCredentialRemedy(problem, this.tokenSource);
 	}
 }
 

--- a/packages/host-service/test/integration/github.integration.test.ts
+++ b/packages/host-service/test/integration/github.integration.test.ts
@@ -19,13 +19,13 @@ describe("github router integration", () => {
 				repo: "hello-world",
 				pullNumber: 1,
 			}),
-		).rejects.toThrow(/no github token/i);
+		).rejects.toThrow(/no github login on this machine/i);
 	});
 
 	test("listPRs throws when no GitHub token is available", async () => {
 		await expect(
 			host.trpc.github.listPRs.query({ owner: "o", repo: "r" }),
-		).rejects.toThrow(/no github token/i);
+		).rejects.toThrow(/no github login on this machine/i);
 	});
 
 	test("getPR rejects unauthenticated callers before reaching handler", async () => {

--- a/packages/host-service/test/integration/workspace-creation-github.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-creation-github.integration.test.ts
@@ -1417,3 +1417,106 @@ describe("GitHub rate-limit errors map to TOO_MANY_REQUESTS", () => {
 		);
 	});
 });
+
+describe("GitHub rejected-credential errors map to actionable UNAUTHORIZED", () => {
+	let host: TestHost;
+	let repoDir: string;
+	const projectId = randomUUID();
+
+	afterEach(async () => {
+		await host.dispose();
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	const badCredentials = () =>
+		Object.assign(new Error("Bad credentials - https://docs.github.com/rest"), {
+			status: 401,
+		});
+
+	const expectRejection = async (
+		promise: Promise<unknown>,
+	): Promise<{ message: string; data?: { code?: string } }> => {
+		const error = await promise.then(
+			() => null,
+			(err: { message: string; data?: { code?: string } }) => err,
+		);
+		expect(error).not.toBeNull();
+		if (!error) throw new Error("unreachable");
+		return error;
+	};
+
+	test("a 401 from both gh and Octokit names the rejected token source", async () => {
+		// Default test execGh rejects, standing in for a gh CLI that 401s too.
+		host = await createTestHost({
+			githubFactory: async () => ({
+				search: {
+					issuesAndPullRequests: async () => {
+						throw badCredentials();
+					},
+				},
+			}),
+			githubToken: "stale-token",
+			githubTokenSource: "gh-cli",
+		});
+		repoDir = await seedRepoFixture(
+			host,
+			projectId,
+			"https://github.com/octocat/hello.git",
+		);
+		const error = await expectRejection(
+			host.trpc.workspaceCreation.searchPullRequests.query({
+				projectId,
+				query: "anything",
+			}),
+		);
+		expect(error.data?.code).toBe("UNAUTHORIZED");
+		expect(error.message).toBe(
+			"GitHub rejected this machine's gh CLI login (not the Superset integration). Run `gh auth login`, then restart Superset.",
+		);
+	});
+
+	test("a 401 with an unknown token source falls back to generic guidance", async () => {
+		host = await createTestHost({
+			githubFactory: async () => ({
+				search: {
+					issuesAndPullRequests: async () => {
+						throw badCredentials();
+					},
+				},
+			}),
+			githubToken: "stale-token",
+		});
+		repoDir = await seedRepoFixture(
+			host,
+			projectId,
+			"https://github.com/octocat/hello.git",
+		);
+		const error = await expectRejection(
+			host.trpc.workspaceCreation.searchGitHubIssues.query({
+				projectId,
+				query: "anything",
+			}),
+		);
+		expect(error.data?.code).toBe("UNAUTHORIZED");
+		expect(error.message).toContain("gh auth login");
+	});
+
+	test("a missing token reports where the login must live", async () => {
+		host = await createTestHost({ githubToken: null });
+		repoDir = await seedRepoFixture(
+			host,
+			projectId,
+			"https://github.com/octocat/hello.git",
+		);
+		const error = await expectRejection(
+			host.trpc.workspaceCreation.searchPullRequests.query({
+				projectId,
+				query: "anything",
+			}),
+		);
+		expect(error.data?.code).toBe("PRECONDITION_FAILED");
+		expect(error.message).toBe(
+			"No GitHub login on this machine (the Superset integration doesn't cover this). Run `gh auth login`.",
+		);
+	});
+});


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/6832 (related, not auto-closing: see Known Limitations)

## Summary
- A 401 from GitHub on the Pull Requests list now names the credential GitHub refused and the one action that replaces it, instead of surfacing Octokit's raw `Bad credentials - https://docs.github.com/rest`.
- The credential provider owns that text, so a missing credential and a rejected one both explain themselves, and a cloud sandbox gets the opposite advice (its token really does come from the integration).
- Collapses duplication the fix would otherwise have been layered on: one env policy for spawning `git`/`gh`, one error mapper shared by both search procedures, token source folded into the token cache.

## Why / Context
The reporter's Pull Requests tab showed `Bad credentials - https://docs.github.com/rest` for over a month while the integrations page listed their repositories, so they disconnected and reconnected the GitHub integration repeatedly.

Those two surfaces measure different auth paths, and nothing said so. The PR list is served by the local host-service and authenticates with the machine's own credentials (`GITHUB_TOKEN`/`GH_TOKEN`, the git credential manager, or `gh auth token`). The integrations page reads cloud tables populated by the GitHub App. Reconnecting the integration could never have fixed a stale local token, and the error text pointed at exactly the wrong knob.

## How It Works
- `GitCredentialProvider` gains one required method, `credentialRemedy(host, problem)`, where `problem` is `"missing"` or `"rejected"`. Only the provider knows where its tokens come from, so only it can say what to change.
- `LocalGitCredentialProvider` records which source produced a token (`env:GITHUB_TOKEN`, `env:GH_TOKEN`, `git-credential`, `gh-cli`) in the token cache entry itself, and names it in the remedy. `CloudGitCredentialProvider` points at the integration.
- `githubRequestError` classifies a failed search once for both `searchPullRequests` and `searchGitHubIssues`: rate limits stay `TOO_MANY_REQUESTS`, 401s become `UNAUTHORIZED` carrying the remedy, everything else passes through. Both procedures previously ended in the same hand-rolled catch tail.
- `getToolEnvironment()` is now the single env policy for spawning the user's tools. `exec-gh` and the credential provider each built their own and disagreed about PATH, which is why a GUI-launched app could fail to find Homebrew's `gh` while the terminal found it.

Message shipped on this branch:

> GitHub rejected this machine's GITHUB_TOKEN (not the Superset integration). Update or unset it, then restart Superset.

## Manual QA Checklist

Driven over CDP against the dev desktop app in a worktree, with a stale `GITHUB_TOKEN` planted in `.env` so GitHub returned a real 401. Same app and same token on both sides; only the host-service revision differed.

- [x] Pre-fix build reproduces the reporter's screenshot exactly: `0 pull requests` plus red `Bad credentials - https://docs.github.com/rest`
- [x] Fixed build renders the new message in the list pane with a working `Try again`
- [x] Message names the resolved credential source (`GITHUB_TOKEN`) rather than a generic string
- [x] No console errors in the renderer during either capture
- [x] Healthy credentials still load the list normally (90 of 3501 PRs across 30+ projects before the token was planted)

One repro-only line made `exec-gh` read the host-service process env instead of the login shell's, so the planted token reached `gh` as well as Octokit. It was applied identically to both revisions and is reverted; it is not in this diff.

## Testing
- `bun run typecheck` (full repo, passes)
- `bunx biome check packages/host-service` (clean)
- `bun test src test/integration/workspace-creation-github.integration.test.ts` in `packages/host-service`: 961 pass, 0 fail
- New coverage: three integration cases (401 naming its source, the second procedure going through the same mapper, missing token) plus unit tests for the 401 classifier and the error mapper

## Design Decisions
- **Provider owns the copy, rather than a message table in the search layer**: the remedy depends entirely on where the token came from, which only the provider knows. This also removed a `typeof x === "function"` probe of an optional interface method.
- **Required interface method, not optional**: making it required surfaced two test doubles that needed updating. An optional method would have let them drift silently.
- **Source stored in the token cache entry, not a parallel map**: the first version kept a second map that had to stay in sync with the cache. Folding it in removed that hazard, and the rewrite exposed a real bug in the first attempt, where a failed lookup could return an already-expired token.

## Known Limitations
- This does not restore anyone's pull requests. It tells the user which credential to fix, so I have not marked it as closing #6832; the reporter still has to refresh their own token. Worth a comment on the issue once this lands.
- Partial Octokit chunk failures still return a truncated page with no banner, so a repo whose token lacks access silently contributes nothing to the list. Pre-existing and out of scope here.
- Multi-chunk pagination interleaving is not globally correct across repos. Pre-existing, tracked under the #5596 family.

## Risks / Rollout
- Risk: low, and confined to the host-service. No schema, auth, or renderer changes; failure paths only.
- Behavior change worth noting: the credential provider now spawns `git`/`gh` with the login shell's environment rather than bare `process.env`, so the two subprocess launchers finally agree. This makes the app resolve the same binaries and auth its own terminals do.
- Rollback: revert the commit. There is no persisted state or migration to unwind.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub PR list and issue search so a 401 names the exact credential GitHub rejected, instead of showing Octokit's raw `Bad credentials - https://docs.github.com/rest` text (#6832).

The PR list authenticates with the machine's own GitHub credentials — `GITHUB_TOKEN`/`GH_TOKEN`, the git credential manager, or `gh auth token` — not the org's GitHub App integration. The raw error pointed at the wrong surface, so the reporter reconnected the integration repeatedly. The credential provider now owns the remedy: missing and rejected tokens each say what to change, and cloud sandboxes correctly get advice pointing at the integration.

- `git`/`gh` subprocesses now share one environment policy, fixing a PATH mismatch where a GUI-launched app couldn't find Homebrew's `gh`.
- Both search procedures route 401s through a shared mapper that keeps rate limits as `TOO_MANY_REQUESTS` and carries the remedy on `UNAUTHORIZED`.
- It doesn't restore the PR list; the user must refresh their own token.

<sup>Written for commit dc4746f409ee00c43048331c8383fb6463c963bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication errors with actionable guidance for missing or rejected credentials.
  * Credential guidance identifies whether authentication came from environment variables, saved Git credentials, or the GitHub CLI.
  * GitHub rate-limit errors are now reported consistently.
  * GitHub issue and pull request searches now provide clearer, standardized error handling.

* **Reliability**
  * Improved command-line tool environment detection, including PATH recovery on macOS.
  * GitHub authentication failures now use appropriate error statuses and remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->