### PR TITLE
fix(desktop): match settings top bar to sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -172,7 +172,7 @@ function SettingsLayout() {
 	);
 
 	return (
-		<div className="flex flex-col h-screen w-screen bg-tertiary">
+		<div className="flex flex-col h-screen w-screen bg-background">
 			{/* CommandPaletteHost (Cmd/Ctrl+K etc.) only mounts inside the
 			    _dashboard route tree; CHECK_RESOURCES needs its own mount here so
 			    the hotkey and native "Resources" menu item still work in Settings. */}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx
@@ -177,7 +177,7 @@ function SettingsLayout() {
 			    _dashboard route tree; CHECK_RESOURCES needs its own mount here so
 			    the hotkey and native "Resources" menu item still work in Settings. */}
 			<CheckResourcesHotkeyMount />
-			<div className="flex h-12 w-full items-center bg-tertiary">
+			<div className="flex h-12 w-full items-center bg-sidebar dark:bg-muted/35">
 				<div
 					className="drag h-full shrink-0"
 					style={{ width: isMac ? "96px" : "8px" }}


### PR DESCRIPTION
## Summary

- use the sidebar surface token for the Settings top bar
- give the translucent top bar and sidebar the same background surface so they composite to the same rendered color

## Testing

- `bunx biome check apps/desktop/src/renderer/routes/_authenticated/settings/layout.tsx`
- `git diff --check`
- CDP-verified in this worktree on renderer `http://localhost:4625/#/settings/account` via port `9261`
  - authenticated session confirmed through the app auth client
  - screenshot captured and visually inspected
  - rendered PNG pixel sampled in blank top-bar and sidebar regions: both RGBA `28, 25, 24, 255`
  - no captured renderer console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the settings page background for improved visual consistency.
  - Refined the settings header appearance, including better dark-mode styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->