### PR TITLE
refactor(desktop): split Typography settings into two always-visible surface sections

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/FontSettingSection.tsx
@@ -1,65 +1,21 @@
-import { Button } from "@superset/ui/button";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@superset/ui/collapsible";
-import { Input } from "@superset/ui/input";
-import { Label } from "@superset/ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@superset/ui/select";
-import { Switch } from "@superset/ui/switch";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-	ChevronRight,
-	Code2,
-	RotateCcw,
-	SlidersHorizontal,
-	SquareTerminal,
-} from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { resolveEditorLineHeight } from "renderer/lib/editor-typography";
+import { useCallback, useMemo } from "react";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import {
 	FONT_SETTINGS_QUERY_KEY,
 	type FontSettings,
 } from "renderer/lib/font-settings";
 import {
-	DEFAULT_TERMINAL_CURSOR_BLINK,
-	DEFAULT_TERMINAL_CURSOR_STYLE,
-	DEFAULT_TERMINAL_FONT_FAMILY,
-	DEFAULT_TERMINAL_FONT_SIZE,
-	DEFAULT_TERMINAL_LIGATURES,
-	DEFAULT_TERMINAL_LINE_HEIGHT,
 	getDefaultTerminalAppearance,
 	resolveTerminalAppearance,
 } from "renderer/lib/terminal/appearance";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
-import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
-import {
-	DEFAULT_CODE_EDITOR_FONT_FAMILY,
-	DEFAULT_CODE_EDITOR_FONT_SIZE,
-} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants";
-import { useSettingsSearchQuery } from "renderer/stores/settings-state";
 import { useTerminalTheme } from "renderer/stores/theme";
-import { FontFamilyCombobox } from "./components/FontFamilyCombobox";
-import { FontPreview } from "./components/FontPreview";
+import {
+	type FontSettingsUpdate,
+	TypographySurfaceCard,
+} from "./components/TypographySurfaceCard";
 import { useSystemFonts } from "./hooks/useSystemFonts";
