### PR TITLE
fix(desktop): rank command palette by contiguous matches, not fuzzy subsequences

### DIFF
--- a/apps/desktop/src/renderer/commandPalette/core/rankCommands.test.ts
+++ b/apps/desktop/src/renderer/commandPalette/core/rankCommands.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from "bun:test";
+import { rankCommands, rankSections, scoreCommand } from "./rankCommands";
+import type { Command, CommandSection } from "./types";
+
+function command(
+	id: string,
+	title: string,
+	section: Command["section"],
+	keywords?: string[],
+): Command {
+	return { id, title, section, keywords };
+}
+
+const DELETE_WORKSPACE = command(
+	"workspace.delete:ws-1",
+	"Delete workspace",
+	"workspace",
+	["archive", "remove", "close"],
+);
+
+// Mirrors the titles and keywords the real providers emit, in the order the
+// palette renders them with a workspace open.
+const SECTIONS: CommandSection[] = [
+	{
+		id: "workspace",
+		label: "Workspace actions",
+		commands: [
+			command("workspace.new", "New workspace", "workspace"),
+			command("workspace.quickCreate", "Quick create workspace", "workspace", [
+				"new",
+				"fast",
+			]),
+			command("files.quickOpen", "Search files", "workspace", [
+				"file picker",
+				"quick open",
+			]),
+			command("workspace.linkTask", "Link task", "workspace", [
+				"issue",
+				"linear",
+			]),
+			command("openIn.preferred:zed", "Open in Zed", "workspace", [
+				"editor",
+				"Zed",
+			]),
+			command("openIn.menu", "Open in…", "workspace", [
+				"editor",
+				"finder",
+				"cursor",
+				"vscode",
+			]),
+			command(
+				"workspace.removeFromSidebar:ws-1",
+				"Remove from sidebar",
+				"workspace",
+				["hide"],
+			),
+			DELETE_WORKSPACE,
+		],
+	},
+	{
+		id: "actions",
+		label: "Actions",
+		commands: [
+			command("actions.toggleTheme", "Toggle theme", "actions", [
+				"dark",
+				"light",
+				"appearance",
+				"color",
+			]),
+			command(
+				"actions.toggleNotificationSounds",
+				"Mute notifications",
+				"actions",
+				["dnd", "silence", "notifications", "ringtone"],
+			),
+			command("actions.toggleLeftSidebar", "Toggle left sidebar", "actions"),
+			command("actions.toggleRightSidebar", "Toggle right sidebar", "actions"),
+			command("actions.showShortcuts", "Show keyboard shortcuts", "actions", [
+				"hotkeys",
+			]),
+			command("actions.checkUpdates", "Check for updates", "actions", [
+				"update",
+				"upgrade",
+			]),
+			command("actions.newWindow", "New window", "actions", ["open", "multi"]),
+			command("resources.check", "Check resources", "actions", [
+				"resources",
+				"memory",
+				"cpu",
+				"ram",
+				"usage",
+				"performance",
+				"monitor",
+				"activity",
+				"processes",
+			]),
+			command("usage.open", "Usage", "actions", [
+				"usage",
+				"tokens",
+				"spend",
+				"cost",
+				"quota",
+				"plan",
+				"billing",
+				"claude",
+				"codex",
+				"model",
+			]),
+		],
+	},
+	{
+		id: "navigation",
+		label: "Navigation",
+		commands: [
+			command("nav.settings", "Settings", "navigation"),
+			command("nav.recentlyViewed", "Recently Viewed", "navigation", [
+				"history",
+				"recent",
+				"back",
+			]),
+			command("nav.workspaces", "Workspaces", "navigation", [
+				"workspace",
+				"project",
+				"repo",
+				"repository",
+				"switch",
+			]),
+			command("nav.docs", "Open documentation", "navigation", ["docs", "help"]),
+		],
+	},
+	{
+		id: "add-project",
+		label: "Add project",
+		commands: [
+			command("addProject.createNew", "Create new project", "add-project", [
+				"add project",
+				"new",
+				"blank",
+				"empty",
+				"folder",
+				"init",
+			]),
+			command("addProject.cloneFromUrl", "Clone from URL", "add-project", [
+				"add project",
+				"repository",
+				"repo",
+				"git",
+				"clone",
+			]),
+		],
+	},
+];
+
+function ids(sections: CommandSection[]): Record<string, string[]> {
+	return Object.fromEntries(
+		sections.map((section) => [
+			section.id,
+			section.commands.map((command) => command.id),
+		]),
+	);
+}
+
+function flatIds(sections: CommandSection[]): string[] {
+	return sections.flatMap((section) =>
+		section.commands.map((command) => command.id),
+	);
+}
+
+describe("rankSections", () => {
+	test("'them' surfaces Toggle theme, not the delete-workspace command", () => {
+		const ranked = rankSections(SECTIONS, "them");
+		expect(flatIds(ranked)[0]).toBe("actions.toggleTheme");
+		expect(flatIds(ranked)).not.toContain(DELETE_WORKSPACE.id);
+	});
+
+	test("'po' matches nothing instead of every command with a p and an o", () => {
+		expect(rankSections(SECTIONS, "po")).toEqual([]);
+	});
+
+	test("a section only ranks first when it holds the best hit", () => {
+		const ranked = rankSections(SECTIONS, "open");
+		expect(ranked.map((section) => section.id)).toEqual([
+			"workspace",
+			"navigation",
+			"actions",
+		]);
+		expect(ids(ranked)).toEqual({
+			workspace: ["openIn.preferred:zed", "openIn.menu", "files.quickOpen"],
+			navigation: ["nav.docs"],
+			actions: ["actions.newWindow"],
+		});
+	});
+
+	test("empty or whitespace query keeps every section in provider order", () => {
+		expect(rankSections(SECTIONS, "")).toBe(SECTIONS);
+		expect(rankSections(SECTIONS, "   ")).toBe(SECTIONS);
+	});
+
+	test("query is case- and whitespace-insensitive", () => {
+		expect(flatIds(rankSections(SECTIONS, "  THEME "))).toEqual([
+			"actions.toggleTheme",
+		]);
+	});
+});
+
+describe("rankCommands", () => {
+	const all = SECTIONS.flatMap((section) => section.commands);
+	const rank = (query: string) => rankCommands(all, query).map((c) => c.id);
+
+	test("title matches outrank keyword matches", () => {
+		expect(rank("usage")).toEqual(["usage.open", "resources.check"]);
+		expect(rank("new")).toEqual([
+			"workspace.new",
+			"actions.newWindow",
+			"addProject.createNew",
+			"workspace.quickCreate",
+		]);
+	});
+
+	test("keywords match as whole-word prefixes", () => {
+		expect(rank("dark")).toEqual(["actions.toggleTheme"]);
+		expect(rank("hide")).toEqual(["workspace.removeFromSidebar:ws-1"]);
+		expect(rank("archive")).toEqual([DELETE_WORKSPACE.id]);
+		expect(rank("delete")).toEqual([DELETE_WORKSPACE.id]);
+		expect(rank("vscode")).toEqual(["openIn.menu"]);
+		expect(rank("docs")).toEqual(["nav.docs"]);
+	});
+
+	test("keywords do not match mid-word", () => {
+		// "repo" and "repository" contain "po"; "appearance" contains "pea".
+		expect(rank("po")).toEqual([]);
+		expect(rank("pea")).toEqual([]);
+	});
+
+	test("title substrings match below word prefixes", () => {
+		expect(rank("space")).toEqual([
+			"workspace.new",
+			"workspace.quickCreate",
+			DELETE_WORKSPACE.id,
+			"nav.workspaces",
+		]);
+		expect(rank("work")).toEqual([
+			"nav.workspaces",
+			"workspace.new",
+			"workspace.quickCreate",
+			DELETE_WORKSPACE.id,
+		]);
+	});
+
+	test("multi-word queries match each word at a word start", () => {
+		expect(rank("open zed")).toEqual(["openIn.preferred:zed"]);
+		expect(rank("check upd")).toEqual(["actions.checkUpdates"]);
+		expect(rank("keyboard shortcuts")).toEqual(["actions.showShortcuts"]);
+		expect(rank("zed open")).toEqual(["openIn.preferred:zed"]);
+	});
+
+	test("ties keep provider order", () => {
+		expect(rank("toggle")).toEqual([
+			"actions.toggleTheme",
+			"actions.toggleLeftSidebar",
+			"actions.toggleRightSidebar",
+		]);
+	});
+});
+
+describe("scoreCommand", () => {
+	const toggleTheme = command("t", "Toggle theme", "actions", ["dark"]);
+
+	test("tiers: exact > prefix > word prefix > substring > keyword", () => {
+		const exact = scoreCommand(toggleTheme, "toggle theme");
+		const prefix = scoreCommand(toggleTheme, "toggle");
+		const wordPrefix = scoreCommand(toggleTheme, "theme");
+		const substring = scoreCommand(toggleTheme, "ggle");
+		const keyword = scoreCommand(toggleTheme, "dark");
+		expect(exact).toBeGreaterThan(prefix);
+		expect(prefix).toBeGreaterThan(wordPrefix);
+		expect(wordPrefix).toBeGreaterThan(substring);
+		expect(substring).toBeGreaterThan(keyword);
+		expect(keyword).toBeGreaterThan(0);
+	});
+
+	test("character subsequences never match", () => {
+		expect(scoreCommand(toggleTheme, "tt")).toBe(0);
+		expect(scoreCommand(toggleTheme, "tgl")).toBe(0);
+		expect(scoreCommand(DELETE_WORKSPACE, "them")).toBe(0);
+	});
+});

