### PR TITLE
fix(ci): smoke tests refuse to run blind behind Vercel Deployment Protection

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -357,6 +357,8 @@ jobs:
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
       - name: Smoke test web routes
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           bun scripts/smoke-routes.ts "https://${{ env.WEB_ALIAS }}" /
 
@@ -478,6 +480,8 @@ jobs:
       # that returned 500 on every route still went green. MARKETING-67/68/69
       # reached production that way.
       - name: Smoke test marketing routes
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           bun scripts/smoke-routes.ts "https://${{ env.MARKETING_ALIAS }}" --localized \
             / /pricing /enterprise /download /join-us /community /contact \
@@ -604,6 +608,8 @@ jobs:
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
       - name: Smoke test admin routes
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           bun scripts/smoke-routes.ts "https://${{ env.ADMIN_ALIAS }}" /
 
@@ -691,6 +697,8 @@ jobs:
           echo "vercel_url=$VERCEL_URL" >> $GITHUB_OUTPUT
 
       - name: Smoke test docs routes
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           bun scripts/smoke-routes.ts "https://${{ env.DOCS_ALIAS }}" /
 

--- a/scripts/smoke-routes.ts
+++ b/scripts/smoke-routes.ts
@@ -21,6 +21,15 @@ if (!baseArg || routes.length === 0) {
 	process.exit(2);
 }
 const base = baseArg.replace(/\/$/, "");
+// Vercel Deployment Protection walls previews behind SSO, which this script
+// would otherwise sail past — a redirect is a legitimate pass for auth-gated
+// routes, so an SSO wall makes every check vacuous. When the bypass secret is
+// present, send it; when protection is on and no secret is available, an SSO
+// redirect at the root fails loudly instead of pretending to test.
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const bypassHeaders: Record<string, string> = bypassSecret
+	? { "x-vercel-protection-bypass": bypassSecret }
+	: {};
 // --localized: also verify each route serves Japanese to a ja Accept-Language
 // request. Only meaningful for apps whose pages are translated server-side.
 const localized = routes.includes("--localized");
@@ -37,9 +46,25 @@ async function waitForReady(timeoutMs = 90_000) {
 	let lastDetail = "no attempt made";
 	while (Date.now() < deadline) {
 		try {
-			const res = await fetch(base, { redirect: "manual" });
+			const res = await fetch(base, {
+				headers: bypassHeaders,
+				redirect: "manual",
+			});
 			// A fresh alias serves 404 until it propagates, so anything except
-			// a real page (2xx) or an auth redirect (3xx) means "not yet".
+			// a real page (2xx) or an auth redirect (3xx) means "not yet". A
+			// Vercel SSO redirect is not an app auth redirect: it means every
+			// later check would be vacuous, so refuse to pretend to test.
+			if (
+				res.status >= 300 &&
+				res.status < 400 &&
+				res.headers.get("location")?.includes("vercel.com/sso-api")
+			) {
+				console.error(
+					`${base} is behind Vercel Deployment Protection and no ` +
+						"VERCEL_AUTOMATION_BYPASS_SECRET is set — checks would be vacuous.",
+				);
+				process.exit(1);
+			}
 			if (res.status < 400) return;
 			lastDetail = `HTTP ${res.status}`;
 		} catch (error) {
@@ -64,7 +89,7 @@ async function hitLocalized(route: string) {
 	let res: Response;
 	try {
 		res = await fetch(url, {
-			headers: { "Accept-Language": "ja" },
+			headers: { ...bypassHeaders, "Accept-Language": "ja" },
 			redirect: "manual",
 		});
 	} catch (error) {


### PR DESCRIPTION
Deployment Protection went on for previews today, which made every smoke gate **vacuously pass** — an SSO redirect is indistinguishable from a legitimate app auth redirect at the status level. Now: the script sends `x-vercel-protection-bypass` when `VERCEL_AUTOMATION_BYPASS_SECRET` is set; without it, an SSO wall at the root **fails loudly** (verified against a live protected preview) instead of pretending to test. All four smoke steps thread the secret.

**Action needed (I can't do this part):** generate the bypass secret in each Vercel project — Settings → Deployment Protection → Protection Bypass for Automation — and add it to GitHub secrets as `VERCEL_AUTOMATION_BYPASS_SECRET`. Until then, preview smoke steps fail honestly.

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops smoke gates from passing vacuously behind Vercel Deployment Protection. Previously an SSO redirect looked like a legitimate app auth redirect, so every check passed while testing nothing; now the script sends `x-vercel-protection-bypass` when the secret is set and exits nonzero when it detects an SSO wall without one. All four deploy smoke steps thread the secret through.

**Migration**
- Generate a bypass secret in each Vercel project (Settings → Deployment Protection → Protection Bypass for Automation) and add it to GitHub secrets as `VERCEL_AUTOMATION_BYPASS_SECRET`.
- Until the secret is set, preview smoke steps fail loudly instead of pretending to test.

<sup>Written for commit aac9d0ede95dc99f63d17aa6b04e3c3600a25c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment smoke tests so protected preview environments are checked reliably.
  * Added support for bypassing Vercel automation protection during readiness and localized-route checks.
  * Smoke tests now fail clearly when redirected to an authentication page instead of reporting a false success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->