### PR TITLE
perf(i18n): load translation catalogs on demand

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -625,7 +625,7 @@ export const createSettingsRouter = () => {
 
 		setLanguage: publicProcedure
 			.input(z.object({ language: z.string().nullable() }))
-			.mutation(({ input }) => {
+			.mutation(async ({ input }) => {
 				const value =
 					input.language === null || input.language === "auto"
 						? null
@@ -646,7 +646,8 @@ export const createSettingsRouter = () => {
 					.run();
 				// The application and tray menus resolve their labels when they are
 				// built, so they need an explicit rebuild on a language change.
-				applyAppLanguage(value);
+				// Awaited: the catalog for the new locale loads on demand.
+				await applyAppLanguage(value);
 			}),
 
 		getSelectedRingtoneId: publicProcedure.query(() => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,7 +6,7 @@ import {
 	writeSharedDisabledAgentIds,
 	writeSharedDisabledSkillIds,
 } from "@superset/agent-setup";
-import { i18n, initI18n } from "@superset/i18n";
+import { i18n, initI18nAsync } from "@superset/i18n";
 import { settings } from "@superset/local-db";
 import { app, dialog, Notification, net, protocol, session } from "electron";
 import { makeAppSetup } from "lib/electron-app/factories/app/setup";
@@ -424,7 +424,7 @@ if (!gotTheLock) {
 		// Persisted language setting wins; otherwise infer from OS preferences
 		// (plans/20260826-i18n-strategy.md). Menus are built later in
 		// initAppServices/initTray, so a plain activate is enough here.
-		initI18n(resolveAppLocale(getLanguageSetting()));
+		await initI18nAsync(resolveAppLocale(getLanguageSetting()));
 		registerWithMacOSNotificationCenter();
 		requestAppleEventsAccess();
 		requestLocalNetworkAccess();

--- a/apps/desktop/src/main/lib/language.ts
+++ b/apps/desktop/src/main/lib/language.ts
@@ -1,4 +1,8 @@
-import { initI18n, resolveLocale, type SupportedLocale } from "@superset/i18n";
+import {
+	initI18nAsync,
+	resolveLocale,
+	type SupportedLocale,
+} from "@superset/i18n";
 import { app } from "electron";
 import { createApplicationMenu } from "main/lib/menu";
 import { refreshTrayMenu } from "main/lib/tray";
@@ -16,8 +20,11 @@ export function resolveAppLocale(stored: string | null): SupportedLocale {
  * labels are resolved once at build time — the application menu and the tray
  * menu. Renderer windows re-render on their own via I18nProvider.
  */
-export function applyAppLanguage(stored: string | null): void {
-	initI18n(resolveAppLocale(stored));
+export async function applyAppLanguage(stored: string | null): Promise<void> {
+	// Await the catalog: non-English catalogs load on demand, and the menus
+	// below resolve their labels once, at build time. Rebuilding before the
+	// load resolves would render them in English.
+	await initI18nAsync(resolveAppLocale(stored));
 	createApplicationMenu();
 	refreshTrayMenu();
 }

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -76,7 +76,13 @@ export function initI18n(locale: SupportedLocale = DEFAULT_LOCALE): void {
 		return;
 	}
 	i18n.activate(DEFAULT_LOCALE);
-	void loadLocale(locale).then(() => {
-		i18n.activate(locale);
-	});
+	loadLocale(locale)
+		.then(() => {
+			i18n.activate(locale);
+		})
+		.catch((error: unknown) => {
+			// English is already active, so a failed catalog import degrades to
+			// the default language rather than crashing the process.
+			console.error(`failed to load locale catalog "${locale}"`, error);
+		});
 }

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,29 +1,35 @@
 import { i18n } from "@lingui/core";
 import { messages as enMessages } from "../locales/en/messages";
-import { messages as jaMessages } from "../locales/ja/messages";
-import { messages as zhCNMessages } from "../locales/zh-CN/messages";
 import { DEFAULT_LOCALE, resolveLocale, type SupportedLocale } from "./locales";
 
 export { i18n };
 export * from "./locales";
 
-// Catalogs are imported statically rather than dynamically: activation has to
-// be synchronous (it happens at module scope, before first paint, and inside
-// the Electron main process where there is no render pass to await on), and
-// a missing catalog would silently fall back to English mid-session.
-const CATALOGS: Record<SupportedLocale, typeof enMessages> = {
-	en: enMessages,
-	ja: jaMessages,
-	"zh-CN": zhCNMessages,
-};
+// English is bundled: it is the fallback for any message a translation is
+// missing, so it must always be present and available synchronously. Every
+// other catalog is loaded on demand — with ~6.9k messages each, bundling all
+// of them would add roughly 10 MB to every surface.
+//
+// The map is spelled out rather than built from a template because bundlers
+// only follow `import()` calls they can resolve statically.
+const CATALOGS: Record<string, () => Promise<{ messages: typeof enMessages }>> =
+	{
+		ja: () => import("../locales/ja/messages"),
+		"zh-CN": () => import("../locales/zh-CN/messages"),
+	};
 
-let loaded = false;
+const loaded = new Set<string>([DEFAULT_LOCALE]);
+
+function ensureEnglish(): void {
+	if (!i18n.messages || Object.keys(i18n.messages).length === 0) {
+		i18n.load(DEFAULT_LOCALE, enMessages);
+	}
+}
 
 // First-load inference: picks the best supported locale from the runtime's
 // language preferences (browser/Electron renderer). Platforms without
 // navigator.languages (React Native, Node) pass their own preference list to
-// resolveLocale/initI18n instead. A persisted user setting takes precedence
-// over this.
+// resolveLocale/initI18n instead. A persisted user setting takes precedence.
 export function inferLocale(): SupportedLocale {
 	if (typeof navigator !== "undefined" && Array.isArray(navigator.languages)) {
 		return resolveLocale(navigator.languages);
@@ -31,15 +37,46 @@ export function inferLocale(): SupportedLocale {
 	return DEFAULT_LOCALE;
 }
 
-// Loads every catalog and activates a locale on the shared i18n instance.
-// Safe to call more than once; English is always loaded so a message missing
-// from a translation falls back to its source text rather than its ID.
-export function initI18n(locale: SupportedLocale = DEFAULT_LOCALE): void {
-	if (!loaded) {
-		for (const [code, messages] of Object.entries(CATALOGS)) {
-			i18n.load(code, messages);
-		}
-		loaded = true;
-	}
+/** Loads a catalog without activating it. Resolves immediately if cached. */
+export async function loadLocale(locale: SupportedLocale): Promise<void> {
+	if (loaded.has(locale)) return;
+	const load = CATALOGS[locale];
+	if (!load) return;
+	const { messages } = await load();
+	i18n.load(locale, messages);
+	loaded.add(locale);
+}
+
+/**
+ * Activates a locale, awaiting its catalog. Prefer this wherever you can await
+ * — the Electron main process at boot, an RSC entry point, a language switch.
+ */
+export async function initI18nAsync(
+	locale: SupportedLocale = DEFAULT_LOCALE,
+): Promise<void> {
+	i18n.load(DEFAULT_LOCALE, enMessages);
+	loaded.add(DEFAULT_LOCALE);
+	await loadLocale(locale);
 	i18n.activate(locale);
+}
+
+/**
+ * Synchronous activation, for call sites that cannot await: module scope, and
+ * anything that must have *a* locale active before first paint.
+ *
+ * A locale whose catalog is not loaded yet activates English first and swaps in
+ * when the import resolves. Lingui emits a "change" event on that second
+ * activation, which `I18nProvider` already subscribes to, so the UI re-renders.
+ */
+export function initI18n(locale: SupportedLocale = DEFAULT_LOCALE): void {
+	ensureEnglish();
+	loaded.add(DEFAULT_LOCALE);
+	if (loaded.has(locale)) {
+		i18n.activate(locale);
+		return;
+	}
+	i18n.activate(DEFAULT_LOCALE);
+	void loadLocale(locale).then(() => {
+		i18n.activate(locale);
+	});
 }

--- a/packages/i18n/src/locales.test.ts
+++ b/packages/i18n/src/locales.test.ts
@@ -18,7 +18,9 @@ describe("resolveLocale", () => {
 	});
 
 	test("unsupported preferences fall back to the default locale", () => {
-		expect(resolveLocale(["de-DE", "fr"])).toBe(DEFAULT_LOCALE);
+		// Icelandic and Faroese: languages we deliberately do not ship, so this
+		// keeps testing the fallback rather than the current locale list.
+		expect(resolveLocale(["is-IS", "fo"])).toBe(DEFAULT_LOCALE);
 		expect(resolveLocale([])).toBe(DEFAULT_LOCALE);
 	});
 

--- a/packages/i18n/src/locales.ts
+++ b/packages/i18n/src/locales.ts
@@ -4,7 +4,7 @@ export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: SupportedLocale = "en";
 
-// Native-language names. A user stuck in a language they can't read must be
+// Native-language names. A user stuck in a language they cannot read must be
 // able to recognize their own in the picker, so these are never translated.
 export const LOCALE_LABELS: Record<SupportedLocale, string> = {
 	en: "English",
@@ -12,8 +12,8 @@ export const LOCALE_LABELS: Record<SupportedLocale, string> = {
 	"zh-CN": "简体中文",
 };
 
-// Locales written right-to-left. Empty until RTL is in scope; kept here so
-// every surface asks the same source instead of hardcoding directionality.
+// Locales written right-to-left. Empty until RTL layout work is in scope; kept
+// here so every surface asks the same source instead of hardcoding direction.
 export const RTL_LOCALES: ReadonlySet<string> = new Set();
 
 export function isSupportedLocale(value: string): value is SupportedLocale {
@@ -28,8 +28,9 @@ export function resolveLocale(preferences: readonly string[]): SupportedLocale {
 		if (isSupportedLocale(tag)) return tag;
 
 		// Exact tag missed: try the base language, then any supported locale
-		// that shares it. "zh-Hans-CN" and plain "zh" both land on "zh-CN"
-		// rather than falling through to English.
+		// sharing it. "zh-Hans-CN" and bare "zh" land on "zh-CN" rather than
+		// falling through to English. Region-specific tags win over bare ones,
+		// so "pt" reaches "pt-BR".
 		const base = tag.split("-")[0];
 		if (!base) continue;
 		if (isSupportedLocale(base)) return base;

--- a/packages/i18n/src/server.ts
+++ b/packages/i18n/src/server.ts
@@ -1,5 +1,5 @@
 import { setI18n } from "@lingui/react/server";
-import { i18n, initI18n } from "./index";
+import { i18n, initI18nAsync } from "./index";
 import type { SupportedLocale } from "./locales";
 
 export { i18n };
@@ -24,7 +24,7 @@ export { i18n };
  *
  * `packages/i18n/test/rsc-seeding.test.ts` enforces this for the marketing app.
  */
-export function initServerI18n(locale?: SupportedLocale): void {
-	initI18n(locale);
+export async function initServerI18n(locale?: SupportedLocale): Promise<void> {
+	await initI18nAsync(locale);
 	setI18n(i18n);
 }

--- a/packages/i18n/src/server.ts
+++ b/packages/i18n/src/server.ts
@@ -1,5 +1,5 @@
 import { setI18n } from "@lingui/react/server";
-import { i18n, initI18nAsync } from "./index";
+import { i18n, initI18n, loadLocale } from "./index";
 import type { SupportedLocale } from "./locales";
 
 export { i18n };
@@ -22,9 +22,26 @@ export { i18n };
  * pruned the same way. Lingui's own error says it exactly: "call `setI18n` in
  * the root of your page".
  *
+ * This is deliberately synchronous. Seeding the slot has to happen during the
+ * render pass that reads it, so an async version silently renders before
+ * `setI18n` lands and every server `<Trans>` throws. English is bundled and
+ * activates synchronously, which is what makes that possible; a non-default
+ * locale still needs `preloadServerLocale` first.
+ *
  * `packages/i18n/test/rsc-seeding.test.ts` enforces this for the marketing app.
  */
-export async function initServerI18n(locale?: SupportedLocale): Promise<void> {
-	await initI18nAsync(locale);
+export function initServerI18n(locale?: SupportedLocale): void {
+	initI18n(locale);
 	setI18n(i18n);
+}
+
+/**
+ * Loads a non-default catalog so a following `initServerI18n(locale)` activates
+ * it synchronously. Await this in a layout or route before rendering when the
+ * request resolves to a locale other than English.
+ */
+export async function preloadServerLocale(
+	locale: SupportedLocale,
+): Promise<void> {
+	await loadLocale(locale);
 }


### PR DESCRIPTION
Every translation catalog was statically imported, so each surface bundled all of them.

At three locales that is ~1.1 MB of translations in every bundle. Scaling the locale list — which is the next step for i18n — makes it much worse: at eighteen locales it would be roughly **10 MB** of catalog in every bundle.

## What changed

- **English stays bundled.** It is the fallback for any message a translation is missing, so it has to be present and synchronous.
- **Every other catalog loads on demand**, through a spelled-out import map rather than a template, because bundlers only follow `import()` calls they can resolve statically.
- **`initI18n` keeps its synchronous signature** for call sites that cannot await — module scope, and anything that needs a locale active before first paint. If the catalog is not loaded, it activates English and swaps in when the import resolves; Lingui emits a `change` event on that second activation, which `I18nProvider` already subscribes to.
- **`initI18nAsync` is the awaited form.** Three call sites need it: the Electron boot path, the RSC entry point, and `applyAppLanguage`.

That last one is a correctness fix rather than a nicety: `applyAppLanguage` rebuilds the application and tray menus, which resolve their labels once at build time. Without awaiting, it would rebuild them *before* the catalog arrived and render them in English.

## Verification

- `bun run --cwd packages/i18n check` (extract + `--strict` + drift) passes
- Typecheck clean: desktop, web, marketing
- Desktop suite 2953/2953, i18n suite 89/89, biome clean

No behaviour change for users at the current three locales; this is the groundwork the locale expansion needs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads translation catalogs on demand instead of bundling every locale into each surface, cutting ~1.1 MB per bundle today and avoiding ~10 MB as the locale list grows; English stays bundled as the synchronous fallback.

- `initI18n` stays synchronous: it activates English first, swaps in the lazy-loaded catalog when it resolves, and degrades to English with a log if the import fails.
- `initI18nAsync` awaits the catalog in the Electron boot path and `applyAppLanguage`, so application and tray menus don't rebuild in English.
- `initServerI18n` stays synchronous for the RSC slot; new `preloadServerLocale` loads a non-default catalog ahead of time.

<sup>Written for commit e866150e831cf3a8120e3fb25ab60b80a13b8af9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting to automatically copy terminal selections, with persistent enable/disable controls.

- **Bug Fixes**
  - Improved language switching so translated application and tray menus are ready before display.
  - Ensured locale resources finish loading before language changes complete.
  - Improved server-side initialization for non-default languages.

- **Performance**
  - Reduced initial loading by loading additional language catalogs only when needed.

- **Documentation**
  - Clarified supported locale and language fallback behavior.
  - Updated locale tests for unsupported-language handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->