### PR TITLE
feat(shared,host-service): pinned Claude model ids in the workspace-create picker, and reject an unsupported model

### DIFF
--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -55,8 +55,11 @@ export function AgentModelSelect({
 			</SelectTrigger>
 			<SelectContent className={contentClassName}>
 				<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
-				{groupModelOptions(models).map((group) => (
-					<SelectGroup key={group.label ?? "ungrouped"}>
+				{groupModelOptions(models).map((group, index) => (
+					// Index-qualified: a catalog may return to an earlier header
+					// (groupModelOptions keeps those as separate sections), and a
+					// bare label would then collide as a React key.
+					<SelectGroup key={`${group.label ?? "ungrouped"}-${index}`}>
 						{group.label !== null && (
 							<>
 								{/* Every kind-change gets a rule, including the one

--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -55,11 +55,14 @@ export function AgentModelSelect({
 			</SelectTrigger>
 			<SelectContent className={contentClassName}>
 				<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
-				{groupModelOptions(models).map((group, index) => (
+				{groupModelOptions(models).map((group) => (
 					<SelectGroup key={group.label ?? "ungrouped"}>
 						{group.label !== null && (
 							<>
-								{index > 0 && <SelectSeparator />}
+								{/* Every kind-change gets a rule, including the one
+								    between the default escape hatch and the first
+								    section — it is not a member of that section. */}
+								<SelectSeparator />
 								<SelectLabel className="text-xs text-muted-foreground">
 									{group.label}
 								</SelectLabel>

--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -2,10 +2,14 @@ import type { AgentModelOption } from "@superset/shared/agent-models";
 import {
 	Select,
 	SelectContent,
+	SelectGroup,
 	SelectItem,
+	SelectLabel,
+	SelectSeparator,
 	SelectTrigger,
 	SelectValue,
 } from "@superset/ui/select";
+import { groupModelOptions } from "./groupModelOptions";
 
 // Radix Select reserves "" for clearing, so "Default" needs a sentinel.
 const DEFAULT_MODEL_VALUE = "__default_model__";
@@ -51,10 +55,22 @@ export function AgentModelSelect({
 			</SelectTrigger>
 			<SelectContent className={contentClassName}>
 				<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
-				{models.map((model) => (
-					<SelectItem key={model.id} value={model.id}>
-						{model.label}
-					</SelectItem>
+				{groupModelOptions(models).map((group, index) => (
+					<SelectGroup key={group.label ?? "ungrouped"}>
+						{group.label !== null && (
+							<>
+								{index > 0 && <SelectSeparator />}
+								<SelectLabel className="text-xs text-muted-foreground">
+									{group.label}
+								</SelectLabel>
+							</>
+						)}
+						{group.options.map((model) => (
+							<SelectItem key={model.id} value={model.id}>
+								{model.label}
+							</SelectItem>
+						))}
+					</SelectGroup>
 				))}
 			</SelectContent>
 		</Select>

--- a/apps/desktop/src/renderer/components/AgentModelSelect/groupModelOptions.test.ts
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/groupModelOptions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { groupModelOptions } from "./groupModelOptions";
+
+describe("groupModelOptions", () => {
+	it("keeps an ungrouped catalog as one headerless block", () => {
+		const groups = groupModelOptions([
+			{ id: "low", label: "Low" },
+			{ id: "high", label: "High" },
+		]);
+		expect(groups).toEqual([
+			{
+				label: null,
+				options: [
+					{ id: "low", label: "Low" },
+					{ id: "high", label: "High" },
+				],
+			},
+		]);
+	});
+
+	it("splits a catalog into its sections in catalog order", () => {
+		const groups = groupModelOptions([
+			{ id: "opus", label: "Opus", group: "Latest" },
+			{ id: "sonnet", label: "Sonnet", group: "Latest" },
+			{ id: "claude-opus-4-8", label: "Opus 4.8", group: "Pinned releases" },
+		]);
+		expect(groups.map((g) => g.label)).toEqual(["Latest", "Pinned releases"]);
+		expect(groups[0]?.options.map((o) => o.id)).toEqual(["opus", "sonnet"]);
+		expect(groups[1]?.options.map((o) => o.id)).toEqual(["claude-opus-4-8"]);
+	});
+
+	it("does not reorder a catalog that returns to an earlier header", () => {
+		const groups = groupModelOptions([
+			{ id: "a", label: "A", group: "One" },
+			{ id: "b", label: "B", group: "Two" },
+			{ id: "c", label: "C", group: "One" },
+		]);
+		expect(groups.map((g) => g.label)).toEqual(["One", "Two", "One"]);
+		expect(groups.map((g) => g.options.map((o) => o.id))).toEqual([
+			["a"],
+			["b"],
+			["c"],
+		]);
+	});
+
+	it("renders every option exactly once", () => {
+		const models = [
+			{ id: "a", label: "A", group: "One" },
+			{ id: "b", label: "B" },
+			{ id: "c", label: "C", group: "Two" },
+		];
+		expect(groupModelOptions(models).flatMap((g) => g.options)).toEqual(models);
+	});
+});

--- a/apps/desktop/src/renderer/components/AgentModelSelect/groupModelOptions.ts
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/groupModelOptions.ts
@@ -1,0 +1,30 @@
+import type { AgentModelOption } from "@superset/shared/agent-models";
+
+export interface AgentModelOptionGroup {
+	/** null renders the options with no header, as one leading block. */
+	label: string | null;
+	options: AgentModelOption[];
+}
+
+/**
+ * Split a catalog into the sections the picker renders, preserving catalog
+ * order both within and across groups — the curated order is the recommended
+ * order, and re-sorting here would silently override it.
+ *
+ * Ungrouped options collapse to a single headerless group, so a catalog that
+ * never sets `group` renders exactly as it did before grouping existed.
+ */
+export function groupModelOptions(
+	options: AgentModelOption[],
+): AgentModelOptionGroup[] {
+	const groups: AgentModelOptionGroup[] = [];
+	for (const option of options) {
+		const label = option.group ?? null;
+		const last = groups[groups.length - 1];
+		// Match only against the most recent group: a catalog that returns to an
+		// earlier header wants a second section there, not a reordered list.
+		if (last && last.label === label) last.options.push(option);
+		else groups.push({ label, options: [option] });
+	}
+	return groups;
+}

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -12,6 +12,7 @@ import {
 	buildAgentCommandString,
 	buildTerminalAgentLaunch,
 	validateAgentEffortSelection,
+	validateAgentModelSelection,
 	validateAgentModeSelection,
 	validateAgentResumeSelection,
 } from "./agents";
@@ -311,6 +312,33 @@ describe("buildTerminalAgentLaunch", () => {
 		);
 	});
 
+	it("rejects a stale model instead of launching on the agent default", () => {
+		const db = createTestDb();
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: "00000000-0000-0000-0000-00000000000d",
+				presetId: "claude",
+				label: "Claude",
+				command: "claude",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: "[]",
+				resumeArgsJson: "[]",
+				envJson: "{}",
+				displayOrder: 3,
+			})
+			.run();
+
+		expect(() =>
+			buildTerminalAgentLaunch(db, {
+				workspaceId: "11111111-1111-1111-1111-111111111111",
+				agent: "claude",
+				prompt: "do the thing",
+				model: "claude-opus-9",
+			}),
+		).toThrow(/Unsupported model "claude-opus-9" for Claude/);
+	});
+
 	it("throws NOT_FOUND for an unknown agent", () => {
 		const db = createTestDb();
 		expect(() =>
@@ -422,6 +450,47 @@ describe("buildTerminalAgentLaunch default account env", () => {
 			prompt: "hi",
 		});
 		expect(launch.fullCommand).toBe("'claude' 'hi'");
+	});
+});
+
+describe("validateAgentModelSelection", () => {
+	it("leaves the model unset so the agent can use its own default", () => {
+		expect(() =>
+			validateAgentModelSelection("claude", "Claude", undefined),
+		).not.toThrow();
+	});
+
+	it("accepts a pinned legacy model for the selected agent", () => {
+		expect(() =>
+			validateAgentModelSelection("claude", "Claude", "claude-opus-4-8"),
+		).not.toThrow();
+	});
+
+	it("rejects an unknown model instead of silently dropping the flag", () => {
+		try {
+			validateAgentModelSelection("claude", "Claude", "claude-opus-9");
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as TRPCError).code).toBe("BAD_REQUEST");
+			expect((error as Error).message).toContain(
+				'Unsupported model "claude-opus-9" for Claude. Choose one of: ',
+			);
+			expect((error as Error).message).toContain("claude-opus-4-8");
+		}
+	});
+
+	it("rejects overrides for agents without model support", () => {
+		try {
+			validateAgentModelSelection("superset", "Superset", "claude-opus-5");
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect(error).toBeInstanceOf(TRPCError);
+			expect((error as TRPCError).code).toBe("BAD_REQUEST");
+			expect((error as Error).message).toBe(
+				"Superset does not support a model override. Omit model to use the agent default.",
+			);
+		}
 	});
 });
 

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -4,6 +4,7 @@ import {
 	buildAgentModelArgs,
 	buildAgentModelEnv,
 	getAgentEffortSupport,
+	getAgentModelSupport,
 	getAgentModeSupport,
 	resolveAgentLaunchPresetId,
 } from "@superset/shared/agent-models";
@@ -194,6 +195,38 @@ export type AgentRunResult = {
 };
 
 /**
+ * Validate an explicit model override before launch. Omitting model always
+ * delegates to the underlying agent's own default.
+ *
+ * Without this the launch builder silently drops an id outside the curated
+ * list, so a stale or mistyped model reads as "Superset ignored my choice":
+ * the agent starts on its own default with no flag, no warning, and a
+ * success exit code.
+ */
+export function validateAgentModelSelection(
+	presetId: string,
+	label: string,
+	model: string | undefined,
+): void {
+	if (!model) return;
+
+	const support = getAgentModelSupport(presetId);
+	if (!support) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `${label} does not support a model override. Omit model to use the agent default.`,
+		});
+	}
+
+	if (!support.models.some((option) => option.id === model)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Unsupported model "${model}" for ${label}. Choose one of: ${support.models.map((option) => option.id).join(", ")}.`,
+		});
+	}
+}
+
+/**
  * Validate an explicit effort override before launch. Omitting effort always
  * delegates to the underlying agent's own default.
  */
@@ -279,9 +312,9 @@ export function validateAgentResumeSelection(
  */
 export function validateAgentLaunchOptions(
 	db: HostDb,
-	input: Pick<AgentRunInput, "agent" | "effort" | "mode">,
+	input: Pick<AgentRunInput, "agent" | "model" | "effort" | "mode">,
 ): void {
-	if (!input.effort && !input.mode) return;
+	if (!input.model && !input.effort && !input.mode) return;
 
 	const config = resolveHostAgentConfig(db, input.agent);
 	if (!config) {
@@ -294,6 +327,7 @@ export function validateAgentLaunchOptions(
 		config.presetId,
 		config.command,
 	);
+	validateAgentModelSelection(launchPresetId, config.label, input.model);
 	validateAgentEffortSelection(launchPresetId, config.label, input.effort);
 	validateAgentModeSelection(launchPresetId, config.label, input.mode);
 }
@@ -322,6 +356,7 @@ export function buildTerminalAgentLaunch(
 		config.presetId,
 		config.command,
 	);
+	validateAgentModelSelection(launchPresetId, config.label, input.model);
 	validateAgentEffortSelection(launchPresetId, config.label, input.effort);
 	validateAgentModeSelection(launchPresetId, config.label, input.mode);
 	validateAgentResumeSelection(config, input.resumeSessionId);

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -117,6 +117,25 @@ describe("buildAgentModelArgs", () => {
 		expect(ids).toContain("claude-haiku-4-5");
 	});
 
+	it("labels claude's aliases and pinned releases as separate sections", () => {
+		const models = getAgentModelSupport("claude")?.models ?? [];
+		const groupOf = (id: string) =>
+			models.find((model) => model.id === id)?.group;
+		expect(groupOf("opus")).toBe("Latest");
+		expect(groupOf("claude-opus-4-8")).toBe("Pinned releases");
+		// The header carries the distinction, so labels stay bare.
+		expect(models.find((model) => model.id === "opus")?.label).toBe("Opus");
+	});
+
+	it("dates codex's retiring models in the picker, not just in a comment", () => {
+		const models = getAgentModelSupport("codex")?.models ?? [];
+		const groupOf = (id: string) =>
+			models.find((model) => model.id === id)?.group;
+		expect(groupOf("gpt-5.6-sol")).toBe("Current");
+		expect(groupOf("gpt-5.4")).toBe("Retiring 2026-08-31");
+		expect(groupOf("gpt-5.3-codex")).toBe("Retiring 2026-08-31");
+	});
+
 	it("passes a pinned legacy claude model through to the CLI flag", () => {
 		expect(buildAgentModelArgs("claude", "claude-opus-4-8")).toEqual([
 			"--model",

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -106,6 +106,24 @@ describe("buildAgentModelArgs", () => {
 		]);
 	});
 
+	it("offers pinned claude releases alongside the latest-tracking aliases", () => {
+		const ids = getAgentModelSupport("claude")?.models.map((m) => m.id) ?? [];
+		// Aliases follow the CLI's newest model; teams standardising on one
+		// release need an id that stays put.
+		expect(ids).toContain("opus");
+		expect(ids).toContain("claude-opus-4-8");
+		expect(ids).toContain("claude-opus-4-7");
+		expect(ids).toContain("claude-sonnet-4-6");
+		expect(ids).toContain("claude-haiku-4-5");
+	});
+
+	it("passes a pinned legacy claude model through to the CLI flag", () => {
+		expect(buildAgentModelArgs("claude", "claude-opus-4-8")).toEqual([
+			"--model",
+			"claude-opus-4-8",
+		]);
+	});
+
 	it("includes opus 5 in claude's curated list", () => {
 		expect(buildAgentModelArgs("claude", "claude-opus-5")).toEqual([
 			"--model",

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -17,6 +17,12 @@
 export interface AgentModelOption {
 	id: string;
 	label: string;
+	/**
+	 * Optional section header this option sits under in the picker. Options
+	 * without one render flat, so a catalog only pays for grouping when its
+	 * list has more than one kind of entry in it.
+	 */
+	group?: string;
 }
 
 export interface AgentModelSupport {
@@ -65,40 +71,51 @@ export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
 	{ id: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex", provider: "OpenAI" },
 ];
 
+const LATEST_GROUP = "Latest";
+const PINNED_GROUP = "Pinned releases";
+const CURRENT_GROUP = "Current";
+const CODEX_RETIRING_GROUP = "Retiring 2026-08-31";
+
 export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 	{
 		presetId: "claude",
 		modelFlag: "--model",
 		models: [
 			// Aliases track whatever the CLI considers newest in each family;
-			// the pinned ids below stay on one model release, which is what
-			// teams standardising on a known model need.
-			{ id: "fable", label: "Fable (latest)" },
-			{ id: "opus", label: "Opus (latest)" },
-			{ id: "sonnet", label: "Sonnet (latest)" },
-			{ id: "haiku", label: "Haiku (latest)" },
-			{ id: "claude-fable-5", label: "Fable 5" },
-			{ id: "claude-opus-5", label: "Opus 5" },
-			{ id: "claude-sonnet-5", label: "Sonnet 5" },
-			{ id: "claude-opus-4-8", label: "Opus 4.8" },
-			{ id: "claude-opus-4-7", label: "Opus 4.7" },
-			{ id: "claude-opus-4-6", label: "Opus 4.6" },
-			{ id: "claude-opus-4-5", label: "Opus 4.5" },
-			{ id: "claude-sonnet-4-6", label: "Sonnet 4.6" },
-			{ id: "claude-haiku-4-5", label: "Haiku 4.5" },
+			// the pinned ids stay on one model release, which is what teams
+			// standardising on a known model need. The group headers carry
+			// that distinction so the labels don't have to.
+			{ id: "fable", label: "Fable", group: LATEST_GROUP },
+			{ id: "opus", label: "Opus", group: LATEST_GROUP },
+			{ id: "sonnet", label: "Sonnet", group: LATEST_GROUP },
+			{ id: "haiku", label: "Haiku", group: LATEST_GROUP },
+			{ id: "claude-fable-5", label: "Fable 5", group: PINNED_GROUP },
+			{ id: "claude-opus-5", label: "Opus 5", group: PINNED_GROUP },
+			{ id: "claude-sonnet-5", label: "Sonnet 5", group: PINNED_GROUP },
+			{ id: "claude-opus-4-8", label: "Opus 4.8", group: PINNED_GROUP },
+			{ id: "claude-opus-4-7", label: "Opus 4.7", group: PINNED_GROUP },
+			{ id: "claude-opus-4-6", label: "Opus 4.6", group: PINNED_GROUP },
+			{ id: "claude-opus-4-5", label: "Opus 4.5", group: PINNED_GROUP },
+			{ id: "claude-sonnet-4-6", label: "Sonnet 4.6", group: PINNED_GROUP },
+			{ id: "claude-haiku-4-5", label: "Haiku 4.5", group: PINNED_GROUP },
 		],
 	},
 	{
 		presetId: "codex",
 		modelFlag: "--model",
 		models: [
-			{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
-			{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
-			{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
-			{ id: "gpt-5.5", label: "GPT-5.5" },
-			// Retiring from Codex on 2026-08-31; superseded by gpt-5.6-terra/luna.
-			{ id: "gpt-5.4", label: "GPT-5.4" },
-			{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+			{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol", group: CURRENT_GROUP },
+			{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra", group: CURRENT_GROUP },
+			{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna", group: CURRENT_GROUP },
+			{ id: "gpt-5.5", label: "GPT-5.5", group: CURRENT_GROUP },
+			// Superseded by gpt-5.6-terra/luna; the header dates the retirement
+			// so it reaches the person picking rather than only this file.
+			{ id: "gpt-5.4", label: "GPT-5.4", group: CODEX_RETIRING_GROUP },
+			{
+				id: "gpt-5.3-codex",
+				label: "GPT-5.3 Codex",
+				group: CODEX_RETIRING_GROUP,
+			},
 		],
 	},
 	{

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -70,11 +70,22 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "claude",
 		modelFlag: "--model",
 		models: [
-			{ id: "fable", label: "Fable" },
-			{ id: "opus", label: "Opus" },
+			// Aliases track whatever the CLI considers newest in each family;
+			// the pinned ids below stay on one model release, which is what
+			// teams standardising on a known model need.
+			{ id: "fable", label: "Fable (latest)" },
+			{ id: "opus", label: "Opus (latest)" },
+			{ id: "sonnet", label: "Sonnet (latest)" },
+			{ id: "haiku", label: "Haiku (latest)" },
+			{ id: "claude-fable-5", label: "Fable 5" },
 			{ id: "claude-opus-5", label: "Opus 5" },
-			{ id: "sonnet", label: "Sonnet" },
-			{ id: "haiku", label: "Haiku" },
+			{ id: "claude-sonnet-5", label: "Sonnet 5" },
+			{ id: "claude-opus-4-8", label: "Opus 4.8" },
+			{ id: "claude-opus-4-7", label: "Opus 4.7" },
+			{ id: "claude-opus-4-6", label: "Opus 4.6" },
+			{ id: "claude-opus-4-5", label: "Opus 4.5" },
+			{ id: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+			{ id: "claude-haiku-4-5", label: "Haiku 4.5" },
 		],
 	},
 	{


### PR DESCRIPTION
## Summary

- Add pinned Claude releases (Opus 4.8/4.7/4.6/4.5, Sonnet 5/4.6, Fable 5, Haiku 4.5) to the workspace-create model picker, alongside the existing family aliases.
- Section the picker into "Latest" and "Pinned releases" so the two kinds are distinguishable without suffixing every label; Codex's retirement date moves out of a source comment and into a "Retiring 2026-08-31" header.
- Add `validateAgentModelSelection`, so a model the agent can't take fails with an actionable message instead of being silently dropped at launch.

## Why / Context

Reported by @iamwix on X, mid-rollout at his org:

> When I go to start a new workspace I can't choose a legacy model from the dropdown or configure it in the settings. For when I don't want to default to Opus 5.

The picker itself has existed since #5248 and renders in both create surfaces. The problem is its contents: Claude's catalog was `fable / opus / claude-opus-5 / sonnet / haiku` — four aliases that resolve to whatever the CLI considers newest, and one pinned id. A team standardising on an older release had nothing to pick.

The second half is worse than a missing option. `buildAgentModelArgs` returns `[]` for any id outside the curated list, so the flag is dropped and the agent launches on its own default — exit code 0, no warning:

```
buildAgentModelArgs("claude", "claude-opus-4-8")  ->  []      # silently ignored
buildAgentModelArgs("claude", "opuss")            ->  []      # typo, silently ignored
```

Effort and mode have validated with a readable error since they shipped (`validateAgentEffortSelection`, `validateAgentModeSelection`); model was the odd one out. This matters more once #6805 lands `--model` on the CLI, SDK, and MCP — that PR's docs already word around the gap ("Unsupported **effort** values fail before launch").

## How It Works

`validateAgentModelSelection` mirrors the effort validator exactly, and is wired into both entry points:

- `buildTerminalAgentLaunch` — a direct agent launch rejects the model before building the command.
- `validateAgentLaunchOptions` — the workspace-create preflight, so `--model bogus` fails **before** the worktree is created rather than after.

Unknown ids now produce `Unsupported model "claude-opus-4-9" for Claude. Choose one of: fable, opus, sonnet, haiku, claude-fable-5, …`. `buildAgentModelArgs` keeps its degrade-to-default behavior as the backstop for callers that bypass validation.

## Manual QA Checklist

### Workspace create
- [ ] New-workspace dialog with a Claude agent selected shows a "Latest" section and a "Pinned releases" section
- [ ] Effort and mode pickers (no groups in their catalogs) still render as flat lists
- [ ] Picking `Opus 4.8` launches `claude --model claude-opus-4-8`
- [ ] `Default model` still omits the flag entirely
- [ ] Selection still sticks per preset across dialog opens and host switches

### API / tRPC error handling
- [ ] `agents.run` with an unknown model returns BAD_REQUEST naming the supported ids
- [ ] `workspaces.create` with an unknown model fails before the worktree exists
- [ ] An agent without model support (e.g. Superset chat) rejects a model override

## Testing

- `bun test packages/shared/src/agent-models.test.ts apps/desktop/src/renderer/components/AgentModelSelect packages/host-service/src/trpc/router/agents/agents.test.ts` — 86 pass
- `bun test packages/host-service/src/trpc/router/workspaces packages/host-service/src/trpc/router/workspace-creation` — 190 pass, no regressions
- `bunx tsc --noEmit` clean for `packages/shared` and `packages/host-service`
- `bunx biome check` clean on the four touched files
- Reverted the two source files and re-ran: the new assertions fail (plus the missing export), confirming the tests can fail

## Design Decisions

- **Sections, not label suffixes.** A `(latest)` suffix on every alias pays for the distinction once per row; a header says it once. Options carry an optional `group`, and a catalog that sets none renders flat exactly as before — so the effort and mode pickers are untouched. Reuses the `SelectGroup`/`SelectLabel`/`SelectSeparator` pattern from the theme picker rather than inventing a list UI.
- **Aliases kept, not replaced.** Most users want "newest Opus" and shouldn't have to re-pick after every release. The pinned ids are additive, and `(latest)` labels keep the dropdown readable now that both kinds sit in one list.
- **No `defaultModelId`.** #6541 pairs its catalog with a per-preset default that removes the `Default model` option and pins Claude to Fable 5 out of the box. That's a product decision about spend, separate from "let me pick an older model", so it isn't here.
- **Validate rather than pass through.** Accepting arbitrary ids would also serve Bedrock/Vertex users with pinned ids like `us.anthropic.claude-opus-4-6-v1`, but it keeps the silent-drop failure for typos. Rejecting is the honest default; a deliberate free-text escape hatch can come later if asked for.

## Known Limitations

- The catalog stays hand-maintained and will drift with CLI releases. #6541 addresses that properly with runtime capability discovery — though notably it does **not** discover Claude's models (it only probes `claude auth status`), so Claude would rely on this same curated list either way.
- The new error strings are not Lingui-wrapped, matching the sibling validators. Neither `packages/host-service` nor `packages/shared` is in `packages/i18n/test/enforced-dirs.ts`, and host-service has no i18n wiring yet; converting it is out of scope here.
- Still no default-model setting. That's the other half of the report ("or configure it in the settings") and wants a `default_model` on `host_agent_configs` plus a control in Settings → Agents.

## Follow-ups

- #6805 (`--model` on CLI/SDK/MCP) should land after this, so the flag is honest the day it ships.
- Per-agent default model in Settings → Agents.
- #6802 is superseded — #6851 already fixed the icon-override bug by adding `launchPresetId`.

## Risks / Rollout

- Risk: a caller passing a model id outside the catalog now gets a hard error instead of a silent fallback. Blast radius is small — no agent model ids are persisted anywhere (not in `packages/db`, not in automations), and the only sender today is the desktop picker, which is catalog-bounded.
- Rollback: revert; `buildAgentModelArgs` degrade-to-default is unchanged underneath.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pinned Claude model releases to the workspace-create model picker and rejects unsupported model overrides before launch. Previously the picker only offered family aliases that track the CLI's newest model, and unknown model IDs were silently dropped, launching the agent on its default with no error.

- The picker now lists Opus 4.8/4.7/4.6/4.5, Sonnet 5/4.6, Fable 5, and Haiku 4.5 alongside the aliases, split into "Latest" and "Pinned releases" sections; Codex gets the same grouping, surfacing retiring models.
- Unsupported or mistyped model IDs now fail before launch with a message naming the supported IDs, and overrides for agents without model support are rejected.
- The default option is visually separated from the first model section, while catalogs without groups still render as flat lists.

<sup>Written for commit 76b4e11ec4e4cab21f8b2942106b07f501aec186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting specific Claude model versions, including pinned releases and latest-model aliases.
  * Organized Claude and Codex models into clearer picker sections, including current and retiring models.
  * Validated model selections against each agent’s supported options before launch.
  * Added clear errors for unsupported models and agents without model-selection support.

* **Bug Fixes**
  * Prevented invalid or stale model selections from silently falling back to an agent’s default model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->