### PR TITLE
fix(desktop): don't throw persisting windows when quit precedes app-state init

### DIFF
--- a/apps/desktop/src/main/lib/app-state/index.ts
+++ b/apps/desktop/src/main/lib/app-state/index.ts
@@ -94,6 +94,10 @@ export async function initAppState(): Promise<void> {
 	console.log(`App state initialized at: ${APP_STATE_PATH}`);
 }
 
+export function isAppStateInitialized(): boolean {
+	return _appState !== null;
+}
+
 export const appState = new Proxy({} as AppStateDB, {
 	get(_target, prop) {
 		if (!_appState) {

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -17,7 +17,11 @@ import { env } from "shared/env.shared";
 import type { AgentLifecycleEvent } from "shared/notification-types";
 import { createIPCHandler } from "trpc-electron/main";
 import { productName } from "~/package.json";
-import { appState, pruneWindowScopedState } from "../lib/app-state";
+import {
+	appState,
+	isAppStateInitialized,
+	pruneWindowScopedState,
+} from "../lib/app-state";
 import { browserManager } from "../lib/browser/browser-manager";
 import { attachEditContextMenu } from "../lib/edit-context-menu";
 import { createApplicationMenu } from "../lib/menu";
@@ -298,6 +302,10 @@ function snapshotWindowState(window: BrowserWindow): WindowState {
 
 /** Persist every open window's bounds + org so they can be restored on relaunch. */
 export function persistOpenWindows(): void {
+	// Quit before initAppState() completed: windows are only created after init,
+	// so there is nothing to snapshot — appState access below would throw, and
+	// writing the empty set would clobber the previous session's restore state.
+	if (!isAppStateInitialized()) return;
 	const persisted: PersistedWindow[] = getAllWindows()
 		.filter((w) => !w.isDestroyed())
 		.map((w) => ({


### PR DESCRIPTION
## Problem

Quitting the app before `initAppState()` has completed (DESKTOP-13X: one event on 1.25.0, a quit ~6s after launch) throws `App state not initialized. Call initAppState() first.` from the `before-quit` handler. The throw escapes the async handler as an unhandled rejection **before** `runQuitCleanup(...)` runs, so the whole quit sequence — stopping host services, terminal-host teardown, persistence shutdown, tray disposal, and the `app.exit` fallback — is skipped. Worst case (quit confirmation enabled, its default): `event.preventDefault()` has already cancelled the quit and only `runQuitCleanup`'s `forceExit(0)` would actually exit, so the confirmed quit silently does nothing and the app stays running.

## Root cause

The multi-window restore work (#5337, new in 1.25.0) made the `before-quit` handler call `persistOpenWindows()` → `pruneWindowScopedState()` → `appState.data.tabsStateByWindow`. `appState` is a Proxy whose get trap throws on **any** property access until `initAppState()` has run, and nothing on this path checked for that.

## Fix

Guard `persistOpenWindows()` with a new `isAppStateInitialized()` exported next to the proxy, returning early when app state isn't ready. Placement rationale — top of `persistOpenWindows()`, not inside `pruneWindowScopedState()`:

- Windows are only created after `initAppState()` in the startup sequence (`main/index.ts`), so pre-init `getAllWindows()` is `[]` and there is genuinely nothing to snapshot or prune.
- Guarding only the prune would let execution continue to `saveWindows([])`, which **clears the previous session's saved window set** — a user quitting during a slow launch would lose their restored windows. Today the throw accidentally prevents that clobber; the early return preserves it deliberately.
- The other two `persistOpenWindows()` callers (debounced move/resize save, per-window `close`) only run once a window exists, i.e. post-init, so the guard is inert for them.

No behaviour change on any initialized path; no try/catch added around the quit handler. Deliberately not touched: the adjacent unguarded `appState.data?.` accesses in the notification code (`windows/main.ts` visibility-context and title callbacks) — same hazard class, different path, out of scope here. The quit-flag machinery (`isQuitting` / `markAppQuitting`) is untouched to avoid conflicting with #6907.

## Verification

- `bunx biome check apps/desktop/src/main/lib/app-state/index.ts apps/desktop/src/main/windows/main.ts` → `Checked 2 files in 43ms. No fixes applied.`
- `cd apps/desktop && bun run typecheck` → `tsc --noEmit` completed clean.
- `bun run test src/main/lib/app-state` → `4 pass, 0 fail`
- `bun run test src/main/lib/quit-sequence.test.ts` → `6 pass, 0 fail`

Refs DESKTOP-13X

https://claude.ai/code/session_01MBhi2zapr6fFn3NLgfxhjA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quitting before `initAppState()` completes used to throw from the `before-quit` handler, which skipped the entire quit cleanup and could leave the app running when quit confirmation was enabled. Now `persistOpenWindows()` checks `isAppStateInitialized()` first and returns early, so quit proceeds normally. This also preserves the previous session's window restore state, because writing an empty window list during a slow startup would have clobbered it. No behavior change when app state is initialized.

Refs DESKTOP-13X

<sup>Written for commit 3437d113d160d7f00dff9e7d65164c97d15c4c7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented application startup from overwriting saved window restoration data before initialization completes.
  - Improved stability by avoiding errors when window state is accessed too early.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->