### PR TITLE
feat(i18n): translate new strings automatically on the PR

### DIFF
--- a/.github/workflows/translate-catalogs.yml
+++ b/.github/workflows/translate-catalogs.yml
@@ -1,0 +1,105 @@
+name: Translate Catalogs
+
+# Every enabled locale is gated by `lingui compile --strict`, so a PR that
+# adds or changes an English string owes a translation in all of them. This
+# workflow closes that gap on the PR itself: when the extracted catalogs have
+# untranslated entries, it fills them with Claude, verifies the strict gate,
+# and pushes the fills back to the PR branch.
+#
+# The push uses a GitHub App token rather than GITHUB_TOKEN because pushes
+# made with GITHUB_TOKEN do not trigger workflows — the PR would be stuck
+# with no checks on its newest commit.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: translate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  translate:
+    name: Fill missing translations
+    # Fork PRs have no secrets; their catalog gap surfaces in the Lint job's
+    # catalog audit instead, for a maintainer to fill.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Bun
+        id: setup-bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Cache dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-revision }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen --ignore-scripts
+
+      - name: Extract catalogs and count missing translations
+        id: missing
+        working-directory: packages/i18n
+        run: |
+          bunx lingui extract --clean --overwrite > /dev/null
+          bun scripts/sort-po-references.ts > /dev/null
+          # Entry-aware count: the PO header is msgid "" / msgstr "" and must
+          # not be mistaken for an untranslated entry.
+          COUNT=$(bun -e '
+            import { readFileSync, readdirSync } from "node:fs";
+            let sum = 0;
+            for (const loc of readdirSync("locales", { withFileTypes: true })
+              .filter((e) => e.isDirectory() && e.name !== "en")
+              .map((e) => e.name)) {
+              const src = readFileSync(`locales/${loc}/messages.po`, "utf8");
+              for (const m of src.matchAll(/msgid "((?:[^"\\]|\\.)+)"\nmsgstr ""/g)) sum++;
+            }
+            console.log(sum);')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Missing translations: $COUNT"
+
+      - name: Translate missing entries
+        if: steps.missing.outputs.count != '0'
+        working-directory: packages/i18n
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: bun scripts/translate-missing.ts
+
+      - name: Verify the strict gate passes with the fills
+        if: steps.missing.outputs.count != '0'
+        working-directory: packages/i18n
+        run: |
+          bun scripts/sort-po-references.ts > /dev/null
+          bunx lingui compile --strict
+          bun scripts/check-stale-translations.ts
+
+      - name: Commit and push fills
+        if: steps.missing.outputs.count != '0'
+        run: |
+          git config user.name "superset-i18n[bot]"
+          git config user.email "i18n-bot@superset.sh"
+          git add packages/i18n/locales
+          if git diff --cached --quiet; then
+            echo "Translator produced no accepted fills; leaving the PR red for a human."
+            exit 1
+          fi
+          git commit -m "chore(i18n): translate new strings across enabled locales"
+          git push

--- a/.github/workflows/translate-catalogs.yml
+++ b/.github/workflows/translate-catalogs.yml
@@ -98,10 +98,10 @@ jobs:
           bunx lingui compile --strict
           bun scripts/check-stale-translations.ts
 
-      - name: Commit and push fills
+      # Commit carries no token: earlier PR-controlled steps can write
+      # .git/hooks, and a hook run by git commit inherits the step env.
+      - name: Commit fills
         if: steps.missing.outputs.count != '0'
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "superset-i18n[bot]"
           git config user.email "i18n-bot@superset.sh"
@@ -110,5 +110,17 @@ jobs:
             echo "Translator produced no accepted fills; leaving the PR red for a human."
             exit 1
           fi
-          git commit -m "chore(i18n): translate new strings across enabled locales"
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"
+          git -c core.hooksPath=/dev/null commit -m "chore(i18n): translate new strings across enabled locales"
+
+      - name: Push fills
+        if: steps.missing.outputs.count != '0'
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The head ref is attacker-named text; it reaches the shell only as
+          # a quoted variable, never by template interpolation.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          git -c core.hooksPath=/dev/null push \
+            "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git" \
+            "HEAD:refs/heads/${HEAD_REF}"

