### PR TITLE
fix(mobile): scope the project picker to the Home scope and say just "Cloud" under Cloud

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -10,6 +10,7 @@ import { useSession } from "@/lib/auth/client";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { posthog } from "@/lib/posthog";
 import { apiClient } from "@/lib/trpc/client";
+import { useWorkspaceScope } from "@/screens/(authenticated)/(home)/hooks/useWorkspaceScope";
 import { useAttachmentsSheet } from "@/screens/(authenticated)/hooks/useAttachmentsSheet";
 import { useComposerDraft } from "@/screens/(authenticated)/hooks/useComposerDraft";
 import { useCreateTerminalWorkspace } from "@/screens/(authenticated)/hooks/useCreateTerminalWorkspace";
@@ -64,6 +65,7 @@ export function NewChatWidget({
 	const selectedTarget =
 		targets.find((target) => target.key === targetKey) ?? defaultTarget;
 	const isCloudTarget = selectedTarget?.kind === "cloud";
+	const cloudScope = useWorkspaceScope() === "cloud";
 
 	const { data: session } = useSession();
 	const organizationId = session?.session?.activeOrganizationId ?? null;
@@ -208,6 +210,9 @@ export function NewChatWidget({
 	// but only a *picked* one. `fixedTarget` pins the composer to a workspace
 	// and is not the user's to clear, so it gets no chips at all: the chip's
 	// press only clears `storeTarget`, which would leave it stuck on screen.
+	// Under Cloud there is no project to show: a sandbox has no real project
+	// structure yet, so the chip is the place itself and the repo it clones is
+	// resolved without asking.
 	const headerChips = fixedTarget
 		? []
 		: storeTarget
@@ -218,16 +223,14 @@ export function NewChatWidget({
 					},
 				]
 			: [
-					{
-						id: "project",
-						label: selectedTarget
-							? isCloudTarget
-								? `${selectedTarget.projectName} · Cloud`
-								: selectedTarget.projectName
-							: "No project",
-						avatar: true,
-						iconUri: selectedTarget?.projectIconUrl ?? undefined,
-					},
+					cloudScope
+						? { id: "project", label: "Cloud" }
+						: {
+								id: "project",
+								label: selectedTarget?.projectName ?? "No project",
+								avatar: true,
+								iconUri: selectedTarget?.projectIconUrl ?? undefined,
+							},
 					...(branchLabel
 						? [{ id: "branch", label: branchLabel, muted: true }]
 						: []),
@@ -293,6 +296,7 @@ export function NewChatWidget({
 				});
 			}}
 			onChipPress={(id) => {
+				if (id === "project" && cloudScope) return;
 				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
 				if (id === "clear-target") {
 					dismiss();

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useNewChatTargets/useNewChatTargets.ts
@@ -3,13 +3,13 @@ import { compareDesc } from "date-fns";
 import { useMemo } from "react";
 import { useCloudProjects } from "@/hooks/useCloudProjects";
 import { toHostProjectItem } from "@/hooks/useHostProjects";
-import { useHostsPresence } from "@/hooks/useHostsPresence";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
-import { useOrgHosts } from "@/hooks/useOrgHosts";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
 } from "@/lib/host-service/client";
+import { useSelectedHost } from "@/screens/(authenticated)/(home)/hooks/useSelectedHost";
+import { useWorkspaceScope } from "@/screens/(authenticated)/(home)/hooks/useWorkspaceScope";
 import { useWorkspacesFilterStore } from "../../../../stores/workspacesFilterStore";
 import { useNewSessionPreferencesStore } from "../../stores/newSessionPreferencesStore";
 
@@ -35,17 +35,18 @@ export function targetKeyFor(projectId: string, machineId: string) {
 }
 
 /**
- * Everywhere a new chat workspace can be created: all (project, online host)
- * pairs from fanning out `project.list` to every online host, plus a cloud
- * target per API-listed project — available with zero machines online. The
- * default pick: last used target, else the filtered project, else the most
- * recently updated workspace's target.
+ * Where a new chat workspace can be created under the current Home scope: the
+ * selected machine's projects (its `project.list`), or a cloud target per
+ * API-listed project when the scope is Cloud. The place is picked by the scope
+ * filter at the top of Home — never here. The default pick: last used target,
+ * else the most recently updated workspace's target.
  */
 export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 	targets: NewChatTarget[];
 	defaultTarget: NewChatTarget | null;
 } {
-	const hosts = useOrgHosts();
+	const scope = useWorkspaceScope();
+	const selectedHost = useSelectedHost();
 	const persistedTargetKey = useNewSessionPreferencesStore(
 		(state) => state.targetKey,
 	);
@@ -56,21 +57,27 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 		(state) => state.hasHydrated,
 	);
 
-	const presence = useHostsPresence(hosts);
-	const onlineHosts = useMemo(
+	// An offline selected machine offers nothing rather than quietly falling
+	// back to another host or Cloud — the scope pick is the user's alone.
+	const scopedHosts = useMemo(
 		() =>
-			hosts
-				.filter((host) => presence?.get(host.machineId) ?? host.isOnline)
-				.map((host) => ({
-					machineId: host.machineId,
-					name: host.name,
-					hostUrl: hostServiceUrl(host.organizationId, host.machineId),
-				})),
-		[hosts, presence],
+			scope === "host" && selectedHost?.isOnline
+				? [
+						{
+							machineId: selectedHost.machineId,
+							name: selectedHost.name,
+							hostUrl: hostServiceUrl(
+								selectedHost.organizationId,
+								selectedHost.machineId,
+							),
+						},
+					]
+				: [],
+		[scope, selectedHost],
 	);
 
 	const projectListQueries = useQueries({
-		queries: onlineHosts.map((host) => ({
+		queries: scopedHosts.map((host) => ({
 			queryKey: ["host-service", "projects", "list", host.machineId],
 			queryFn: () =>
 				getHostServiceClientByUrl(host.hostUrl).project.list.query(),
@@ -84,7 +91,7 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 
 	const targets = useMemo<NewChatTarget[]>(() => {
 		const result: NewChatTarget[] = [];
-		onlineHosts.forEach((host, index) => {
+		scopedHosts.forEach((host, index) => {
 			for (const row of projectListQueries[index]?.data ?? []) {
 				const project = toHostProjectItem(row);
 				result.push({
@@ -99,20 +106,22 @@ export function useNewChatTargets(workspaces: HostWorkspaceItem[] = []): {
 				});
 			}
 		});
-		for (const project of cloudProjects) {
-			result.push({
-				key: targetKeyFor(project.id, CLOUD_TARGET_ID),
-				kind: "cloud",
-				projectId: project.id,
-				projectName: project.name,
-				projectIconUrl: project.iconUrl,
-				machineId: CLOUD_TARGET_ID,
-				hostName: "Cloud",
-				hostUrl: "",
-			});
+		if (scope === "cloud") {
+			for (const project of cloudProjects) {
+				result.push({
+					key: targetKeyFor(project.id, CLOUD_TARGET_ID),
+					kind: "cloud",
+					projectId: project.id,
+					projectName: project.name,
+					projectIconUrl: project.iconUrl,
+					machineId: CLOUD_TARGET_ID,
+					hostName: "Cloud",
+					hostUrl: "",
+				});
+			}
 		}
 		return result.sort((a, b) => a.projectName.localeCompare(b.projectName));
-	}, [onlineHosts, projectListQueries, cloudProjects]);
+	}, [scope, scopedHosts, projectListQueries, cloudProjects]);
 
 	const defaultTarget = useMemo<NewChatTarget | null>(() => {
 		if (targets.length === 0) return null;

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/agent/AgentPickerScreen.tsx
@@ -3,6 +3,7 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { SquareTerminal } from "lucide-react-native";
 import { useMemo } from "react";
 import { Image, Pressable, ScrollView, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
@@ -43,6 +44,7 @@ export function AgentMark({
 export function AgentPickerScreen() {
 	const router = useRouter();
 	const theme = useTheme();
+	const insets = useSafeAreaInsets();
 	const agentId = useNewSessionPreferencesStore((state) => state.agentId);
 	const setAgentId = useNewSessionPreferencesStore((state) => state.setAgentId);
 	const { machineId } = useLocalSearchParams<{ machineId?: string }>();
@@ -100,7 +102,11 @@ export function AgentPickerScreen() {
 	return (
 		<ScrollView
 			className="bg-background flex-1 px-6"
-			contentContainerStyle={{ flexGrow: 1, paddingVertical: 8 }}
+			contentContainerStyle={{
+				flexGrow: 1,
+				paddingTop: 8,
+				paddingBottom: insets.bottom + 8,
+			}}
 		>
 			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.Button icon="xmark" onPress={() => router.back()} />

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/branch/BranchPickerScreen.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
@@ -51,6 +52,7 @@ function BranchRow({
 export function BranchPickerScreen() {
 	const router = useRouter();
 	const theme = useTheme();
+	const insets = useSafeAreaInsets();
 	const [query, setQuery] = useState("");
 	const params = useLocalSearchParams<{
 		projectId?: string;
@@ -158,7 +160,10 @@ export function BranchPickerScreen() {
 			</View>
 			<ScrollView
 				className="bg-background"
-				contentContainerStyle={{ paddingBottom: 24, paddingHorizontal: 24 }}
+				contentContainerStyle={{
+					paddingBottom: insets.bottom + 8,
+					paddingHorizontal: 24,
+				}}
 				keyboardShouldPersistTaps="handled"
 			>
 				{defaultBranch ? (

--- a/apps/mobile/screens/(authenticated)/(home)/new-session/project/ProjectPickerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/new-session/project/ProjectPickerScreen.tsx
@@ -1,9 +1,7 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { Cloud } from "lucide-react-native";
-import { useMemo } from "react";
-import { Pressable, ScrollView, View } from "react-native";
-import { Icon } from "@/components/ui/icon";
+import { Pressable, ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
 import { posthog } from "@/lib/posthog";
@@ -15,14 +13,15 @@ import {
 import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 
 /**
- * One sheet, sectioned by where the workspace would run: Cloud first — it is
- * never offline — then each online machine. A tap picks both the place and
- * the project.
+ * One flat list of the selected machine's projects. Where the workspace runs
+ * is picked at the top of Home, never here — and under Cloud the composer
+ * doesn't open this at all.
  */
 export function ProjectPickerScreen() {
 	const router = useRouter();
 	const routeParams = useLocalSearchParams<{ selectedKey?: string }>();
 	const theme = useTheme();
+	const insets = useSafeAreaInsets();
 	const { targets, defaultTarget } = useNewChatTargets();
 	const targetKey = useNewSessionPreferencesStore((state) => state.targetKey);
 	const setTargetKey = useNewSessionPreferencesStore(
@@ -34,22 +33,6 @@ export function ProjectPickerScreen() {
 		(targets.find((target) => target.key === targetKey)?.key ??
 			defaultTarget?.key ??
 			null);
-
-	const sections = useMemo(() => {
-		const cloud = targets.filter((target) => target.kind === "cloud");
-		const byHost = new Map<string, { name: string; rows: NewChatTarget[] }>();
-		for (const target of targets) {
-			if (target.kind !== "host") continue;
-			const group = byHost.get(target.machineId);
-			if (group) group.rows.push(target);
-			else
-				byHost.set(target.machineId, {
-					name: target.hostName,
-					rows: [target],
-				});
-		}
-		return { cloud, hosts: [...byHost.values()] };
-	}, [targets]);
 
 	const select = (key: string) => {
 		const picked = targets.find((target) => target.key === key);
@@ -88,7 +71,11 @@ export function ProjectPickerScreen() {
 	return (
 		<ScrollView
 			className="bg-background flex-1 px-6"
-			contentContainerStyle={{ flexGrow: 1, paddingVertical: 8 }}
+			contentContainerStyle={{
+				flexGrow: 1,
+				paddingTop: 8,
+				paddingBottom: insets.bottom + 8,
+			}}
 		>
 			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.Button icon="xmark" onPress={() => router.back()} />
@@ -101,36 +88,7 @@ export function ProjectPickerScreen() {
 					No projects available
 				</Text>
 			) : null}
-			{sections.cloud.length > 0 ? (
-				<>
-					<View className="flex-row items-center gap-2 pb-1 pt-2">
-						<Icon
-							as={Cloud}
-							className="text-muted-foreground size-4"
-							strokeWidth={1.75}
-						/>
-						<Text className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
-							Cloud
-						</Text>
-					</View>
-					{sections.cloud.map(renderRow)}
-				</>
-			) : null}
-			{sections.hosts.map((host, index) => (
-				<View
-					key={host.name + String(index)}
-					className={
-						sections.cloud.length > 0 || index > 0
-							? "border-border/60 mt-3 border-t pt-3"
-							: undefined
-					}
-				>
-					<Text className="text-muted-foreground pb-1 text-xs font-semibold uppercase tracking-wide">
-						{host.name}
-					</Text>
-					{host.rows.map(renderRow)}
-				</View>
-			))}
+			{targets.map(renderRow)}
 		</ScrollView>
 	);
 }


### PR DESCRIPTION
## Summary
- The new-session project picker lists only the projects for the place picked at the top of Home — the selected machine, or Cloud — instead of every online machine plus a Cloud section.
- Under Cloud scope the composer chip just says "Cloud" and doesn't open a picker: a sandbox has no real project structure yet.
- The last row of the project/agent/branch pickers no longer sits under the home indicator.

## Why / Context
#6651 fanned `project.list` across every online host and appended a cloud target per API project, and the picker rendered all of it in sections. Home already has a scope filter that picks Cloud or a machine, so the picker was choosing the place twice. Its Cloud section was also the retired `v2_projects` catalog — nothing writes that table since #6436 (`docs/cloud-sandbox-considerations.md` › Model tracks it as Open), so presenting it as a project structure was noise.

Separately, the picker's scroll content had 8px of bottom padding, so the last row sat under the home indicator and was only visible by over-scrolling.

## How It Works
- `useNewChatTargets` reads `useWorkspaceScope` + `useSelectedHost`. Host scope → that machine's `project.list` only, and only while it's online (an offline pick offers nothing rather than quietly moving you to another host or Cloud — same stance as the scope filter). Cloud scope → the API's cloud projects only. The composer, branch query and create path all hang off this hook, so switching scope at the top of Home re-targets the composer without re-picking.
- `ProjectPickerScreen` is a flat list; the Cloud/host section headers are gone.
- `NewChatWidget`: under Cloud the project chip is a plain "Cloud" label and inert. The row the create resolves against is still picked the way `defaultTarget` always did (last used, else first alphabetically) — the request is unchanged, the id just isn't surfaced. The "· Cloud" chip suffix is gone under host scope since the scope filter already says where you are.
- The three pickers pad their scroll content by `insets.bottom + 8`.

## Manual QA Checklist
Run on an iPhone 17 (iOS 26) sim against production with a live host:
- [x] App boots and lists real workspaces under both the machine scope and Cloud scope
- [ ] Host scope: composer project chip opens a flat list of that machine's projects, no Cloud section
- [ ] Cloud scope: composer header reads "Cloud · <branch>", tapping "Cloud" does nothing, branch chip still lists remote branches
- [ ] Flip scope at the top of Home → composer re-targets without re-picking
- [ ] Project picker: last row fully visible without over-scrolling
- [ ] Agent and branch pickers unchanged apart from bottom padding

## Testing
- `bun run test` in `apps/mobile`: 47 pass
- `bunx biome check` on the changed files: clean
- `bunx turbo typecheck --filter=@superset/mobile`: no errors in the changed files (18 pre-existing errors in `packages/workspace-fs`, unrelated)

## Known Limitations
- Cloud create still depends on a legacy `v2_projects` row. With several rows in an org, which repo the sandbox clones is an invisible last-used-or-first choice from the phone. Internal-only, and it goes away when the environment entity replaces the row — the UI here won't need to change.
- Host scope with the selected machine offline offers no projects, by design.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the new-session project picker to the place already picked at the top of Home, so it no longer lists every online machine's projects plus a Cloud section. Under Cloud scope the composer chip reads just "Cloud" and opens nothing, since a sandbox has no project structure yet. Also pads the picker scroll content by the bottom safe-area inset so the last row no longer sits under the home indicator.

- Project targets now come only from the selected machine (host scope) or the API's cloud projects (Cloud scope); an offline selected machine offers no projects.
- Cloud create still resolves against a legacy `v2_projects` row, unchanged, but the id is no longer surfaced in the UI.
- Agent and branch pickers changed only for the bottom padding fix.

<sup>Written for commit 46896da9dd76e42ed0b0ea610eb98e17d5246a7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New chat targets now reflect the selected Home scope, showing only relevant host or cloud projects.
  - Cloud targets are clearly identified with a non-interactive Cloud chip.
  - Project selection now displays all available targets in a single, streamlined list.

- **Bug Fixes**
  - Improved picker layouts on devices with home indicators and display cutouts by applying safe-area spacing.
  - Cloud chips no longer trigger navigation or haptic feedback when pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->