### PR TITLE
fix(desktop): stop sidebar status fan-out for an unreachable host

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
@@ -170,7 +170,22 @@ export function DashboardSidebarWorkspaceStatusProvider({
 }) {
 	const [store] = useState(() => new SidebarWorkspaceStatusStore());
 	const queryClient = useQueryClient();
-	const { cache: hostWorkspacesCache } = useHostWorkspaces();
+	const { workspaces: hostWorkspaceItems, cache: hostWorkspacesCache } =
+		useHostWorkspaces();
+
+	// `hostReachable` reflects whether the host's last live fetch actually
+	// succeeded — unlike a host's self-reported `isOnline`, which stays true
+	// while the host itself is up even when the relay in between is flaky.
+	// A row whose host is currently unreachable gets no live subscription:
+	// holding a socket open to a host that's failing every attempt just adds
+	// reconnect churn (and the re-renders it drives) for a stream with
+	// nothing to report — the 30s workspace-list poll already re-adds the
+	// subscription the moment the host answers again.
+	const reachableByWorkspaceId = useMemo(() => {
+		const map = new Map<string, boolean>();
+		for (const item of hostWorkspaceItems) map.set(item.id, item.hostReachable);
+		return map;
+	}, [hostWorkspaceItems]);
 
 	const computedTargets = useMemo<WorkspaceStatusTarget[]>(
 		() =>
@@ -180,11 +195,13 @@ export function DashboardSidebarWorkspaceStatusProvider({
 				// a socket to it keeps its VM awake for as long as the app is open,
 				// and the sidebar is open all day. Its status goes live when the
 				// workspace itself is opened and its own subscribers connect.
-				hostUrl: hostWorkspacesCache.isSandboxHost(workspace.hostId)
-					? null
-					: hostWorkspacesCache.resolveHostUrl(workspace.hostId),
+				hostUrl:
+					hostWorkspacesCache.isSandboxHost(workspace.hostId) ||
+					reachableByWorkspaceId.get(workspace.id) === false
+						? null
+						: hostWorkspacesCache.resolveHostUrl(workspace.hostId),
 			})),
-		[workspaces, hostWorkspacesCache],
+		[workspaces, hostWorkspacesCache, reachableByWorkspaceId],
 	);
 	// Fingerprint-stabilized: the host-workspaces cache object churns identity
 	// on unrelated updates, and the subscription effect below must only re-run


### PR DESCRIPTION
## Summary

Follow-up to #6953. While verifying that fix against a real remote host, deleting a workspace whose host's relay tunnel was flaky made the whole app appear to freeze (no clicks registered, only a native reload recovered it), even though the delete itself completed successfully. Confirmed via console logging that the freeze is unrelated to delete — it's driven by `DashboardSidebarWorkspaceStatusProvider`.

That provider fans out one live event-bus subscription and one terminal-agent-bindings query per sidebar-visible workspace, skipping only sandbox rows. A host's self-reported `isOnline` flag stays true as long as its host-service process is up, even when the *relay tunnel* between the client and that host is currently failing (503/502) — a real scenario, not hypothetical, since relay edges can flap independently of the host itself. In that state, the subscription opens, immediately fails, and retries with backoff (1s → 30s, already reasonable) — but every reconnect/probe cycle invalidates bindings and diff-stats queries for every row on that host, and with a full sidebar tree re-rendering on each cycle, this reads as sustained jank/unresponsiveness rather than a clean, quiet retry.

This was never visible before #6953, because a workspace on a remote host never had a sidebar row at all, so nothing ever subscribed to that host's live events from the renderer.

## Fix

Gate the fan-out on `hostReachable` (from `useHostWorkspaces()` — reflects whether the host's last live fetch actually succeeded) in addition to the existing sandbox check. A workspace on a currently-unreachable host gets no subscription; the existing 30s `workspace.list` poll re-admits it automatically once the host answers again. `bindingRowsByIndex`'s `useQueries` is already gated on `target.hostUrl !== null`, so nulling `hostUrl` here disables both the event-bus subscription and the bindings query fan-out in one place.

## Test plan

- [x] `bun run lint` / `bun run typecheck` — clean across the monorepo
- [x] `bun test` (apps/desktop) — same 5 pre-existing failures as on `main` (Shell Environment/PATH + createWorktree hook tolerance, environment/test-isolation issues unrelated to this file), no new failures
- [x] No existing test file for this provider (no RTL harness for it currently); the change is a small, type-checked derivation gated by an existing, already-typed field, so I didn't add new test scaffolding for a component that has none — flagging this in case maintainers want it covered differently
- [ ] Live re-verification against the same real flaky-relay host that reproduced the original freeze — I don't have a live repro environment for this PR by itself; happy to re-test if a reviewer can confirm reachable/unreachable transitions against a real relay-flaky host

## Related

Surfaced while testing #6953 — not a regression in that PR's own logic, but a pre-existing gap in this provider's resilience that #6953 makes reachable for the first time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the sidebar from opening live status subscriptions for workspaces whose host is currently unreachable, preventing reconnect churn that made the app feel frozen.

- Gates the live event-bus subscription and bindings query fan-out on `hostReachable` from `useHostWorkspaces()`, in addition to the existing sandbox check.
- A host's self-reported `isOnline` stays true even when the relay tunnel in between is flaky, so previously a failing subscription kept retrying and re-rendering every sidebar row.
- Workspaces on unreachable hosts get re-admitted automatically by the existing 30s `workspace.list` poll once the host answers again.

<sup>Written for commit b2fda70151346761f7a8abc321718a71214c1d12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace connection handling in the dashboard sidebar.
  * Live updates are now paused when a workspace host is unreachable, reducing connection errors and improving status accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->