### PR TITLE
feat(integrations): offer trigger-only integrations only where their triggers are

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
@@ -1,6 +1,7 @@
 import {
 	type DraftTrigger,
 	describeTriggerProblems,
+	enabledTriggerKinds,
 	summarizeTriggerProblems,
 } from "@superset/shared/automation-triggers";
 import { FEATURE_FLAGS } from "@superset/shared/constants";
@@ -82,11 +83,7 @@ export function TriggersEditor({
 		FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS,
 	);
 	const providers = useMemo(() => {
-		const kinds = new Set(
-			Array.isArray(enabledKinds)
-				? enabledKinds.filter((kind) => typeof kind === "string")
-				: [],
-		);
+		const kinds = enabledTriggerKinds(enabledKinds);
 		return TRIGGER_PROVIDERS.filter(
 			(provider) => provider.kind === "schedule" || kinds.has(provider.kind),
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/integrations/components/IntegrationsSettings/IntegrationsSettings.tsx
@@ -1,10 +1,12 @@
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import {
-	INTEGRATIONS,
 	type IntegrationProvider,
+	offeredIntegrations,
 } from "@superset/shared/integrations";
 import { Button } from "@superset/ui/button";
 import { Skeleton } from "@superset/ui/skeleton";
-import { useCallback, useEffect, useState } from "react";
+import { useFeatureFlagPayload } from "posthog-js/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { BsMicrosoftTeams } from "react-icons/bs";
 import { FaGithub, FaGoogle, FaSlack } from "react-icons/fa";
 import { HiOutlineArrowTopRightOnSquare } from "react-icons/hi2";
@@ -58,6 +60,14 @@ export function IntegrationsSettings({
 	// window against the other one's organization.
 	const activeOrganizationId = useActiveOrganizationId();
 	const searchQuery = useSettingsSearchQuery();
+
+	const enabledTriggerKinds = useFeatureFlagPayload(
+		FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS,
+	);
+	const offered = useMemo(
+		() => offeredIntegrations(enabledTriggerKinds),
+		[enabledTriggerKinds],
+	);
 
 	const { data: integrations, isPending: isIntegrationsPending } =
 		cloudTrpc.integration.list.useQuery(
@@ -189,7 +199,7 @@ export function IntegrationsSettings({
 			</div>
 
 			<div className="space-y-1">
-				{INTEGRATIONS.map((integration) => {
+				{offered.map((integration) => {
 					const itemId = integrationSettingItemId(integration.provider);
 					if (!isItemVisible(itemId, visibleItems)) return null;
 					const state = providerStates[integration.provider];

--- a/apps/web/src/app/(dashboard-legacy)/integrations/google/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/google/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { FaGoogle } from "react-icons/fa";
 import { api } from "@/trpc/server";
 import { IntegrationErrorHandler } from "../components/IntegrationErrorHandler";
+import { requireOfferedIntegration } from "../utils/requireOfferedIntegration";
 import { ConnectionControls } from "./components/ConnectionControls";
 
 const CALLBACK_MESSAGES = {
@@ -27,6 +28,7 @@ const CALLBACK_MESSAGES = {
 };
 
 export default async function GoogleIntegrationPage() {
+	await requireOfferedIntegration("google");
 	const trpc = await api();
 	const organization = await trpc.user.myOrganization.query();
 

--- a/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/microsoft-teams/page.tsx
@@ -14,6 +14,7 @@ import {
 	type CallbackMessage,
 	IntegrationErrorHandler,
 } from "../components/IntegrationErrorHandler";
+import { requireOfferedIntegration } from "../utils/requireOfferedIntegration";
 import { ConnectionControls } from "./components/ConnectionControls";
 
 // Graph's own words are the useful part of a refused subscription — they name
@@ -48,6 +49,7 @@ const CALLBACK_MESSAGES = {
 };
 
 export default async function MicrosoftTeamsIntegrationPage() {
+	await requireOfferedIntegration("microsoft_teams");
 	const trpc = await api();
 	const organization = await trpc.user.myOrganization.query();
 

--- a/apps/web/src/app/(dashboard-legacy)/integrations/notion/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/notion/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { SiNotion } from "react-icons/si";
 import { api } from "@/trpc/server";
 import { IntegrationErrorHandler } from "../components/IntegrationErrorHandler";
+import { requireOfferedIntegration } from "../utils/requireOfferedIntegration";
 import { ConnectionControls } from "./components/ConnectionControls";
 
 const CALLBACK_MESSAGES = {
@@ -23,6 +24,7 @@ const CALLBACK_MESSAGES = {
 };
 
 export default async function NotionIntegrationPage() {
+	await requireOfferedIntegration("notion");
 	const trpc = await api();
 	const organization = await trpc.user.myOrganization.query();
 

--- a/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/page.tsx
@@ -1,17 +1,16 @@
 "use client";
 
+import { FEATURE_FLAGS } from "@superset/shared/constants";
 import {
-	INTEGRATIONS,
 	type IntegrationProvider,
+	offeredIntegrations,
 } from "@superset/shared/integrations";
+import { useFeatureFlagPayload } from "posthog-js/react";
 import type { ReactNode } from "react";
 import { BsMicrosoftTeams } from "react-icons/bs";
 import { FaGithub, FaGoogle, FaSlack } from "react-icons/fa";
 import { SiLinear, SiNotion, SiSentry } from "react-icons/si";
-import {
-	IntegrationCard,
-	type IntegrationCardProps,
-} from "./components/IntegrationCard";
+import { IntegrationCard } from "./components/IntegrationCard";
 
 const CARD_STYLES: Record<
 	IntegrationProvider,
@@ -29,17 +28,15 @@ const CARD_STYLES: Record<
 	google: { accentColor: "#4285F4", icon: <FaGoogle className="size-8" /> },
 };
 
-const integrations: IntegrationCardProps[] = INTEGRATIONS.map(
-	(integration) => ({
-		id: integration.webPath.replace("/integrations/", ""),
-		name: integration.label,
-		description: integration.description,
-		category: integration.category,
-		...CARD_STYLES[integration.provider],
-	}),
-);
-
 export default function IntegrationsPage() {
+	// Before the flag resolves this is the standalone set, which is what
+	// everyone outside the flag sees anyway; the trigger-only providers join
+	// once the payload arrives.
+	const enabledTriggerKinds = useFeatureFlagPayload(
+		FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS,
+	);
+	const integrations = offeredIntegrations(enabledTriggerKinds);
+
 	return (
 		<div className="space-y-8">
 			<section>
@@ -50,7 +47,14 @@ export default function IntegrationsPage() {
 
 				<div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 					{integrations.map((integration) => (
-						<IntegrationCard key={integration.id} {...integration} />
+						<IntegrationCard
+							key={integration.provider}
+							id={integration.webPath.replace("/integrations/", "")}
+							name={integration.label}
+							description={integration.description}
+							category={integration.category}
+							{...CARD_STYLES[integration.provider]}
+						/>
 					))}
 				</div>
 			</section>

--- a/apps/web/src/app/(dashboard-legacy)/integrations/sentry/page.tsx
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/sentry/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { SiSentry } from "react-icons/si";
 import { api } from "@/trpc/server";
 import { IntegrationErrorHandler } from "../components/IntegrationErrorHandler";
+import { requireOfferedIntegration } from "../utils/requireOfferedIntegration";
 import { ConnectionControls } from "./components/ConnectionControls";
 
 const CALLBACK_MESSAGES = {
@@ -27,6 +28,7 @@ const CALLBACK_MESSAGES = {
 };
 
 export default async function SentryIntegrationPage() {
+	await requireOfferedIntegration("sentry");
 	const trpc = await api();
 	const organization = await trpc.user.myOrganization.query();
 

--- a/apps/web/src/app/(dashboard-legacy)/integrations/utils/requireOfferedIntegration/index.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/utils/requireOfferedIntegration/index.ts
@@ -1,0 +1,1 @@
+export { requireOfferedIntegration } from "./requireOfferedIntegration";

--- a/apps/web/src/app/(dashboard-legacy)/integrations/utils/requireOfferedIntegration/requireOfferedIntegration.ts
+++ b/apps/web/src/app/(dashboard-legacy)/integrations/utils/requireOfferedIntegration/requireOfferedIntegration.ts
@@ -1,0 +1,46 @@
+import { auth } from "@superset/auth/server";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import {
+	type IntegrationProvider,
+	isIntegrationOffered,
+} from "@superset/shared/integrations";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+
+import { posthogServer } from "@/lib/posthog-server";
+
+const getTriggerFlagPayload = cache(async (): Promise<unknown> => {
+	const session = await auth.api.getSession({
+		headers: await headers(),
+	});
+	if (!session?.user) return undefined;
+
+	try {
+		return await posthogServer.getFeatureFlagPayload(
+			FEATURE_FLAGS.AUTOMATION_EVENT_TRIGGERS,
+			session.user.id,
+			undefined,
+			{ personProperties: { email: session.user.email } },
+		);
+	} catch (error) {
+		console.error(
+			"[integrations] Failed to load the automation-event-triggers flag",
+			error,
+		);
+		return undefined;
+	}
+});
+
+/**
+ * 404s a provider page the caller isn't offered. The index never links to
+ * it, and a page the flag hides shouldn't be one URL away; a failed flag
+ * lookup reads as not offered, the same as everywhere else the flag is read.
+ */
+export async function requireOfferedIntegration(
+	provider: IntegrationProvider,
+): Promise<void> {
+	if (!isIntegrationOffered(provider, await getTriggerFlagPayload())) {
+		notFound();
+	}
+}

--- a/packages/shared/src/automation-triggers.ts
+++ b/packages/shared/src/automation-triggers.ts
@@ -412,6 +412,21 @@ export const draftTriggerSchema = z.object({
 export type DraftTrigger = z.infer<typeof draftTriggerSchema>;
 export type TriggerConfigInput = DraftTrigger["config"];
 
+/**
+ * The trigger kinds the AUTOMATION_EVENT_TRIGGERS flag payload enables. Off,
+ * unloaded, offline, or a payload that isn't an array all mean none — Scheduled
+ * is offered regardless and is then the only kind. Strings, not kinds: the
+ * payload is edited by hand in PostHog, and an unknown entry simply enables
+ * nothing.
+ */
+export function enabledTriggerKinds(payload: unknown): Set<string> {
+	return new Set(
+		Array.isArray(payload)
+			? payload.filter((kind): kind is string => typeof kind === "string")
+			: [],
+	);
+}
+
 /** One problem, addressed to a specific trigger so the form can mark that row. */
 export type TriggerProblem = {
 	index: number;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -145,6 +145,12 @@ export const FEATURE_FLAGS = {
 	 * offered. Off, unloaded, offline, or a payload that isn't an array all
 	 * mean Scheduled only — the event providers exist on main ahead of their
 	 * credentials being provisioned, and each is exposed by adding its kind.
+	 *
+	 * The same payload decides which integrations the settings and web
+	 * integrations pages offer: one that only feeds automations is shown when
+	 * one of its kinds is enabled (`offeredIntegrations` in
+	 * `@superset/shared/integrations`), so a provider is connectable exactly
+	 * when its triggers are.
 	 */
 	AUTOMATION_EVENT_TRIGGERS: "automation-event-triggers",
 	/**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -106,8 +106,6 @@ export const FEATURE_FLAGS = {
 	ELECTRIC_TASKS_ACCESS: "electric-tasks-access",
 	/** Gates access to the experimental mobile-first agents UI on web. */
 	WEB_AGENTS_UI_ACCESS: "web-agents-ui-access",
-	/** Gates access to GitHub integration (currently buggy, internal only). */
-	GITHUB_INTEGRATION_ACCESS: "github-integration-access",
 	/** Gates access to Cloud features (environment variables, sandboxes). */
 	CLOUD_ACCESS: "cloud-access",
 	/** When enabled, blocks remote agent execution on the desktop (e.g., for enterprise orgs). */

--- a/packages/shared/src/integrations.ts
+++ b/packages/shared/src/integrations.ts
@@ -1,3 +1,8 @@
+import {
+	enabledTriggerKinds,
+	type TriggerConfigInput,
+} from "./automation-triggers";
+
 /**
  * The integration roster every surface renders from: the web integrations
  * index, the desktop settings pane, and desktop settings search. Icons and
@@ -10,6 +15,16 @@ export interface Integration {
 	description: string;
 	category: string;
 	webPath: string;
+	/** The trigger kinds a connection to this provider feeds. */
+	triggerKinds: readonly TriggerConfigInput["kind"][];
+	/**
+	 * Powers something besides automations — repositories and pull requests,
+	 * the Slack app, tasks — so it is offered whether or not its trigger kinds
+	 * are. Everything else is offered only where at least one of its kinds is
+	 * in the AUTOMATION_EVENT_TRIGGERS payload: a connection nothing can use
+	 * is not worth a Connect button.
+	 */
+	standalone?: boolean;
 }
 
 export const INTEGRATIONS = [
@@ -19,6 +34,8 @@ export const INTEGRATIONS = [
 		description: "Sync issues bidirectionally with Linear.",
 		category: "Task Management",
 		webPath: "/integrations/linear",
+		triggerKinds: ["linear"],
+		standalone: true,
 	},
 	{
 		provider: "github",
@@ -26,6 +43,8 @@ export const INTEGRATIONS = [
 		description: "Connect repos and sync pull requests.",
 		category: "Version Control",
 		webPath: "/integrations/github",
+		triggerKinds: ["github"],
+		standalone: true,
 	},
 	{
 		provider: "slack",
@@ -33,6 +52,8 @@ export const INTEGRATIONS = [
 		description: "Manage tasks from Slack conversations.",
 		category: "Communication",
 		webPath: "/integrations/slack",
+		triggerKinds: ["slack"],
+		standalone: true,
 	},
 	{
 		provider: "notion",
@@ -40,6 +61,7 @@ export const INTEGRATIONS = [
 		description: "Run automations on data source and comment activity.",
 		category: "Knowledge",
 		webPath: "/integrations/notion",
+		triggerKinds: ["notion"],
 	},
 	{
 		provider: "microsoft_teams",
@@ -47,6 +69,7 @@ export const INTEGRATIONS = [
 		description: "Trigger automations from Teams channel messages.",
 		category: "Communication",
 		webPath: "/integrations/microsoft-teams",
+		triggerKinds: ["microsoft_teams"],
 	},
 	{
 		provider: "sentry",
@@ -54,6 +77,7 @@ export const INTEGRATIONS = [
 		description: "Run automations when Sentry issues change.",
 		category: "Monitoring",
 		webPath: "/integrations/sentry",
+		triggerKinds: ["sentry"],
 	},
 	{
 		provider: "google",
@@ -61,7 +85,31 @@ export const INTEGRATIONS = [
 		description: "Trigger automations from Google Calendar and Gmail.",
 		category: "Productivity",
 		webPath: "/integrations/google",
+		triggerKinds: ["google_calendar", "gmail"],
 	},
 ] as const satisfies readonly Integration[];
 
 export type IntegrationProvider = (typeof INTEGRATIONS)[number]["provider"];
+
+/**
+ * The integrations to offer, given the AUTOMATION_EVENT_TRIGGERS payload — the
+ * same value that decides the Add Trigger menu, so a provider never shows a
+ * Connect button its triggers can't follow, or a trigger nothing can connect.
+ */
+export function offeredIntegrations(triggerFlagPayload: unknown) {
+	const kinds = enabledTriggerKinds(triggerFlagPayload);
+	return INTEGRATIONS.filter(
+		(integration: Integration) =>
+			integration.standalone === true ||
+			integration.triggerKinds.some((kind) => kinds.has(kind)),
+	);
+}
+
+export function isIntegrationOffered(
+	provider: IntegrationProvider,
+	triggerFlagPayload: unknown,
+): boolean {
+	return offeredIntegrations(triggerFlagPayload).some(
+		(integration) => integration.provider === provider,
+	);
+}


### PR DESCRIPTION
## Summary
- Desktop `Settings → Integrations` and web `/integrations` now offer Notion, Microsoft Teams, Sentry and Google only to users whose `automation-event-triggers` payload enables one of their trigger kinds — today, `@superset.sh`. GitHub, Slack and Linear stay visible to everyone.
- The four trigger-only web provider pages 404 for anyone not offered them.
- No new flag: the Add Trigger menu and the integrations pages read the same payload, so a provider is connectable exactly when its triggers are.

## Why / Context
The four providers shipped on 08-17 purely as trigger feeds, and their connect flows aren't provisioned for outside organizations (Sentry's app is unpublished, Teams needs a tenant plus protected-API approval, Google's consent screen and Pub/Sub aren't set up). The Add Trigger menu already hides those kinds outside the flag, so a Connect button for a provider whose triggers you can't add was a dead end.

GitHub, Slack and Linear are deliberately exempt: GitHub feeds workspace repo rows, PR sync and sandbox clone tokens; the Slack app's link flow lands on `/integrations/slack/linked`; Tasks' "Connect Linear" CTA navigates to `/settings/integrations`.

## How It Works
- `@superset/shared/integrations`: each entry declares `triggerKinds`; GitHub/Slack/Linear are `standalone: true`. `offeredIntegrations(payload)` filters the roster, `isIntegrationOffered(provider, payload)` checks one.
- `@superset/shared/automation-triggers`: `enabledTriggerKinds(payload)` is the parser `TriggersEditor` used to inline; it now imports it.
- Desktop `IntegrationsSettings` and web `integrations/page.tsx` read the payload with `useFeatureFlagPayload` and map over `offeredIntegrations`.
- Web `notion` / `sentry` / `google` / `microsoft-teams` pages call `requireOfferedIntegration(provider)`, which reads the payload server-side via `posthogServer.getFeatureFlagPayload` with the email person property (same pattern as `getPagesAccess`) and `notFound()`s.
- Visibility only: the API connect and callback routes are unchanged, matching how `PLUGINS` and `CHAT_V3` are documented.

## Manual QA Checklist
Not exercised in a running app — typecheck, lint and tests only. To confirm:
- [ ] Desktop, `@superset.sh` account: Settings → Integrations lists all seven
- [ ] Desktop, outside account (or flag off): lists GitHub, Slack, Linear only; Tasks → Connect Linear still lands on the page
- [ ] Web `/integrations` as each: same two sets; cards link correctly
- [ ] Web `/integrations/sentry` outside the flag → 404; inside → renders
- [ ] Automations → Add Trigger unchanged for both audiences

## Testing
- `bun run typecheck` in `packages/shared`, `apps/web`, `apps/desktop` — clean
- `bun run lint` — clean
- `bun run --cwd packages/shared test` — 821 pass
- `bun run --cwd apps/desktop test src/renderer/routes/_authenticated/settings src/renderer/routes/_authenticated/_dashboard/automations` — 66 pass
- `bun run --cwd apps/web test` — 34 pass
- `bun run --cwd packages/i18n check` — clean

## Design Decisions
- **Same flag instead of a second one**: a separate integrations flag would have to be kept in sync with the trigger flag by hand, which is the drift that produced the current state. Per-provider control already exists — add or remove a kind in the payload and both surfaces follow.
- **`standalone` in code, not in the flag**: whether a provider has a non-automation use is a property of the code, not a rollout decision.

## Known Limitations
- Desktop settings search still indexes the hidden integrations (`SETTINGS_ITEMS` is static), so searching "sentry" outside the flag shows a count of 1 on a section that then renders nothing.
- The web index renders the standalone set until the flag loads, so `@superset.sh` users see the other four pop in.

## Follow-ups
- `github-integration-access` and `slack-integration-access` are 100% in PostHog with no code references since #3152 / #4823, and `FEATURE_FLAGS.GITHUB_INTEGRATION_ACCESS` is unused — archive/delete candidates.

## Rollout
- No PostHog change required; the flag's description was updated to say it also gates integrations.
- Rollback: revert; the flag stays as it is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Offers Notion, Microsoft Teams, Sentry, and Google integrations only when the `automation-event-triggers` flag enables at least one of their trigger kinds, so Connect buttons no longer lead to dead ends. GitHub, Slack, and Linear remain available to everyone because they also serve non-automation use cases.

**Details**
- Filtering uses the same flag payload that gates the Add Trigger menu; no new flag or migration.
- `@superset/shared` exposes `enabledTriggerKinds` and `offeredIntegrations` used by desktop settings and web `/integrations`.
- Web pages for the four trigger-only providers 404 via `requireOfferedIntegration` when not offered.
- Drops the unused `GITHUB_INTEGRATION_ACCESS` flag constant; the PostHog flag was at 100% with no readers and is archived alongside `slack-integration-access`.
- Known side effects: desktop search still indexes hidden integrations, and web index shows the standalone set until the flag loads.

<sup>Written for commit 4c6270d4370789856cce621618baf259d4bd6471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integration availability now reflects enabled automation triggers across settings, web pages, and automation editors.
  * Standalone integrations remain available regardless of trigger configuration.
  * Schedule-based triggers remain available independently of enabled trigger kinds.
* **Bug Fixes**
  * Unavailable integration pages now return a not-found response instead of loading inaccessible data.
* **Documentation**
  * Updated feature-flag guidance to clarify how trigger settings control available integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->