--- a/apps/desktop/src/renderer/commandPalette/core/rankCommands.ts
+++ b/apps/desktop/src/renderer/commandPalette/core/rankCommands.ts
@@ -1,0 +1,117 @@
+import type { Command, CommandSection } from "./types";
+
+const TITLE_EXACT = 100;
+const TITLE_PREFIX = 90;
+const TITLE_WORD_PREFIX = 80;
+const TITLE_ALL_TOKENS = 70;
+const TITLE_SUBSTRING = 60;
+const KEYWORD_PREFIX = 50;
+const ALL_TOKENS = 40;
+
+type Searchable = Pick<Command, "title" | "keywords">;
+
+function normalize(text: string): string {
+	return text.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function words(text: string): string[] {
+	return text.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+}
+
+function hasWordPrefix(wordList: string[], prefix: string): boolean {
+	return wordList.some((word) => word.startsWith(prefix));
+}
+
+/**
+ * 0 means no match. Matches are contiguous (whole query or whole query
+ * tokens at word starts), never character subsequences: "po" must not hit
+ * "Toggle theme" via "ap-p-earance col-o-r". Ties keep provider order.
+ */
+export function scoreCommand(command: Searchable, rawQuery: string): number {
+	const query = normalize(rawQuery);
+	if (!query) return 1;
+
+	const title = normalize(command.title);
+	if (title === query) return TITLE_EXACT;
+	if (title.startsWith(query)) return TITLE_PREFIX;
+
+	const titleWords = words(title);
+	if (hasWordPrefix(titleWords, query)) return TITLE_WORD_PREFIX;
+
+	const tokens = words(query);
+	if (
+		tokens.length > 0 &&
+		tokens.every((token) => hasWordPrefix(titleWords, token))
+	) {
+		return TITLE_ALL_TOKENS;
+	}
+
+	if (title.includes(query)) return TITLE_SUBSTRING;
+
+	const keywords = (command.keywords ?? []).map(normalize);
+	if (
+		keywords.some(
+			(keyword) =>
+				keyword.startsWith(query) || hasWordPrefix(words(keyword), query),
+		)
+	) {
+		return KEYWORD_PREFIX;
+	}
+
+	const allWords = [...titleWords, ...keywords.flatMap(words)];
+	if (
+		tokens.length > 0 &&
+		tokens.every((token) => hasWordPrefix(allWords, token))
+	) {
+		return ALL_TOKENS;
+	}
+
+	return 0;
+}
+
+interface Scored<T> {
+	command: T;
+	score: number;
+}
+
+function scoreAll<T extends Searchable>(
+	commands: T[],
+	query: string,
+): Scored<T>[] {
+	return commands
+		.map((command) => ({ command, score: scoreCommand(command, query) }))
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score);
+}
+
+export function rankCommands<T extends Searchable>(
+	commands: T[],
+	query: string,
+): T[] {
+	if (!normalize(query)) return commands;
+	return scoreAll(commands, query).map((entry) => entry.command);
+}
+
+/** Drops empty sections and orders the rest by their best hit. */
+export function rankSections(
+	sections: CommandSection[],
+	query: string,
+): CommandSection[] {
+	if (!normalize(query)) return sections;
+	return sections
+		.flatMap((section) => {
+			const scored = scoreAll(section.commands, query);
+			if (scored.length === 0) return [];
+			return [
+				{
+					section: {
+						...section,
+						commands: scored.map((entry) => entry.command),
+					},
+					best: scored[0].score,
+				},
+			];
+		})
+		.sort((a, b) => b.best - a.best)
+		.map((entry) => entry.section);
+}

