### PR TITLE
fix(desktop): keep font previews inside their grid track

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
@@ -622,7 +622,9 @@ export function FontSettingSection({
 				</div>
 				<div className="grid gap-5">
 					{showEditor && (
-						<div>
+						// min-w-0: grid items default to min-width auto, so the preview's
+						// nowrap footer would otherwise widen the item past its track.
+						<div className="min-w-0">
 							<div className="mb-2 flex items-center justify-between gap-3">
 								<Button
 									variant="ghost"
@@ -658,7 +660,7 @@ export function FontSettingSection({
 					)}
 
 					{showTerminal && (
-						<div>
+						<div className="min-w-0">
 							<div className="mb-2 flex items-center justify-between gap-3">
 								<Button
 									variant="ghost"


### PR DESCRIPTION
Fixes the width regression I introduced in #6915 (reported by Kiet with a screenshot).

**Cause:** #6915 made the footer's font stack `truncate` (nowrap). Nowrap text drives an element's intrinsic min-content width to the full one-line length, and the grid items wrapping each preview are plain divs with the default `min-width: auto` — so instead of truncating, each card widened to its min-content (~1309px) past the 848px track, pushing the Live surfaces section wider than its sibling cards and forcing horizontal page overflow. Before #6915 the footer text wrapped, so min-content stayed small and the bug was latent.

**Fix:** `min-w-0` on the two grid items, the standard escape from grid/flex `min-width: auto`, letting truncation shrink as intended.

**CDP verification (live app):** card widths back to exactly 848px == grid track, `gridScrollWidth == clientWidth` (was 1309 vs 848), page horizontal overflow 0 (was ~130px), footer single line at 27px with internal `scrollWidth == clientWidth` (truncating, not overflowing). Screenshot confirms the section aligns with the settings card above again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the font preview cards overflowing their grid track by adding `min-w-0` to the two grid items, so the nowrap footer truncates instead of widening the cards past the 848px track and forcing horizontal page overflow. Cards now stay at exactly the track width with no page overflow.

<sup>Written for commit f8672523adc84264d502f3d06bcf067293b9217a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor and terminal previews in Appearance Settings expanding their layout unexpectedly.
  * Preview content now remains properly contained within its grid area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->