--- a/.github/workflows/translate-catalogs.yml
+++ b/.github/workflows/translate-catalogs.yml
@@ -33,12 +33,19 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          # Least privilege: pushing the fills needs contents only.
+          permission-contents: write
 
       - name: Checkout PR head
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          # The stale-translation check resolves a merge base.
+          fetch-depth: 0
+          # Extract and the translator execute repo-controlled code (lingui
+          # config, scripts), so the token must not sit in git config where a
+          # malicious PR could read it. It is passed only to the push step.
+          persist-credentials: false
 
       - name: Setup Bun
         id: setup-bun
@@ -93,6 +100,8 @@ jobs:
 
       - name: Commit and push fills
         if: steps.missing.outputs.count != '0'
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "superset-i18n[bot]"
           git config user.email "i18n-bot@superset.sh"
@@ -102,4 +111,4 @@ jobs:
             exit 1
           fi
           git commit -m "chore(i18n): translate new strings across enabled locales"
-          git push
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/bun.lock
+++ b/bun.lock
@@ -997,7 +997,7 @@
         "@lingui/react": "6.6.0",
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
+        "@anthropic-ai/sdk": "0.78.0",
         "@ast-grep/napi": "0.41.1",
         "@lingui/cli": "6.6.0",
         "@lingui/format-po": "6.6.0",

--- a/bun.lock
+++ b/bun.lock
@@ -997,6 +997,7 @@
         "@lingui/react": "6.6.0",
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@ast-grep/napi": "0.41.1",
         "@lingui/cli": "6.6.0",
         "@lingui/format-po": "6.6.0",

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -53,3 +53,14 @@ If an edit genuinely does not invalidate a translation (fixing an English typo,
 rewording a sentence the translation already renders correctly), add the message
 to `locales/en-only-changes.txt`. Exemptions are keyed to the exact English text
 they were granted for, so the next edit to that message is checked again.
+
+## New strings translate themselves on the PR
+
+Adding an English string leaves every enabled locale with an empty entry, which
+`compile --strict` refuses. The `Translate Catalogs` workflow closes that gap on
+the PR: it extracts, fills the missing entries with Claude — anchored to each
+catalog's own existing translations for register and terminology — validates
+placeholder, tag, and ICU integrity (rejected fills stay empty so the strict
+gate fails loudly), and pushes the fills back to the branch. To run it locally
+instead: `bun run --cwd packages/i18n translate` with `ANTHROPIC_API_KEY` set.
+Machine fills are a floor, not a ceiling — reword them freely in the same PR.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -48,6 +48,7 @@
 		"@lingui/react": "6.6.0"
 	},
 	"devDependencies": {
+		"@anthropic-ai/sdk": "0.78.0",
 		"@ast-grep/napi": "0.41.1",
 		"@lingui/cli": "6.6.0",
 		"@lingui/format-po": "6.6.0",
@@ -55,7 +56,6 @@
 		"@types/react": "19.2.14",
 		"bun-types": "1.3.14",
 		"react": "19.2.3",
-		"typescript": "6.0.3",
-		"@anthropic-ai/sdk": "^0.78.0"
+		"typescript": "6.0.3"
 	}
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -40,7 +40,8 @@
 		"pretypecheck": "lingui extract --clean --overwrite && bun scripts/sort-po-references.ts && lingui compile --strict",
 		"test": "bun test",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
-		"clean": "git clean -xdf .cache .turbo node_modules"
+		"clean": "git clean -xdf .cache .turbo node_modules",
+		"translate": "bun scripts/translate-missing.ts && bun scripts/sort-po-references.ts && lingui compile --strict"
 	},
 	"dependencies": {
 		"@lingui/core": "6.6.0",
@@ -54,6 +55,7 @@
 		"@types/react": "19.2.14",
 		"bun-types": "1.3.14",
 		"react": "19.2.3",
-		"typescript": "6.0.3"
+		"typescript": "6.0.3",
+		"@anthropic-ai/sdk": "^0.78.0"
 	}
 }

