### PR TITLE
fix(docs): compact language switcher to an icon beside the GitHub mark

### DIFF
--- a/apps/docs/src/app/components/NavigationBar/NavigationBar.tsx
+++ b/apps/docs/src/app/components/NavigationBar/NavigationBar.tsx
@@ -3,7 +3,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { LanguageSwitcher } from "@superset/i18n/react";
 import { COMPANY } from "@superset/shared/constants";
-import { Globe, Menu } from "lucide-react";
+import { Languages, Menu } from "lucide-react";
 import Link from "next/link";
 import { MobileSearchIcon } from "@/app/(docs)/[[...slug]]/components/DocsPageLayout/components/PageClient/components/MobileSearchIcon";
 import {
@@ -68,13 +68,6 @@ export default function NavigationBar() {
 					<MobileSearchIcon />
 					<SidebarTrigger />
 					<ul className="navbar:flex items-center gap-2 hidden shrink-0">
-						<li className="flex items-center gap-1.5 px-2 text-sm text-muted-foreground transition-colors focus-within:text-foreground hover:text-foreground">
-							<Globe aria-hidden className="size-4 shrink-0" />
-							<LanguageSwitcher
-								label={t({ id: "docs.nav.languageLabel", message: "Language" })}
-								className="cursor-pointer appearance-none bg-transparent outline-none [&>option]:bg-background [&>option]:text-foreground"
-							/>
-						</li>
 						<NavLink href={COMPANY.CHANGELOG_URL} external>
 							<Trans id="docs.nav.changelog">Changelog</Trans>
 						</NavLink>
@@ -102,6 +95,16 @@ export default function NavigationBar() {
 								></path>
 							</svg>
 						</NavLink>
+						{/* Icon-only: the navbar is tight, so the trigger is just the
+						    translation glyph; the real select sits on top invisibly,
+						    keeping the native accessible menu. */}
+						<li className="relative flex items-center px-1 text-muted-foreground transition-colors focus-within:text-foreground hover:text-foreground">
+							<Languages aria-hidden className="size-[1.35em]" />
+							<LanguageSwitcher
+								label={t({ id: "docs.nav.languageLabel", message: "Language" })}
+								className="absolute inset-0 cursor-pointer opacity-0"
+							/>
+						</li>
 						<a
 							href={`${COMPANY.MARKETING_URL}/download`}
 							className="ml-2 rounded-md bg-primary px-3.5 py-1.5 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-85"


### PR DESCRIPTION
Per Kiet's review of the navbar: the globe + language text spent too much space. Now icon-only — the **Languages (文A) glyph** — placed next to the GitHub icon, with the native select overlaid invisibly (opacity-0, inset-0) so keyboard/screen-reader behavior is exactly the native menu. Screenshot in session. docs typecheck + biome green.

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts the docs navbar language switcher from a globe with a text label to a standalone icon, freeing space in a tight navbar. The native select is overlaid invisibly on the icon, so keyboard and screen-reader behavior is unchanged.

<sup>Written for commit 25eec8fa2bddbca7000684e79a06c709f467578d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the navigation bar to use a translation icon.
  * Simplified the desktop language selector to an icon-only presentation while retaining accessible language selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->