### PR TITLE
ci: smoke test deployed previews and arm the RSC seeding guard for every Next app

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -356,6 +356,10 @@ jobs:
           vercel alias $VERCEL_URL ${{ env.WEB_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
+      - name: Smoke test web routes
+        run: |
+          bun scripts/smoke-routes.ts "https://${{ env.WEB_ALIAS }}" /
+
       - name: Save web success status
         run: |
           cat > web-status.env << EOF
@@ -469,6 +473,17 @@ jobs:
             --env ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY)
           vercel alias $VERCEL_URL ${{ env.MARKETING_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
+
+      # Until now the pipeline deployed and never requested a page, so a build
+      # that returned 500 on every route still went green. MARKETING-67/68/69
+      # reached production that way.
+      - name: Smoke test marketing routes
+        run: |
+          bun scripts/smoke-routes.ts "https://${{ env.MARKETING_ALIAS }}" \
+            / /pricing /enterprise /download /join-us /community /contact \
+            /blog /changelog /compare /roadmap /leaderboard /marketplace \
+            /agent-orchestration /parallel-coding-agents /factory-2026 \
+            /mcp-install /stats /team /starchart
 
       - name: Save marketing success status
         run: |
@@ -588,6 +603,10 @@ jobs:
           vercel alias $VERCEL_URL ${{ env.ADMIN_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
+      - name: Smoke test admin routes
+        run: |
+          bun scripts/smoke-routes.ts "https://${{ env.ADMIN_ALIAS }}" /
+
       - name: Save admin success status
         run: |
           cat > admin-status.env << EOF
@@ -670,6 +689,10 @@ jobs:
             --env SECRETS_ENCRYPTION_KEY=$SECRETS_ENCRYPTION_KEY)
           vercel alias $VERCEL_URL ${{ env.DOCS_ALIAS }} --scope=$VERCEL_ORG_ID --token=$VERCEL_TOKEN
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
+
+      - name: Smoke test docs routes
+        run: |
+          bun scripts/smoke-routes.ts "https://${{ env.DOCS_ALIAS }}" /
 
       - name: Save docs success status
         run: |

--- a/packages/i18n/test/rsc-seeding.test.ts
+++ b/packages/i18n/test/rsc-seeding.test.ts
@@ -8,6 +8,10 @@ import { join, resolve } from "node:path";
 // seeding there covers a full document load and nothing else. Every route
 // entry has to seed for itself or its server components throw mid-render.
 // Regression guard for MARKETING-67/68/69.
+//
+// Note this never showed up in CI or locally: a document request renders the
+// layout, so only a real client-side navigation against a deployment failed.
+// That is why the guard is static rather than a smoke test.
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
 const ROUTE_ENTRY = /(?:^|\/)(?:page|not-found)\.tsx$/;
 // Anchored to the start of a line so a mention inside a comment or a string
@@ -15,22 +19,48 @@ const ROUTE_ENTRY = /(?:^|\/)(?:page|not-found)\.tsx$/;
 // resolve to the real helper.
 const SEEDS = /^\s*initServerI18n\(\);/m;
 const IMPORTS = /^import\s*\{[^}]*\binitServerI18n\b[^}]*\}\s*from\s*["']/m;
+const USES_I18N = /<Trans\b|useLingui\(/;
+const CLIENT_COMPONENT = /^\s*["']use client["']/m;
+
+// Every Next.js app in the repo. Apps with no server-rendered translation are
+// still listed: the check arms itself the moment one is added, which is the
+// point — marketing had no guard until it had already broken in production.
+const NEXT_APPS = ["marketing", "web", "admin", "docs"] as const;
+
+async function scan(app: string) {
+	const srcDir = join(REPO_ROOT, "apps", app, "src");
+	const entries: { file: string; source: string }[] = [];
+	let hasServerI18n = false;
+
+	const glob = new Bun.Glob("**/*.{ts,tsx}");
+	for await (const file of glob.scan({ cwd: srcDir })) {
+		const source = await Bun.file(join(srcDir, file)).text();
+		const isClient = CLIENT_COMPONENT.test(source);
+		if (!isClient && USES_I18N.test(source)) hasServerI18n = true;
+		if (file.startsWith("app/") && ROUTE_ENTRY.test(file) && !isClient) {
+			entries.push({ file, source });
+		}
+	}
+	return { entries, hasServerI18n };
+}
 
 describe("RSC route entries seed i18n", () => {
-	test("every marketing server route entry calls initServerI18n()", async () => {
-		const appDir = join(REPO_ROOT, "apps/marketing/src/app");
-		const offenders: string[] = [];
-		const glob = new Bun.Glob("**/*.tsx");
-		for await (const file of glob.scan({ cwd: appDir })) {
-			if (!ROUTE_ENTRY.test(file)) continue;
-			const source = await Bun.file(join(appDir, file)).text();
-			// Client components render on the client, where the I18nProvider
-			// supplies the instance through context instead.
-			if (/^\s*["']use client["']/m.test(source)) continue;
-			if (!SEEDS.test(source) || !IMPORTS.test(source)) {
-				offenders.push(file);
+	for (const app of NEXT_APPS) {
+		test(`${app}: every server route entry calls initServerI18n()`, async () => {
+			const { entries, hasServerI18n } = await scan(app);
+
+			// An app whose translated markup is entirely in client components
+			// gets its i18n instance from the I18nProvider through context, so
+			// there is nothing to seed and nothing to enforce yet.
+			if (!hasServerI18n) {
+				expect(entries.length).toBeGreaterThanOrEqual(0);
+				return;
 			}
-		}
-		expect(offenders).toEqual([]);
-	});
+
+			const offenders = entries
+				.filter(({ source }) => !SEEDS.test(source) || !IMPORTS.test(source))
+				.map(({ file }) => `${app}/${file}`);
+			expect(offenders).toEqual([]);
+		});
+	}
 });

--- a/scripts/smoke-routes.ts
+++ b/scripts/smoke-routes.ts
@@ -63,10 +63,20 @@ async function hit(route: string, mode: "document" | "rsc") {
 		failures.push({ route, mode, detail: `HTTP ${res.status}` });
 		return;
 	}
+	// A route we listed should exist. A 404 here means the page is gone or
+	// failed to render into one, which is exactly what we are watching for.
+	// Redirects are fine: auth-gated routes legitimately send you to sign-in.
+	if (res.status === 404) {
+		failures.push({ route, mode, detail: "HTTP 404" });
+		return;
+	}
 	const body = await res.text();
 	// A caught server-component error still returns 200 with a digest in the
 	// payload, so status alone is not enough.
-	const digest = body.match(/"digest"\s*:\s*"([^"]+)"/);
+	// Next embeds flight data as an escaped JSON string, so the payload reads
+	// \"digest\":\"abc\" rather than "digest":"abc". Match both — an
+	// unescaped-only pattern silently passes every real error page.
+	const digest = body.match(/\\?"digest\\?"\s*:\s*\\?"([^"\\]+)/);
 	if (digest) {
 		failures.push({ route, mode, detail: `error digest ${digest[1]}` });
 		return;

--- a/scripts/smoke-routes.ts
+++ b/scripts/smoke-routes.ts
@@ -1,0 +1,97 @@
+// Requests every route of a deployed Next app two ways and fails on any 5xx.
+//
+// The second way is an RSC request, the shape a client-side navigation uses.
+//
+// Scope, so this is not mistaken for more than it is: we send `RSC: 1` but no
+// `Next-Router-State-Tree`. Without that header Next renders the full tree
+// including the root layout, so this does NOT reproduce the segment pruning
+// that caused MARKETING-67/68/69. Fabricating a tree is not the answer — a
+// hand-built one 500s against a healthy deploy, and its shape is coupled to
+// the Next version, so it fails closed for the wrong reason. Layout pruning
+// is covered statically instead, by packages/i18n/test/rsc-seeding.test.ts.
+//
+// What this does catch is everything that only breaks once deployed: a
+// missing environment variable, a failing data fetch, a route that throws
+// under the serverless runtime. Today CI deploys and never requests a page.
+//
+// Usage: bun scripts/smoke-routes.ts <base-url> <route>...
+const [baseArg, ...routes] = process.argv.slice(2);
+if (!baseArg || routes.length === 0) {
+	console.error("usage: bun scripts/smoke-routes.ts <base-url> <route>...");
+	process.exit(2);
+}
+const base = baseArg.replace(/\/$/, "");
+
+type Failure = { route: string; mode: string; detail: string };
+const failures: Failure[] = [];
+
+// The alias is assigned seconds before this runs and can take a moment to
+// resolve. Without this the gate fails intermittently on a healthy deploy,
+// and a flaky gate is one somebody turns off.
+async function waitForReady(timeoutMs = 90_000) {
+	const deadline = Date.now() + timeoutMs;
+	let lastDetail = "no attempt made";
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(base, { redirect: "manual" });
+			if (res.status < 500) return;
+			lastDetail = `HTTP ${res.status}`;
+		} catch (error) {
+			lastDetail = String(error);
+		}
+		await new Promise((r) => setTimeout(r, 3000));
+	}
+	console.error(`${base} never became reachable: ${lastDetail}`);
+	process.exit(1);
+}
+
+async function hit(route: string, mode: "document" | "rsc") {
+	const url =
+		mode === "document"
+			? `${base}${route}`
+			: `${base}${route}${route.includes("?") ? "&" : "?"}_rsc=smoke`;
+	const headers: Record<string, string> =
+		mode === "rsc" ? { RSC: "1" } : {};
+	let res: Response;
+	try {
+		res = await fetch(url, { headers, redirect: "manual" });
+	} catch (error) {
+		failures.push({ route, mode, detail: `request failed: ${String(error)}` });
+		return;
+	}
+	if (res.status >= 500) {
+		failures.push({ route, mode, detail: `HTTP ${res.status}` });
+		return;
+	}
+	const body = await res.text();
+	// A caught server-component error still returns 200 with a digest in the
+	// payload, so status alone is not enough.
+	const digest = body.match(/"digest"\s*:\s*"([^"]+)"/);
+	if (digest) {
+		failures.push({ route, mode, detail: `error digest ${digest[1]}` });
+		return;
+	}
+	if (/An error occurred in the Server Components render/.test(body)) {
+		failures.push({ route, mode, detail: "server components render error" });
+	}
+}
+
+await waitForReady();
+
+for (const route of routes) {
+	await hit(route, "document");
+	await hit(route, "rsc");
+	const bad = failures.filter((f) => f.route === route);
+	console.log(
+		`${bad.length === 0 ? "ok  " : "FAIL"} ${route}${bad.length ? "  " + bad.map((b) => `${b.mode}: ${b.detail}`).join("; ") : ""}`,
+	);
+}
+
+if (failures.length > 0) {
+	console.error(`\n${failures.length} check(s) failed:`);
+	for (const f of failures) {
+		console.error(`  ${f.route} [${f.mode}] ${f.detail}`);
+	}
+	process.exit(1);
+}
+console.log(`\nall ${routes.length} routes ok (document + RSC)`);

--- a/scripts/smoke-routes.ts
+++ b/scripts/smoke-routes.ts
@@ -34,7 +34,9 @@ async function waitForReady(timeoutMs = 90_000) {
 	while (Date.now() < deadline) {
 		try {
 			const res = await fetch(base, { redirect: "manual" });
-			if (res.status < 500) return;
+			// A fresh alias serves 404 until it propagates, so anything except
+			// a real page (2xx) or an auth redirect (3xx) means "not yet".
+			if (res.status < 400) return;
 			lastDetail = `HTTP ${res.status}`;
 		} catch (error) {
 			lastDetail = String(error);
@@ -50,8 +52,7 @@ async function hit(route: string, mode: "document" | "rsc") {
 		mode === "document"
 			? `${base}${route}`
 			: `${base}${route}${route.includes("?") ? "&" : "?"}_rsc=smoke`;
-	const headers: Record<string, string> =
-		mode === "rsc" ? { RSC: "1" } : {};
+	const headers: Record<string, string> = mode === "rsc" ? { RSC: "1" } : {};
 	let res: Response;
 	try {
 		res = await fetch(url, { headers, redirect: "manual" });
@@ -93,7 +94,7 @@ for (const route of routes) {
 	await hit(route, "rsc");
 	const bad = failures.filter((f) => f.route === route);
 	console.log(
-		`${bad.length === 0 ? "ok  " : "FAIL"} ${route}${bad.length ? "  " + bad.map((b) => `${b.mode}: ${b.detail}`).join("; ") : ""}`,
+		`${bad.length === 0 ? "ok  " : "FAIL"} ${route}${bad.length ? `  ${bad.map((b) => `${b.mode}: ${b.detail}`).join("; ")}` : ""}`,
 	);
 }
 

--- a/scripts/smoke-routes.ts
+++ b/scripts/smoke-routes.ts
@@ -60,15 +60,11 @@ async function hit(route: string, mode: "document" | "rsc") {
 		failures.push({ route, mode, detail: `request failed: ${String(error)}` });
 		return;
 	}
-	if (res.status >= 500) {
+	// Any 4xx or 5xx on a listed route is a failure: 404 means the page is
+	// gone, 401/403 mean a public route got gated, 5xx is the app breaking.
+	// Redirects are fine — auth-gated routes legitimately send you to sign-in.
+	if (res.status >= 400) {
 		failures.push({ route, mode, detail: `HTTP ${res.status}` });
-		return;
-	}
-	// A route we listed should exist. A 404 here means the page is gone or
-	// failed to render into one, which is exactly what we are watching for.
-	// Redirects are fine: auth-gated routes legitimately send you to sign-in.
-	if (res.status === 404) {
-		failures.push({ route, mode, detail: "HTTP 404" });
 		return;
 	}
 	const body = await res.text();


### PR DESCRIPTION
## Why

Two gaps let MARKETING-67/68/69 (the RSC i18n incident, 100+ users) reach production:

1. **The deploy pipeline never requested a page.** It built, deployed, aliased, and posted a comment. A deployment that 500s on every route still went green.
2. **The RSC seeding guard from #6950 only covered `apps/marketing`.** web, admin, and docs have the identical footgun and no guard.

## What

- `scripts/smoke-routes.ts` — after each preview deploy, walks the app's routes as a document request and as an `RSC: 1` request, failing on any 5xx, on a 404 for a listed route, or on a 200 that carries an error digest (how a caught server-component error presents). Waits for the alias to resolve first so the gate doesn't flake.
- `packages/i18n/test/rsc-seeding.test.ts` now covers all four Next apps and **arms itself**: an app whose translated markup is entirely in client components has nothing to seed, so the check stays quiet until the first server-rendered `<Trans>` appears, then requires every route entry in that app to seed.

## Verification (all real output)

- Local fixture server: 500 → exit 1, 404 → exit 1, RSC-only 500 → exit 1, escaped `\"digest\"` payload → exit 1, "Server Components render" error text → exit 1, healthy route → exit 0, 302 → exit 0 (auth redirects are legitimate).
- Production superset.sh: all routes pass, both request modes.
- Guard: removing one `initServerI18n()` from a marketing page fails the suite naming that file; adding a single server-side `<Trans>` to web arms it and names all 21 unseeded web entries; a mention in a comment does not satisfy the anchored pattern.

Scope honestly stated: the smoke test sends `RSC: 1` without a router state tree, so it does **not** reproduce the client-nav layout pruning that caused the incident — a fabricated tree 500s against a healthy deploy and its shape follows the Next version. Pruning stays covered by the static guard.

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds smoke tests for deployed previews and expands the RSC seeding guard to all four Next apps, closing both gaps that let MARKETING-67/68/69 reach production.

**Smoke tests**
- The deploy pipeline previously aliased and commented without ever requesting a page; a build that 500s on every route still passed.
- `scripts/smoke-routes.ts` requests each route as a document and as an `RSC: 1` request, failing on any 4xx or 5xx, or on a 200 carrying an error digest.
- It waits for the alias to serve a real page or auth redirect before checking, so it doesn't flake against a not-yet-propagated alias.
- The request sends no router state tree, so it doesn't reproduce the client-nav layout pruning behind the incident; a fabricated tree 500s against healthy deploys and its shape tracks the Next version.

**Seeding guard**
- The guard previously covered only `apps/marketing` and now covers marketing, web, admin, and docs.
- It arms itself: an app with no server-rendered `<Trans>` stays quiet until the first one appears, then requires every route entry in that app to seed.

<sup>Written for commit ad41fb7b524480386384527e72e1ff893f72109a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated smoke tests for preview deployments across web, marketing, admin, and documentation sites.
  * Preview checks now validate standard and server-rendered requests across key routes.
  * Deployment validation detects server errors, missing pages, and rendering failures.

* **Tests**
  * Expanded internationalization checks across all supported Next.js applications to verify server routes initialize translations correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->