### PR TITLE
fix(mobile): move workspace search into a sheet with the native search bar

### DIFF
--- a/apps/mobile/app/(authenticated)/(home)/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/(home)/_layout.tsx
@@ -10,6 +10,15 @@ export default function HomeLayout() {
 		>
 			<Stack.Screen name="index" options={{ title: "" }} />
 			<Stack.Screen
+				name="search"
+				options={{
+					presentation: "formSheet",
+					title: "Search",
+					sheetAllowedDetents: [1.0],
+					sheetGrabberVisible: true,
+				}}
+			/>
+			<Stack.Screen
 				name="filter"
 				options={{
 					presentation: "formSheet",

--- a/apps/mobile/app/(authenticated)/(home)/search.tsx
+++ b/apps/mobile/app/(authenticated)/(home)/search.tsx
@@ -1,0 +1,3 @@
+import { SearchScreen } from "@/screens/(authenticated)/(home)/search";
+
+export default SearchScreen;

--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -2,13 +2,10 @@ import { LegendList } from "@legendapp/list/react-native";
 import { useQueryClient } from "@tanstack/react-query";
 import { isAfter } from "date-fns";
 import * as Haptics from "expo-haptics";
-import { useFocusEffect, useRouter } from "expo-router";
-import { Search } from "lucide-react-native";
+import { Stack, useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
 import { RefreshControl, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Icon } from "@/components/ui/icon";
-import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import {
 	type CloudWorkspaceStatus,
@@ -81,7 +78,6 @@ type HomeListItem =
 			workspace: HostWorkspaceItem;
 			cloudStatus?: CloudWorkspaceStatus;
 	  }
-	| { kind: "note"; label: string }
 	| { kind: "hostOffline"; hostName: string };
 
 function homeListItemKey(item: HomeListItem): string {
@@ -90,10 +86,8 @@ function homeListItemKey(item: HomeListItem): string {
 			return `project:${item.projectId}`;
 		case "workspace":
 			return `ws:${item.workspace.id}`;
-		case "hostOffline":
-			return "host-offline";
 		default:
-			return `note:${item.label}`;
+			return "host-offline";
 	}
 }
 
@@ -101,7 +95,6 @@ export function HomeScreen() {
 	const router = useRouter();
 	const sort = useWorkspacesFilterStore((store) => store.sort);
 	const hasHydrated = useWorkspacesFilterStore((store) => store.hasHydrated);
-	const [searchQuery, setSearchQuery] = useState("");
 	const [visibleIds, setVisibleIds] = useState<string[]>([]);
 	const [refreshing, setRefreshing] = useState(false);
 	const { height: windowHeight } = useWindowDimensions();
@@ -157,8 +150,6 @@ export function HomeScreen() {
 		(state) => state.toggleProject,
 	);
 
-	const searching = searchQuery.trim().length > 0;
-
 	// Recency ranks a workspace by its latest activity — the newest of its own
 	// update and its terminals'.
 	const activityTs = useCallback(
@@ -196,48 +187,13 @@ export function HomeScreen() {
 		[workspaces],
 	);
 
-	const projectNamesById = useMemo(
-		() => new Map(projects.map((project) => [project.id, project.name])),
-		[projects],
-	);
-
-	const matchesQuery = useCallback(
-		(workspace: HostWorkspaceItem) => {
-			const needle = searchQuery.trim().toLowerCase();
-			if (!needle) return true;
-			const sessions = terminalsByWorkspace.get(workspace.id) ?? [];
-			return (
-				workspace.name.toLowerCase().includes(needle) ||
-				workspace.branch.toLowerCase().includes(needle) ||
-				(
-					(workspace.projectId
-						? projectNamesById.get(workspace.projectId)
-						: undefined) ?? ""
-				)
-					.toLowerCase()
-					.includes(needle) ||
-				sessions.some((row) => row.title.toLowerCase().includes(needle))
-			);
-		},
-		[searchQuery, projectNamesById, terminalsByWorkspace],
-	);
-
 	const listItems = useMemo<HomeListItem[]>(() => {
 		const items: HomeListItem[] = [];
 
 		// Under Cloud the sandboxes are the whole list: flat, no project headers
 		// to group them by and no machine to be offline.
 		if (cloudScope) {
-			const cloudPool = searching
-				? cloudItems.filter(matchesQuery)
-				: cloudItems;
-			if (searching) {
-				items.push({
-					kind: "note",
-					label: `${cloudPool.length} ${cloudPool.length === 1 ? "result" : "results"} in Cloud`,
-				});
-			}
-			for (const workspace of [...cloudPool].sort(byPinThenActivity)) {
+			for (const workspace of [...cloudItems].sort(byPinThenActivity)) {
 				items.push({
 					kind: "workspace",
 					workspace,
@@ -254,21 +210,9 @@ export function HomeScreen() {
 			return items;
 		}
 
-		const onThisHost = liveWorkspaces.filter(
+		const pool = liveWorkspaces.filter(
 			(workspace) => workspace.hostId === selectedHost?.machineId,
 		);
-
-		// Search reaches every project on this host but no further — the
-		// workspace query is per-host, so other machines aren't in memory to
-		// search. The count says "on this host" rather than implying otherwise.
-		const pool = searching ? onThisHost.filter(matchesQuery) : onThisHost;
-
-		if (searching) {
-			items.push({
-				kind: "note",
-				label: `${pool.length} ${pool.length === 1 ? "result" : "results"} on this host`,
-			});
-		}
 
 		// A project id the host no longer reports is as good as none: grouping
 		// under it would render the workspace nowhere, since sections come from
@@ -310,7 +254,6 @@ export function HomeScreen() {
 
 		for (const section of sections) {
 			const isCollapsed =
-				!searching &&
 				collapseHydrated &&
 				!!collapsed[
 					collapsedProjectKey(selectedHost?.machineId ?? "", section.project.id)
@@ -351,8 +294,6 @@ export function HomeScreen() {
 		cloudScope,
 		selectedHost,
 		projects,
-		searching,
-		matchesQuery,
 		byPinThenActivity,
 		activityTs,
 		collapsed,
@@ -474,13 +415,6 @@ export function HomeScreen() {
 
 	const renderItem = useCallback(
 		({ item }: { item: HomeListItem }) => {
-			if (item.kind === "note") {
-				return (
-					<Text className="text-muted-foreground px-4 pb-1 pt-3 font-semibold text-xs">
-						{item.label}
-					</Text>
-				);
-			}
 			if (item.kind === "hostOffline") {
 				return (
 					<View className="py-16">
@@ -557,37 +491,6 @@ export function HomeScreen() {
 		/>
 	);
 
-	// Search lives in the page, not the native header: activating a
-	// UISearchController on iOS 26 lays an invisible view over the screen's
-	// content that swallows every touch — results can't be tapped and search
-	// won't dismiss (unfixed through rns 4.27 / iOS 26.5).
-	const listHeader = (
-		<>
-			<View className="px-4 pb-1 pt-1">
-				<View className="relative justify-center">
-					<View className="absolute left-3 z-10">
-						<Icon
-							as={Search}
-							className="text-muted-foreground size-4"
-							strokeWidth={2}
-						/>
-					</View>
-					<Input
-						autoCapitalize="none"
-						autoCorrect={false}
-						className="rounded-full pl-9"
-						clearButtonMode="always"
-						returnKeyType="search"
-						onChangeText={setSearchQuery}
-						placeholder="Search workspaces"
-						value={searchQuery}
-					/>
-				</View>
-			</View>
-			{scopeBar}
-		</>
-	);
-
 	return (
 		<>
 			<OrganizationHeaderButton
@@ -599,6 +502,23 @@ export function HomeScreen() {
 					router.push("/(authenticated)/(home)/organizations");
 				}}
 			/>
+			{/* Search opens as a sheet rather than a search bar in this header: on
+			    a root screen a UISearchController on iOS 26 lays an invisible view
+			    over the content that swallows every touch (#6659); on the sheet's
+			    own header the same bar works. Hidden while the host is
+			    offline — its list isn't shown, so there is nothing to search. */}
+			{!cloudScope && selectedHost && !selectedHost.isOnline ? null : (
+				<Stack.Toolbar placement="right">
+					<Stack.Toolbar.Button
+						icon="magnifyingglass"
+						accessibilityLabel="Search workspaces"
+						onPress={() => {
+							void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+							router.push("/(authenticated)/(home)/search");
+						}}
+					/>
+				</Stack.Toolbar>
+			)}
 			{!cloudScope && selectedHost && !selectedHost.isOnline ? (
 				<View
 					className="bg-background flex-1"
@@ -626,7 +546,7 @@ export function HomeScreen() {
 					extraData={renderItem}
 					keyExtractor={homeListItemKey}
 					renderItem={renderItem}
-					ListHeaderComponent={listHeader}
+					ListHeaderComponent={scopeBar}
 					viewabilityConfig={VIEWABILITY_CONFIG}
 					onViewableItemsChanged={onViewableItemsChanged}
 					refreshControl={
@@ -636,11 +556,9 @@ export function HomeScreen() {
 						isReady && cloudReady && hasHydrated && !isLoadingOrganizations ? (
 							<View className="items-center justify-center py-20">
 								<Text className="text-center text-muted-foreground">
-									{searching
-										? "No workspaces match your search"
-										: cloudScope
-											? "No cloud workspaces yet"
-											: "No projects on this host yet"}
+									{cloudScope
+										? "No cloud workspaces yet"
+										: "No projects on this host yet"}
 								</Text>
 							</View>
 						) : null

--- a/apps/mobile/screens/(authenticated)/(home)/search/SearchScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/search/SearchScreen.tsx
@@ -1,0 +1,252 @@
+import {
+	type NativeStackNavigationProp,
+	Stack,
+	useNavigation,
+	useRouter,
+} from "expo-router";
+import { FolderGit2 } from "lucide-react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FlatList, Pressable, View } from "react-native";
+import type { SearchBarCommands } from "react-native-screens";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+import { useCloudWorkspaceItems } from "@/hooks/useCloudWorkspaceItems";
+import { useHostProjects } from "@/hooks/useHostProjects";
+import {
+	type HostWorkspaceItem,
+	useHostWorkspaces,
+} from "@/hooks/useHostWorkspaces";
+import { useTheme } from "@/hooks/useTheme";
+import {
+	type TerminalsHost,
+	useHostsTerminals,
+} from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
+import { useWorkspacesFilterStore } from "@/screens/(authenticated)/(home)/home/stores/workspacesFilterStore";
+import { useSelectedHost } from "@/screens/(authenticated)/(home)/hooks/useSelectedHost";
+import { useWorkspaceScope } from "@/screens/(authenticated)/(home)/hooks/useWorkspaceScope";
+import { usePinnedWorkspacesStore } from "@/screens/(authenticated)/stores/pinnedWorkspacesStore";
+
+/**
+ * The native search bar lives in this sheet, not on the home screen: on a
+ * root screen, activating a UISearchController on iOS 26 lays an invisible
+ * view over the content that swallows every touch (#6659, unfixed through
+ * react-native-screens 4.27 / iOS 26.5). On a formSheet's own header the same bar activates
+ * properly — results tap, search dismisses (verified iOS 26.0). A nested
+ * Stack inside the sheet never activates the controller, so no cancel ✕.
+ *
+ * The pool mirrors the home list's scope: the selected machine's workspaces,
+ * or Cloud's sandboxes — the workspace query is per-host, so other machines
+ * aren't in memory to search. The count row says which pool answered.
+ */
+export function SearchScreen() {
+	const router = useRouter();
+	const navigation =
+		useNavigation<NativeStackNavigationProp<Record<string, undefined>>>();
+	const theme = useTheme();
+	const searchBarRef = useRef<SearchBarCommands>(null);
+	const [query, setQuery] = useState("");
+	const sort = useWorkspacesFilterStore((store) => store.sort);
+	const selectedHost = useSelectedHost();
+	const cloudScope = useWorkspaceScope() === "cloud";
+	const { workspaces } = useHostWorkspaces(selectedHost);
+	const { items: cloudItems, targets: sandboxes } = useCloudWorkspaceItems();
+	const { projects } = useHostProjects(selectedHost);
+	const pinnedAt = usePinnedWorkspacesStore((state) => state.pinnedAt);
+
+	// Same hosts the home list polls, so the query keys are shared and the
+	// sheet decorates from cache instead of paying its own fan-out.
+	const terminalHosts = useMemo<TerminalsHost[]>(
+		() =>
+			cloudScope
+				? sandboxes.map((sandbox) => ({
+						organizationId: sandbox.organizationId,
+						machineId: sandbox.workspaceId,
+						isOnline: true,
+						refetchIntervalMs: 30_000,
+					}))
+				: selectedHost
+					? [selectedHost]
+					: [],
+		[selectedHost, sandboxes, cloudScope],
+	);
+	const { terminalsByWorkspace } = useHostsTerminals(terminalHosts);
+
+	const projectNamesById = useMemo(
+		() => new Map(projects.map((project) => [project.id, project.name])),
+		[projects],
+	);
+
+	const matchesQuery = useCallback(
+		(workspace: HostWorkspaceItem) => {
+			const needle = query.trim().toLowerCase();
+			if (!needle) return true;
+			const sessions = terminalsByWorkspace.get(workspace.id) ?? [];
+			return (
+				workspace.name.toLowerCase().includes(needle) ||
+				workspace.branch.toLowerCase().includes(needle) ||
+				(
+					(workspace.projectId
+						? projectNamesById.get(workspace.projectId)
+						: undefined) ?? ""
+				)
+					.toLowerCase()
+					.includes(needle) ||
+				sessions.some((row) => row.title.toLowerCase().includes(needle))
+			);
+		},
+		[query, projectNamesById, terminalsByWorkspace],
+	);
+
+	const activityTs = useCallback(
+		(workspace: HostWorkspaceItem) => {
+			const workspaceTs = new Date(workspace[sort]).getTime();
+			if (sort !== "updatedAt") return workspaceTs;
+			const terminalTs = (terminalsByWorkspace.get(workspace.id) ?? []).reduce(
+				(newest, row) => Math.max(newest, row.ts),
+				0,
+			);
+			return Math.max(workspaceTs, terminalTs);
+		},
+		[sort, terminalsByWorkspace],
+	);
+
+	const byPinThenActivity = useCallback(
+		(a: HostWorkspaceItem, b: HostWorkspaceItem) => {
+			const aPin = pinnedAt[a.id];
+			const bPin = pinnedAt[b.id];
+			if (aPin !== undefined || bPin !== undefined) {
+				if (aPin === undefined) return 1;
+				if (bPin === undefined) return -1;
+				return aPin - bPin;
+			}
+			return activityTs(b) - activityTs(a);
+		},
+		[pinnedAt, activityTs],
+	);
+
+	const results = useMemo(() => {
+		const pool = cloudScope
+			? cloudItems
+			: workspaces.filter(
+					(workspace) =>
+						workspace.worktreeExists !== false &&
+						workspace.hostId === selectedHost?.machineId,
+				);
+		return pool.filter(matchesQuery).sort(byPinThenActivity);
+	}, [
+		cloudScope,
+		cloudItems,
+		workspaces,
+		selectedHost,
+		matchesQuery,
+		byPinThenActivity,
+	]);
+
+	const searching = query.trim().length > 0;
+
+	// `autoFocus` is Android-only in react-native-screens. Focusing at mount
+	// lands on a bar the sheet has not installed in its header yet, so wait
+	// for the presentation to finish.
+	useEffect(
+		() =>
+			navigation.addListener("transitionEnd", (event) => {
+				if (!event.data.closing) searchBarRef.current?.focus();
+			}),
+		[navigation],
+	);
+
+	const open = useCallback(
+		(workspace: HostWorkspaceItem) => {
+			// A push alone would land behind this sheet — the modal sits above
+			// the whole stack — so close first; the routing queue keeps order.
+			router.back();
+			router.push(`/(authenticated)/workspace/${workspace.id}`);
+		},
+		[router],
+	);
+
+	return (
+		<>
+			<Stack.Toolbar placement="left">
+				<Stack.Toolbar.Button
+					icon="xmark"
+					accessibilityLabel="Close"
+					onPress={() => router.back()}
+				/>
+			</Stack.Toolbar>
+			<Stack.SearchBar
+				ref={searchBarRef}
+				placeholder="Search workspaces"
+				placement="stacked"
+				hideWhenScrolling={false}
+				hideNavigationBar={false}
+				obscureBackground={false}
+				textColor={theme.foreground}
+				hintTextColor={theme.mutedForeground}
+				tintColor={theme.foreground}
+				onChangeText={(event) => setQuery(event.nativeEvent.text)}
+				onCancelButtonPress={() => setQuery("")}
+			/>
+			<FlatList
+				className="bg-background"
+				contentInsetAdjustmentBehavior="automatic"
+				contentContainerClassName="pb-8"
+				data={results}
+				keyExtractor={(workspace) => workspace.id}
+				keyboardDismissMode="on-drag"
+				keyboardShouldPersistTaps="handled"
+				ListHeaderComponent={
+					searching ? (
+						<Text className="text-muted-foreground px-4 pb-1 pt-2 font-semibold text-xs">
+							{`${results.length} ${results.length === 1 ? "result" : "results"} ${cloudScope ? "in Cloud" : "on this host"}`}
+						</Text>
+					) : null
+				}
+				renderItem={({ item: workspace }) => {
+					const projectName = workspace.projectId
+						? projectNamesById.get(workspace.projectId)
+						: undefined;
+					return (
+						<Pressable
+							className="flex-row items-center gap-3 px-4 py-2.5"
+							onPress={() => open(workspace)}
+							ph-label="search-workspace-row"
+						>
+							<View className="size-6 items-center justify-center">
+								<Icon
+									as={FolderGit2}
+									className="text-muted-foreground size-5"
+									strokeWidth={1.75}
+								/>
+							</View>
+							<View className="min-w-0 flex-1">
+								<Text className="font-semibold text-[14px]" numberOfLines={1}>
+									{workspace.name}
+								</Text>
+								<Text
+									className="text-muted-foreground text-[11.5px]"
+									numberOfLines={1}
+								>
+									{projectName
+										? `${projectName} · ${workspace.branch}`
+										: workspace.branch}
+								</Text>
+							</View>
+						</Pressable>
+					);
+				}}
+				ListEmptyComponent={
+					<View className="items-center py-16">
+						<Text className="text-muted-foreground text-sm">
+							{searching
+								? "No workspaces match your search"
+								: cloudScope
+									? "No cloud workspaces yet"
+									: "No workspaces on this host yet"}
+						</Text>
+					</View>
+				}
+			/>
+		</>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/search/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/search/index.ts
@@ -1,0 +1,1 @@
+export { SearchScreen } from "./SearchScreen";


### PR DESCRIPTION
## Summary
- Home loses the in-page search pill; a native magnifying-glass button in the header opens a full-height **Search** sheet.
- The sheet uses the native iOS search bar (`Stack.SearchBar`, a `UISearchController`) on its own header. In that presentation context it activates properly — field shrinks, Liquid Glass ✕ cancel appears — and results stay tappable, unlike the root screen where iOS 26 swallows every touch (#6659).
- Matching (name, branch, project, session titles) and pin/recency ordering are unchanged, scoped to the active host or Cloud as before.

## Why / Context
#6659 moved search in-page because a `UISearchController` on the root screen on iOS 26 lays an invisible view over the content that eats every touch (unfixed upstream through react-native-screens 4.27). The in-page pill is not native and scrolls away with the list. Giving search its own sheet sidesteps the bug: on the sheet's own header the same controller works.

## How It Works
- `HomeScreen` renders a right `Stack.Toolbar` button (hidden while the selected host is offline, mirroring the list it searched) that pushes `/(authenticated)/(home)/search`, a `formSheet` route with a full-height detent and native title.
- `SearchScreen` renders `Stack.SearchBar` (stacked placement, bar and nav bar always visible) plus a `FlatList` with automatic content insets as the sole content child. The filtering logic moved out of `HomeScreen` unchanged; the sheet reads the same host/cloud/terminal queries, so it adds no requests.
- Tapping a result calls `router.back()` then `router.push(workspace)` — a push alone would land behind the modal.
- `autoFocus` is Android-only in react-native-screens; the sheet focuses the bar through its ref on the stack's `transitionEnd` event.

## Manual QA
Done on an iPhone 17 Pro simulator, iOS 26.0, against production data:
- [x] Header magnifier opens the sheet; the bar is focused on open with the controller active (field shrinks, glass ✕ appears)
- [x] Typing filters live with the "N results on this host" row; session titles match too
- [x] Tapping a result dismisses the sheet and opens the workspace; back returns to home with no sheet left behind
- [x] Glass ✕ clears the search; header ✕ closes the sheet while search is active
- [x] Magnifier hidden when the selected host is offline

Not verified by hand: Cloud scope (flag-gated) beyond code parity with the previous filter.

## Testing
- `bun run lint`
- `bun run typecheck` — 0 errors in `apps/mobile`; the 18 remaining are pre-existing in `packages/port-scanner`, `pty-daemon`, `workspace-fs` and identical on the base commit
- `bun run test` in `apps/mobile` (47 pass)

## Design Decisions
- **Sheet's own header, not a nested `_layout` Stack**: inside a nested Stack the `UISearchController` never activates (no cancel button, looks like a plain field; `obscureBackground`/`hideNavigationBar` have no effect). On the sheet's own header it activates and touches still work — the difference from #6659 is the presentation context.
- **Lean result rows instead of `WorkspaceRow`**: search is find-and-open; the full row needs pull-request, diff-stat and attention plumbing that would duplicate most of `HomeScreen`.
- **Scope**: the sheet searches what the list shows (selected host or Cloud); other hosts aren't in memory.

## Known Limitations
- react-native-screens logs "FormSheet with ScrollView expects at most 2 subviews. Got 5" in dev for this shape (toolbar + search bar + list); the layout renders correctly.
- UIKit labels the glass cancel button "Close", the same accessibility label as the header ✕.

https://claude.ai/code/session_01Ck1GRWn2c2mjHBE3e2yaZ1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves workspace search from the in-page pill on Home into a full-height search sheet with the native iOS search bar. The native bar works on the sheet's own header, where the same controller on the root screen swallowed every touch on iOS 26 (#6659).

- Home now opens the sheet from a native magnifying-glass toolbar button instead of the in-page pill.
- Matching (name, branch, project, session titles) and pin/recency ordering are unchanged, scoped to the active host or Cloud.
- Tapping a result closes the sheet, then opens the workspace.
- The magnifier is hidden while the selected host is offline.
- The search bar is focused when the sheet opens.
- In dev, `react-native-screens` logs a subview-count warning for the sheet; the layout renders correctly.

<sup>Written for commit 74a0f82e5e4e58a681cc17cf920313108ad95dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated workspace search screen accessible from the home screen.
  * Search across workspace names, branches, projects, and terminal sessions.
  * Results are sorted by pinned status and recent activity, with result counts and empty states.
  * Selecting a result opens the corresponding workspace.
  * Search is unavailable when the selected host is offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->