-import { toFontWeightOverride } from "./utils/toFontWeightOverride";
-
-type FontSettingKey = keyof FontSettings;
-type NumericSettingKey =
-	| "terminalFontSize"
-	| "terminalLineHeight"
-	| "terminalLetterSpacing"
-	| "editorFontSize"
-	| "editorLineHeight"
-	| "editorLetterSpacing";
 
 const EMPTY_FONT_SETTINGS: FontSettings = {
 	terminalFontFamily: null,
@@ -79,54 +35,6 @@ const EMPTY_FONT_SETTINGS: FontSettings = {
 	editorLigatures: null,
 };
 
-const VARIANT_CONFIG = {
-	editor: {
-		title: "Editor typography",
-		description: "Typography used in V2 editors and diff views.",
-		defaultFamily: DEFAULT_CODE_EDITOR_FONT_FAMILY,
-		defaultSize: DEFAULT_CODE_EDITOR_FONT_SIZE,
-		defaultLineHeight: 1.5,
-		familyKey: "editorFontFamily",
-		sizeKey: "editorFontSize",
-		lineHeightKey: "editorLineHeight",
-		letterSpacingKey: "editorLetterSpacing",
-		fontWeightKey: "editorFontWeight",
-		ligaturesKey: "editorLigatures",
-		groupKeys: [
-			"editorFontFamily",
-			"editorFontSize",
-			"editorLineHeight",
-			"editorLetterSpacing",
-			"editorFontWeight",
-			"editorLigatures",
-		] satisfies FontSettingKey[],
-	},
-	terminal: {
-		title: "Terminal typography",
-		description: "Typography and cursor behavior used in V2 terminal panels.",
-		defaultFamily: DEFAULT_TERMINAL_FONT_FAMILY,
-		defaultSize: DEFAULT_TERMINAL_FONT_SIZE,
-		defaultLineHeight: DEFAULT_TERMINAL_LINE_HEIGHT,
-		familyKey: "terminalFontFamily",
-		sizeKey: "terminalFontSize",
-		lineHeightKey: "terminalLineHeight",
-		letterSpacingKey: "terminalLetterSpacing",
-		fontWeightKey: "terminalFontWeight",
-		ligaturesKey: "terminalLigatures",
-		groupKeys: [
-			"terminalFontFamily",
-			"terminalFontSize",
-			"terminalLineHeight",
-			"terminalLetterSpacing",
-			"terminalFontWeight",
-			"terminalLigatures",
-			"terminalMinimumContrast",
-			"terminalCursorStyle",
-			"terminalCursorBlink",
-		] satisfies FontSettingKey[],
-	},
-} as const;
-
 interface FontSettingSectionProps {
 	showEditor?: boolean;
 	showTerminal?: boolean;
@@ -136,11 +44,6 @@ export function FontSettingSection({
 	showEditor = true,
 	showTerminal = true,
 }: FontSettingSectionProps) {
-	const [variant, setVariant] = useState<"editor" | "terminal">(
-		showEditor ? "editor" : "terminal",
-	);
-	const config = VARIANT_CONFIG[variant];
-	const searchQuery = useSettingsSearchQuery();
 	const utils = electronTrpc.useUtils();
 	const queryClient = useQueryClient();
 	const terminalTheme = useTerminalTheme();
@@ -215,84 +118,17 @@ export function FontSettingSection({
 	});
 
 	const { fonts: systemFonts, isLoading: fontsLoading } = useSystemFonts();
-	const [drafts, setDrafts] = useState<
-		Partial<Record<NumericSettingKey, string>>
-	>({});
-	const [advancedOpen, setAdvancedOpen] = useState(false);
-
-	useEffect(() => {
-		if (!showEditor && !showTerminal) return;
-		if (variant === "editor" && !showEditor) setVariant("terminal");
-		if (variant === "terminal" && !showTerminal) setVariant("editor");
-	}, [showEditor, showTerminal, variant]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset in-progress input when persisted or optimistic settings change
-	useEffect(() => {
-		setDrafts({});
-	}, [fontSettings]);
 
 	const settings = useMemo(
 		() => ({ ...EMPTY_FONT_SETTINGS, ...fontSettings }),
 		[fontSettings],
 	);
-	const mutateSetting = useCallback(
-		(key: FontSettingKey, value: FontSettings[FontSettingKey]) => {
-			setFontSettings.mutate({ [key]: value });
+	const mutateSettings = useCallback(
+		(input: FontSettingsUpdate) => {
+			setFontSettings.mutate(input);
 		},
 		[setFontSettings],
 	);
-
-	const numericValue = useCallback(
-		(key: NumericSettingKey, fallback: number) => {
-			const draft = drafts[key];
-			if (draft != null) {
-				const parsed = Number.parseFloat(draft);
-				if (Number.isFinite(parsed)) return parsed;
-			}
-			return settings[key] ?? fallback;
-		},
-		[drafts, settings],
-	);
-
-	const commitNumeric = useCallback(
-		(key: NumericSettingKey, min: number, max: number, step: number) => {
-			const raw = drafts[key];
-			if (raw == null) return;
-			const value = Number.parseFloat(raw);
-			const isStep = Math.abs(value / step - Math.round(value / step)) < 1e-9;
-			if (Number.isFinite(value) && value >= min && value <= max && isStep) {
-				mutateSetting(key, value);
-			}
-			setDrafts((current) => {
-				const next = { ...current };
-				delete next[key];
-				return next;
-			});
-		},
-		[drafts, mutateSetting],
-	);
-
-	const currentFamily = settings[config.familyKey];
-	const editorPreviewSize = numericValue(
-		"editorFontSize",
-		DEFAULT_CODE_EDITOR_FONT_SIZE,
-	);
-	const editorPreviewLineHeight =
-		drafts.editorLineHeight == null && settings.editorLineHeight == null
-			? resolveEditorLineHeight(editorPreviewSize) / editorPreviewSize
-			: numericValue("editorLineHeight", 1.5);
-	const terminalPreviewSize = numericValue(
-		"terminalFontSize",
-		DEFAULT_TERMINAL_FONT_SIZE,
-	);
-	const terminalPreviewLineHeight = numericValue(
-		"terminalLineHeight",
-		DEFAULT_TERMINAL_LINE_HEIGHT,
-	);
-	const hasOverrides = config.groupKeys.some((key) => settings[key] !== null);
-
-	const inputValue = (key: NumericSettingKey, fallback: number) =>
-		drafts[key] ?? String(settings[key] ?? fallback);
 
 	return (
 		<section aria-labelledby="typography-title">
@@ -301,409 +137,32 @@ export function FontSettingSection({
 					Typography
 				</h3>
 				<p className="text-xs text-muted-foreground">
-					Select a live surface, then adjust its typography. Changes appear
-					immediately.
+					Each surface has its own typography. Changes appear immediately in the
+					live previews.
 				</p>
 			</div>
 
-			<div className="rounded-lg border bg-card/40 p-4">
-				<div className="mb-4 flex items-start justify-between gap-4">
-					<div>
-						<div className="flex items-center gap-2">
-							{variant === "editor" ? (
-								<Code2 className="size-4 text-muted-foreground" />
-							) : (
-								<SquareTerminal className="size-4 text-muted-foreground" />
-							)}
-							<h4 className="text-sm font-medium">
-								<HighlightText text={config.title} query={searchQuery} />
-							</h4>
-						</div>
-						<p className="mt-1 text-xs text-muted-foreground">
-							{config.description}
-							{variant === "terminal" && (
-								<>
-									{" "}
-									<a
-										href="https://www.nerdfonts.com"
-										target="_blank"
-										rel="noopener noreferrer"
-										className="text-primary hover:underline"
-									>
-										Nerd Fonts
-									</a>{" "}
-									are recommended.
-								</>
-							)}
-						</p>
-					</div>
-					{hasOverrides && (
-						<Button
-							variant="ghost"
-							size="sm"
-							className="h-8 gap-1.5 px-2.5 text-xs text-muted-foreground"
-							onClick={() => {
-								setFontSettings.mutate(
-									Object.fromEntries(
-										config.groupKeys.map((key) => [key, null]),
-									),
-								);
-								setDrafts({});
-							}}
-						>
-							<RotateCcw className="size-3.5" />
-							Reset {variant}
-						</Button>
-					)}
-				</div>
-
-				<div>
-					<div className="grid grid-cols-[minmax(0,1fr)_7rem] gap-3">
-						<div className="space-y-1.5">
-							<Label className="text-xs">Font family</Label>
-							<FontFamilyCombobox
-								value={currentFamily}
-								defaultValue={config.defaultFamily}
-								onValueChange={(value) =>
-									mutateSetting(config.familyKey, value)
-								}
-								disabled={isLoading}
-								variant={variant}
-								fonts={systemFonts}
-								fontsLoading={fontsLoading}
-							/>
-						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor={`${variant}-font-size`} className="text-xs">
-								Font size
-							</Label>
-							<div className="relative">
-								<Input
-									id={`${variant}-font-size`}
-									type="number"
-									min={10}
-									max={24}
-									step={0.5}
-									value={inputValue(config.sizeKey, config.defaultSize)}
-									onChange={(event) =>
-										setDrafts((current) => ({
-											...current,
-											[config.sizeKey]: event.target.value,
-										}))
-									}
-									onBlur={() => commitNumeric(config.sizeKey, 10, 24, 0.5)}
-									onKeyDown={(event) => {
-										if (event.key === "Enter") event.currentTarget.blur();
-									}}
-									disabled={isLoading}
-									className="pr-7"
-									aria-label={`${config.title} font size`}
-								/>
-								<span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-muted-foreground">
-									px
-								</span>
-							</div>
-						</div>
-					</div>
-
-					<Collapsible
-						open={advancedOpen}
-						onOpenChange={setAdvancedOpen}
-						className="mt-4"
-					>
-						<CollapsibleTrigger asChild>
-							<Button
-								variant="outline"
-								size="sm"
-								className="h-9 w-full justify-between px-3 text-xs font-normal"
-							>
-								<span className="flex items-center gap-2">
-									<SlidersHorizontal className="size-3.5 text-muted-foreground" />
-									Fine tune typography
-								</span>
-								<ChevronRight
-									className={`size-3.5 text-muted-foreground transition-transform ${advancedOpen ? "rotate-90" : ""}`}
-								/>
-							</Button>
-						</CollapsibleTrigger>
-						<CollapsibleContent className="pt-3">
-							<div className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
-								<div className="space-y-1.5">
-									<Label htmlFor={`${variant}-line-height`} className="text-xs">
-										Line height
-									</Label>
-									<Input
-										id={`${variant}-line-height`}
-										type="number"
-										min={1}
-										max={2.5}
-										step={0.1}
-										value={inputValue(
-											config.lineHeightKey,
-											config.defaultLineHeight,
-										)}
-										onChange={(event) =>
-											setDrafts((current) => ({
-												...current,
-												[config.lineHeightKey]: event.target.value,
-											}))
-										}
-										onBlur={() =>
-											commitNumeric(config.lineHeightKey, 1, 2.5, 0.1)
-										}
-										onKeyDown={(event) => {
-											if (event.key === "Enter") event.currentTarget.blur();
-										}}
-									/>
-								</div>
-								<div className="space-y-1.5">
-									<Label
-										htmlFor={`${variant}-letter-spacing`}
-										className="text-xs"
-									>
-										Letter spacing (px)
-									</Label>
-									<Input
-										id={`${variant}-letter-spacing`}
-										type="number"
-										min={-2}
-										max={4}
-										step={0.1}
-										value={inputValue(config.letterSpacingKey, 0)}
-										onChange={(event) =>
-											setDrafts((current) => ({
-												...current,
-												[config.letterSpacingKey]: event.target.value,
-											}))
-										}
-										onBlur={() =>
-											commitNumeric(config.letterSpacingKey, -2, 4, 0.1)
-										}
-										onKeyDown={(event) => {
-											if (event.key === "Enter") event.currentTarget.blur();
-										}}
-									/>
-								</div>
-								<div className="space-y-1.5">
-									<Label className="text-xs">Font weight</Label>
-									<Select
-										value={String(settings[config.fontWeightKey] ?? 400)}
-										onValueChange={(value) =>
-											mutateSetting(
-												config.fontWeightKey,
-												toFontWeightOverride(value),
-											)
-										}
-									>
-										<SelectTrigger size="sm" className="w-full">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{[100, 200, 300, 400, 500, 600, 700, 800, 900].map(
-												(weight) => (
-													<SelectItem key={weight} value={String(weight)}>
-														{weight}
-													</SelectItem>
-												),
-											)}
-										</SelectContent>
-									</Select>
-								</div>
-								<div className="flex items-center justify-between gap-3 min-h-14">
-									<div>
-										<Label htmlFor={`${variant}-ligatures`} className="text-xs">
-											Ligatures
-										</Label>
-										<p className="text-[11px] text-muted-foreground">
-											Combine sequences such as =&gt; and !==.
-										</p>
-									</div>
-									<Switch
-										id={`${variant}-ligatures`}
-										checked={
-											settings[config.ligaturesKey] ??
-											(variant === "terminal"
-												? DEFAULT_TERMINAL_LIGATURES
-												: true)
-										}
-										onCheckedChange={(checked) =>
-											mutateSetting(config.ligaturesKey, checked)
-										}
-									/>
-								</div>
-
-								{variant === "terminal" && (
-									<>
-										<div className="space-y-1.5">
-											<Label className="text-xs">Minimum contrast</Label>
-											<Select
-												value={String(
-													settings.terminalMinimumContrast ?? "default",
-												)}
-												onValueChange={(value) =>
-													mutateSetting(
-														"terminalMinimumContrast",
-														value === "default" ? null : Number(value),
-													)
-												}
-											>
-												<SelectTrigger size="sm" className="w-full">
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													<SelectItem value="default">Theme default</SelectItem>
-													<SelectItem value="3">3:1</SelectItem>
-													<SelectItem value="4.5">4.5:1 (AA)</SelectItem>
-													<SelectItem value="7">7:1 (AAA)</SelectItem>
-												</SelectContent>
-											</Select>
-										</div>
-										<div className="space-y-1.5">
-											<Label className="text-xs">Cursor style</Label>
-											<Select
-												value={
-													settings.terminalCursorStyle ??
-													DEFAULT_TERMINAL_CURSOR_STYLE
-												}
-												onValueChange={(value) =>
-													mutateSetting(
-														"terminalCursorStyle",
-														value as "block" | "bar" | "underline",
-													)
-												}
-											>
-												<SelectTrigger size="sm" className="w-full">
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													<SelectItem value="block">Block</SelectItem>
-													<SelectItem value="bar">Bar</SelectItem>
-													<SelectItem value="underline">Underline</SelectItem>
-												</SelectContent>
-											</Select>
-										</div>
-										<div className="flex items-center justify-between gap-3 min-h-14 sm:col-span-2">
-											<div>
-												<Label
-													htmlFor="terminal-cursor-blink"
-													className="text-xs"
-												>
-													Cursor blinking
-												</Label>
-												<p className="text-[11px] text-muted-foreground">
-													Animate the active terminal cursor.
-												</p>
-											</div>
-											<Switch
-												id="terminal-cursor-blink"
-												checked={
-													settings.terminalCursorBlink ??
-													DEFAULT_TERMINAL_CURSOR_BLINK
-												}
-												onCheckedChange={(checked) =>
-													mutateSetting("terminalCursorBlink", checked)
-												}
-											/>
-										</div>
-									</>
-								)}
-							</div>
-						</CollapsibleContent>
-					</Collapsible>
-				</div>
-			</div>
-
-			<div className="mt-5">
-				<div className="mb-3">
-					<p className="text-xs font-medium">Live surfaces</p>
-					<p className="text-[11px] text-muted-foreground">
-						Both previews stay visible. Select either one to edit its settings.
-					</p>
-				</div>
-				<div className="grid gap-5">
-					{showEditor && (
-						// min-w-0: grid items default to min-width auto, so the preview's
-						// nowrap footer would otherwise widen the item past its track.
-						<div className="min-w-0">
-							<div className="mb-2 flex items-center justify-between gap-3">
-								<Button
-									variant="ghost"
-									size="sm"
-									aria-pressed={variant === "editor"}
-									className="-ml-2 h-8 gap-2 px-2 text-xs"
-									onClick={() => setVariant("editor")}
-								>
-									<Code2 className="size-3.5" />
-									Editor
-									{variant === "editor" && (
-										<span className="text-primary">Editing</span>
-									)}
-								</Button>
-								<span className="text-[10px] tabular-nums text-muted-foreground">
-									{editorPreviewSize}px ·{" "}
-									{Number(editorPreviewLineHeight.toFixed(2))} line height
-								</span>
-							</div>
-							<FontPreview
-								fontFamily={
-									settings.editorFontFamily ?? DEFAULT_CODE_EDITOR_FONT_FAMILY
-								}
-								fontSize={editorPreviewSize}
-								lineHeight={editorPreviewLineHeight}
-								letterSpacing={numericValue("editorLetterSpacing", 0)}
-								fontWeight={settings.editorFontWeight ?? 400}
-								ligatures={settings.editorLigatures ?? true}
-								variant="editor"
-								isCustomFont={settings.editorFontFamily !== null}
-							/>
-						</div>
-					)}
-
-					{showTerminal && (
-						<div className="min-w-0">
-							<div className="mb-2 flex items-center justify-between gap-3">
-								<Button
-									variant="ghost"
-									size="sm"
-									aria-pressed={variant === "terminal"}
-									className="-ml-2 h-8 gap-2 px-2 text-xs"
-									onClick={() => setVariant("terminal")}
-								>
-									<SquareTerminal className="size-3.5" />
-									Terminal
-									{variant === "terminal" && (
-										<span className="text-primary">Editing</span>
-									)}
-								</Button>
-								<span className="text-[10px] tabular-nums text-muted-foreground">
-									{terminalPreviewSize}px ·{" "}
-									{Number(terminalPreviewLineHeight.toFixed(2))} line height
-								</span>
-							</div>
-							<FontPreview
-								fontFamily={
-									settings.terminalFontFamily ?? DEFAULT_TERMINAL_FONT_FAMILY
-								}
-								fontSize={terminalPreviewSize}
-								lineHeight={terminalPreviewLineHeight}
-								letterSpacing={numericValue("terminalLetterSpacing", 0)}
-								fontWeight={settings.terminalFontWeight ?? 400}
-								ligatures={
-									settings.terminalLigatures ?? DEFAULT_TERMINAL_LIGATURES
-								}
-								variant="terminal"
-								isCustomFont={settings.terminalFontFamily !== null}
-								minimumContrast={settings.terminalMinimumContrast}
-								cursorStyle={
-									settings.terminalCursorStyle ?? DEFAULT_TERMINAL_CURSOR_STYLE
-								}
-								cursorBlink={
-									settings.terminalCursorBlink ?? DEFAULT_TERMINAL_CURSOR_BLINK
-								}
-							/>
-						</div>
-					)}
-				</div>
+			<div className="rounded-lg border border-border overflow-hidden divide-y divide-border">
+				{showEditor && (
+					<TypographySurfaceCard
+						variant="editor"
+						settings={settings}
+						isLoading={isLoading}
+						onChange={mutateSettings}
+						fonts={systemFonts}
+						fontsLoading={fontsLoading}
+					/>
+				)}
+				{showTerminal && (
+					<TypographySurfaceCard
+						variant="terminal"
+						settings={settings}
+						isLoading={isLoading}
+						onChange={mutateSettings}
+						fonts={systemFonts}
+						fontsLoading={fontsLoading}
+					/>
+				)}
 			</div>
 		</section>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/components/TypographySurfaceCard/TypographySurfaceCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/components/TypographySurfaceCard/TypographySurfaceCard.tsx
@@ -1,0 +1,463 @@
+import { Button } from "@superset/ui/button";
+import { Input } from "@superset/ui/input";
+import { Label } from "@superset/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@superset/ui/select";
+import { Switch } from "@superset/ui/switch";
+import type { inferRouterInputs } from "@trpc/server";
+import type { AppRouter } from "lib/trpc/routers";
+import { Code2, RotateCcw, SquareTerminal } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { resolveEditorLineHeight } from "renderer/lib/editor-typography";
+import type { FontSettings } from "renderer/lib/font-settings";
+import {
+	DEFAULT_TERMINAL_CURSOR_BLINK,
+	DEFAULT_TERMINAL_CURSOR_STYLE,
+	DEFAULT_TERMINAL_FONT_FAMILY,
+	DEFAULT_TERMINAL_FONT_SIZE,
+	DEFAULT_TERMINAL_LIGATURES,
+	DEFAULT_TERMINAL_LINE_HEIGHT,
+} from "renderer/lib/terminal/appearance";
+import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
+import {
+	DEFAULT_CODE_EDITOR_FONT_FAMILY,
+	DEFAULT_CODE_EDITOR_FONT_SIZE,
+} from "renderer/screens/main/components/WorkspaceView/components/CodeEditor/constants";
+import { useSettingsSearchQuery } from "renderer/stores/settings-state";
+import type { FontInfo } from "../../hooks/useSystemFonts";
+import { toFontWeightOverride } from "../../utils/toFontWeightOverride";
+import { FontFamilyCombobox } from "../FontFamilyCombobox";
+import { FontPreview } from "../FontPreview";
+
+export type FontSettingsUpdate =
+	inferRouterInputs<AppRouter>["settings"]["setFontSettings"];
+
+type FontSettingKey = keyof FontSettings;
+type NumericSettingKey =
+	| "terminalFontSize"
+	| "terminalLineHeight"
+	| "terminalLetterSpacing"
+	| "editorFontSize"
+	| "editorLineHeight"
+	| "editorLetterSpacing";
+
+const VARIANT_CONFIG = {
+	editor: {
+		title: "Editor typography",
+		description: "Typography used in V2 editors and diff views.",
+		defaultFamily: DEFAULT_CODE_EDITOR_FONT_FAMILY,
+		defaultSize: DEFAULT_CODE_EDITOR_FONT_SIZE,
+		defaultLineHeight: 1.5,
+		familyKey: "editorFontFamily",
+		sizeKey: "editorFontSize",
+		lineHeightKey: "editorLineHeight",
+		letterSpacingKey: "editorLetterSpacing",
+		fontWeightKey: "editorFontWeight",
+		ligaturesKey: "editorLigatures",
+		groupKeys: [
+			"editorFontFamily",
+			"editorFontSize",
+			"editorLineHeight",
+			"editorLetterSpacing",
+			"editorFontWeight",
+			"editorLigatures",
+		] satisfies FontSettingKey[],
+	},
+	terminal: {
+		title: "Terminal typography",
+		description: "Typography and cursor behavior used in V2 terminal panels.",
+		defaultFamily: DEFAULT_TERMINAL_FONT_FAMILY,
+		defaultSize: DEFAULT_TERMINAL_FONT_SIZE,
+		defaultLineHeight: DEFAULT_TERMINAL_LINE_HEIGHT,
+		familyKey: "terminalFontFamily",
+		sizeKey: "terminalFontSize",
+		lineHeightKey: "terminalLineHeight",
+		letterSpacingKey: "terminalLetterSpacing",
+		fontWeightKey: "terminalFontWeight",
+		ligaturesKey: "terminalLigatures",
+		groupKeys: [
+			"terminalFontFamily",
+			"terminalFontSize",
+			"terminalLineHeight",
+			"terminalLetterSpacing",
+			"terminalFontWeight",
+			"terminalLigatures",
+			"terminalMinimumContrast",
+			"terminalCursorStyle",
+			"terminalCursorBlink",
+		] satisfies FontSettingKey[],
+	},
+} as const;
+
+interface TypographySurfaceCardProps {
+	variant: "editor" | "terminal";
+	settings: FontSettings;
+	isLoading: boolean;
+	onChange: (input: FontSettingsUpdate) => void;
+	fonts: FontInfo[];
+	fontsLoading: boolean;
+}
+
+export function TypographySurfaceCard({
+	variant,
+	settings,
+	isLoading,
+	onChange,
+	fonts,
+	fontsLoading,
+}: TypographySurfaceCardProps) {
+	const config = VARIANT_CONFIG[variant];
+	const searchQuery = useSettingsSearchQuery();
+	const [drafts, setDrafts] = useState<
+		Partial<Record<NumericSettingKey, string>>
+	>({});
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset in-progress input when persisted or optimistic settings change
+	useEffect(() => {
+		setDrafts({});
+	}, [settings]);
+
+	const mutateSetting = useCallback(
+		(key: FontSettingKey, value: FontSettings[FontSettingKey]) => {
+			onChange({ [key]: value });
+		},
+		[onChange],
+	);
+
+	const numericValue = useCallback(
+		(key: NumericSettingKey, fallback: number) => {
+			const draft = drafts[key];
+			if (draft != null) {
+				const parsed = Number.parseFloat(draft);
+				if (Number.isFinite(parsed)) return parsed;
+			}
+			return settings[key] ?? fallback;
+		},
+		[drafts, settings],
+	);
+
+	const commitNumeric = useCallback(
+		(key: NumericSettingKey, min: number, max: number, step: number) => {
+			const raw = drafts[key];
+			if (raw == null) return;
+			const value = Number.parseFloat(raw);
+			const isStep = Math.abs(value / step - Math.round(value / step)) < 1e-9;
+			if (Number.isFinite(value) && value >= min && value <= max && isStep) {
+				mutateSetting(key, value);
+			}
+			setDrafts((current) => {
+				const next = { ...current };
+				delete next[key];
+				return next;
+			});
+		},
+		[drafts, mutateSetting],
+	);
+
+	const currentFamily = settings[config.familyKey];
+	const hasOverrides = config.groupKeys.some((key) => settings[key] !== null);
+
+	const inputValue = (key: NumericSettingKey, fallback: number) =>
+		drafts[key] ?? String(settings[key] ?? fallback);
+
+	const previewSize = numericValue(config.sizeKey, config.defaultSize);
+	const previewLineHeight =
+		variant === "editor" &&
+		drafts.editorLineHeight == null &&
+		settings.editorLineHeight == null
+			? resolveEditorLineHeight(previewSize) / previewSize
+			: numericValue(config.lineHeightKey, config.defaultLineHeight);
+
+	return (
+		<div className="p-4">
+			<div className="mb-4 flex items-start justify-between gap-4">
+				<div>
+					<div className="flex items-center gap-2">
+						{variant === "editor" ? (
+							<Code2 className="size-4 text-muted-foreground" />
+						) : (
+							<SquareTerminal className="size-4 text-muted-foreground" />
+						)}
+						<h4 className="text-sm font-medium">
+							<HighlightText text={config.title} query={searchQuery} />
+						</h4>
+					</div>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{config.description}
+						{variant === "terminal" && (
+							<>
+								{" "}
+								<a
+									href="https://www.nerdfonts.com"
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-primary hover:underline"
+								>
+									Nerd Fonts
+								</a>{" "}
+								are recommended.
+							</>
+						)}
+					</p>
+				</div>
+				{hasOverrides && (
+					<Button
+						variant="ghost"
+						size="sm"
+						className="h-8 gap-1.5 px-2.5 text-xs text-muted-foreground"
+						onClick={() => {
+							onChange(
+								Object.fromEntries(config.groupKeys.map((key) => [key, null])),
+							);
+							setDrafts({});
+						}}
+					>
+						<RotateCcw className="size-3.5" />
+						Reset {variant}
+					</Button>
+				)}
+			</div>
+
+			<div className="grid grid-cols-[minmax(0,1fr)_7rem] gap-3">
+				<div className="space-y-1.5">
+					<Label className="text-xs">Font family</Label>
+					<FontFamilyCombobox
+						value={currentFamily}
+						defaultValue={config.defaultFamily}
+						onValueChange={(value) => mutateSetting(config.familyKey, value)}
+						disabled={isLoading}
+						variant={variant}
+						fonts={fonts}
+						fontsLoading={fontsLoading}
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor={`${variant}-font-size`} className="text-xs">
+						Font size
+					</Label>
+					<div className="relative">
+						<Input
+							id={`${variant}-font-size`}
+							type="number"
+							min={10}
+							max={24}
+							step={0.5}
+							value={inputValue(config.sizeKey, config.defaultSize)}
+							onChange={(event) =>
+								setDrafts((current) => ({
+									...current,
+									[config.sizeKey]: event.target.value,
+								}))
+							}
+							onBlur={() => commitNumeric(config.sizeKey, 10, 24, 0.5)}
+							onKeyDown={(event) => {
+								if (event.key === "Enter") event.currentTarget.blur();
+							}}
+							disabled={isLoading}
+							className="pr-7"
+							aria-label={`${config.title} font size`}
+						/>
+						<span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-muted-foreground">
+							px
+						</span>
+					</div>
+				</div>
+			</div>
+
+			<div className="mt-4 grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
+				<div className="space-y-1.5">
+					<Label htmlFor={`${variant}-line-height`} className="text-xs">
+						Line height
+					</Label>
+					<Input
+						id={`${variant}-line-height`}
+						type="number"
+						min={1}
+						max={2.5}
+						step={0.1}
+						value={inputValue(config.lineHeightKey, config.defaultLineHeight)}
+						onChange={(event) =>
+							setDrafts((current) => ({
+								...current,
+								[config.lineHeightKey]: event.target.value,
+							}))
+						}
+						onBlur={() => commitNumeric(config.lineHeightKey, 1, 2.5, 0.1)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter") event.currentTarget.blur();
+						}}
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor={`${variant}-letter-spacing`} className="text-xs">
+						Letter spacing (px)
+					</Label>
+					<Input
+						id={`${variant}-letter-spacing`}
+						type="number"
+						min={-2}
+						max={4}
+						step={0.1}
+						value={inputValue(config.letterSpacingKey, 0)}
+						onChange={(event) =>
+							setDrafts((current) => ({
+								...current,
+								[config.letterSpacingKey]: event.target.value,
+							}))
+						}
+						onBlur={() => commitNumeric(config.letterSpacingKey, -2, 4, 0.1)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter") event.currentTarget.blur();
+						}}
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label className="text-xs">Font weight</Label>
+					<Select
+						value={String(settings[config.fontWeightKey] ?? 400)}
+						onValueChange={(value) =>
+							mutateSetting(config.fontWeightKey, toFontWeightOverride(value))
+						}
+					>
+						<SelectTrigger size="sm" className="w-full">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{[100, 200, 300, 400, 500, 600, 700, 800, 900].map((weight) => (
+								<SelectItem key={weight} value={String(weight)}>
+									{weight}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+				<div className="flex items-center justify-between gap-3 min-h-14">
+					<div>
+						<Label htmlFor={`${variant}-ligatures`} className="text-xs">
+							Ligatures
+						</Label>
+						<p className="text-[11px] text-muted-foreground">
+							Combine sequences such as =&gt; and !==.
+						</p>
+					</div>
+					<Switch
+						id={`${variant}-ligatures`}
+						checked={
+							settings[config.ligaturesKey] ??
+							(variant === "terminal" ? DEFAULT_TERMINAL_LIGATURES : true)
+						}
+						onCheckedChange={(checked) =>
+							mutateSetting(config.ligaturesKey, checked)
+						}
+					/>
+				</div>
+
+				{variant === "terminal" && (
+					<>
+						<div className="space-y-1.5">
+							<Label className="text-xs">Minimum contrast</Label>
+							<Select
+								value={String(settings.terminalMinimumContrast ?? "default")}
+								onValueChange={(value) =>
+									mutateSetting(
+										"terminalMinimumContrast",
+										value === "default" ? null : Number(value),
+									)
+								}
+							>
+								<SelectTrigger size="sm" className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="default">Theme default</SelectItem>
+									<SelectItem value="3">3:1</SelectItem>
+									<SelectItem value="4.5">4.5:1 (AA)</SelectItem>
+									<SelectItem value="7">7:1 (AAA)</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="space-y-1.5">
+							<Label className="text-xs">Cursor style</Label>
+							<Select
+								value={
+									settings.terminalCursorStyle ?? DEFAULT_TERMINAL_CURSOR_STYLE
+								}
+								onValueChange={(value) =>
+									mutateSetting(
+										"terminalCursorStyle",
+										value as "block" | "bar" | "underline",
+									)
+								}
+							>
+								<SelectTrigger size="sm" className="w-full">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="block">Block</SelectItem>
+									<SelectItem value="bar">Bar</SelectItem>
+									<SelectItem value="underline">Underline</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="flex items-center justify-between gap-3 min-h-14 sm:col-span-2">
+							<div>
+								<Label htmlFor="terminal-cursor-blink" className="text-xs">
+									Cursor blinking
+								</Label>
+								<p className="text-[11px] text-muted-foreground">
+									Animate the active terminal cursor.
+								</p>
+							</div>
+							<Switch
+								id="terminal-cursor-blink"
+								checked={
+									settings.terminalCursorBlink ?? DEFAULT_TERMINAL_CURSOR_BLINK
+								}
+								onCheckedChange={(checked) =>
+									mutateSetting("terminalCursorBlink", checked)
+								}
+							/>
+						</div>
+					</>
+				)}
+			</div>
+
+			{/* min-w-0 wrapper: FontPreview's nowrap footer must not widen the card */}
+			<div className="mt-4 min-w-0">
+				<div className="mb-2 flex items-center justify-between gap-3">
+					<span className="text-xs text-muted-foreground">Live preview</span>
+					<span className="text-[10px] tabular-nums text-muted-foreground">
+						{previewSize}px · {Number(previewLineHeight.toFixed(2))} line height
+					</span>
+				</div>
+				<FontPreview
+					fontFamily={currentFamily ?? config.defaultFamily}
+					fontSize={previewSize}
+					lineHeight={previewLineHeight}
+					letterSpacing={numericValue(config.letterSpacingKey, 0)}
+					fontWeight={settings[config.fontWeightKey] ?? 400}
+					ligatures={
+						settings[config.ligaturesKey] ??
+						(variant === "terminal" ? DEFAULT_TERMINAL_LIGATURES : true)
+					}
+					variant={variant}
+					isCustomFont={currentFamily !== null}
+					{...(variant === "terminal"
+						? {
+								minimumContrast: settings.terminalMinimumContrast,
+								cursorStyle:
+									settings.terminalCursorStyle ?? DEFAULT_TERMINAL_CURSOR_STYLE,
+								cursorBlink:
+									settings.terminalCursorBlink ?? DEFAULT_TERMINAL_CURSOR_BLINK,
+							}
+						: {})}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/components/TypographySurfaceCard/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/FontSettingSection/components/TypographySurfaceCard/index.ts
@@ -1,0 +1,4 @@
+export {
+	type FontSettingsUpdate,
+	TypographySurfaceCard,
+} from "./TypographySurfaceCard";


### PR DESCRIPTION
## Summary
- Replaces the confusing Typography UI — one shared control card whose target surface (Editor vs Terminal) was switched by clicking the preview headers below it — with two self-contained sections, each showing its own controls, reset button, and live preview.
- Sections render as divider-separated rows inside a single bordered container (same visual pattern as ThemeSection), with no card background.
- The "Fine tune typography" collapsible is removed; line height, letter spacing, font weight, ligatures (and the terminal-only contrast/cursor rows) are always visible.

## Why / Context
Clicking a preview to change which surface the settings card above edits was easy to miss and read as "select a live surface" rather than "there are two independent settings groups". Showing both groups outright removes the hidden mode entirely.

## How It Works
- `FontSettingSection` keeps the data layer (font-settings query, optimistic `setFontSettings` mutation with terminal-runtime sync, system-font discovery) and renders a `divide-y` container.
- New `TypographySurfaceCard` renders one variant end-to-end from a per-variant config (title, defaults, setting keys); it owns its own numeric draft state so edits on one surface never touch the other.
- The mutation payload is now typed off the router input (`inferRouterInputs<AppRouter>["settings"]["setFontSettings"]`) instead of `Partial<FontSettings>`, which surfaced that `terminalMinimumContrast` is a literal union.

## Manual QA (via CDP against the running dev app)
- [x] Both sections render with their own live previews; no `aria-pressed` toggle buttons remain
- [x] Changing terminal font size 14→16 updates only the terminal preview and persists; editor stays untouched
- [x] Per-surface Reset appears once that surface has an override and restores defaults (persisted values return to null)
- [x] Fine-tune fields (line height, letter spacing, weight, ligatures, terminal contrast/cursor) render inline in both sections
- [x] Settings search still targets the sections via unchanged `APPEARANCE_EDITOR_FONT` / `APPEARANCE_TERMINAL_FONT` item ids

## Testing
- `bun run typecheck` (apps/desktop)
- `biome check` on the changed directory

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the shared Typography control card — which switched between Editor and Terminal when you clicked its preview header — with two always-visible sections, each with its own controls, reset button, and live preview.

**Refactors**
- Removes the "Fine tune typography" collapsible; line height, letter spacing, font weight, ligatures, and terminal contrast/cursor controls are always visible.
- Gives each section its own numeric draft state so edits on one surface never affect the other.
- Types the mutation payload from the router input instead of `Partial<FontSettings>`; settings search item IDs are unchanged.

<sup>Written for commit 9c24b7140c606ceb0157919899fe66d4fd75c704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned typography settings with separate configuration cards for the editor and terminal.
  * Added controls for font family, size, line height, spacing, weight, ligatures, and terminal-specific cursor and contrast options.
  * Added live font previews and the ability to reset surface-specific typography overrides.

* **Improvements**
  * Invalid numeric entries are safely discarded, while valid changes are applied on blur or Enter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->