### PR TITLE
fix(desktop): notify for OpenCode permission and question prompts

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
 		"build": "fumadocs-mdx && next build",
 		"dev": "dotenv -e ../../.env -- sh -c 'exec next dev --port ${DOCS_PORT:-3004}'",
 		"start": "next start",
-		"typecheck": "fumadocs-mdx && next typegen && tsc --noEmit",
+		"typecheck": "next typegen && fumadocs-mdx && tsc --noEmit",
 		"postinstall": "fumadocs-mdx"
 	},
 	"dependencies": {

--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -24,7 +24,7 @@ import { getOpenCodeConfigDir, getOpenCodePluginDir } from "./paths";
 export const OPENCODE_PLUGIN_FILE = "superset-notify.js";
 
 const OPENCODE_PLUGIN_SIGNATURE = "// Superset opencode plugin";
-const OPENCODE_PLUGIN_VERSION = "v8";
+const OPENCODE_PLUGIN_VERSION = "v9";
 export const OPENCODE_PLUGIN_MARKER = `${OPENCODE_PLUGIN_SIGNATURE} ${OPENCODE_PLUGIN_VERSION}`;
 
 /**

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import * as realOs from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const TEST_ROOT = path.join(
 	realOs.tmpdir(),
@@ -78,6 +79,7 @@ const {
 	getAmpPluginContent,
 	getGeminiSettingsJsonContent,
 	getMastraHooksJsonContent,
+	getOpenCodePluginContent,
 	getOmpExtensionContent,
 	getOmpExtensionPath,
 	OMP_EXTENSION_MARKER,
@@ -97,6 +99,90 @@ const managedClaudeHookCommand = getClaudeManagedHookCommand();
 const managedDroidHookCommand = getManagedNotifyHookCommand("droid");
 const managedCodexHookCommand = getManagedNotifyHookCommand("codex");
 const managedMastraHookCommand = getManagedNotifyHookCommand("mastracode");
+
+describe("agent-wrappers opencode", () => {
+	const originalTerminalId = process.env.SUPERSET_TERMINAL_ID;
+	let pluginImportCounter = 0;
+
+	const loadOpenCodePlugin = async () => {
+		mkdirSync(TEST_ROOT, { recursive: true });
+		const pluginPath = path.join(
+			TEST_ROOT,
+			`opencode-notify-${pluginImportCounter++}.mjs`,
+		);
+		writeFileSync(pluginPath, getOpenCodePluginContent("/tmp/notify.sh"));
+		return import(pathToFileURL(pluginPath).href);
+	};
+
+	beforeEach(() => {
+		delete (
+			globalThis as typeof globalThis & {
+				__supersetOpencodeNotifyPluginV9?: boolean;
+			}
+		).__supersetOpencodeNotifyPluginV9;
+	});
+
+	afterEach(() => {
+		if (originalTerminalId === undefined) {
+			delete process.env.SUPERSET_TERMINAL_ID;
+		} else {
+			process.env.SUPERSET_TERMINAL_ID = originalTerminalId;
+		}
+	});
+
+	it.each([
+		"permission.asked",
+		"question.asked",
+	])("notifies for the current %s event", async (eventType) => {
+		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
+		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
+		const notifications: string[] = [];
+		const hooks = await SupersetNotifyPlugin({
+			$: (
+				_parts: TemplateStringsArray,
+				_notifyPath: string,
+				payload: string,
+			) => {
+				notifications.push(JSON.parse(payload).hook_event_name);
+			},
+			client: {
+				session: {
+					list: async () => ({
+						data: [{ id: "root-session" }],
+					}),
+				},
+			},
+		});
+
+		await hooks.event({
+			event: {
+				type: eventType,
+				properties: { sessionID: "root-session" },
+			},
+		});
+
+		expect(notifications).toEqual(["PermissionRequest"]);
+	});
+
+	it("retains the legacy permission.ask notification hook", async () => {
+		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
+		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
+		const notifications: string[] = [];
+		const hooks = await SupersetNotifyPlugin({
+			$: (
+				_parts: TemplateStringsArray,
+				_notifyPath: string,
+				payload: string,
+			) => {
+				notifications.push(JSON.parse(payload).hook_event_name);
+			},
+		});
+
+		await hooks["permission.ask"]({}, { status: "ask" });
+
+		expect(notifications).toEqual(["PermissionRequest"]);
+	});
+});
 
 describe("agent-wrappers copilot", () => {
 	beforeEach(() => {

--- a/packages/agent-setup/templates/opencode-plugin.template.js
+++ b/packages/agent-setup/templates/opencode-plugin.template.js
@@ -5,7 +5,7 @@
  * This plugin sends desktop notifications when OpenCode sessions need attention.
  * It hooks into session.status (busy/idle), session.idle, session.error, and permission.ask events.
  *
- * ROBUSTNESS FEATURES (v8):
+ * ROBUSTNESS FEATURES (v9):
  * - Session-scoped: Tracks root sessionID, ignores events from other sessions
  * - Deduplication: Only sends Start on idle→busy, Stop on busy→idle transitions
  * - Safe defaults: On error, assumes child session to avoid false positives
@@ -23,8 +23,8 @@
  * @see https://github.com/sst/opencode/blob/dev/packages/app/src/context/notification.tsx
  */
 export const SupersetNotifyPlugin = async ({ $, client }) => {
-  if (globalThis.__supersetOpencodeNotifyPluginV8) return {};
-  globalThis.__supersetOpencodeNotifyPluginV8 = true;
+  if (globalThis.__supersetOpencodeNotifyPluginV9) return {};
+  globalThis.__supersetOpencodeNotifyPluginV9 = true;
 
   // Only run inside a v2 Superset terminal session.
   if (!process?.env?.SUPERSET_TERMINAL_ID) return {};
@@ -184,6 +184,17 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
       // Skip notifications for child/subagent sessions
       if (await isChildSession(sessionID)) {
         log('Skipping child session');
+        return;
+      }
+
+      // Current OpenCode versions publish permission and question prompts as
+      // bus events. The legacy permission.ask plugin hook below is retained
+      // for older versions that still invoke it directly.
+      if (
+        event.type === "permission.asked" ||
+        event.type === "question.asked"
+      ) {
+        await notify("PermissionRequest");
         return;
       }
 


### PR DESCRIPTION
## What & why

Fixes #3652.

OpenCode now publishes interactive permission and question prompts as `permission.asked` and `question.asked` bus events. The Superset notification plugin only handled the legacy `permission.ask` hook, so current prompts never reached the desktop notification pipeline.

Handle both current event types after root-session filtering, retain the legacy hook for compatibility, and bump the managed plugin marker to v9 so the updated integration is provisioned.

## How I tested it

- `bun run lint`
- `bun run typecheck`
- `bun run test` (20 tasks, including 1,336 host-service tests; 0 failures)
- CDP end-to-end against this worktree on renderer `http://localhost:4785`, CDP port `9252`, with OpenCode 1.18.21:
  - created a real OpenCode session through the desktop UI
  - triggered `question.asked` through OpenCode's question tool
  - triggered `permission.asked` by reading `/etc/hosts` through the read tool
  - confirmed each emitted `PermissionRequest`, reached the host-service notification endpoint with HTTP 200, and set yellow pane/tab/workspace attention state
  - switched to another terminal before a second question arrived and confirmed the hidden OpenCode pane still received attention state and retained the interactive prompt

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not applicable: same-repository branch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop notifications for OpenCode permission and question prompts, and fixes a docs typecheck race. OpenCode now emits `permission.asked` and `question.asked` bus events, which the Superset notification plugin didn't handle, so interactive prompts never reached the desktop notification pipeline.

- Handles both new event types after root-session filtering; the legacy `permission.ask` hook stays for older OpenCode versions.
- Bumps the managed plugin marker to v9 so the updated integration is provisioned.
- Adds tests covering both event types and the legacy hook.

**Bug Fixes**
- Runs fumadocs-mdx after `next typegen` in docs so `tsc` doesn't start against a partially written `.source/server.ts` file.

<sup>Written for commit 0723fcdd0d0255614eabd9bf60cb76cd6e110250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenCode now surfaces permission and question requests as notifications, helping you respond to agent prompts promptly.
- **Bug Fixes**
  - Improved handling of OpenCode permission events while preserving compatibility with existing permission prompts.
- **Tests**
  - Added coverage to verify that OpenCode notifications are emitted correctly for permission and question requests.
- **Chores**
  - Updated the OpenCode plugin version marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->