### PR TITLE
fix(marketing): seed RSC i18n per route entry, not just the root layout

### DIFF
--- a/apps/marketing/src/app/(legal)/[slug]/page.tsx
+++ b/apps/marketing/src/app/(legal)/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
+import { initServerI18n } from "@/app/i18n-server";
 import { getAllLegalSlugs, getLegalPage } from "@/lib/legal";
 
 interface PageProps {
@@ -18,6 +19,8 @@ function formatDate(date: string | Date): string {
 }
 
 export default async function LegalPage({ params }: PageProps) {
+	initServerI18n();
+
 	const { slug } = await params;
 	const page = getLegalPage(slug);
 

--- a/apps/marketing/src/app/agent-orchestration/page.tsx
+++ b/apps/marketing/src/app/agent-orchestration/page.tsx
@@ -2,11 +2,14 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CategoryArticle } from "@/app/components/CategoryArticle";
+import { initServerI18n } from "@/app/i18n-server";
 import { getCategoryPage } from "@/lib/category";
 
 const SLUG = "agent-orchestration";
 
 export default function AgentOrchestrationPage() {
+	initServerI18n();
+
 	const page = getCategoryPage(SLUG);
 
 	if (!page) {

--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import { initServerI18n } from "@/app/i18n-server";
 import {
 	ArticleJsonLd,
 	BreadcrumbJsonLd,
@@ -21,6 +22,8 @@ interface PageProps {
 }
 
 export default async function BlogPostPage({ params }: PageProps) {
+	initServerI18n();
+
 	const { slug } = await params;
 	const post = getBlogPost(slug);
 

--- a/apps/marketing/src/app/blog/page.tsx
+++ b/apps/marketing/src/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 import type { Metadata } from "next";
+import { initServerI18n } from "@/app/i18n-server";
 import { getBlogPosts } from "@/lib/blog";
 import { BlogCard } from "./components/BlogCard";
 import { GridCross } from "./components/GridCross";
@@ -31,6 +32,8 @@ export const metadata: Metadata = {
 };
 
 export default async function BlogPage() {
+	initServerI18n();
+
 	const posts = getBlogPosts();
 
 	return (

--- a/apps/marketing/src/app/changelog/[slug]/page.tsx
+++ b/apps/marketing/src/app/changelog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import { initServerI18n } from "@/app/i18n-server";
 import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import { getAllChangelogSlugs, getChangelogEntry } from "@/lib/changelog";
 import { changelogMdxComponents } from "../components/ChangelogEntry/changelog-mdx-components";
@@ -12,6 +13,8 @@ interface PageProps {
 }
 
 export default async function ChangelogEntryPage({ params }: PageProps) {
+	initServerI18n();
+
 	const { slug } = await params;
 	const entry = getChangelogEntry(slug);
 

--- a/apps/marketing/src/app/changelog/page.tsx
+++ b/apps/marketing/src/app/changelog/page.tsx
@@ -4,6 +4,7 @@ import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
 import { FaGithub } from "react-icons/fa";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { getChangelogEntries } from "@/lib/changelog";
 import { ChangelogEntry } from "./components/ChangelogEntry";
 
@@ -34,6 +35,8 @@ export const metadata: Metadata = {
 };
 
 export default async function ChangelogPage() {
+	initServerI18n();
+
 	const entries = getChangelogEntries();
 
 	return (

--- a/apps/marketing/src/app/community/page.tsx
+++ b/apps/marketing/src/app/community/page.tsx
@@ -4,6 +4,7 @@ import { i18n } from "@superset/i18n";
 import { COMPANY } from "@superset/shared/constants";
 import { ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
+import { initServerI18n } from "@/app/i18n-server";
 import { getGitHubRepoSlug } from "@/lib/github";
 
 export const metadata: Metadata = {
@@ -112,6 +113,8 @@ const COMMUNITY_LINKS = [
 ];
 
 export default async function CommunityPage() {
+	initServerI18n();
+
 	const stars = await getGitHubStars();
 
 	return (

--- a/apps/marketing/src/app/compare/[slug]/page.tsx
+++ b/apps/marketing/src/app/compare/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import { mdxComponents } from "@/app/blog/components/mdx-components";
+import { initServerI18n } from "@/app/i18n-server";
 import {
 	BreadcrumbJsonLd,
 	ComparisonJsonLd,
@@ -24,6 +25,8 @@ interface PageProps {
 }
 
 export default async function ComparePageRoute({ params }: PageProps) {
+	initServerI18n();
+
 	const { slug } = await params;
 	const page = getComparisonPage(slug);
 

--- a/apps/marketing/src/app/compare/page.tsx
+++ b/apps/marketing/src/app/compare/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { getComparisonPages } from "@/lib/compare";
 import { formatCompareDate } from "@/lib/compare-utils";
 
@@ -30,6 +31,8 @@ export const metadata: Metadata = {
 };
 
 export default async function ComparePage() {
+	initServerI18n();
+
 	const pages = getComparisonPages();
 
 	const oneVsOne = pages.filter((p) => p.type === "1v1");

--- a/apps/marketing/src/app/contact/page.tsx
+++ b/apps/marketing/src/app/contact/page.tsx
@@ -2,6 +2,7 @@ import { Trans } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { ContactForm } from "./components/ContactForm";
 
 export const metadata: Metadata = {
@@ -13,6 +14,8 @@ export const metadata: Metadata = {
 };
 
 export default function ContactPage() {
+	initServerI18n();
+
 	// Named locals so the paragraph extracts with `{supportEmail}` /
 	// `{foundersEmail}` instead of positional `{0}` / `{1}`.
 	const supportEmail = `support${COMPANY.EMAIL_DOMAIN}`;

--- a/apps/marketing/src/app/download/page.tsx
+++ b/apps/marketing/src/app/download/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { initServerI18n } from "@/app/i18n-server";
 import { DownloadInterstitial } from "./components/DownloadInterstitial";
 
 export const metadata: Metadata = {
@@ -8,5 +9,7 @@ export const metadata: Metadata = {
 };
 
 export default function DownloadPage() {
+	initServerI18n();
+
 	return <DownloadInterstitial />;
 }

--- a/apps/marketing/src/app/enterprise/page.tsx
+++ b/apps/marketing/src/app/enterprise/page.tsx
@@ -3,6 +3,7 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { GridCross } from "@/app/blog/components/GridCross";
 import { Soc2Badge } from "@/app/components/Soc2Badge";
+import { initServerI18n } from "@/app/i18n-server";
 import { EnterpriseContactForm } from "./components/EnterpriseContactForm";
 import { EnterpriseFAQ } from "./components/EnterpriseFAQ";
 
@@ -15,6 +16,8 @@ export const metadata: Metadata = {
 };
 
 export default function EnterprisePage() {
+	initServerI18n();
+
 	const { t } = useLingui();
 
 	return (

--- a/apps/marketing/src/app/factory-2026/page.tsx
+++ b/apps/marketing/src/app/factory-2026/page.tsx
@@ -2,6 +2,7 @@ import { Trans } from "@lingui/react/macro";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { AttentionChart } from "./components/AttentionChart";
 import { ForecastChart } from "./components/ForecastChart";
 import { ForecastEntry } from "./components/ForecastEntry";
@@ -36,6 +37,8 @@ export const metadata: Metadata = {
 };
 
 export default function Factory2026Page() {
+	initServerI18n();
+
 	return (
 		<main className="relative min-h-screen">
 			{/* Vertical guide lines */}

--- a/apps/marketing/src/app/join-us/page.tsx
+++ b/apps/marketing/src/app/join-us/page.tsx
@@ -1,6 +1,7 @@
 import { Trans } from "@lingui/react/macro";
 import type { Metadata } from "next";
 import Script from "next/script";
+import { initServerI18n } from "@/app/i18n-server";
 
 declare global {
 	namespace React.JSX {
@@ -36,6 +37,8 @@ export const metadata: Metadata = {
 };
 
 export default function JoinUsPage() {
+	initServerI18n();
+
 	return (
 		<main className="relative min-h-screen bg-background">
 			<div className="max-w-[90rem] mx-auto px-6 pt-24 md:pt-32">

--- a/apps/marketing/src/app/leaderboard/page.tsx
+++ b/apps/marketing/src/app/leaderboard/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Silkscreen } from "next/font/google";
 import Link from "next/link";
 import { FactoryBackdrop } from "@/app/components/FactoryBackdrop";
+import { initServerI18n } from "@/app/i18n-server";
 import { fetchStandings, fetchStats } from "@/app/utils/fetchLeaderboard";
 import { LeaderboardBoard } from "./components/LeaderboardBoard";
 
@@ -40,6 +41,8 @@ export const revalidate = 300;
 const DEFAULT_PERIOD = "30d" as const;
 
 export default async function LeaderboardPage() {
+	initServerI18n();
+
 	const [standings, stats] = await Promise.all([
 		fetchStandings({ period: DEFAULT_PERIOD, metric: "tokens", limit: 50 }),
 		fetchStats({ period: DEFAULT_PERIOD }),

--- a/apps/marketing/src/app/marketplace/agents/page.tsx
+++ b/apps/marketing/src/app/marketplace/agents/page.tsx
@@ -3,6 +3,7 @@ import { COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import { ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
+import { initServerI18n } from "@/app/i18n-server";
 import { marketplaceSubmissionLinks } from "@/lib/marketplace";
 
 export const metadata: Metadata = {
@@ -15,6 +16,8 @@ export const metadata: Metadata = {
 };
 
 export default function MarketplaceAgentsPage() {
+	initServerI18n();
+
 	return (
 		<main className="min-h-screen">
 			<div className="mx-auto max-w-4xl px-6 py-10">

--- a/apps/marketing/src/app/marketplace/page.tsx
+++ b/apps/marketing/src/app/marketplace/page.tsx
@@ -3,6 +3,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { initServerI18n } from "@/app/i18n-server";
 
 export const metadata: Metadata = {
 	title: "Marketplace",
@@ -35,6 +36,8 @@ const marketplaceLinks = [
 ] as const;
 
 export default function MarketplacePage() {
+	initServerI18n();
+
 	const { t } = useLingui();
 
 	return (

--- a/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Download } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { initServerI18n } from "@/app/i18n-server";
 import { BreadcrumbJsonLd, JsonLdScript } from "@/components/JsonLd";
 import {
 	getAllThemeSlugs,
@@ -54,6 +55,8 @@ export async function generateMetadata({
 }
 
 export default async function ThemeDetailPage({ params }: PageProps) {
+	initServerI18n();
+
 	const { slug } = await params;
 	const theme = getThemeListing(slug);
 

--- a/apps/marketing/src/app/marketplace/themes/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/page.tsx
@@ -5,6 +5,7 @@ import { ThemePreviewCard } from "@superset/ui/theme-preview-card";
 import { ArrowUpRight, Download } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { initServerI18n } from "@/app/i18n-server";
 import { themeListings } from "@/lib/marketplace";
 
 export const metadata: Metadata = {
@@ -17,6 +18,8 @@ export const metadata: Metadata = {
 };
 
 export default function MarketplaceThemesPage() {
+	initServerI18n();
+
 	const { t } = useLingui();
 
 	return (

--- a/apps/marketing/src/app/mcp-install/page.tsx
+++ b/apps/marketing/src/app/mcp-install/page.tsx
@@ -2,6 +2,7 @@ import { Trans } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { MCP_SERVER_URL } from "@/lib/api-url";
 import { McpCapabilities } from "./components/McpCapabilities";
 import { McpExamples } from "./components/McpExamples";
@@ -16,6 +17,8 @@ export const metadata: Metadata = {
 };
 
 export default function McpPage() {
+	initServerI18n();
+
 	return (
 		<main className="relative min-h-screen">
 			{/* Header + Install section */}

--- a/apps/marketing/src/app/not-found.tsx
+++ b/apps/marketing/src/app/not-found.tsx
@@ -2,7 +2,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import Link from "next/link";
-
+import { initServerI18n } from "@/app/i18n-server";
 import { NotFoundGrid } from "./components/NotFoundGrid";
 import { Pixel404 } from "./components/Pixel404";
 
@@ -12,6 +12,8 @@ export const metadata: Metadata = {
 };
 
 export default function NotFound() {
+	initServerI18n();
+
 	const { t } = useLingui();
 
 	return (

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import dynamic from "next/dynamic";
+import { initServerI18n } from "@/app/i18n-server";
 import {
 	FAQPageJsonLd,
 	HomeWebPageJsonLd,
@@ -40,6 +41,8 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
+	initServerI18n();
+
 	return (
 		<main className="flex flex-col bg-background">
 			<FAQPageJsonLd

--- a/apps/marketing/src/app/parallel-coding-agents/page.tsx
+++ b/apps/marketing/src/app/parallel-coding-agents/page.tsx
@@ -2,11 +2,14 @@ import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CategoryArticle } from "@/app/components/CategoryArticle";
+import { initServerI18n } from "@/app/i18n-server";
 import { getCategoryPage } from "@/lib/category";
 
 const SLUG = "parallel-coding-agents";
 
 export default function ParallelCodingAgentsPage() {
+	initServerI18n();
+
 	const page = getCategoryPage(SLUG);
 
 	if (!page) {

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import { i18n } from "@superset/i18n";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
+import { initServerI18n } from "@/app/i18n-server";
 import { FAQPageJsonLd } from "@/components/JsonLd";
 import { ComparisonTable } from "./components/ComparisonTable";
 import { PricingFAQ } from "./components/PricingFAQ";
@@ -18,6 +19,8 @@ export const metadata: Metadata = {
 };
 
 export default function PricingPage() {
+	initServerI18n();
+
 	// JSON-LD is machine-facing, so it gets rendered strings rather than the
 	// message descriptors the UI components resolve through Lingui.
 	const faqJsonLdItems = PRICING_FAQ_ITEMS.map((item) => ({

--- a/apps/marketing/src/app/roadmap/page.tsx
+++ b/apps/marketing/src/app/roadmap/page.tsx
@@ -2,6 +2,7 @@ import { Trans } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { RoadmapBoard } from "./components/RoadmapBoard";
 
 export const metadata: Metadata = {
@@ -28,6 +29,8 @@ export const metadata: Metadata = {
 };
 
 export default function RoadmapPage() {
+	initServerI18n();
+
 	const company = COMPANY.NAME;
 
 	return (

--- a/apps/marketing/src/app/starchart/page.tsx
+++ b/apps/marketing/src/app/starchart/page.tsx
@@ -3,6 +3,7 @@ import { COMPANY } from "@superset/shared/constants";
 import { Button } from "@superset/ui/button";
 import type { Metadata } from "next";
 import { GridCross } from "@/app/blog/components/GridCross";
+import { initServerI18n } from "@/app/i18n-server";
 import { formatStarCount, getGitHubRepoSlug } from "@/lib/github";
 import { StarChartSection } from "./components/StarChartSection";
 import { getStarHistory } from "./utils/getStarHistory";
@@ -44,6 +45,8 @@ function formatWeekDate(date: string): string {
 }
 
 export default async function StarChartPage() {
+	initServerI18n();
+
 	const { t } = useLingui();
 	const history = await getStarHistory();
 	const points = history?.points ?? [];

--- a/apps/marketing/src/app/stats/page.tsx
+++ b/apps/marketing/src/app/stats/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Silkscreen } from "next/font/google";
 import Link from "next/link";
 import { FactoryBackdrop } from "@/app/components/FactoryBackdrop";
+import { initServerI18n } from "@/app/i18n-server";
 import { fetchStats } from "@/app/utils/fetchLeaderboard";
 import { formatDayRange } from "@/app/utils/formatUsage";
 import { StatsBody } from "./components/StatsBody";
@@ -40,6 +41,8 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 export default async function StatsPage() {
+	initServerI18n();
+
 	const stats = await fetchStats({ period: "all" });
 	const range = stats?.range ? formatDayRange(stats.range) : null;
 

--- a/apps/marketing/src/app/team/[id]/page.tsx
+++ b/apps/marketing/src/app/team/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-icons/ri";
 import { GridCross } from "@/app/blog/components/GridCross";
 import { mdxComponents } from "@/app/blog/components/mdx-components";
+import { initServerI18n } from "@/app/i18n-server";
 import { BreadcrumbJsonLd, JsonLdScript } from "@/components/JsonLd";
 import { getAllPeople, getPersonById } from "@/lib/people";
 import { TeamBio } from "../components/TeamBio";
@@ -63,6 +64,8 @@ function PersonJsonLd({
 }
 
 export default async function TeamMemberPage({ params }: PageProps) {
+	initServerI18n();
+
 	const { id } = await params;
 	const person = getPersonById(id);
 

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -8,6 +8,7 @@ import {
 	RiLinkedinBoxFill,
 	RiTwitterXFill,
 } from "react-icons/ri";
+import { initServerI18n } from "@/app/i18n-server";
 import { getAllPeople } from "@/lib/people";
 import { CTASection } from "../components/CTASection";
 import { TeamBio } from "./components/TeamBio";
@@ -36,6 +37,8 @@ export const metadata: Metadata = {
 };
 
 export default function TeamPage() {
+	initServerI18n();
+
 	const { t } = useLingui();
 	const people = getAllPeople();
 

--- a/apps/marketing/src/app/user/[handle]/page.tsx
+++ b/apps/marketing/src/app/user/[handle]/page.tsx
@@ -16,6 +16,7 @@ import { tierRgb } from "@/app/components/TierBadge";
 import { TierIcon } from "@/app/components/TierIcon";
 import { TierTube } from "@/app/components/TierTube";
 import { TokenSplitBar } from "@/app/components/TokenSplitBar";
+import { initServerI18n } from "@/app/i18n-server";
 import { avatarUrl } from "@/app/utils/avatarUrl";
 import { fetchParticipant } from "@/app/utils/fetchLeaderboard";
 import {
@@ -79,6 +80,8 @@ export async function generateMetadata({
 }
 
 export default async function UserProfilePage({ params }: PageProps) {
+	initServerI18n();
+
 	const { t } = useLingui();
 	const { handle } = await params;
 	const profile = await fetchParticipant(handle, { period: "all" });

--- a/packages/i18n/src/server.ts
+++ b/packages/i18n/src/server.ts
@@ -14,9 +14,15 @@ export { i18n };
  * module layer its own copy of the shared singleton, so the client-side
  * `I18nProvider` never activates it.
  *
- * Call this once from a root layout: it covers every server component rendered
- * beneath. Entry points that render *outside* the root layout (opengraph-image
- * routes, global-error) need their own call.
+ * Call this from every route entry that renders server components — each
+ * `page.tsx`, plus `not-found.tsx` and any other entry (opengraph-image
+ * routes, global-error). A root layout is NOT enough: a client-side navigation
+ * re-renders only the segments below the shared layout, so the layout body
+ * never runs and the slot stays empty for the whole page. `template.tsx` is
+ * pruned the same way. Lingui's own error says it exactly: "call `setI18n` in
+ * the root of your page".
+ *
+ * `packages/i18n/test/rsc-seeding.test.ts` enforces this for the marketing app.
  */
 export function initServerI18n(locale?: SupportedLocale): void {
 	initI18n(locale);

--- a/packages/i18n/test/rsc-seeding.test.ts
+++ b/packages/i18n/test/rsc-seeding.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { join, resolve } from "node:path";
+
+// Lingui's RSC `<Trans>`/`useLingui()` read the i18n instance from a
+// React.cache slot that `initServerI18n()` seeds. The slot lives for exactly
+// one render pass, and a client-side navigation renders only the segments
+// below the shared layout — the root layout and any template are pruned, so
+// seeding there covers a full document load and nothing else. Every route
+// entry has to seed for itself or its server components throw mid-render.
+// Regression guard for MARKETING-67/68/69.
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const ROUTE_ENTRY = /(?:^|\/)(?:page|not-found)\.tsx$/;
+
+describe("RSC route entries seed i18n", () => {
+	test("every marketing server route entry calls initServerI18n()", async () => {
+		const appDir = join(REPO_ROOT, "apps/marketing/src/app");
+		const offenders: string[] = [];
+		const glob = new Bun.Glob("**/*.tsx");
+		for await (const file of glob.scan({ cwd: appDir })) {
+			if (!ROUTE_ENTRY.test(file)) continue;
+			const source = await Bun.file(join(appDir, file)).text();
+			// Client components render on the client, where the I18nProvider
+			// supplies the instance through context instead.
+			if (/^\s*["']use client["']/m.test(source)) continue;
+			if (!source.includes("initServerI18n(")) {
+				offenders.push(file);
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/packages/i18n/test/rsc-seeding.test.ts
+++ b/packages/i18n/test/rsc-seeding.test.ts
@@ -10,6 +10,11 @@ import { join, resolve } from "node:path";
 // Regression guard for MARKETING-67/68/69.
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
 const ROUTE_ENTRY = /(?:^|\/)(?:page|not-found)\.tsx$/;
+// Anchored to the start of a line so a mention inside a comment or a string
+// literal cannot satisfy the check; paired with the import so the call has to
+// resolve to the real helper.
+const SEEDS = /^\s*initServerI18n\(\);/m;
+const IMPORTS = /^import\s*\{[^}]*\binitServerI18n\b[^}]*\}\s*from\s*["']/m;
 
 describe("RSC route entries seed i18n", () => {
 	test("every marketing server route entry calls initServerI18n()", async () => {
@@ -22,7 +27,7 @@ describe("RSC route entries seed i18n", () => {
 			// Client components render on the client, where the I18nProvider
 			// supplies the instance through context instead.
 			if (/^\s*["']use client["']/m.test(source)) continue;
-			if (!source.includes("initServerI18n(")) {
+			if (!SEEDS.test(source) || !IMPORTS.test(source)) {
 				offenders.push(file);
 			}
 		}


### PR DESCRIPTION
## Problem

Since `8d12655d7` (#6943) deployed, every server component on the marketing site that renders `<Trans>` or calls `useLingui()` throws during a **client-side navigation**. A visitor who clicks any in-site link hits a React error boundary on the destination page.

Live in production now:

- `MARKETING-68` — ``You tried to use `Trans` in Server Component, but i18n instance for RSC hasn't been setup.`` — 45 events, 8 users
- `MARKETING-69` — same for `useLingui` — 6 events, 5 users
- `MARKETING-67` — the browser-side face of it: "An error occurred in the Server Components render", 14 events, **10 users**, `handled: yes` (an error boundary caught it)

All on release `8d12655d7`, all first seen within minutes of that deploy.

## Root cause

Lingui's RSC `Trans`/`useLingui` read the active i18n instance out of a `React.cache()` slot that `setI18n()` seeds. That slot lives for exactly **one render pass**.

`initServerI18n()` was called only in the root layout. On a client-side navigation Next renders only the segments at and below the changed segment — the shared root layout is pruned, its body never runs, and the slot stays empty for the entire page. A full document load renders the layout, so the bug is invisible on hard loads and on every static check.

Verified directly against a local build with a real router-state-tree header:

| request | root layout renders? | root template renders? |
|---|---|---|
| document load | yes | yes |
| soft navigation | **no** | **no** |

`template.tsx` was tried first and is pruned identically, so it is not a fix.

Lingui's own error text says it exactly: *"call `setI18n` in the root of your page"* — page, not layout.

## Fix

Call `initServerI18n()` at the top of every marketing route entry (30 files: each `page.tsx` plus `not-found.tsx`). It is idempotent and cheap — catalogs load once behind a guard, then `i18n.activate()`.

Also:
- Corrected the doc comment on `initServerI18n()`, which asserted the false claim ("call this once from a root layout: it covers every server component rendered beneath") that produced this bug.
- Added `packages/i18n/test/rsc-seeding.test.ts`, a ratchet in the style of the existing i18n enforcement tests: any marketing server route entry missing the call fails the build. Without it the one-liner is forgettable and this regresses on the next new page.

No catalog changes; no behaviour change on document loads.

## Verification

All run on this branch, real output:

- **Repro, before**: soft-nav to `/pricing` → 4 `i18n instance for RSC` throws. Document load → 0. Isolated across an 8-way request matrix; only "RSC + router-state-tree pointing at a different route" (a genuine soft navigation) triggers it.
- **A/B**: with the call added to `/pricing` only, `/pricing` → 0 errors while `/stats` (untouched control) → still 4.
- **After, full sweep**: 21/21 routes + `/` + a 404 → `http=200`, **0 lingui errors** on soft navigation.
- **Negative control on the fix**: reverting `stats/page.tsx` brings the 4 errors back; restoring it clears them.
- **Negative control on the test**: removing the call from `stats/page.tsx` fails the new test naming `stats/page.tsx`; restoring it passes.
- `bunx biome check apps/marketing/src packages/i18n` → clean, no fixes applied.
- `cd apps/marketing && bun run typecheck` → clean.
- `cd packages/i18n && bun test` → 90 pass, 0 fail.
- `bun run --cwd packages/i18n check` → exit 0, catalogs byte-identical.

Refs MARKETING-67
Refs MARKETING-68
Refs MARKETING-69

https://claude.ai/code/session_01AnoeAZJf7hbF8uXC4Efrqb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes marketing server components using `<Trans>` or `useLingui()` throwing during client-side navigation by seeding the RSC i18n instance at every route entry instead of only the root layout. Resolves the errors reported in MARKETING-67/68/69.

**Details**
- Calls `initServerI18n()` at the top of 30 marketing route entries (`page.tsx` plus `not-found.tsx`).
- Corrects the `initServerI18n()` doc comment to warn that a root layout does not cover client-side navigations.
- Adds a build-time test that fails if any marketing server route entry omits the call; the check is anchored to a real import and call so mentions in comments or strings can't satisfy it.
- No catalog changes; document loads behave the same as before.

<sup>Written for commit 4a4b446c5c15974e6b3dbcd22300ad9f9e0f23af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved localized content availability across marketing pages and server-rendered routes.
  * Ensured translations remain consistent during page rendering and navigation.

* **Bug Fixes**
  * Resolved inconsistent translations when navigating between marketing pages.

* **Tests**
  * Added coverage to verify internationalization is initialized across applicable server-rendered routes.

* **Documentation**
  * Clarified internationalization requirements for server-rendered route entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->