### PR TITLE
refactor(ui,chat-ui,desktop): one clipboard-file reader for every paste handler

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor/MarkdownEditor.tsx
@@ -1,6 +1,7 @@
 import "../../styles/hljs-github.css";
 import "./markdown-editor.css";
 
+import { getClipboardFiles } from "@superset/ui/lib/clipboard-files";
 import { cn } from "@superset/ui/utils";
 import { Extension } from "@tiptap/core";
 import { Blockquote } from "@tiptap/extension-blockquote";
@@ -180,25 +181,6 @@ function isMarkdownTable(text: string): boolean {
 	}
 
 	return /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(lines[1]);
-}
-
-function getClipboardFiles(data: DataTransfer | null): File[] {
-	if (!data) return [];
-
-	const files = Array.from(data.files ?? []);
-	const fileKeys = new Set(files.map((file) => `${file.name}:${file.size}`));
-
-	for (const item of Array.from(data.items ?? [])) {
-		if (item.kind !== "file") continue;
-		const file = item.getAsFile();
-		if (!file) continue;
-		const key = `${file.name}:${file.size}`;
-		if (fileKeys.has(key)) continue;
-		fileKeys.add(key);
-		files.push(file);
-	}
-
-	return files;
 }
 
 export function MarkdownEditor({

--- a/apps/desktop/src/renderer/components/TiptapPromptEditor/TiptapPromptEditor.tsx
+++ b/apps/desktop/src/renderer/components/TiptapPromptEditor/TiptapPromptEditor.tsx
@@ -10,6 +10,7 @@ import {
 	CommandItem,
 	CommandList,
 } from "@superset/ui/command";
+import { getClipboardFiles } from "@superset/ui/lib/clipboard-files";
 import { Popover, PopoverAnchor, PopoverContent } from "@superset/ui/popover";
 import { cn } from "@superset/ui/utils";
 import { type Editor, Extension } from "@tiptap/core";
@@ -572,12 +573,7 @@ export function TiptapPromptEditor({
 			},
 
 			handlePaste: (_view, event) => {
-				const clipItems = event.clipboardData?.items;
-				if (!clipItems) return false;
-				const files = Array.from(clipItems)
-					.filter((i) => i.kind === "file")
-					.map((i) => i.getAsFile())
-					.filter((f): f is File => f !== null);
+				const files = getClipboardFiles(event.clipboardData);
 				if (files.length > 0) {
 					event.preventDefault();
 					attachmentsRef.current.add(files);

--- a/packages/chat-ui/src/components/PromptInput/components/ComposerBody/ComposerBody.tsx
+++ b/packages/chat-ui/src/components/PromptInput/components/ComposerBody/ComposerBody.tsx
@@ -6,6 +6,7 @@ import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
 import { LexicalTypeaheadMenuPlugin } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { getClipboardFiles } from "@superset/ui/lib/clipboard-files";
 import { cn } from "@superset/ui/utils";
 import {
 	$createNodeSelection,
@@ -325,9 +326,9 @@ export function ComposerBody({
 		const unregisterPaste = editor.registerCommand<ClipboardEvent>(
 			PASTE_COMMAND,
 			(event) => {
-				const files =
-					event instanceof ClipboardEvent ? event.clipboardData?.files : null;
-				if (files && files.length > 0) {
+				if (!(event instanceof ClipboardEvent)) return false;
+				const files = getClipboardFiles(event.clipboardData);
+				if (files.length > 0) {
 					event.preventDefault();
 					addFilesRef.current(files);
 					return true;

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -35,6 +35,7 @@ import {
 	useState,
 	useSyncExternalStore,
 } from "react";
+import { getClipboardFiles } from "../../lib/clipboard-files";
 import { isEnterSubmit } from "../../lib/keyboard";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
@@ -1102,23 +1103,7 @@ export const PromptInputTextarea = ({
 	};
 
 	const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {
-		const items = event.clipboardData?.items;
-
-		if (!items) {
-			return;
-		}
-
-		const files: File[] = [];
-
-		for (const item of items) {
-			if (item.kind === "file") {
-				const file = item.getAsFile();
-				if (file) {
-					files.push(file);
-				}
-			}
-		}
-
+		const files = getClipboardFiles(event.clipboardData);
 		if (files.length > 0) {
 			event.preventDefault();
 			attachments.add(files);

--- a/packages/ui/src/lib/clipboard-files.test.ts
+++ b/packages/ui/src/lib/clipboard-files.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { getClipboardFiles } from "./clipboard-files";
+
+function makeFile(
+	name: string,
+	bytes: string,
+	options: { type?: string; lastModified?: number } = {},
+): File {
+	return new File([bytes], name, {
+		type: options.type ?? "image/png",
+		lastModified: options.lastModified ?? 1,
+	});
+}
+
+/**
+ * A clipboard payload. `items` is given explicitly because the whole point of
+ * the helper is that it does not mirror `files` — a real multi-file paste can
+ * surface one item for several files.
+ */
+function makeTransfer(options: {
+	files?: File[];
+	items?: Array<{ kind: string; file?: File | null }>;
+}): DataTransfer {
+	return {
+		files: options.files ?? [],
+		items: (options.items ?? []).map((item) => ({
+			kind: item.kind,
+			getAsFile: () => item.file ?? null,
+		})),
+	} as unknown as DataTransfer;
+}
+
+describe("getClipboardFiles", () => {
+	it("returns every file when the payload carries several", () => {
+		const a = makeFile("a.png", "a");
+		const b = makeFile("b.png", "bb");
+		const c = makeFile("c.png", "ccc");
+
+		expect(
+			getClipboardFiles(
+				makeTransfer({
+					files: [a, b, c],
+					// A Finder copy of three files: both lists carry all three.
+					items: [
+						{ kind: "file", file: a },
+						{ kind: "file", file: b },
+						{ kind: "file", file: c },
+					],
+				}),
+			),
+		).toEqual([a, b, c]);
+	});
+
+	it("falls back to items when the payload exposes no files list", () => {
+		const a = makeFile("a.png", "a");
+		const b = makeFile("b.png", "bb");
+
+		expect(
+			getClipboardFiles(
+				makeTransfer({
+					files: [],
+					items: [
+						{ kind: "file", file: a },
+						{ kind: "file", file: b },
+					],
+				}),
+			),
+		).toEqual([a, b]);
+	});
+
+	it("counts a file listed in both sources once", () => {
+		const a = makeFile("a.png", "a");
+		const b = makeFile("b.png", "bb");
+
+		expect(
+			getClipboardFiles(
+				makeTransfer({
+					files: [a, b],
+					items: [
+						{ kind: "file", file: a },
+						{ kind: "file", file: b },
+					],
+				}),
+			),
+		).toEqual([a, b]);
+	});
+
+	it("counts a file once when the two lists disagree on lastModified", () => {
+		// Chromium builds a separate File per accessor and timestamps each on
+		// creation, so the same pasted screenshot arrives a millisecond apart in
+		// the two lists. Keying on lastModified attaches every image twice.
+		const viaFiles = makeFile("image.png", "xy", {
+			lastModified: 1787880688223,
+		});
+		const viaItems = makeFile("image.png", "xy", {
+			lastModified: 1787880688224,
+		});
+
+		expect(
+			getClipboardFiles(
+				makeTransfer({
+					files: [viaFiles],
+					items: [{ kind: "file", file: viaItems }],
+				}),
+			),
+		).toEqual([viaFiles]);
+	});
+
+	it("ignores string items and items with no file behind them", () => {
+		const a = makeFile("a.png", "a");
+
+		expect(
+			getClipboardFiles(
+				makeTransfer({
+					files: [],
+					items: [
+						{ kind: "string" },
+						{ kind: "file", file: null },
+						{ kind: "file", file: a },
+					],
+				}),
+			),
+		).toEqual([a]);
+	});
+
+	it("returns nothing for an absent or empty payload", () => {
+		expect(getClipboardFiles(null)).toEqual([]);
+		expect(getClipboardFiles(undefined)).toEqual([]);
+		expect(getClipboardFiles(makeTransfer({}))).toEqual([]);
+	});
+});

--- a/packages/ui/src/lib/clipboard-files.ts
+++ b/packages/ui/src/lib/clipboard-files.ts
@@ -1,0 +1,42 @@
+/**
+ * Every File carried by a clipboard or drag payload, in order.
+ *
+ * Reads both lists a `DataTransfer` exposes and merges them. Measured against
+ * a real macOS pasteboard, the two agree on every payload shape we could
+ * produce (Finder copies of one or many files, mixed file types, screenshots,
+ * images alongside text or HTML), so `files` alone is what actually carries a
+ * paste today; `items` stays in as a fallback for any payload that surfaces a
+ * file only through `getAsFile()`.
+ *
+ * De-duplicate on name, size and type, and on nothing else. Chromium
+ * synthesizes a separate File object per accessor and stamps each one's
+ * `lastModified` with `Date.now()` as it is created, so the two lists disagree
+ * about the same pasted screenshot whenever the millisecond ticks between the
+ * calls. Folding that field into the key attaches the image twice, on roughly
+ * one paste in eight (measured over CDP against a real pasteboard) — an
+ * intermittent duplicate is worse to chase than a consistent one.
+ */
+export function getClipboardFiles(
+	data: DataTransfer | null | undefined,
+): File[] {
+	if (!data) return [];
+
+	const files = Array.from(data.files ?? []);
+	const seen = new Set(files.map(fileKey));
+
+	for (const item of Array.from(data.items ?? [])) {
+		if (item.kind !== "file") continue;
+		const file = item.getAsFile();
+		if (!file) continue;
+		const key = fileKey(file);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		files.push(file);
+	}
+
+	return files;
+}
+
+function fileKey(file: File): string {
+	return `${file.name}:${file.size}:${file.type}`;
+}


### PR DESCRIPTION
## Summary

- Adds `getClipboardFiles` to `packages/ui/src/lib/` and routes all four paste
  handlers through it, replacing three divergent implementations.
- **No behaviour change.** This started as a fix for a reported "multipaste
  doesn't work when pasting multiple things at the same time" bug. I could not
  reproduce that bug, and the measurements below are the evidence.

## Why / Context

Four handlers each read files off a `DataTransfer` their own way:

| Handler | Read from |
|---|---|
| `packages/ui` `PromptInputTextarea` | `items` only |
| desktop `TiptapPromptEditor` | `items` only |
| `chat-ui` `ComposerBody` (Lexical) | `files` only |
| desktop `MarkdownEditor` | both, de-duplicated |

The merged form in `MarkdownEditor` arrived with #5283, when pasted images went
missing from the new-workspace prompt. It was never shared, so the other three
kept their own shapes.

## What the measurements showed

Driven over CDP against the real desktop app: files written to the macOS
pasteboard with `NSPasteboard.writeObjects`, focused by a real click, pasted
with a real Cmd+V. All candidate implementations were run against the *same*
live paste event, so the comparison is exact.

| Payload | files | items | itemsOnly | filesOnly | union(name:size) | union(+lastModified) |
|---|---|---|---|---|---|---|
| 3 PNGs (Finder copy) | 3 | 3 | 3 | 3 | 3 | 3 |
| png + pdf + txt | 3 | 3 | 3 | 3 | 3 | 3 |
| screenshot bytes | 1 | 1 | 1 | 1 | 1 | **2** |
| 3 images as raw bytes | 1 | 1 | 1 | 1 | 1 | 1 |
| image + text | 1 | 2 | 1 | 1 | 1 | **2** |
| same name + same size x2 | 2 | 2 | 2 | 2 | 2 | 2 |
| html + image | 1 | 2 | 1 | 1 | 1 | 1 |

Three conclusions:

1. **`items` never under-reported against `files`.** The multi-file paste bug
   does not reproduce on any payload shape I could construct. The three
   pre-existing implementations are equivalent in practice.
2. **Never key clipboard de-duplication on `lastModified`.** Chromium
   synthesizes a separate `File` per accessor and stamps each with `Date.now()`
   as it is created, so the same pasted screenshot came back as `...223` via
   `files` and `...224` via `items`. I had "strengthened" the key that way; it
   duplicates the attachment. Reverted, and there is now a test for it.
3. **Copying several images as raw bytes yields one file to the page** (3
   NSImages written, `files.length === 1`). That loss happens at the
   Chromium/macOS pasteboard boundary, so no JS handler can recover images 2..n.
   Not addressed here.

## Before / after

The one defect I could reproduce end to end is the `lastModified` duplicate, so
that is what the before/after covers. Eight identical single-image pastes:

```
BEFORE (lastModified in key): per-paste cards [1,1,2,1,1,1,1,1]  total 9  duplicated 1/8
AFTER  (name:size:type):      per-paste cards [1,1,1,1,1,1,1,1]  total 8  duplicated 0/8
```

It is intermittent by nature: it fires only when the millisecond ticks between
the two accessor calls, which makes it the kind of duplicate that is painful to
chase in the wild.

## Manual QA

Verified in the running desktop app (this worktree, Vite 4625), signed in, with
real pasteboard payloads and real Cmd+V.

### New-workspace composer
- [x] Finder copy of 3 PNGs attaches 3 cards, correct thumbnails
- [x] Mixed png + pdf + txt attaches 3 cards (image card plus two file cards)
- [x] Screenshot bytes attach exactly one card, repeatedly (20 consecutive pastes)
- [x] Two files with identical name and identical byte size both attach
- [x] Image + text and HTML + image attach the image
- [x] Text-only paste still inserts text and attaches nothing

### Terminal pane
- [x] 3-file paste is intercepted by the existing image-paste fallback: all 3
      files present in the payload, event does not reach `document`, no path or
      garbage inserted
- [x] Text paste still reaches the PTY
- [x] `terminal-image-paste-fallback.ts` is untouched by this PR

## Testing

- `bun test packages/ui/src packages/chat-ui/src` (41 pass)
- 6 new tests in `clipboard-files.test.ts`; confirmed each fails against the
  implementation it guards (items-only, and the `lastModified` key)
- `bun run --cwd packages/ui typecheck`, `bun run --cwd packages/chat-ui typecheck`,
  `bun run --cwd apps/desktop typecheck`
- `bunx biome check`, `bunx sherif`
- Pre-existing unrelated failures in
  `apps/desktop/src/renderer/lib/terminal/font-settle.test.ts` (fail on a clean
  checkout of that file, import nothing this PR touches)

## Design decisions

- **Merge both lists rather than pick one.** They agree today, so this is
  belt-and-braces. It cannot return fewer files than any implementation it
  replaces, which is the property worth having in shared code.
- **De-duplicate on `name:size:type`.** The only fields stable across the two
  accessors. See conclusion 2.

## Known limitations

- Several images copied as raw bytes still arrive as one file. Upstream of this
  code.
- `maxFiles` and `maxFileSize` on `PromptInput` are ignored when a controller
  provider is supplied, since the provider's `add` skips the local filters.
  Pre-existing, unrelated, not touched here.

## Risks / Rollout

- Risk: low. Pure consolidation, no behaviour change measured across seven
  payload shapes and four surfaces.
- Rollback: revert the two commits; each handler's previous implementation is
  restored intact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates all four paste handlers onto one shared `getClipboardFiles` helper and fixes an intermittent duplicate-attachment bug. `MarkdownEditor` previously de-duplicated on `lastModified`, which Chromium stamps anew per accessor, so roughly one in eight identical image pastes attached the image twice; the new helper keys on `name:size:type` instead.

**Refactors**
- Replaces the two `items`-only readers, the `files`-only reader, and the merged `MarkdownEditor` reader with one helper in `packages/ui/src/lib/`.
- Measured against a real macOS pasteboard, all implementations returned the same files, so this is consolidation, not a behavior change.
- Adds 6 tests in `clipboard-files.test.ts`, including one that guards against the `lastModified` key.

<sup>Written for commit 074debd20654f2b1afafee0711a812fb7b843550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file attachment handling when pasting content into editors and prompt fields.
  * Prevented duplicate pasted files and ensured files are detected across supported clipboard formats.
  * Gracefully handles empty, unavailable, or non-file clipboard content.

* **Tests**
  * Added coverage for clipboard file extraction, deduplication, fallback behavior, and invalid clipboard data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->