### PR TITLE
fix(host-service): dedupe replayed Codex token events across rollout files

### DIFF
--- a/packages/host-service/src/trpc/router/usage/history/codex-replay.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/codex-replay.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectLogFiles, sortCodexFiles } from "./logs";
+import { parseCodexLogFile, type UsageLogEntry } from "./parse";
+
+const root = mkdtempSync(join(tmpdir(), "codex-replay-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+interface Turn {
+	input: number;
+	cached: number;
+	output: number;
+	reasoning: number;
+}
+
+interface Rollout {
+	/** Session start / spawn instant, and the name the rollout is stored under. */
+	start: string;
+	/** Parent turns the fork re-emits, all stamped at `start`. */
+	replayed?: Turn[];
+	/** Turns this thread ran itself, at their own timestamps. */
+	own?: Array<{ at: string; turn: Turn }>;
+	/** Pre-0.145 rollouts leave `cache_write_input_tokens` out entirely. */
+	omitCacheWrite?: boolean;
+}
+
+function counts(turn: Turn, omitCacheWrite: boolean) {
+	return {
+		input_tokens: turn.input,
+		cached_input_tokens: turn.cached,
+		...(omitCacheWrite ? {} : { cache_write_input_tokens: 0 }),
+		output_tokens: turn.output,
+		reasoning_output_tokens: turn.reasoning,
+		total_tokens: turn.input + turn.output,
+	};
+}
+
+let sequence = 0;
+
+function writeRollout(dir: string, rollout: Rollout): void {
+	const omitCacheWrite = rollout.omitCacheWrite ?? false;
+	const replayed = rollout.replayed ?? [];
+	const own = rollout.own ?? [];
+	const lines: string[] = [
+		JSON.stringify({
+			timestamp: rollout.start,
+			type: "session_meta",
+			payload: { cwd: "/tmp/codex-project" },
+		}),
+		JSON.stringify({
+			timestamp: rollout.start,
+			type: "turn_context",
+			payload: { model: "gpt-5.6-sol", cwd: "/tmp/codex-project" },
+		}),
+	];
+	const running: Turn = { input: 0, cached: 0, output: 0, reasoning: 0 };
+	const emit = (at: string, turn: Turn) => {
+		running.input += turn.input;
+		running.cached += turn.cached;
+		running.output += turn.output;
+		running.reasoning += turn.reasoning;
+		lines.push(
+			JSON.stringify({
+				timestamp: at,
+				type: "event_msg",
+				payload: {
+					type: "token_count",
+					info: {
+						total_token_usage: counts({ ...running }, omitCacheWrite),
+						last_token_usage: counts(turn, omitCacheWrite),
+						model_context_window: 258400,
+					},
+				},
+			}),
+		);
+	};
+	for (const turn of replayed) emit(rollout.start, turn);
+	for (const { at, turn } of own) emit(at, turn);
+
+	mkdirSync(dir, { recursive: true });
+	const stamp = rollout.start.slice(0, 19).replace(/:/g, "-");
+	const id = (sequence++).toString().padStart(12, "0");
+	writeFileSync(
+		join(dir, `rollout-${stamp}-019f-7a00-b000-${id}.jsonl`),
+		`${lines.join("\n")}\n`,
+	);
+}
+
+async function collect(
+	dir: string,
+	cutoffMs: number,
+): Promise<UsageLogEntry[]> {
+	const files = await collectLogFiles(dir, 31);
+	// The directory walk yields no particular order, so hand the parser the
+	// worst one: any chronology in the result is the production sort's doing.
+	files.sort((a, b) => (a.path < b.path ? 1 : -1));
+	const entries: UsageLogEntry[] = [];
+	const seenTurnKeys = new Set<string>();
+	for (const file of sortCodexFiles(files)) {
+		await parseCodexLogFile(file, seenTurnKeys, cutoffMs, entries);
+	}
+	return entries;
+}
+
+function outputsByDay(entries: UsageLogEntry[]): Record<string, number[]> {
+	const byDay = new Map<string, number[]>();
+	for (const entry of entries) {
+		const day = new Date(entry.timestampMs).toISOString().slice(0, 10);
+		const outputs = byDay.get(day) ?? [];
+		outputs.push(entry.output);
+		outputs.sort((a, b) => a - b);
+		byDay.set(day, outputs);
+	}
+	return Object.fromEntries(byDay);
+}
+
+// P1 and P3 cost exactly the same: keyed on the delta alone they would
+// collapse into one turn, so the thread's running total has to be part of it.
+const P1: Turn = { input: 20_000, cached: 11_000, output: 200, reasoning: 60 };
+const P2: Turn = { input: 27_000, cached: 23_000, output: 320, reasoning: 90 };
+const P3: Turn = { input: 20_000, cached: 11_000, output: 200, reasoning: 60 };
+const PARENT_OUTPUT = [P1.output, P2.output, P3.output].sort((a, b) => a - b);
+const OWN_A: Turn = {
+	input: 31_000,
+	cached: 27_000,
+	output: 700,
+	reasoning: 0,
+};
+const OWN_B: Turn = {
+	input: 33_000,
+	cached: 28_000,
+	output: 900,
+	reasoning: 0,
+};
+
+const CUTOFF = Date.parse("2026-08-01T00:00:00.000Z");
+
+describe("parseCodexLogFile across forked rollouts", () => {
+	test("counts a replayed history once, on the day the thread spent it", async () => {
+		const dir = join(root, "in-window");
+		writeRollout(dir, {
+			start: "2026-08-20T10:00:00.000Z",
+			own: [
+				{ at: "2026-08-20T10:00:00.000Z", turn: P1 },
+				{ at: "2026-08-20T10:05:00.000Z", turn: P2 },
+				{ at: "2026-08-20T10:10:00.000Z", turn: P3 },
+			],
+			omitCacheWrite: true,
+		});
+		for (const [start, own] of [
+			["2026-08-21T09:00:00.000Z", OWN_A],
+			["2026-08-21T09:30:00.000Z", OWN_B],
+		] as const) {
+			writeRollout(dir, {
+				start,
+				replayed: [P1, P2, P3],
+				own: [{ at: start, turn: own }],
+			});
+		}
+
+		const entries = await collect(dir, CUTOFF);
+
+		expect(outputsByDay(entries)).toEqual({
+			"2026-08-20": PARENT_OUTPUT,
+			"2026-08-21": [OWN_A.output, OWN_B.output],
+		});
+		expect(entries).toHaveLength(5);
+	});
+
+	test("a replay of turns older than the window adds nothing", async () => {
+		const dir = join(root, "crossing-cutoff");
+		writeRollout(dir, {
+			start: "2026-07-01T10:00:00.000Z",
+			own: [
+				{ at: "2026-07-01T10:00:00.000Z", turn: P1 },
+				{ at: "2026-07-01T10:05:00.000Z", turn: P2 },
+				{ at: "2026-07-01T10:10:00.000Z", turn: P3 },
+			],
+			omitCacheWrite: true,
+		});
+		for (const [start, own] of [
+			["2026-08-21T09:00:00.000Z", OWN_A],
+			["2026-08-21T09:30:00.000Z", OWN_B],
+		] as const) {
+			writeRollout(dir, {
+				start,
+				replayed: [P1, P2, P3],
+				own: [{ at: start, turn: own }],
+			});
+		}
+
+		const entries = await collect(dir, CUTOFF);
+
+		expect(outputsByDay(entries)).toEqual({
+			"2026-08-21": [OWN_A.output, OWN_B.output],
+		});
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/entries.ts
+++ b/packages/host-service/src/trpc/router/usage/history/entries.ts
@@ -6,7 +6,7 @@ import { collectCopilotEntries } from "./copilot";
 import { collectCursorEntries } from "./cursor";
 import { collectFxEntries } from "./fx";
 import { collectGrokEntries, grokHomes } from "./grok";
-import { collectLogFiles, dedupeLogFiles } from "./logs";
+import { collectLogFiles, dedupeLogFiles, sortCodexFiles } from "./logs";
 import { collectOpencodeEntries } from "./opencode";
 import type { UsageLogEntry } from "./parse";
 import { parseClaudeLogFile, parseCodexLogFile } from "./parse";
@@ -99,8 +99,17 @@ export async function collectUsageEntries(
 	for (const entry of claudeEntriesByMessage.values()) {
 		entries.push(entry);
 	}
-	for (const file of codexFiles) {
-		await parseCodexLogFile(file, cutoffMs, entries, sessionLabels);
+	// Oldest rollout first, so a turn is kept by the thread that made it
+	// rather than by whichever fork replayed it into its own file.
+	const codexTurnKeys = new Set<string>();
+	for (const file of sortCodexFiles(codexFiles)) {
+		await parseCodexLogFile(
+			file,
+			codexTurnKeys,
+			cutoffMs,
+			entries,
+			sessionLabels,
+		);
 	}
 
 	// The remaining providers are independent of each other and of the two

--- a/packages/host-service/src/trpc/router/usage/history/logs.ts
+++ b/packages/host-service/src/trpc/router/usage/history/logs.ts
@@ -1,6 +1,6 @@
 import type { Dirent } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 export interface LogFile {
 	path: string;
@@ -60,4 +60,22 @@ export function dedupeLogFiles(files: LogFile[]): LogFile[] {
 		byPath.set(file.path, file);
 	}
 	return [...byPath.values()];
+}
+
+/**
+ * Orders codex rollouts by when the session STARTED, which is the order the
+ * cross-file turn dedupe needs: the earliest file carrying an event is the
+ * one that keeps it. `rollout-<local-start>-<uuid>.jsonl` leads with a
+ * fixed-width timestamp, so comparing names compares start times — mtime
+ * would not, since a long-running parent outlives the fork it spawned.
+ * `localeCompare` would not either; it is locale-sensitive and can treat
+ * punctuation as ignorable.
+ */
+export function sortCodexFiles(files: LogFile[]): LogFile[] {
+	return [...files].sort((a, b) => {
+		const left = basename(a.path);
+		const right = basename(b.path);
+		if (left < right) return -1;
+		return left > right ? 1 : 0;
+	});
 }

--- a/packages/host-service/src/trpc/router/usage/history/parse.ts
+++ b/packages/host-service/src/trpc/router/usage/history/parse.ts
@@ -9,8 +9,10 @@
  *   `message.id + requestId` — the same message is rewritten into multiple
  *   files on resume/fork/compaction, and naive parsers over-count.
  * - Codex: read `payload.info.last_token_usage` (per-turn delta), never
- *   `total_token_usage` (cumulative). Model/cwd ride on `turn_context`
- *   events and carry forward. `input_tokens` is INCLUSIVE of cached tokens.
+ *   `total_token_usage` (cumulative) — except as dedupe context, since Codex
+ *   replays a thread's whole `token_count` history into every fork and
+ *   subagent rollout. Model/cwd ride on `turn_context` events and carry
+ *   forward. `input_tokens` is INCLUSIVE of cached tokens.
  * - Reasoning tokens are a subset of output — never added on top.
  */
 
@@ -201,6 +203,14 @@ export async function parseClaudeLogFile(
 	});
 }
 
+interface CodexTokenUsage {
+	input_tokens?: number;
+	cached_input_tokens?: number;
+	cache_write_input_tokens?: number;
+	output_tokens?: number;
+	reasoning_output_tokens?: number;
+}
+
 interface CodexLine {
 	type?: string;
 	timestamp?: string;
@@ -210,20 +220,41 @@ interface CodexLine {
 		cwd?: string;
 		message?: string;
 		info?: {
-			last_token_usage?: {
-				input_tokens?: number;
-				cached_input_tokens?: number;
-				cache_write_input_tokens?: number;
-				output_tokens?: number;
-				reasoning_output_tokens?: number;
-			};
+			last_token_usage?: CodexTokenUsage;
+			total_token_usage?: CodexTokenUsage;
 		};
 	};
 }
 
-/** Parses `$CODEX_HOME/sessions/**\/*.jsonl` rollout files. */
+/** Counts are normalised: pre-0.145 rollouts omit `cache_write_input_tokens`
+ * where the replayed copies re-serialise it as 0, and the same call has to
+ * key identically in the thread that made it and in every replay of it. */
+function codexUsageCounts(usage: CodexTokenUsage | undefined): string {
+	return [
+		usage?.input_tokens ?? 0,
+		usage?.cached_input_tokens ?? 0,
+		usage?.cache_write_input_tokens ?? 0,
+		usage?.output_tokens ?? 0,
+		usage?.reasoning_output_tokens ?? 0,
+	].join(",");
+}
+
+/**
+ * Parses `$CODEX_HOME/sessions/**\/*.jsonl` rollout files. `seenTurnKeys` is
+ * shared across all files so the history Codex replays into forks and
+ * subagents is counted once.
+ *
+ * A fork's rollout repeats its parent thread's entire `token_count` history,
+ * re-stamped to the spawn instant, so one API call is recorded once per
+ * descendant file (measured: 126x inflation on a heavily forked day). The
+ * turn's own delta identifies it, paired with the thread's running total so
+ * that two distinct turns of identical cost stay distinct. Callers must visit
+ * files in rollout-chronological order (`sortCodexFiles`), or a replay
+ * outlives the original and drags the usage onto the wrong day.
+ */
 export async function parseCodexLogFile(
 	file: LogFile,
+	seenTurnKeys: Set<string>,
 	cutoffMs: number,
 	out: UsageLogEntry[],
 	sessionLabels?: Map<string, string>,
@@ -231,10 +262,6 @@ export async function parseCodexLogFile(
 	const sessionId = sessionIdForFile(file.path);
 	let currentModel: string | null = null;
 	let currentCwd: string | null = null;
-	// Codex occasionally re-emits the same token_count event back-to-back;
-	// skipping consecutive identical deltas brings summed deltas within ~1%
-	// of the session's own cumulative total_token_usage counter.
-	let previousDeltaSignature: string | null = null;
 
 	await forEachLine(file.path, (line) => {
 		const wantLabel = sessionLabels ? !sessionLabels.has(sessionId) : false;
@@ -274,9 +301,15 @@ export async function parseCodexLogFile(
 		const usage = parsed.payload.info?.last_token_usage;
 		if (!usage) return;
 
-		const signature = JSON.stringify(usage);
-		if (signature === previousDeltaSignature) return;
-		previousDeltaSignature = signature;
+		// Claimed before the cutoff test, not after: a replay is re-stamped to
+		// the spawn instant, so the original it copies is routinely older than
+		// the window and a dedupe that only sees in-window events would let
+		// the copy through as fresh usage.
+		const dedupeKey = `${codexUsageCounts(usage)}|${codexUsageCounts(
+			parsed.payload.info?.total_token_usage,
+		)}`;
+		if (seenTurnKeys.has(dedupeKey)) return;
+		seenTurnKeys.add(dedupeKey);
 
 		const timestampMs = entryTimestamp(parsed.timestamp, file.mtimeMs);
 		if (timestampMs < cutoffMs) return;


### PR DESCRIPTION
## What & why

Codex 0.144 and 0.145 replay the parent thread's entire `token_count` history into forked and subagent rollout files, re-timestamped to the spawn instant. `parseCodexLogFile` only skips consecutive identical deltas within a single file, so the same API call gets counted once per descendant file. On heavily forked days that inflates reported Codex usage by up to 126x.

`parseClaudeLogFile` already handles the equivalent problem, deduping globally on `message.id + requestId` through a Map shared across every file. This gives the Codex path the same treatment, with three differences that matter:

- The key is the `last_token_usage` delta paired with the thread's running `total_token_usage`. The delta alone would merge two genuinely distinct turns that happened to cost the same; the pair will not.
- The key is claimed before the cutoff check rather than at the push site. Many replayed events have their originals outside the window, so a dedupe that only sees post-cutoff events cannot recognise them. The Claude path can claim its key after the cutoff because its rewrites keep the original timestamp instead of re-stamping to the spawn instant.
- Codex files are visited in rollout-chronological order, so the earliest file carrying an event keeps it. Sorting is on the filename's start timestamp rather than mtime, since a long-running parent outlives the fork it spawned.

Counts are normalised with `?? 0` before keying, because pre-0.145 records omit `cache_write_input_tokens` while the replayed copies re-serialise it as `0`.

Deliberately not fixed by excluding forked files: those carry a large share of genuinely new daily usage, so dropping them undercounts badly.

## How I tested it

Against `ccusage@20.0.20 codex daily -z UTC` over 30 days of my own rollout history: every day with usage now matches exactly on output, cache-read and uncached-input. Before, the worst day reported 126x its real cache reads. No day moved down, and days that were already correct are unchanged.

`codex-replay.test.ts` writes real temp rollouts: a parent with three turns, plus two subagents that each replay all three at their spawn instant and then take a turn of their own. The fixture is built so the first and third parent turns have identical deltas, so keying on the delta alone would silently drop one, and the parent omits `cache_write_input_tokens` while the replays serialise it as `0`. Files are handed to the parser in reverse-chronological order, so any correct ordering in the result comes from the production sort.

Two tests: that a replayed history is counted once on the day the thread spent it, and that a replay of turns older than the window adds nothing. Each assertion was mutation-tested, so none is vacuous:

| change that should break it | caught by |
|---|---|
| per-file dedupe set instead of shared | both tests |
| claim the key after the cutoff check | the out-of-window test only |
| drop the `?? 0` normalisation | both tests |
| visit files unsorted | both; the parent's day disappears entirely |

The cutoff row is the useful one: only the out-of-window case exposes it, which is why a version that claims the key at the push site still passes a casual suite while undercounting.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex usage over-counting when forks and subagents replay the parent thread's entire token history, so the same API call is now counted once per day instead of once per descendant file.

- Dedupes replayed events across rollout files using the per-turn delta paired with the thread's running total, so identical-cost turns remain distinct.
- Claims the dedupe key before the cutoff check so replays of turns older than the window are not counted as fresh usage.
- Visits rollout files in start-time order so the earliest file carrying an event keeps it.
- Normalizes missing cache-write fields so pre-0.145 records match their replayed copies.

<sup>Written for commit a0a5c0e897e778a4b94d84ed8d11f61d53e00f3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex usage history accuracy by preventing replayed turns from being counted multiple times.
  * Correctly attributes usage to the original thread, including when activity is replayed in forks or subagents.
  * Ensures older replayed turns do not incorrectly increase usage totals within the selected period.

* **Tests**
  * Added coverage for forked Codex rollouts, turn deduplication, sorting, and cutoff handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->