--- a/apps/desktop/src/renderer/commandPalette/modules/navigation/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/navigation/commands.tsx
@@ -39,6 +39,7 @@ export const navigationProvider: CommandProvider = {
 				title: "Open documentation",
 				section: "navigation",
 				icon: BookOpenIcon,
+				keywords: ["docs", "help"],
 				run: () => {
 					window.open("https://docs.superset.sh", "_blank", "noreferrer");
 				},

--- a/apps/desktop/src/renderer/commandPalette/modules/workspace/commands.tsx
+++ b/apps/desktop/src/renderer/commandPalette/modules/workspace/commands.tsx
@@ -19,27 +19,25 @@ export const workspaceProvider: CommandProvider = {
 	provide: (context) => {
 		// Not gated on context.workspace — quick-create should work from any
 		// v2 dashboard view (e.g. the workspaces list), not just an open one.
-		const commands: Command[] = [
-			{
-				id: "workspace.quickCreate",
-				title: "Quick create workspace",
-				section: "workspace",
-				icon: ZapIcon,
-				hotkeyId: "QUICK_CREATE_WORKSPACE",
-				keywords: ["new", "fast"],
-				when: (ctx) => ctx.isV2CloudEnabled,
-				run: (ctx) =>
-					useQuickCreateWorkspaceIntent
-						.getState()
-						.request(ctx.workspace?.projectId ?? null),
-			},
-		];
+		const quickCreate: Command = {
+			id: "workspace.quickCreate",
+			title: "Quick create workspace",
+			section: "workspace",
+			icon: ZapIcon,
+			hotkeyId: "QUICK_CREATE_WORKSPACE",
+			keywords: ["new", "fast"],
+			when: (ctx) => ctx.isV2CloudEnabled,
+			run: (ctx) =>
+				useQuickCreateWorkspaceIntent
+					.getState()
+					.request(ctx.workspace?.projectId ?? null),
+		};
 
-		if (!context.workspace) return commands;
+		if (!context.workspace) return [quickCreate];
 		const workspace = context.workspace;
 		const isMain = workspace.workspaceType === "main";
 
-		commands.push(
+		const commands: Command[] = [
 			{
 				id: "workspace.new",
 				title: "New workspace",
@@ -49,6 +47,7 @@ export const workspaceProvider: CommandProvider = {
 				run: () =>
 					useNewWorkspaceModalStore.getState().openModal(workspace.projectId),
 			},
+			quickCreate,
 			{
 				id: "files.quickOpen",
 				title: "Search files",
@@ -69,7 +68,7 @@ export const workspaceProvider: CommandProvider = {
 				keywords: ["issue", "linear"],
 				renderFrame: () => <LinkTaskFrame workspaceId={workspace.id} />,
 			},
-		);
+		];
 
 		if (workspace.projectId) {
 			commands.push({
@@ -91,7 +90,7 @@ export const workspaceProvider: CommandProvider = {
 		if (!isMain) {
 			commands.push({
 				id: `workspace.delete:${workspace.id}`,
-				title: `Delete ${workspace.name}`,
+				title: "Delete workspace",
 				section: "workspace",
 				icon: Trash2Icon,
 				keywords: ["archive", "remove", "close"],

--- a/apps/desktop/src/renderer/commandPalette/ui/CommandItemRow/CommandItemRow.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/CommandItemRow/CommandItemRow.tsx
@@ -13,10 +13,7 @@ export function CommandItemRow({ command, onSelect }: CommandItemRowProps) {
 	const hasShortcut =
 		Boolean(command.hotkeyId) && display.text && display.text !== "Unassigned";
 	return (
-		<CommandItem
-			value={`${command.id} ${command.title} ${(command.keywords ?? []).join(" ")}`}
-			onSelect={() => onSelect(command)}
-		>
+		<CommandItem value={command.id} onSelect={() => onSelect(command)}>
 			{command.iconUrl ? (
 				<img
 					src={command.iconUrl}

--- a/apps/desktop/src/renderer/commandPalette/ui/CommandListView/CommandListView.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/CommandListView/CommandListView.tsx
@@ -1,21 +1,28 @@
 import { CommandEmpty, CommandGroup, CommandList } from "@superset/ui/command";
+import { useMemo } from "react";
 import { useCommandContext } from "../../core/ContextProvider";
+import { rankSections } from "../../core/rankCommands";
 import type { Command } from "../../core/types";
 import { useActiveCommands } from "../../core/useActiveCommands";
 import { CommandItemRow } from "../CommandItemRow/CommandItemRow";
 
 interface CommandListViewProps {
+	query: string;
 	onSelect: (command: Command) => void;
 }
 
-export function CommandListView({ onSelect }: CommandListViewProps) {
+export function CommandListView({ query, onSelect }: CommandListViewProps) {
 	const context = useCommandContext();
 	const sections = useActiveCommands(context);
+	const ranked = useMemo(
+		() => rankSections(sections, query),
+		[sections, query],
+	);
 
 	return (
 		<CommandList>
 			<CommandEmpty>No commands found.</CommandEmpty>
-			{sections.map((section) => (
+			{ranked.map((section) => (
 				<CommandGroup key={section.id} heading={section.label}>
 					{section.commands.map((command) => (
 						<CommandItemRow

--- a/apps/desktop/src/renderer/commandPalette/ui/CommandPalette/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/CommandPalette/CommandPalette.tsx
@@ -132,7 +132,7 @@ export function CommandPalette() {
 				</DialogHeader>
 				<Command
 					onKeyDown={handleRootKeyDown}
-					shouldFilter={!currentFrame || !currentFrame.command.renderFrame}
+					shouldFilter={false}
 					className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 [&_[cmdk-list]]:max-h-[min(500px,calc(80vh-3rem))]"
 				>
 					<CommandInput
@@ -147,10 +147,11 @@ export function CommandPalette() {
 						{currentFrame ? (
 							<SubPaletteView
 								parent={currentFrame.command}
+								query={query}
 								onSelect={handleSelect}
 							/>
 						) : (
-							<CommandListView onSelect={handleSelect} />
+							<CommandListView query={query} onSelect={handleSelect} />
 						)}
 					</QueryContext.Provider>
 				</Command>

--- a/apps/desktop/src/renderer/commandPalette/ui/SubPaletteView/SubPaletteView.tsx
+++ b/apps/desktop/src/renderer/commandPalette/ui/SubPaletteView/SubPaletteView.tsx
@@ -1,15 +1,21 @@
 import { CommandEmpty, CommandGroup, CommandList } from "@superset/ui/command";
 import { useMemo } from "react";
 import { useCommandContext } from "../../core/ContextProvider";
+import { rankCommands } from "../../core/rankCommands";
 import type { Command } from "../../core/types";
 import { CommandItemRow } from "../CommandItemRow/CommandItemRow";
 
 interface SubPaletteViewProps {
 	parent: Command;
+	query: string;
 	onSelect: (command: Command) => void;
 }
 
-export function SubPaletteView({ parent, onSelect }: SubPaletteViewProps) {
+export function SubPaletteView({
+	parent,
+	query,
+	onSelect,
+}: SubPaletteViewProps) {
 	const context = useCommandContext();
 
 	const children = useMemo<Command[]>(() => {
@@ -18,11 +24,18 @@ export function SubPaletteView({ parent, onSelect }: SubPaletteViewProps) {
 		return parent.children;
 	}, [parent, context]);
 
+	const visible = useMemo(
+		() =>
+			rankCommands(
+				children.filter((c) => (c.when ? c.when(context) : true)),
+				query,
+			),
+		[children, context, query],
+	);
+
 	if (parent.renderFrame) {
 		return <>{parent.renderFrame()}</>;
 	}
-
-	const visible = children.filter((c) => (c.when ? c.when(context) : true));
 
 	return (
 		<CommandList>


### PR DESCRIPTION
## Summary
- Command palette search no longer uses cmdk's fuzzy subsequence scorer; results are ranked by contiguous title/keyword matches and sections are ordered by their best hit.
- "Delete <workspace name>" is now "Delete workspace" so the workspace name stops leaking into search; "Quick create workspace" sits under "New workspace".
- Regression tests for the reported cases (`them` ranking a delete row above "Toggle theme", `po` matching nearly every command).

## Why / Context
Three things compounded:
1. The cmdk item value was `id + title + keywords`, and cmdk's default `command-score` treats any in-order character subsequence as a hit. `po` scored 0.03 against "Toggle theme" (a‑**p**‑pearance col‑**o**‑r) and `them` scored 0.0047 against "Delete Plugin Architecture Review…" (dele**t**e … arc**h**itectur**e** … re**m**ove) — both counted as matches.
2. cmdk 1.1.1's section re-ordering is a silent no-op: it queries groups by `data-value="<react id>"` but the DOM attribute holds the heading text. Sections stayed in provider order, so a 0.005 hit in "Workspace actions" sat above a 0.89 hit in "Actions".
3. Long workspace names in the delete row's title turned every common word in the name into a title match.

## How It Works
- `core/rankCommands.ts`: `scoreCommand` returns a tier — title exact › title prefix › word prefix in title › every query word is a word prefix in the title › title substring › keyword (whole-word prefix only, no mid-word) › query words spread across title + keywords › 0. No character-subsequence matching. Ties keep provider order.
- `rankSections` drops empty sections and orders the rest by their best hit; `rankCommands` does the same for a flat list (sub-palettes).
- `CommandPalette` sets `shouldFilter={false}` and passes the query to `CommandListView` / `SubPaletteView`, which rank themselves — the same pattern the Theme and Workspaces frames already used. `CommandItemRow`'s cmdk `value` is now just the command id (selection identity only).
- "Open documentation" gained `docs`/`help` keywords — the one query that only worked before because of the fuzz.

## Manual QA Checklist
- [ ] `them` → "Toggle theme" first; no "Delete workspace" row
- [ ] `po` → "No commands found."
- [ ] `open` → Workspace actions (Open in <app>, Open in…, Search files), then Navigation (Open documentation), then Actions (New window)
- [ ] `delete` / `archive` → "Delete workspace"; confirm dialog still names the workspace
- [ ] Workspace section order: New workspace, Quick create workspace, Search files, Link task, Remove from sidebar, Delete workspace
- [ ] Sub-palette (Settings ›, Open in… ›) still filters by the query
- [ ] Arrow keys / Enter pick the top-ranked row after each keystroke

## Testing
- `bun test src/renderer/commandPalette/core/rankCommands.test.ts` — 13 pass
- `bun run typecheck` (apps/desktop)
- `bunx biome check` on the palette directory
- `bun run --cwd packages/i18n check`
- Not exercised in the running app — the wiring change is small and `shouldFilter={false}` + `CommandEmpty` is already proven by the existing frames, but the QA list above is the fast way to confirm.

## Design Decisions
- **Contiguous matching over a stricter fuzzy threshold**: any subsequence scorer will keep producing surprising hits on long dynamic titles; word-prefix matching is what users expect from a command palette and is easy to reason about.
- **Ties keep provider order rather than a coverage/length tiebreak**: a coverage tiebreak reordered same-tier siblings in surprising ways ("Open in…" over "Open in Zed", "New window" over "New workspace"); provider order is the deliberate section design.
- **Ranking in the views rather than a custom cmdk `filter`**: cmdk's group sort is broken in 1.1.1, so a custom filter alone would not fix section order.

## Known Limitations
- Dropping subsequence matching means abbreviations like `tgl` no longer hit "Toggle theme". Multi-word prefixes (`tog th`) still do.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the command palette's search ranking to use contiguous matches instead of fuzzy subsequences, so "po" no longer matches nearly every command and "them" no longer surfaces "Delete workspace". Sections now re-order by their best hit instead of staying in provider order.

**Bug Fixes**
- Reworks ranking to prefer title exact, prefix, word-prefix, substring, then keyword matches; ties keep provider order.
- Renames "Delete <workspace name>" to "Delete workspace" so long names stop leaking into search, and moves "Quick create workspace" under "New workspace".
- Adds `docs`/`help` keywords to "Open documentation", which previously only matched via fuzzy scoring.
- Drops character-subsequence matching, so abbreviations like `tgl` no longer hit "Toggle theme" (multi-word prefixes like `tog th` still do).

<sup>Written for commit 1c13b38f0d10380c7451647c71afa96bbc064da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved command palette search with relevance-based ranking for titles and keywords.
  - Added support for matching multi-word queries and whole-word prefixes.
  - Added documentation and help keywords to the documentation command.
  - Added a quick-create workspace command when no workspace is active.
  - Standardized the workspace deletion command label.

- **Bug Fixes**
  - Command results now preserve provider order when scores are tied.
  - Empty searches display commands in their original order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->