### PR TITLE
fix(desktop): font preview card border and footer overflow

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
@@ -652,7 +652,6 @@ export function FontSettingSection({
 								fontWeight={settings.editorFontWeight ?? 400}
 								ligatures={settings.editorLigatures ?? true}
 								variant="editor"
-								isActive={variant === "editor"}
 								isCustomFont={settings.editorFontFamily !== null}
 							/>
 						</div>
@@ -691,7 +690,6 @@ export function FontSettingSection({
 									settings.terminalLigatures ?? DEFAULT_TERMINAL_LIGATURES
 								}
 								variant="terminal"
-								isActive={variant === "terminal"}
 								isCustomFont={settings.terminalFontFamily !== null}
 								minimumContrast={settings.terminalMinimumContrast}
 								cursorStyle={

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/components/FontPreview/FontPreview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/components/FontPreview/FontPreview.tsx
@@ -43,7 +43,6 @@ export function FontPreview({
 	fontWeight,
 	ligatures,
 	variant,
-	isActive = false,
 	isCustomFont,
 	minimumContrast = null,
 	cursorStyle = "block",
@@ -56,7 +55,6 @@ export function FontPreview({
 	fontWeight: number;
 	ligatures: boolean;
 	variant: "editor" | "terminal";
-	isActive?: boolean;
 	isCustomFont: boolean;
 	minimumContrast?: number | null;
 	cursorStyle?: "block" | "bar" | "underline";
@@ -82,11 +80,7 @@ export function FontPreview({
 	} satisfies CSSProperties;
 
 	return (
-		<div
-			className={`overflow-hidden rounded-lg border bg-background text-foreground ${
-				isActive ? "border-primary/50" : ""
-			}`}
-		>
+		<div className="overflow-hidden rounded-lg border bg-background text-foreground">
 			<div className="flex h-9 items-center gap-2 border-b bg-muted/50 px-3 text-[11px] text-muted-foreground">
 				{isTerminal ? (
 					<>
@@ -171,9 +165,11 @@ export function FontPreview({
 					</SyntaxHighlighter>
 				</div>
 			)}
-			<div className="flex h-7 items-center border-t bg-muted/30 px-3 text-[10px] text-muted-foreground">
-				<span>{fontFamily}</span>
-				<span className="ml-auto">
+			<div className="flex h-7 items-center gap-3 border-t bg-muted/30 px-3 text-[10px] text-muted-foreground">
+				<span className="min-w-0 truncate" title={fontFamily}>
+					{fontFamily}
+				</span>
+				<span className="ml-auto shrink-0 whitespace-nowrap">
 					{fontWeight} · {ligatures ? "Ligatures on" : "Ligatures off"}
 					{isTerminal && minimumContrast !== null
 						? ` · ${minimumContrast}:1 contrast`


### PR DESCRIPTION
Two visual bugs in the Appearance settings' Live surfaces previews, reported by Kiet with screenshots.

## Border

The active preview card used `border-primary/50`. With the default dark theme's near-white `--primary`, that renders a bright gray frame (measured `rgb(127,125,123)` vs the normal `rgb(42,40,39)` border) that reads as a broken border — most visibly along the top edge. The active surface is already indicated by the **Editing** label and `aria-pressed` on the toggle buttons, so the card now keeps the standard border and the dead `isActive` prop is removed end to end.

## Footer overflow

The footer is pinned to `h-7` but a long terminal font stack wrapped to two lines, spilling outside the card and pushing "400 · Ligatures on" out of the box. The font stack now truncates to one line (full value available via `title` tooltip) and the right-side label is `shrink-0 whitespace-nowrap`.

## Verification (CDP against the running dev app)

- Computed borders on both preview cards now `rgb(42,40,39)` on all edges (was `oklab(0.93…/0.5)` ≈ white@50% on the active card).
- Footer `scrollHeight` 27 == `clientHeight` 27 (was 36 vs 27 — the overflow).
- Zoomed screenshots before/after confirm; desktop typecheck and biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two visual bugs in the font preview cards in Appearance settings: the active card’s near-white border that looked broken, and the footer overflowing when a long font stack wrapped. The active card now uses the standard border (the `isActive` prop is removed end to end), and the font stack truncates to one line with the full value available via a tooltip.

<sup>Written for commit 182bc7d276e5d48d7a7c565a29d3b1a489d9e2ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated font previews in Appearance Settings to use a cleaner, consistent presentation without an active-selection highlight.
  - Improved preview footer spacing and alignment for easier scanning.
  - Long font-family names now truncate neatly and reveal the full name on hover.
  - Metadata remains aligned and visible without wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->