### PR TITLE
fix(desktop): preserve provider profile and sync sidebar state

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -6,7 +6,7 @@ import {
 	useMatchRoute,
 	useNavigate,
 } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CommandPaletteHost } from "renderer/commandPalette";
 import { Redirect } from "renderer/components/Redirect";
 import { useIsV2CloudEnabled } from "renderer/hooks/useIsV2CloudEnabled";
@@ -25,6 +25,8 @@ import { DeleteWorkspaceDialog } from "renderer/screens/main/components/Workspac
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { usePortsDisplayMode } from "renderer/stores/inline-workspace-ports";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
+import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
+import { syncPersistedStoreAcrossWindows } from "renderer/stores/syncPersistedStoreAcrossWindows";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
 	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
@@ -58,6 +60,19 @@ function DashboardLayout() {
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
 	const quickCreateWorkspace = useQuickCreateWorkspace();
 	useDevSeedV2Sidebar();
+	useEffect(() => {
+		const stopWorkspaceSidebarSync = syncPersistedStoreAcrossWindows(
+			useWorkspaceSidebarStore,
+		);
+		const stopSectionCollapseSync = syncPersistedStoreAcrossWindows(
+			useSidebarSectionsCollapseStore,
+		);
+
+		return () => {
+			stopWorkspaceSidebarSync();
+			stopSectionCollapseSync();
+		};
+	}, []);
 	// Get current workspace from route to pre-select project in new workspace modal
 	const matchRoute = useMatchRoute();
 	const currentWorkspaceMatch = matchRoute({

--- a/apps/desktop/src/renderer/stores/sidebar-sections-collapse.ts
+++ b/apps/desktop/src/renderer/stores/sidebar-sections-collapse.ts
@@ -3,6 +3,9 @@ import { devtools, persist } from "zustand/middleware";
 
 export type SidebarSectionKey = "cloud" | "pinned" | "sessions" | "workspaces";
 
+export const SIDEBAR_SECTIONS_COLLAPSE_STORAGE_KEY =
+	"sidebar-workspaces-collapse";
+
 interface SidebarSectionsCollapseState {
 	collapsed: Record<SidebarSectionKey, boolean>;
 	toggle: (section: SidebarSectionKey) => void;
@@ -30,7 +33,7 @@ export const useSidebarSectionsCollapseStore =
 				{
 					// Legacy key: v0 held only the workspaces-list flag as
 					// { isCollapsed }, before Pinned/Sessions became collapsible.
-					name: "sidebar-workspaces-collapse",
+					name: SIDEBAR_SECTIONS_COLLAPSE_STORAGE_KEY,
 					version: 1,
 					migrate: (persisted, version) => {
 						if (version === 0) {

--- a/apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/index.ts
+++ b/apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/index.ts
@@ -1,0 +1,1 @@
+export { syncPersistedStoreAcrossWindows } from "./syncPersistedStoreAcrossWindows";

--- a/apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/syncPersistedStoreAcrossWindows.test.ts
+++ b/apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/syncPersistedStoreAcrossWindows.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, mock, test } from "bun:test";
+import { syncPersistedStoreAcrossWindows } from "./syncPersistedStoreAcrossWindows";
+
+function makeEventTarget() {
+	let listener: ((event: StorageEvent) => void) | undefined;
+	return {
+		target: {
+			addEventListener: mock(
+				(_type: "storage", next: (event: StorageEvent) => void) => {
+					listener = next;
+				},
+			),
+			removeEventListener: mock(
+				(_type: "storage", removed: (event: StorageEvent) => void) => {
+					if (listener === removed) listener = undefined;
+				},
+			),
+		},
+		dispatch: (event: Pick<StorageEvent, "key" | "newValue">) =>
+			listener?.(event as StorageEvent),
+	};
+}
+
+describe("syncPersistedStoreAcrossWindows", () => {
+	test("rehydrates only when another renderer updates the store key", () => {
+		const events = makeEventTarget();
+		const rehydrate = mock(() => Promise.resolve());
+		const store = {
+			persist: {
+				getOptions: () => ({ name: "sidebar-store" }),
+				rehydrate,
+			},
+		};
+
+		const cleanup = syncPersistedStoreAcrossWindows(store, events.target);
+
+		events.dispatch({ key: "another-store", newValue: "{}" });
+		events.dispatch({ key: "sidebar-store", newValue: null });
+		expect(rehydrate).not.toHaveBeenCalled();
+
+		events.dispatch({ key: "sidebar-store", newValue: "{}" });
+		expect(rehydrate).toHaveBeenCalledTimes(1);
+
+		cleanup();
+		events.dispatch({ key: "sidebar-store", newValue: "{}" });
+		expect(rehydrate).toHaveBeenCalledTimes(1);
+		expect(events.target.removeEventListener).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/syncPersistedStoreAcrossWindows.ts
+++ b/apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/syncPersistedStoreAcrossWindows.ts
@@ -1,0 +1,44 @@
+interface PersistedStore {
+	persist: {
+		getOptions: () => { name?: string };
+		rehydrate: () => Promise<void> | void;
+	};
+}
+
+interface StorageEventTarget {
+	addEventListener: (
+		type: "storage",
+		listener: (event: StorageEvent) => void,
+	) => void;
+	removeEventListener: (
+		type: "storage",
+		listener: (event: StorageEvent) => void,
+	) => void;
+}
+
+/**
+ * Keeps a Zustand persist store current when another renderer writes its
+ * localStorage key. Zustand hydrates on startup but does not subscribe to
+ * storage events itself.
+ *
+ * This follows Zustand's documented cross-tab synchronization recipe. The
+ * returned cleanup also prevents duplicate listeners during renderer HMR.
+ */
+export function syncPersistedStoreAcrossWindows(
+	store: PersistedStore,
+	eventTarget: StorageEventTarget = window,
+): () => void {
+	const handleStorage = (event: StorageEvent) => {
+		if (
+			event.key !== store.persist.getOptions().name ||
+			event.newValue === null
+		) {
+			return;
+		}
+
+		void store.persist.rehydrate();
+	};
+
+	eventTarget.addEventListener("storage", handleStorage);
+	return () => eventTarget.removeEventListener("storage", handleStorage);
+}

--- a/apps/desktop/src/renderer/stores/workspace-sidebar-state.ts
+++ b/apps/desktop/src/renderer/stores/workspace-sidebar-state.ts
@@ -5,6 +5,7 @@ export const DEFAULT_WORKSPACE_SIDEBAR_WIDTH = 280;
 export const COLLAPSED_WORKSPACE_SIDEBAR_WIDTH = 52;
 const MIN_WORKSPACE_SIDEBAR_WIDTH = 225;
 export const MAX_WORKSPACE_SIDEBAR_WIDTH = 400;
+export const WORKSPACE_SIDEBAR_STORAGE_KEY = "workspace-sidebar-store";
 
 // Threshold for snapping to collapsed state
 const COLLAPSE_THRESHOLD = 120;
@@ -113,7 +114,7 @@ export const useWorkspaceSidebarStore = create<WorkspaceSidebarState>()(
 				},
 			}),
 			{
-				name: "workspace-sidebar-store",
+				name: WORKSPACE_SIDEBAR_STORAGE_KEY,
 				version: 2,
 				// Exclude ephemeral state from persistence
 				partialize: (state) => ({

--- a/packages/host-service/src/trpc/router/agent-tooling/agent-tooling.test.ts
+++ b/packages/host-service/src/trpc/router/agent-tooling/agent-tooling.test.ts
@@ -17,6 +17,7 @@ const CONFIG_ID = "3c2f9d8f-5678-4abc-8def-0123456789ab";
 let root: string;
 let worktree: string;
 let db: ReturnType<typeof drizzle<typeof schema>>;
+let previousSupersetHomeDir: string | undefined;
 
 function createCaller() {
 	const ctx = { db, isAuthenticated: true } as unknown as HostServiceContext;
@@ -57,7 +58,9 @@ function writeCommand(configDir: string, name: string): void {
 }
 
 beforeEach(() => {
+	previousSupersetHomeDir = process.env.SUPERSET_HOME_DIR;
 	root = mkdtempSync(join(tmpdir(), "agent-tooling-router-test-"));
+	process.env.SUPERSET_HOME_DIR = root;
 	worktree = join(root, "worktree");
 	mkdirSync(worktree, { recursive: true });
 	const sqlite = new Database(":memory:");
@@ -67,6 +70,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	if (previousSupersetHomeDir === undefined) {
+		delete process.env.SUPERSET_HOME_DIR;
+	} else {
+		process.env.SUPERSET_HOME_DIR = previousSupersetHomeDir;
+	}
 	rmSync(root, { recursive: true, force: true });
 	clearSlashCommandDiscoveryCache();
 });

--- a/packages/host-service/src/trpc/router/usage/default-account.test.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HostDb } from "../../../db/index.ts";
+import {
+	getDefaultAccountSelections,
+	syncDefaultAccountPointer,
+	syncDefaultAccountPointers,
+} from "./default-account.ts";
+
+function mockDb(defaultClaudeConfigDir: string | null | undefined): HostDb {
+	return {
+		select: () => ({
+			from: () => ({
+				get: () =>
+					defaultClaudeConfigDir === undefined
+						? undefined
+						: { defaultClaudeConfigDir, defaultCodexHome: null },
+			}),
+		}),
+	} as unknown as HostDb;
+}
+
+describe("host-wide default account pointers", () => {
+	let home: string;
+	let previousHome: string | undefined;
+
+	beforeEach(() => {
+		previousHome = process.env.SUPERSET_HOME_DIR;
+		home = mkdtempSync(join(tmpdir(), "superset-default-account-"));
+		process.env.SUPERSET_HOME_DIR = home;
+	});
+
+	afterEach(() => {
+		if (previousHome === undefined) delete process.env.SUPERSET_HOME_DIR;
+		else process.env.SUPERSET_HOME_DIR = previousHome;
+		rmSync(home, { recursive: true, force: true });
+	});
+
+	it("does not let an empty second org reset a selected account at boot", () => {
+		const selected = "/Users/kietho/.claude-work";
+		syncDefaultAccountPointers(mockDb(selected));
+		syncDefaultAccountPointers(mockDb(undefined));
+
+		expect(getDefaultAccountSelections(mockDb(undefined)).claudeConfigDir).toBe(
+			selected,
+		);
+		expect(
+			readFileSync(join(home, "state", "default-claude-config-dir"), "utf8"),
+		).toBe(selected);
+	});
+
+	it("treats an existing empty pointer as an explicit system-default choice", () => {
+		const selected = "/Users/kietho/.claude-work";
+		const db = mockDb(selected);
+		syncDefaultAccountPointer("claude", null);
+
+		expect(getDefaultAccountSelections(db).claudeConfigDir).toBeNull();
+		expect(existsSync(join(home, "state", "default-claude-config-dir"))).toBe(
+			true,
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/default-account.test.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HostDb } from "../../../db/index.ts";
@@ -60,5 +66,26 @@ describe("host-wide default account pointers", () => {
 		expect(existsSync(join(home, "state", "default-claude-config-dir"))).toBe(
 			true,
 		);
+	});
+
+	it("keeps the first legacy selection when org migrations race", () => {
+		const first = "/Users/kietho/.claude-work";
+		const second = "/Users/kietho/.claude-personal";
+
+		syncDefaultAccountPointers(mockDb(first));
+		syncDefaultAccountPointers(mockDb(second));
+
+		expect(getDefaultAccountSelections(mockDb(second)).claudeConfigDir).toBe(
+			first,
+		);
+	});
+
+	it("propagates pointer I/O failures instead of treating them as absent", () => {
+		const pointerPath = join(home, "state", "default-claude-config-dir");
+		mkdirSync(pointerPath, { recursive: true });
+
+		expect(() =>
+			getDefaultAccountSelections(mockDb("/Users/kietho/.claude-work")),
+		).toThrow();
 	});
 });

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -8,10 +8,11 @@
 import { randomUUID } from "node:crypto";
 import {
 	existsSync,
+	linkSync,
 	mkdirSync,
 	readFileSync,
 	renameSync,
-	rmSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -34,6 +35,14 @@ function supersetHomeDir(): string {
 	return process.env.SUPERSET_HOME_DIR?.trim() || join(homedir(), ".superset");
 }
 
+function defaultAccountPointerPath(provider: UsageAccountProvider): string {
+	return join(supersetHomeDir(), "state", POINTER_NAMES[provider]);
+}
+
+function temporaryPointerPath(pointerPath: string): string {
+	return `${pointerPath}.${process.pid}.${randomUUID()}.tmp`;
+}
+
 /**
  * Publishes a selection where the agent wrappers can re-read it on every
  * launch (buildDefaultAccountResolver in agent-setup), so switching accounts
@@ -50,13 +59,48 @@ export function syncDefaultAccountPointer(
 	try {
 		const dir = join(supersetHomeDir(), "state");
 		mkdirSync(dir, { recursive: true });
-		const pointerPath = join(dir, POINTER_NAMES[provider]);
-		temporaryPath = `${pointerPath}.${process.pid}.${randomUUID()}.tmp`;
+		const pointerPath = defaultAccountPointerPath(provider);
+		temporaryPath = temporaryPointerPath(pointerPath);
 		writeFileSync(temporaryPath, selection ?? "");
 		renameSync(temporaryPath, pointerPath);
 		temporaryPath = null;
 	} finally {
-		if (temporaryPath) rmSync(temporaryPath, { force: true });
+		if (temporaryPath) {
+			try {
+				unlinkSync(temporaryPath);
+			} catch {
+				// Best-effort cleanup after a failed write or rename.
+			}
+		}
+	}
+}
+
+/**
+ * Publishes a fully written legacy value only if no host-wide pointer exists.
+ * Linking the temporary file is an atomic create-if-absent claim, so two org
+ * services migrating concurrently cannot replace each other's selection.
+ */
+function migrateDefaultAccountPointer(
+	provider: UsageAccountProvider,
+	selection: string,
+): void {
+	const dir = join(supersetHomeDir(), "state");
+	mkdirSync(dir, { recursive: true });
+	const pointerPath = defaultAccountPointerPath(provider);
+	const temporaryPath = temporaryPointerPath(pointerPath);
+	try {
+		writeFileSync(temporaryPath, selection);
+		try {
+			linkSync(temporaryPath, pointerPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+		}
+	} finally {
+		try {
+			unlinkSync(temporaryPath);
+		} catch {
+			// Best-effort cleanup after a failed write or link.
+		}
 	}
 }
 
@@ -65,12 +109,10 @@ function readDefaultAccountPointer(provider: UsageAccountProvider): {
 	selection: string | null;
 } {
 	try {
-		const value = readFileSync(
-			join(supersetHomeDir(), "state", POINTER_NAMES[provider]),
-			"utf8",
-		);
+		const value = readFileSync(defaultAccountPointerPath(provider), "utf8");
 		return { exists: true, selection: value || null };
-	} catch {
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 		return { exists: false, selection: null };
 	}
 }
@@ -106,24 +148,35 @@ export function getDefaultAccountSelections(
 	// unrelated org reset the selected account merely by starting up.
 	if (!claudePointer.exists && legacyClaudeConfigDir) {
 		try {
-			syncDefaultAccountPointer("claude", legacyClaudeConfigDir);
+			migrateDefaultAccountPointer("claude", legacyClaudeConfigDir);
 		} catch {
 			// Migration is best-effort; the legacy DB value remains usable.
 		}
 	}
 	if (!codexPointer.exists && legacyCodexHome) {
 		try {
-			syncDefaultAccountPointer("codex", legacyCodexHome);
+			migrateDefaultAccountPointer("codex", legacyCodexHome);
 		} catch {
 			// Migration is best-effort; the legacy DB value remains usable.
 		}
 	}
+	// Re-read after migration: if another org won the atomic claim, this call
+	// must immediately use the winning host-wide value rather than its own
+	// losing legacy DB value.
+	const resolvedClaudePointer = claudePointer.exists
+		? claudePointer
+		: readDefaultAccountPointer("claude");
+	const resolvedCodexPointer = codexPointer.exists
+		? codexPointer
+		: readDefaultAccountPointer("codex");
 
 	return {
-		claudeConfigDir: claudePointer.exists
-			? claudePointer.selection
+		claudeConfigDir: resolvedClaudePointer.exists
+			? resolvedClaudePointer.selection
 			: legacyClaudeConfigDir,
-		codexHome: codexPointer.exists ? codexPointer.selection : legacyCodexHome,
+		codexHome: resolvedCodexPointer.exists
+			? resolvedCodexPointer.selection
+			: legacyCodexHome,
 	};
 }
 

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -5,7 +5,15 @@
  * provider CLI itself keeps owning every login end to end.
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { HostDb } from "../../../db/index.ts";
@@ -30,28 +38,50 @@ function supersetHomeDir(): string {
  * Publishes a selection where the agent wrappers can re-read it on every
  * launch (buildDefaultAccountResolver in agent-setup), so switching accounts
  * reaches existing terminals the next time the agent starts — the PTY env
- * alone is frozen at spawn. Empty file = system default. Best-effort: the DB
- * stays the source of truth and the wrapper falls back to the spawn-time env.
+ * alone is frozen at spawn. Empty file = system default. The host-wide pointer
+ * is authoritative; write failures propagate so the UI cannot report a switch
+ * that agent launches would not observe.
  */
 export function syncDefaultAccountPointer(
 	provider: UsageAccountProvider,
 	selection: string | null,
 ): void {
+	let temporaryPath: string | null = null;
 	try {
 		const dir = join(supersetHomeDir(), "state");
 		mkdirSync(dir, { recursive: true });
-		writeFileSync(join(dir, POINTER_NAMES[provider]), selection ?? "");
-	} catch {
-		// Wrapper keeps using the spawn-time env until the next successful sync.
+		const pointerPath = join(dir, POINTER_NAMES[provider]);
+		temporaryPath = `${pointerPath}.${process.pid}.${randomUUID()}.tmp`;
+		writeFileSync(temporaryPath, selection ?? "");
+		renameSync(temporaryPath, pointerPath);
+		temporaryPath = null;
+	} finally {
+		if (temporaryPath) rmSync(temporaryPath, { force: true });
 	}
 }
 
-/** Reconciles both pointer files from the DB — run at host boot so files
- * from an older build (or a crashed switch) heal. */
+function readDefaultAccountPointer(provider: UsageAccountProvider): {
+	exists: boolean;
+	selection: string | null;
+} {
+	try {
+		const value = readFileSync(
+			join(supersetHomeDir(), "state", POINTER_NAMES[provider]),
+			"utf8",
+		);
+		return { exists: true, selection: value || null };
+	} catch {
+		return { exists: false, selection: null };
+	}
+}
+
+/**
+ * Migrates legacy org-scoped selections into the host-wide pointer files.
+ * Existing pointers are authoritative and are never overwritten at boot:
+ * more than one org-specific host-service can share the same Superset home.
+ */
 export function syncDefaultAccountPointers(db: HostDb): void {
-	const selections = getDefaultAccountSelections(db);
-	syncDefaultAccountPointer("claude", selections.claudeConfigDir);
-	syncDefaultAccountPointer("codex", selections.codexHome);
+	getDefaultAccountSelections(db);
 }
 
 export interface DefaultAccountSelections {
@@ -65,9 +95,35 @@ export function getDefaultAccountSelections(
 	db: HostDb,
 ): DefaultAccountSelections {
 	const row = db.select().from(hostSettings).get();
+	const claudePointer = readDefaultAccountPointer("claude");
+	const codexPointer = readDefaultAccountPointer("codex");
+	const legacyClaudeConfigDir = row?.defaultClaudeConfigDir ?? null;
+	const legacyCodexHome = row?.defaultCodexHome ?? null;
+
+	// Before pointer files existed, these values lived only in each org DB.
+	// Migrate a concrete legacy selection only when no host-wide pointer exists.
+	// A missing/null row must not publish an empty pointer: doing so lets an
+	// unrelated org reset the selected account merely by starting up.
+	if (!claudePointer.exists && legacyClaudeConfigDir) {
+		try {
+			syncDefaultAccountPointer("claude", legacyClaudeConfigDir);
+		} catch {
+			// Migration is best-effort; the legacy DB value remains usable.
+		}
+	}
+	if (!codexPointer.exists && legacyCodexHome) {
+		try {
+			syncDefaultAccountPointer("codex", legacyCodexHome);
+		} catch {
+			// Migration is best-effort; the legacy DB value remains usable.
+		}
+	}
+
 	return {
-		claudeConfigDir: row?.defaultClaudeConfigDir ?? null,
-		codexHome: row?.defaultCodexHome ?? null,
+		claudeConfigDir: claudePointer.exists
+			? claudePointer.selection
+			: legacyClaudeConfigDir,
+		codexHome: codexPointer.exists ? codexPointer.selection : legacyCodexHome,
 	};
 }
 


### PR DESCRIPTION
## Summary

- keep workspace sidebar width/collapse state synchronized across renderer windows
- keep sidebar section collapse state synchronized across renderer windows
- make the host-wide provider profile pointer authoritative across org-scoped host services
- migrate concrete legacy profile selections only when no pointer exists
- write pointer updates atomically and surface failures to the UI

## Provider profile reproduction

Before the fix, booting a host service backed by an org DB with no `host_settings` row rewrote the shared `default-claude-config-dir` pointer to an empty string. New Claude agents then fell back to the system account even though the active org DB still selected the work profile.

## Verification

- `bun test apps/desktop/src/renderer/stores/syncPersistedStoreAcrossWindows/syncPersistedStoreAcrossWindows.test.ts`
- `bun test packages/host-service/src/trpc/router/usage/default-account.test.ts packages/agent-setup/src/default-account-resolver.test.ts`
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd packages/host-service typecheck`
- Biome and `git diff --check`
- CDP against the matching dev renderer (`localhost:4625`, CDP `9465`): Settings → Usage continued to show `kiet@superset.sh` as the Claude default after an empty second-org startup simulation and route remount
- actual Claude wrapper launch resolved `/Users/kietho/.claude-work` and authenticated as `kiet@superset.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar workspace and section-collapse settings now stay synchronized across open windows.
  * Legacy account settings are migrated automatically when applicable.

* **Bug Fixes**
  * Improved reliability when saving default account selections.
  * Preserved explicit system-default choices instead of treating them as missing.
  * Ensured existing selections are not reset when another account has no selection.
  * Improved handling of account settings across launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->