### PR TITLE
chore: lint fixes for tag-folders merge

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/TriggersCard/TriggersCard.tsx
@@ -182,8 +182,7 @@ export function TriggersCard({
 									: {}),
 							})
 						}
-					/>
-					{" "}
+					/>{" "}
 					<span>tagged</span>{" "}
 					<AutomationTagsPicker
 						className={SCOPE_CHIP}
@@ -193,7 +192,6 @@ export function TriggersCard({
 						onChange={(tags) => onUpdate({ tags })}
 					/>
 				</Trans>
-
 			</div>
 			<RelayOfflineNotice hostId={hostId} className="mt-1" />
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.test.ts
@@ -357,15 +357,14 @@ describe("buildDashboardSidebarProjects with tag-derived folders", () => {
 		if (folder.type !== "section") throw new Error("expected section");
 		expect(folder.section.id).toBe(buildSidebarFolderKey("project-1", "perf"));
 		expect(folder.section.name).toBe("perf");
-		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual(
-			["w-1", "w-2"],
-		);
+		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual([
+			"w-1",
+			"w-2",
+		]);
 
 		const topLevelIds = project.children
 			.filter((child) => child.type === "workspace")
-			.map((child) =>
-				child.type === "workspace" ? child.workspace.id : null,
-			);
+			.map((child) => (child.type === "workspace" ? child.workspace.id : null));
 		expect(topLevelIds).toEqual(["w-3"]);
 	});
 
@@ -384,14 +383,12 @@ describe("buildDashboardSidebarProjects with tag-derived folders", () => {
 
 		const folder = project.children.find((child) => child.type === "section");
 		if (folder?.type !== "section") throw new Error("expected section");
-		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual(
-			["w-tagged"],
-		);
+		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual([
+			"w-tagged",
+		]);
 		const topLevelIds = project.children
 			.filter((child) => child.type === "workspace")
-			.map((child) =>
-				child.type === "workspace" ? child.workspace.id : null,
-			);
+			.map((child) => (child.type === "workspace" ? child.workspace.id : null));
 		expect(topLevelIds).toEqual(["w-stale"]);
 	});
 
@@ -407,9 +404,9 @@ describe("buildDashboardSidebarProjects with tag-derived folders", () => {
 		const folder = project.children.find((child) => child.type === "section");
 		if (folder?.type !== "section") throw new Error("expected section");
 		expect(folder.section.id).toBe("section-1");
-		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual(
-			["w-legacy"],
-		);
+		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual([
+			"w-legacy",
+		]);
 	});
 
 	it("a workspace row with the tags field ABSENT renders exactly like an untagged one", () => {
@@ -446,9 +443,9 @@ describe("buildDashboardSidebarProjects with tag-derived folders", () => {
 		const [folder] = sections;
 		if (folder.type !== "section") throw new Error("expected section");
 		expect(folder.section.color).toBe("#ff0000");
-		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual(
-			["w-1"],
-		);
+		expect(folder.section.workspaces.map((workspace) => workspace.id)).toEqual([
+			"w-1",
+		]);
 		// Members inherit the customised folder colour.
 		expect(folder.section.workspaces[0]?.accentColor).toBe("#ff0000");
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/buildDashboardSidebarProjects.ts
@@ -1,9 +1,9 @@
-import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
 import {
 	getProjectFolderTagIndex,
 	resolveWorkspaceSectionId,
 	type TagFolderRef,
 } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
+import type { WorkspaceTransactionSnapshot } from "renderer/stores/workspace-creates";
 import { getV2WorkspaceDisplayName } from "renderer/utils/getV2WorkspaceDisplayName";
 import type {
 	DashboardSidebarPinnedWorkspace,
@@ -298,7 +298,8 @@ export function buildDashboardSidebarProjects({
 		const effectiveSectionId = resolveWorkspaceSectionId({
 			tags: workspace.tags,
 			localSectionId: workspace.sectionId,
-			index: folderIndexByProjectId.get(workspace.projectId) ?? emptyFolderIndex,
+			index:
+				folderIndexByProjectId.get(workspace.projectId) ?? emptyFolderIndex,
 		});
 
 		if (effectiveSectionId) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -13,9 +13,9 @@ import {
 	isAutoIncludedLocalMainWorkspace,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
-import { deriveTagFolders } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useSandboxAccess } from "renderer/routes/_authenticated/providers/SandboxAccessProvider";
+import { deriveTagFolders } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import { useWorkspaceTransactionsStore } from "renderer/stores/workspace-creates";
 import type {
 	DashboardSidebarPinnedWorkspace,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useMigrateLegacySidebarFolders/migrateLegacySidebarFolders.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useMigrateLegacySidebarFolders/migrateLegacySidebarFolders.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "bun:test";
 import { buildSidebarFolderKey } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import {
 	type LegacyFolderMigrationIo,
-	migrateLegacySidebarFolders,
 	type MigrationHostRow,
 	type MigrationLocalRow,
 	type MigrationSectionRow,
+	migrateLegacySidebarFolders,
 } from "./migrateLegacySidebarFolders";
 
 const PROJECT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -31,7 +31,9 @@ function makeLegacySection(
 function makeHarness(args: {
 	sections: MigrationSectionRow[];
 	localRows?: MigrationLocalRow[];
-	hostRows?: Array<Omit<MigrationHostRow, "projectId"> & { projectId?: string | null }>;
+	hostRows?: Array<
+		Omit<MigrationHostRow, "projectId"> & { projectId?: string | null }
+	>;
 	rejectWritesFor?: Set<string>;
 }) {
 	const writes: Array<{ workspaceId: string; tags: string[] }> = [];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useMigrateLegacySidebarFolders/migrateLegacySidebarFolders.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useMigrateLegacySidebarFolders/migrateLegacySidebarFolders.ts
@@ -140,10 +140,7 @@ export async function migrateLegacySidebarFolders(
 			const tags = normalizeWorkspaceTags(hostRow.tags);
 			if (tags.includes(tag)) continue;
 			try {
-				await io.writeTags(
-					hostRow.id,
-					normalizeWorkspaceTags([...tags, tag]),
-				);
+				await io.writeTags(hostRow.id, normalizeWorkspaceTags([...tags, tag]));
 			} catch {
 				rejected = true;
 				break;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useMigrateLegacySidebarFolders/useMigrateLegacySidebarFolders.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useMigrateLegacySidebarFolders/useMigrateLegacySidebarFolders.ts
@@ -4,8 +4,8 @@ import { useCollections } from "renderer/routes/_authenticated/providers/Collect
 import { isSidebarWorkspaceVisible } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import {
-	migrateLegacySidebarFolders,
 	type MigrationHostRow,
+	migrateLegacySidebarFolders,
 } from "./migrateLegacySidebarFolders";
 
 // Session-scoped: a folder whose host REJECTED a write is parked until the

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useNavigateAwayFromWorkspace/useNavigateAwayFromWorkspace.ts
@@ -41,7 +41,10 @@ export function useNavigateAwayFromWorkspace() {
 			const target = resolveWorkspaceRemovalNavigationTarget({
 				activeWorkspaceId,
 				removedWorkspaceId: workspaceId,
-				orderedWorkspaceIds: getFlattenedV2WorkspaceIds(collections, workspaces),
+				orderedWorkspaceIds: getFlattenedV2WorkspaceIds(
+					collections,
+					workspaces,
+				),
 				// Before the host fan-out settles, an unlisted sibling means
 				// "unknown", not "gone" — prefer navigating to it over home; the
 				// workspace route's own not-found handling covers a true miss.

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/getFlattenedV2WorkspaceIds/getFlattenedV2WorkspaceIds.test.ts
@@ -34,7 +34,14 @@ function makeCollections(args: {
 }): Collections {
 	return {
 		v2SidebarProjects: fakeCollection(
-			[{ projectId: PROJECT_ID, createdAt: DATE, tabOrder: 1, isCollapsed: false }],
+			[
+				{
+					projectId: PROJECT_ID,
+					createdAt: DATE,
+					tabOrder: 1,
+					isCollapsed: false,
+				},
+			],
 			(row) => row.projectId,
 		),
 		v2SidebarSections: fakeCollection(

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -1,4 +1,8 @@
 import type { Pane } from "@superset/panes";
+import {
+	normalizeWorkspaceTag,
+	normalizeWorkspaceTags,
+} from "@superset/shared/workspace-tags";
 import { useCallback } from "react";
 import { terminalRuntimeRegistry } from "renderer/lib/terminal/terminal-runtime-registry";
 import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
@@ -6,6 +10,7 @@ import {
 	extractPaneIds,
 	type PaneLifecycleRow,
 } from "renderer/routes/_authenticated/components/utils/paneLifecycleRows";
+import { useOptimisticActions } from "renderer/routes/_authenticated/hooks/useOptimisticActions";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
 import {
@@ -13,11 +18,6 @@ import {
 	getPrependTabOrder,
 	isSidebarWorkspaceVisible,
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
-import {
-	normalizeWorkspaceTag,
-	normalizeWorkspaceTags,
-} from "@superset/shared/workspace-tags";
-import { useOptimisticActions } from "renderer/routes/_authenticated/hooks/useOptimisticActions";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import {
@@ -145,7 +145,10 @@ function getHostWorkspaceTags(
 function getEffectiveSectionId(
 	collections: Pick<AppCollections, "v2SidebarSections">,
 	hostWorkspaces: readonly TagFolderWorkspaceInput[],
-	row: { workspaceId: string; sidebarState: { projectId: string | null; sectionId: string | null } },
+	row: {
+		workspaceId: string;
+		sidebarState: { projectId: string | null; sectionId: string | null };
+	},
 ): string | null {
 	return resolveWorkspaceSectionId({
 		tags: getHostWorkspaceTags(hostWorkspaces, row.workspaceId),
@@ -314,7 +317,11 @@ export function useDashboardSidebarState() {
 				tag: parsed.tag,
 				createdAt: new Date(),
 				tabOrder: getNextTabOrder(
-					getProjectTopLevelItems(collections, hostWorkspaces, parsed.projectId),
+					getProjectTopLevelItems(
+						collections,
+						hostWorkspaces,
+						parsed.projectId,
+					),
 				),
 				isCollapsed: false,
 				color: null,
@@ -538,7 +545,8 @@ export function useDashboardSidebarState() {
 			if (!trimmed) return;
 			const existing = collections.v2SidebarSections.get(sectionId);
 			const parsed = parseSidebarFolderKey(sectionId);
-			const currentTag = normalizeWorkspaceTag(existing?.tag) ?? parsed?.tag ?? null;
+			const currentTag =
+				normalizeWorkspaceTag(existing?.tag) ?? parsed?.tag ?? null;
 			if (currentTag === null) {
 				// Unconverted legacy row: label-only rename; the migration pass
 				// converts it (with this name) once its host is reachable.
@@ -743,7 +751,8 @@ export function useDashboardSidebarState() {
 			if (!section && !parsed) return;
 			const projectId = section?.projectId ?? parsed?.projectId;
 			if (!projectId) return;
-			const folderTag = normalizeWorkspaceTag(section?.tag) ?? parsed?.tag ?? null;
+			const folderTag =
+				normalizeWorkspaceTag(section?.tag) ?? parsed?.tag ?? null;
 
 			// Groups interleave with ungrouped rows, so replace the deleted
 			// section's own slot with its members instead of dumping them

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.test.ts
@@ -225,7 +225,12 @@ describe("withQuotaGuard", () => {
 describe("cross-window storage events", () => {
 	type Listener = (event: { key: string | null; storageArea: unknown }) => void;
 
-	function withWindowShim<T>(run: (fire: (key: string, area: unknown) => void, shimLocalStorage: unknown) => T): T {
+	function withWindowShim<T>(
+		run: (
+			fire: (key: string, area: unknown) => void,
+			shimLocalStorage: unknown,
+		) => T,
+	): T {
 		const listeners = new Set<Listener>();
 		const shimLocalStorage = {
 			getItem: () => null,
@@ -246,7 +251,8 @@ describe("cross-window storage events", () => {
 		(globalThis as { window?: unknown }).window = shimWindow;
 		try {
 			return run((key, area) => {
-				for (const listener of [...listeners]) listener({ key, storageArea: area });
+				for (const listener of [...listeners])
+					listener({ key, storageArea: area });
 			}, shimLocalStorage);
 		} finally {
 			if (hadWindow) (globalThis as { window?: unknown }).window = previous;
@@ -294,7 +300,11 @@ describe("cross-window storage events", () => {
 			const custom = withQuotaGuard(
 				{
 					storageKey: "k",
-					storage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+					storage: {
+						getItem: () => null,
+						setItem: () => {},
+						removeItem: () => {},
+					},
 				},
 				{ reclaim: () => 0, onPersistFailed: () => {} },
 			) as { storageEventApi?: unknown };

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/withQuotaGuard.ts
@@ -99,7 +99,10 @@ export interface QuotaGuardStorageEventApi {
 function crossWindowStorageEventApi(
 	guarded: QuotaGuardStorage,
 ): QuotaGuardStorageEventApi {
-	const wrappedByListener = new Map<StorageEventListener, StorageEventListener>();
+	const wrappedByListener = new Map<
+		StorageEventListener,
+		StorageEventListener
+	>();
 	return {
 		addEventListener: (type, listener) => {
 			if (type !== "storage" || wrappedByListener.has(listener)) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/utils/workspaceTagFolders/workspaceTagFolders.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/utils/workspaceTagFolders/workspaceTagFolders.test.ts
@@ -148,7 +148,10 @@ describe("deriveTagFolders", () => {
 	it("a workspace row with the tags field ABSENT derives nothing and does not crash", () => {
 		// Rows served by an older host (or an old IndexedDB snapshot) carry
 		// the field absent, not null — the earlier attempt crashed here.
-		const legacyRow = { id: "w1", projectId: PROJECT_A } as TagFolderWorkspaceInput;
+		const legacyRow = {
+			id: "w1",
+			projectId: PROJECT_A,
+		} as TagFolderWorkspaceInput;
 		expect(deriveTagFolders([], [legacyRow])).toEqual([]);
 	});
 
@@ -268,7 +271,12 @@ describe("resolveWorkspaceFolder", () => {
 
 describe("resolveWorkspaceSectionId", () => {
 	const index = getProjectFolderTagIndex(
-		[makeSection({ sectionId: buildSidebarFolderKey(PROJECT_A, "perf"), tag: "perf" })],
+		[
+			makeSection({
+				sectionId: buildSidebarFolderKey(PROJECT_A, "perf"),
+				tag: "perf",
+			}),
+		],
 		PROJECT_A,
 	);
 
@@ -321,9 +329,9 @@ describe("applyFolderTagChange", () => {
 	const folderTags = ["perf", "infra"];
 
 	it("replaces the project's folder tags with the target tag", () => {
-		expect(applyFolderTagChange(["perf", "scratch"], folderTags, "infra")).toEqual(
-			["infra", "scratch"],
-		);
+		expect(
+			applyFolderTagChange(["perf", "scratch"], folderTags, "infra"),
+		).toEqual(["infra", "scratch"]);
 	});
 
 	it("only touches tags the project has a folder for", () => {
@@ -335,9 +343,9 @@ describe("applyFolderTagChange", () => {
 	});
 
 	it("null target strips folder membership only", () => {
-		expect(applyFolderTagChange(["perf", "scratch"], folderTags, null)).toEqual([
-			"scratch",
-		]);
+		expect(applyFolderTagChange(["perf", "scratch"], folderTags, null)).toEqual(
+			["scratch"],
+		);
 	});
 
 	it("normalizes both sides of the comparison", () => {

--- a/packages/cli/src/commands/workspaces/update/command.ts
+++ b/packages/cli/src/commands/workspaces/update/command.ts
@@ -51,7 +51,11 @@ export default command({
 				? options.tag
 				: undefined;
 
-		if (options.name === undefined && taskId === undefined && tags === undefined) {
+		if (
+			options.name === undefined &&
+			taskId === undefined &&
+			tags === undefined
+		) {
 			throw new CLIError(
 				"No fields to update",
 				"Pass --name, --task-id, --clear-task, --tag, or --clear-tags",

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -835,7 +835,7 @@ export const workspacesRouter = router({
 					baseBranch: input.baseBranch,
 					idempotencyId: input.id,
 					taskId: input.taskId,
-								tags: input.tags,
+					tags: input.tags,
 				});
 				workspaceRow = result.workspace;
 				alreadyExists = result.alreadyExists;
@@ -956,7 +956,7 @@ export const workspacesRouter = router({
 							baseBranch: baseShortName,
 							idempotencyId: input.id,
 							taskId: input.taskId,
-								tags: input.tags,
+							tags: input.tags,
 						});
 						workspaceRow = result.workspace;
 						alreadyExists = result.alreadyExists;
@@ -1021,7 +1021,7 @@ export const workspacesRouter = router({
 										baseBranch: baseShortName,
 										idempotencyId: input.id,
 										taskId: input.taskId,
-								tags: input.tags,
+										tags: input.tags,
 									});
 									adoptedRow = result.workspace;
 									alreadyExists = result.alreadyExists;

--- a/packages/host-service/src/workspaces/local-workspace-store.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.ts
@@ -6,7 +6,7 @@ import { getHostId } from "@superset/shared/host-info";
 import { normalizeWorkspaceTags } from "@superset/shared/workspace-tags";
 import { eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../db";
-import { workspaceTags, workspaces } from "../db/schema";
+import { workspaces, workspaceTags } from "../db/schema";
 import type { EventBus } from "../events";
 import type { WorkspaceSnapshot } from "../events/types";
 import type { ApiClient } from "../types";
@@ -233,7 +233,8 @@ export function updateLocalWorkspace(
 	const existing = getLocalWorkspace(ctx.db, id);
 	if (!existing) return undefined;
 	const { tags, ...columns } = patch;
-	const normalizedTags = tags === undefined ? undefined : normalizeWorkspaceTags(tags);
+	const normalizedTags =
+		tags === undefined ? undefined : normalizeWorkspaceTags(tags);
 	// Tag replacement is delete-then-insert; the transaction keeps a throw
 	// between them from losing the whole set.
 	ctx.db.transaction((tx) => {
@@ -250,7 +251,11 @@ export function updateLocalWorkspace(
 				const now = Date.now();
 				tx.insert(workspaceTags)
 					.values(
-						normalizedTags.map((tag) => ({ workspaceId: id, tag, createdAt: now })),
+						normalizedTags.map((tag) => ({
+							workspaceId: id,
+							tag,
+							createdAt: now,
+						})),
 					)
 					.run();
 			}

--- a/packages/host-service/src/workspaces/workspace-tags.test.ts
+++ b/packages/host-service/src/workspaces/workspace-tags.test.ts
@@ -5,7 +5,7 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../db";
 import * as schema from "../db/schema";
-import { workspaceTags, workspaces } from "../db/schema";
+import { workspaces, workspaceTags } from "../db/schema";
 import type { EventBus } from "../events";
 import type { WorkspaceChangedMessage } from "../events/types";
 import {
@@ -49,7 +49,14 @@ function seedWorkspace(
 ) {
 	return insertLocalWorkspace(
 		{ db, eventBus },
-		{ id, projectId: null, worktreePath: `/tmp/${id}`, branch: id, name: id, tags },
+		{
+			id,
+			projectId: null,
+			worktreePath: `/tmp/${id}`,
+			branch: id,
+			name: id,
+			tags,
+		},
 	);
 }
 

--- a/packages/shared/src/workspace-tags.test.ts
+++ b/packages/shared/src/workspace-tags.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-	WORKSPACE_TAG_MAX_LENGTH,
-	WORKSPACE_TAGS_MAX_PER_WORKSPACE,
 	normalizeWorkspaceTag,
 	normalizeWorkspaceTags,
+	WORKSPACE_TAG_MAX_LENGTH,
+	WORKSPACE_TAGS_MAX_PER_WORKSPACE,
 	workspaceTagsInputSchema,
 } from "./workspace-tags";
 
@@ -19,9 +19,9 @@ describe("normalizeWorkspaceTag", () => {
 	});
 
 	test("returns null for over-length", () => {
-		expect(
-			normalizeWorkspaceTag("a".repeat(WORKSPACE_TAG_MAX_LENGTH)),
-		).toBe("a".repeat(WORKSPACE_TAG_MAX_LENGTH));
+		expect(normalizeWorkspaceTag("a".repeat(WORKSPACE_TAG_MAX_LENGTH))).toBe(
+			"a".repeat(WORKSPACE_TAG_MAX_LENGTH),
+		);
 		expect(
 			normalizeWorkspaceTag("a".repeat(WORKSPACE_TAG_MAX_LENGTH + 1)),
 		).toBeNull();
@@ -63,9 +63,10 @@ describe("normalizeWorkspaceTags", () => {
 
 describe("workspaceTagsInputSchema", () => {
 	test("parses to normalized, deduped, sorted set", () => {
-		expect(
-			workspaceTagsInputSchema.parse(["Perf", " perf", "Alpha"]),
-		).toEqual(["alpha", "perf"]);
+		expect(workspaceTagsInputSchema.parse(["Perf", " perf", "Alpha"])).toEqual([
+			"alpha",
+			"perf",
+		]);
 	});
 
 	test("rejects empty tags instead of dropping them", () => {

--- a/packages/shared/src/workspace-tags.ts
+++ b/packages/shared/src/workspace-tags.ts
@@ -19,10 +19,7 @@ export function normalizeWorkspaceTag(
 		return null;
 	}
 	const normalized = tag.trim().toLowerCase();
-	if (
-		normalized.length === 0 ||
-		normalized.length > WORKSPACE_TAG_MAX_LENGTH
-	) {
+	if (normalized.length === 0 || normalized.length > WORKSPACE_TAG_MAX_LENGTH) {
 		return null;
 	}
 	return normalized;


### PR DESCRIPTION
Admin-merging #6990 bypassed the Lint check, which then failed on main with 25 errors, all in that PR's files: biome formatting and import organization only. `bun run lint:fix` output, verified with lint green, zero typecheck errors in the touched packages, and the affected test suites passing (no non-baseline failures).

https://claude.ai/code/session_01Scu1EHDFD5QL6ryyxHCx72

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 25 Biome formatting and import-ordering errors that the admin merge of #6990 bypassed on main. No behavior changes.

<sup>Written for commit 7e8ad0525aa5793351309d28d9844d5d9010208f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied formatting and import-order cleanup across dashboard, workspace, CLI, and host-service code.
  * Improved readability of several declarations, function calls, assertions, and type definitions.

* **Tests**
  * Reformatted test fixtures, assertions, helper signatures, and imports without changing test coverage or behavior.

* **Refactor**
  * No user-visible functionality or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->