### PR TITLE
docs: translate the README into all sixteen shipped languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ### Run 100+ Coding Agents in Parallel
 
+<sub>
+
+[English](README.md) | [日本語](readme/README.ja.md) | [简体中文](readme/README.zh-CN.md) | [繁體中文](readme/README.zh-TW.md) | [한국어](readme/README.ko.md) | [Français](readme/README.fr.md) | [Español](readme/README.es.md) | [Deutsch](readme/README.de.md) | [Português](readme/README.pt-BR.md) | [Italiano](readme/README.it.md) | [Русский](readme/README.ru.md) | [Türkçe](readme/README.tr.md) | [Polski](readme/README.pl.md) | [Nederlands](readme/README.nl.md) | [Bahasa Indonesia](readme/README.id.md) | [Čeština](readme/README.cs.md) | [Tiếng Việt](readme/README.vi.md)
+
+</sub>
+
 [![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
 [![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](LICENSE.md)

--- a/readme/README.cs.md
+++ b/readme/README.cs.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude a OpenCode pracují paralelně v pracovních prostorech Supersetu s živými diffy" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Spusťte 100+ kódovacích agentů paralelně
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Toto je překlad anglického README, které je závazné.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex nebo libovolný CLI agent, každý ve vlastním izolovaném worktree.<br />
+Trávte čas dodáváním, ne čekáním.
+
+<br />
+
+[**Stáhnout pro macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Dokumentace](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Kódujte 10x rychleji bez nákladů na přepínání
+
+Superset spouští CLI kódovací agenty paralelně v izolovaných git worktree, s vestavěným terminálem, review a workflow otevření v editoru.
+
+- **Spouštějte více agentů současně** bez režie přepínání kontextu
+- **Izolujte každý úkol** ve vlastním git worktree, takže si agenti navzájem nezasahují do práce
+- **Sledujte všechny své agenty** z jednoho místa a dostaňte upozornění, když potřebují pozornost
+- **Rychle kontrolujte a upravujte změny** ve vestavěném diff prohlížeči a editoru
+- **Otevřete kterýkoli pracovní prostor tam, kde ho potřebujete** — předání do editoru nebo terminálu jedním kliknutím
+- **Dostaňte se ke svým pracovním prostorům odkudkoli** přes vzdálené hostitele, CLI, SDK nebo MCP
+
+Méně čekání, více dodávání.
+
+## Funkce
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Paralelní pracovní prostory
+
+Spusťte 100+ kódovacích agentů najednou, každého ve vlastním git worktree s vlastní větví, terminálem a prostředím. Porovnejte výsledky a slučte vítěze.
+
+[Dokumentace →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude streamuje migraci billingu, zatímco další agenti běží v paralelních pracovních prostorech" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Monitorování agentů
+
+Sledujte každého agenta z postranního panelu — indikátory práce, zvuky dokončení a odznaky v docku, když někdo potřebuje vaši pozornost.
+
+[Dokumentace →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Agent dokončuje svůj úkol a stav v postranním panelu se přepíná z práce na hotovo" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Vestavěný terminál
+
+Karty, neomezené rozdělení, předvolby a perzistentní relace, které přežijí restart. Stiskněte ⌘I pro bohatý editor promptů s víceřádkovými úpravami a @-zmínkami souborů.
+
+[Dokumentace →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Psaní navazujícího dotazu s @-zmínkou souboru v bohatém editoru promptů vedle rozděleného terminálu" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Vestavěný diff prohlížeč
+
+Prohlížejte, komentujte a upravujte změny agentů bez opuštění aplikace, a až budou hotové, commitněte a pushněte je.
+
+[Dokumentace →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Kontrola změn agenta v diff prohlížeči" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Vestavěný prohlížeč a porty
+
+Prohlížejte běžící dev servery v panelu prohlížeče. Porty se detekují pro každý pracovní prostor zvlášť, takže každý worktree má vlastní náhled.
+
+[Dokumentace →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Vestavěný prohlížeč s náhledem dev serveru a detekovanými porty" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automatizace
+
+Spouštějte relace agentů podle plánu: přes noc roztřiďte issues, připravte týdenní changelog, udržujte závislosti aktuální.
+
+[Dokumentace →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Naplánované automatizace agentů" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Vzdálený přístup
+
+Připojte další počítač a dostaňte se k jeho pracovním prostorům odkudkoli: z desktopové aplikace, CLI nebo telefonu. Probuďte offline hostitele vlastním příkazem.
+
+[Dokumentace →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hostitelé a členové v nastavení organizace" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Skriptujte z libovolného shellu: vytvářejte pracovní prostory, spouštějte agenty, čtěte jejich terminály a spravujte automatizace jedinou binárkou. Pokud agent umí spustit příkaz, umí řídit Superset.
+
+[Dokumentace →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Vytvoření pracovního prostoru a spuštění agenta ze Superset CLI" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Paleta příkazů
+
+Přejděte na libovolný pracovní prostor, akci nebo nastavení z jednoho vyhledávacího pole.
+
+[Dokumentace →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Psaní v paletě příkazů a živé filtrování akcí pracovního prostoru" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Také v balení:**
+
+- **[Vestavěné skills](https://docs.superset.sh/skills)**: agenti přicházejí s přednahranými skills `superset:*` (orchestrace paralelních agentů, plánování automatizací, odesílání zpětné vazby, diagnostika problémů), automaticky poskytnutými při spuštění
+- **[Výběr modelu a vlastní agenti](https://docs.superset.sh/agent-integration)**: při spuštění zvolte model a úroveň uvažování a přidejte libovolného terminálového agenta s vlastní ikonou
+- **[Skripty pro nastavení pracovního prostoru](https://docs.superset.sh/setup-teardown-scripts)**: automatizujte nastavení prostředí, instalaci závislostí a dev servery pro každý pracovní prostor
+- **[Předvolby terminálu](https://docs.superset.sh/terminal-presets)**: uložte si rozložení agentů a shellů a otevřete je jedním stiskem klávesy
+- **[Slack a Linear](https://docs.superset.sh/use-with-linear)**: vytvářejte pracovní prostory ze zpráv na Slacku nebo issues v Linearu
+- **[Otevření ve vašem IDE](https://docs.superset.sh/use-with-ide)**: předání jedním kliknutím do Cursoru, VS Code nebo jakéhokoli editoru
+- **[Vlastní motivy](https://docs.superset.sh/custom-themes)**: vytvářejte, upravujte a importujte soubory motivů
+- **[Klávesové zkratky](https://docs.superset.sh/keyboard-shortcuts)**: každou akci lze přemapovat přes **Nastavení → Klávesové zkratky** (⌘/)
+- **[Přineste si vlastní poskytovatele](https://docs.superset.sh/providers)**: připojte OpenRouter, Bedrock, Vertex nebo Vercel AI Gateway
+- **A mnoho dalšího**: dodáváme denně, takže tento seznam je věčně pozadu. Skutečný seznam funkcí je [changelog](https://superset.sh/changelog).
+
+## Podporovaní agenti
+
+Superset funguje s libovolným CLI kódovacím agentem, mimo jiné:
+
+| Agent | Stav |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Plně podporován |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Plně podporován |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Plně podporován |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Plně podporován |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Plně podporován |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Plně podporován |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Plně podporován |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Plně podporován |
+| Jakýkoli jiný CLI agent | Funguje bez konfigurace |
+
+Pokud běží v terminálu, běží na Supersetu
+
+Agenti dostávají víc než jen terminál:
+
+- **Výběr modelu**: při spuštění agenta zvolte model a úroveň uvažování
+- **Nastavení pro každého agenta**: dolaďte spouštěcí příkazy, šablony promptů a přepsání modelu v Nastavení → Agenti
+- **Vlastní agenti**: přidejte libovolného terminálového agenta s vlastní ikonou a bude fungovat jako vestavěný
+- **Stav a upozornění**: indikátory práce, zvuky dokončení a odznaky v docku, když vás agent potřebuje
+- **Vestavěný chat**: mluvte s modely v chatovacím panelu, s inline schvalováním nástrojů a kontrolou plánu
+
+## Víc než desktopová aplikace
+
+Každé rozhraní komunikuje se stejnými pracovními prostory, takže můžete úkol začít v aplikaci a zkontrolovat ho odkudkoli.
+
+| Rozhraní | Co dostanete |
+|:--------|:-------------|
+| [**Desktopová aplikace**](https://github.com/superset-sh/superset/releases/latest) | Plnohodnotné IDE: terminály, diff prohlížeč, vestavěný prohlížeč, automatizace |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Jediná binárka `superset` pro správu pracovních prostorů, agentů, terminálů a hostitelů z libovolného shellu |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Řiďte Superset programově pomocí [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) z Node, Bunu nebo Dena |
+| [**MCP server**](https://docs.superset.sh/mcp) | Nechte Claude Code, Codex, Cursor a další agenty vytvářet a spravovat pracovní prostory samostatně |
+
+CLI je přibalené k desktopové aplikaci, nebo ho nainstalujte samostatně:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Brzy dorazí iOS aplikace, takže na své agenty dohlédnete i z telefonu.
+
+## Instalace
+
+Stáhněte si desktopovou aplikaci:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (experimentální; primární platformou je macOS)
+- **Windows**: zatím není k dispozici
+- [Všechny buildy](https://github.com/superset-sh/superset/releases/latest)
+
+Jediné, co potřebujete mít nainstalované, je [Git](https://git-scm.com/). [gh](https://cli.github.com/) je volitelný a odemyká PR workflow; Superset vám ho nabídne nainstalovat.
+
+## Vývoj
+
+Chcete na Supersetu bastlit nebo přispět PR? Naklonujte repozitář, přidejte ho do
+nainstalované aplikace Superset a vytvořte pracovní prostor pro svou změnu:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Poté z terminálu daného pracovního prostoru spusťte vývojové nastavení:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Spusťte `setup.local.sh` jednou v každém novém worktree. Nakonfiguruje identitu
+aplikace a porty specifické pro pracovní prostor, aby vývojová desktopová aplikace mohla
+běžet vedle nainstalované aplikace Superset a dalších vývojových worktree.
+
+Není potřeba účet Neon ani přihlašovací údaje třetích stran. `setup.local.sh` nastartuje
+lokální stack Postgres + Electric přes Docker a naplní dev účet. Přihlaste se
+tlačítkem **"Sign in as dev"** (nebo `admin@local.test` / `supersetdev`).
+
+Předpoklady: [Bun](https://bun.sh/) v1.3.14+ (připnutý v `.bun-version`), `docker`, `jq` a `caddy`, který `bun dev` spouští jako lokální HTTPS proxy (`brew install jq caddy && caddy trust`).
+
+Kompletního průvodce najdete v [**DEVELOPMENT.md**](../DEVELOPMENT.md): co dělá skript nastavení, ruční nastavení proti skutečným službám, běžné příkazy, řešení problémů a jak sestavit desktopovou aplikaci. Proces přispívání je popsán v [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Konfigurace
+
+Nakonfigurujte skripty setup, teardown a run pracovního prostoru v `.superset/config.json`. Viz [úplná dokumentace](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Klávesové zkratky si můžete přizpůsobit přes **Nastavení → Klávesové zkratky** (⌘/); viz [úplný seznam zkratek](https://docs.superset.sh/keyboard-shortcuts).
+
+## Technologie
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Ve výchozím stavu soukromé
+
+- **Dostupný zdrojový kód**: kompletní zdrojový kód je na GitHubu pod licencí Elastic License 2.0 (ELv2).
+- **Explicitní připojení**: sami si volíte, které agenty, poskytovatele a integrace připojíte.
+
+## Přispívání
+
+Příspěvky vítáme! V [CONTRIBUTING.md](../CONTRIBUTING.md) najdete, jak se nastavit a otevřít PR. Chyby a požadavky na funkce patří do [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Komunita
+
+Připojte se ke komunitě Supersetu — získáte pomoc, můžete sdílet zpětnou vazbu a poznat další uživatele:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: chatujte s týmem a komunitou
+- **[Twitter](https://x.com/superset_sh)**: sledujte novinky a oznámení
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: hlaste chyby a žádejte o funkce
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: ptejte se a sdílejte nápady
+
+### Tým
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licence a co je navždy zdarma
+
+**Desktopová aplikace je navždy zdarma.** Paralelní spouštění agentů na vlastním počítači nebude nikdy vyžadovat platbu. Cokoli zpoplatníme, bude volitelná služba navíc.
+
+Celá aplikace je v tomto repozitáři pod licencí [Elastic License 2.0](../LICENSE.md): používejte ji, forkněte ji, upravujte ji, provozujte ji na vlastní infrastruktuře pro svůj tým. Jediné, co nejde, je přebalit samotný Superset jako službu, kterou prodáváte ostatním.

--- a/readme/README.de.md
+++ b/readme/README.de.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude und OpenCode arbeiten parallel in Superset-Arbeitsbereichen mit Live-Diffs" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Führe über 100 Coding-Agenten parallel aus
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Dies ist eine Übersetzung des [englischen READMEs](../README.md), das die maßgebliche Version ist.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex oder jeder andere CLI-Agent, jeder in seinem eigenen isolierten Worktree.<br />
+Verbring deine Zeit mit Shippen, nicht mit Warten.
+
+<br />
+
+[**Für macOS herunterladen**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Dokumentation](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Programmiere 10x schneller, ohne Kosten fürs Kontextwechseln
+
+Superset führt CLI-basierte Coding-Agenten parallel in isolierten Git-Worktrees aus, mit integriertem Terminal, Review und Öffnen-im-Editor-Workflows.
+
+- **Führe mehrere Agenten gleichzeitig aus**, ohne den Overhead ständiger Kontextwechsel
+- **Isoliere jede Aufgabe** in ihrem eigenen Git-Worktree, damit sich die Agenten nicht gegenseitig in die Quere kommen
+- **Behalte alle deine Agenten im Blick** von einem Ort aus und werde benachrichtigt, wenn sie Aufmerksamkeit brauchen
+- **Prüfe und bearbeite Änderungen schnell** mit dem integrierten Diff-Viewer und Editor
+- **Öffne jeden Arbeitsbereich dort, wo du ihn brauchst**, mit Ein-Klick-Übergabe an deinen Editor oder dein Terminal
+- **Erreiche deine Arbeitsbereiche von überall** über Remote-Hosts, die CLI, das SDK oder MCP
+
+Weniger warten, mehr shippen.
+
+## Funktionen
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Parallele Arbeitsbereiche
+
+Führe über 100 Coding-Agenten gleichzeitig aus, jeden in seinem eigenen Git-Worktree mit eigener Branch, eigenem Terminal und eigener Umgebung. Vergleiche die Ergebnisse und merge den Gewinner.
+
+[Docs →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude streamt eine Billing-Migration, während andere Agenten in parallelen Arbeitsbereichen laufen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Agenten-Überwachung
+
+Verfolge jeden Agenten über die Seitenleiste, mit Aktivitätsanzeigen, Abschluss-Klängen und Dock-Badges, wenn einer deine Aufmerksamkeit braucht.
+
+[Docs →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Ein Agent schließt seine Aufgabe ab und der Status in der Seitenleiste springt von „arbeitet“ auf „fertig“" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Integriertes Terminal
+
+Tabs, unbegrenzte Splits, Presets und persistente Sessions, die Neustarts überleben. Drücke ⌘I für einen komfortablen Prompt-Editor mit mehrzeiliger Bearbeitung und @-Datei-Erwähnungen.
+
+[Docs →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Eine Rückfrage mit einer @-Datei-Erwähnung im Prompt-Editor neben einem geteilten Terminal tippen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Integrierter Diff-Viewer
+
+Prüfe, kommentiere und bearbeite Agenten-Änderungen, ohne die App zu verlassen, und mache dann Commit und Push, wenn alles fertig ist.
+
+[Docs →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Die Änderungen eines Agenten im Diff-Viewer prüfen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### In-App-Browser & Ports
+
+Sieh dir laufende Dev-Server in einem Browser-Panel an. Ports werden pro Arbeitsbereich erkannt, sodass jeder Worktree seine eigene Vorschau bekommt.
+
+[Docs →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="In-App-Browser mit Vorschau eines Dev-Servers und erkannten Ports" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automatisierungen
+
+Führe Agenten-Sessions nach Zeitplan aus: Issues über Nacht triagieren, den wöchentlichen Changelog entwerfen, Abhängigkeiten aktuell halten.
+
+[Docs →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Geplante Agenten-Automatisierungen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Fernzugriff
+
+Verbinde einen weiteren Rechner und erreiche seine Arbeitsbereiche von überall: über die Desktop-App, die CLI oder dein Smartphone. Wecke Offline-Hosts mit einem eigenen Befehl auf.
+
+[Docs →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hosts und Mitglieder in den Organisationseinstellungen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset-CLI
+
+Skripte es aus jeder Shell: Arbeitsbereiche erstellen, Agenten starten, ihre Terminals lesen und Automatisierungen verwalten, alles mit einem einzigen Binary. Wenn ein Agent einen Befehl ausführen kann, kann er Superset steuern.
+
+[Docs →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Einen Arbeitsbereich erstellen und einen Agenten über die Superset-CLI starten" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Befehlspalette
+
+Spring von einem einzigen Suchfeld aus zu jedem Arbeitsbereich, jeder Aktion oder Einstellung.
+
+[Docs →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="In der Befehlspalette tippen und Arbeitsbereich-Aktionen live filtern" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Außerdem mit dabei:**
+
+- **[Integrierte Skills](https://docs.superset.sh/skills)**: Agenten kommen mit vorinstallierten `superset:*`-Skills (parallele Agenten orchestrieren, Automatisierungen planen, Feedback einreichen, Probleme diagnostizieren), die beim Start automatisch bereitgestellt werden
+- **[Modellauswahl & eigene Agenten](https://docs.superset.sh/agent-integration)**: wähle beim Start ein Modell und den Reasoning-Aufwand und füge jeden Terminal-Agenten mit eigenem Icon hinzu
+- **[Setup-Skripte für Arbeitsbereiche](https://docs.superset.sh/setup-teardown-scripts)**: automatisiere Umgebungs-Setup, Abhängigkeitsinstallation und Dev-Server pro Arbeitsbereich
+- **[Terminal-Presets](https://docs.superset.sh/terminal-presets)**: speichere Agenten- und Shell-Layouts und öffne sie mit einem Tastendruck
+- **[Slack & Linear](https://docs.superset.sh/use-with-linear)**: erstelle Arbeitsbereiche aus Slack-Nachrichten oder Linear-Issues
+- **[In deiner IDE öffnen](https://docs.superset.sh/use-with-ide)**: Ein-Klick-Übergabe an Cursor, VS Code oder jeden anderen Editor
+- **[Eigene Themes](https://docs.superset.sh/custom-themes)**: erstelle, bearbeite und importiere Theme-Dateien
+- **[Tastenkürzel](https://docs.superset.sh/keyboard-shortcuts)**: jede Aktion lässt sich unter **Einstellungen → Tastenkürzel** (⌘/) neu belegen
+- **[Bring deine eigenen Provider mit](https://docs.superset.sh/providers)**: verbinde OpenRouter, Bedrock, Vertex oder Vercel AI Gateway
+- **Und vieles mehr**: wir shippen täglich, diese Liste hinkt also immer hinterher. Der [Changelog](https://superset.sh/changelog) ist die echte Funktionsliste.
+
+## Unterstützte Agenten
+
+Superset funktioniert mit jedem CLI-basierten Coding-Agenten, unter anderem:
+
+| Agent | Status |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Vollständig unterstützt |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Vollständig unterstützt |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Vollständig unterstützt |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Vollständig unterstützt |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Vollständig unterstützt |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Vollständig unterstützt |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Vollständig unterstützt |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Vollständig unterstützt |
+| Jeder andere CLI-Agent | Funktioniert ohne Konfiguration |
+
+Wenn es im Terminal läuft, läuft es auf Superset
+
+Agenten bekommen mehr als nur ein Terminal:
+
+- **Modellauswahl**: wähle beim Start eines Agenten ein Modell und den Reasoning-Aufwand
+- **Einstellungen pro Agent**: passe Startbefehle, Prompt-Vorlagen und Modell-Overrides unter Einstellungen → Agenten an
+- **Eigene Agenten**: füge jeden Terminal-Agenten mit eigenem Icon hinzu und er funktioniert wie ein integrierter
+- **Status und Benachrichtigungen**: Aktivitätsanzeigen, Abschluss-Klänge und Dock-Badges, wenn ein Agent dich braucht
+- **Integrierter Chat**: sprich mit Modellen in einem Chat-Panel, mit Inline-Tool-Freigaben und Plan-Review
+
+## Mehr als eine Desktop-App
+
+Jede Oberfläche spricht mit denselben Arbeitsbereichen, du kannst also eine Aufgabe in der App starten und von überall nach ihr sehen.
+
+| Oberfläche | Was du bekommst |
+|:--------|:-------------|
+| [**Desktop-App**](https://github.com/superset-sh/superset/releases/latest) | Die komplette IDE: Terminals, Diff-Viewer, In-App-Browser, Automatisierungen |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Ein einziges `superset`-Binary, um Arbeitsbereiche, Agenten, Terminals und Hosts aus jeder Shell zu verwalten |
+| [**TypeScript-SDK**](https://docs.superset.sh/sdk/getting-started) | Steuere Superset programmatisch mit [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) aus Node, Bun oder Deno |
+| [**MCP-Server**](https://docs.superset.sh/mcp) | Lass Claude Code, Codex, Cursor und andere Agenten Arbeitsbereiche selbst erstellen und verwalten |
+
+Die CLI ist in der Desktop-App enthalten, oder installiere sie eigenständig:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Eine iOS-App kommt bald, damit du vom Smartphone aus nach deinen Agenten sehen kannst.
+
+## Installation
+
+Lade die Desktop-App herunter:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64-AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (experimentell; macOS ist die primäre Zielplattform)
+- **Windows**: noch nicht verfügbar
+- [Alle Builds](https://github.com/superset-sh/superset/releases/latest)
+
+Alles, was du installiert brauchst, ist [Git](https://git-scm.com/). [gh](https://cli.github.com/) ist optional und schaltet die PR-Workflows frei; Superset bietet an, es für dich zu installieren.
+
+## Entwicklung
+
+Du willst an Superset hacken oder eine PR beisteuern? Klone das Repository, füge es der
+installierten Superset-App hinzu und erstelle einen Arbeitsbereich für deine Änderung:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Führe dann das Entwicklungs-Setup im Terminal dieses Arbeitsbereichs aus:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Führe `setup.local.sh` einmal in jedem neuen Worktree aus. Es konfiguriert die
+arbeitsbereichsspezifische App-Identität und Ports, damit die Entwicklungs-Desktop-App
+neben der installierten Superset-App und anderen Entwicklungs-Worktrees laufen kann.
+
+Es sind weder ein Neon-Konto noch Zugangsdaten von Drittanbietern nötig. `setup.local.sh` startet
+einen lokalen Postgres-+-Electric-Stack über Docker und legt ein Dev-Konto an. Melde dich
+mit dem Button **„Sign in as dev“** an (oder `admin@local.test` / `supersetdev`).
+
+Voraussetzungen: [Bun](https://bun.sh/) v1.3.14+ (in `.bun-version` gepinnt), `docker`, `jq` und `caddy`, das `bun dev` als lokalen HTTPS-Proxy verwendet (`brew install jq caddy && caddy trust`).
+
+Siehe [**DEVELOPMENT.md**](../DEVELOPMENT.md) für die komplette Anleitung: was das Setup-Skript macht, manuelles Setup gegen echte Dienste, gängige Befehle, Fehlerbehebung und wie man die Desktop-App baut. Der Contribution-Prozess steht in [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Konfiguration
+
+Konfiguriere Setup-, Teardown- und Run-Skripte für Arbeitsbereiche in `.superset/config.json`. Siehe die [vollständige Dokumentation](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Tastenkürzel lassen sich unter **Einstellungen → Tastenkürzel** (⌘/) anpassen; siehe die [vollständige Liste der Tastenkürzel](https://docs.superset.sh/keyboard-shortcuts).
+
+## Tech-Stack
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Standardmäßig privat
+
+- **Source Available**: der komplette Quellcode liegt auf GitHub unter der Elastic License 2.0 (ELv2).
+- **Explizite Verbindungen**: du entscheidest, welche Agenten, Provider und Integrationen verbunden werden.
+
+## Mitmachen
+
+Beiträge sind willkommen! Siehe [CONTRIBUTING.md](../CONTRIBUTING.md) für den Einstieg und wie du eine PR öffnest. Bugs und Feature-Wünsche gehören in die [Issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Community
+
+Tritt der Superset-Community bei, um Hilfe zu bekommen, Feedback zu teilen und dich mit anderen auszutauschen:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: chatte mit dem Team und der Community
+- **[Twitter](https://x.com/superset_sh)**: folge uns für Updates und Ankündigungen
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: melde Bugs und wünsch dir Features
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: stell Fragen und teile Ideen
+
+### Team
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Lizenz & was für immer kostenlos bleibt
+
+**Die Desktop-App ist für immer kostenlos.** Agenten parallel auf deinem eigenen Rechner laufen zu lassen wird niemals etwas kosten. Alles, wofür wir Geld verlangen, wird ein optionaler Dienst obendrauf sein.
+
+Die gesamte App liegt in diesem Repository unter der [Elastic License 2.0](../LICENSE.md): nutze sie, forke sie, verändere sie, hoste sie selbst für dein Team. Das Einzige, was nicht geht, ist, Superset selbst als Dienst neu zu verpacken und an andere zu verkaufen.

--- a/readme/README.es.md
+++ b/readme/README.es.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude y OpenCode trabajando en paralelo en espacios de trabajo de Superset con diffs en vivo" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Ejecuta más de 100 agentes de código en paralelo
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Esta es una traducción del [README en inglés](../README.md), que es la versión canónica.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex o cualquier agente CLI, cada uno en su propio worktree aislado.<br />
+Dedica tu tiempo a lanzar código, no a esperar.
+
+<br />
+
+[**Descargar para macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentación](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Programa 10 veces más rápido sin coste de cambio de contexto
+
+Superset ejecuta agentes de código basados en CLI en paralelo en worktrees de git aislados, con terminal, revisión y flujos de apertura en el editor integrados.
+
+- **Ejecuta varios agentes a la vez** sin la sobrecarga del cambio de contexto
+- **Aísla cada tarea** en su propio worktree de git para que los agentes no interfieran entre sí
+- **Supervisa todos tus agentes** desde un solo lugar y recibe notificaciones cuando necesiten atención
+- **Revisa y edita los cambios rápidamente** con el visor de diffs y el editor integrados
+- **Abre cualquier espacio de trabajo donde lo necesites** con un traspaso en un clic a tu editor o terminal
+- **Accede a tus espacios de trabajo desde cualquier lugar** mediante hosts remotos, la CLI, el SDK o MCP
+
+Espera menos, lanza más.
+
+## Funcionalidades
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Espacios de trabajo paralelos
+
+Ejecuta más de 100 agentes de código a la vez, cada uno en su propio worktree de git con su propia branch, terminal y entorno. Compara los resultados y haz merge del ganador.
+
+[Docs →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude transmitiendo una migración de facturación mientras otros agentes trabajan en espacios de trabajo paralelos" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Supervisión de agentes
+
+Sigue cada agente desde la barra lateral, con indicadores de actividad, avisos sonoros al terminar y globos en el dock cuando alguno necesita tu atención.
+
+[Docs →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Un agente terminando su tarea y el estado de la barra lateral pasando de trabajando a terminado" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Terminal integrado
+
+Pestañas, divisiones infinitas, presets y sesiones persistentes que sobreviven a los reinicios. Pulsa ⌘I para un editor de prompts enriquecido con edición multilínea y menciones de archivos con @.
+
+[Docs →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Escribiendo un mensaje de seguimiento con una mención de archivo con @ en el editor de prompts enriquecido junto a un terminal dividido" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Visor de diffs integrado
+
+Inspecciona, comenta y edita los cambios de los agentes sin salir de la app, y luego haz commit y push cuando esté listo.
+
+[Docs →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Revisando los cambios de un agente en el visor de diffs" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Navegador integrado y puertos
+
+Previsualiza los servidores de desarrollo en ejecución en un panel de navegador. Los puertos se detectan por espacio de trabajo, así que cada worktree tiene su propia vista previa.
+
+[Docs →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Navegador integrado previsualizando un servidor de desarrollo con los puertos detectados" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automatizaciones
+
+Ejecuta sesiones de agentes de forma programada: clasifica issues durante la noche, redacta el changelog semanal, mantén las dependencias al día.
+
+[Docs →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Automatizaciones de agentes programadas" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Acceso remoto
+
+Conecta otra máquina y accede a sus espacios de trabajo desde cualquier lugar: la app de escritorio, la CLI o tu teléfono. Despierta hosts sin conexión con un comando personalizado.
+
+[Docs →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hosts y miembros en la configuración de la organización" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### CLI de Superset
+
+Automatízalo desde cualquier shell: crea espacios de trabajo, lanza agentes, lee sus terminales y gestiona automatizaciones con un solo binario. Si un agente puede ejecutar un comando, puede manejar Superset.
+
+[Docs →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Creando un espacio de trabajo y lanzando un agente desde la CLI de Superset" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Paleta de comandos
+
+Salta a cualquier espacio de trabajo, acción o ajuste desde un único cuadro de búsqueda.
+
+[Docs →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Escribiendo en la paleta de comandos y filtrando acciones de espacios de trabajo en vivo" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**También incluido:**
+
+- **[Habilidades integradas](https://docs.superset.sh/skills)**: los agentes vienen precargados con las habilidades `superset:*` (orquestar agentes en paralelo, programar automatizaciones, enviar feedback, diagnosticar problemas), aprovisionadas automáticamente al lanzarlos
+- **[Selector de modelo y agentes personalizados](https://docs.superset.sh/agent-integration)**: elige un modelo y un nivel de razonamiento al lanzar, y añade cualquier agente de terminal con su propio icono
+- **[Scripts de configuración de espacios de trabajo](https://docs.superset.sh/setup-teardown-scripts)**: automatiza la preparación del entorno, la instalación de dependencias y los servidores de desarrollo por espacio de trabajo
+- **[Presets de terminal](https://docs.superset.sh/terminal-presets)**: guarda disposiciones de agentes y shells y ábrelas con una sola tecla
+- **[Slack y Linear](https://docs.superset.sh/use-with-linear)**: crea espacios de trabajo desde mensajes de Slack o issues de Linear
+- **[Abrir en tu IDE](https://docs.superset.sh/use-with-ide)**: traspaso en un clic a Cursor, VS Code o cualquier editor
+- **[Temas personalizados](https://docs.superset.sh/custom-themes)**: crea, edita e importa archivos de tema
+- **[Atajos de teclado](https://docs.superset.sh/keyboard-shortcuts)**: cada acción se puede reasignar en **Configuración → Atajos de teclado** (⌘/)
+- **[Trae tus propios proveedores](https://docs.superset.sh/providers)**: conecta OpenRouter, Bedrock, Vertex o Vercel AI Gateway
+- **Y mucho más**: lanzamos a diario, así que esta lista siempre va por detrás. El [changelog](https://superset.sh/changelog) es la verdadera lista de funcionalidades.
+
+## Agentes compatibles
+
+Superset funciona con cualquier agente de código basado en CLI, incluidos:
+
+| Agente | Estado |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Totalmente compatible |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Totalmente compatible |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Totalmente compatible |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Totalmente compatible |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Totalmente compatible |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Totalmente compatible |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Totalmente compatible |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Totalmente compatible |
+| Cualquier otro agente CLI | Funciona sin configuración |
+
+Si funciona en un terminal, funciona en Superset
+
+Los agentes obtienen más que un terminal:
+
+- **Selector de modelo**: elige un modelo y un nivel de razonamiento al lanzar un agente
+- **Configuración por agente**: ajusta comandos de lanzamiento, plantillas de prompts y modelos en Configuración → Agentes
+- **Agentes personalizados**: añade cualquier agente de terminal con su propio icono y funcionará como uno integrado
+- **Estado y notificaciones**: indicadores de actividad, avisos sonoros al terminar y globos en el dock cuando un agente te necesita
+- **Chat integrado**: habla con los modelos en un panel de chat, con aprobación de herramientas en línea y revisión de planes
+
+## Más que una app de escritorio
+
+Todas las superficies hablan con los mismos espacios de trabajo, así que puedes empezar una tarea en la app y seguirla desde cualquier lugar.
+
+| Superficie | Qué obtienes |
+|:--------|:-------------|
+| [**App de escritorio**](https://github.com/superset-sh/superset/releases/latest) | El IDE completo: terminales, visor de diffs, navegador integrado, automatizaciones |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Un único binario `superset` para gestionar espacios de trabajo, agentes, terminales y hosts desde cualquier shell |
+| [**SDK de TypeScript**](https://docs.superset.sh/sdk/getting-started) | Maneja Superset mediante código con [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) desde Node, Bun o Deno |
+| [**Servidor MCP**](https://docs.superset.sh/mcp) | Deja que Claude Code, Codex, Cursor y otros agentes creen y gestionen espacios de trabajo por sí mismos |
+
+La CLI viene incluida con la app de escritorio, o instálala por separado:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Pronto llegará una app para iOS para que puedas seguir a tus agentes desde el teléfono.
+
+## Instalación
+
+Descarga la app de escritorio:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [AppImage x64](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (experimental; macOS es el objetivo principal)
+- **Windows**: aún no disponible
+- [Todas las builds](https://github.com/superset-sh/superset/releases/latest)
+
+Lo único que necesitas tener instalado es [Git](https://git-scm.com/). [gh](https://cli.github.com/) es opcional y desbloquea los flujos de PR; Superset se ofrece a instalarlo por ti.
+
+## Desarrollo
+
+¿Quieres trastear con Superset o contribuir con una PR? Clona el repositorio, añádelo a
+la app de Superset instalada y crea un espacio de trabajo para tu cambio:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Luego ejecuta la configuración de desarrollo desde el terminal de ese espacio de trabajo:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Ejecuta `setup.local.sh` una vez en cada worktree nuevo. Configura la identidad de la app
+y los puertos específicos del espacio de trabajo para que la app de escritorio de desarrollo
+pueda ejecutarse junto a la app de Superset instalada y otros worktrees de desarrollo.
+
+No se necesita cuenta de Neon ni credenciales de terceros. `setup.local.sh` levanta
+una pila local de Postgres + Electric mediante Docker y crea una cuenta de desarrollo. Inicia sesión
+con el botón **"Sign in as dev"** (o `admin@local.test` / `supersetdev`).
+
+Requisitos previos: [Bun](https://bun.sh/) v1.3.14+ (fijado en `.bun-version`), `docker`, `jq` y `caddy`, que `bun dev` ejecuta como proxy HTTPS local (`brew install jq caddy && caddy trust`).
+
+Consulta [**DEVELOPMENT.md**](../DEVELOPMENT.md) para la guía completa: qué hace el script de configuración, la configuración manual contra servicios reales, comandos habituales, resolución de problemas y cómo compilar la app de escritorio. El proceso de contribución está en [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Configuración
+
+Configura los scripts de setup, teardown y run de los espacios de trabajo en `.superset/config.json`. Consulta la [documentación completa](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Los atajos de teclado se pueden personalizar en **Configuración → Atajos de teclado** (⌘/); consulta la [lista completa de atajos](https://docs.superset.sh/keyboard-shortcuts).
+
+## Stack tecnológico
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Privado por defecto
+
+- **Código fuente disponible**: todo el código está en GitHub bajo la Elastic License 2.0 (ELv2).
+- **Conexiones explícitas**: tú eliges qué agentes, proveedores e integraciones conectar.
+
+## Contribuir
+
+¡Las contribuciones son bienvenidas! Consulta [CONTRIBUTING.md](../CONTRIBUTING.md) para saber cómo prepararte y abrir una PR. Los bugs y las peticiones de funcionalidades van en las [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Comunidad
+
+Únete a la comunidad de Superset para obtener ayuda, compartir feedback y conectar con otros usuarios:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: chatea con el equipo y la comunidad
+- **[Twitter](https://x.com/superset_sh)**: síguenos para novedades y anuncios
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: informa de bugs y pide funcionalidades
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: haz preguntas y comparte ideas
+
+### Equipo
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licencia y qué es gratis para siempre
+
+**La app de escritorio es gratis para siempre.** Ejecutar agentes en paralelo en tu propia máquina nunca requerirá pago. Todo lo que cobremos será un servicio opcional adicional.
+
+Toda la app está en este repositorio bajo la [Elastic License 2.0](../LICENSE.md): úsala, haz un fork, modifícala, autoalójala para tu equipo. Lo único que queda fuera es reempaquetar el propio Superset como un servicio que vendas a terceros.

--- a/readme/README.fr.md
+++ b/readme/README.fr.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude et OpenCode travaillant en parallèle dans des espaces de travail Superset avec des diffs en direct" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Exécutez plus de 100 agents de codage en parallèle
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Ceci est une traduction du [README anglais](../README.md), qui reste la version de référence.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex ou n'importe quel agent CLI, chacun dans son propre worktree isolé.<br />
+Passez votre temps à livrer, pas à attendre.
+
+<br />
+
+[**Télécharger pour macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentation](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Codez 10x plus vite, sans coût de changement de contexte
+
+Superset exécute des agents de codage en ligne de commande en parallèle dans des worktrees git isolés, avec terminal, revue de code et ouverture dans l'éditeur intégrés.
+
+- **Exécutez plusieurs agents simultanément** sans la surcharge du changement de contexte
+- **Isolez chaque tâche** dans son propre worktree git pour que les agents n'interfèrent pas entre eux
+- **Surveillez tous vos agents** depuis un seul endroit et soyez notifié quand ils ont besoin de vous
+- **Relisez et modifiez les changements rapidement** avec la visionneuse de diff et l'éditeur intégrés
+- **Ouvrez n'importe quel espace de travail là où vous en avez besoin** avec une passation en un clic vers votre éditeur ou votre terminal
+- **Accédez à vos espaces de travail depuis n'importe où** via les hôtes distants, la CLI, le SDK ou MCP
+
+Attendez moins, livrez plus.
+
+## Fonctionnalités
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Espaces de travail parallèles
+
+Exécutez plus de 100 agents de codage à la fois, chacun dans son propre worktree git avec sa propre branche, son terminal et son environnement. Comparez les résultats et mergez le gagnant.
+
+[Docs →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude diffusant une migration de facturation pendant que d'autres agents tournent dans des espaces de travail parallèles" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Supervision des agents
+
+Suivez chaque agent depuis la barre latérale, avec indicateurs d'activité, carillons de fin de tâche et badges sur le dock quand l'un d'eux a besoin de votre attention.
+
+[Docs →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Un agent terminant sa tâche et le statut de la barre latérale passant de « en cours » à « terminé »" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Terminal intégré
+
+Onglets, divisions illimitées, préréglages et sessions persistantes qui survivent aux redémarrages. Appuyez sur ⌘I pour un éditeur de prompt enrichi avec édition multiligne et mentions de fichiers via @.
+
+[Docs →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Saisie d'une relance avec une mention de fichier @ dans l'éditeur de prompt enrichi à côté d'un terminal divisé" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Visionneuse de diff intégrée
+
+Inspectez, commentez et modifiez les changements des agents sans quitter l'app, puis faites commit et push quand c'est prêt.
+
+[Docs →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Revue des changements d'un agent dans la visionneuse de diff" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Navigateur intégré et ports
+
+Prévisualisez les serveurs de dev en cours d'exécution dans un panneau navigateur. Les ports sont détectés par espace de travail, chaque worktree a donc son propre aperçu.
+
+[Docs →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Navigateur intégré prévisualisant un serveur de dev avec les ports détectés" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automatisations
+
+Exécutez des sessions d'agent selon un planning : triez les issues pendant la nuit, rédigez le changelog hebdomadaire, gardez les dépendances à jour.
+
+[Docs →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Automatisations d'agents planifiées" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Accès distant
+
+Connectez une autre machine et accédez à ses espaces de travail depuis n'importe où : l'app de bureau, la CLI ou votre téléphone. Réveillez les hôtes hors ligne avec une commande personnalisée.
+
+[Docs →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hôtes et membres dans les paramètres de l'organisation" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### CLI Superset
+
+Scriptez tout depuis n'importe quel shell : créez des espaces de travail, lancez des agents, lisez leurs terminaux et gérez les automatisations avec un seul binaire. Si un agent peut exécuter une commande, il peut piloter Superset.
+
+[Docs →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Création d'un espace de travail et lancement d'un agent depuis la CLI Superset" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Palette de commandes
+
+Accédez à n'importe quel espace de travail, action ou paramètre depuis une seule zone de recherche.
+
+[Docs →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Saisie dans la palette de commandes et filtrage en direct des actions d'espace de travail" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Également inclus :**
+
+- **[Compétences intégrées](https://docs.superset.sh/skills)** : les agents arrivent préchargés avec les compétences `superset:*` (orchestrer des agents parallèles, planifier des automatisations, envoyer des retours, diagnostiquer des problèmes), provisionnées automatiquement au lancement
+- **[Sélecteur de modèle et agents personnalisés](https://docs.superset.sh/agent-integration)** : choisissez un modèle et un niveau de raisonnement au lancement, et ajoutez n'importe quel agent de terminal avec sa propre icône
+- **[Scripts de configuration d'espace de travail](https://docs.superset.sh/setup-teardown-scripts)** : automatisez la configuration de l'environnement, l'installation des dépendances et les serveurs de dev par espace de travail
+- **[Préréglages de terminal](https://docs.superset.sh/terminal-presets)** : enregistrez des dispositions d'agents et de shells et ouvrez-les d'une seule touche
+- **[Slack et Linear](https://docs.superset.sh/use-with-linear)** : créez des espaces de travail depuis des messages Slack ou des issues Linear
+- **[Ouvrir dans votre IDE](https://docs.superset.sh/use-with-ide)** : passation en un clic vers Cursor, VS Code ou n'importe quel éditeur
+- **[Thèmes personnalisés](https://docs.superset.sh/custom-themes)** : créez, modifiez et importez des fichiers de thème
+- **[Raccourcis clavier](https://docs.superset.sh/keyboard-shortcuts)** : chaque action est remappable via **Paramètres → Raccourcis clavier** (⌘/)
+- **[Apportez vos propres fournisseurs](https://docs.superset.sh/providers)** : connectez OpenRouter, Bedrock, Vertex ou Vercel AI Gateway
+- **Et bien plus encore** : nous livrons tous les jours, cette liste est donc perpétuellement en retard. Le [changelog](https://superset.sh/changelog) est la vraie liste des fonctionnalités.
+
+## Agents pris en charge
+
+Superset fonctionne avec n'importe quel agent de codage en ligne de commande, notamment :
+
+| Agent | Statut |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Entièrement pris en charge |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Entièrement pris en charge |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Entièrement pris en charge |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Entièrement pris en charge |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Entièrement pris en charge |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Entièrement pris en charge |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Entièrement pris en charge |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Entièrement pris en charge |
+| Tout autre agent CLI | Fonctionne sans configuration |
+
+S'il tourne dans un terminal, il tourne sur Superset
+
+Les agents obtiennent plus qu'un terminal :
+
+- **Sélecteur de modèle** : choisissez un modèle et un niveau de raisonnement quand vous lancez un agent
+- **Paramètres par agent** : ajustez les commandes de lancement, les modèles de prompt et les modèles de langage dans Paramètres → Agents
+- **Agents personnalisés** : ajoutez n'importe quel agent de terminal avec sa propre icône et il fonctionne comme un agent intégré
+- **Statut et notifications** : indicateurs d'activité, carillons de fin de tâche et badges sur le dock quand un agent a besoin de vous
+- **Chat intégré** : discutez avec les modèles dans un panneau de chat, avec approbation des outils en ligne et revue de plan
+
+## Plus qu'une app de bureau
+
+Chaque surface parle aux mêmes espaces de travail : vous pouvez démarrer une tâche dans l'app et la suivre depuis n'importe où.
+
+| Surface | Ce que vous obtenez |
+|:--------|:-------------|
+| [**App de bureau**](https://github.com/superset-sh/superset/releases/latest) | L'IDE complet : terminaux, visionneuse de diff, navigateur intégré, automatisations |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Un seul binaire `superset` pour gérer espaces de travail, agents, terminaux et hôtes depuis n'importe quel shell |
+| [**SDK TypeScript**](https://docs.superset.sh/sdk/getting-started) | Pilotez Superset par programmation avec [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) depuis Node, Bun ou Deno |
+| [**Serveur MCP**](https://docs.superset.sh/mcp) | Laissez Claude Code, Codex, Cursor et d'autres agents créer et gérer eux-mêmes des espaces de travail |
+
+La CLI est fournie avec l'app de bureau, ou installez-la seule :
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Une app iOS arrive bientôt pour que vous puissiez suivre vos agents depuis votre téléphone.
+
+## Installation
+
+Téléchargez l'app de bureau :
+
+- **macOS** : [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux** : [AppImage x64](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (expérimental ; macOS est la cible principale)
+- **Windows** : pas encore disponible
+- [Tous les builds](https://github.com/superset-sh/superset/releases/latest)
+
+Tout ce dont vous avez besoin est [Git](https://git-scm.com/). [gh](https://cli.github.com/) est facultatif et débloque les workflows de PR ; Superset propose de l'installer pour vous.
+
+## Développement
+
+Envie de bidouiller Superset ou de contribuer une PR ? Clonez le dépôt, ajoutez-le à
+l'app Superset installée et créez un espace de travail pour votre changement :
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Puis lancez la configuration de développement depuis le terminal de cet espace de travail :
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Exécutez `setup.local.sh` une fois dans chaque nouveau worktree. Il configure l'identité
+d'app et les ports propres à l'espace de travail pour que l'app de bureau de développement
+puisse tourner à côté de l'app Superset installée et des autres worktrees de développement.
+
+Aucun compte Neon ni identifiant tiers n'est nécessaire. `setup.local.sh` démarre
+une pile locale Postgres + Electric via Docker et amorce un compte de dev. Connectez-vous
+avec le bouton **« Sign in as dev »** (ou `admin@local.test` / `supersetdev`).
+
+Prérequis : [Bun](https://bun.sh/) v1.3.14+ (épinglé dans `.bun-version`), `docker`, `jq` et `caddy`, que `bun dev` exécute comme proxy HTTPS local (`brew install jq caddy && caddy trust`).
+
+Voir [**DEVELOPMENT.md**](../DEVELOPMENT.md) pour le guide complet : ce que fait le script de configuration, la configuration manuelle avec de vrais services, les commandes courantes, le dépannage et comment builder l'app de bureau. Le processus de contribution est décrit dans [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Configuration
+
+Configurez les scripts de setup, de teardown et de run des espaces de travail dans `.superset/config.json`. Voir la [documentation complète](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Les raccourcis clavier sont personnalisables via **Paramètres → Raccourcis clavier** (⌘/) ; voir la [liste complète des raccourcis](https://docs.superset.sh/keyboard-shortcuts).
+
+## Pile technique
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Privé par défaut
+
+- **Source disponible** : le code source complet est sur GitHub sous licence Elastic License 2.0 (ELv2).
+- **Connexions explicites** : c'est vous qui choisissez quels agents, fournisseurs et intégrations connecter.
+
+## Contribuer
+
+Les contributions sont les bienvenues ! Voir [CONTRIBUTING.md](../CONTRIBUTING.md) pour savoir comment vous installer et ouvrir une PR. Les bugs et demandes de fonctionnalités vont dans les [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Communauté
+
+Rejoignez la communauté Superset pour obtenir de l'aide, partager vos retours et échanger avec d'autres utilisateurs :
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)** : discutez avec l'équipe et la communauté
+- **[Twitter](https://x.com/superset_sh)** : suivez-nous pour les mises à jour et les annonces
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)** : signalez des bugs et demandez des fonctionnalités
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)** : posez des questions et partagez vos idées
+
+### Équipe
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licence et ce qui est gratuit pour toujours
+
+**L'app de bureau est gratuite pour toujours.** Exécuter des agents en parallèle sur votre propre machine ne nécessitera jamais de paiement. Tout ce que nous facturerons sera un service optionnel en plus.
+
+L'app entière est dans ce dépôt sous [Elastic License 2.0](../LICENSE.md) : utilisez-la, forkez-la, modifiez-la, hébergez-la vous-même pour votre équipe. La seule chose exclue est de reconditionner Superset lui-même en un service que vous vendez à d'autres.

--- a/readme/README.id.md
+++ b/readme/README.id.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude dan OpenCode bekerja paralel di workspace Superset dengan diff langsung" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Jalankan 100+ Agen Coding Secara Paralel
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Ini adalah terjemahan dari README bahasa Inggris, yang menjadi acuan resmi.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex, atau agen CLI apa pun, masing-masing di worktree terisolasinya sendiri.<br />
+Habiskan waktu Anda untuk shipping, bukan menunggu.
+
+<br />
+
+[**Unduh untuk macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Dokumentasi](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Coding 10x Lebih Cepat Tanpa Biaya Berpindah Konteks
+
+Superset menjalankan agen coding berbasis CLI secara paralel di git worktree yang terisolasi, dengan alur kerja terminal, review, dan buka-di-editor bawaan.
+
+- **Jalankan banyak agen sekaligus** tanpa beban berpindah konteks
+- **Isolasi tiap tugas** di git worktree-nya sendiri sehingga agen tidak saling mengganggu
+- **Pantau semua agen Anda** dari satu tempat dan dapatkan notifikasi saat mereka butuh perhatian
+- **Review dan edit perubahan dengan cepat** lewat diff viewer dan editor bawaan
+- **Buka workspace mana pun di tempat yang Anda butuhkan** dengan serah terima sekali klik ke editor atau terminal Anda
+- **Akses workspace Anda dari mana saja** lewat host jarak jauh, CLI, SDK, atau MCP
+
+Lebih sedikit menunggu, lebih banyak shipping.
+
+## Fitur
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Workspace Paralel
+
+Jalankan 100+ agen coding sekaligus, masing-masing di git worktree-nya sendiri dengan branch, terminal, dan lingkungannya sendiri. Bandingkan hasilnya dan merge pemenangnya.
+
+[Dokumentasi →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude sedang men-streaming migrasi billing sementara agen lain berjalan di workspace paralel" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Pemantauan Agen
+
+Lacak setiap agen dari sidebar, dengan indikator bekerja, bunyi penanda selesai, dan badge dock saat ada yang butuh perhatian Anda.
+
+[Dokumentasi →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Agen menyelesaikan tugasnya dan status di sidebar berubah dari bekerja menjadi selesai" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Terminal Bawaan
+
+Tab, split tanpa batas, preset, dan sesi persisten yang bertahan setelah restart. Tekan ⌘I untuk editor prompt kaya dengan pengeditan multibaris dan mention file dengan @.
+
+[Dokumentasi →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Mengetik tindak lanjut dengan mention file @ di editor prompt kaya di samping terminal yang di-split" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Diff Viewer Bawaan
+
+Periksa, komentari, dan edit perubahan agen tanpa meninggalkan aplikasi, lalu commit dan push saat sudah siap.
+
+[Dokumentasi →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Me-review perubahan agen di diff viewer" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Browser Dalam Aplikasi & Port
+
+Pratinjau server dev yang berjalan di panel browser. Port dideteksi per workspace, jadi setiap worktree mendapat pratinjaunya sendiri.
+
+[Dokumentasi →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Browser dalam aplikasi menampilkan pratinjau server dev dengan port yang terdeteksi" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Otomatisasi
+
+Jalankan sesi agen sesuai jadwal: triase issue semalaman, susun draf changelog mingguan, jaga dependensi tetap mutakhir.
+
+[Dokumentasi →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Otomatisasi agen terjadwal" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Akses Jarak Jauh
+
+Hubungkan mesin lain dan akses workspace-nya dari mana saja: aplikasi desktop, CLI, atau ponsel Anda. Bangunkan host yang offline dengan perintah kustom.
+
+[Dokumentasi →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Host dan anggota di pengaturan organisasi" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Skrip dari shell mana pun: buat workspace, luncurkan agen, baca terminal mereka, dan kelola otomatisasi dengan satu binary. Kalau sebuah agen bisa menjalankan perintah, ia bisa mengendalikan Superset.
+
+[Dokumentasi →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Membuat workspace dan meluncurkan agen dari Superset CLI" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Palet Perintah
+
+Lompat ke workspace, aksi, atau pengaturan mana pun dari satu kotak pencarian.
+
+[Dokumentasi →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Mengetik di palet perintah dan memfilter aksi workspace secara langsung" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Juga sudah termasuk:**
+
+- **[Skill bawaan](https://docs.superset.sh/skills)**: agen sudah dimuat dengan skill `superset:*` (mengorkestrasi agen paralel, menjadwalkan otomatisasi, mengirim umpan balik, mendiagnosis masalah), disediakan otomatis saat diluncurkan
+- **[Pemilih model & agen kustom](https://docs.superset.sh/agent-integration)**: pilih model dan tingkat penalaran saat meluncurkan, dan tambahkan agen terminal apa pun dengan ikonnya sendiri
+- **[Skrip setup workspace](https://docs.superset.sh/setup-teardown-scripts)**: otomatiskan setup env, instalasi dependensi, dan server dev per workspace
+- **[Preset terminal](https://docs.superset.sh/terminal-presets)**: simpan tata letak agen dan shell lalu buka dengan satu tekanan tombol
+- **[Slack & Linear](https://docs.superset.sh/use-with-linear)**: buat workspace dari pesan Slack atau issue Linear
+- **[Buka di IDE Anda](https://docs.superset.sh/use-with-ide)**: serah terima sekali klik ke Cursor, VS Code, atau editor apa pun
+- **[Tema kustom](https://docs.superset.sh/custom-themes)**: buat, edit, dan impor berkas tema
+- **[Pintasan keyboard](https://docs.superset.sh/keyboard-shortcuts)**: setiap aksi bisa dipetakan ulang lewat **Pengaturan → Pintasan Keyboard** (⌘/)
+- **[Bawa provider Anda sendiri](https://docs.superset.sh/providers)**: hubungkan OpenRouter, Bedrock, Vertex, atau Vercel AI Gateway
+- **Dan masih banyak lagi**: kami shipping setiap hari, jadi daftar ini selalu tertinggal. [Changelog](https://superset.sh/changelog) adalah daftar fitur yang sebenarnya.
+
+## Agen yang Didukung
+
+Superset bekerja dengan agen coding berbasis CLI apa pun, termasuk:
+
+| Agen | Status |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Didukung penuh |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Didukung penuh |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Didukung penuh |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Didukung penuh |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Didukung penuh |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Didukung penuh |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Didukung penuh |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Didukung penuh |
+| Agen CLI lainnya | Bekerja tanpa konfigurasi |
+
+Kalau bisa berjalan di terminal, ia bisa berjalan di Superset
+
+Agen mendapat lebih dari sekadar terminal:
+
+- **Pemilih model**: pilih model dan tingkat penalaran saat Anda meluncurkan agen
+- **Pengaturan per agen**: atur perintah peluncuran, templat prompt, dan override model di Pengaturan → Agen
+- **Agen kustom**: tambahkan agen terminal apa pun dengan ikonnya sendiri dan ia bekerja seperti agen bawaan
+- **Status dan notifikasi**: indikator bekerja, bunyi penanda selesai, dan badge dock saat agen membutuhkan Anda
+- **Chat bawaan**: bicaralah dengan model di panel chat, dengan persetujuan tool inline dan review rencana
+
+## Lebih dari Sekadar Aplikasi Desktop
+
+Setiap permukaan berbicara dengan workspace yang sama, jadi Anda bisa memulai tugas di aplikasi dan memeriksanya dari mana saja.
+
+| Permukaan | Yang Anda dapat |
+|:--------|:-------------|
+| [**Aplikasi Desktop**](https://github.com/superset-sh/superset/releases/latest) | IDE lengkap: terminal, diff viewer, browser dalam aplikasi, otomatisasi |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Satu binary `superset` untuk mengelola workspace, agen, terminal, dan host dari shell mana pun |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Kendalikan Superset secara programatik dengan [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) dari Node, Bun, atau Deno |
+| [**MCP Server**](https://docs.superset.sh/mcp) | Biarkan Claude Code, Codex, Cursor, dan agen lainnya membuat dan mengelola workspace sendiri |
+
+CLI sudah dibundel dengan aplikasi desktop, atau pasang secara terpisah:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Aplikasi iOS segera hadir sehingga Anda bisa memantau agen dari ponsel.
+
+## Instalasi
+
+Unduh aplikasi desktop:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (eksperimental; macOS adalah target utama)
+- **Windows**: belum tersedia
+- [Semua build](https://github.com/superset-sh/superset/releases/latest)
+
+Yang perlu terpasang hanya [Git](https://git-scm.com/). [gh](https://cli.github.com/) bersifat opsional dan membuka alur kerja PR; Superset menawarkan untuk memasangnya bagi Anda.
+
+## Pengembangan
+
+Ingin mengutak-atik Superset atau menyumbang PR? Clone repositorinya, tambahkan ke
+aplikasi Superset yang terpasang, lalu buat workspace untuk perubahan Anda:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Lalu jalankan setup pengembangan dari terminal workspace tersebut:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Jalankan `setup.local.sh` sekali di setiap worktree baru. Skrip ini mengonfigurasi identitas
+aplikasi dan port yang spesifik per workspace, sehingga aplikasi desktop versi pengembangan
+bisa berjalan berdampingan dengan aplikasi Superset yang terpasang dan worktree pengembangan lainnya.
+
+Tidak perlu akun Neon atau kredensial pihak ketiga. `setup.local.sh` menyiapkan
+stack Postgres + Electric lokal via Docker dan mengisi akun dev. Masuk
+dengan tombol **"Sign in as dev"** (atau `admin@local.test` / `supersetdev`).
+
+Prasyarat: [Bun](https://bun.sh/) v1.3.14+ (dipatok di `.bun-version`), `docker`, `jq`, dan `caddy`, yang dijalankan `bun dev` sebagai proxy HTTPS lokal (`brew install jq caddy && caddy trust`).
+
+Lihat [**DEVELOPMENT.md**](../DEVELOPMENT.md) untuk panduan lengkap: apa yang dilakukan skrip setup, setup manual dengan layanan sungguhan, perintah umum, pemecahan masalah, dan cara mem-build aplikasi desktop. Proses kontribusi ada di [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Konfigurasi
+
+Konfigurasikan skrip setup, teardown, dan run workspace di `.superset/config.json`. Lihat [dokumentasi lengkap](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Pintasan keyboard bisa dikustomisasi lewat **Pengaturan → Pintasan Keyboard** (⌘/); lihat [daftar pintasan lengkap](https://docs.superset.sh/keyboard-shortcuts).
+
+## Tech Stack
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Privat Secara Default
+
+- **Sumber tersedia**: kode sumber lengkap ada di GitHub di bawah Elastic License 2.0 (ELv2).
+- **Koneksi eksplisit**: Anda yang memilih agen, provider, dan integrasi mana yang dihubungkan.
+
+## Berkontribusi
+
+Kami menyambut kontribusi! Lihat [CONTRIBUTING.md](../CONTRIBUTING.md) untuk cara menyiapkan lingkungan dan membuka PR. Bug dan permintaan fitur masuk ke [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Komunitas
+
+Bergabunglah dengan komunitas Superset untuk mendapat bantuan, berbagi umpan balik, dan terhubung dengan pengguna lain:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: mengobrol dengan tim dan komunitas
+- **[Twitter](https://x.com/superset_sh)**: ikuti untuk pembaruan dan pengumuman
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: laporkan bug dan ajukan permintaan fitur
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: ajukan pertanyaan dan bagikan ide
+
+### Tim
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Lisensi & yang gratis selamanya
+
+**Aplikasi desktop gratis selamanya.** Menjalankan agen secara paralel di mesin Anda sendiri tidak akan pernah memerlukan pembayaran. Apa pun yang kami kenakan biaya akan berupa layanan opsional di atasnya.
+
+Seluruh aplikasi ada di repositori ini di bawah [Elastic License 2.0](../LICENSE.md): gunakan, fork, modifikasi, self-host untuk tim Anda. Satu-satunya yang tidak boleh adalah mengemas ulang Superset itu sendiri sebagai layanan yang Anda jual ke orang lain.

--- a/readme/README.it.md
+++ b/readme/README.it.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude e OpenCode al lavoro in parallelo in workspace Superset con diff in tempo reale" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Esegui più di 100 agenti di coding in parallelo
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Traduzione del README in inglese, che resta la versione di riferimento.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex o qualsiasi agente CLI, ognuno nel proprio worktree isolato.<br />
+Passa il tempo a rilasciare, non ad aspettare.
+
+<br />
+
+[**Scarica per macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentazione](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Scrivi codice 10 volte più veloce, senza costi di cambio contesto
+
+Superset esegue agenti di coding CLI in parallelo su worktree git isolati, con terminale integrato, revisione delle modifiche e apertura diretta nell'editor.
+
+- **Esegui più agenti contemporaneamente** senza l'overhead del cambio di contesto
+- **Isola ogni attività** nel proprio worktree git, così gli agenti non interferiscono tra loro
+- **Monitora tutti i tuoi agenti** da un unico posto e ricevi una notifica quando serve il tuo intervento
+- **Rivedi e modifica le modifiche rapidamente** con il visualizzatore di diff e l'editor integrati
+- **Apri qualsiasi workspace dove ti serve** con il passaggio in un clic al tuo editor o terminale
+- **Raggiungi i tuoi workspace da ovunque** tramite host remoti, la CLI, l'SDK o MCP
+
+Aspetta meno, rilascia di più.
+
+## Funzionalità
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Workspace paralleli
+
+Esegui più di 100 agenti di coding alla volta, ognuno nel proprio worktree git con il proprio branch, terminale e ambiente. Confronta i risultati e fai il merge del migliore.
+
+[Documentazione →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude esegue in streaming una migrazione del billing mentre altri agenti lavorano in workspace paralleli" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Monitoraggio degli agenti
+
+Tieni traccia di ogni agente dalla barra laterale, con indicatori di lavoro, suoni di completamento e badge nel dock quando uno richiede la tua attenzione.
+
+[Documentazione →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Un agente termina la sua attività e lo stato nella barra laterale passa da in lavorazione a completato" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Terminale integrato
+
+Schede, split infiniti, preset e sessioni persistenti che sopravvivono ai riavvii. Premi ⌘I per un editor di prompt avanzato con modifica multilinea e menzioni @-file.
+
+[Documentazione →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Digitazione di un follow-up con una menzione @-file nell'editor di prompt avanzato accanto a un terminale diviso" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Visualizzatore di diff integrato
+
+Ispeziona, commenta e modifica le modifiche degli agenti senza uscire dall'app, poi fai commit e push quando è tutto pronto.
+
+[Documentazione →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Revisione delle modifiche di un agente nel visualizzatore di diff" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Browser in-app e porte
+
+Visualizza in anteprima i dev server in esecuzione in un pannello browser. Le porte vengono rilevate per workspace, così ogni worktree ha la propria anteprima.
+
+[Documentazione →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Browser in-app che mostra l'anteprima di un dev server con le porte rilevate" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automazioni
+
+Esegui sessioni di agenti su pianificazione: fai il triage delle issue durante la notte, prepara la bozza del changelog settimanale, mantieni aggiornate le dipendenze.
+
+[Documentazione →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Automazioni di agenti pianificate" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Accesso remoto
+
+Collega un'altra macchina e raggiungi i suoi workspace da ovunque: l'app desktop, la CLI o il tuo telefono. Riattiva gli host offline con un comando personalizzato.
+
+[Documentazione →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Host e membri nelle impostazioni dell'organizzazione" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### CLI di Superset
+
+Scriptalo da qualsiasi shell: crea workspace, avvia agenti, leggi i loro terminali e gestisci le automazioni con un singolo binario. Se un agente può eseguire un comando, può pilotare Superset.
+
+[Documentazione →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Creazione di un workspace e avvio di un agente dalla CLI di Superset" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Palette dei comandi
+
+Salta a qualsiasi workspace, azione o impostazione da un'unica casella di ricerca.
+
+[Documentazione →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Digitazione nella palette dei comandi con filtraggio in tempo reale delle azioni del workspace" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Inclusi nella confezione:**
+
+- **[Skill integrate](https://docs.superset.sh/skills)**: gli agenti arrivano precaricati con le skill `superset:*` (orchestrare agenti paralleli, pianificare automazioni, inviare feedback, diagnosticare problemi), fornite automaticamente all'avvio
+- **[Selettore di modello e agenti personalizzati](https://docs.superset.sh/agent-integration)**: scegli un modello e il livello di ragionamento all'avvio, e aggiungi qualsiasi agente da terminale con la propria icona
+- **[Script di setup del workspace](https://docs.superset.sh/setup-teardown-scripts)**: automatizza la configurazione dell'ambiente, l'installazione delle dipendenze e i dev server per ogni workspace
+- **[Preset del terminale](https://docs.superset.sh/terminal-presets)**: salva layout di agenti e shell e aprili con un solo tasto
+- **[Slack e Linear](https://docs.superset.sh/use-with-linear)**: crea workspace da messaggi Slack o issue Linear
+- **[Apri nel tuo IDE](https://docs.superset.sh/use-with-ide)**: passaggio in un clic a Cursor, VS Code o qualsiasi editor
+- **[Temi personalizzati](https://docs.superset.sh/custom-themes)**: crea, modifica e importa file di tema
+- **[Scorciatoie da tastiera](https://docs.superset.sh/keyboard-shortcuts)**: ogni azione è rimappabile in **Impostazioni → Scorciatoie da tastiera** (⌘/)
+- **[Porta i tuoi provider](https://docs.superset.sh/providers)**: collega OpenRouter, Bedrock, Vertex o Vercel AI Gateway
+- **E molto altro**: rilasciamo ogni giorno, quindi questa lista è perennemente indietro. Il [changelog](https://superset.sh/changelog) è la vera lista delle funzionalità.
+
+## Agenti supportati
+
+Superset funziona con qualsiasi agente di coding basato su CLI, tra cui:
+
+| Agente | Stato |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Supporto completo |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Supporto completo |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Supporto completo |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Supporto completo |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Supporto completo |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Supporto completo |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Supporto completo |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Supporto completo |
+| Qualsiasi altro agente CLI | Funziona senza configurazione |
+
+Se gira in un terminale, gira su Superset
+
+Gli agenti ottengono più di un semplice terminale:
+
+- **Selettore di modello**: scegli un modello e il livello di ragionamento quando avvii un agente
+- **Impostazioni per agente**: regola comandi di avvio, template di prompt e override dei modelli in Impostazioni → Agenti
+- **Agenti personalizzati**: aggiungi qualsiasi agente da terminale con la propria icona e funzionerà come uno integrato
+- **Stato e notifiche**: indicatori di lavoro, suoni di completamento e badge nel dock quando un agente ha bisogno di te
+- **Chat integrata**: parla con i modelli in un pannello di chat, con approvazioni degli strumenti inline e revisione dei piani
+
+## Più di un'app desktop
+
+Ogni superficie parla con gli stessi workspace, così puoi avviare un'attività nell'app e controllarla da ovunque.
+
+| Superficie | Cosa ottieni |
+|:--------|:-------------|
+| [**App desktop**](https://github.com/superset-sh/superset/releases/latest) | L'IDE completo: terminali, visualizzatore di diff, browser in-app, automazioni |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Un singolo binario `superset` per gestire workspace, agenti, terminali e host da qualsiasi shell |
+| [**SDK TypeScript**](https://docs.superset.sh/sdk/getting-started) | Pilota Superset programmaticamente con [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) da Node, Bun o Deno |
+| [**Server MCP**](https://docs.superset.sh/mcp) | Lascia che Claude Code, Codex, Cursor e altri agenti creino e gestiscano i workspace in autonomia |
+
+La CLI è inclusa nell'app desktop, oppure installala standalone:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Un'app iOS è in arrivo, così potrai controllare i tuoi agenti dal telefono.
+
+## Installazione
+
+Scarica l'app desktop:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (sperimentale; macOS è la piattaforma principale)
+- **Windows**: non ancora disponibile
+- [Tutte le build](https://github.com/superset-sh/superset/releases/latest)
+
+L'unica cosa che serve avere installata è [Git](https://git-scm.com/). [gh](https://cli.github.com/) è opzionale e sblocca i flussi di lavoro per le PR; Superset si offre di installarlo per te.
+
+## Sviluppo
+
+Vuoi lavorare su Superset o contribuire con una PR? Clona il repository, aggiungilo
+all'app Superset installata e crea un workspace per la tua modifica:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Poi esegui il setup di sviluppo dal terminale di quel workspace:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Esegui `setup.local.sh` una volta in ogni nuovo worktree. Configura l'identità
+dell'app e le porte specifiche del workspace, così l'app desktop di sviluppo può
+girare accanto all'app Superset installata e agli altri worktree di sviluppo.
+
+Non servono account Neon né credenziali di terze parti. `setup.local.sh` avvia
+uno stack locale Postgres + Electric via Docker e crea un account di sviluppo. Accedi
+con il pulsante **"Sign in as dev"** (oppure `admin@local.test` / `supersetdev`).
+
+Prerequisiti: [Bun](https://bun.sh/) v1.3.14+ (fissato in `.bun-version`), `docker`, `jq` e `caddy`, che `bun dev` esegue come proxy HTTPS locale (`brew install jq caddy && caddy trust`).
+
+Consulta [**DEVELOPMENT.md**](../DEVELOPMENT.md) per la guida completa: cosa fa lo script di setup, il setup manuale con servizi reali, i comandi comuni, la risoluzione dei problemi e come compilare l'app desktop. Il processo di contribuzione è descritto in [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Configurazione
+
+Configura gli script di setup, teardown e run del workspace in `.superset/config.json`. Vedi la [documentazione completa](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Le scorciatoie da tastiera sono personalizzabili in **Impostazioni → Scorciatoie da tastiera** (⌘/); vedi la [lista completa delle scorciatoie](https://docs.superset.sh/keyboard-shortcuts).
+
+## Stack tecnologico
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Privato per impostazione predefinita
+
+- **Source Available**: il codice sorgente completo è su GitHub sotto Elastic License 2.0 (ELv2).
+- **Connessioni esplicite**: scegli tu quali agenti, provider e integrazioni collegare.
+
+## Contribuire
+
+I contributi sono benvenuti! Vedi [CONTRIBUTING.md](../CONTRIBUTING.md) per come configurare l'ambiente e aprire una PR. Bug e richieste di funzionalità vanno nelle [issue](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Community
+
+Unisciti alla community di Superset per ricevere aiuto, condividere feedback e connetterti con altri utenti:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: chatta con il team e la community
+- **[Twitter](https://x.com/superset_sh)**: seguici per aggiornamenti e annunci
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: segnala bug e richiedi funzionalità
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: fai domande e condividi idee
+
+### Team
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licenza e cosa è gratis per sempre
+
+**L'app desktop è gratis per sempre.** Eseguire agenti in parallelo sulla tua macchina non richiederà mai un pagamento. Tutto ciò che faremo pagare sarà un servizio opzionale in aggiunta.
+
+L'intera app è in questo repo sotto la [Elastic License 2.0](../LICENSE.md): usala, forkala, modificala, ospitala per il tuo team. L'unica cosa esclusa è riconfezionare Superset stesso come servizio da vendere ad altri.

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -1,0 +1,341 @@
+<div align="center">
+
+<img width="full" alt="並列のSupersetワークスペースでライブ差分を表示しながら動作するClaudeとOpenCode" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### 100以上のコーディングエージェントを並列実行
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*本ドキュメントは英語版READMEの翻訳です。内容は英語版が正となります。*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code、Codex、その他あらゆるCLIエージェントを、それぞれ独立したworktreeで実行。<br />
+待つ時間ではなく、出荷する時間に使いましょう。
+
+<br />
+
+[**macOS版をダウンロード**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [ドキュメント](https://docs.superset.sh) &nbsp;&bull;&nbsp; [変更履歴](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## 切り替えコストなしで10倍速くコーディング
+
+Supersetは、CLIベースのコーディングエージェントを独立したgit worktree間で並列実行します。ターミナル、レビュー、エディタで開くワークフローも内蔵しています。
+
+- **複数のエージェントを同時に実行** — コンテキスト切り替えのオーバーヘッドはありません
+- **各タスクを独立したgit worktreeに分離** — エージェント同士が干渉しません
+- **すべてのエージェントを一箇所で監視** — 対応が必要になれば通知が届きます
+- **変更をすばやくレビュー・編集** — 内蔵の差分ビューアとエディタで
+- **必要な場所でワークスペースを開く** — ワンクリックでエディタやターミナルへ引き継ぎ
+- **どこからでもワークスペースにアクセス** — リモートホスト、CLI、SDK、MCP経由で
+
+待ち時間を減らして、もっと出荷しましょう。
+
+## 機能
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### 並列ワークスペース
+
+100以上のコーディングエージェントを一度に実行。それぞれが独自のブランチ、ターミナル、環境を持つgit worktreeで動作します。結果を比較して、最良のものをマージしましょう。
+
+[ドキュメント →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="他のエージェントが並列ワークスペースで動作する中、課金システムの移行をストリーミングするClaude" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### エージェント監視
+
+サイドバーからすべてのエージェントを追跡。作業中インジケーター、完了チャイム、対応が必要なときのDockバッジ付きです。
+
+[ドキュメント →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="タスクを完了したエージェントと、作業中から完了に切り替わるサイドバーのステータス" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 内蔵ターミナル
+
+タブ、無制限の分割、プリセット、再起動後も維持される永続セッション。⌘Iを押すと、複数行編集と@ファイルメンションに対応したリッチプロンプトエディタが開きます。
+
+[ドキュメント →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="分割ターミナルの隣で、リッチプロンプトエディタに@ファイルメンション付きのフォローアップを入力する様子" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 内蔵差分ビューア
+
+アプリを離れずにエージェントの変更を確認・コメント・編集し、準備ができたらコミットしてプッシュできます。
+
+[ドキュメント →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="差分ビューアでエージェントの変更をレビューする様子" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### アプリ内ブラウザとポート
+
+実行中の開発サーバーをブラウザペインでプレビュー。ポートはワークスペースごとに検出されるため、各worktreeが独自のプレビューを持てます。
+
+[ドキュメント →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="検出されたポートで開発サーバーをプレビューするアプリ内ブラウザ" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### オートメーション
+
+エージェントセッションをスケジュール実行:夜間にissueをトリアージし、週次の変更履歴を下書きし、依存関係を最新に保ちます。
+
+[ドキュメント →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="スケジュールされたエージェントオートメーション" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### リモートアクセス
+
+別のマシンを接続し、そのワークスペースにどこからでもアクセス:デスクトップアプリ、CLI、スマートフォンから。オフラインのホストはカスタムコマンドで起動できます。
+
+[ドキュメント →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="組織設定のホストとメンバー" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+どのシェルからでもスクリプト化:ワークスペースの作成、エージェントの起動、ターミナルの読み取り、オートメーションの管理を単一のバイナリで。コマンドを実行できるエージェントなら、Supersetを操作できます。
+
+[ドキュメント →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Superset CLIからワークスペースを作成してエージェントを起動する様子" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### コマンドパレット
+
+1つの検索ボックスから任意のワークスペース、アクション、設定にジャンプ。
+
+[ドキュメント →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="コマンドパレットに入力してワークスペースのアクションをリアルタイムに絞り込む様子" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**さらに同梱されている機能:**
+
+- **[内蔵スキル](https://docs.superset.sh/skills)**: エージェントには `superset:*` スキル(並列エージェントのオーケストレーション、オートメーションのスケジュール、フィードバックの送信、問題の診断)が起動時に自動でプロビジョニングされます
+- **[モデルピッカーとカスタムエージェント](https://docs.superset.sh/agent-integration)**: 起動時にモデルと推論の強度を選択でき、任意のターミナルエージェントを独自のアイコン付きで追加できます
+- **[ワークスペースセットアップスクリプト](https://docs.superset.sh/setup-teardown-scripts)**: 環境設定、依存関係のインストール、開発サーバーの起動をワークスペースごとに自動化
+- **[ターミナルプリセット](https://docs.superset.sh/terminal-presets)**: エージェントとシェルのレイアウトを保存し、キー1つで開けます
+- **[SlackとLinear](https://docs.superset.sh/use-with-linear)**: SlackメッセージやLinearのissueからワークスペースを立ち上げ
+- **[IDEで開く](https://docs.superset.sh/use-with-ide)**: Cursor、VS Code、任意のエディタへワンクリックで引き継ぎ
+- **[カスタムテーマ](https://docs.superset.sh/custom-themes)**: テーマファイルの作成、編集、インポート
+- **[キーボードショートカット](https://docs.superset.sh/keyboard-shortcuts)**: すべてのアクションは**設定 → キーボードショートカット**(⌘/)で再割り当てできます
+- **[プロバイダーの持ち込み](https://docs.superset.sh/providers)**: OpenRouter、Bedrock、Vertex、Vercel AI Gatewayを接続
+- **その他多数**: 毎日出荷しているため、このリストは常に追いついていません。本当の機能リストは[変更履歴](https://superset.sh/changelog)です。
+
+## 対応エージェント
+
+Supersetは、次のものを含むあらゆるCLIベースのコーディングエージェントで動作します:
+
+| エージェント | ステータス |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | 完全対応 |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | 完全対応 |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | 完全対応 |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | 完全対応 |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | 完全対応 |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | 完全対応 |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | 完全対応 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | 完全対応 |
+| その他のCLIエージェント | 設定不要で動作 |
+
+ターミナルで動くものなら、Supersetでも動きます
+
+エージェントが得られるのはターミナルだけではありません:
+
+- **モデルピッカー**: エージェント起動時にモデルと推論の強度を選択できます
+- **エージェントごとの設定**: 起動コマンド、プロンプトテンプレート、モデルの上書きを設定 → エージェントで調整できます
+- **カスタムエージェント**: 任意のターミナルエージェントを独自のアイコン付きで追加すれば、内蔵エージェントと同じように動作します
+- **ステータスと通知**: 作業中インジケーター、完了チャイム、エージェントが対応を必要とするときのDockバッジ
+- **内蔵チャット**: チャットペインでモデルと対話。インラインのツール承認とプランレビュー付きです
+
+## デスクトップアプリだけではありません
+
+すべてのサーフェスが同じワークスペースにつながっているため、アプリでタスクを開始してどこからでも確認できます。
+
+| サーフェス | できること |
+|:--------|:-------------|
+| [**デスクトップアプリ**](https://github.com/superset-sh/superset/releases/latest) | フル機能のIDE:ターミナル、差分ビューア、アプリ内ブラウザ、オートメーション |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | ワークスペース、エージェント、ターミナル、ホストをあらゆるシェルから管理できる単一の `superset` バイナリ |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk)を使ってNode、Bun、DenoからSupersetをプログラムで操作 |
+| [**MCPサーバー**](https://docs.superset.sh/mcp) | Claude Code、Codex、Cursorなどのエージェント自身にワークスペースを作成・管理させる |
+
+CLIはデスクトップアプリに同梱されていますが、単体でもインストールできます:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+iOSアプリも近日公開予定です。スマートフォンからエージェントを確認できるようになります。
+
+## インストール
+
+デスクトップアプリをダウンロード:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage)(実験的。macOSが主要ターゲットです)
+- **Windows**: 現時点では未対応
+- [すべてのビルド](https://github.com/superset-sh/superset/releases/latest)
+
+必要なのは[Git](https://git-scm.com/)だけです。[gh](https://cli.github.com/)は任意ですが、インストールするとPRワークフローが使えるようになります。Supersetが代わりにインストールを提案してくれます。
+
+## 開発
+
+Supersetをいじってみたい、またはPRを送りたいですか?リポジトリをクローンし、インストール済みのSupersetアプリに追加して、変更用のワークスペースを作成してください:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+次に、そのワークスペースのターミナルから開発セットアップを実行します:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+`setup.local.sh` は新しいworktreeごとに1回実行してください。ワークスペース固有のアプリIDとポートを設定するため、開発版のデスクトップアプリをインストール済みのSupersetアプリや他の開発用worktreeと並行して実行できます。
+
+Neonアカウントやサードパーティの認証情報は不要です。`setup.local.sh` がDocker経由でローカルのPostgres + Electricスタックを立ち上げ、開発用アカウントをシードします。**「Sign in as dev」**ボタン(または `admin@local.test` / `supersetdev`)でサインインしてください。
+
+前提条件: [Bun](https://bun.sh/) v1.3.14+(`.bun-version` で固定)、`docker`、`jq`、`caddy`。`caddy` は `bun dev` がローカルHTTPSプロキシとして実行します(`brew install jq caddy && caddy trust`)。
+
+完全なガイドは[**DEVELOPMENT.md**](../DEVELOPMENT.md)を参照してください:セットアップスクリプトの内容、実サービスに対する手動セットアップ、よく使うコマンド、トラブルシューティング、デスクトップアプリのビルド方法を説明しています。コントリビューションの手順は[**CONTRIBUTING.md**](../CONTRIBUTING.md)にあります。
+
+## 設定
+
+ワークスペースのセットアップ、ティアダウン、実行スクリプトは `.superset/config.json` で設定します。[完全なドキュメント](https://docs.superset.sh/setup-teardown-scripts)を参照してください。
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+キーボードショートカットは**設定 → キーボードショートカット**(⌘/)でカスタマイズできます。[ショートカット一覧](https://docs.superset.sh/keyboard-shortcuts)も参照してください。
+
+## 技術スタック
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## デフォルトでプライベート
+
+- **ソース公開**: 全ソースコードはElastic License 2.0(ELv2)の下でGitHubに公開されています。
+- **明示的な接続**: どのエージェント、プロバイダー、インテグレーションを接続するかは、あなた自身が選択します。
+
+## コントリビューション
+
+コントリビューションを歓迎します!環境構築とPRの作成方法は[CONTRIBUTING.md](../CONTRIBUTING.md)を参照してください。バグ報告や機能リクエストは[issues](https://github.com/superset-sh/superset/issues)へお願いします。
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## コミュニティ
+
+Supersetコミュニティに参加して、サポートを受けたり、フィードバックを共有したり、他のユーザーとつながりましょう:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: チームやコミュニティとチャット
+- **[Twitter](https://x.com/superset_sh)**: 最新情報とお知らせをフォロー
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: バグ報告と機能リクエスト
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: 質問やアイデアの共有
+
+### チーム
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## ライセンスと永久無料の範囲
+
+**デスクトップアプリは永久に無料です。**自分のマシンでエージェントを並列実行することに、料金がかかることは決してありません。課金があるとしても、その上に載るオプションサービスだけです。
+
+アプリ全体がこのリポジトリに[Elastic License 2.0](../LICENSE.md)の下で公開されています:使う、フォークする、改変する、チームでセルフホストする、すべて自由です。唯一できないのは、Superset自体をサービスとして再パッケージし、他者に販売することだけです。

--- a/readme/README.ko.md
+++ b/readme/README.ko.md
@@ -1,0 +1,341 @@
+<div align="center">
+
+<img width="full" alt="병렬 Superset 워크스페이스에서 실시간 차이를 보여주며 작업 중인 Claude와 OpenCode" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### 100개 이상의 코딩 에이전트를 병렬로 실행
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*이 문서는 영어 README의 번역본이며, 영어 원문이 우선합니다.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex를 비롯한 모든 CLI 에이전트를 각각 격리된 worktree에서 실행하세요.<br />
+기다리는 대신 출시하는 데 시간을 쓰세요.
+
+<br />
+
+[**macOS용 다운로드**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [문서](https://docs.superset.sh) &nbsp;&bull;&nbsp; [변경 로그](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## 전환 비용 없이 10배 빠른 코딩
+
+Superset은 CLI 기반 코딩 에이전트를 격리된 git worktree에서 병렬로 실행하며, 터미널, 리뷰, 에디터로 열기 워크플로를 기본 제공합니다.
+
+- **여러 에이전트를 동시에 실행** — 컨텍스트 전환 부담이 없습니다
+- **각 작업을 격리된 git worktree에 분리** — 에이전트끼리 서로 간섭하지 않습니다
+- **모든 에이전트를 한곳에서 모니터링** — 개입이 필요하면 알림을 받습니다
+- **변경 사항을 빠르게 리뷰하고 편집** — 내장 차이 뷰어와 에디터로
+- **필요한 곳 어디서든 워크스페이스 열기** — 클릭 한 번으로 에디터나 터미널에 인계
+- **어디서나 워크스페이스에 접근** — 원격 호스트, CLI, SDK, MCP를 통해
+
+덜 기다리고, 더 많이 출시하세요.
+
+## 기능
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### 병렬 워크스페이스
+
+100개 이상의 코딩 에이전트를 한 번에 실행하세요. 각자 자기만의 브랜치, 터미널, 환경을 갖춘 git worktree에서 동작합니다. 결과를 비교하고 가장 좋은 것을 머지하세요.
+
+[문서 →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="다른 에이전트들이 병렬 워크스페이스에서 실행되는 동안 결제 마이그레이션을 스트리밍하는 Claude" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 에이전트 모니터링
+
+사이드바에서 모든 에이전트를 추적하세요. 작업 중 표시, 완료 알림음, 그리고 개입이 필요할 때의 Dock 배지를 제공합니다.
+
+[문서 →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="에이전트가 작업을 마치고 사이드바 상태가 작업 중에서 완료로 바뀌는 모습" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 내장 터미널
+
+탭, 무제한 분할, 프리셋, 재시작 후에도 유지되는 지속 세션. ⌘I를 누르면 여러 줄 편집과 @ 파일 멘션을 지원하는 리치 프롬프트 에디터가 열립니다.
+
+[문서 →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="분할 터미널 옆의 리치 프롬프트 에디터에서 @ 파일 멘션과 함께 후속 지시를 입력하는 모습" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 내장 차이 뷰어
+
+앱을 벗어나지 않고 에이전트의 변경 사항을 검토하고, 코멘트를 달고, 편집한 다음, 준비되면 커밋하고 푸시하세요.
+
+[문서 →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="차이 뷰어에서 에이전트의 변경 사항을 리뷰하는 모습" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 앱 내 브라우저와 포트
+
+실행 중인 개발 서버를 브라우저 패널에서 미리 보세요. 포트는 워크스페이스별로 감지되므로 모든 worktree가 자기만의 미리보기를 갖습니다.
+
+[문서 →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="감지된 포트로 개발 서버를 미리 보는 앱 내 브라우저" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 자동화
+
+에이전트 세션을 일정에 따라 실행하세요: 밤사이 이슈 분류, 주간 변경 로그 초안 작성, 의존성 최신 상태 유지.
+
+[문서 →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="일정에 따라 실행되는 에이전트 자동화" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 원격 액세스
+
+다른 컴퓨터를 연결하고 그 워크스페이스에 어디서든 접근하세요: 데스크톱 앱, CLI, 휴대폰으로. 오프라인 호스트는 사용자 지정 명령으로 깨울 수 있습니다.
+
+[문서 →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="조직 설정의 호스트와 멤버" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+어떤 셸에서든 스크립트로 제어하세요: 단일 바이너리로 워크스페이스 생성, 에이전트 실행, 터미널 읽기, 자동화 관리까지. 명령을 실행할 수 있는 에이전트라면 Superset을 조종할 수 있습니다.
+
+[문서 →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Superset CLI에서 워크스페이스를 만들고 에이전트를 실행하는 모습" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 명령 팔레트
+
+하나의 검색창에서 어떤 워크스페이스, 동작, 설정으로든 이동하세요.
+
+[문서 →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="명령 팔레트에 입력하며 워크스페이스 동작을 실시간으로 필터링하는 모습" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**이 밖에도 기본 제공:**
+
+- **[내장 스킬](https://docs.superset.sh/skills)**: 에이전트에는 `superset:*` 스킬(병렬 에이전트 오케스트레이션, 자동화 예약, 피드백 제출, 문제 진단)이 실행 시 자동으로 프로비저닝됩니다
+- **[모델 선택기와 커스텀 에이전트](https://docs.superset.sh/agent-integration)**: 실행 시 모델과 추론 강도를 선택하고, 어떤 터미널 에이전트든 전용 아이콘과 함께 추가할 수 있습니다
+- **[워크스페이스 설정 스크립트](https://docs.superset.sh/setup-teardown-scripts)**: 환경 설정, 의존성 설치, 개발 서버를 워크스페이스별로 자동화
+- **[터미널 프리셋](https://docs.superset.sh/terminal-presets)**: 에이전트와 셸 레이아웃을 저장하고 키 하나로 열기
+- **[Slack & Linear](https://docs.superset.sh/use-with-linear)**: Slack 메시지나 Linear 이슈에서 곧바로 워크스페이스 생성
+- **[IDE에서 열기](https://docs.superset.sh/use-with-ide)**: Cursor, VS Code 등 어떤 에디터로든 클릭 한 번에 인계
+- **[커스텀 테마](https://docs.superset.sh/custom-themes)**: 테마 파일을 만들고, 편집하고, 가져오기
+- **[키보드 단축키](https://docs.superset.sh/keyboard-shortcuts)**: 모든 동작은 **설정 → 키보드 단축키**(⌘/)에서 다시 매핑할 수 있습니다
+- **[직접 프로바이더 연결](https://docs.superset.sh/providers)**: OpenRouter, Bedrock, Vertex, Vercel AI Gateway 연결
+- **그리고 더 많은 기능**: 매일 출시하기 때문에 이 목록은 늘 뒤처져 있습니다. 진짜 기능 목록은 [변경 로그](https://superset.sh/changelog)입니다.
+
+## 지원 에이전트
+
+Superset은 다음을 포함한 모든 CLI 기반 코딩 에이전트와 함께 작동합니다:
+
+| 에이전트 | 상태 |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | 완전 지원 |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | 완전 지원 |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | 완전 지원 |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | 완전 지원 |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | 완전 지원 |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | 완전 지원 |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | 완전 지원 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | 완전 지원 |
+| 그 밖의 모든 CLI 에이전트 | 별도 설정 없이 작동 |
+
+터미널에서 돌아간다면, Superset에서도 돌아갑니다
+
+에이전트는 터미널 그 이상을 얻습니다:
+
+- **모델 선택기**: 에이전트를 실행할 때 모델과 추론 강도를 선택
+- **에이전트별 설정**: 설정 → 에이전트에서 실행 명령, 프롬프트 템플릿, 모델 오버라이드를 조정
+- **커스텀 에이전트**: 어떤 터미널 에이전트든 전용 아이콘과 함께 추가하면 내장 에이전트처럼 작동
+- **상태와 알림**: 작업 중 표시, 완료 알림음, 에이전트가 개입을 필요로 할 때의 Dock 배지
+- **내장 채팅**: 채팅 패널에서 모델과 대화. 인라인 도구 승인과 계획 리뷰 지원
+
+## 데스크톱 앱, 그 이상
+
+모든 사용 환경이 같은 워크스페이스에 연결되므로, 앱에서 작업을 시작하고 어디서든 확인할 수 있습니다.
+
+| 사용 환경 | 제공 기능 |
+|:--------|:-------------|
+| [**데스크톱 앱**](https://github.com/superset-sh/superset/releases/latest) | 완전한 IDE: 터미널, 차이 뷰어, 앱 내 브라우저, 자동화 |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | 어떤 셸에서든 워크스페이스, 에이전트, 터미널, 호스트를 관리하는 단일 `superset` 바이너리 |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk)로 Node, Bun, Deno에서 Superset을 프로그래밍 방식으로 제어 |
+| [**MCP 서버**](https://docs.superset.sh/mcp) | Claude Code, Codex, Cursor 같은 에이전트가 직접 워크스페이스를 만들고 관리 |
+
+CLI는 데스크톱 앱에 번들로 포함되어 있으며, 단독으로 설치할 수도 있습니다:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+iOS 앱도 곧 출시됩니다. 휴대폰에서 에이전트를 확인할 수 있게 됩니다.
+
+## 설치
+
+데스크톱 앱 다운로드:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (실험적; macOS가 주 지원 대상입니다)
+- **Windows**: 아직 제공되지 않음
+- [모든 빌드](https://github.com/superset-sh/superset/releases/latest)
+
+필요한 것은 [Git](https://git-scm.com/)뿐입니다. [gh](https://cli.github.com/)는 선택 사항으로 PR 워크플로를 사용할 수 있게 해 주며, Superset이 대신 설치해 주겠다고 제안합니다.
+
+## 개발
+
+Superset을 직접 만져 보거나 PR을 기여하고 싶으신가요? 저장소를 클론하고, 설치된 Superset 앱에 추가한 다음, 변경 작업용 워크스페이스를 만드세요:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+그런 다음 해당 워크스페이스 터미널에서 개발 설정을 실행하세요:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+`setup.local.sh`는 새 worktree마다 한 번씩 실행하세요. 워크스페이스별 앱 아이덴티티와 포트를 구성해서 개발용 데스크톱 앱이 설치된 Superset 앱 및 다른 개발 worktree와 나란히 실행될 수 있게 합니다.
+
+Neon 계정이나 서드파티 자격 증명은 필요 없습니다. `setup.local.sh`가 Docker로 로컬 Postgres + Electric 스택을 띄우고 개발 계정을 시드합니다. **"Sign in as dev"** 버튼(또는 `admin@local.test` / `supersetdev`)으로 로그인하세요.
+
+사전 요구 사항: [Bun](https://bun.sh/) v1.3.14+(`.bun-version`에 고정), `docker`, `jq`, `caddy`. `caddy`는 `bun dev`가 로컬 HTTPS 프록시로 실행합니다(`brew install jq caddy && caddy trust`).
+
+전체 가이드는 [**DEVELOPMENT.md**](../DEVELOPMENT.md)를 참고하세요: 설정 스크립트가 하는 일, 실제 서비스 대상 수동 설정, 자주 쓰는 명령, 문제 해결, 데스크톱 앱 빌드 방법을 다룹니다. 기여 절차는 [**CONTRIBUTING.md**](../CONTRIBUTING.md)에 있습니다.
+
+## 구성
+
+워크스페이스의 설정, 정리, 실행 스크립트는 `.superset/config.json`에서 구성합니다. [전체 문서](https://docs.superset.sh/setup-teardown-scripts)를 참고하세요.
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+키보드 단축키는 **설정 → 키보드 단축키**(⌘/)에서 사용자 지정할 수 있습니다. [전체 단축키 목록](https://docs.superset.sh/keyboard-shortcuts)도 참고하세요.
+
+## 기술 스택
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## 기본이 프라이빗
+
+- **소스 공개**: 전체 소스가 Elastic License 2.0(ELv2)으로 GitHub에 공개되어 있습니다.
+- **명시적 연결**: 어떤 에이전트, 프로바이더, 통합을 연결할지 직접 선택합니다.
+
+## 기여
+
+기여를 환영합니다! 환경을 준비하고 PR을 여는 방법은 [CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요. 버그와 기능 요청은 [issues](https://github.com/superset-sh/superset/issues)에 남겨 주세요.
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## 커뮤니티
+
+Superset 커뮤니티에 참여해 도움을 받고, 피드백을 나누고, 다른 사용자와 교류하세요:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: 팀 및 커뮤니티와 대화
+- **[Twitter](https://x.com/superset_sh)**: 업데이트와 소식 팔로우
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: 버그 신고와 기능 요청
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: 질문과 아이디어 공유
+
+### 팀
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## 라이선스, 그리고 영원히 무료인 것
+
+**데스크톱 앱은 영원히 무료입니다.** 자신의 컴퓨터에서 에이전트를 병렬로 실행하는 데는 결코 비용이 들지 않습니다. 유료화가 있더라도 그 위에 얹히는 선택적 서비스일 뿐입니다.
+
+앱 전체가 이 저장소에 [Elastic License 2.0](../LICENSE.md)으로 공개되어 있습니다: 사용하고, 포크하고, 수정하고, 팀을 위해 셀프 호스팅하세요. 유일하게 안 되는 것은 Superset 자체를 서비스로 재포장해 다른 사람에게 판매하는 것뿐입니다.

--- a/readme/README.nl.md
+++ b/readme/README.nl.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude en OpenCode werken parallel in Superset-werkruimtes met live diffs" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Draai 100+ coding agents parallel
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Dit is een vertaling van de Engelse README, die leidend is.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex of elke andere CLI-agent, elk in een eigen geïsoleerde worktree.<br />
+Besteed je tijd aan shippen, niet aan wachten.
+
+<br />
+
+[**Download voor macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentatie](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Codeer 10x sneller zonder omschakelkosten
+
+Superset draait CLI-gebaseerde coding agents parallel in geïsoleerde git-worktrees, met ingebouwde workflows voor terminal, review en openen-in-editor.
+
+- **Draai meerdere agents tegelijk** zonder de overhead van contextwisselingen
+- **Isoleer elke taak** in een eigen git-worktree zodat agents elkaar niet in de weg zitten
+- **Houd al je agents in de gaten** vanaf één plek en krijg een melding wanneer ze aandacht nodig hebben
+- **Bekijk en bewerk wijzigingen snel** met de ingebouwde diff-viewer en editor
+- **Open elke werkruimte waar je die nodig hebt** met overdracht in één klik naar je editor of terminal
+- **Bereik je werkruimtes overal vandaan** via remote hosts, de CLI, de SDK of MCP
+
+Minder wachten, meer shippen.
+
+## Functies
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Parallelle werkruimtes
+
+Draai 100+ coding agents tegelijk, elk in een eigen git-worktree met een eigen branch, terminal en omgeving. Vergelijk de resultaten en merge de winnaar.
+
+[Docs →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude streamt een billing-migratie terwijl andere agents in parallelle werkruimtes draaien" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Agent-monitoring
+
+Volg elke agent vanuit de zijbalk, met werkindicatoren, voltooiingsgeluiden en dock-badges wanneer er één je aandacht nodig heeft.
+
+[Docs →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Een agent die zijn taak afrondt terwijl de status in de zijbalk omslaat van bezig naar klaar" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Ingebouwde terminal
+
+Tabbladen, oneindig veel splits, presets en persistente sessies die herstarts overleven. Druk op ⌘I voor een rijke prompteditor met meerregelig bewerken en @-bestandsvermeldingen.
+
+[Docs →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Een vervolgvraag typen met een @-bestandsvermelding in de rijke prompteditor naast een gesplitste terminal" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Ingebouwde diff-viewer
+
+Inspecteer, becommentarieer en bewerk agent-wijzigingen zonder de app te verlaten, en commit en push wanneer het klaar is.
+
+[Docs →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="De wijzigingen van een agent reviewen in de diff-viewer" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### In-app browser & poorten
+
+Bekijk draaiende dev-servers in een browserpaneel. Poorten worden per werkruimte gedetecteerd, dus elke worktree krijgt een eigen preview.
+
+[Docs →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="In-app browser met een preview van een dev-server met gedetecteerde poorten" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automatiseringen
+
+Draai agent-sessies volgens schema: trieer issues 's nachts, stel de wekelijkse changelog op, houd dependencies actueel.
+
+[Docs →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Geplande agent-automatiseringen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Externe toegang
+
+Verbind een andere machine en bereik zijn werkruimtes overal vandaan: de desktop-app, de CLI of je telefoon. Wek offline hosts met een aangepast commando.
+
+[Docs →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hosts en leden in organisatie-instellingen" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Script het vanuit elke shell: maak werkruimtes aan, start agents, lees hun terminals en beheer automatiseringen met één binary. Als een agent een commando kan uitvoeren, kan hij Superset aansturen.
+
+[Docs →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Een werkruimte aanmaken en een agent starten vanuit de Superset CLI" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Commandopalet
+
+Spring naar elke werkruimte, actie of instelling vanuit één zoekvak.
+
+[Docs →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Typen in het commandopalet en live werkruimte-acties filteren" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Ook inbegrepen:**
+
+- **[Ingebouwde skills](https://docs.superset.sh/skills)**: agents komen voorgeladen met `superset:*`-skills (parallelle agents orkestreren, automatiseringen inplannen, feedback indienen, problemen diagnosticeren), automatisch klaargezet bij de start
+- **[Modelkiezer & aangepaste agents](https://docs.superset.sh/agent-integration)**: kies bij de start een model en redeneerinspanning, en voeg elke terminal-agent toe met een eigen icoon
+- **[Setup-scripts voor werkruimtes](https://docs.superset.sh/setup-teardown-scripts)**: automatiseer env-setup, dependency-installaties en dev-servers per werkruimte
+- **[Terminal-presets](https://docs.superset.sh/terminal-presets)**: sla agent- en shell-layouts op en open ze met één toetsaanslag
+- **[Slack & Linear](https://docs.superset.sh/use-with-linear)**: start werkruimtes vanuit Slack-berichten of Linear-issues
+- **[Openen in je IDE](https://docs.superset.sh/use-with-ide)**: overdracht in één klik naar Cursor, VS Code of elke andere editor
+- **[Aangepaste thema's](https://docs.superset.sh/custom-themes)**: bouw, bewerk en importeer themabestanden
+- **[Sneltoetsen](https://docs.superset.sh/keyboard-shortcuts)**: elke actie is opnieuw toewijsbaar via **Instellingen → Sneltoetsen** (⌘/)
+- **[Gebruik je eigen providers](https://docs.superset.sh/providers)**: verbind OpenRouter, Bedrock, Vertex of Vercel AI Gateway
+- **En nog veel meer**: we shippen dagelijks, dus deze lijst loopt altijd achter. De [changelog](https://superset.sh/changelog) is de echte featurelijst.
+
+## Ondersteunde agents
+
+Superset werkt met elke CLI-gebaseerde coding agent, waaronder:
+
+| Agent | Status |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Volledig ondersteund |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Volledig ondersteund |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Volledig ondersteund |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Volledig ondersteund |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Volledig ondersteund |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Volledig ondersteund |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Volledig ondersteund |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Volledig ondersteund |
+| Elke andere CLI-agent | Werkt zonder configuratie |
+
+Als het in een terminal draait, draait het op Superset
+
+Agents krijgen meer dan alleen een terminal:
+
+- **Modelkiezer**: kies een model en redeneerinspanning wanneer je een agent start
+- **Instellingen per agent**: stem startcommando's, prompt-templates en modeloverrides af in Instellingen → Agents
+- **Aangepaste agents**: voeg elke terminal-agent toe met een eigen icoon en hij werkt als een ingebouwde
+- **Status en meldingen**: werkindicatoren, voltooiingsgeluiden en dock-badges wanneer een agent je nodig heeft
+- **Ingebouwde chat**: praat met modellen in een chatpaneel, met inline toolgoedkeuringen en planreview
+
+## Meer dan een desktop-app
+
+Elk oppervlak praat met dezelfde werkruimtes, dus je kunt een taak in de app starten en er overal op terugkomen.
+
+| Oppervlak | Wat je krijgt |
+|:--------|:-------------|
+| [**Desktop-app**](https://github.com/superset-sh/superset/releases/latest) | De volledige IDE: terminals, diff-viewer, in-app browser, automatiseringen |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Eén `superset`-binary om werkruimtes, agents, terminals en hosts vanuit elke shell te beheren |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Stuur Superset programmatisch aan met [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) vanuit Node, Bun of Deno |
+| [**MCP-server**](https://docs.superset.sh/mcp) | Laat Claude Code, Codex, Cursor en andere agents zelf werkruimtes aanmaken en beheren |
+
+De CLI wordt meegeleverd met de desktop-app, of installeer hem los:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Er komt binnenkort een iOS-app zodat je je agents vanaf je telefoon kunt checken.
+
+## Installatie
+
+Download de desktop-app:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (experimenteel; macOS is het primaire doelplatform)
+- **Windows**: nog niet beschikbaar
+- [Alle builds](https://github.com/superset-sh/superset/releases/latest)
+
+Het enige dat je geïnstalleerd moet hebben is [Git](https://git-scm.com/). [gh](https://cli.github.com/) is optioneel en ontgrendelt de PR-workflows; Superset biedt aan het voor je te installeren.
+
+## Ontwikkeling
+
+Wil je aan Superset sleutelen of een PR bijdragen? Cloneer de repository, voeg hem toe aan de
+geïnstalleerde Superset-app en maak een werkruimte aan voor je wijziging:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Draai daarna de development-setup vanuit de terminal van die werkruimte:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Draai `setup.local.sh` één keer in elke nieuwe worktree. Het configureert werkruimte-specifieke
+app-identiteit en poorten, zodat de development-desktop-app naast de geïnstalleerde
+Superset-app en andere development-worktrees kan draaien.
+
+Er is geen Neon-account en er zijn geen third-party credentials nodig. `setup.local.sh` zet
+een lokale Postgres + Electric-stack op via Docker en seedt een dev-account. Log in
+met de knop **"Sign in as dev"** (of `admin@local.test` / `supersetdev`).
+
+Vereisten: [Bun](https://bun.sh/) v1.3.14+ (vastgezet in `.bun-version`), `docker`, `jq` en `caddy`, dat `bun dev` draait als de lokale HTTPS-proxy (`brew install jq caddy && caddy trust`).
+
+Zie [**DEVELOPMENT.md**](../DEVELOPMENT.md) voor de volledige gids: wat het setup-script doet, handmatige setup tegen echte services, veelgebruikte commando's, troubleshooting en hoe je de desktop-app bouwt. Het bijdrageproces staat in [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Configuratie
+
+Configureer setup-, teardown- en run-scripts voor werkruimtes in `.superset/config.json`. Zie de [volledige documentatie](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Sneltoetsen zijn aanpasbaar via **Instellingen → Sneltoetsen** (⌘/); zie de [volledige sneltoetsenlijst](https://docs.superset.sh/keyboard-shortcuts).
+
+## Tech-stack
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Standaard privé
+
+- **Broncode beschikbaar**: de volledige broncode staat op GitHub onder de Elastic License 2.0 (ELv2).
+- **Expliciete verbindingen**: jij kiest welke agents, providers en integraties je verbindt.
+
+## Bijdragen
+
+We verwelkomen bijdragen! Zie [CONTRIBUTING.md](../CONTRIBUTING.md) voor hoe je aan de slag gaat en een PR opent. Bugs en featureverzoeken horen in [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Community
+
+Word lid van de Superset-community om hulp te krijgen, feedback te delen en andere gebruikers te ontmoeten:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: chat met het team en de community
+- **[Twitter](https://x.com/superset_sh)**: volg voor updates en aankondigingen
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: meld bugs en vraag features aan
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: stel vragen en deel ideeën
+
+### Team
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licentie & wat voor altijd gratis is
+
+**De desktop-app is voor altijd gratis.** Agents parallel draaien op je eigen machine zal nooit betaling vereisen. Alles waarvoor we geld vragen, wordt een optionele service daarbovenop.
+
+De hele app staat in deze repo onder de [Elastic License 2.0](../LICENSE.md): gebruik hem, fork hem, pas hem aan, self-host hem voor je team. Het enige dat niet mag, is Superset zelf herverpakken als een service die je aan anderen verkoopt.

--- a/readme/README.pl.md
+++ b/readme/README.pl.md
@@ -1,0 +1,347 @@
+<div align="center">
+
+<img width="full" alt="Claude i OpenCode pracujące równolegle w obszarach roboczych Superset z podglądem różnic na żywo" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Uruchamiaj ponad 100 agentów kodujących równolegle
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Tłumaczenie angielskiego README, który pozostaje wersją kanoniczną.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex lub dowolny agent CLI — każdy we własnym, izolowanym worktree.<br />
+Poświęcaj czas na dostarczanie, nie na czekanie.
+
+<br />
+
+[**Pobierz na macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Dokumentacja](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Pisz kod 10 razy szybciej bez kosztów przełączania
+
+Superset uruchamia agentów kodujących opartych na CLI równolegle w izolowanych worktree git, z wbudowanym terminalem, przeglądem zmian i otwieraniem w edytorze.
+
+- **Uruchamiaj wielu agentów jednocześnie** bez narzutu przełączania kontekstu
+- **Izoluj każde zadanie** we własnym worktree git, aby agenci nie wchodzili sobie w drogę
+- **Śledź wszystkich agentów** z jednego miejsca i otrzymuj powiadomienia, gdy potrzebują uwagi
+- **Szybko przeglądaj i edytuj zmiany** dzięki wbudowanemu podglądowi różnic i edytorowi
+- **Otwieraj dowolny obszar roboczy tam, gdzie potrzeba** — przekazanie do edytora lub terminala jednym kliknięciem
+- **Sięgaj po swoje obszary robocze zewsząd** przez zdalne hosty, CLI, SDK lub MCP
+
+Czekaj mniej, dostarczaj więcej.
+
+## Funkcje
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Równoległe obszary robocze
+
+Uruchamiaj ponad 100 agentów kodujących naraz — każdy we własnym worktree git z własną gałęzią, terminalem i środowiskiem. Porównaj wyniki i scal zwycięzcę.
+
+[Dokumentacja →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude strumieniuje migrację rozliczeń, podczas gdy inni agenci pracują w równoległych obszarach roboczych" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Monitorowanie agentów
+
+Śledź każdego agenta z paska bocznego — ze wskaźnikami pracy, dźwiękami ukończenia i plakietkami w docku, gdy któryś potrzebuje uwagi.
+
+[Dokumentacja →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Agent kończy zadanie, a status na pasku bocznym zmienia się z pracuje na gotowe" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Wbudowany terminal
+
+Karty, nieskończone podziały, presety i trwałe sesje, które przetrwają restarty. Naciśnij ⌘I, aby otworzyć rozbudowany edytor promptów z edycją wielowierszową i wzmiankami plików przez @.
+
+[Dokumentacja →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Wpisywanie kolejnego polecenia ze wzmianką pliku przez @ w rozbudowanym edytorze promptów obok podzielonego terminala" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Wbudowany podgląd różnic
+
+Sprawdzaj, komentuj i edytuj zmiany agentów bez opuszczania aplikacji, a gdy wszystko gotowe — zrób commit i push.
+
+[Dokumentacja →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Przeglądanie zmian agenta w podglądzie różnic" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Przeglądarka w aplikacji i porty
+
+Podglądaj działające serwery deweloperskie w panelu przeglądarki. Porty są wykrywane per obszar roboczy, więc każdy worktree ma własny podgląd.
+
+[Dokumentacja →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Przeglądarka w aplikacji z podglądem serwera deweloperskiego i wykrytymi portami" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automatyzacje
+
+Uruchamiaj sesje agentów według harmonogramu: rób nocny triage zgłoszeń, przygotowuj szkic cotygodniowego changeloga, dbaj o świeżość zależności.
+
+[Dokumentacja →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Zaplanowane automatyzacje agentów" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Dostęp zdalny
+
+Podłącz inną maszynę i korzystaj z jej obszarów roboczych zewsząd: z aplikacji desktopowej, CLI lub telefonu. Wybudzaj hosty offline własnym poleceniem.
+
+[Dokumentacja →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hosty i członkowie w ustawieniach organizacji" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Skryptuj z dowolnej powłoki: twórz obszary robocze, uruchamiaj agentów, czytaj ich terminale i zarządzaj automatyzacjami jednym plikiem binarnym. Jeśli agent potrafi uruchomić polecenie, potrafi też sterować Supersetem.
+
+[Dokumentacja →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Tworzenie obszaru roboczego i uruchamianie agenta z Superset CLI" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Paleta poleceń
+
+Przeskakuj do dowolnego obszaru roboczego, akcji lub ustawienia z jednego pola wyszukiwania.
+
+[Dokumentacja →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Wpisywanie w palecie poleceń i filtrowanie akcji obszaru roboczego na żywo" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Również w zestawie:**
+
+- **[Wbudowane umiejętności](https://docs.superset.sh/skills)**: agenci przychodzą z gotowymi umiejętnościami `superset:*` (orkiestracja równoległych agentów, planowanie automatyzacji, zgłaszanie opinii, diagnozowanie problemów), instalowanymi automatycznie przy starcie
+- **[Wybór modelu i własni agenci](https://docs.superset.sh/agent-integration)**: wybierz model i poziom rozumowania przy starcie oraz dodaj dowolnego agenta terminalowego z własną ikoną
+- **[Skrypty konfiguracji obszaru roboczego](https://docs.superset.sh/setup-teardown-scripts)**: automatyzuj konfigurację środowiska, instalację zależności i serwery deweloperskie per obszar roboczy
+- **[Presety terminala](https://docs.superset.sh/terminal-presets)**: zapisuj układy agentów i powłok i otwieraj je jednym klawiszem
+- **[Slack i Linear](https://docs.superset.sh/use-with-linear)**: twórz obszary robocze z wiadomości Slack lub zgłoszeń Linear
+- **[Otwieranie w Twoim IDE](https://docs.superset.sh/use-with-ide)**: przekazanie jednym kliknięciem do Cursor, VS Code lub dowolnego edytora
+- **[Własne motywy](https://docs.superset.sh/custom-themes)**: twórz, edytuj i importuj pliki motywów
+- **[Skróty klawiszowe](https://docs.superset.sh/keyboard-shortcuts)**: każdą akcję można przemapować w **Ustawienia → Skróty klawiszowe** (⌘/)
+- **[Własni dostawcy](https://docs.superset.sh/providers)**: podłącz OpenRouter, Bedrock, Vertex lub Vercel AI Gateway
+- **I wiele więcej**: wydajemy codziennie, więc ta lista jest wiecznie w tyle. Prawdziwą listą funkcji jest [changelog](https://superset.sh/changelog).
+
+## Obsługiwani agenci
+
+Superset działa z każdym agentem kodującym opartym na CLI, w tym:
+
+| Agent | Status |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Pełne wsparcie |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Pełne wsparcie |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Pełne wsparcie |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Pełne wsparcie |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Pełne wsparcie |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Pełne wsparcie |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Pełne wsparcie |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Pełne wsparcie |
+| Dowolny inny agent CLI | Działa bez konfiguracji |
+
+Jeśli działa w terminalu, działa w Superset
+
+Agenci dostają więcej niż terminal:
+
+- **Wybór modelu**: wybierz model i poziom rozumowania przy uruchamianiu agenta
+- **Ustawienia per agent**: dostosuj polecenia startowe, szablony promptów i nadpisania modeli w Ustawienia → Agenci
+- **Własni agenci**: dodaj dowolnego agenta terminalowego z własną ikoną, a będzie działał jak wbudowany
+- **Status i powiadomienia**: wskaźniki pracy, dźwięki ukończenia i plakietki w docku, gdy agent Cię potrzebuje
+- **Wbudowany czat**: rozmawiaj z modelami w panelu czatu, z zatwierdzaniem narzędzi inline i przeglądem planów
+
+## Więcej niż aplikacja desktopowa
+
+Każda powierzchnia korzysta z tych samych obszarów roboczych, więc zadanie rozpoczęte w aplikacji można sprawdzać zewsząd.
+
+| Powierzchnia | Co otrzymujesz |
+|:--------|:-------------|
+| [**Aplikacja desktopowa**](https://github.com/superset-sh/superset/releases/latest) | Pełne IDE: terminale, podgląd różnic, przeglądarka w aplikacji, automatyzacje |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Pojedynczy plik binarny `superset` do zarządzania obszarami roboczymi, agentami, terminalami i hostami z dowolnej powłoki |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Steruj Supersetem programistycznie przez [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) z Node, Bun lub Deno |
+| [**Serwer MCP**](https://docs.superset.sh/mcp) | Pozwól Claude Code, Codex, Cursor i innym agentom samodzielnie tworzyć obszary robocze i nimi zarządzać |
+
+CLI jest dołączone do aplikacji desktopowej; można je też zainstalować osobno:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Wkrótce pojawi się aplikacja na iOS, aby doglądać agentów z telefonu.
+
+## Instalacja
+
+Pobierz aplikację desktopową:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (eksperymentalne; głównym celem jest macOS)
+- **Windows**: jeszcze niedostępne
+- [Wszystkie kompilacje](https://github.com/superset-sh/superset/releases/latest)
+
+Jedyne, co trzeba mieć zainstalowane, to [Git](https://git-scm.com/). [gh](https://cli.github.com/) jest opcjonalny i odblokowuje przepływy pracy z PR; Superset zaproponuje jego instalację.
+
+## Rozwój
+
+Chcesz rozwijać Superset lub wnieść PR? Sklonuj repozytorium, dodaj je do
+zainstalowanej aplikacji Superset i utwórz obszar roboczy dla swojej zmiany:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Następnie uruchom konfigurację deweloperską z terminala tego obszaru roboczego:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Uruchom `setup.local.sh` raz w każdym nowym worktree. Skrypt konfiguruje
+specyficzną dla obszaru roboczego tożsamość aplikacji i porty, dzięki czemu
+deweloperska aplikacja desktopowa może działać obok zainstalowanego Superset
+i innych deweloperskich worktree.
+
+Konto Neon ani poświadczenia zewnętrzne nie są potrzebne. `setup.local.sh` uruchamia
+lokalny stos Postgres + Electric przez Docker i tworzy konto deweloperskie. Zaloguj się
+przyciskiem **"Sign in as dev"** (lub `admin@local.test` / `supersetdev`).
+
+Wymagania: [Bun](https://bun.sh/) v1.3.14+ (przypięty w `.bun-version`), `docker`, `jq` i `caddy`, którego `bun dev` uruchamia jako lokalne proxy HTTPS (`brew install jq caddy && caddy trust`).
+
+Zobacz [**DEVELOPMENT.md**](../DEVELOPMENT.md) — pełny przewodnik: co robi skrypt konfiguracyjny, ręczna konfiguracja z prawdziwymi usługami, częste polecenia, rozwiązywanie problemów i budowanie aplikacji desktopowej. Proces wnoszenia zmian opisano w [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Konfiguracja
+
+Skonfiguruj skrypty setup, teardown i run obszaru roboczego w `.superset/config.json`. Zobacz [pełną dokumentację](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Skróty klawiszowe można dostosować w **Ustawienia → Skróty klawiszowe** (⌘/); zobacz [pełną listę skrótów](https://docs.superset.sh/keyboard-shortcuts).
+
+## Stos technologiczny
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Prywatność domyślnie
+
+- **Source Available**: pełny kod źródłowy jest na GitHubie na licencji Elastic License 2.0 (ELv2).
+- **Jawne połączenia**: to Ty wybierasz, które agenty, dostawców i integracje podłączyć.
+
+## Wnoszenie zmian
+
+Zapraszamy do współtworzenia! Zobacz [CONTRIBUTING.md](../CONTRIBUTING.md), aby dowiedzieć się, jak się przygotować i otworzyć PR. Błędy i propozycje funkcji zgłaszaj w [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Społeczność
+
+Dołącz do społeczności Superset, aby uzyskać pomoc, dzielić się opiniami i nawiązywać kontakty z innymi użytkownikami:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: rozmawiaj z zespołem i społecznością
+- **[Twitter](https://x.com/superset_sh)**: obserwuj, aby śledzić aktualizacje i ogłoszenia
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: zgłaszaj błędy i proponuj funkcje
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: zadawaj pytania i dziel się pomysłami
+
+### Zespół
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licencja i co jest darmowe na zawsze
+
+**Aplikacja desktopowa jest darmowa na zawsze.** Równoległe uruchamianie agentów na własnej maszynie nigdy nie będzie wymagać płatności. Wszystko, za co pobierzemy opłaty, będzie opcjonalną usługą dodatkową.
+
+Cała aplikacja znajduje się w tym repozytorium na licencji [Elastic License 2.0](../LICENSE.md): używaj jej, forkuj, modyfikuj, hostuj samodzielnie dla swojego zespołu. Jedyną rzeczą wykluczoną jest przepakowanie samego Superset jako usługi sprzedawanej innym.

--- a/readme/README.pt-BR.md
+++ b/readme/README.pt-BR.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude e OpenCode trabalhando em paralelo em áreas de trabalho do Superset com diffs ao vivo" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Execute mais de 100 agentes de código em paralelo
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Esta é uma tradução do [README em inglês](../README.md), que é a versão canônica.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex ou qualquer agente de CLI, cada um em seu próprio worktree isolado.<br />
+Passe seu tempo entregando, não esperando.
+
+<br />
+
+[**Baixar para macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Documentação](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Programe 10x mais rápido sem custo de troca de contexto
+
+O Superset executa agentes de código baseados em CLI em paralelo em worktrees git isolados, com terminal, revisão e fluxos de abrir no editor integrados.
+
+- **Execute vários agentes ao mesmo tempo** sem a sobrecarga da troca de contexto
+- **Isole cada tarefa** em seu próprio worktree git para que os agentes não interfiram uns nos outros
+- **Monitore todos os seus agentes** de um só lugar e seja notificado quando precisarem de atenção
+- **Revise e edite mudanças rapidamente** com o visualizador de diff e o editor integrados
+- **Abra qualquer área de trabalho onde você precisar** com passagem em um clique para o seu editor ou terminal
+- **Acesse suas áreas de trabalho de qualquer lugar** via hosts remotos, CLI, SDK ou MCP
+
+Espere menos, entregue mais.
+
+## Recursos
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Áreas de trabalho paralelas
+
+Execute mais de 100 agentes de código de uma vez, cada um em seu próprio worktree git com sua própria branch, terminal e ambiente. Compare os resultados e faça merge do vencedor.
+
+[Docs →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude transmitindo uma migração de cobrança enquanto outros agentes rodam em áreas de trabalho paralelas" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Monitoramento de agentes
+
+Acompanhe cada agente pela barra lateral, com indicadores de atividade, sons de conclusão e badges no dock quando algum precisar da sua atenção.
+
+[Docs →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Um agente terminando sua tarefa e o status na barra lateral mudando de trabalhando para concluído" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Terminal integrado
+
+Abas, divisões infinitas, presets e sessões persistentes que sobrevivem a reinicializações. Pressione ⌘I para um editor de prompt avançado com edição em várias linhas e menções de arquivos com @.
+
+[Docs →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Digitando uma mensagem de acompanhamento com uma menção de arquivo @ no editor de prompt avançado ao lado de um terminal dividido" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Visualizador de diff integrado
+
+Inspecione, comente e edite as mudanças dos agentes sem sair do app, e depois faça commit e push quando estiver pronto.
+
+[Docs →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Revisando as mudanças de um agente no visualizador de diff" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Navegador integrado e portas
+
+Visualize servidores de dev em execução em um painel de navegador. As portas são detectadas por área de trabalho, então cada worktree tem sua própria prévia.
+
+[Docs →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Navegador integrado exibindo a prévia de um servidor de dev com as portas detectadas" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Automações
+
+Execute sessões de agentes de forma agendada: faça triagem de issues durante a noite, redija o changelog semanal, mantenha as dependências em dia.
+
+[Docs →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Automações de agentes agendadas" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Acesso remoto
+
+Conecte outra máquina e acesse as áreas de trabalho dela de qualquer lugar: pelo app desktop, pela CLI ou pelo celular. Acorde hosts offline com um comando personalizado.
+
+[Docs →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Hosts e membros nas configurações da organização" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### CLI do Superset
+
+Automatize de qualquer shell: crie áreas de trabalho, inicie agentes, leia seus terminais e gerencie automações com um único binário. Se um agente consegue executar um comando, ele consegue controlar o Superset.
+
+[Docs →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Criando uma área de trabalho e iniciando um agente pela CLI do Superset" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Paleta de comandos
+
+Vá para qualquer área de trabalho, ação ou configuração a partir de uma única caixa de busca.
+
+[Docs →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Digitando na paleta de comandos e filtrando ações de áreas de trabalho ao vivo" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Também na caixa:**
+
+- **[Habilidades integradas](https://docs.superset.sh/skills)**: os agentes já vêm carregados com as habilidades `superset:*` (orquestrar agentes em paralelo, agendar automações, enviar feedback, diagnosticar problemas), provisionadas automaticamente na inicialização
+- **[Seletor de modelo e agentes personalizados](https://docs.superset.sh/agent-integration)**: escolha um modelo e o nível de raciocínio na inicialização, e adicione qualquer agente de terminal com seu próprio ícone
+- **[Scripts de configuração de área de trabalho](https://docs.superset.sh/setup-teardown-scripts)**: automatize a configuração do ambiente, a instalação de dependências e os servidores de dev por área de trabalho
+- **[Presets de terminal](https://docs.superset.sh/terminal-presets)**: salve layouts de agentes e shells e abra-os com uma única tecla
+- **[Slack e Linear](https://docs.superset.sh/use-with-linear)**: crie áreas de trabalho a partir de mensagens do Slack ou issues do Linear
+- **[Abrir na sua IDE](https://docs.superset.sh/use-with-ide)**: passagem em um clique para o Cursor, o VS Code ou qualquer editor
+- **[Temas personalizados](https://docs.superset.sh/custom-themes)**: crie, edite e importe arquivos de tema
+- **[Atalhos de teclado](https://docs.superset.sh/keyboard-shortcuts)**: toda ação pode ser remapeada em **Configurações → Atalhos de teclado** (⌘/)
+- **[Traga seus próprios provedores](https://docs.superset.sh/providers)**: conecte OpenRouter, Bedrock, Vertex ou Vercel AI Gateway
+- **E muito mais**: lançamos todo dia, então esta lista está perpetuamente atrasada. O [changelog](https://superset.sh/changelog) é a verdadeira lista de recursos.
+
+## Agentes compatíveis
+
+O Superset funciona com qualquer agente de código baseado em CLI, incluindo:
+
+| Agente | Status |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Totalmente compatível |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Totalmente compatível |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Totalmente compatível |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Totalmente compatível |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Totalmente compatível |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Totalmente compatível |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Totalmente compatível |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Totalmente compatível |
+| Qualquer outro agente de CLI | Funciona sem configuração |
+
+Se roda em um terminal, roda no Superset
+
+Os agentes recebem mais do que um terminal:
+
+- **Seletor de modelo**: escolha um modelo e o nível de raciocínio ao iniciar um agente
+- **Configurações por agente**: ajuste comandos de inicialização, templates de prompt e substituições de modelo em Configurações → Agentes
+- **Agentes personalizados**: adicione qualquer agente de terminal com seu próprio ícone e ele funciona como um integrado
+- **Status e notificações**: indicadores de atividade, sons de conclusão e badges no dock quando um agente precisar de você
+- **Chat integrado**: converse com os modelos em um painel de chat, com aprovações de ferramentas inline e revisão de planos
+
+## Mais do que um app desktop
+
+Todas as superfícies conversam com as mesmas áreas de trabalho, então você pode começar uma tarefa no app e acompanhá-la de qualquer lugar.
+
+| Superfície | O que você ganha |
+|:--------|:-------------|
+| [**App desktop**](https://github.com/superset-sh/superset/releases/latest) | A IDE completa: terminais, visualizador de diff, navegador integrado, automações |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Um único binário `superset` para gerenciar áreas de trabalho, agentes, terminais e hosts de qualquer shell |
+| [**SDK TypeScript**](https://docs.superset.sh/sdk/getting-started) | Controle o Superset programaticamente com [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) a partir de Node, Bun ou Deno |
+| [**Servidor MCP**](https://docs.superset.sh/mcp) | Deixe o Claude Code, o Codex, o Cursor e outros agentes criarem e gerenciarem áreas de trabalho por conta própria |
+
+A CLI vem junto com o app desktop, ou instale-a separadamente:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Um app para iOS chega em breve para você acompanhar seus agentes pelo celular.
+
+## Instalação
+
+Baixe o app desktop:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [AppImage x64](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (experimental; o macOS é o alvo principal)
+- **Windows**: ainda não disponível
+- [Todas as builds](https://github.com/superset-sh/superset/releases/latest)
+
+Tudo o que você precisa ter instalado é o [Git](https://git-scm.com/). O [gh](https://cli.github.com/) é opcional e desbloqueia os fluxos de PR; o Superset se oferece para instalá-lo para você.
+
+## Desenvolvimento
+
+Quer mexer no Superset ou contribuir com uma PR? Clone o repositório, adicione-o ao
+app do Superset instalado e crie uma área de trabalho para a sua mudança:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Depois execute a configuração de desenvolvimento no terminal dessa área de trabalho:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Execute `setup.local.sh` uma vez em cada worktree novo. Ele configura a identidade
+do app e as portas específicas da área de trabalho para que o app desktop de desenvolvimento
+possa rodar ao lado do app do Superset instalado e de outros worktrees de desenvolvimento.
+
+Não é preciso conta na Neon nem credenciais de terceiros. O `setup.local.sh` sobe
+uma stack local de Postgres + Electric via Docker e cria uma conta de dev. Entre
+com o botão **"Sign in as dev"** (ou `admin@local.test` / `supersetdev`).
+
+Pré-requisitos: [Bun](https://bun.sh/) v1.3.14+ (fixado em `.bun-version`), `docker`, `jq` e `caddy`, que o `bun dev` executa como proxy HTTPS local (`brew install jq caddy && caddy trust`).
+
+Veja [**DEVELOPMENT.md**](../DEVELOPMENT.md) para o guia completo: o que o script de configuração faz, configuração manual com serviços reais, comandos comuns, solução de problemas e como compilar o app desktop. O processo de contribuição está em [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Configuração
+
+Configure os scripts de setup, teardown e run das áreas de trabalho em `.superset/config.json`. Veja a [documentação completa](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Os atalhos de teclado são personalizáveis em **Configurações → Atalhos de teclado** (⌘/); veja a [lista completa de atalhos](https://docs.superset.sh/keyboard-shortcuts).
+
+## Stack de tecnologia
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Privado por padrão
+
+- **Código-fonte disponível**: o código completo está no GitHub sob a Elastic License 2.0 (ELv2).
+- **Conexões explícitas**: você escolhe quais agentes, provedores e integrações conectar.
+
+## Contribuindo
+
+Contribuições são bem-vindas! Veja [CONTRIBUTING.md](../CONTRIBUTING.md) para saber como se preparar e abrir uma PR. Bugs e pedidos de recursos vão nas [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Comunidade
+
+Junte-se à comunidade do Superset para obter ajuda, compartilhar feedback e se conectar com outros usuários:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: converse com o time e a comunidade
+- **[Twitter](https://x.com/superset_sh)**: siga para novidades e anúncios
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: relate bugs e peça recursos
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: faça perguntas e compartilhe ideias
+
+### Time
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Licença e o que é grátis para sempre
+
+**O app desktop é grátis para sempre.** Executar agentes em paralelo na sua própria máquina nunca exigirá pagamento. Qualquer coisa que cobrarmos será um serviço opcional por cima.
+
+O app inteiro está neste repositório sob a [Elastic License 2.0](../LICENSE.md): use, faça fork, modifique, hospede você mesmo para o seu time. A única coisa fora de questão é reempacotar o próprio Superset como um serviço que você vende para terceiros.

--- a/readme/README.ru.md
+++ b/readme/README.ru.md
@@ -1,0 +1,347 @@
+<div align="center">
+
+<img width="full" alt="Claude и OpenCode работают параллельно в рабочих областях Superset с живыми diff" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Запускайте 100+ агентов для кодинга параллельно
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Перевод английского README; канонической является английская версия.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex или любой CLI-агент — каждый в своём изолированном worktree.<br />
+Тратьте время на выпуск фич, а не на ожидание.
+
+<br />
+
+[**Скачать для macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Документация](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Пишите код в 10 раз быстрее без затрат на переключение
+
+Superset запускает CLI-агентов для кодинга параллельно в изолированных git worktree, со встроенным терминалом, ревью изменений и открытием в редакторе.
+
+- **Запускайте несколько агентов одновременно** без накладных расходов на переключение контекста
+- **Изолируйте каждую задачу** в отдельном git worktree, чтобы агенты не мешали друг другу
+- **Следите за всеми агентами** из одного места и получайте уведомления, когда им нужно внимание
+- **Быстро проверяйте и правьте изменения** во встроенном просмотрщике diff и редакторе
+- **Открывайте любую рабочую область там, где нужно** — передача в редактор или терминал в один клик
+- **Подключайтесь к рабочим областям откуда угодно** через удалённые хосты, CLI, SDK или MCP
+
+Меньше ожидания — больше релизов.
+
+## Возможности
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Параллельные рабочие области
+
+Запускайте 100+ агентов для кодинга одновременно — каждый в собственном git worktree со своей веткой, терминалом и окружением. Сравните результаты и смержите лучший.
+
+[Документация →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude стримит миграцию биллинга, пока другие агенты работают в параллельных рабочих областях" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Мониторинг агентов
+
+Отслеживайте каждого агента из боковой панели: индикаторы работы, звуковые сигналы о завершении и бейджи в доке, когда агенту нужно ваше внимание.
+
+[Документация →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Агент завершает задачу, и статус в боковой панели меняется с «работает» на «готово»" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Встроенный терминал
+
+Вкладки, бесконечные сплиты, пресеты и постоянные сессии, переживающие перезапуски. Нажмите ⌘I — откроется расширенный редактор промптов с многострочным вводом и упоминаниями файлов через @.
+
+[Документация →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Ввод уточнения с упоминанием файла через @ в расширенном редакторе промптов рядом с разделённым терминалом" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Встроенный просмотрщик diff
+
+Изучайте, комментируйте и правьте изменения агентов, не выходя из приложения, а затем делайте commit и push, когда всё готово.
+
+[Документация →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Ревью изменений агента в просмотрщике diff" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Встроенный браузер и порты
+
+Просматривайте запущенные dev-серверы в панели браузера. Порты определяются для каждой рабочей области, так что у каждого worktree — своё превью.
+
+[Документация →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Встроенный браузер показывает превью dev-сервера с определёнными портами" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Автоматизации
+
+Запускайте сессии агентов по расписанию: разбирайте issue за ночь, готовьте черновик еженедельного changelog, держите зависимости свежими.
+
+[Документация →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Автоматизации агентов по расписанию" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Удалённый доступ
+
+Подключите другую машину и работайте с её рабочими областями откуда угодно: из десктопного приложения, CLI или с телефона. Будите офлайн-хосты пользовательской командой.
+
+[Документация →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Хосты и участники в настройках организации" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Скриптуйте из любой оболочки: создавайте рабочие области, запускайте агентов, читайте их терминалы и управляйте автоматизациями одним бинарником. Если агент умеет выполнять команды, он умеет управлять Superset.
+
+[Документация →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Создание рабочей области и запуск агента из Superset CLI" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Палитра команд
+
+Переходите к любой рабочей области, действию или настройке из одной строки поиска.
+
+[Документация →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Ввод в палитре команд с живой фильтрацией действий рабочей области" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Также в комплекте:**
+
+- **[Встроенные навыки](https://docs.superset.sh/skills)**: агенты поставляются с предустановленными навыками `superset:*` (оркестрация параллельных агентов, планирование автоматизаций, отправка отзывов, диагностика проблем), которые устанавливаются автоматически при запуске
+- **[Выбор модели и пользовательские агенты](https://docs.superset.sh/agent-integration)**: выбирайте модель и уровень рассуждений при запуске и добавляйте любого терминального агента с собственной иконкой
+- **[Скрипты настройки рабочей области](https://docs.superset.sh/setup-teardown-scripts)**: автоматизируйте настройку окружения, установку зависимостей и dev-серверы для каждой рабочей области
+- **[Пресеты терминала](https://docs.superset.sh/terminal-presets)**: сохраняйте раскладки агентов и оболочек и открывайте их одним нажатием
+- **[Slack и Linear](https://docs.superset.sh/use-with-linear)**: создавайте рабочие области из сообщений Slack или задач Linear
+- **[Открытие в вашей IDE](https://docs.superset.sh/use-with-ide)**: передача в Cursor, VS Code или любой редактор в один клик
+- **[Пользовательские темы](https://docs.superset.sh/custom-themes)**: создавайте, редактируйте и импортируйте файлы тем
+- **[Горячие клавиши](https://docs.superset.sh/keyboard-shortcuts)**: любое действие можно переназначить в **Настройки → Горячие клавиши** (⌘/)
+- **[Свои провайдеры](https://docs.superset.sh/providers)**: подключайте OpenRouter, Bedrock, Vertex или Vercel AI Gateway
+- **И многое другое**: мы выпускаем обновления каждый день, так что этот список вечно отстаёт. Настоящий список возможностей — [changelog](https://superset.sh/changelog).
+
+## Поддерживаемые агенты
+
+Superset работает с любым CLI-агентом для кодинга, в том числе:
+
+| Агент | Статус |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Полная поддержка |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Полная поддержка |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Полная поддержка |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Полная поддержка |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Полная поддержка |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Полная поддержка |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Полная поддержка |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Полная поддержка |
+| Любой другой CLI-агент | Работает без настройки |
+
+Если он запускается в терминале, он работает в Superset
+
+Агенты получают больше, чем просто терминал:
+
+- **Выбор модели**: выбирайте модель и уровень рассуждений при запуске агента
+- **Настройки для каждого агента**: настраивайте команды запуска, шаблоны промптов и переопределения моделей в Настройки → Агенты
+- **Пользовательские агенты**: добавьте любого терминального агента с собственной иконкой — он будет работать как встроенный
+- **Статус и уведомления**: индикаторы работы, звуковые сигналы о завершении и бейджи в доке, когда агенту нужно внимание
+- **Встроенный чат**: общайтесь с моделями в панели чата — с инлайн-подтверждением инструментов и ревью планов
+
+## Больше, чем десктопное приложение
+
+Все поверхности работают с одними и теми же рабочими областями: начните задачу в приложении и проверяйте её откуда угодно.
+
+| Поверхность | Что вы получаете |
+|:--------|:-------------|
+| [**Десктопное приложение**](https://github.com/superset-sh/superset/releases/latest) | Полноценная IDE: терминалы, просмотрщик diff, встроенный браузер, автоматизации |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Единый бинарник `superset` для управления рабочими областями, агентами, терминалами и хостами из любой оболочки |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Управляйте Superset программно через [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) из Node, Bun или Deno |
+| [**Сервер MCP**](https://docs.superset.sh/mcp) | Позвольте Claude Code, Codex, Cursor и другим агентам самим создавать рабочие области и управлять ими |
+
+CLI идёт в комплекте с десктопным приложением, либо установите его отдельно:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Скоро выйдет приложение для iOS, чтобы следить за агентами с телефона.
+
+## Установка
+
+Скачайте десктопное приложение:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (экспериментально; основная платформа — macOS)
+- **Windows**: пока недоступно
+- [Все сборки](https://github.com/superset-sh/superset/releases/latest)
+
+Из установленного нужен только [Git](https://git-scm.com/). [gh](https://cli.github.com/) необязателен и открывает рабочие процессы с PR; Superset предложит установить его за вас.
+
+## Разработка
+
+Хотите поработать над Superset или прислать PR? Клонируйте репозиторий, добавьте его
+в установленное приложение Superset и создайте рабочую область для своих изменений:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Затем запустите настройку окружения разработки из терминала этой рабочей области:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Запускайте `setup.local.sh` один раз в каждом новом worktree. Скрипт настраивает
+идентичность приложения и порты для конкретной рабочей области, чтобы десктопное
+приложение для разработки могло работать рядом с установленным Superset и другими
+worktree для разработки.
+
+Аккаунт Neon и сторонние учётные данные не нужны. `setup.local.sh` поднимает
+локальный стек Postgres + Electric через Docker и создаёт dev-аккаунт. Войдите
+кнопкой **"Sign in as dev"** (или `admin@local.test` / `supersetdev`).
+
+Требования: [Bun](https://bun.sh/) v1.3.14+ (зафиксирован в `.bun-version`), `docker`, `jq` и `caddy`, который `bun dev` запускает как локальный HTTPS-прокси (`brew install jq caddy && caddy trust`).
+
+Полное руководство — в [**DEVELOPMENT.md**](../DEVELOPMENT.md): что делает скрипт настройки, ручная настройка с реальными сервисами, частые команды, устранение неполадок и сборка десктопного приложения. Процесс участия описан в [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Конфигурация
+
+Настройте скрипты setup, teardown и run для рабочих областей в `.superset/config.json`. См. [полную документацию](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Горячие клавиши настраиваются в **Настройки → Горячие клавиши** (⌘/); см. [полный список сочетаний](https://docs.superset.sh/keyboard-shortcuts).
+
+## Технологический стек
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Приватность по умолчанию
+
+- **Source Available**: полный исходный код доступен на GitHub под лицензией Elastic License 2.0 (ELv2).
+- **Явные подключения**: вы сами выбираете, какие агенты, провайдеры и интеграции подключать.
+
+## Участие в разработке
+
+Мы рады вкладу сообщества! См. [CONTRIBUTING.md](../CONTRIBUTING.md) о том, как настроить окружение и открыть PR. Баги и запросы функций — в [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Сообщество
+
+Присоединяйтесь к сообществу Superset, чтобы получать помощь, делиться отзывами и общаться с другими пользователями:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: общайтесь с командой и сообществом
+- **[Twitter](https://x.com/superset_sh)**: подписывайтесь на обновления и анонсы
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: сообщайте о багах и предлагайте функции
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: задавайте вопросы и делитесь идеями
+
+### Команда
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Лицензия и что бесплатно навсегда
+
+**Десктопное приложение бесплатно навсегда.** Параллельный запуск агентов на собственной машине никогда не потребует оплаты. Всё платное будет необязательным сервисом сверху.
+
+Всё приложение находится в этом репозитории под [Elastic License 2.0](../LICENSE.md): используйте, форкайте, изменяйте, разворачивайте для своей команды. Единственное, что запрещено — переупаковывать сам Superset в сервис и продавать его другим.

--- a/readme/README.tr.md
+++ b/readme/README.tr.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude ve OpenCode, canlı farklarla paralel Superset çalışma alanlarında çalışıyor" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### 100'den Fazla Kodlama Ajanını Paralel Çalıştırın
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Bu, İngilizce README'nin çevirisidir; esas sürüm İngilizce olandır.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex veya herhangi bir CLI ajanı — her biri kendi izole worktree'sinde.<br />
+Zamanınızı beklemeye değil, ürün çıkarmaya ayırın.
+
+<br />
+
+[**macOS için indirin**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Belgeler](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Bağlam Değiştirme Maliyeti Olmadan 10 Kat Hızlı Kod Yazın
+
+Superset, CLI tabanlı kodlama ajanlarını izole git worktree'lerinde paralel çalıştırır; yerleşik terminal, inceleme ve editörde açma iş akışlarıyla birlikte gelir.
+
+- **Birden fazla ajanı aynı anda çalıştırın** — bağlam değiştirme yükü olmadan
+- **Her görevi kendi git worktree'sinde izole edin** — ajanlar birbirine karışmaz
+- **Tüm ajanlarınızı tek yerden izleyin** ve ilgi gerektirdiklerinde bildirim alın
+- **Değişiklikleri hızlıca inceleyip düzenleyin** — yerleşik fark görüntüleyici ve editörle
+- **Herhangi bir çalışma alanını ihtiyacınız olan yerde açın** — tek tıkla editörünüze veya terminalinize devredin
+- **Çalışma alanlarınıza her yerden erişin** — uzak ana bilgisayarlar, CLI, SDK veya MCP üzerinden
+
+Daha az bekleyin, daha çok ürün çıkarın.
+
+## Özellikler
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Paralel Çalışma Alanları
+
+Aynı anda 100'den fazla kodlama ajanı çalıştırın; her biri kendi dalı, terminali ve ortamıyla kendi git worktree'sinde. Sonuçları karşılaştırın ve kazananı merge edin.
+
+[Belgeler →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Diğer ajanlar paralel çalışma alanlarında çalışırken Claude bir faturalama migrasyonunu akış halinde yazıyor" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Ajan İzleme
+
+Her ajanı kenar çubuğundan takip edin: çalışma göstergeleri, tamamlanma sesleri ve bir ajan ilginizi gerektirdiğinde dock rozetleri.
+
+[Belgeler →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Bir ajan görevini bitiriyor ve kenar çubuğundaki durum çalışıyordan tamamlandıya geçiyor" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Yerleşik Terminal
+
+Sekmeler, sınırsız bölmeler, ön ayarlar ve yeniden başlatmalara dayanan kalıcı oturumlar. Çok satırlı düzenleme ve @-dosya bahisleri içeren zengin istem editörü için ⌘I tuşlarına basın.
+
+[Belgeler →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Bölünmüş bir terminalin yanında, zengin istem editöründe @-dosya bahsiyle bir devam mesajı yazılıyor" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Yerleşik Fark Görüntüleyici
+
+Ajan değişikliklerini uygulamadan çıkmadan inceleyin, yorumlayın ve düzenleyin; hazır olduğunda commit ve push yapın.
+
+[Belgeler →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Bir ajanın değişiklikleri fark görüntüleyicide inceleniyor" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Uygulama İçi Tarayıcı ve Portlar
+
+Çalışan geliştirme sunucularını bir tarayıcı bölmesinde önizleyin. Portlar çalışma alanı başına algılanır, böylece her worktree kendi önizlemesine sahip olur.
+
+[Belgeler →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Uygulama içi tarayıcı, algılanan portlarla bir geliştirme sunucusunu önizliyor" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Otomasyonlar
+
+Ajan oturumlarını zamanlamayla çalıştırın: geceleri issue triyajı yapın, haftalık changelog taslağını hazırlayın, bağımlılıkları güncel tutun.
+
+[Belgeler →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Zamanlanmış ajan otomasyonları" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Uzaktan Erişim
+
+Başka bir makineyi bağlayın ve çalışma alanlarına her yerden erişin: masaüstü uygulaması, CLI veya telefonunuz. Çevrimdışı ana bilgisayarları özel bir komutla uyandırın.
+
+[Belgeler →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Organizasyon ayarlarında ana bilgisayarlar ve üyeler" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Herhangi bir kabuktan betikleyin: tek bir ikili dosyayla çalışma alanları oluşturun, ajanlar başlatın, terminallerini okuyun ve otomasyonları yönetin. Bir ajan komut çalıştırabiliyorsa Superset'i de yönetebilir.
+
+[Belgeler →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Superset CLI ile bir çalışma alanı oluşturuluyor ve bir ajan başlatılıyor" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Komut Paleti
+
+Tek bir arama kutusundan herhangi bir çalışma alanına, eyleme veya ayara atlayın.
+
+[Belgeler →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Komut paletine yazılıyor ve çalışma alanı eylemleri canlı filtreleniyor" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Kutudan çıkanlar:**
+
+- **[Yerleşik beceriler](https://docs.superset.sh/skills)**: ajanlar `superset:*` becerileriyle önceden yüklü gelir (paralel ajanları orkestre etme, otomasyon zamanlama, geri bildirim gönderme, sorun teşhisi) ve başlatmada otomatik sağlanır
+- **[Model seçici ve özel ajanlar](https://docs.superset.sh/agent-integration)**: başlatmada model ve akıl yürütme seviyesi seçin, kendi simgesiyle herhangi bir terminal ajanı ekleyin
+- **[Çalışma alanı kurulum betikleri](https://docs.superset.sh/setup-teardown-scripts)**: ortam kurulumunu, bağımlılık yüklemelerini ve geliştirme sunucularını çalışma alanı başına otomatikleştirin
+- **[Terminal ön ayarları](https://docs.superset.sh/terminal-presets)**: ajan ve kabuk düzenlerini kaydedin, tek tuşla açın
+- **[Slack ve Linear](https://docs.superset.sh/use-with-linear)**: Slack mesajlarından veya Linear issue'larından çalışma alanları oluşturun
+- **[IDE'nizde açın](https://docs.superset.sh/use-with-ide)**: tek tıkla Cursor'a, VS Code'a veya herhangi bir editöre devredin
+- **[Özel temalar](https://docs.superset.sh/custom-themes)**: tema dosyaları oluşturun, düzenleyin ve içe aktarın
+- **[Klavye kısayolları](https://docs.superset.sh/keyboard-shortcuts)**: her eylem **Ayarlar → Klavye kısayolları** (⌘/) üzerinden yeniden atanabilir
+- **[Kendi sağlayıcılarınızı getirin](https://docs.superset.sh/providers)**: OpenRouter, Bedrock, Vertex veya Vercel AI Gateway bağlayın
+- **Ve çok daha fazlası**: her gün yeni sürüm çıkarıyoruz, bu yüzden bu liste hep geride kalıyor. Gerçek özellik listesi [changelog](https://superset.sh/changelog) sayfasıdır.
+
+## Desteklenen Ajanlar
+
+Superset, aşağıdakiler dahil CLI tabanlı her kodlama ajanıyla çalışır:
+
+| Ajan | Durum |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Tam destek |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Tam destek |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Tam destek |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Tam destek |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Tam destek |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Tam destek |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Tam destek |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Tam destek |
+| Başka herhangi bir CLI ajanı | Yapılandırma gerektirmeden çalışır |
+
+Bir terminalde çalışıyorsa Superset üzerinde de çalışır
+
+Ajanlar bir terminalden fazlasını elde eder:
+
+- **Model seçici**: bir ajanı başlatırken model ve akıl yürütme seviyesi seçin
+- **Ajan başına ayarlar**: Ayarlar → Ajanlar altında başlatma komutlarını, istem şablonlarını ve model geçersiz kılmalarını ayarlayın
+- **Özel ajanlar**: kendi simgesiyle herhangi bir terminal ajanı ekleyin; yerleşik bir ajan gibi çalışır
+- **Durum ve bildirimler**: çalışma göstergeleri, tamamlanma sesleri ve bir ajan sizi beklediğinde dock rozetleri
+- **Yerleşik sohbet**: bir sohbet bölmesinde modellerle konuşun; satır içi araç onayları ve plan incelemesiyle
+
+## Bir Masaüstü Uygulamasından Fazlası
+
+Her yüzey aynı çalışma alanlarıyla konuşur; bir görevi uygulamada başlatıp her yerden kontrol edebilirsiniz.
+
+| Yüzey | Ne elde edersiniz |
+|:--------|:-------------|
+| [**Masaüstü Uygulaması**](https://github.com/superset-sh/superset/releases/latest) | Eksiksiz IDE: terminaller, fark görüntüleyici, uygulama içi tarayıcı, otomasyonlar |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Herhangi bir kabuktan çalışma alanlarını, ajanları, terminalleri ve ana bilgisayarları yönetmek için tek bir `superset` ikili dosyası |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Node, Bun veya Deno üzerinden [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) ile Superset'i programatik olarak yönetin |
+| [**MCP Sunucusu**](https://docs.superset.sh/mcp) | Claude Code, Codex, Cursor ve diğer ajanların çalışma alanlarını kendilerinin oluşturup yönetmesine izin verin |
+
+CLI, masaüstü uygulamasıyla birlikte gelir; tek başına da kurabilirsiniz:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Ajanlarınızı telefonunuzdan kontrol edebilmeniz için bir iOS uygulaması da yakında geliyor.
+
+## Kurulum
+
+Masaüstü uygulamasını indirin:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (deneysel; birincil hedef macOS)
+- **Windows**: henüz mevcut değil
+- [Tüm derlemeler](https://github.com/superset-sh/superset/releases/latest)
+
+Kurulu olması gereken tek şey [Git](https://git-scm.com/). [gh](https://cli.github.com/) isteğe bağlıdır ve PR iş akışlarının kilidini açar; Superset sizin için kurmayı önerir.
+
+## Geliştirme
+
+Superset üzerinde çalışmak veya bir PR ile katkıda bulunmak mı istiyorsunuz? Depoyu klonlayın,
+kurulu Superset uygulamasına ekleyin ve değişikliğiniz için bir çalışma alanı oluşturun:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Ardından o çalışma alanı terminalinden geliştirme kurulumunu çalıştırın:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+`setup.local.sh` betiğini her yeni worktree'de bir kez çalıştırın. Betik, çalışma alanına özgü
+uygulama kimliğini ve portları yapılandırır; böylece geliştirme masaüstü uygulaması, kurulu
+Superset uygulaması ve diğer geliştirme worktree'leriyle yan yana çalışabilir.
+
+Neon hesabı veya üçüncü taraf kimlik bilgileri gerekmez. `setup.local.sh`, Docker üzerinden
+yerel bir Postgres + Electric yığını başlatır ve bir geliştirme hesabı oluşturur.
+**"Sign in as dev"** düğmesiyle (veya `admin@local.test` / `supersetdev`) oturum açın.
+
+Önkoşullar: [Bun](https://bun.sh/) v1.3.14+ (`.bun-version` dosyasında sabitlenmiştir), `docker`, `jq` ve `bun dev` komutunun yerel HTTPS proxy'si olarak çalıştırdığı `caddy` (`brew install jq caddy && caddy trust`).
+
+Tam kılavuz için [**DEVELOPMENT.md**](../DEVELOPMENT.md) dosyasına bakın: kurulum betiğinin ne yaptığı, gerçek servislerle manuel kurulum, yaygın komutlar, sorun giderme ve masaüstü uygulamasının nasıl derleneceği. Katkı süreci [**CONTRIBUTING.md**](../CONTRIBUTING.md) dosyasındadır.
+
+## Yapılandırma
+
+Çalışma alanı kurulum, kaldırma ve çalıştırma betiklerini `.superset/config.json` dosyasında yapılandırın. [Tam belgelere](https://docs.superset.sh/setup-teardown-scripts) bakın.
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Klavye kısayolları **Ayarlar → Klavye kısayolları** (⌘/) üzerinden özelleştirilebilir; [tam kısayol listesine](https://docs.superset.sh/keyboard-shortcuts) bakın.
+
+## Teknoloji Yığını
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Varsayılan Olarak Gizli
+
+- **Source Available**: kaynak kodun tamamı Elastic License 2.0 (ELv2) altında GitHub'dadır.
+- **Açık Bağlantılar**: hangi ajanları, sağlayıcıları ve entegrasyonları bağlayacağınızı siz seçersiniz.
+
+## Katkıda Bulunma
+
+Katkılarınızı bekliyoruz! Kurulum ve PR açma adımları için [CONTRIBUTING.md](../CONTRIBUTING.md) dosyasına bakın. Hatalar ve özellik istekleri [issues](https://github.com/superset-sh/superset/issues) sayfasına gider.
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Topluluk
+
+Yardım almak, geri bildirim paylaşmak ve diğer kullanıcılarla bağlantı kurmak için Superset topluluğuna katılın:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: ekiple ve toplulukla sohbet edin
+- **[Twitter](https://x.com/superset_sh)**: güncellemeler ve duyurular için takip edin
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: hata bildirin ve özellik isteyin
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: soru sorun ve fikirlerinizi paylaşın
+
+### Ekip
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Lisans ve Sonsuza Kadar Ücretsiz Olanlar
+
+**Masaüstü uygulaması sonsuza kadar ücretsizdir.** Kendi makinenizde ajanları paralel çalıştırmak hiçbir zaman ödeme gerektirmeyecek. Ücretlendireceğimiz her şey, bunun üzerine isteğe bağlı bir hizmet olacak.
+
+Uygulamanın tamamı bu depoda [Elastic License 2.0](../LICENSE.md) altındadır: kullanın, fork edin, değiştirin, ekibiniz için kendiniz barındırın. Tek yasak, Superset'in kendisini başkalarına sattığınız bir hizmet olarak yeniden paketlemektir.

--- a/readme/README.vi.md
+++ b/readme/README.vi.md
@@ -1,0 +1,346 @@
+<div align="center">
+
+<img width="full" alt="Claude và OpenCode làm việc song song trong các workspace Superset với diff trực tiếp" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### Chạy song song 100+ coding agent
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*Đây là bản dịch của README tiếng Anh; bản tiếng Anh là bản chuẩn.*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code, Codex, hay bất kỳ CLI agent nào, mỗi agent trong một worktree cách ly riêng.<br />
+Dành thời gian để ship, không phải để chờ.
+
+<br />
+
+[**Tải về cho macOS**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [Tài liệu](https://docs.superset.sh) &nbsp;&bull;&nbsp; [Changelog](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## Code nhanh gấp 10 lần mà không tốn chi phí chuyển ngữ cảnh
+
+Superset chạy song song các coding agent dạng CLI trong những git worktree cách ly, với terminal, review và luồng mở-trong-editor tích hợp sẵn.
+
+- **Chạy nhiều agent cùng lúc** mà không mất công chuyển ngữ cảnh
+- **Cách ly từng tác vụ** trong git worktree riêng để các agent không giẫm chân nhau
+- **Theo dõi mọi agent** từ một nơi và nhận thông báo khi chúng cần bạn chú ý
+- **Xem và sửa thay đổi nhanh chóng** với trình xem diff và editor tích hợp
+- **Mở bất kỳ workspace nào ở nơi bạn cần** — bàn giao một cú nhấp sang editor hoặc terminal của bạn
+- **Truy cập workspace của bạn từ bất cứ đâu** qua host từ xa, CLI, SDK hoặc MCP
+
+Chờ ít hơn, ship nhiều hơn.
+
+## Tính năng
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### Workspace song song
+
+Chạy 100+ coding agent cùng lúc, mỗi agent trong một git worktree riêng với nhánh, terminal và môi trường riêng. So sánh kết quả và merge phương án thắng cuộc.
+
+[Tài liệu →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude đang stream một cuộc migration billing trong khi các agent khác chạy ở những workspace song song" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Giám sát agent
+
+Theo dõi từng agent từ thanh bên, với chỉ báo đang làm việc, âm báo hoàn thành và badge trên Dock khi có agent cần bạn chú ý.
+
+[Tài liệu →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="Một agent hoàn thành tác vụ và trạng thái trên thanh bên chuyển từ đang làm việc sang xong" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Terminal tích hợp
+
+Tab, chia màn hình không giới hạn, preset và các phiên bền vững sống sót qua khởi động lại. Nhấn ⌘I để mở trình soạn prompt phong phú với chỉnh sửa nhiều dòng và nhắc file bằng @.
+
+[Tài liệu →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="Gõ câu hỏi tiếp theo với một lượt nhắc file bằng @ trong trình soạn prompt phong phú cạnh terminal được chia đôi" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Trình xem diff tích hợp
+
+Kiểm tra, bình luận và chỉnh sửa thay đổi của agent mà không cần rời ứng dụng, rồi commit và push khi đã sẵn sàng.
+
+[Tài liệu →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="Review thay đổi của một agent trong trình xem diff" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Trình duyệt trong ứng dụng & cổng
+
+Xem trước các dev server đang chạy trong một khung trình duyệt. Cổng được phát hiện theo từng workspace, nên mỗi worktree có bản xem trước riêng.
+
+[Tài liệu →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="Trình duyệt trong ứng dụng xem trước một dev server với các cổng được phát hiện" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Tự động hóa
+
+Chạy các phiên agent theo lịch: phân loại issue qua đêm, soạn changelog hàng tuần, giữ dependency luôn mới.
+
+[Tài liệu →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="Các tự động hóa agent theo lịch" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Truy cập từ xa
+
+Kết nối một máy khác và truy cập workspace của nó từ bất cứ đâu: ứng dụng desktop, CLI hoặc điện thoại của bạn. Đánh thức host đang offline bằng lệnh tùy chỉnh.
+
+[Tài liệu →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="Host và thành viên trong cài đặt tổ chức" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+Viết script từ bất kỳ shell nào: tạo workspace, khởi chạy agent, đọc terminal của chúng và quản lý tự động hóa với một binary duy nhất. Nếu một agent chạy được lệnh, nó điều khiển được Superset.
+
+[Tài liệu →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="Tạo một workspace và khởi chạy một agent từ Superset CLI" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Bảng lệnh
+
+Nhảy đến bất kỳ workspace, hành động hay cài đặt nào từ một ô tìm kiếm duy nhất.
+
+[Tài liệu →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="Gõ trong bảng lệnh và lọc trực tiếp các hành động của workspace" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**Cũng có sẵn trong hộp:**
+
+- **[Skill tích hợp](https://docs.superset.sh/skills)**: agent được nạp sẵn các skill `superset:*` (điều phối agent song song, lên lịch tự động hóa, gửi phản hồi, chẩn đoán sự cố), được cung cấp tự động khi khởi chạy
+- **[Bộ chọn model & agent tùy chỉnh](https://docs.superset.sh/agent-integration)**: chọn model và mức độ suy luận khi khởi chạy, và thêm bất kỳ terminal agent nào với icon riêng
+- **[Script thiết lập workspace](https://docs.superset.sh/setup-teardown-scripts)**: tự động hóa thiết lập env, cài đặt dependency và dev server cho từng workspace
+- **[Preset terminal](https://docs.superset.sh/terminal-presets)**: lưu bố cục agent và shell rồi mở chúng bằng một phím bấm
+- **[Slack & Linear](https://docs.superset.sh/use-with-linear)**: tạo workspace từ tin nhắn Slack hoặc issue Linear
+- **[Mở trong IDE của bạn](https://docs.superset.sh/use-with-ide)**: bàn giao một cú nhấp sang Cursor, VS Code hoặc bất kỳ editor nào
+- **[Theme tùy chỉnh](https://docs.superset.sh/custom-themes)**: tạo, chỉnh sửa và nhập file theme
+- **[Phím tắt](https://docs.superset.sh/keyboard-shortcuts)**: mọi hành động đều gán lại được qua **Cài đặt → Phím tắt** (⌘/)
+- **[Mang provider của riêng bạn](https://docs.superset.sh/providers)**: kết nối OpenRouter, Bedrock, Vertex hoặc Vercel AI Gateway
+- **Và còn nhiều nữa**: chúng tôi ship hàng ngày, nên danh sách này luôn bị tụt hậu. [Changelog](https://superset.sh/changelog) mới là danh sách tính năng thật sự.
+
+## Các agent được hỗ trợ
+
+Superset hoạt động với bất kỳ coding agent dạng CLI nào, bao gồm:
+
+| Agent | Trạng thái |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | Hỗ trợ đầy đủ |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | Hỗ trợ đầy đủ |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | Hỗ trợ đầy đủ |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | Hỗ trợ đầy đủ |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | Hỗ trợ đầy đủ |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | Hỗ trợ đầy đủ |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Hỗ trợ đầy đủ |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | Hỗ trợ đầy đủ |
+| Bất kỳ CLI agent nào khác | Hoạt động không cần cấu hình |
+
+Nếu nó chạy được trong terminal, nó chạy được trên Superset
+
+Agent nhận được nhiều hơn một chiếc terminal:
+
+- **Bộ chọn model**: chọn model và mức độ suy luận khi bạn khởi chạy agent
+- **Cài đặt theo từng agent**: tinh chỉnh lệnh khởi chạy, mẫu prompt và ghi đè model trong Cài đặt → Agent
+- **Agent tùy chỉnh**: thêm bất kỳ terminal agent nào với icon riêng và nó hoạt động như agent tích hợp sẵn
+- **Trạng thái và thông báo**: chỉ báo đang làm việc, âm báo hoàn thành và badge trên Dock khi một agent cần bạn
+- **Chat tích hợp**: trò chuyện với các model trong khung chat, với phê duyệt công cụ inline và review kế hoạch
+
+## Nhiều hơn một ứng dụng desktop
+
+Mọi bề mặt đều nói chuyện với cùng những workspace, nên bạn có thể bắt đầu một tác vụ trong ứng dụng và theo dõi nó từ bất cứ đâu.
+
+| Bề mặt | Bạn nhận được gì |
+|:--------|:-------------|
+| [**Ứng dụng desktop**](https://github.com/superset-sh/superset/releases/latest) | IDE đầy đủ: terminal, trình xem diff, trình duyệt trong ứng dụng, tự động hóa |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | Một binary `superset` duy nhất để quản lý workspace, agent, terminal và host từ bất kỳ shell nào |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | Điều khiển Superset bằng lập trình với [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) từ Node, Bun hoặc Deno |
+| [**MCP Server**](https://docs.superset.sh/mcp) | Để Claude Code, Codex, Cursor và các agent khác tự tạo và quản lý workspace |
+
+CLI được đóng gói kèm ứng dụng desktop, hoặc cài riêng:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+Ứng dụng iOS sẽ sớm ra mắt để bạn theo dõi các agent từ điện thoại.
+
+## Cài đặt
+
+Tải ứng dụng desktop:
+
+- **macOS**: [Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**: [x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage) (thử nghiệm; macOS là nền tảng chính)
+- **Windows**: chưa có
+- [Tất cả các bản build](https://github.com/superset-sh/superset/releases/latest)
+
+Tất cả những gì bạn cần cài là [Git](https://git-scm.com/). [gh](https://cli.github.com/) là tùy chọn và mở khóa các luồng làm việc PR; Superset sẽ đề nghị cài nó cho bạn.
+
+## Phát triển
+
+Muốn vọc Superset hay đóng góp một PR? Clone repository, thêm nó vào
+ứng dụng Superset đã cài, rồi tạo một workspace cho thay đổi của bạn:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+Sau đó chạy thiết lập phát triển từ terminal của workspace đó:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+Chạy `setup.local.sh` một lần trong mỗi worktree mới. Nó cấu hình danh tính ứng dụng
+và cổng riêng cho từng workspace để ứng dụng desktop bản phát triển có thể chạy
+song song với ứng dụng Superset đã cài và các worktree phát triển khác.
+
+Không cần tài khoản Neon hay thông tin xác thực bên thứ ba. `setup.local.sh` dựng
+một stack Postgres + Electric cục bộ qua Docker và seed sẵn một tài khoản dev. Đăng nhập
+bằng nút **"Sign in as dev"** (hoặc `admin@local.test` / `supersetdev`).
+
+Yêu cầu trước: [Bun](https://bun.sh/) v1.3.14+ (ghim trong `.bun-version`), `docker`, `jq` và `caddy`, thứ mà `bun dev` chạy làm proxy HTTPS cục bộ (`brew install jq caddy && caddy trust`).
+
+Xem [**DEVELOPMENT.md**](../DEVELOPMENT.md) để có hướng dẫn đầy đủ: script thiết lập làm gì, thiết lập thủ công với dịch vụ thật, các lệnh thường dùng, xử lý sự cố và cách build ứng dụng desktop. Quy trình đóng góp nằm trong [**CONTRIBUTING.md**](../CONTRIBUTING.md).
+
+## Cấu hình
+
+Cấu hình các script setup, teardown và run của workspace trong `.superset/config.json`. Xem [tài liệu đầy đủ](https://docs.superset.sh/setup-teardown-scripts).
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+Phím tắt có thể tùy chỉnh qua **Cài đặt → Phím tắt** (⌘/); xem [danh sách phím tắt đầy đủ](https://docs.superset.sh/keyboard-shortcuts).
+
+## Công nghệ sử dụng
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## Riêng tư theo mặc định
+
+- **Mã nguồn công khai**: toàn bộ mã nguồn ở trên GitHub theo giấy phép Elastic License 2.0 (ELv2).
+- **Kết nối tường minh**: bạn tự chọn agent, provider và tích hợp nào được kết nối.
+
+## Đóng góp
+
+Chúng tôi hoan nghênh mọi đóng góp! Xem [CONTRIBUTING.md](../CONTRIBUTING.md) để biết cách thiết lập và mở một PR. Bug và yêu cầu tính năng gửi vào [issues](https://github.com/superset-sh/superset/issues).
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## Cộng đồng
+
+Tham gia cộng đồng Superset để được trợ giúp, chia sẻ phản hồi và kết nối với những người dùng khác:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**: trò chuyện với đội ngũ và cộng đồng
+- **[Twitter](https://x.com/superset_sh)**: theo dõi để nhận cập nhật và thông báo
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**: báo bug và yêu cầu tính năng
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**: đặt câu hỏi và chia sẻ ý tưởng
+
+### Đội ngũ
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## Giấy phép & những gì miễn phí mãi mãi
+
+**Ứng dụng desktop miễn phí mãi mãi.** Chạy song song các agent trên máy của chính bạn sẽ không bao giờ phải trả tiền. Bất cứ thứ gì chúng tôi thu phí sẽ là dịch vụ tùy chọn nằm bên trên.
+
+Toàn bộ ứng dụng nằm trong repo này theo giấy phép [Elastic License 2.0](../LICENSE.md): cứ dùng, fork, chỉnh sửa, tự host cho đội ngũ của bạn. Điều duy nhất không được phép là đóng gói lại chính Superset thành dịch vụ bạn bán cho người khác.

--- a/readme/README.zh-CN.md
+++ b/readme/README.zh-CN.md
@@ -1,0 +1,341 @@
+<div align="center">
+
+<img width="full" alt="Claude 与 OpenCode 在并行的 Superset 工作区中工作并实时显示差异" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### 并行运行 100+ 个编码智能体
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*本文档是英文版 README 的翻译,内容以英文版为准。*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code、Codex 或任何 CLI 智能体,各自运行在独立的 worktree 中。<br />
+把时间花在交付上,而不是等待上。
+
+<br />
+
+[**下载 macOS 版**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [文档](https://docs.superset.sh) &nbsp;&bull;&nbsp; [更新日志](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## 零切换成本,编码快 10 倍
+
+Superset 在相互隔离的 git worktree 中并行运行基于 CLI 的编码智能体,并内置终端、审查和在编辑器中打开的工作流。
+
+- **同时运行多个智能体**,没有上下文切换的开销
+- **将每个任务隔离**在独立的 git worktree 中,智能体之间互不干扰
+- **在一个地方监控所有智能体**,需要你介入时会收到通知
+- **快速审查和编辑更改**,使用内置的差异查看器和编辑器
+- **在任何需要的地方打开工作区**,一键交接到你的编辑器或终端
+- **随时随地访问你的工作区**,通过远程主机、CLI、SDK 或 MCP
+
+少等待,多交付。
+
+## 功能
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### 并行工作区
+
+一次运行 100+ 个编码智能体,每个都在自己的 git worktree 中,拥有独立的分支、终端和环境。比较结果,合并最优方案。
+
+[文档 →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude 正在流式输出一次计费迁移,其他智能体在并行工作区中运行" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 智能体监控
+
+从侧边栏跟踪每个智能体,配有工作指示器、完成提示音,以及需要你介入时的 Dock 徽标。
+
+[文档 →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="一个智能体完成任务,侧边栏状态从工作中切换为已完成" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 内置终端
+
+标签页、无限分屏、预设,以及在重启后依然保留的持久会话。按 ⌘I 打开富文本提示词编辑器,支持多行编辑和 @ 文件提及。
+
+[文档 →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="在分屏终端旁的富文本提示词编辑器中输入带 @ 文件提及的后续指令" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 内置差异查看器
+
+无需离开应用即可检查、评论和编辑智能体的更改,准备就绪后提交并推送。
+
+[文档 →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="在差异查看器中审查智能体的更改" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 应用内浏览器与端口
+
+在浏览器窗格中预览正在运行的开发服务器。端口按工作区检测,每个 worktree 都有自己的预览。
+
+[文档 →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="应用内浏览器预览开发服务器并显示检测到的端口" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 自动化
+
+按计划运行智能体会话:夜间分诊 issue、起草每周更新日志、保持依赖最新。
+
+[文档 →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="按计划运行的智能体自动化" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 远程访问
+
+连接另一台机器,随时随地访问它的工作区:桌面应用、CLI 或手机。用自定义命令唤醒离线主机。
+
+[文档 →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="组织设置中的主机与成员" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+在任何 shell 中编写脚本:用单个二进制文件创建工作区、启动智能体、读取它们的终端、管理自动化。只要智能体能运行命令,它就能驱动 Superset。
+
+[文档 →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="通过 Superset CLI 创建工作区并启动智能体" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 命令面板
+
+在一个搜索框中跳转到任何工作区、操作或设置。
+
+[文档 →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="在命令面板中输入并实时筛选工作区操作" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**开箱即用的还有:**
+
+- **[内置技能](https://docs.superset.sh/skills)**:智能体预装 `superset:*` 技能(编排并行智能体、安排自动化、提交反馈、诊断问题),启动时自动配置
+- **[模型选择器与自定义智能体](https://docs.superset.sh/agent-integration)**:启动时选择模型和推理力度,并可为任何终端智能体添加专属图标
+- **[工作区设置脚本](https://docs.superset.sh/setup-teardown-scripts)**:按工作区自动化环境配置、依赖安装和开发服务器
+- **[终端预设](https://docs.superset.sh/terminal-presets)**:保存智能体和 shell 布局,一键打开
+- **[Slack 与 Linear](https://docs.superset.sh/use-with-linear)**:从 Slack 消息或 Linear issue 直接创建工作区
+- **[在你的 IDE 中打开](https://docs.superset.sh/use-with-ide)**:一键交接到 Cursor、VS Code 或任何编辑器
+- **[自定义主题](https://docs.superset.sh/custom-themes)**:构建、编辑和导入主题文件
+- **[键盘快捷键](https://docs.superset.sh/keyboard-shortcuts)**:每个操作都可通过**设置 → 键盘快捷键**(⌘/)重新映射
+- **[自带提供商](https://docs.superset.sh/providers)**:连接 OpenRouter、Bedrock、Vertex 或 Vercel AI Gateway
+- **还有更多**:我们每天发布新版本,这份列表永远落后于实际。真正的功能列表是[更新日志](https://superset.sh/changelog)。
+
+## 支持的智能体
+
+Superset 适用于任何基于 CLI 的编码智能体,包括:
+
+| 智能体 | 状态 |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | 完全支持 |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | 完全支持 |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | 完全支持 |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | 完全支持 |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | 完全支持 |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | 完全支持 |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | 完全支持 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | 完全支持 |
+| 任何其他 CLI 智能体 | 无需配置即可使用 |
+
+只要能在终端里运行,就能在 Superset 上运行
+
+智能体得到的不只是一个终端:
+
+- **模型选择器**:启动智能体时选择模型和推理力度
+- **按智能体设置**:在设置 → 智能体中调整启动命令、提示词模板和模型覆盖
+- **自定义智能体**:添加任何终端智能体并配上专属图标,它就像内置的一样工作
+- **状态与通知**:工作指示器、完成提示音,以及智能体需要你时的 Dock 徽标
+- **内置聊天**:在聊天窗格中与模型对话,支持内联工具批准和计划审查
+
+## 不只是一个桌面应用
+
+每个界面都连接到同样的工作区,你可以在应用里开始一个任务,然后在任何地方查看进展。
+
+| 界面 | 你能得到什么 |
+|:--------|:-------------|
+| [**桌面应用**](https://github.com/superset-sh/superset/releases/latest) | 完整的 IDE:终端、差异查看器、应用内浏览器、自动化 |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | 单个 `superset` 二进制文件,在任何 shell 中管理工作区、智能体、终端和主机 |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | 通过 [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) 在 Node、Bun 或 Deno 中以编程方式驱动 Superset |
+| [**MCP 服务器**](https://docs.superset.sh/mcp) | 让 Claude Code、Codex、Cursor 等智能体自己创建和管理工作区 |
+
+CLI 随桌面应用一起提供,也可以独立安装:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+iOS 应用即将推出,让你可以在手机上查看你的智能体。
+
+## 安装
+
+下载桌面应用:
+
+- **macOS**:[Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**:[x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage)(实验性;macOS 是主要目标平台)
+- **Windows**:暂不可用
+- [所有构建版本](https://github.com/superset-sh/superset/releases/latest)
+
+你只需要安装 [Git](https://git-scm.com/)。[gh](https://cli.github.com/) 是可选的,用于解锁 PR 工作流;Superset 会主动提议为你安装。
+
+## 开发
+
+想折腾 Superset 或贡献一个 PR?克隆仓库,把它添加到已安装的 Superset 应用中,然后为你的更改创建一个工作区:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+然后在该工作区的终端中运行开发环境设置:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+在每个新 worktree 中运行一次 `setup.local.sh`。它会配置工作区专属的应用标识和端口,让开发版桌面应用可以与已安装的 Superset 应用及其他开发 worktree 并行运行。
+
+无需 Neon 账号或第三方凭据。`setup.local.sh` 会通过 Docker 启动本地 Postgres + Electric 栈并植入一个开发账号。用 **"Sign in as dev"** 按钮(或 `admin@local.test` / `supersetdev`)登录即可。
+
+前置条件:[Bun](https://bun.sh/) v1.3.14+(固定在 `.bun-version` 中)、`docker`、`jq` 和 `caddy`,`bun dev` 会将 `caddy` 作为本地 HTTPS 代理运行(`brew install jq caddy && caddy trust`)。
+
+完整指南见 [**DEVELOPMENT.md**](../DEVELOPMENT.md):设置脚本做了什么、针对真实服务的手动设置、常用命令、故障排查,以及如何构建桌面应用。贡献流程见 [**CONTRIBUTING.md**](../CONTRIBUTING.md)。
+
+## 配置
+
+在 `.superset/config.json` 中配置工作区的设置、清理和运行脚本。参见[完整文档](https://docs.superset.sh/setup-teardown-scripts)。
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+键盘快捷键可通过**设置 → 键盘快捷键**(⌘/)自定义;参见[完整快捷键列表](https://docs.superset.sh/keyboard-shortcuts)。
+
+## 技术栈
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## 默认私密
+
+- **源码可见**:完整源码以 Elastic License 2.0(ELv2)许可发布在 GitHub 上。
+- **显式连接**:由你决定连接哪些智能体、提供商和集成。
+
+## 贡献
+
+我们欢迎贡献!参见 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解如何搭建环境并提交 PR。Bug 和功能请求请提交到 [issues](https://github.com/superset-sh/superset/issues)。
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## 社区
+
+加入 Superset 社区,获取帮助、分享反馈,并与其他用户交流:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**:与团队和社区聊天
+- **[Twitter](https://x.com/superset_sh)**:关注以获取更新和公告
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**:报告 bug 和请求功能
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**:提问和分享想法
+
+### 团队
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## 许可与永久免费的部分
+
+**桌面应用永久免费。**在你自己的机器上并行运行智能体永远不需要付费。我们收费的任何东西都会是在此之上的可选服务。
+
+整个应用都在这个仓库中,采用 [Elastic License 2.0](../LICENSE.md) 许可:使用它、fork 它、修改它、为你的团队自托管它,都可以。唯一不允许的,是把 Superset 本身重新打包成服务卖给他人。

--- a/readme/README.zh-TW.md
+++ b/readme/README.zh-TW.md
@@ -1,0 +1,341 @@
+<div align="center">
+
+<img width="full" alt="Claude 與 OpenCode 在平行的 Superset 工作區中工作並即時顯示差異" src="../apps/marketing/public/images/readme-hero.gif" />
+
+### 平行執行 100+ 個編碼代理程式
+
+[English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+*本文件為英文版 README 的翻譯,內容以英文版為準。*
+
+[![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)
+[![License](https://img.shields.io/badge/license-Elastic%20License%202.0-blue?style=flat)](../LICENSE.md)
+[![Twitter](https://img.shields.io/badge/@superset__sh-555?logo=x)](https://x.com/superset_sh)
+[![Discord](https://img.shields.io/badge/Discord-555?logo=discord)](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+Claude Code、Codex 或任何 CLI 代理程式,各自執行在獨立的 worktree 中。<br />
+把時間花在交付上,而不是等待上。
+
+<br />
+
+[**下載 macOS 版**](https://github.com/superset-sh/superset/releases/latest) &nbsp;&bull;&nbsp; [文件](https://docs.superset.sh) &nbsp;&bull;&nbsp; [更新日誌](https://github.com/superset-sh/superset/releases) &nbsp;&bull;&nbsp; [Discord](https://discord.gg/cZeD9WYcV7)
+
+<br />
+
+
+</div>
+
+## 零切換成本,寫程式快 10 倍
+
+Superset 在相互隔離的 git worktree 中平行執行以 CLI 為基礎的編碼代理程式,並內建終端、審查以及在編輯器中開啟的工作流程。
+
+- **同時執行多個代理程式**,沒有情境切換的負擔
+- **將每項任務隔離**在獨立的 git worktree 中,代理程式之間互不干擾
+- **在同一個地方監控所有代理程式**,需要你介入時會收到通知
+- **快速審查與編輯變更**,使用內建的差異檢視器和編輯器
+- **在任何需要的地方開啟工作區**,一鍵交接到你的編輯器或終端
+- **隨時隨地存取你的工作區**,透過遠端主機、CLI、SDK 或 MCP
+
+少等待,多交付。
+
+## 功能
+
+<table>
+<tr>
+<td width="50%" valign="middle">
+
+### 平行工作區
+
+一次執行 100+ 個編碼代理程式,每個都在自己的 git worktree 中,擁有獨立的分支、終端和環境。比較結果,合併最佳方案。
+
+[文件 →](https://docs.superset.sh/workspaces)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/workspaces"><img src="../apps/marketing/public/images/readme/agents-working.gif" alt="Claude 正在串流輸出一次計費系統遷移,其他代理程式在平行工作區中執行" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 代理程式監控
+
+從側邊欄追蹤每個代理程式,搭配工作指示器、完成提示音,以及需要你介入時的 Dock 徽章。
+
+[文件 →](https://docs.superset.sh/agent-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/agent-integration"><img src="../apps/marketing/public/images/readme/agent-monitoring.gif" alt="一個代理程式完成任務,側邊欄狀態從工作中切換為已完成" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 內建終端
+
+分頁、無限分割、預設,以及重新啟動後依然保留的持續性工作階段。按 ⌘I 開啟富文字提示編輯器,支援多行編輯和 @ 檔案提及。
+
+[文件 →](https://docs.superset.sh/terminal-integration)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/terminal-integration"><img src="../apps/marketing/public/images/readme/terminal.gif" alt="在分割終端旁的富文字提示編輯器中輸入帶 @ 檔案提及的後續指令" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 內建差異檢視器
+
+不必離開應用程式即可檢視、評論和編輯代理程式的變更,準備就緒後提交並推送。
+
+[文件 →](https://docs.superset.sh/diff-viewer)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/diff-viewer"><img src="../apps/marketing/public/images/readme/diff-viewer.png" alt="在差異檢視器中審查代理程式的變更" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 應用程式內瀏覽器與連接埠
+
+在瀏覽器窗格中預覽正在執行的開發伺服器。連接埠依工作區偵測,每個 worktree 都有自己的預覽。
+
+[文件 →](https://docs.superset.sh/browser)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/browser"><img src="../apps/marketing/public/images/readme/browser-ports.png" alt="應用程式內瀏覽器預覽開發伺服器並顯示偵測到的連接埠" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 自動化
+
+依排程執行代理程式工作階段:夜間分類 issue、草擬每週更新日誌、讓相依套件保持最新。
+
+[文件 →](https://docs.superset.sh/automations)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/automations"><img src="../apps/marketing/public/images/readme/automations.png" alt="依排程執行的代理程式自動化" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 遠端存取
+
+連接另一台機器,隨時隨地存取它的工作區:桌面應用程式、CLI 或手機。用自訂命令喚醒離線主機。
+
+[文件 →](https://docs.superset.sh/remote-access)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/remote-access"><img src="../apps/docs/public/images/remote-workspaces-hosts-members.png" alt="組織設定中的主機與成員" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### Superset CLI
+
+在任何 shell 中撰寫指令碼:用單一執行檔建立工作區、啟動代理程式、讀取它們的終端、管理自動化。只要代理程式能執行命令,它就能操作 Superset。
+
+[文件 →](https://docs.superset.sh/cli/getting-started)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/cli/getting-started"><img src="../apps/marketing/public/images/readme/cli-demo.gif" alt="透過 Superset CLI 建立工作區並啟動代理程式" width="100%" /></a>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="middle">
+
+### 命令面板
+
+在同一個搜尋框中跳轉到任何工作區、動作或設定。
+
+[文件 →](https://docs.superset.sh/keyboard-shortcuts)
+
+</td>
+<td width="50%">
+  <a href="https://docs.superset.sh/keyboard-shortcuts"><img src="../apps/marketing/public/images/readme/command-palette.gif" alt="在命令面板中輸入並即時篩選工作區動作" width="100%" /></a>
+</td>
+</tr>
+</table>
+
+**隨附的還有:**
+
+- **[內建技能](https://docs.superset.sh/skills)**:代理程式預載 `superset:*` 技能(協調平行代理程式、排程自動化、回報意見、診斷問題),啟動時自動佈建
+- **[模型選擇器與自訂代理程式](https://docs.superset.sh/agent-integration)**:啟動時選擇模型和推理力度,並可為任何終端代理程式加上專屬圖示
+- **[工作區設定指令碼](https://docs.superset.sh/setup-teardown-scripts)**:依工作區自動化環境設定、相依套件安裝和開發伺服器
+- **[終端預設](https://docs.superset.sh/terminal-presets)**:儲存代理程式和 shell 版面配置,一鍵開啟
+- **[Slack 與 Linear](https://docs.superset.sh/use-with-linear)**:從 Slack 訊息或 Linear issue 直接建立工作區
+- **[在你的 IDE 中開啟](https://docs.superset.sh/use-with-ide)**:一鍵交接到 Cursor、VS Code 或任何編輯器
+- **[自訂佈景主題](https://docs.superset.sh/custom-themes)**:建立、編輯和匯入佈景主題檔案
+- **[鍵盤快速鍵](https://docs.superset.sh/keyboard-shortcuts)**:每個動作都可透過**設定 → 鍵盤快速鍵**(⌘/)重新對應
+- **[自帶供應商](https://docs.superset.sh/providers)**:連接 OpenRouter、Bedrock、Vertex 或 Vercel AI Gateway
+- **還有更多**:我們每天出貨,這份清單永遠落後於實際。真正的功能清單是[更新日誌](https://superset.sh/changelog)。
+
+## 支援的代理程式
+
+Superset 適用於任何以 CLI 為基礎的編碼代理程式,包括:
+
+| 代理程式 | 狀態 |
+|:------|:-------|
+| <img height="16" align="top" alt="Amp Code" src="../packages/ui/src/assets/icons/preset-icons/amp.svg" /> &nbsp;[Amp Code](https://ampcode.com/) | 完整支援 |
+| <img height="16" align="top" alt="Antigravity" src="../packages/ui/src/assets/icons/preset-icons/antigravity.svg" /> &nbsp;[Antigravity CLI](https://antigravity.google/) | 完整支援 |
+| <img height="16" align="top" alt="Claude Code" src="../packages/ui/src/assets/icons/preset-icons/claude.svg" /> &nbsp;[Claude Code](https://github.com/anthropics/claude-code) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/codex-white.svg" /><img height="16" align="top" alt="OpenAI Codex CLI" src="../packages/ui/src/assets/icons/preset-icons/codex.svg" /></picture> &nbsp;[OpenAI Codex CLI](https://github.com/openai/codex) | 完整支援 |
+| <img height="16" align="top" alt="Cursor Agent" src="../packages/ui/src/assets/icons/preset-icons/cursor.svg" /> &nbsp;[Cursor Agent](https://docs.cursor.com/agent) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/droid-white.svg" /><img height="16" align="top" alt="Droid" src="../packages/ui/src/assets/icons/preset-icons/droid.svg" /></picture> &nbsp;[Droid](https://www.factory.ai/) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/fx-white.svg" /><img height="16" align="top" alt="fx" src="../packages/ui/src/assets/icons/preset-icons/fx.svg" /></picture> &nbsp;[fx](https://fx.sh/) | 完整支援 |
+| <img height="16" align="top" alt="Gemini CLI" src="../packages/ui/src/assets/icons/preset-icons/gemini.svg" /> &nbsp;[Gemini CLI](https://github.com/google-gemini/gemini-cli) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/copilot-white.svg" /><img height="16" align="top" alt="GitHub Copilot" src="../packages/ui/src/assets/icons/preset-icons/copilot.svg" /></picture> &nbsp;[GitHub Copilot](https://github.com/features/copilot) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/grok-white.svg" /><img height="16" align="top" alt="Grok" src="../packages/ui/src/assets/icons/preset-icons/grok.svg" /></picture> &nbsp;[Grok](https://x.ai/) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/hermes-white.svg" /><img height="16" align="top" alt="Hermes" src="../packages/ui/src/assets/icons/preset-icons/hermes.svg" /></picture> &nbsp;[Hermes](https://github.com/NousResearch/hermes-agent) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/kimi-white.svg" /><img height="16" align="top" alt="Kimi Code" src="../packages/ui/src/assets/icons/preset-icons/kimi.svg" /></picture> &nbsp;[Kimi Code](https://www.kimi.com/) | 完整支援 |
+| <img height="16" align="top" alt="Kiro" src="../packages/ui/src/assets/icons/preset-icons/kiro.svg" /> &nbsp;[Kiro](https://kiro.dev/cli/) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/mastracode-white.svg" /><img height="16" align="top" alt="Mastra Code" src="../packages/ui/src/assets/icons/preset-icons/mastracode.svg" /></picture> &nbsp;[Mastra Code](https://mastra.ai/) | 完整支援 |
+| <img height="16" align="top" alt="Mistral Vibe" src="../packages/ui/src/assets/icons/preset-icons/vibe.svg" /> &nbsp;[Mistral Vibe](https://mistral.ai/) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Oh My Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Oh My Pi](https://github.com/can1357/oh-my-pi) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/opencode-white.svg" /><img height="16" align="top" alt="OpenCode" src="../packages/ui/src/assets/icons/preset-icons/opencode.svg" /></picture> &nbsp;[OpenCode](https://github.com/opencode-ai/opencode) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/pi-white.svg" /><img height="16" align="top" alt="Pi" src="../packages/ui/src/assets/icons/preset-icons/pi.svg" /></picture> &nbsp;[Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | 完整支援 |
+| <picture><source media="(prefers-color-scheme: dark)" srcset="../packages/ui/src/assets/icons/preset-icons/polygraph-white.svg" /><img height="16" align="top" alt="Polygraph" src="../packages/ui/src/assets/icons/preset-icons/polygraph.svg" /></picture> &nbsp;[Polygraph](https://trypolygraph.com/) | 完整支援 |
+| 任何其他 CLI 代理程式 | 無需設定即可使用 |
+
+只要能在終端裡執行,就能在 Superset 上執行
+
+代理程式得到的不只是一個終端:
+
+- **模型選擇器**:啟動代理程式時選擇模型和推理力度
+- **依代理程式設定**:在設定 → 代理程式中調整啟動命令、提示範本和模型覆寫
+- **自訂代理程式**:加入任何終端代理程式並配上專屬圖示,它就和內建的一樣運作
+- **狀態與通知**:工作指示器、完成提示音,以及代理程式需要你時的 Dock 徽章
+- **內建聊天**:在聊天窗格中與模型對話,支援內嵌工具核准和計畫審查
+
+## 不只是一個桌面應用程式
+
+每個介面都連接到同樣的工作區,你可以在應用程式中開始一項任務,然後在任何地方查看進度。
+
+| 介面 | 你能得到什麼 |
+|:--------|:-------------|
+| [**桌面應用程式**](https://github.com/superset-sh/superset/releases/latest) | 完整的 IDE:終端、差異檢視器、應用程式內瀏覽器、自動化 |
+| [**CLI**](https://docs.superset.sh/cli/getting-started) | 單一 `superset` 執行檔,在任何 shell 中管理工作區、代理程式、終端和主機 |
+| [**TypeScript SDK**](https://docs.superset.sh/sdk/getting-started) | 透過 [`@superset_sh/sdk`](https://www.npmjs.com/package/@superset_sh/sdk) 在 Node、Bun 或 Deno 中以程式方式操作 Superset |
+| [**MCP 伺服器**](https://docs.superset.sh/mcp) | 讓 Claude Code、Codex、Cursor 等代理程式自己建立和管理工作區 |
+
+CLI 隨桌面應用程式一起提供,也可以獨立安裝:
+
+```bash
+curl -fsSL https://superset.sh/cli/install.sh | sh
+# or
+brew install superset-sh/tap/superset
+```
+
+iOS 應用程式即將推出,讓你可以在手機上查看你的代理程式。
+
+## 安裝
+
+下載桌面應用程式:
+
+- **macOS**:[Apple Silicon (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-arm64.dmg) · [Intel (.dmg)](https://github.com/superset-sh/superset/releases/latest/download/Superset-x64.dmg)
+- **Linux**:[x64 AppImage](https://github.com/superset-sh/superset/releases/latest/download/Superset-x86_64.AppImage)(實驗性;macOS 是主要目標平台)
+- **Windows**:暫不提供
+- [所有建置版本](https://github.com/superset-sh/superset/releases/latest)
+
+你只需要安裝 [Git](https://git-scm.com/)。[gh](https://cli.github.com/) 是選用的,可解鎖 PR 工作流程;Superset 會主動提議為你安裝。
+
+## 開發
+
+想研究 Superset 或貢獻一個 PR?複製儲存庫,把它加入已安裝的 Superset 應用程式,然後為你的變更建立一個工作區:
+
+```bash
+git clone https://github.com/superset-sh/superset.git
+```
+
+然後在該工作區的終端中執行開發環境設定:
+
+```bash
+./.superset/setup.local.sh
+bun run dev
+```
+
+在每個新的 worktree 中執行一次 `setup.local.sh`。它會設定工作區專屬的應用程式識別與連接埠,讓開發版桌面應用程式可以與已安裝的 Superset 應用程式及其他開發 worktree 並行執行。
+
+不需要 Neon 帳號或第三方憑證。`setup.local.sh` 會透過 Docker 啟動本機 Postgres + Electric 堆疊並植入一個開發帳號。用 **「Sign in as dev」**按鈕(或 `admin@local.test` / `supersetdev`)登入即可。
+
+先決條件:[Bun](https://bun.sh/) v1.3.14+(固定在 `.bun-version` 中)、`docker`、`jq` 和 `caddy`,`bun dev` 會將 `caddy` 作為本機 HTTPS 代理伺服器執行(`brew install jq caddy && caddy trust`)。
+
+完整指南見 [**DEVELOPMENT.md**](../DEVELOPMENT.md):設定指令碼做了什麼、針對真實服務的手動設定、常用命令、疑難排解,以及如何建置桌面應用程式。貢獻流程見 [**CONTRIBUTING.md**](../CONTRIBUTING.md)。
+
+## 組態
+
+在 `.superset/config.json` 中設定工作區的設定、清理和執行指令碼。參見[完整文件](https://docs.superset.sh/setup-teardown-scripts)。
+
+```json
+{
+  "setup": ["./.superset/setup.sh"],
+  "teardown": ["./.superset/teardown.sh"],
+  "run": ["./.superset/run.sh"]
+}
+```
+
+鍵盤快速鍵可透過**設定 → 鍵盤快速鍵**(⌘/)自訂;參見[完整快速鍵清單](https://docs.superset.sh/keyboard-shortcuts)。
+
+## 技術堆疊
+
+<p>
+  <a href="https://www.electronjs.org/"><img src="https://img.shields.io/badge/Electron-191970?logo=Electron&logoColor=white" alt="Electron" /></a>
+  <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-%2320232a.svg?logo=react&logoColor=%2361DAFB" alt="React" /></a>
+  <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/Tailwindcss-%2338B2AC.svg?logo=tailwind-css&logoColor=white" alt="TailwindCSS" /></a>
+  <a href="https://bun.sh/"><img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" /></a>
+  <a href="https://turbo.build/"><img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /></a>
+  <a href="https://vitejs.dev/"><img src="https://img.shields.io/badge/Vite-%23646CFF.svg?logo=vite&logoColor=white" alt="Vite" /></a>
+  <a href="https://biomejs.dev/"><img src="https://img.shields.io/badge/Biome-339AF0?logo=biome&logoColor=white" alt="Biome" /></a>
+  <a href="https://orm.drizzle.team/"><img src="https://img.shields.io/badge/Drizzle%20ORM-FFE873?logo=drizzle&logoColor=black" alt="Drizzle ORM" /></a>
+  <a href="https://neon.tech/"><img src="https://img.shields.io/badge/Neon-00E9CA?logo=neon&logoColor=white" alt="Neon" /></a>
+  <a href="https://trpc.io/"><img src="https://img.shields.io/badge/tRPC-2596BE?logo=trpc&logoColor=white" alt="tRPC" /></a>
+</p>
+
+## 預設保持私密
+
+- **原始碼公開**:完整原始碼以 Elastic License 2.0(ELv2)授權發布在 GitHub 上。
+- **明確連接**:由你決定要連接哪些代理程式、供應商和整合。
+
+## 貢獻
+
+我們歡迎貢獻!參見 [CONTRIBUTING.md](../CONTRIBUTING.md) 了解如何建置環境並提交 PR。Bug 和功能請求請提交到 [issues](https://github.com/superset-sh/superset/issues)。
+
+<a href="https://github.com/superset-sh/superset/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=superset-sh/superset" />
+</a>
+
+## 社群
+
+加入 Superset 社群,取得協助、分享意見,並與其他使用者交流:
+
+- **[Discord](https://discord.gg/cZeD9WYcV7)**:與團隊和社群聊天
+- **[Twitter](https://x.com/superset_sh)**:追蹤以取得更新和公告
+- **[GitHub Issues](https://github.com/superset-sh/superset/issues)**:回報 bug 和請求功能
+- **[GitHub Discussions](https://github.com/superset-sh/superset/discussions)**:提問和分享想法
+
+### 團隊
+
+[![Avi Twitter](https://img.shields.io/badge/Avi-@avimakesrobots-555?logo=x)](https://x.com/avimakesrobots)
+[![Kiet Twitter](https://img.shields.io/badge/Kiet-@flyakiet-555?logo=x)](https://x.com/flyakiet)
+[![Satya Twitter](https://img.shields.io/badge/Satya-@saddle__paddle-555?logo=x)](https://x.com/saddle_paddle)
+
+## 授權與永久免費的部分
+
+**桌面應用程式永久免費。**在你自己的機器上平行執行代理程式永遠不需要付費。我們若收費,也會是建立在其上的選用服務。
+
+整個應用程式都在這個儲存庫中,採用 [Elastic License 2.0](../LICENSE.md) 授權:使用它、fork 它、修改它、為你的團隊自行架設,都可以。唯一不允許的,是把 Superset 本身重新包裝成服務販售給他人。


### PR DESCRIPTION
Adds the onlook-style language toggle row to the README — but pointing at **in-repo translations we control** (onlook's row links to a third-party auto-translation service, which would be off-brand for a repo that just shipped 16 hand-verified locale catalogs).

- `readme/README.<locale>.md` × 16, each **anchored to its locale's shipped catalog terminology** (the README says ワークスペース / 工作區 / obszar roboczy exactly where the app does; worktree stays `worktree` everywhere; Turkish suffixes vowel-harmony-checked; de is du-register, pt-BR Brazilian, zh-TW Taiwan vocabulary not glyph conversion)
- Native-name toggle row on the root README and inside each translation; each file notes English as canonical
- Independently verified per file: image/fence counts and the full ordered 109-URL set byte-identical to the original, every `../` link resolves, no unprefixed relative paths, root toggle links all resolve

Known trade-off: translated READMEs can drift when README.md changes; accepted (standard across OSS), English marked canonical, and the low churn of a README makes this the right surface for it — unlike docs, which stay English by design.

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a language toggle row to the README and ships `readme/README.<locale>.md` translations for all sixteen shipped locales, so readers can switch to their language instead of a third-party auto-translation service. Translations reuse the terminology already shipped in each locale's catalog, so the README says ワークスペース, 工作區, or obszar roboczy exactly where the app does and keeps `worktree` untranslated.

**Notes**
- Each translation marks the English README as canonical.
- Brands, commands, badges, and code blocks stay untranslated; image/fence counts and the full 109-URL set are byte-identical to the original, and all relative links resolve.
- Accepted trade-off: translations can drift when `README.md` changes, which is standard for OSS and fine given the README's low churn.

<sup>Written for commit 1395a93f001f41442abe9b60e5c2d96bee0a9d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README translations in 16 languages, including Czech, German, Spanish, French, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Portuguese (Brazil), Russian, Turkish, Vietnamese, Simplified Chinese, and Traditional Chinese.
  * Added a language selector to the main README for easier navigation between translations.
  * Localized documentation covers features, supported agents, installation, configuration, development, privacy, contribution, and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->