### PR TITLE
fix(trpc): let the hourly MRR refresh collect the run it started

### DIFF
--- a/packages/trpc/src/router/analytics/business.ts
+++ b/packages/trpc/src/router/analytics/business.ts
@@ -270,10 +270,11 @@ export async function refreshSigmaMrr({
 	pollIntervalMs?: number;
 } = {}): Promise<MrrResult> {
 	const startedAt = Date.now();
-	// Ignore the cache on the first step only. Otherwise a scheduled refresh
-	// that runs more often than the entry expires would read its own previous
-	// result and never actually refresh. Subsequent steps must consult the
-	// cache, since that is where the finished run lands.
+	// Ignore the cache on every step. The job runs more often than the entry
+	// expires, so honouring it would hand back the previous result before the
+	// pending run is ever collected — the tile would then only move when the
+	// entry lapsed, with a Sigma run burnt every hour for nothing. The finished
+	// run is returned straight from the pending branch, not via the cache.
 	let last = await advanceSigmaMrr({ ignoreCache: true });
 	while (
 		!last.available &&
@@ -281,7 +282,7 @@ export async function refreshSigmaMrr({
 		Date.now() - startedAt < timeBudgetMs
 	) {
 		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-		last = await advanceSigmaMrr();
+		last = await advanceSigmaMrr({ ignoreCache: true });
 	}
 	return last;
 }


### PR DESCRIPTION
## Summary
- The hourly `/api/analytics/jobs/refresh-mrr` job now actually refreshes the admin MRR tile: every poll step ignores the cache, so it collects the Sigma run it started instead of handing back the previous 12h entry.

## Why / Context
Admin MRR was trailing Stripe. The schedule is fine — Vercel logs show 24 hourly `POST 200`s on the route in the last 24h and no `[refresh-mrr]` errors — but `refreshSigmaMrr` ignored the cache only on its first step, the one that starts the Sigma run. Every poll after that honoured the cache, found the still-valid 12h entry, returned it, and the loop exited with `refreshed: true` holding the old data. The run it had just started was never collected and its pending handle expired after 10 minutes.

Net effect: the tile only moved when the cache entry lapsed (up to 12h stale), and ~24 Sigma runs a day were burnt for nothing.

## How It Works
One-line change at the poll step plus a corrected comment. With `ignoreCache` on every step, `advanceSigmaMrr` reads the pending run id → collects it once Sigma finishes → writes the fresh 12h entry → returns it straight from the pending branch (which is where it always landed; the old comment claimed the cache was needed to see it). The tile path (`business.getMrr`) is unchanged and still serves the cache immediately.

Edge: if a tile poll collects the run between two job steps, the job starts one more run. That requires the cache to already be expired, which a working job prevents.

## Testing
- `bun run typecheck` in `packages/trpc`
- `bunx biome check` on the file
- `bun test` in `packages/trpc` — 99 pass, 0 fail
- Not exercised against Stripe locally (needs Sigma + the shared Redis). Post-deploy check: the tile's "last refresh" should stay ≤1h old; before this it drifted up to 12h.

## Known Limitations
- Even fully fresh, the series trails Stripe's live Billing dashboard by ~1 day: the query is bounded by `exchange_rates_from_usd` (24h freshness per Stripe's Sigma docs; the change-events table is 3h) and shifts fx dates back a day. Closing that gap is a query change, out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hourly MRR refresh job so it collects the Sigma run it starts, instead of handing back the previous 12h cache entry.

Previously only the first poll step ignored the cache; every poll after that found the old entry still valid, returned it, and exited with `refreshed: true` while the pending run expired uncollected. The admin MRR tile only moved when the cache lapsed (up to 12h stale), and ~24 Sigma runs a day were wasted. Now every poll step ignores the cache, so the finished run is returned straight from the pending branch.

The tile still serves the cache immediately, and the known ~1-day lag behind Stripe's live dashboard (due to exchange-rate data freshness) is unchanged.

<sup>Written for commit 47a9dc1de8955a8b619b53b4e5b89a562c5bb8ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recurring revenue updates by ensuring polling retrieves the latest pending payment data instead of repeatedly showing cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->