### PR TITLE
feat(usage): analytics for every agent CLI that records usage (grok, cursor, opencode, copilot, pi, omp, fx)

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/UsageHistorySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/UsageHistorySection.tsx
@@ -51,14 +51,26 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 			: (["claude", "codex"] satisfies Provider[]);
 	})();
 
+	// A range switch can leave every active series hidden by stale toggles —
+	// ignore the stored hides then, rather than render an empty chart.
+	const effectiveHidden = activeProviders.some(
+		(provider) => !hiddenProviders.has(provider),
+	)
+		? hiddenProviders
+		: new Set<Provider>();
+
 	const toggleProvider = (provider: Provider) => {
 		setHiddenProviders((previous) => {
 			const next = new Set(previous);
 			if (next.has(provider)) {
 				next.delete(provider);
-			} else if (next.size < activeProviders.length - 1) {
-				// Never hide the last visible series — an empty chart reads as broken.
-				next.add(provider);
+			} else {
+				// Never hide the last visible series — an empty chart reads as
+				// broken. Count only active providers; hidden inactive ones don't.
+				const visibleActive = activeProviders.filter(
+					(active) => !next.has(active),
+				).length;
+				if (visibleActive > 1) next.add(provider);
 			}
 			return next;
 		});
@@ -161,7 +173,7 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 											? (metric === "usd" ? totalsFor.usd : totalsFor.tokens) /
 												denominator
 											: 0;
-									const hidden = hiddenProviders.has(provider);
+									const hidden = effectiveHidden.has(provider);
 									const icon = getPresetIcon(
 										PROVIDER_ICON_KEY[provider],
 										isDark,
@@ -259,7 +271,7 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 						<UsageAreaChart
 							history={history}
 							metric={metric}
-							hiddenProviders={hiddenProviders}
+							hiddenProviders={effectiveHidden}
 							selectedDay={selectedDay}
 							onSelectDay={setSelectedDay}
 						/>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/UsageHistorySection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/UsageHistorySection.tsx
@@ -2,6 +2,10 @@ import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
 import { cn } from "@superset/ui/utils";
 import { useState } from "react";
 import { LuX } from "react-icons/lu";
+import {
+	getPresetIcon,
+	useIsDarkTheme,
+} from "renderer/assets/app-icons/preset-icons";
 import { useHostUsageHistory } from "../../hooks/useHostUsageHistory";
 import { UsageAreaChart } from "./components/UsageAreaChart";
 import { UsageMetricTiles } from "./components/UsageMetricTiles";
@@ -10,6 +14,7 @@ import { UsageProjectBars } from "./components/UsageProjectBars";
 import type { HistoryMetric } from "./constants";
 import {
 	PROVIDER_CHART_CONFIG,
+	PROVIDER_ICON_KEY,
 	PROVIDER_ORDER,
 	RANGE_OPTIONS,
 } from "./constants";
@@ -26,6 +31,7 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 	const [selectedDay, setSelectedDay] = useState<string | null>(null);
 	const historyQuery = useHostUsageHistory(hostUrl, days);
 	const history = historyQuery.data ?? null;
+	const isDark = useIsDarkTheme();
 
 	const firstDay = history?.buckets[0]?.day;
 	const lastDay = history?.buckets[history.buckets.length - 1]?.day;
@@ -34,12 +40,23 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 			? (history.buckets.find((bucket) => bucket.day === selectedDay) ?? null)
 			: null;
 
+	// Only providers with usage in range get a share row — nine zero rows
+	// would drown the two that matter. No usage at all: show the classic two.
+	const activeProviders = (() => {
+		const withUsage = PROVIDER_ORDER.filter((provider) =>
+			history?.buckets.some((bucket) => bucket.providers[provider]),
+		);
+		return withUsage.length > 0
+			? withUsage
+			: (["claude", "codex"] satisfies Provider[]);
+	})();
+
 	const toggleProvider = (provider: Provider) => {
 		setHiddenProviders((previous) => {
 			const next = new Set(previous);
 			if (next.has(provider)) {
 				next.delete(provider);
-			} else if (next.size < PROVIDER_ORDER.length - 1) {
+			} else if (next.size < activeProviders.length - 1) {
 				// Never hide the last visible series — an empty chart reads as broken.
 				next.add(provider);
 			}
@@ -125,7 +142,7 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 								)}
 							</div>
 							<div className="flex flex-col gap-1.5">
-								{PROVIDER_ORDER.map((provider) => {
+								{activeProviders.map((provider) => {
 									const totalsFor = history.buckets.reduce(
 										(acc, bucket) => {
 											const slot = bucket.providers[provider];
@@ -145,6 +162,10 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 												denominator
 											: 0;
 									const hidden = hiddenProviders.has(provider);
+									const icon = getPresetIcon(
+										PROVIDER_ICON_KEY[provider],
+										isDark,
+									);
 									return (
 										<button
 											key={provider}
@@ -165,6 +186,9 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 													background: PROVIDER_CHART_CONFIG[provider].color,
 												}}
 											/>
+											{icon && (
+												<img src={icon} alt="" className="size-3.5 shrink-0" />
+											)}
 											<span className="min-w-0 truncate">
 												{PROVIDER_CHART_CONFIG[provider].label}
 											</span>
@@ -195,9 +219,13 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 											<LuX className="size-3" />
 										</button>
 									</div>
-									{PROVIDER_ORDER.map((provider) => {
+									{activeProviders.map((provider) => {
 										const slot = selectedBucket.providers[provider];
 										if (!slot) return null;
+										const icon = getPresetIcon(
+											PROVIDER_ICON_KEY[provider],
+											isDark,
+										);
 										return (
 											<div
 												key={provider}
@@ -209,6 +237,9 @@ export function UsageHistorySection({ hostUrl }: { hostUrl: string | null }) {
 														background: PROVIDER_CHART_CONFIG[provider].color,
 													}}
 												/>
+												{icon && (
+													<img src={icon} alt="" className="size-3 shrink-0" />
+												)}
 												<span className="text-muted-foreground">
 													{PROVIDER_CHART_CONFIG[provider].label}
 												</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/components/UsageAreaChart/UsageAreaChart.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/components/UsageAreaChart/UsageAreaChart.tsx
@@ -44,12 +44,24 @@ export function UsageAreaChart({
 }) {
 	const data = useMemo(
 		() =>
-			history.buckets.map((bucket) => ({
-				day: bucket.day,
-				claude: bucket.providers.claude?.[metric] ?? 0,
-				codex: bucket.providers.codex?.[metric] ?? 0,
-			})),
+			history.buckets.map((bucket) => {
+				const values: Partial<Record<Provider, number>> = {};
+				for (const provider of PROVIDER_ORDER) {
+					values[provider] = bucket.providers[provider]?.[metric] ?? 0;
+				}
+				return { day: bucket.day, ...values };
+			}),
 		[history, metric],
+	);
+
+	// Providers with no usage in range draw nothing — nine flat baselines
+	// would read as noise.
+	const presentProviders = useMemo(
+		() =>
+			PROVIDER_ORDER.filter((provider) =>
+				history.buckets.some((bucket) => bucket.providers[provider]),
+			),
+		[history],
 	);
 
 	const formatValue = metric === "usd" ? formatUsd : formatTokens;
@@ -130,21 +142,21 @@ export function UsageAreaChart({
 						strokeDasharray="4 3"
 					/>
 				)}
-				{PROVIDER_ORDER.filter(
-					(provider) => !hiddenProviders.has(provider),
-				).map((provider) => (
-					<Area
-						key={provider}
-						dataKey={provider}
-						type="monotone"
-						stroke={`var(--color-${provider})`}
-						fill={`var(--color-${provider})`}
-						strokeWidth={2}
-						fillOpacity={0.12}
-						dot={false}
-						isAnimationActive={false}
-					/>
-				))}
+				{presentProviders
+					.filter((provider) => !hiddenProviders.has(provider))
+					.map((provider) => (
+						<Area
+							key={provider}
+							dataKey={provider}
+							type="monotone"
+							stroke={`var(--color-${provider})`}
+							fill={`var(--color-${provider})`}
+							strokeWidth={2}
+							fillOpacity={0.12}
+							dot={false}
+							isAnimationActive={false}
+						/>
+					))}
 			</AreaChart>
 		</ChartContainer>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageHistorySection/constants.ts
@@ -2,15 +2,50 @@ import type { ChartConfig } from "@superset/ui/chart";
 
 /**
  * Fixed categorical hue order — color follows the provider, never its rank.
- * Both hexes validated (light + dark surfaces) with the dataviz palette
- * checker: lightness band, chroma, CVD ΔE ≥ 20, contrast ≥ 3:1 all pass.
+ * All nine hexes validated (light + dark surfaces) with the dataviz palette
+ * checker in this order: lightness band, chroma, adjacent-pair CVD ΔE,
+ * normal-vision floor, contrast ≥ 3:1 all pass.
  */
 export const PROVIDER_CHART_CONFIG = {
 	claude: { label: "Claude Code", color: "#d06a48" },
 	codex: { label: "Codex", color: "#1596d6" },
+	grok: { label: "Grok", color: "#2f9e63" },
+	cursor: { label: "Cursor", color: "#8a63d2" },
+	opencode: { label: "OpenCode", color: "#b3852d" },
+	copilot: { label: "Copilot", color: "#22a5b8" },
+	pi: { label: "Pi", color: "#b04a82" },
+	omp: { label: "Oh My Pi", color: "#829c2e" },
+	fx: { label: "fx", color: "#5b6bd6" },
 } satisfies ChartConfig;
 
-export const PROVIDER_ORDER = ["claude", "codex"] as const;
+/** Preset-icon registry keys per provider (cursor's icon is keyed by its
+ * agent id `cursor-agent`; omp shares pi's mark). */
+export const PROVIDER_ICON_KEY: Record<
+	keyof typeof PROVIDER_CHART_CONFIG,
+	string
+> = {
+	claude: "claude",
+	codex: "codex",
+	grok: "grok",
+	cursor: "cursor-agent",
+	opencode: "opencode",
+	copilot: "copilot",
+	pi: "pi",
+	omp: "omp",
+	fx: "fx",
+};
+
+export const PROVIDER_ORDER = [
+	"claude",
+	"codex",
+	"grok",
+	"cursor",
+	"opencode",
+	"copilot",
+	"pi",
+	"omp",
+	"fx",
+] as const;
 
 export type HistoryMetric = "usd" | "tokens";
 export const RANGE_OPTIONS = [7, 30, 90] as const;

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -10,9 +10,9 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { HostDb } from "../../../db/index.ts";
 import { hostSettings } from "../../../db/schema.ts";
-import type { UsageProvider } from "./types.ts";
+import type { UsageAccountProvider } from "./types.ts";
 
-const POINTER_NAMES: Record<UsageProvider, string> = {
+const POINTER_NAMES: Record<UsageAccountProvider, string> = {
 	claude: "default-claude-config-dir",
 	codex: "default-codex-home",
 };
@@ -34,7 +34,7 @@ function supersetHomeDir(): string {
  * stays the source of truth and the wrapper falls back to the spawn-time env.
  */
 export function syncDefaultAccountPointer(
-	provider: UsageProvider,
+	provider: UsageAccountProvider,
 	selection: string | null,
 ): void {
 	try {
@@ -73,7 +73,7 @@ export function getDefaultAccountSelections(
 
 export function setDefaultAccountSelection(
 	db: HostDb,
-	provider: UsageProvider,
+	provider: UsageAccountProvider,
 	selection: string | null,
 ): void {
 	const values =

--- a/packages/host-service/src/trpc/router/usage/history/aggregate.ts
+++ b/packages/host-service/src/trpc/router/usage/history/aggregate.ts
@@ -170,6 +170,7 @@ export async function computeUsageHistory(
 	const { entries, sessionLabels, scannedFiles } = await collectUsageEntries(
 		days,
 		cutoffMs,
+		{ cwdCandidates: cwdLabels.map((label) => label.prefix) },
 	);
 
 	const bucketsByDay = new Map<string, UsageDailyBucket>();
@@ -232,7 +233,10 @@ export async function computeUsageHistory(
 
 	for (const entry of entries) {
 		const rate = matchModelRate(entry.provider, entry.model);
-		const usd = costUsd(rate, entry);
+		// A harness-reported real cost beats the API-list-rate estimate, and an
+		// entry priced by its own harness is never "approximate".
+		const estimated = entry.costUsd === undefined;
+		const usd = entry.costUsd ?? costUsd(rate, entry);
 		const tokens = entryTokens(entry);
 
 		const day = dayKey(entry.timestampMs);
@@ -259,10 +263,11 @@ export async function computeUsageHistory(
 				model: entry.model,
 				usd: 0,
 				tokens: 0,
-				approximate: rate.approximate,
+				approximate: false,
 			};
 			modelsByKey.set(modelKey, model);
 		}
+		model.approximate ||= estimated && rate.approximate;
 		model.usd += usd;
 		model.tokens += tokens;
 
@@ -313,8 +318,13 @@ export async function computeUsageHistory(
 		totals.cacheWrite += entry.cacheWrite5m + entry.cacheWrite1h;
 		totals.output += entry.output;
 		totals.reasoningOutput += entry.reasoningOutput;
-		totals.cacheSavingsUsd += cacheSavingsUsd(rate, entry);
-		totals.approximate ||= rate.approximate;
+		// Savings are rate-derived; for harness-priced entries the matched rate
+		// may be a fallback, so only estimate savings where the cost itself is
+		// a rate estimate too.
+		if (estimated) {
+			totals.cacheSavingsUsd += cacheSavingsUsd(rate, entry);
+			totals.approximate ||= rate.approximate;
+		}
 	}
 
 	// Emit a contiguous day series so charts show gaps as zero, not missing.

--- a/packages/host-service/src/trpc/router/usage/history/copilot.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/copilot.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { CopilotUsageRow } from "./copilot";
+import { copilotRowsToEntries } from "./copilot";
+import type { UsageLogEntry } from "./parse";
+
+// The sqlite read path itself can't run under bun (better-sqlite3 is
+// node-only); this covers the row mapping the query feeds.
+
+function row(over: Partial<CopilotUsageRow> = {}): CopilotUsageRow {
+	return {
+		session_id: "sess-1",
+		model: "claude-sonnet-4.5",
+		input_tokens: 120,
+		output_tokens: 300,
+		cache_read_tokens: 800,
+		cache_write_tokens: 40,
+		reasoning_tokens: 60,
+		created_at: "2026-08-20 12:00:00",
+		cwd: "/tmp/proj",
+		summary: "Debug the login flow",
+		...over,
+	};
+}
+
+describe("copilotRowsToEntries", () => {
+	test("maps usage rows joined with their session", () => {
+		const out: UsageLogEntry[] = [];
+		const labels = new Map<string, string>();
+		copilotRowsToEntries([row()], 0, out, labels);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			provider: "copilot",
+			model: "claude-sonnet-4.5",
+			cwd: "/tmp/proj",
+			sessionId: "sess-1",
+			uncachedInput: 120,
+			cachedInput: 800,
+			cacheWrite5m: 40,
+			output: 300,
+			reasoningOutput: 60,
+			// created_at is SQLite's datetime('now') — UTC without a marker.
+			timestampMs: Date.parse("2026-08-20T12:00:00.000Z"),
+		});
+		expect(labels.get("sess-1")).toBe("Debug the login flow");
+	});
+
+	test("respects the cutoff and tolerates null columns", () => {
+		const out: UsageLogEntry[] = [];
+		copilotRowsToEntries(
+			[
+				row({ created_at: "2026-08-01 12:00:00" }),
+				row({ created_at: null }),
+				row({ session_id: null, cwd: null, summary: null, model: null }),
+			],
+			Date.parse("2026-08-10T00:00:00.000Z"),
+			out,
+		);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			sessionId: "unknown",
+			model: "unknown",
+			cwd: null,
+		});
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/copilot.ts
+++ b/packages/host-service/src/trpc/router/usage/history/copilot.ts
@@ -1,0 +1,97 @@
+/**
+ * Copilot CLI usage. `~/.copilot/session-store.db` (SQLite) has an
+ * `assistant_usage_events` table with per-request token counts joined to a
+ * `sessions` table carrying the cwd and a summary. Opened read-only — the
+ * CLI may hold the database concurrently.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import type { UsageLogEntry } from "./parse";
+import { num } from "./parse";
+
+export function copilotDbPath(): string {
+	return join(homedir(), ".copilot", "session-store.db");
+}
+
+export interface CopilotUsageRow {
+	session_id: string | null;
+	model: string | null;
+	input_tokens: number | null;
+	output_tokens: number | null;
+	cache_read_tokens: number | null;
+	cache_write_tokens: number | null;
+	reasoning_tokens: number | null;
+	created_at: string | null;
+	cwd: string | null;
+	summary: string | null;
+}
+
+/** `created_at` is SQLite's `datetime('now')` — UTC without a zone marker. */
+function parseUtcTimestamp(raw: string | null): number {
+	if (!raw) return 0;
+	const parsed = Date.parse(`${raw.replace(" ", "T")}Z`);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Pure row → entry mapping, exported for tests (bun can't load sqlite). */
+export function copilotRowsToEntries(
+	rows: CopilotUsageRow[],
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+): void {
+	for (const row of rows) {
+		const timestampMs = parseUtcTimestamp(row.created_at);
+		if (!timestampMs || timestampMs < cutoffMs) continue;
+		const sessionId = row.session_id ?? "unknown";
+		if (row.summary && sessionLabels && !sessionLabels.has(sessionId)) {
+			sessionLabels.set(sessionId, row.summary);
+		}
+		out.push({
+			provider: "copilot",
+			model: row.model || "unknown",
+			timestampMs,
+			cwd: row.cwd ?? null,
+			sessionId,
+			// Cache reads/writes are separate columns (Anthropic-style), so
+			// input_tokens is taken as the non-cached count.
+			uncachedInput: num(row.input_tokens),
+			cachedInput: num(row.cache_read_tokens),
+			cacheWrite5m: num(row.cache_write_tokens),
+			cacheWrite1h: 0,
+			output: num(row.output_tokens),
+			reasoningOutput: num(row.reasoning_tokens),
+		});
+	}
+}
+
+/** Returns 1 when the database was scanned, 0 when absent/unreadable. */
+export function collectCopilotEntries(
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+	dbPath: string = copilotDbPath(),
+): number {
+	let db: InstanceType<typeof Database> | null = null;
+	try {
+		db = new Database(dbPath, { readonly: true, fileMustExist: true });
+		const rows = db
+			.prepare(
+				`SELECT e.session_id, e.model, e.input_tokens, e.output_tokens,
+				        e.cache_read_tokens, e.cache_write_tokens, e.reasoning_tokens,
+				        e.created_at, s.cwd, s.summary
+				 FROM assistant_usage_events e
+				 LEFT JOIN sessions s ON s.id = e.session_id
+				 WHERE e.created_at >= datetime(? / 1000, 'unixepoch')`,
+			)
+			.all(cutoffMs) as CopilotUsageRow[];
+		copilotRowsToEntries(rows, cutoffMs, out, sessionLabels);
+		return 1;
+	} catch {
+		return 0;
+	} finally {
+		db?.close();
+	}
+}

--- a/packages/host-service/src/trpc/router/usage/history/cursor.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/cursor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { cursorEventsToEntries } from "./cursor";
+
+describe("cursorEventsToEntries", () => {
+	test("maps events with token usage into priced entries", () => {
+		const entries = cursorEventsToEntries(
+			[
+				{
+					timestamp: "1787004840166",
+					model: "composer-2.5",
+					conversationId: "conv-1",
+					tokenUsage: {
+						inputTokens: 80,
+						outputTokens: 190,
+						cacheReadTokens: 20_160,
+						totalCents: 0.4547,
+					},
+				},
+				// Non-token events (no tokenUsage) are skipped.
+				{ timestamp: "1787004840166", model: "composer-2.5" },
+			],
+			0,
+		);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			provider: "cursor",
+			model: "composer-2.5",
+			sessionId: "conv-1",
+			timestampMs: 1_787_004_840_166,
+			uncachedInput: 80,
+			cachedInput: 20_160,
+			output: 190,
+			costUsd: 0.4547 / 100,
+		});
+	});
+
+	test("drops events before the cutoff and events without timestamps", () => {
+		const entries = cursorEventsToEntries(
+			[
+				{
+					timestamp: "1000",
+					model: "composer-2.5",
+					conversationId: "conv-1",
+					tokenUsage: { inputTokens: 1, outputTokens: 1 },
+				},
+				{
+					model: "composer-2.5",
+					conversationId: "conv-2",
+					tokenUsage: { inputTokens: 1, outputTokens: 1 },
+				},
+			],
+			2000,
+		);
+		expect(entries).toHaveLength(0);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/cursor.ts
+++ b/packages/host-service/src/trpc/router/usage/history/cursor.ts
@@ -1,0 +1,304 @@
+/**
+ * Cursor CLI usage. cursor-agent keeps no token counts on disk (chat blobs
+ * in `~/.cursor/chats/<md5(cwd)>/<conversationId>/store.db` hold messages
+ * only), but the CLI's own bearer token authorizes Cursor's dashboard RPCs,
+ * and `GetFilteredUsageEvents` returns per-request events with exact token
+ * splits and the real cost in cents.
+ *
+ * The token comes from where the CLI stores it: the macOS keychain item
+ * `cursor-access-token` / `cursor-user`, else an `auth.json` fallback
+ * (`~/.cursor/auth.json`, `$XDG_CONFIG_HOME/cursor/auth.json`).
+ *
+ * Events carry no cwd — attribution goes through the local chats dir, whose
+ * first path segment is md5(cwd): hash the caller's known workspace/project
+ * paths and match. Unmatched conversations stay unattributed.
+ */
+
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import Database from "better-sqlite3";
+import type { UsageLogEntry } from "./parse";
+import { num } from "./parse";
+
+const execFileAsync = promisify(execFile);
+
+const CURSOR_API_BASE = "https://api2.cursor.sh";
+const PAGE_SIZE = 300;
+// 90 days of heavy use fits well inside this; a runaway pagination must not.
+const MAX_PAGES = 40;
+const FETCH_TIMEOUT_MS = 15_000;
+// Same rationale as the quota cache: don't re-hit an undocumented endpoint
+// for every render poll. Keyed per cutoff so range switches stay fresh.
+const EVENTS_CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_LABEL_DB_OPENS = 200;
+
+export interface CursorUsageEvent {
+	timestamp?: string;
+	model?: string;
+	conversationId?: string;
+	tokenUsage?: {
+		inputTokens?: number;
+		outputTokens?: number;
+		cacheReadTokens?: number;
+		cacheWriteTokens?: number;
+		totalCents?: number;
+	};
+	chargedCents?: number;
+}
+
+export function cursorChatsDir(): string {
+	return join(homedir(), ".cursor", "chats");
+}
+
+async function readAuthJsonToken(path: string): Promise<string | null> {
+	try {
+		const parsed = JSON.parse(await readFile(path, "utf-8")) as {
+			accessToken?: string;
+			access_token?: string;
+		};
+		return parsed.accessToken ?? parsed.access_token ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** The CLI's stored login, read the way cursor-agent itself stores it. */
+export async function readCursorAccessToken(): Promise<string | null> {
+	if (process.platform === "darwin") {
+		try {
+			const { stdout } = await execFileAsync("security", [
+				"find-generic-password",
+				"-s",
+				"cursor-access-token",
+				"-a",
+				"cursor-user",
+				"-w",
+			]);
+			const token = stdout.trim();
+			if (token) return token;
+		} catch {
+			// No keychain item — fall through to the file fallbacks.
+		}
+	}
+	const configHome =
+		process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
+	for (const path of [
+		join(homedir(), ".cursor", "auth.json"),
+		join(configHome, "cursor", "auth.json"),
+	]) {
+		const token = await readAuthJsonToken(path);
+		if (token) return token;
+	}
+	return null;
+}
+
+async function fetchUsageEvents(
+	token: string,
+	cutoffMs: number,
+): Promise<CursorUsageEvent[]> {
+	const events: CursorUsageEvent[] = [];
+	const endDate = Date.now();
+	for (let page = 1; page <= MAX_PAGES; page++) {
+		const res = await fetch(
+			`${CURSOR_API_BASE}/aiserver.v1.DashboardService/GetFilteredUsageEvents`,
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${token}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					teamId: 0,
+					startDate: String(cutoffMs),
+					endDate: String(endDate),
+					page,
+					pageSize: PAGE_SIZE,
+				}),
+				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			},
+		);
+		if (!res.ok) {
+			throw new Error(`Cursor usage request failed (HTTP ${res.status})`);
+		}
+		const data = (await res.json()) as {
+			totalUsageEventsCount?: number;
+			usageEventsDisplay?: CursorUsageEvent[];
+		};
+		const pageEvents = data.usageEventsDisplay ?? [];
+		events.push(...pageEvents);
+		const total = data.totalUsageEventsCount ?? 0;
+		if (pageEvents.length < PAGE_SIZE || events.length >= total) break;
+	}
+	return events;
+}
+
+let cachedEvents: {
+	cutoffMs: number;
+	fetchedAt: number;
+	events: CursorUsageEvent[];
+} | null = null;
+
+/** Pure event → entry mapping, exported for tests. */
+export function cursorEventsToEntries(
+	events: CursorUsageEvent[],
+	cutoffMs: number,
+): UsageLogEntry[] {
+	const entries: UsageLogEntry[] = [];
+	for (const event of events) {
+		const usage = event.tokenUsage;
+		if (!usage) continue;
+		const timestampMs = Number(event.timestamp);
+		if (!Number.isFinite(timestampMs) || timestampMs < cutoffMs) continue;
+		const cents = usage.totalCents ?? event.chargedCents;
+		const costUsd =
+			typeof cents === "number" && Number.isFinite(cents) && cents > 0
+				? cents / 100
+				: undefined;
+		entries.push({
+			provider: "cursor",
+			model: event.model || "unknown",
+			timestampMs,
+			cwd: null,
+			sessionId: event.conversationId || "unknown",
+			// Cursor reports cache reads separately from inputTokens.
+			uncachedInput: num(usage.inputTokens),
+			cachedInput: num(usage.cacheReadTokens),
+			cacheWrite5m: num(usage.cacheWriteTokens),
+			cacheWrite1h: 0,
+			output: num(usage.outputTokens),
+			reasoningOutput: 0,
+			...(costUsd !== undefined ? { costUsd } : {}),
+		});
+	}
+	return entries;
+}
+
+interface ChatDirIndex {
+	/** conversationId → md5-of-cwd segment. */
+	hashByConversation: Map<string, string>;
+	/** conversationId → store.db path, for title lookup. */
+	dbByConversation: Map<string, string>;
+}
+
+async function indexChatsDir(chatsDir: string): Promise<ChatDirIndex> {
+	const hashByConversation = new Map<string, string>();
+	const dbByConversation = new Map<string, string>();
+	let hashes: string[] = [];
+	try {
+		const entries = await readdir(chatsDir, { withFileTypes: true });
+		hashes = entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+	} catch {
+		return { hashByConversation, dbByConversation };
+	}
+	for (const hash of hashes) {
+		let conversations: string[];
+		try {
+			const entries = await readdir(join(chatsDir, hash), {
+				withFileTypes: true,
+			});
+			conversations = entries
+				.filter((entry) => entry.isDirectory())
+				.map((entry) => entry.name);
+		} catch {
+			continue;
+		}
+		for (const conversation of conversations) {
+			hashByConversation.set(conversation, hash);
+			dbByConversation.set(
+				conversation,
+				join(chatsDir, hash, conversation, "store.db"),
+			);
+		}
+	}
+	return { hashByConversation, dbByConversation };
+}
+
+/** The chat's user-visible title from store.db's meta row (hex-coded JSON). */
+function readChatTitle(dbPath: string): string | null {
+	let db: InstanceType<typeof Database> | null = null;
+	try {
+		db = new Database(dbPath, { readonly: true, fileMustExist: true });
+		const row = db.prepare("SELECT value FROM meta LIMIT 1").get() as
+			| { value: string | Buffer }
+			| undefined;
+		if (!row) return null;
+		let raw =
+			typeof row.value === "string" ? row.value : row.value.toString("utf-8");
+		if (/^[0-9a-f]+$/i.test(raw) && raw.length % 2 === 0) {
+			raw = Buffer.from(raw, "hex").toString("utf-8");
+		}
+		const meta = JSON.parse(raw) as { name?: string };
+		return typeof meta.name === "string" && meta.name ? meta.name : null;
+	} catch {
+		return null;
+	} finally {
+		db?.close();
+	}
+}
+
+/**
+ * Fetches and appends cursor entries. Network/auth failures are the caller's
+ * to swallow — cursor must never take the local providers down with it.
+ */
+export async function collectCursorEntries(
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+	cwdCandidates: readonly string[] = [],
+	chatsDir: string = cursorChatsDir(),
+): Promise<void> {
+	const token = await readCursorAccessToken();
+	if (!token) return;
+
+	let events: CursorUsageEvent[];
+	if (
+		cachedEvents &&
+		cachedEvents.cutoffMs === cutoffMs &&
+		Date.now() - cachedEvents.fetchedAt < EVENTS_CACHE_TTL_MS
+	) {
+		events = cachedEvents.events;
+	} else {
+		events = await fetchUsageEvents(token, cutoffMs);
+		cachedEvents = { cutoffMs, fetchedAt: Date.now(), events };
+	}
+
+	const entries = cursorEventsToEntries(events, cutoffMs);
+	if (entries.length === 0) return;
+
+	const { hashByConversation, dbByConversation } =
+		await indexChatsDir(chatsDir);
+	const cwdByHash = new Map<string, string>();
+	for (const cwd of cwdCandidates) {
+		cwdByHash.set(createHash("md5").update(cwd).digest("hex"), cwd);
+	}
+
+	let labelOpens = 0;
+	const labeled = new Set<string>();
+	for (const entry of entries) {
+		const hash = hashByConversation.get(entry.sessionId);
+		if (hash) {
+			entry.cwd = cwdByHash.get(hash) ?? null;
+		}
+		if (
+			sessionLabels &&
+			!sessionLabels.has(entry.sessionId) &&
+			!labeled.has(entry.sessionId) &&
+			labelOpens < MAX_LABEL_DB_OPENS
+		) {
+			labeled.add(entry.sessionId);
+			const dbPath = dbByConversation.get(entry.sessionId);
+			if (dbPath) {
+				labelOpens++;
+				const title = readChatTitle(dbPath);
+				if (title) sessionLabels.set(entry.sessionId, title);
+			}
+		}
+		out.push(entry);
+	}
+}

--- a/packages/host-service/src/trpc/router/usage/history/cursor.ts
+++ b/packages/host-service/src/trpc/router/usage/history/cursor.ts
@@ -130,8 +130,11 @@ async function fetchUsageEvents(
 		};
 		const pageEvents = data.usageEventsDisplay ?? [];
 		events.push(...pageEvents);
+		// A short page always ends the scan; the reported total only ends it
+		// early when present — a missing count must not truncate to one page.
+		if (pageEvents.length < PAGE_SIZE) break;
 		const total = data.totalUsageEventsCount ?? 0;
-		if (pageEvents.length < PAGE_SIZE || events.length >= total) break;
+		if (total > 0 && events.length >= total) break;
 	}
 	return events;
 }

--- a/packages/host-service/src/trpc/router/usage/history/entries.ts
+++ b/packages/host-service/src/trpc/router/usage/history/entries.ts
@@ -2,9 +2,15 @@ import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { discoverClaudeProfiles, discoverCodexHomes } from "../profiles";
+import { collectCopilotEntries } from "./copilot";
+import { collectCursorEntries } from "./cursor";
+import { collectFxEntries } from "./fx";
+import { collectGrokEntries, grokHomes } from "./grok";
 import { collectLogFiles, dedupeLogFiles } from "./logs";
+import { collectOpencodeEntries } from "./opencode";
 import type { UsageLogEntry } from "./parse";
 import { parseClaudeLogFile, parseCodexLogFile } from "./parse";
+import { collectPiEntries } from "./pi";
 
 export interface CollectedUsage {
 	entries: UsageLogEntry[];
@@ -14,9 +20,16 @@ export interface CollectedUsage {
 	scannedFiles: number;
 }
 
+export interface CollectUsageOptions {
+	/** Known workspace/project roots — cursor's only way to attribute a cwd
+	 * (its chat dirs are keyed by md5 of the launch cwd). */
+	cwdCandidates?: readonly string[];
+}
+
 export async function collectUsageEntries(
 	days: number,
 	cutoffMs: number,
+	options: CollectUsageOptions = {},
 ): Promise<CollectedUsage> {
 	const home = homedir();
 
@@ -90,9 +103,66 @@ export async function collectUsageEntries(
 		await parseCodexLogFile(file, cutoffMs, entries, sessionLabels);
 	}
 
+	// The remaining providers are independent of each other and of the two
+	// above; each contributes into its own array so concurrent pushes can't
+	// interleave, and one provider's failure never takes down the rest.
+	let extraScannedFiles = 0;
+	const collectors: Array<{
+		run: (out: UsageLogEntry[]) => Promise<number | undefined>;
+	}> = [
+		...grokHomes().map((grokHome) => ({
+			run: (out: UsageLogEntry[]) =>
+				collectGrokEntries(grokHome, cutoffMs, out, sessionLabels),
+		})),
+		{
+			run: (out: UsageLogEntry[]) =>
+				collectOpencodeEntries(cutoffMs, out, sessionLabels),
+		},
+		{
+			run: (out: UsageLogEntry[]) =>
+				collectPiEntries("pi", days, cutoffMs, out, sessionLabels),
+		},
+		{
+			run: (out: UsageLogEntry[]) =>
+				collectPiEntries("omp", days, cutoffMs, out, sessionLabels),
+		},
+		{ run: (out: UsageLogEntry[]) => collectFxEntries(cutoffMs, out) },
+		{
+			run: (out: UsageLogEntry[]) =>
+				Promise.resolve(collectCopilotEntries(cutoffMs, out, sessionLabels)),
+		},
+		{
+			// Cursor is the one networked collector (no local token counts
+			// exist) — a signed-out CLI or an offline host contributes nothing.
+			run: async (out: UsageLogEntry[]) => {
+				await collectCursorEntries(
+					cutoffMs,
+					out,
+					sessionLabels,
+					options.cwdCandidates ?? [],
+				);
+				return 0;
+			},
+		},
+	];
+	const results = await Promise.allSettled(
+		collectors.map(async ({ run }) => {
+			const out: UsageLogEntry[] = [];
+			const scanned = await run(out);
+			return { out, scanned: scanned ?? 0 };
+		}),
+	);
+	for (const result of results) {
+		if (result.status !== "fulfilled") continue;
+		extraScannedFiles += result.value.scanned;
+		for (const entry of result.value.out) {
+			entries.push(entry);
+		}
+	}
+
 	return {
 		entries,
 		sessionLabels,
-		scannedFiles: claudeFiles.length + codexFiles.length,
+		scannedFiles: claudeFiles.length + codexFiles.length + extraScannedFiles,
 	};
 }

--- a/packages/host-service/src/trpc/router/usage/history/fx.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/fx.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectFxEntries } from "./fx";
+import type { UsageLogEntry } from "./parse";
+
+const root = mkdtempSync(join(tmpdir(), "fx-usage-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+const NOW = Date.now() - 60_000;
+
+function checkpoint(
+	timestampMs: number,
+	models: Array<Record<string, unknown>>,
+) {
+	return {
+		timestamp_ms: timestampMs,
+		kind: "usage_checkpointed",
+		payload: { usage: { models } },
+	};
+}
+
+describe("collectFxEntries", () => {
+	test("diffs cumulative checkpoints into per-turn entries", async () => {
+		const dir = join(root, "session-1");
+		mkdirSync(dir, { recursive: true });
+		const lines = [
+			{
+				timestamp_ms: NOW - 10_000,
+				kind: "session_started",
+				payload: { workspace_root: "/tmp/proj" },
+			},
+			checkpoint(NOW - 5_000, [
+				{
+					model: "zai/glm-5.2",
+					total_cost: 0.02,
+					input_tokens: 16_000,
+					output_tokens: 4,
+					cache_read_tokens: 12_000,
+					cache_write_tokens: 0,
+				},
+			]),
+			checkpoint(NOW, [
+				{
+					model: "zai/glm-5.2",
+					total_cost: 0.05,
+					input_tokens: 40_000,
+					output_tokens: 104,
+					cache_read_tokens: 30_000,
+					cache_write_tokens: 100,
+				},
+			]),
+		];
+		writeFileSync(
+			join(dir, "events.jsonl"),
+			lines.map((line) => JSON.stringify(line)).join("\n"),
+		);
+
+		const out: UsageLogEntry[] = [];
+		const scanned = await collectFxEntries(0, out, root);
+		expect(scanned).toBe(1);
+		expect(out).toHaveLength(2);
+		expect(out[0]).toMatchObject({
+			provider: "fx",
+			model: "zai/glm-5.2",
+			cwd: "/tmp/proj",
+			sessionId: "session-1",
+			// input_tokens includes cached tokens (OpenAI-style API).
+			uncachedInput: 4_000,
+			cachedInput: 12_000,
+			output: 4,
+			costUsd: 0.02,
+		});
+		expect(out[1]).toMatchObject({
+			uncachedInput: 6_000,
+			cachedInput: 18_000,
+			cacheWrite5m: 100,
+			output: 100,
+		});
+		expect(out[1]?.costUsd).toBeCloseTo(0.03, 10);
+	});
+
+	test("pre-cutoff checkpoints still advance the baseline", async () => {
+		const dir = join(root, "session-2");
+		mkdirSync(dir, { recursive: true });
+		const lines = [
+			checkpoint(NOW - 5_000, [
+				{ model: "m", total_cost: 0, input_tokens: 100, output_tokens: 10 },
+			]),
+			checkpoint(NOW, [
+				{ model: "m", total_cost: 0, input_tokens: 150, output_tokens: 15 },
+			]),
+		];
+		writeFileSync(
+			join(dir, "events.jsonl"),
+			lines.map((line) => JSON.stringify(line)).join("\n"),
+		);
+		const out: UsageLogEntry[] = [];
+		await collectFxEntries(NOW - 1_000, out, root);
+		const sessionEntries = out.filter((e) => e.sessionId === "session-2");
+		expect(sessionEntries).toHaveLength(1);
+		expect(sessionEntries[0]).toMatchObject({
+			uncachedInput: 50,
+			output: 5,
+		});
+	});
+
+	test("missing root contributes nothing", async () => {
+		const out: UsageLogEntry[] = [];
+		const scanned = await collectFxEntries(0, out, join(root, "absent"));
+		expect(scanned).toBe(0);
+		expect(out).toHaveLength(0);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/fx.ts
+++ b/packages/host-service/src/trpc/router/usage/history/fx.ts
@@ -1,0 +1,132 @@
+/**
+ * fx usage. Each session dir under `~/.fx/sessions/<id>/` holds an
+ * `events.jsonl` whose `usage_checkpointed` events carry CUMULATIVE per-model
+ * token totals and a real cost; consecutive checkpoints are diffed to get
+ * per-turn deltas (the global `~/.fx/usage.jsonl` has per-generation facts
+ * but no session/cwd, so the session logs are the better source). The
+ * `session_started` payload carries the workspace root.
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { UsageLogEntry } from "./parse";
+import { forEachLine, num } from "./parse";
+
+export function fxSessionsRoot(): string {
+	return join(homedir(), ".fx", "sessions");
+}
+
+interface FxModelUsage {
+	model?: string;
+	total_cost?: number;
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_read_tokens?: number;
+	cache_write_tokens?: number;
+}
+
+interface FxEventLine {
+	timestamp_ms?: number;
+	kind?: string;
+	payload?: {
+		workspace_root?: string;
+		origin_workspace_root?: string;
+		usage?: { models?: FxModelUsage[] };
+	};
+}
+
+/** Returns the number of session logs scanned. */
+export async function collectFxEntries(
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	root: string = fxSessionsRoot(),
+): Promise<number> {
+	let sessionDirs: string[];
+	try {
+		const entries = await readdir(root, { withFileTypes: true });
+		sessionDirs = entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+	} catch {
+		return 0;
+	}
+
+	let scanned = 0;
+	for (const sessionDir of sessionDirs) {
+		const eventsPath = join(root, sessionDir, "events.jsonl");
+		try {
+			if ((await stat(eventsPath)).mtimeMs < cutoffMs) continue;
+		} catch {
+			continue;
+		}
+		scanned++;
+
+		let cwd: string | null = null;
+		// Cumulative totals per model from the previous checkpoint.
+		const previousByModel = new Map<string, Required<FxModelUsage>>();
+		await forEachLine(eventsPath, (line) => {
+			if (
+				!line.includes('"session_started"') &&
+				!line.includes('"usage_checkpointed"')
+			) {
+				return;
+			}
+			let parsed: FxEventLine;
+			try {
+				parsed = JSON.parse(line);
+			} catch {
+				return;
+			}
+			if (parsed.kind === "session_started") {
+				cwd =
+					parsed.payload?.workspace_root ??
+					parsed.payload?.origin_workspace_root ??
+					cwd;
+				return;
+			}
+			if (parsed.kind !== "usage_checkpointed") return;
+			const timestampMs = num(parsed.timestamp_ms);
+			for (const model of parsed.payload?.usage?.models ?? []) {
+				if (!model.model) continue;
+				const current = {
+					model: model.model,
+					total_cost: num(model.total_cost),
+					input_tokens: num(model.input_tokens),
+					output_tokens: num(model.output_tokens),
+					cache_read_tokens: num(model.cache_read_tokens),
+					cache_write_tokens: num(model.cache_write_tokens),
+				};
+				const previous = previousByModel.get(model.model);
+				previousByModel.set(model.model, current);
+
+				const delta = (field: keyof Omit<Required<FxModelUsage>, "model">) =>
+					Math.max(0, current[field] - (previous?.[field] ?? 0));
+				const input = delta("input_tokens");
+				const cached = delta("cache_read_tokens");
+				const cacheWrite = delta("cache_write_tokens");
+				const output = delta("output_tokens");
+				const cost = delta("total_cost");
+				if (input + cached + cacheWrite + output === 0) continue;
+				if (!timestampMs || timestampMs < cutoffMs) continue;
+
+				out.push({
+					provider: "fx",
+					model: model.model,
+					timestampMs,
+					cwd,
+					sessionId: sessionDir,
+					// fx fronts OpenAI-style APIs: input_tokens includes cached.
+					uncachedInput: Math.max(0, input - cached),
+					cachedInput: cached,
+					cacheWrite5m: cacheWrite,
+					cacheWrite1h: 0,
+					output,
+					reasoningOutput: 0,
+					...(cost > 0 ? { costUsd: cost } : {}),
+				});
+			}
+		});
+	}
+	return scanned;
+}

--- a/packages/host-service/src/trpc/router/usage/history/grok.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/grok.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectGrokEntries } from "./grok";
+import type { UsageLogEntry } from "./parse";
+
+const home = mkdtempSync(join(tmpdir(), "grok-usage-"));
+afterAll(() => rmSync(home, { recursive: true, force: true }));
+
+function writeFixture({
+	sid,
+	promptTokens,
+	cachedTokens,
+	ts,
+}: {
+	sid: string;
+	promptTokens: number;
+	cachedTokens: number;
+	ts: string;
+}) {
+	mkdirSync(join(home, "logs"), { recursive: true });
+	const line = JSON.stringify({
+		ts,
+		sid,
+		msg: "shell.turn.inference_done",
+		ctx: {
+			prompt_tokens: promptTokens,
+			cached_prompt_tokens: cachedTokens,
+			completion_tokens: 40,
+			reasoning_tokens: 15,
+		},
+	});
+	const noise = JSON.stringify({ ts, sid, msg: "shell.turn.started", ctx: {} });
+	writeFileSync(join(home, "logs", "unified.jsonl"), `${noise}\n${line}\n`);
+
+	const sessionDir = join(home, "sessions", "%2Ftmp%2Fproj", sid);
+	mkdirSync(sessionDir, { recursive: true });
+	writeFileSync(
+		join(sessionDir, "summary.json"),
+		JSON.stringify({
+			info: { id: sid, cwd: "/tmp/proj" },
+			current_model_id: "grok-4.6",
+			session_summary: "Fix the flaky test",
+		}),
+	);
+}
+
+describe("collectGrokEntries", () => {
+	test("joins unified-log turns with session metadata", async () => {
+		writeFixture({
+			sid: "sid-1",
+			promptTokens: 1000,
+			cachedTokens: 600,
+			ts: "2026-08-20T12:00:00.000Z",
+		});
+		const out: UsageLogEntry[] = [];
+		const labels = new Map<string, string>();
+		const scanned = await collectGrokEntries(home, 0, out, labels);
+		expect(scanned).toBe(1);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			provider: "grok",
+			model: "grok-4.6",
+			cwd: "/tmp/proj",
+			sessionId: "sid-1",
+			// prompt_tokens includes cached tokens (OpenAI-compatible API).
+			uncachedInput: 400,
+			cachedInput: 600,
+			output: 40,
+			reasoningOutput: 15,
+		});
+		expect(labels.get("sid-1")).toBe("Fix the flaky test");
+	});
+
+	test("drops turns before the cutoff", async () => {
+		writeFixture({
+			sid: "sid-2",
+			promptTokens: 100,
+			cachedTokens: 0,
+			ts: "2026-08-20T12:00:00.000Z",
+		});
+		const out: UsageLogEntry[] = [];
+		await collectGrokEntries(home, Date.parse("2026-08-21T00:00:00.000Z"), out);
+		expect(out).toHaveLength(0);
+	});
+
+	test("missing home contributes nothing", async () => {
+		const out: UsageLogEntry[] = [];
+		const scanned = await collectGrokEntries(join(home, "absent"), 0, out);
+		expect(scanned).toBe(0);
+		expect(out).toHaveLength(0);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/grok.ts
+++ b/packages/host-service/src/trpc/router/usage/history/grok.ts
@@ -1,0 +1,179 @@
+/**
+ * Grok CLI usage. Grok's per-session transcripts (chat_history.jsonl) carry
+ * no token counts — the only local record is the CLI's unified log
+ * (`$GROK_HOME/logs/unified.jsonl`), whose `shell.turn.inference_done`
+ * events hold per-turn token usage keyed by session id. Model, cwd, and a
+ * session title come from each session's `summary.json`
+ * (`$GROK_HOME/sessions/<encoded-cwd>/<sid>/summary.json`), joined by sid.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { UsageLogEntry } from "./parse";
+import { entryTimestamp, forEachLine, num } from "./parse";
+
+export function grokHomes(): string[] {
+	const homes = new Set<string>([join(homedir(), ".grok")]);
+	const fromEnv = process.env.GROK_HOME?.trim();
+	if (fromEnv) homes.add(fromEnv);
+	return [...homes];
+}
+
+interface GrokUnifiedLine {
+	ts?: string;
+	sid?: string;
+	msg?: string;
+	ctx?: {
+		prompt_tokens?: number;
+		cached_prompt_tokens?: number;
+		completion_tokens?: number;
+		reasoning_tokens?: number;
+	};
+}
+
+interface GrokSessionMeta {
+	model: string | null;
+	cwd: string | null;
+	label: string | null;
+}
+
+// One corrupt or enormous sessions root must not stall the scan.
+const MAX_SESSION_DIRS = 4096;
+
+/**
+ * Indexes `<home>/sessions/<encoded-cwd>/<sid>` by sid. Only summary.json is
+ * read, and only for sids the caller actually saw in the unified log.
+ */
+async function indexGrokSessions(
+	home: string,
+	wantedSids: ReadonlySet<string>,
+): Promise<Map<string, GrokSessionMeta>> {
+	const meta = new Map<string, GrokSessionMeta>();
+	const sessionsDir = join(home, "sessions");
+	let groups: string[];
+	try {
+		const entries = await readdir(sessionsDir, { withFileTypes: true });
+		groups = entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+	} catch {
+		return meta;
+	}
+	let visited = 0;
+	for (const group of groups) {
+		let sids: string[];
+		try {
+			const entries = await readdir(join(sessionsDir, group), {
+				withFileTypes: true,
+			});
+			sids = entries
+				.filter((entry) => entry.isDirectory())
+				.map((entry) => entry.name);
+		} catch {
+			continue;
+		}
+		for (const sid of sids) {
+			if (++visited > MAX_SESSION_DIRS) return meta;
+			if (!wantedSids.has(sid) || meta.has(sid)) continue;
+			try {
+				const raw = await readFile(
+					join(sessionsDir, group, sid, "summary.json"),
+					"utf-8",
+				);
+				const summary = JSON.parse(raw) as {
+					info?: { cwd?: string };
+					current_model_id?: string;
+					session_summary?: string;
+					generated_title?: string;
+				};
+				meta.set(sid, {
+					model:
+						typeof summary.current_model_id === "string"
+							? summary.current_model_id
+							: null,
+					cwd: typeof summary.info?.cwd === "string" ? summary.info.cwd : null,
+					label: summary.session_summary || summary.generated_title || null,
+				});
+			} catch {
+				// Missing/corrupt summary — the entries still count, unattributed.
+			}
+		}
+	}
+	return meta;
+}
+
+/**
+ * Collects grok entries from one home. Returns the number of log files
+ * scanned (0 or 1 per home).
+ */
+export async function collectGrokEntries(
+	home: string,
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+): Promise<number> {
+	const logPath = join(home, "logs", "unified.jsonl");
+	let mtimeMs: number;
+	try {
+		mtimeMs = (await stat(logPath)).mtimeMs;
+	} catch {
+		return 0;
+	}
+
+	interface PendingEntry {
+		sid: string;
+		entry: UsageLogEntry;
+	}
+	const pending: PendingEntry[] = [];
+	await forEachLine(logPath, (line) => {
+		if (!line.includes('"shell.turn.inference_done"')) return;
+		let parsed: GrokUnifiedLine;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			return;
+		}
+		if (parsed.msg !== "shell.turn.inference_done") return;
+		const ctx = parsed.ctx;
+		const sid = typeof parsed.sid === "string" ? parsed.sid : "";
+		if (!ctx || !sid) return;
+		const timestampMs = entryTimestamp(parsed.ts, mtimeMs);
+		if (timestampMs < cutoffMs) return;
+
+		// xAI's API is OpenAI-compatible: prompt_tokens INCLUDES cached tokens.
+		const prompt = num(ctx.prompt_tokens);
+		const cached = num(ctx.cached_prompt_tokens);
+		pending.push({
+			sid,
+			entry: {
+				provider: "grok",
+				model: "unknown",
+				timestampMs,
+				cwd: null,
+				sessionId: sid,
+				uncachedInput: Math.max(0, prompt - cached),
+				cachedInput: cached,
+				cacheWrite5m: 0,
+				cacheWrite1h: 0,
+				output: num(ctx.completion_tokens),
+				// Reasoning is a subset of completion tokens — never added on top.
+				reasoningOutput: num(ctx.reasoning_tokens),
+			},
+		});
+	});
+	if (pending.length === 0) return 1;
+
+	const wanted = new Set(pending.map(({ sid }) => sid));
+	const sessions = await indexGrokSessions(home, wanted);
+	for (const { sid, entry } of pending) {
+		const meta = sessions.get(sid);
+		if (meta) {
+			if (meta.model) entry.model = meta.model;
+			entry.cwd = meta.cwd;
+			if (meta.label) sessionLabels?.set(sid, meta.label);
+		}
+		out.push(entry);
+	}
+	return 1;
+}

--- a/packages/host-service/src/trpc/router/usage/history/leaderboard-days.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/leaderboard-days.test.ts
@@ -35,6 +35,20 @@ describe("groupEntriesByDay", () => {
 		});
 	});
 
+	test("a harness-reported cost replaces the rate estimate", () => {
+		const [row] = groupEntriesByDay([
+			entry({
+				provider: "opencode",
+				model: "some-unknown-model",
+				costUsd: 1.25,
+			}),
+		]);
+		expect(row?.usdEstimate).toBe(1.25);
+		// Priced by the harness itself — not an approximation, even though the
+		// model is absent from the rate table.
+		expect(row?.approximate).toBe(false);
+	});
+
 	test("splits the same day across models", () => {
 		const rows = groupEntriesByDay([
 			entry(),

--- a/packages/host-service/src/trpc/router/usage/history/leaderboard-days.ts
+++ b/packages/host-service/src/trpc/router/usage/history/leaderboard-days.ts
@@ -79,9 +79,9 @@ export function groupEntriesByDay(entries: UsageLogEntry[]): LeaderboardDay[] {
 		bucket.cacheWrite1h += entry.cacheWrite1h;
 		bucket.output += entry.output;
 		bucket.reasoningOutput += entry.reasoningOutput;
-		bucket.usdEstimate += costUsd(rate, entry);
+		bucket.usdEstimate += entry.costUsd ?? costUsd(rate, entry);
 
-		bucket.approximate ||= rate.approximate;
+		bucket.approximate ||= entry.costUsd === undefined && rate.approximate;
 		bucket.sessionIds.add(entry.sessionId);
 	}
 

--- a/packages/host-service/src/trpc/router/usage/history/opencode.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/opencode.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectOpencodeEntries } from "./opencode";
+import type { UsageLogEntry } from "./parse";
+
+const storage = mkdtempSync(join(tmpdir(), "opencode-usage-"));
+afterAll(() => rmSync(storage, { recursive: true, force: true }));
+
+const SESSION = "ses_test1";
+const NOW = Date.parse("2026-08-20T12:00:00.000Z");
+
+function writeMessage(name: string, message: Record<string, unknown>) {
+	const dir = join(storage, "message", SESSION);
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, name), JSON.stringify(message));
+}
+
+describe("collectOpencodeEntries", () => {
+	test("maps assistant messages with their recorded cost", async () => {
+		writeMessage("msg_1.json", {
+			sessionID: SESSION,
+			role: "assistant",
+			time: { created: NOW - 500, completed: NOW },
+			modelID: "claude-sonnet-5",
+			providerID: "anthropic",
+			path: { cwd: "/tmp/proj" },
+			cost: 0.042,
+			tokens: {
+				input: 120,
+				output: 300,
+				reasoning: 40,
+				cache: { read: 900, write: 80 },
+			},
+		});
+		writeMessage("msg_2.json", {
+			sessionID: SESSION,
+			role: "user",
+			time: { created: NOW },
+		});
+		const sessionMetaDir = join(storage, "session", "projhash");
+		mkdirSync(sessionMetaDir, { recursive: true });
+		writeFileSync(
+			join(sessionMetaDir, `${SESSION}.json`),
+			JSON.stringify({ id: SESSION, title: "Refactor the sidebar" }),
+		);
+
+		const out: UsageLogEntry[] = [];
+		const labels = new Map<string, string>();
+		const scanned = await collectOpencodeEntries(0, out, labels, storage);
+		expect(scanned).toBe(2);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			provider: "opencode",
+			model: "claude-sonnet-5",
+			cwd: "/tmp/proj",
+			sessionId: SESSION,
+			uncachedInput: 120,
+			cachedInput: 900,
+			cacheWrite5m: 80,
+			output: 300,
+			reasoningOutput: 40,
+			costUsd: 0.042,
+		});
+		expect(labels.get(SESSION)).toBe("Refactor the sidebar");
+	});
+
+	test("drops messages before the cutoff", async () => {
+		const out: UsageLogEntry[] = [];
+		await collectOpencodeEntries(NOW + 1, out, undefined, storage);
+		expect(out).toHaveLength(0);
+	});
+
+	test("missing storage contributes nothing", async () => {
+		const out: UsageLogEntry[] = [];
+		const scanned = await collectOpencodeEntries(
+			0,
+			out,
+			undefined,
+			join(storage, "absent"),
+		);
+		expect(scanned).toBe(0);
+		expect(out).toHaveLength(0);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/opencode.ts
+++ b/packages/host-service/src/trpc/router/usage/history/opencode.ts
@@ -1,0 +1,160 @@
+/**
+ * OpenCode usage. Every assistant message is one small JSON file under
+ * `<data>/opencode/storage/message/<sessionID>/msg_*.json` carrying
+ * normalized tokens (input is already non-cached — opencode subtracts cache
+ * reads/writes itself), the model, the cwd, and a real cost in USD. Session
+ * titles live in `<data>/opencode/storage/session/<projectID>/<ses>.json`.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { UsageLogEntry } from "./parse";
+import { num } from "./parse";
+
+export function opencodeStorageDir(): string {
+	const dataHome =
+		process.env.XDG_DATA_HOME?.trim() || join(homedir(), ".local", "share");
+	return join(dataHome, "opencode", "storage");
+}
+
+interface OpencodeMessage {
+	sessionID?: string;
+	role?: string;
+	time?: { created?: number; completed?: number };
+	modelID?: string;
+	providerID?: string;
+	path?: { cwd?: string };
+	cost?: number;
+	tokens?: {
+		input?: number;
+		output?: number;
+		reasoning?: number;
+		cache?: { read?: number; write?: number };
+	};
+}
+
+async function readSessionTitles(
+	storageDir: string,
+	wantedSessions: ReadonlySet<string>,
+	sessionLabels: Map<string, string>,
+): Promise<void> {
+	const sessionRoot = join(storageDir, "session");
+	let projectDirs: string[];
+	try {
+		const entries = await readdir(sessionRoot, { withFileTypes: true });
+		projectDirs = entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+	} catch {
+		return;
+	}
+	for (const projectDir of projectDirs) {
+		let files: string[];
+		try {
+			files = await readdir(join(sessionRoot, projectDir));
+		} catch {
+			continue;
+		}
+		for (const file of files) {
+			if (!file.endsWith(".json")) continue;
+			const sessionId = file.slice(0, -".json".length);
+			if (!wantedSessions.has(sessionId) || sessionLabels.has(sessionId)) {
+				continue;
+			}
+			try {
+				const raw = await readFile(
+					join(sessionRoot, projectDir, file),
+					"utf-8",
+				);
+				const session = JSON.parse(raw) as { title?: string };
+				if (typeof session.title === "string" && session.title) {
+					sessionLabels.set(sessionId, session.title);
+				}
+			} catch {
+				// Unreadable session metadata — the entries stay unlabeled.
+			}
+		}
+	}
+}
+
+/** Returns the number of message files scanned. */
+export async function collectOpencodeEntries(
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+	storageDir: string = opencodeStorageDir(),
+): Promise<number> {
+	const messageRoot = join(storageDir, "message");
+	let sessionDirs: string[];
+	try {
+		const entries = await readdir(messageRoot, { withFileTypes: true });
+		sessionDirs = entries
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+	} catch {
+		return 0;
+	}
+
+	let scanned = 0;
+	const seenSessions = new Set<string>();
+	for (const sessionDir of sessionDirs) {
+		const dirPath = join(messageRoot, sessionDir);
+		// The mtime of the session's message dir bounds every message inside it
+		// — skipping old sessions wholesale keeps the scan cheap on heavy users.
+		try {
+			if ((await stat(dirPath)).mtimeMs < cutoffMs) continue;
+		} catch {
+			continue;
+		}
+		let files: string[];
+		try {
+			files = await readdir(dirPath);
+		} catch {
+			continue;
+		}
+		for (const file of files) {
+			if (!file.endsWith(".json")) continue;
+			scanned++;
+			let message: OpencodeMessage;
+			try {
+				message = JSON.parse(await readFile(join(dirPath, file), "utf-8"));
+			} catch {
+				continue;
+			}
+			if (message.role !== "assistant") continue;
+			const timestampMs = num(message.time?.completed ?? message.time?.created);
+			if (!timestampMs || timestampMs < cutoffMs) continue;
+			const tokens = message.tokens;
+			if (!tokens) continue;
+			const uncachedInput = num(tokens.input);
+			const cachedInput = num(tokens.cache?.read);
+			const cacheWrite = num(tokens.cache?.write);
+			const output = num(tokens.output);
+			if (uncachedInput + cachedInput + cacheWrite + output === 0) continue;
+
+			const sessionId = message.sessionID ?? sessionDir;
+			seenSessions.add(sessionId);
+			const cost = num(message.cost);
+			out.push({
+				provider: "opencode",
+				model: message.modelID || "unknown",
+				timestampMs,
+				cwd: typeof message.path?.cwd === "string" ? message.path.cwd : null,
+				sessionId,
+				uncachedInput,
+				cachedInput,
+				cacheWrite5m: cacheWrite,
+				cacheWrite1h: 0,
+				output,
+				reasoningOutput: num(tokens.reasoning),
+				...(cost > 0 ? { costUsd: cost } : {}),
+			});
+		}
+	}
+
+	if (sessionLabels && seenSessions.size > 0) {
+		await readSessionTitles(storageDir, seenSessions, sessionLabels);
+	}
+	return scanned;
+}

--- a/packages/host-service/src/trpc/router/usage/history/parse.ts
+++ b/packages/host-service/src/trpc/router/usage/history/parse.ts
@@ -33,6 +33,9 @@ export interface UsageLogEntry {
 	cacheWrite1h: number;
 	output: number;
 	reasoningOutput: number;
+	/** Provider-reported real cost in USD (opencode/pi/fx/cursor record one).
+	 * When present it replaces the API-list-rate estimate. */
+	costUsd?: number;
 }
 
 export function sessionIdForFile(path: string): string {
@@ -43,7 +46,7 @@ const SESSION_LABEL_MAX = 80;
 
 /** First real user prompt of a session, trimmed to one short line. Command
  * invocations, caveats, and system-reminder wrappers don't count. */
-function toSessionLabel(text: unknown): string | null {
+export function toSessionLabel(text: unknown): string | null {
 	if (typeof text !== "string") return null;
 	const trimmed = text.trim();
 	if (
@@ -61,7 +64,7 @@ function toSessionLabel(text: unknown): string | null {
 		: line;
 }
 
-async function forEachLine(
+export async function forEachLine(
 	path: string,
 	onLine: (line: string) => void,
 ): Promise<void> {
@@ -76,7 +79,7 @@ async function forEachLine(
 	}
 }
 
-function num(value: unknown): number {
+export function num(value: unknown): number {
 	// Clamp negatives — a corrupt count must not subtract from totals.
 	return typeof value === "number" && Number.isFinite(value) && value > 0
 		? value
@@ -85,7 +88,10 @@ function num(value: unknown): number {
 
 /** Entry timestamp: parseable and not in the future (26h clock-skew
  * tolerance) wins; otherwise the file's mtime; never NaN. */
-function entryTimestamp(raw: string | undefined, mtimeMs: number): number {
+export function entryTimestamp(
+	raw: string | undefined,
+	mtimeMs: number,
+): number {
 	const parsed = raw ? Date.parse(raw) : Number.NaN;
 	if (Number.isFinite(parsed) && parsed <= Date.now() + 26 * 60 * 60 * 1000) {
 		return parsed;

--- a/packages/host-service/src/trpc/router/usage/history/pi.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pi.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UsageLogEntry } from "./parse";
+import { collectPiEntries } from "./pi";
+
+const root = mkdtempSync(join(tmpdir(), "pi-usage-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+const NOW = Date.now() - 60_000;
+
+describe("collectPiEntries", () => {
+	test("reads header cwd, assistant usage, and a session label", async () => {
+		const dir = join(root, "--tmp-proj--");
+		mkdirSync(dir, { recursive: true });
+		const lines = [
+			{
+				type: "session",
+				id: "s1",
+				timestamp: new Date(NOW).toISOString(),
+				cwd: "/tmp/proj",
+			},
+			{
+				type: "message",
+				timestamp: new Date(NOW).toISOString(),
+				message: { role: "user", content: "Add retry logic", timestamp: NOW },
+			},
+			{
+				type: "message",
+				timestamp: new Date(NOW).toISOString(),
+				message: {
+					role: "assistant",
+					model: "gpt-5.6",
+					timestamp: NOW,
+					usage: {
+						input: 150,
+						output: 220,
+						cacheRead: 700,
+						cacheWrite: 30,
+						cost: { total: 0.0123 },
+					},
+				},
+			},
+		];
+		writeFileSync(
+			join(dir, "abc.jsonl"),
+			lines.map((line) => JSON.stringify(line)).join("\n"),
+		);
+
+		const out: UsageLogEntry[] = [];
+		const labels = new Map<string, string>();
+		const scanned = await collectPiEntries("omp", 30, 0, out, labels, root);
+		expect(scanned).toBe(1);
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			provider: "omp",
+			model: "gpt-5.6",
+			cwd: "/tmp/proj",
+			sessionId: "abc",
+			uncachedInput: 150,
+			cachedInput: 700,
+			cacheWrite5m: 30,
+			output: 220,
+			costUsd: 0.0123,
+		});
+		expect(labels.get("abc")).toBe("Add retry logic");
+	});
+
+	test("missing root contributes nothing", async () => {
+		const out: UsageLogEntry[] = [];
+		const scanned = await collectPiEntries(
+			"pi",
+			30,
+			0,
+			out,
+			undefined,
+			join(root, "absent"),
+		);
+		expect(scanned).toBe(0);
+		expect(out).toHaveLength(0);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/pi.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pi.ts
@@ -1,0 +1,134 @@
+/**
+ * Pi / Oh My Pi usage (omp is a pi fork with the same session format).
+ * Sessions are JSONL trees under `~/.pi/agent/sessions/--<encoded-cwd>--/`
+ * (resp. `~/.omp/...`): a `{type:"session"}` header carrying the cwd, then
+ * `{type:"message"}` entries whose assistant messages hold the model and a
+ * usage block (input/output/cacheRead/cacheWrite plus a computed cost).
+ * Entries are appended exactly once each — branching is by parent id — so no
+ * cross-file dedupe is needed.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { UsageProvider } from "../types";
+import type { LogFile } from "./logs";
+import { collectLogFiles } from "./logs";
+import type { UsageLogEntry } from "./parse";
+import {
+	entryTimestamp,
+	forEachLine,
+	num,
+	sessionIdForFile,
+	toSessionLabel,
+} from "./parse";
+
+export function piSessionsRoot(provider: "pi" | "omp"): string {
+	return join(homedir(), `.${provider}`, "agent", "sessions");
+}
+
+interface PiLine {
+	type?: string;
+	timestamp?: string;
+	cwd?: string;
+	message?: {
+		role?: string;
+		model?: string;
+		timestamp?: number;
+		content?: string | Array<{ type?: string; text?: string }>;
+		usage?: {
+			input?: number;
+			output?: number;
+			cacheRead?: number;
+			cacheWrite?: number;
+			cost?: { total?: number };
+		};
+	};
+}
+
+async function parsePiLogFile(
+	provider: UsageProvider,
+	file: LogFile,
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+): Promise<void> {
+	const sessionId = sessionIdForFile(file.path);
+	let sessionCwd: string | null = null;
+	await forEachLine(file.path, (line) => {
+		const wantLabel = sessionLabels ? !sessionLabels.has(sessionId) : false;
+		if (
+			!line.includes('"session"') &&
+			!line.includes('"assistant"') &&
+			!(wantLabel && line.includes('"user"'))
+		) {
+			return;
+		}
+		let parsed: PiLine;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			return;
+		}
+		if (parsed.type === "session") {
+			if (typeof parsed.cwd === "string") sessionCwd = parsed.cwd;
+			return;
+		}
+		if (parsed.type !== "message") return;
+		const message = parsed.message;
+		if (!message) return;
+
+		if (wantLabel && message.role === "user") {
+			const content = message.content;
+			const text =
+				typeof content === "string"
+					? content
+					: content?.find((block) => block.type === "text")?.text;
+			const label = toSessionLabel(text);
+			if (label) sessionLabels?.set(sessionId, label);
+			return;
+		}
+		if (message.role !== "assistant") return;
+		const usage = message.usage;
+		if (!usage || !message.model) return;
+
+		const timestampMs =
+			typeof message.timestamp === "number" && message.timestamp > 0
+				? message.timestamp
+				: entryTimestamp(parsed.timestamp, file.mtimeMs);
+		if (timestampMs < cutoffMs) return;
+
+		const cost = num(usage.cost?.total);
+		out.push({
+			provider,
+			model: message.model,
+			timestampMs,
+			cwd: sessionCwd,
+			sessionId,
+			// Pi stores the provider-reported input count, which excludes the
+			// cache fields it tracks separately.
+			uncachedInput: num(usage.input),
+			cachedInput: num(usage.cacheRead),
+			cacheWrite5m: num(usage.cacheWrite),
+			cacheWrite1h: 0,
+			output: num(usage.output),
+			reasoningOutput: 0,
+			...(cost > 0 ? { costUsd: cost } : {}),
+		});
+	});
+}
+
+/** Returns the number of session files scanned. */
+export async function collectPiEntries(
+	provider: "pi" | "omp",
+	days: number,
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+	root: string = piSessionsRoot(provider),
+): Promise<number> {
+	const files = await collectLogFiles(root, days + 1);
+	for (const file of files) {
+		await parsePiLogFile(provider, file, cutoffMs, out, sessionLabels);
+	}
+	return files.length;
+}

--- a/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { matchModelRate } from "./pricing";
+
+describe("matchModelRate", () => {
+	test("matches vendor-qualified ids from multi-model harnesses", () => {
+		const rate = matchModelRate("opencode", "anthropic/claude-sonnet-5");
+		expect(rate.approximate).toBe(false);
+		expect(rate.inputPerM).toBe(3);
+		expect(rate.outputPerM).toBe(15);
+	});
+
+	test("unknown models fall back to the cheapest rate, marked approximate", () => {
+		const rate = matchModelRate("fx", "zai/glm-5.2");
+		expect(rate.approximate).toBe(true);
+	});
+
+	test("plain ids still match their provider table", () => {
+		const rate = matchModelRate("grok", "grok-4.6");
+		expect(rate.approximate).toBe(false);
+		expect(rate.inputPerM).toBe(2);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/pricing.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.ts
@@ -115,13 +115,23 @@ export function matchModelRate(
 ): MatchedRate {
 	const rates = RATES_BY_PROVIDER[provider];
 	const normalized = model.toLowerCase();
+	// Multi-model harnesses vendor-qualify ids ("anthropic/claude-sonnet-4");
+	// also match on the segment after the last slash so those don't fall
+	// through to the cheapest rate.
+	const candidates = [normalized];
+	const slash = normalized.lastIndexOf("/");
+	if (slash >= 0 && slash < normalized.length - 1) {
+		candidates.push(normalized.slice(slash + 1));
+	}
 	let best: { prefix: string; rate: ModelRate } | null = null;
-	for (const [prefix, rate] of Object.entries(rates)) {
-		if (
-			normalized.startsWith(prefix) &&
-			(!best || prefix.length > best.prefix.length)
-		) {
-			best = { prefix, rate };
+	for (const candidate of candidates) {
+		for (const [prefix, rate] of Object.entries(rates)) {
+			if (
+				candidate.startsWith(prefix) &&
+				(!best || prefix.length > best.prefix.length)
+			) {
+				best = { prefix, rate };
+			}
 		}
 	}
 	if (best) return { ...best.rate, approximate: false };

--- a/packages/host-service/src/trpc/router/usage/history/pricing.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.ts
@@ -49,9 +49,41 @@ const CODEX_RATES: Record<string, ModelRate> = {
 	"gpt-4o": { inputPerM: 2.5, outputPerM: 10 },
 };
 
+const GROK_RATES: Record<string, ModelRate> = {
+	"grok-4.6": { inputPerM: 2, outputPerM: 6 },
+	"grok-4.5": { inputPerM: 2, outputPerM: 6 },
+	"grok-4-fast": { inputPerM: 0.2, outputPerM: 0.5 },
+	"grok-4": { inputPerM: 3, outputPerM: 15 },
+	"grok-code": { inputPerM: 0.2, outputPerM: 1.5 },
+	"grok-3-mini": { inputPerM: 0.3, outputPerM: 0.5 },
+	"grok-3": { inputPerM: 3, outputPerM: 15 },
+};
+
+// Cursor prices per request server-side; its usage events carry the real
+// cost, so this table is only the fallback for events without one.
+const CURSOR_RATES: Record<string, ModelRate> = {
+	composer: { inputPerM: 1.25, outputPerM: 10 },
+};
+
+/** Multi-model harnesses (opencode, pi, omp, copilot, fx) route to many
+ * upstream providers — match against every table we know. Harness-reported
+ * costs, when present, take precedence over these rates anyway. */
+const MULTI_PROVIDER_RATES: Record<string, ModelRate> = {
+	...CLAUDE_RATES,
+	...CODEX_RATES,
+	...GROK_RATES,
+};
+
 const RATES_BY_PROVIDER: Record<UsageProvider, Record<string, ModelRate>> = {
 	claude: CLAUDE_RATES,
 	codex: CODEX_RATES,
+	grok: GROK_RATES,
+	cursor: CURSOR_RATES,
+	opencode: MULTI_PROVIDER_RATES,
+	copilot: MULTI_PROVIDER_RATES,
+	pi: MULTI_PROVIDER_RATES,
+	omp: MULTI_PROVIDER_RATES,
+	fx: MULTI_PROVIDER_RATES,
 };
 
 const cheapestByProvider = new Map<UsageProvider, ModelRate>();

--- a/packages/host-service/src/trpc/router/usage/types.ts
+++ b/packages/host-service/src/trpc/router/usage/types.ts
@@ -1,4 +1,22 @@
-export type UsageProvider = "claude" | "codex";
+/**
+ * Providers that can appear in usage history/analytics. Quota accounts exist
+ * only for "claude" and "codex"; the rest surface transcript-derived token
+ * history. Agents whose CLIs record no usable local usage data (gemini, amp,
+ * kimi, vibe, kiro, droid, hermes, mastracode) are intentionally absent.
+ */
+export type UsageProvider =
+	| "claude"
+	| "codex"
+	| "grok"
+	| "cursor"
+	| "opencode"
+	| "copilot"
+	| "pi"
+	| "omp"
+	| "fx";
+
+/** The subset of providers with quota accounts and switchable logins. */
+export type UsageAccountProvider = "claude" | "codex";
 
 export type UsageAccountStatus =
 	/** Quota fetched successfully. */
@@ -25,7 +43,7 @@ export interface UsageQuotaWindow {
 }
 
 export interface UsageAccount {
-	provider: UsageProvider;
+	provider: UsageAccountProvider;
 	/** Stable key for the credential source (config path or keychain item),
 	 * used to dedupe and as a React key. */
 	accountKey: string;


### PR DESCRIPTION
## Summary
- Usage history/analytics now covers nine providers instead of two: claude, codex, **grok, cursor, opencode, copilot, pi, omp, fx** — one failure-isolated collector per provider in `packages/host-service/src/trpc/router/usage/history/`.
- Harness-reported real costs (cursor/opencode/pi/fx record one) override the API-list-rate estimate and are never marked "approximate".
- The desktop usage panel renders all providers with a validated 9-hue palette and each agent's preset icon next to its series color; only providers with usage in range get rows.

## Why / Context
The token-spend analytics only counted Claude Code and Codex, while Superset launches many more agent CLIs. Every harness that actually records usage data is now included; CLIs verified to record **no** local token data (gemini, amp, kimi, vibe, kiro, droid, hermes, mastracode, agy) are intentionally skipped.

## How It Works
Per-provider data sources, each reverse-engineered and verified against real machine data:

| Provider | Source |
|---|---|
| grok | `$GROK_HOME/logs/unified.jsonl` `shell.turn.inference_done` events (transcripts carry no tokens); model/cwd/title joined by sid from each session's `summary.json` |
| cursor | **No local token data exists.** The CLI's stored bearer token (macOS keychain `cursor-access-token`, else `auth.json`) authorizes Cursor's `GetFilteredUsageEvents` dashboard RPC → exact token splits + real cost per request. cwd attribution hashes known workspace/project paths against the `md5(cwd)`-keyed `~/.cursor/chats` dirs; chat titles come from each conversation's `store.db` meta row. 5-min TTL cache, page cap, 15s timeout |
| opencode | `storage/message/<ses>/msg_*.json` — tokens already cache-normalized, real cost, cwd; titles from `storage/session/` |
| copilot | `~/.copilot/session-store.db` sqlite: `assistant_usage_events` joined to `sessions` (cwd, summary), opened read-only |
| pi / omp | `~/.{pi,omp}/agent/sessions/**/*.jsonl` (shared parser): header carries cwd, assistant messages carry usage + computed cost |
| fx | per-session `events.jsonl` `usage_checkpointed` events hold *cumulative* per-model totals — consecutive checkpoints are diffed into per-turn entries (the global `usage.jsonl` has per-generation facts but no session/cwd) |

Cross-cutting:
- `UsageLogEntry.costUsd` override: aggregation and the leaderboard prefer the harness's own cost over the rate estimate; approximate-flagging only applies to rate-estimated entries.
- Accounts/quota remains claude+codex via a new narrower `UsageAccountProvider` type — only the history union widened.
- Collectors run concurrently under `Promise.allSettled`; a signed-out CLI, missing dir, locked db, or offline host contributes nothing and never fails the scan.
- Grok pricing added to the rate table ($2/$6 per M for 4.5/4.6 per current published xAI rates); multi-model harnesses match against the merged claude+codex+grok tables as fallback.
- Chart palette: 9 fixed hues validated (lightness band, chroma floor, adjacent-pair CVD ΔE, normal-vision floor, contrast ≥3:1) on both light and dark surfaces.

## Manual QA Checklist
Validated on a machine with real data for six of the nine providers:

- [x] 90-day `computeUsageHistory` scan: claude $26.2k-equiv, codex $2.2k, pi $0.52, grok $0.49, cursor $0.41, fx $0.00 — models, cwd attribution, and session labels populated for each
- [x] Cursor entries priced from the API's own cents match Cursor's `GetAggregatedUsageEvents` total to the cent ($0.027)
- [x] fx per-turn deltas reproduce the CLI's own cumulative counters (16,338 incl. 12,992 cached → 3,346 uncached)
- [x] Grok turns join to session model/cwd/title via sid
- [x] Scan cost: ~7s for 90 days (~6s baseline before this change)
- [x] Absent homes / signed-out CLIs contribute zero entries without failing the scan
- [ ] Usage settings panel visual pass in the packaged app (dev app verified via HMR; no CDP screenshot — dev instance was running without a debug port)

## Testing
- `bun test src/trpc/router/usage/` — 55 pass (new: grok, opencode, pi, fx, copilot row-mapping, cursor event-mapping, leaderboard cost-override)
- `bun run typecheck` (host-service + desktop)
- `bun run lint:fix` (biome, repo-wide)
- `bun run --cwd packages/i18n check`

## Design Decisions
- **Cursor via cloud API instead of local files**: cursor-agent's `store.db` blobs contain messages only — no token counts anywhere on disk. The dashboard RPC is the same undocumented-endpoint pattern the quota fetchers already use, and it returns *exact* costs. Guarded by TTL cache + page cap + timeout, and the whole collector is optional.
- **`costUsd` override instead of provider rate tables for composer/glm/etc.**: harnesses that price their own requests are more accurate than any table we could maintain.
- **copilot sqlite tests**: `bun test` can't load better-sqlite3 (oven-sh/bun#4290), so the row mapping is unit-tested pure; the query runs under the same Electron runtime that already uses better-sqlite3 for host.db.

## Known Limitations
- Cursor events carry no cwd, so attribution only works for conversations launched from known workspace/project roots; others land unattributed (absent from project rollups, still counted in totals/models).
- Copilot's `input_tokens` semantics are assumed Anthropic-style (cache columns separate); no rows existed locally to verify. Worst case is undercounting uncached input.
- The panel subtitle still says "estimate from local session logs"; cursor rows are real costs from Cursor's API.

## Risks / Rollout
- Risk: the cursor collector adds one networked dependency to the history scan. Failure modes (no token, 401, timeout, schema drift) all degrade to "no cursor rows", never a failed scan.
- Rollback: revert; no schema, flags, or migrations involved. The leaderboard payload's provider field was already a free string server-side.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Usage history analytics now covers nine agent CLIs instead of two, adding failure-isolated collectors for grok, cursor, opencode, copilot, pi, omp, and fx.

**New Features**:
- Harness-reported costs (cursor, opencode, pi, fx) replace rate-table estimates and are never marked approximate; a reported cost of 0 (subscription-billed turns) still falls back to the rate estimate.
- Cursor has no local token data, so it fetches exact costs from the dashboard API using the CLI's stored bearer token, cached for 5 minutes; pagination is driven by page size so a missing total count won't truncate the scan.
- Pricing matches vendor-qualified model ids (like `anthropic/claude-sonnet-5`) by the segment after the last slash instead of falling back to the cheapest rate.
- Collectors run concurrently; a signed-out CLI, missing directory, locked database, or offline host contributes nothing without failing the scan.
- Quota accounts remain claude-and-codex-only; the history provider union widened.
- The usage panel shows all nine providers with theme-aware icons, renders only providers with usage in range (falling back to claude+codex when none), and resets stale provider hides after a range switch so the chart can't render empty.
- Providers with no local token data (gemini, amp, kimi, vibe, kiro, droid, hermes, mastracode, agy) are skipped.

<sup>Written for commit b77117c780624fc9d77ee4c0e582cc89cb2bc215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage history now supports Grok, Cursor, OpenCode, Copilot, Pi, Oh My Pi, and fx.
  * Charts and provider details display only providers with recorded activity.
  * Provider icons are shown alongside usage indicators.
* **Improvements**
  * Reported provider costs are used when available for more accurate totals.
  * Usage collection continues even if one provider’s data cannot be read.
* **Tests**
  * Added coverage for usage collection, filtering, cost calculations, and missing data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->