### PR TITLE
fix(agent-setup): handle Codex interrupted turns

### DIFF
--- a/apps/desktop/docs/EXTERNAL_FILES.md
+++ b/apps/desktop/docs/EXTERNAL_FILES.md
@@ -42,7 +42,7 @@ its hook entries into these files while preserving user-defined entries:
 | File | Purpose |
 |------|---------|
 | `~/.claude/settings.json` | Claude Code hook registration merge |
-| `~/.codex/hooks.json` | Codex hook registration merge (`SessionStart`, `UserPromptSubmit`, `Stop`) |
+| `~/.codex/hooks.json` | Codex hook registration merge (`SessionStart`, `SessionEnd`, `UserPromptSubmit`, `Stop`, `Interrupt`) |
 | `~/.factory/settings.json` | Factory Droid hook registration (`UserPromptSubmit`, `Notification`, `PostToolUse`, `Stop`) |
 | `~/.omp/agent/extensions/superset-hooks.ts` (or `$OMP_CODING_AGENT_DIR/extensions/superset-hooks.ts`) | Oh My Pi lifecycle extension (`session_start`, `agent_start`, `before_agent_start`, `tool_execution_end`, `agent_end`, `session_end`, `session_shutdown`) |
 | `~/.pi/agent/extensions/superset-hooks.ts` | Pi lifecycle extension (`session_start`, `before_agent_start`, `agent_end`, `session_end`) |
@@ -52,13 +52,15 @@ registration for durable prompt/tool lifecycle events. The wrapper in
 `~/.superset[-{workspace}]/bin/codex` enables those hooks — appending
 `--dangerously-bypass-hook-trust` when the launch command doesn't already pass
 it, because Codex silently skips untrusted `hooks.json` entries and Superset
-would otherwise lose the Stop signal — and keeps the session-log watcher as a
-best-effort compatibility bridge for Start and permission events on older
-Codex releases. It does not override the legacy `notify` callback because that
-callback cannot distinguish main-agent and subagent completions. On startup,
-Superset rewrites only its own managed entries in `~/.codex/hooks.json` to
-point at the current environment's `notify.sh`, while preserving any
-user-defined Codex hooks.
+would otherwise lose lifecycle signals — and keeps the session-log watcher as
+a best-effort compatibility bridge for Start and permission events on older
+Codex releases. Native `Stop` reports normal turn completion, `Interrupt`
+reports an aborted turn, and `SessionEnd` reports session teardown. The wrapper
+also keeps its clean-exit SessionEnd report for older Codex releases. It does
+not override the legacy `notify` callback because that callback cannot
+distinguish main-agent and subagent completions. On startup, Superset rewrites
+only its own managed entries in `~/.codex/hooks.json` to point at the current
+environment's `notify.sh`, while preserving any user-defined Codex hooks.
 
 ### `zsh/` and `bash/` - Shell Integration
 

