### PR TITLE
fix(marketing): serve the request's language, and make regressing this a blocked deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -479,7 +479,7 @@ jobs:
       # reached production that way.
       - name: Smoke test marketing routes
         run: |
-          bun scripts/smoke-routes.ts "https://${{ env.MARKETING_ALIAS }}" \
+          bun scripts/smoke-routes.ts "https://${{ env.MARKETING_ALIAS }}" --localized \
             / /pricing /enterprise /download /join-us /community /contact \
             /blog /changelog /compare /roadmap /leaderboard /marketplace \
             /agent-orchestration /parallel-coding-agents /factory-2026 \

--- a/apps/marketing/src/app/(legal)/[slug]/page.tsx
+++ b/apps/marketing/src/app/(legal)/[slug]/page.tsx
@@ -19,7 +19,7 @@ function formatDate(date: string | Date): string {
 }
 
 export default async function LegalPage({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { slug } = await params;
 	const page = getLegalPage(slug);

--- a/apps/marketing/src/app/agent-orchestration/page.tsx
+++ b/apps/marketing/src/app/agent-orchestration/page.tsx
@@ -7,8 +7,8 @@ import { getCategoryPage } from "@/lib/category";
 
 const SLUG = "agent-orchestration";
 
-export default function AgentOrchestrationPage() {
-	initServerI18n();
+export default async function AgentOrchestrationPage() {
+	await initServerI18n();
 
 	const page = getCategoryPage(SLUG);
 

--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -22,7 +22,7 @@ interface PageProps {
 }
 
 export default async function BlogPostPage({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { slug } = await params;
 	const post = getBlogPost(slug);

--- a/apps/marketing/src/app/blog/page.tsx
+++ b/apps/marketing/src/app/blog/page.tsx
@@ -32,7 +32,7 @@ export const metadata: Metadata = {
 };
 
 export default async function BlogPage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const posts = getBlogPosts();
 

--- a/apps/marketing/src/app/changelog/[slug]/page.tsx
+++ b/apps/marketing/src/app/changelog/[slug]/page.tsx
@@ -13,7 +13,7 @@ interface PageProps {
 }
 
 export default async function ChangelogEntryPage({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { slug } = await params;
 	const entry = getChangelogEntry(slug);

--- a/apps/marketing/src/app/changelog/page.tsx
+++ b/apps/marketing/src/app/changelog/page.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ChangelogPage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const entries = getChangelogEntries();
 

--- a/apps/marketing/src/app/community/page.tsx
+++ b/apps/marketing/src/app/community/page.tsx
@@ -113,7 +113,7 @@ const COMMUNITY_LINKS = [
 ];
 
 export default async function CommunityPage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const stars = await getGitHubStars();
 

--- a/apps/marketing/src/app/compare/[slug]/page.tsx
+++ b/apps/marketing/src/app/compare/[slug]/page.tsx
@@ -25,7 +25,7 @@ interface PageProps {
 }
 
 export default async function ComparePageRoute({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { slug } = await params;
 	const page = getComparisonPage(slug);

--- a/apps/marketing/src/app/compare/page.tsx
+++ b/apps/marketing/src/app/compare/page.tsx
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ComparePage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const pages = getComparisonPages();
 

--- a/apps/marketing/src/app/contact/page.tsx
+++ b/apps/marketing/src/app/contact/page.tsx
@@ -13,8 +13,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function ContactPage() {
-	initServerI18n();
+export default async function ContactPage() {
+	await initServerI18n();
 
 	// Named locals so the paragraph extracts with `{supportEmail}` /
 	// `{foundersEmail}` instead of positional `{0}` / `{1}`.

--- a/apps/marketing/src/app/download/page.tsx
+++ b/apps/marketing/src/app/download/page.tsx
@@ -8,8 +8,8 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: true },
 };
 
-export default function DownloadPage() {
-	initServerI18n();
+export default async function DownloadPage() {
+	await initServerI18n();
 
 	return <DownloadInterstitial />;
 }

--- a/apps/marketing/src/app/enterprise/page.tsx
+++ b/apps/marketing/src/app/enterprise/page.tsx
@@ -15,8 +15,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function EnterprisePage() {
-	initServerI18n();
+export default async function EnterprisePage() {
+	await initServerI18n();
 
 	const { t } = useLingui();
 

--- a/apps/marketing/src/app/factory-2026/page.tsx
+++ b/apps/marketing/src/app/factory-2026/page.tsx
@@ -36,8 +36,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function Factory2026Page() {
-	initServerI18n();
+export default async function Factory2026Page() {
+	await initServerI18n();
 
 	return (
 		<main className="relative min-h-screen">

--- a/apps/marketing/src/app/i18n-server.ts
+++ b/apps/marketing/src/app/i18n-server.ts
@@ -1,3 +1,47 @@
-// Re-exported so existing imports keep working; the implementation and the
-// explanation of why RSC needs it live in @superset/i18n/server.
-export { initServerI18n } from "@superset/i18n/server";
+import {
+	initServerI18n as activateServerI18n,
+	preloadServerLocale,
+} from "@superset/i18n/server";
+import { resolveLocale, type SupportedLocale } from "@superset/i18n";
+import { headers } from "next/headers";
+
+// "ja,en-US;q=0.9,en;q=0.8" -> ["ja", "en-US", "en"], ordered by quality.
+function parseAcceptLanguage(header: string | null): string[] {
+	if (!header) return [];
+	return header
+		.split(",")
+		.map((part) => {
+			const [tag, ...params] = part.trim().split(";");
+			const q = params
+				.map((p) => p.trim())
+				.find((p) => p.startsWith("q="))
+				?.slice(2);
+			const quality = q ? Number.parseFloat(q) : 1;
+			return { tag: (tag ?? "").trim(), quality };
+		})
+		.filter((e) => e.tag && e.tag !== "*" && Number.isFinite(e.quality))
+		.sort((a, b) => b.quality - a.quality)
+		.map((e) => e.tag);
+}
+
+/**
+ * Activates i18n for a React Server Components render, in the language the
+ * request asked for.
+ *
+ * A bare seeding call activates the default locale, which renders the whole
+ * RSC pass in English no matter what Accept-Language says — client components
+ * then re-localize on hydration, so visitors saw English heroes above
+ * localized bodies plus a hydration mismatch on every such page. Every route
+ * entry must await this (the layout is pruned on client-side navigation, so
+ * seeding there covers only full document loads — see @superset/i18n/server).
+ *
+ * These pages are already dynamically rendered (the nav resolves the session
+ * per request), so reading headers() adds no new rendering cost.
+ */
+export async function initServerI18n(): Promise<SupportedLocale> {
+	const acceptLanguage = (await headers()).get("accept-language");
+	const locale = resolveLocale(parseAcceptLanguage(acceptLanguage));
+	await preloadServerLocale(locale);
+	activateServerI18n(locale);
+	return locale;
+}

--- a/apps/marketing/src/app/i18n-server.ts
+++ b/apps/marketing/src/app/i18n-server.ts
@@ -1,8 +1,8 @@
+import { resolveLocale, type SupportedLocale } from "@superset/i18n";
 import {
 	initServerI18n as activateServerI18n,
 	preloadServerLocale,
 } from "@superset/i18n/server";
-import { resolveLocale, type SupportedLocale } from "@superset/i18n";
 import { headers } from "next/headers";
 
 // "ja,en-US;q=0.9,en;q=0.8" -> ["ja", "en-US", "en"], ordered by quality.

--- a/apps/marketing/src/app/join-us/page.tsx
+++ b/apps/marketing/src/app/join-us/page.tsx
@@ -36,8 +36,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function JoinUsPage() {
-	initServerI18n();
+export default async function JoinUsPage() {
+	await initServerI18n();
 
 	return (
 		<main className="relative min-h-screen bg-background">

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -103,16 +103,16 @@ export const metadata: Metadata = {
 	manifest: "/manifest.json",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	initServerI18n();
+	const locale = await initServerI18n();
 
 	return (
 		<html
-			lang="en"
+			lang={locale}
 			className={`dark overscroll-none ${ibmPlexMono.variable} ${inter.variable}`}
 			suppressHydrationWarning
 		>

--- a/apps/marketing/src/app/leaderboard/page.tsx
+++ b/apps/marketing/src/app/leaderboard/page.tsx
@@ -41,7 +41,7 @@ export const revalidate = 300;
 const DEFAULT_PERIOD = "30d" as const;
 
 export default async function LeaderboardPage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const [standings, stats] = await Promise.all([
 		fetchStandings({ period: DEFAULT_PERIOD, metric: "tokens", limit: 50 }),

--- a/apps/marketing/src/app/marketplace/agents/page.tsx
+++ b/apps/marketing/src/app/marketplace/agents/page.tsx
@@ -15,8 +15,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function MarketplaceAgentsPage() {
-	initServerI18n();
+export default async function MarketplaceAgentsPage() {
+	await initServerI18n();
 
 	return (
 		<main className="min-h-screen">

--- a/apps/marketing/src/app/marketplace/page.tsx
+++ b/apps/marketing/src/app/marketplace/page.tsx
@@ -35,8 +35,8 @@ const marketplaceLinks = [
 	},
 ] as const;
 
-export default function MarketplacePage() {
-	initServerI18n();
+export default async function MarketplacePage() {
+	await initServerI18n();
 
 	const { t } = useLingui();
 

--- a/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/[slug]/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({
 }
 
 export default async function ThemeDetailPage({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { slug } = await params;
 	const theme = getThemeListing(slug);

--- a/apps/marketing/src/app/marketplace/themes/page.tsx
+++ b/apps/marketing/src/app/marketplace/themes/page.tsx
@@ -17,8 +17,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function MarketplaceThemesPage() {
-	initServerI18n();
+export default async function MarketplaceThemesPage() {
+	await initServerI18n();
 
 	const { t } = useLingui();
 

--- a/apps/marketing/src/app/mcp-install/page.tsx
+++ b/apps/marketing/src/app/mcp-install/page.tsx
@@ -16,8 +16,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function McpPage() {
-	initServerI18n();
+export default async function McpPage() {
+	await initServerI18n();
 
 	return (
 		<main className="relative min-h-screen">

--- a/apps/marketing/src/app/not-found.tsx
+++ b/apps/marketing/src/app/not-found.tsx
@@ -11,8 +11,8 @@ export const metadata: Metadata = {
 	robots: { index: false },
 };
 
-export default function NotFound() {
-	initServerI18n();
+export default async function NotFound() {
+	await initServerI18n();
 
 	const { t } = useLingui();
 

--- a/apps/marketing/src/app/page.tsx
+++ b/apps/marketing/src/app/page.tsx
@@ -40,8 +40,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function Home() {
-	initServerI18n();
+export default async function Home() {
+	await initServerI18n();
 
 	return (
 		<main className="flex flex-col bg-background">

--- a/apps/marketing/src/app/parallel-coding-agents/page.tsx
+++ b/apps/marketing/src/app/parallel-coding-agents/page.tsx
@@ -7,8 +7,8 @@ import { getCategoryPage } from "@/lib/category";
 
 const SLUG = "parallel-coding-agents";
 
-export default function ParallelCodingAgentsPage() {
-	initServerI18n();
+export default async function ParallelCodingAgentsPage() {
+	await initServerI18n();
 
 	const page = getCategoryPage(SLUG);
 

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -18,8 +18,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function PricingPage() {
-	initServerI18n();
+export default async function PricingPage() {
+	await initServerI18n();
 
 	// JSON-LD is machine-facing, so it gets rendered strings rather than the
 	// message descriptors the UI components resolve through Lingui.

--- a/apps/marketing/src/app/roadmap/page.tsx
+++ b/apps/marketing/src/app/roadmap/page.tsx
@@ -28,8 +28,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function RoadmapPage() {
-	initServerI18n();
+export default async function RoadmapPage() {
+	await initServerI18n();
 
 	const company = COMPANY.NAME;
 

--- a/apps/marketing/src/app/starchart/page.tsx
+++ b/apps/marketing/src/app/starchart/page.tsx
@@ -45,7 +45,7 @@ function formatWeekDate(date: string): string {
 }
 
 export default async function StarChartPage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const { t } = useLingui();
 	const history = await getStarHistory();

--- a/apps/marketing/src/app/stats/page.tsx
+++ b/apps/marketing/src/app/stats/page.tsx
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 export default async function StatsPage() {
-	initServerI18n();
+	await initServerI18n();
 
 	const stats = await fetchStats({ period: "all" });
 	const range = stats?.range ? formatDayRange(stats.range) : null;

--- a/apps/marketing/src/app/team/[id]/page.tsx
+++ b/apps/marketing/src/app/team/[id]/page.tsx
@@ -64,7 +64,7 @@ function PersonJsonLd({
 }
 
 export default async function TeamMemberPage({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { id } = await params;
 	const person = getPersonById(id);

--- a/apps/marketing/src/app/team/page.tsx
+++ b/apps/marketing/src/app/team/page.tsx
@@ -36,8 +36,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function TeamPage() {
-	initServerI18n();
+export default async function TeamPage() {
+	await initServerI18n();
 
 	const { t } = useLingui();
 	const people = getAllPeople();

--- a/apps/marketing/src/app/user/[handle]/page.tsx
+++ b/apps/marketing/src/app/user/[handle]/page.tsx
@@ -80,7 +80,7 @@ export async function generateMetadata({
 }
 
 export default async function UserProfilePage({ params }: PageProps) {
-	initServerI18n();
+	await initServerI18n();
 
 	const { t } = useLingui();
 	const { handle } = await params;

--- a/packages/i18n/test/rsc-seeding.test.ts
+++ b/packages/i18n/test/rsc-seeding.test.ts
@@ -17,7 +17,11 @@ const ROUTE_ENTRY = /(?:^|\/)(?:page|not-found)\.tsx$/;
 // Anchored to the start of a line so a mention inside a comment or a string
 // literal cannot satisfy the check; paired with the import so the call has to
 // resolve to the real helper.
-const SEEDS = /^\s*initServerI18n\(\);/m;
+// The call must be awaited: a bare initServerI18n() activates the default
+// locale and served every visitor English heroes above localized bodies —
+// request-locale resolution is async, so an un-awaited call cannot have
+// worked. (Regression guard for the 2026-08-29 production finding.)
+const SEEDS = /^\s*(?:const\s+\w+\s*=\s*)?await initServerI18n\(\);/m;
 const IMPORTS = /^import\s*\{[^}]*\binitServerI18n\b[^}]*\}\s*from\s*["']/m;
 const USES_I18N = /<Trans\b|useLingui\(/;
 const CLIENT_COMPONENT = /^\s*["']use client["']/m;

--- a/scripts/smoke-routes.ts
+++ b/scripts/smoke-routes.ts
@@ -21,6 +21,10 @@ if (!baseArg || routes.length === 0) {
 	process.exit(2);
 }
 const base = baseArg.replace(/\/$/, "");
+// --localized: also verify each route serves Japanese to a ja Accept-Language
+// request. Only meaningful for apps whose pages are translated server-side.
+const localized = routes.includes("--localized");
+if (localized) routes.splice(routes.indexOf("--localized"), 1);
 
 type Failure = { route: string; mode: string; detail: string };
 const failures: Failure[] = [];
@@ -45,6 +49,46 @@ async function waitForReady(timeoutMs = 90_000) {
 	}
 	console.error(`${base} never became reachable: ${lastDetail}`);
 	process.exit(1);
+}
+
+// Served-locale check: request the document as a Japanese browser would and
+// verify the server actually localized it. Two signals, both read from the
+// raw served HTML so client-side patch-up cannot mask a server regression:
+// the html lang attribute must be the resolved locale, and the page must
+// contain CJK text. Guards the failure mode where RSC seeding activates the
+// default locale and every visitor gets English (found in production
+// 2026-08-29 on 25 pages, invisible to status-code checks).
+const CJK = /[\u3040-\u30ff\u3400-\u9fff]/g;
+async function hitLocalized(route: string) {
+	const url = `${base}${route}`;
+	let res: Response;
+	try {
+		res = await fetch(url, {
+			headers: { "Accept-Language": "ja" },
+			redirect: "manual",
+		});
+	} catch (error) {
+		failures.push({
+			route,
+			mode: "ja",
+			detail: `request failed: ${String(error)}`,
+		});
+		return;
+	}
+	if (res.status >= 300) return; // redirects and errors are the plain pass's job
+	const body = await res.text();
+	const lang = body.match(/<html[^>]*\slang="([^"]*)"/)?.[1];
+	if (lang !== undefined && lang !== "ja") {
+		failures.push({ route, mode: "ja", detail: `served lang="${lang}"` });
+		return;
+	}
+	if ((body.match(CJK)?.length ?? 0) < 10) {
+		failures.push({
+			route,
+			mode: "ja",
+			detail: "no Japanese text in served HTML",
+		});
+	}
 }
 
 async function hit(route: string, mode: "document" | "rsc") {
@@ -88,6 +132,7 @@ await waitForReady();
 for (const route of routes) {
 	await hit(route, "document");
 	await hit(route, "rsc");
+	if (localized) await hitLocalized(route);
 	const bad = failures.filter((f) => f.route === route);
 	console.log(
 		`${bad.length === 0 ? "ok  " : "FAIL"} ${route}${bad.length ? `  ${bad.map((b) => `${b.mode}: ${b.detail}`).join("; ")}` : ""}`,


### PR DESCRIPTION
## The failure mode

A production page review (152 screenshots, en/ja/ru/tr) found **25 marketing pages serving English heroes or whole English bodies** to non-English visitors, each with a React #418 hydration mismatch. Root cause: every route entry called bare `initServerI18n()`, which activates the **default locale** regardless of `Accept-Language` — the entire RSC pass rendered English, and client components re-localized on hydration (masking it on some pages, mismatching on all). **Sentry saw none of it**: recoverable hydration errors aren't captured, so this class was invisible to monitoring, and status-code smoke tests can't see it either.

## Point fix

`initServerI18n()` in marketing now resolves `Accept-Language` per request (quality-ordered), preloads that catalog, activates it, and returns the locale; all 31 route entries `await` it; the layout writes the resolved locale into `<html lang>` (was hardcoded `"en"`). Pages are already dynamic (session-aware nav), so no rendering-cost change.

**Runtime proof (local build)**: ja request → `lang="ja"`, 1,501 CJK chars, hero どのチームにも分かりやすい料金; en request unchanged; only remaining English is by-design SEO `<meta description>`.

## Systematic guards — the "this must never ship again" part

1. **Build-time**: the RSC seeding ratchet now requires the *awaited request-aware* call. A bare or un-awaited `initServerI18n()` — the exact bug — fails `bun test packages/i18n`. Proven by reverting one call site: 3 pass / 1 fail naming the file.
2. **Deploy-time**: `smoke-routes.ts --localized` (wired into the marketing deploy step) fetches every route with `Accept-Language: ja` and fails on served `lang≠"ja"` or a page with no Japanese text — both read the **raw served HTML**, so client-side patch-up cannot mask a server regression. Run against production today it fails on every page, including ones the browser review had passed.

## Follow-ups noted, not in this PR

- Capture React recoverable/hydration errors into Sentry (the monitoring blind spot)
- `app.superset.sh/cli/auth/code` renders its error string pre-catalog-load (client-side timing, all locales)
- CSP on app.superset.sh blocks the Cloudflare Insights beacon on every page

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marketing pages now render in the request's language instead of always English. The old `initServerI18n()` activated the default locale regardless of `Accept-Language`, so 25 pages sent English heroes or whole English bodies to ja/ru/tr visitors, and every one produced a React hydration mismatch that Sentry never captured because recoverable hydration errors aren't reported.

**Bug Fixes**
- The marketing `initServerI18n()` now reads `Accept-Language` per request, preloads and activates that catalog, and returns the locale; all 31 route entries `await` it.
- The layout writes the resolved locale into `<html lang>` instead of hardcoded `"en"`.
- No rendering-cost change — pages are already dynamically rendered for the session-aware nav, and the only remaining English in a ja page is the by-design SEO meta description.

**Regression Guards**
- The RSC seeding test now rejects a bare or un-awaited `initServerI18n()` call; reverting one call site fails the build.
- `smoke-routes.ts --localized`, wired into the marketing deploy step, fetches every route with `Accept-Language: ja` and fails when the served HTML has `lang="en"` or no Japanese text, so client-side patch-up can't mask a server regression.

<sup>Written for commit 9377cffeeff0f491b2e19276f2d65b2ab1af3805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketing pages now serve content in the language requested by the browser.
  * The page language attribute reflects the selected locale.

* **Bug Fixes**
  * Improved localized rendering by ensuring translations load before page content appears.
  * Enhanced localization consistency across marketing, blog, legal, marketplace, and 404 pages.

* **Tests**
  * Added smoke-test coverage to verify Japanese localization and translated page content across routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->