--- a/packages/i18n/scripts/translate-missing.test.ts
+++ b/packages/i18n/scripts/translate-missing.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { integrityError, stripIcu } from "./translate-missing";
+
+describe("stripIcu", () => {
+	test("removes ICU blocks, keeps simple placeholders", () => {
+		expect(stripIcu("Hello {name}")).toBe("Hello {name}");
+		expect(stripIcu("{n, plural, one {# item} other {# items}} left")).toBe(
+			" left",
+		);
+		expect(
+			stripIcu("{n, plural, one {a {nested} b} other {c}} and {keep}"),
+		).toBe(" and {keep}");
+	});
+});
+
+describe("integrityError", () => {
+	test("accepts a faithful translation", () => {
+		expect(integrityError("Open {name}", "Ouvrir {name}", "fr")).toBeNull();
+	});
+
+	test("rejects a dropped placeholder", () => {
+		expect(integrityError("Open {name}", "Ouvrir", "fr")).toContain("{name}");
+	});
+
+	test("rejects a translated placeholder identifier", () => {
+		expect(integrityError("Open {name}", "Ouvrir {nom}", "fr")).toContain(
+			"{name}",
+		);
+	});
+
+	test("rejects unbalanced tag markers", () => {
+		expect(
+			integrityError("<0>Learn more</0>", "En savoir plus</0>", "fr"),
+		).toBe("tag markers changed");
+		expect(
+			integrityError("<0>Learn more<1/></0>", "<0>En savoir plus</0>", "fr"),
+		).toBe("tag markers changed");
+	});
+
+	test("rejects a removed ICU block", () => {
+		expect(
+			integrityError(
+				"{n, plural, one {# file} other {# files}}",
+				"des fichiers",
+				"fr",
+			),
+		).toBe("ICU structure changed");
+	});
+
+	test("ICU branch prose may be reworded without placeholder complaints", () => {
+		expect(
+			integrityError(
+				"{n, plural, one {one {thing}} other {many}}",
+				"{n, plural, one {une chose} other {plusieurs}}",
+				"fr",
+			),
+		).toBeNull();
+	});
+
+	test("requires few/many for Slavic plurals", () => {
+		const source = "{n, plural, one {# file} other {# files}}";
+		expect(
+			integrityError(source, "{n, plural, one {# plik} other {# pliki}}", "pl"),
+		).toBe("Slavic plural missing few/many branches");
+		expect(
+			integrityError(
+				source,
+				"{n, plural, one {# plik} few {# pliki} many {# plików} other {# pliku}}",
+				"pl",
+			),
+		).toBeNull();
+		// Non-Slavic locales are not held to the four-branch rule.
+		expect(
+			integrityError(source, "{n, plural, one {# file} other {# files}}", "fr"),
+		).toBeNull();
+	});
+});

