### PR TITLE
fix(ui): keep the maxFiles budget in step within a single tick

### DIFF
--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -290,6 +290,8 @@ export function PromptInputProvider({
 		[],
 	);
 	// Read at call time so `add` stays stable while still seeing the live count.
+	// Re-synced from state on every render, and advanced by `add` itself so two
+	// calls in the same tick do not both budget against the pre-add count.
 	const attachmentCountRef = useRef(0);
 	attachmentCountRef.current = attachmentFiles.length;
 
@@ -309,6 +311,10 @@ export function PromptInputProvider({
 			if (incoming.length === 0) {
 				return;
 			}
+			// Keep the budget in step within this tick. Validation deliberately
+			// stays outside the updater: it calls onError, and React invokes
+			// updaters twice under StrictMode, which would double every toast.
+			attachmentCountRef.current += incoming.length;
 
 			setAttachmentFiles((prev) =>
 				prev.concat(

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -262,16 +262,35 @@ export function PromptInputProvider({
 		attachmentsStore?.get ?? getEmptyAttachments,
 	);
 	const attachmentFiles = attachmentsStore ? storeFiles : localFiles;
+	// A synchronous mirror of the list. React defers state updaters to render,
+	// so without this a same-tick `clear(); add(...)` (or two adds in a row)
+	// would budget against a list that no longer reflects what just happened.
+	// The render assignment below re-syncs it from the authoritative state.
+	const attachmentFilesRef =
+		useRef<PromptInputAttachmentItem[]>(attachmentFiles);
+	attachmentFilesRef.current = attachmentFiles;
+	const attachmentCountRef = useRef(0);
+	attachmentCountRef.current = attachmentFiles.length;
+
+	// Every list mutation funnels through here, so this is the one place the
+	// mirror has to be kept honest: add, remove, clear, takeFiles and setFiles
+	// all land their new length before the call returns.
 	const setAttachmentFiles = useCallback(
 		(
 			updater: (
 				prev: PromptInputAttachmentItem[],
 			) => PromptInputAttachmentItem[],
 		) => {
+			const base = attachmentsStore
+				? attachmentsStore.get()
+				: attachmentFilesRef.current;
+			const next = updater(base);
+			attachmentFilesRef.current = next;
+			attachmentCountRef.current = next.length;
 			if (attachmentsStore) {
-				attachmentsStore.set(updater(attachmentsStore.get()));
+				attachmentsStore.set(next);
 			} else {
-				setLocalFiles(updater);
+				setLocalFiles(next);
 			}
 		},
 		[attachmentsStore],
@@ -289,12 +308,6 @@ export function PromptInputProvider({
 		},
 		[],
 	);
-	// Read at call time so `add` stays stable while still seeing the live count.
-	// Re-synced from state on every render, and advanced by `add` itself so two
-	// calls in the same tick do not both budget against the pre-add count.
-	const attachmentCountRef = useRef(0);
-	attachmentCountRef.current = attachmentFiles.length;
-
 	const add = useCallback(
 		(files: File[] | FileList) => {
 			const registration = constraintsRef.current;
@@ -311,11 +324,6 @@ export function PromptInputProvider({
 			if (incoming.length === 0) {
 				return;
 			}
-			// Keep the budget in step within this tick. Validation deliberately
-			// stays outside the updater: it calls onError, and React invokes
-			// updaters twice under StrictMode, which would double every toast.
-			attachmentCountRef.current += incoming.length;
-
 			setAttachmentFiles((prev) =>
 				prev.concat(
 					incoming.map((file) => ({

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -381,8 +381,10 @@ export function PromptInputProvider({
 	);
 
 	const takeFiles = useCallback(() => {
-		const takenFiles = attachmentsRef.current;
-		attachmentsRef.current = [];
+		// The mirror, not the render-time ref: a submit in the same tick as an
+		// add would otherwise return the pre-add list and then clear the files
+		// it never handed back.
+		const takenFiles = attachmentFilesRef.current;
 		setAttachmentFiles(() => []);
 		if (fileInputRef.current) {
 			fileInputRef.current.value = "";
@@ -390,16 +392,12 @@ export function PromptInputProvider({
 		return takenFiles;
 	}, [setAttachmentFiles]);
 
-	// Keep a ref to attachments for cleanup on unmount (avoids stale closure)
-	const attachmentsRef = useRef(attachmentFiles);
-	attachmentsRef.current = attachmentFiles;
-
 	// Cleanup blob URLs on unmount to prevent memory leaks. With an external
 	// store the files outlive the provider, so their URLs must stay valid.
 	useEffect(() => {
 		if (attachmentsStore) return;
 		return () => {
-			for (const f of attachmentsRef.current) {
+			for (const f of attachmentFilesRef.current) {
 				if (f.url) {
 					URL.revokeObjectURL(f.url);
 				}


### PR DESCRIPTION
Follow-up to #6939. CodeRabbit raised this on that PR, but the review landed after it was merged, so the fix needs its own PR.

## The bug

`attachmentCountRef.current = attachmentFiles.length` is a **render-time** assignment. Two `add()` calls before the next render therefore both budget against the pre-add count, so each admits up to the full remaining capacity and together they can exceed `maxFiles`.

```
maxFiles = 5, tray empty
add(3 files) -> sees count 0, capacity 5, admits 3
add(3 files) -> still sees count 0 (no render yet), admits 3
                                              => 6 attachments
```

## The fix

Advance the ref as each batch is admitted. The render-time assignment still re-syncs it from state afterwards, so removals and clears stay authoritative.

## Why not CodeRabbit's suggestion

It proposed moving validation inside the `setAttachmentFiles((prev) => ...)` updater and using `prev.length`. That is the right instinct for freshness, but `applyAttachmentConstraints` calls `onError`, and React invokes state updaters twice under StrictMode — every rejection would fire two toasts. Correcting the budget in place keeps the side effect outside the updater.

## Testing

- `bun test packages/ui/src` — 50 pass
- `bun run --cwd packages/ui typecheck`, `bunx biome check`

**Not verified in the running app.** Re-running the in-app cap test needs the new-workspace composer, and the workspace I had been testing in is mid-onboarding with no project after an unrelated `setup.sh --force` (its Neon branch had been deleted by the branch-cleanup sweep). The earlier in-app checks — 7 files against `maxFiles={5}` attaching 5 with a toast, 12MB against a 10MB cap attaching none — were run against the code this sits on top of, and this change only tightens the count between two calls in one tick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a same-tick race where attachment count checks used a render-time snapshot, letting consecutive `add()` calls collectively exceed `maxFiles` and a `clear(); add(...)` reject files that now fit.

All list mutations now funnel through a synchronous mirror ref that updates the list and count before returning, and `takeFiles()` reads that mirror too — so a submit right after an add no longer clears files it never handed back. Validation stays outside the React state updater because StrictMode invokes updaters twice and would double the error toast.

<sup>Written for commit bf08454d64b017ca14fb6b7decb472bae246b43e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file attachment validation when adding multiple batches quickly.
  * Attachment limits are now tracked accurately across consecutive additions, preventing invalid uploads caused by outdated counts.
  * Multiple add actions in the same moment now consistently respect the configured attachment constraints.
  * Attachment counts now remain synchronized with the selected files for more reliable upload behavior.
  * Improved consistency when removing attachments or navigating away while files are selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->