### PR TITLE
fix(shared): raise MIN_HOST_SERVICE_VERSION so pre-1.22 hosts hit the version gate instead of a blank terminal pane

### DIFF
--- a/packages/shared/src/host-version.ts
+++ b/packages/shared/src/host-version.ts
@@ -21,5 +21,10 @@
  *
  * 0.8.0 — v2 terminal creation moved to `terminal.createSession`; the
  * WebSocket route is attach-only by `terminalId`.
+ *
+ * 1.21.0 — session listing consolidated into `terminal.list` (#6341), which
+ * every current caller uses; hosts without it render a blank terminal pane
+ * with no error (#6525). Host-service versions were unified with the app's
+ * at that point, so the jump from the old 0.8.x line is intentional.
  */
-export const MIN_HOST_SERVICE_VERSION = "0.8.0";
+export const MIN_HOST_SERVICE_VERSION = "1.21.0";


### PR DESCRIPTION
Fixes #6525

## What

Raises `MIN_HOST_SERVICE_VERSION` in `packages/shared/src/host-version.ts` from `0.8.0` to `1.21.0`, so a current client talking to a host-service that predates `terminal.list` gets the explicit "Host needs an update" screen instead of a blank terminal pane with no error.

## How the minimum was chosen

The issue title says `terminal.list` appeared in 1.22.0, but it only compared the 1.20.2 and 1.22.0 bundles. `git log -S` points at 483321d67 ("consolidate terminal session listing into terminal.list", #6341), and the first release tags containing that commit are `cli-v1.21.0` / `desktop-v1.21.0` — `git grep` confirms the `terminal.list` procedure is present in the tagged 1.21.0 host-service source and absent in 1.20.2. So **1.21.0** is the earliest host that implements the procedure, and the floor is set there rather than 1.22.0 to avoid gating out working 1.21.x hosts.

Host-service historically had its own 0.8.x version line before versions were unified with the app, so the jump from 0.8.0 to 1.21.0 is intentional. Both comparators handle it as plain version ordering: the desktop gate uses `semver.satisfies(hostVersion, ">=1.21.0")` (`useRemoteHostStatus`), mobile uses a numeric x.y.z compare (`useHostCompatibility`) — a 0.8.x–1.20.x host trips both, 1.21.0+ passes.

## Reproduction / verification (dev app over CDP)

Simulated an old host in the dev desktop app by patching the bundled host-service to report `1.20.2` from `host.info` and removing the `terminal.list` procedure (same `NOT_FOUND` an old host returns), with the version gate exercised over the real relay path. A background terminal session was created in a workspace via the host-service API (the CLI path), then the workspace was opened through the UI.

- **Before** (`MIN_HOST_SERVICE_VERSION = "0.8.0"`): the workspace opens normally past the gate, `terminal.list` returns 404 `NOT_FOUND`, and the live session gets no pane — blank workspace, no error, host looks healthy. (CDP screenshot `05-before-demoapp.png`; direct probe: `host.info → version 1.20.2`, `terminal.list → 404 No procedure found`.)
- **After** (this fix, same simulation): opening the same workspace renders the `WorkspaceHostIncompatibleState` screen — "Host needs an update", showing the host name with RUNNING `1.20.2` / REQUIRED `≥ 1.21.0`. (CDP screenshots `06-after-reload.png`, `08-after-gate-journey.png`.)

The simulation patch was reverted; the only product change is the constant + doc comment.

## Validation

- `bun run --cwd packages/shared typecheck` ✅, `bun run --cwd packages/shared test` ✅ (850 pass)
- `bun run --cwd apps/desktop typecheck` ✅
- `bun run --cwd apps/mobile typecheck` has 3 pre-existing errors in `JumpToFileSheet.tsx` / `NewSessionSheet.tsx`, unrelated to this change
- No existing tests reference `MIN_HOST_SERVICE_VERSION`

https://claude.ai/code/session_012YpyZZMMXKGZyqCq5rkGpp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises `MIN_HOST_SERVICE_VERSION` in `packages/shared/src/host-version.ts` from `0.8.0` to `1.21.0`, so pre-1.21 hosts now show the "Host needs an update" screen instead of rendering a blank terminal pane with no error when `terminal.list` is missing. Fixes #6525.

- `terminal.list` shipped in host-service 1.21.0 (#6341), and every current caller uses it.
- 1.21.0 is the earliest host that implements the procedure, so 1.21.x hosts still pass the gate.
- Host-service versions were unified with the app's at that point, so the jump from the old 0.8.x line is intentional.
- Both the desktop and mobile comparators correctly reject 0.8.x–1.20.x hosts and accept 1.21.0+.

<sup>Written for commit 7b701503b6adc6aaf34d85b26551cf8b8c9ce99f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/6998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated the minimum supported host service version to 1.21.0.
  - Hosts now support consolidated session listing through terminal services.
  - Older hosts display a blank terminal pane instead of an error.
  - Host service and app versions are now aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->