--- a/packages/i18n/scripts/translate-missing.ts
+++ b/packages/i18n/scripts/translate-missing.ts
@@ -1,0 +1,260 @@
+/**
+ * Fills untranslated entries in the locale catalogs with Claude.
+ *
+ * With every locale gated by `compile --strict`, a PR that adds an English
+ * string owes a translation in each enabled locale before CI passes. This
+ * script closes that gap: it finds every empty msgstr, translates them in one
+ * request per locale — anchored to the catalog's own existing translations so
+ * register and terminology stay consistent — validates placeholder, tag, and
+ * ICU integrity against the English source, and writes back only fills that
+ * pass. A fill that fails validation stays empty, so the strict gate still
+ * fails loudly rather than shipping a broken string.
+ *
+ * Usage:
+ *   bun scripts/translate-missing.ts             # all enabled locales
+ *   bun scripts/translate-missing.ts --locale de # one locale
+ *   bun scripts/translate-missing.ts --dry-run   # report, write nothing
+ *
+ * Auth: ANTHROPIC_API_KEY (or any credential the SDK resolves).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import Anthropic from "@anthropic-ai/sdk";
+import { SUPPORTED_LOCALES } from "../src/locales";
+
+const LOCALES_DIR = join(import.meta.dir, "../locales");
+const ENTRY = /msgid "((?:[^"\\]|\\.)*)"\nmsgstr "((?:[^"\\]|\\.)*)"/g;
+
+// Languages with no plural inflection: both ICU branches must carry the same
+// text. Slavic locales need the full one/few/many/other set instead.
+const NO_PLURAL = new Set([
+	"ja",
+	"zh-CN",
+	"zh-TW",
+	"th",
+	"id",
+	"vi",
+	"ko",
+	"tr",
+]);
+const FOUR_BRANCH = new Set(["ru", "pl", "cs"]);
+
+function unescapePo(value: string): string {
+	return value
+		.replace(/\\"/g, '"')
+		.replace(/\\n/g, "\n")
+		.replace(/\\\\/g, "\\");
+}
+
+function escapePo(value: string): string {
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, "\\n");
+}
+
+function readCatalog(locale: string): Map<string, string> {
+	const source = readFileSync(join(LOCALES_DIR, locale, "messages.po"), "utf8");
+	const entries = new Map<string, string>();
+	for (const match of source.matchAll(ENTRY)) {
+		const id = unescapePo(match[1] ?? "");
+		if (id) entries.set(id, unescapePo(match[2] ?? ""));
+	}
+	return entries;
+}
+
+// Placeholder, tag-marker, and ICU-keyword integrity. ICU branch bodies are
+// prose the translation may reword, so strip ICU blocks before comparing
+// simple placeholders.
+export function stripIcu(text: string): string {
+	let out = "";
+	let i = 0;
+	while (i < text.length) {
+		if (
+			text[i] === "{" &&
+			/^\{\s*\w+\s*,\s*(plural|select|selectordinal)\b/.test(text.slice(i))
+		) {
+			let depth = 0;
+			while (i < text.length) {
+				if (text[i] === "{") depth++;
+				else if (text[i] === "}" && --depth === 0) {
+					i++;
+					break;
+				}
+				i++;
+			}
+			continue;
+		}
+		out += text[i++];
+	}
+	return out;
+}
+
+export function integrityError(
+	source: string,
+	translation: string,
+	locale: string,
+): string | null {
+	const placeholders = (text: string) =>
+		new Set(
+			[...stripIcu(text).matchAll(/\{([A-Za-z0-9_]+)\}/g)].map((m) => m[1]),
+		);
+	for (const name of placeholders(source)) {
+		if (!placeholders(translation).has(name)) return `missing {${name}}`;
+	}
+	const tags = (text: string) =>
+		[...text.matchAll(/<\/?(\d+)\/?>/g)].map((m) => m[0]).sort();
+	if (tags(source).join() !== tags(translation).join())
+		return "tag markers changed";
+	const icu = (text: string) =>
+		[...text.matchAll(/\{\s*(\w+)\s*,\s*(plural|select|selectordinal)\b/g)]
+			.map((m) => `${m[1]}:${m[2]}`)
+			.sort();
+	if (icu(source).join() !== icu(translation).join())
+		return "ICU structure changed";
+	if (FOUR_BRANCH.has(locale) && /\{\s*\w+\s*,\s*plural\s*,/.test(source)) {
+		if (!/\bfew\s*\{/.test(translation) || !/\bmany\s*\{/.test(translation)) {
+			return "Slavic plural missing few/many branches";
+		}
+	}
+	return null;
+}
+
+// A few dozen existing translations of short strings anchor register and
+// terminology far better than a glossary we would have to maintain by hand.
+function styleAnchors(
+	english: Map<string, string>,
+	target: Map<string, string>,
+): string {
+	const anchors: string[] = [];
+	for (const [id, en] of english) {
+		const translated = target.get(id);
+		if (!translated || translated === en) continue;
+		if (en.length < 4 || en.length > 80 || en.includes("{")) continue;
+		anchors.push(`"${en}" -> "${translated}"`);
+		if (anchors.length >= 40) break;
+	}
+	return anchors.join("\n");
+}
+
+async function translateLocale(
+	client: Anthropic,
+	locale: string,
+	english: Map<string, string>,
+	dryRun: boolean,
+): Promise<{ filled: number; rejected: string[] }> {
+	const target = readCatalog(locale);
+	const missing = new Map<string, string>();
+	for (const [id, en] of english) {
+		if (en && target.get(id) === "") missing.set(id, en);
+	}
+	if (missing.size === 0) return { filled: 0, rejected: [] };
+
+	const pluralRule = NO_PLURAL.has(locale)
+		? "This language has no plural inflection: every ICU plural must carry identical text in all branches."
+		: FOUR_BRANCH.has(locale)
+			? "ICU plurals MUST expand to one/few/many/other with the case this language requires after a numeral. Never copy the two English branches."
+			: "Adjust ICU plural branches to what this language grammatically requires.";
+
+	const stream = client.messages.stream({
+		model: "claude-opus-5",
+		max_tokens: 32000,
+		thinking: { type: "adaptive" },
+		system: [
+			"You translate UI strings for Superset, a desktop IDE for running coding agents.",
+			"Audience: professional software engineers. Register: concise developer-tool copy.",
+			"Rules that must hold for every string:",
+			"- Placeholders like {name} or {0} survive verbatim; never translate the identifier.",
+			"- Tag markers <0>…</0> and <1/> stay balanced and wrap the corresponding words.",
+			`- ${pluralRule}`,
+			"- Brand and product names (Superset, GitHub, Claude, Slack, VS Code, Cursor, …), code, file paths, CLI flags, and keyboard glyphs stay verbatim.",
+			"- Match the register, terminology, and vocabulary of the existing translations shown below — they are the source of truth for how this catalog renders recurring terms.",
+			"Respond with ONLY a JSON object mapping each message id to its translation. No markdown, no commentary.",
+		].join("\n"),
+		messages: [
+			{
+				role: "user",
+				content: [
+					`Target language: ${locale}`,
+					"",
+					"Existing translations from this catalog (style and terminology anchors):",
+					styleAnchors(english, target),
+					"",
+					"Translate these entries (id -> English source):",
+					JSON.stringify(Object.fromEntries(missing), null, 1),
+				].join("\n"),
+			},
+		],
+	});
+	const response = await stream.finalMessage();
+	const text = response.content
+		.filter((block): block is Anthropic.TextBlock => block.type === "text")
+		.map((block) => block.text)
+		.join("");
+	const jsonText = text.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "");
+	const fills = JSON.parse(jsonText) as Record<string, string>;
+
+	const rejected: string[] = [];
+	const accepted = new Map<string, string>();
+	for (const [id, en] of missing) {
+		const fill = fills[id];
+		if (typeof fill !== "string" || fill.length === 0) {
+			rejected.push(`${id}: no translation returned`);
+			continue;
+		}
+		const problem = integrityError(en, fill, locale);
+		if (problem) {
+			rejected.push(`${id}: ${problem}`);
+			continue;
+		}
+		accepted.set(id, fill);
+	}
+
+	if (!dryRun && accepted.size > 0) {
+		const path = join(LOCALES_DIR, locale, "messages.po");
+		let source = readFileSync(path, "utf8");
+		for (const [id, fill] of accepted) {
+			source = source.replace(
+				`msgid "${escapePo(id)}"\nmsgstr ""`,
+				`msgid "${escapePo(id)}"\nmsgstr "${escapePo(fill)}"`,
+			);
+		}
+		writeFileSync(path, source);
+	}
+	return { filled: accepted.size, rejected };
+}
+
+if (import.meta.main) await main();
+
+async function main() {
+	const dryRun = process.argv.includes("--dry-run");
+	const localeFlag = process.argv.indexOf("--locale");
+	const only = localeFlag !== -1 ? process.argv[localeFlag + 1] : undefined;
+
+	const english = readCatalog("en");
+	const client = new Anthropic();
+	let failures = 0;
+
+	for (const locale of SUPPORTED_LOCALES) {
+		if (locale === "en" || (only && locale !== only)) continue;
+		const { filled, rejected } = await translateLocale(
+			client,
+			locale,
+			english,
+			dryRun,
+		);
+		if (filled === 0 && rejected.length === 0) continue;
+		console.log(`${locale}: filled ${filled}${dryRun ? " (dry run)" : ""}`);
+		for (const reason of rejected) {
+			console.error(`  rejected ${reason}`);
+			failures++;
+		}
+	}
+
+	if (failures > 0) {
+		console.error(
+			`\n${failures} fill(s) rejected — the strict compile will fail on these.`,
+		);
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
## Why

Sixteen locales sit behind `compile --strict`, so **every PR that adds an English string owes sixteen translations before CI passes**. #6952 already paid this tax by hand. This closes the loop on the PR itself, keeping strict-mode's guarantee (no locale ever ships partially translated) without making "add a button" cost a translation errand.

## How

**`packages/i18n/scripts/translate-missing.ts`** — finds every empty `msgstr`, translates each locale's gap in one Claude request anchored to ~40 of that catalog's *own existing translations* (register and terminology come from the catalog, not a hand-maintained glossary), then validates every fill against the English source: placeholders, tag markers, ICU structure, and the one/few/many/other requirement for ru/pl/cs. **A fill that fails validation stays empty** — the strict gate then fails loudly rather than a broken string shipping.

**`Translate Catalogs` workflow** — on same-repo PRs: extract → count gaps (entry-aware; the PO header is `msgid ""` and must not count) → translate → re-verify `compile --strict` + the stale check → push the commit back. The push uses a GitHub App token because `GITHUB_TOKEN` pushes trigger no workflows and would leave the PR checkless on its newest commit. Fork PRs (no secrets) surface their gap in the existing catalog audit for a maintainer.

Machine fills are a floor, not a ceiling — reword freely in the same PR; the stale-check keys exemptions to exact English text so later edits re-check.

## Verification

- Validator unit tests (8): dropped/renamed placeholders, unbalanced tags, removed ICU, Slavic plurals missing few/many all rejected; faithful translations and reworded ICU prose accepted
- Counter tested against real catalogs: baseline 0, one blanked entry → 1, restored → 0; skips the `en-only-changes.txt` exemption file
- Workflow YAML validated; catalog gate, i18n tests (116), and desktop typecheck green

The live API path first exercises on the next PR that adds a string — the strict compile after the translator means its failure mode is a red check, never a silent merge.

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow that fills missing locale translations on the PR itself, so adding an English string no longer requires manual translation in all sixteen locales before `compile --strict` passes.

**New Features**
- The `Translate Catalogs` workflow extracts catalogs, translates empty entries with Claude, verifies `compile --strict`, and pushes fills back to the PR branch.
- `scripts/translate-missing.ts` anchors each locale's fills on that catalog's existing translations and validates placeholders, tag markers, ICU structure, and one/few/many/other for `ru`/`pl`/`cs`; fills that fail stay empty so the strict gate fails loudly.
- Also runnable locally with `bun run --cwd packages/i18n translate`.

**Rollout notes**
- Pushes use a least-privilege GitHub App token (`contents:write`) passed only to the push step, since `GITHUB_TOKEN` pushes trigger no workflows and would leave the PR checkless.
- Commit and push run with hooks disabled, the token absent from the commit env, and the head ref reaching the shell only as a quoted environment variable, since a branch name can contain shell metacharacters.
- Checkout persists no credentials and fetches full history so the stale-translation check can resolve its merge base.
- Fork PRs surface their gap in the existing catalog audit for a maintainer.

<sup>Written for commit ac750f2ab26ad73075e7f03cf7a6ca1b671802c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated translation of missing locale catalog entries during pull requests.
  * Added local translation support with dry-run and locale-specific options.
  * Added validation to preserve placeholders, tags, ICU formatting, and locale-specific plural rules.
  * Added strict checks that reject invalid translations and identify unresolved entries.
* **Documentation**
  * Documented the automated translation workflow and local command.
* **Tests**
  * Added coverage for translation integrity and ICU formatting validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->