--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -156,8 +156,10 @@ export function getCodexGlobalHooksJsonPath(): string {
 
 const CODEX_MANAGED_EVENTS: Record<string, { matcher?: string }> = {
 	SessionStart: {},
+	SessionEnd: {},
 	UserPromptSubmit: {},
 	Stop: {},
+	Interrupt: {},
 };
 
 function codexHooksSpec(

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -1415,8 +1415,10 @@ describe("agent-wrappers codex hooks.json", () => {
 		const expectedCommand = managedCodexHookCommand;
 		for (const eventName of [
 			"SessionStart",
+			"SessionEnd",
 			"UserPromptSubmit",
 			"Stop",
+			"Interrupt",
 		] as const) {
 			const hooks = parsed.hooks[eventName];
 			expect(Array.isArray(hooks)).toBe(true);
@@ -1528,8 +1530,14 @@ describe("agent-wrappers codex hooks.json", () => {
 		).toBe(true);
 
 		const expectedManagedCommand = managedCodexHookCommand;
-		// Adds managed hooks for SessionStart, UserPromptSubmit, Stop
-		for (const eventName of ["SessionStart", "UserPromptSubmit", "Stop"]) {
+		// Adds managed hooks for session, prompt, completion, and interruption lifecycle events.
+		for (const eventName of [
+			"SessionStart",
+			"SessionEnd",
+			"UserPromptSubmit",
+			"Stop",
+			"Interrupt",
+		]) {
 			expect(
 				parsed.hooks[eventName].some(
 					(def: { hooks: Array<{ command: string }> }) =>
@@ -1614,8 +1622,10 @@ describe("agent-wrappers codex hooks.json", () => {
 		const expectedManagedCommand = managedCodexHookCommand;
 		for (const eventName of [
 			"SessionStart",
+			"SessionEnd",
 			"UserPromptSubmit",
 			"Stop",
+			"Interrupt",
 		] as const) {
 			const hooks = parsed.hooks[eventName];
 			expect(Array.isArray(hooks)).toBe(true);

--- a/packages/agent-setup/templates/codex-wrapper-exec.template.sh
+++ b/packages/agent-setup/templates/codex-wrapper-exec.template.sh
@@ -147,10 +147,12 @@ _superset_debug "codex exited status=$SUPERSET_CODEX_STATUS"
 
 _superset_cleanup_session_watcher
 
-# Codex has no SessionEnd hook, so the wrapper reports it. Only on a normal
-# exit (status < 128): a signal death (SIGHUP from a killed pty/daemon) must
-# stay unreported so the session remains a resume candidate. The signal traps
-# above bypass this line entirely.
+# Current Codex releases have a native SessionEnd hook. Keep this wrapper
+# report as a compatibility fallback for older releases that do not: v2
+# binding teardown is idempotent, so a duplicate from a current release is
+# harmless. Only report a normal exit (status < 128); a signal death (SIGHUP
+# from a killed pty/daemon) must stay unreported so the session remains a
+# resume candidate. The signal traps above bypass this line entirely.
 if [ "$_superset_has_superset_context" = "1" ] && [ -f "$_superset_notify_path" ] && [ "$SUPERSET_CODEX_STATUS" -lt 128 ]; then
   _superset_debug "emitting SessionEnd status=$SUPERSET_CODEX_STATUS"
   bash "$_superset_notify_path" '{"hook_event_name":"SessionEnd"}' >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- register Superset managed hooks for Codex `Interrupt` and native `SessionEnd` events
- normalize interrupted turns through the existing Stop lifecycle so workspaces do not remain stuck as active
- retain the wrapper SessionEnd fallback for older Codex releases and document the lifecycle coverage

## Root cause

Codex emits `Stop` only for normal turn completion. Aborted turns (including the TUI interrupt path) emit `Interrupt`; Superset already normalized that raw event to `Stop`, but never installed an `Interrupt` hook in `~/.codex/hooks.json`. Claude Code had broader lifecycle hook coverage, which is why it did not exhibit the same stuck-state behavior.

## Validation

- `bun test packages/agent-setup/src` (266 pass)
- targeted agent setup + host-service mapping tests (98 pass)
- `bun run --cwd packages/agent-setup typecheck`
- `bunx biome check` on changed TypeScript files
- `git diff --check`
- CDP against the exact worktree dev renderer (`http://localhost:4805/#/v2-workspace/0eaab6fd-6427-40de-8608-fd423d23b6d9`): opened a Codex terminal through the UI, submitted a `sleep 30` task via rich input, interrupted it with Escape, observed raw Codex `Interrupt`, confirmed `terminal_agent_bindings.last_event_type = Stop`, and confirmed the renderer cleared its active Working state

## Notes

Installed Codex v0.150.1 and its source both support `Interrupt` and `SessionEnd`. API/model-error terminal failures still have no public Codex failure hook, so this change deliberately avoids guessing completion from unstable TUI output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex interrupted turns leaving workspaces stuck as active. Adds managed `Interrupt` and `SessionEnd` hooks in `~/.codex/hooks.json` so aborted turns normalize through the existing Stop lifecycle, and keeps the wrapper-side `SessionEnd` fallback for older Codex releases.

- Registers hooks for `Interrupt` and `SessionEnd` events in the Codex hook configuration.
- The wrapper's `SessionEnd` report remains for older releases; duplicates are harmless because binding teardown is idempotent.

<sup>Written for commit 2f24b2e075b21a1cb9d07cf3a907ab767e4efc06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded Codex lifecycle event support to include interruption and session completion events.
  * Improved compatibility across current and older Codex releases through native hook registration and fallback reporting.
  * Preserved existing session-start, prompt submission, and stop event handling.
* **Documentation**
  * Updated Codex hook behavior and event reporting guidance, including compatibility and duplicate-report handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->