### PR TITLE
fix(workspace-client): value-compare relay preflight probes

### DIFF
--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -200,6 +200,15 @@ function fileWatchKey(workspaceId: string, absolutePath: string): string {
 	return `${workspaceId}\0${absolutePath}`;
 }
 
+function probesEqual(
+	left: RelayAffinityProbe | null,
+	right: RelayAffinityProbe | null,
+): boolean {
+	if (left === right) return true;
+	if (left === null || right === null) return false;
+	return left.status === right.status && left.region === right.region;
+}
+
 function setConnectionStatus(
 	state: ConnectionState,
 	next: { state?: HostConnectionState; probe?: RelayAffinityProbe | null },
@@ -207,12 +216,20 @@ function setConnectionStatus(
 	const current = state.status;
 	const nextState = next.state ?? current.state;
 	const nextProbe = "probe" in next ? (next.probe ?? null) : current.probe;
-	if (nextState === current.state && nextProbe === current.probe) return;
+	// Value-compare probes: the preflight allocates a fresh result object per
+	// dial, so identity comparison republished an unchanged 503 on every
+	// backoff attempt — fanning a no-op "transition" out to every status
+	// subscriber (and their React commits) for as long as a host stayed down.
+	if (nextState === current.state && probesEqual(nextProbe, current.probe)) {
+		return;
+	}
 
 	state.status = {
 		state: nextState,
 		since: nextState === current.state ? current.since : Date.now(),
-		probe: nextProbe,
+		// Keep the old probe object when only the state moved, so subscribers
+		// keying on probe identity don't re-derive from an equal value.
+		probe: probesEqual(nextProbe, current.probe) ? current.probe : nextProbe,
 	};
 	for (const listener of state.statusListeners) listener(state.status);
 }


### PR DESCRIPTION
## What & why

Every backoff attempt against a down host allocated a fresh but identical `{ status: 503 }` relay-preflight probe object, and `setConnectionStatus` compared probes by identity, so each retry was broadcast to every status subscriber as a "transition": React commits on every attempt, for as long as the host stayed down. Compare probes by value (`status` + `region`) and keep the old probe object when nothing changed, so `useSyncExternalStore` consumers see a stable snapshot.

This PR was trimmed on 2026-09-02 to just this change. The original three commits are at `9be2f4593` for reference:

- The app-wide freeze after deleting a workspace turned out to be two copies of `@radix-ui/react-dismissable-layer` from the context-menu bump in #6898, not a Radix exit-transition race. It is fixed by the dependency pin in #7108; the `releaseStuckBodyPointerEventsLock` band-aid is not needed and is dropped.
- Remote-host sidebar placement and the offline-snapshot removal are tracked under #7100 and dropped here.
- The 1 s connection linger and the sidebar status-provider reachability gate were churn reductions with no user-visible bug attached; dropped to keep this minimal and easy to bring back if wanted.

## How I tested it

`packages/workspace-client` tests (15 pass), `packages/workspace-client` and `apps/desktop` typecheck, biome on the changed file.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

https://claude.ai/code/session_017rHcm7o3gYeA3DATA2AHqM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary connection status notifications when relay probe results remain equivalent.
  * Preserved relay probe information consistently across connection state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->