### PR TITLE
docs: collapse the README language row into a disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 ### Run 100+ Coding Agents in Parallel
 
-<sub>
+<details>
+<summary>🌐 Read this in other languages</summary>
+<br />
 
 [English](README.md) | [日本語](readme/README.ja.md) | [简体中文](readme/README.zh-CN.md) | [繁體中文](readme/README.zh-TW.md) | [한국어](readme/README.ko.md) | [Français](readme/README.fr.md) | [Español](readme/README.es.md) | [Deutsch](readme/README.de.md) | [Português](readme/README.pt-BR.md) | [Italiano](readme/README.it.md) | [Русский](readme/README.ru.md) | [Türkçe](readme/README.tr.md) | [Polski](readme/README.pl.md) | [Nederlands](readme/README.nl.md) | [Bahasa Indonesia](readme/README.id.md) | [Čeština](readme/README.cs.md) | [Tiếng Việt](readme/README.vi.md)
 
-</sub>
+</details>
 
 [![GitHub stars](https://img.shields.io/github/stars/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/superset-sh/superset?style=flat&logo=github)](https://github.com/superset-sh/superset/releases)

--- a/readme/README.cs.md
+++ b/readme/README.cs.md
@@ -4,7 +4,13 @@
 
 ### Spusťte 100+ kódovacích agentů paralelně
 
+<details>
+<summary>🌐 Číst v jiných jazycích</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Toto je překlad anglického README, které je závazné.*
 

--- a/readme/README.de.md
+++ b/readme/README.de.md
@@ -4,7 +4,13 @@
 
 ### Führe über 100 Coding-Agenten parallel aus
 
+<details>
+<summary>🌐 In anderen Sprachen lesen</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Dies ist eine Übersetzung des [englischen READMEs](../README.md), das die maßgebliche Version ist.*
 

--- a/readme/README.es.md
+++ b/readme/README.es.md
@@ -4,7 +4,13 @@
 
 ### Ejecuta más de 100 agentes de código en paralelo
 
+<details>
+<summary>🌐 Leer en otros idiomas</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Esta es una traducción del [README en inglés](../README.md), que es la versión canónica.*
 

--- a/readme/README.fr.md
+++ b/readme/README.fr.md
@@ -4,7 +4,13 @@
 
 ### Exécutez plus de 100 agents de codage en parallèle
 
+<details>
+<summary>🌐 Lire dans une autre langue</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Ceci est une traduction du [README anglais](../README.md), qui reste la version de référence.*
 

--- a/readme/README.id.md
+++ b/readme/README.id.md
@@ -4,7 +4,13 @@
 
 ### Jalankan 100+ Agen Coding Secara Paralel
 
+<details>
+<summary>🌐 Baca dalam bahasa lain</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Ini adalah terjemahan dari README bahasa Inggris, yang menjadi acuan resmi.*
 

--- a/readme/README.it.md
+++ b/readme/README.it.md
@@ -4,7 +4,13 @@
 
 ### Esegui più di 100 agenti di coding in parallelo
 
+<details>
+<summary>🌐 Leggi in altre lingue</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Traduzione del README in inglese, che resta la versione di riferimento.*
 

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -4,7 +4,13 @@
 
 ### 100以上のコーディングエージェントを並列実行
 
+<details>
+<summary>🌐 他の言語で読む</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *本ドキュメントは英語版READMEの翻訳です。内容は英語版が正となります。*
 

--- a/readme/README.ko.md
+++ b/readme/README.ko.md
@@ -4,7 +4,13 @@
 
 ### 100개 이상의 코딩 에이전트를 병렬로 실행
 
+<details>
+<summary>🌐 다른 언어로 보기</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *이 문서는 영어 README의 번역본이며, 영어 원문이 우선합니다.*
 

--- a/readme/README.nl.md
+++ b/readme/README.nl.md
@@ -4,7 +4,13 @@
 
 ### Draai 100+ coding agents parallel
 
+<details>
+<summary>🌐 Lees in andere talen</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Dit is een vertaling van de Engelse README, die leidend is.*
 

--- a/readme/README.pl.md
+++ b/readme/README.pl.md
@@ -4,7 +4,13 @@
 
 ### Uruchamiaj ponad 100 agentów kodujących równolegle
 
+<details>
+<summary>🌐 Przeczytaj w innych językach</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Tłumaczenie angielskiego README, który pozostaje wersją kanoniczną.*
 

--- a/readme/README.pt-BR.md
+++ b/readme/README.pt-BR.md
@@ -4,7 +4,13 @@
 
 ### Execute mais de 100 agentes de código em paralelo
 
+<details>
+<summary>🌐 Ler em outros idiomas</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Esta é uma tradução do [README em inglês](../README.md), que é a versão canônica.*
 

--- a/readme/README.ru.md
+++ b/readme/README.ru.md
@@ -4,7 +4,13 @@
 
 ### Запускайте 100+ агентов для кодинга параллельно
 
+<details>
+<summary>🌐 Читать на других языках</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Перевод английского README; канонической является английская версия.*
 

--- a/readme/README.tr.md
+++ b/readme/README.tr.md
@@ -4,7 +4,13 @@
 
 ### 100'den Fazla Kodlama Ajanını Paralel Çalıştırın
 
+<details>
+<summary>🌐 Diğer dillerde oku</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Bu, İngilizce README'nin çevirisidir; esas sürüm İngilizce olandır.*
 

--- a/readme/README.vi.md
+++ b/readme/README.vi.md
@@ -4,7 +4,13 @@
 
 ### Chạy song song 100+ coding agent
 
+<details>
+<summary>🌐 Đọc bằng ngôn ngữ khác</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *Đây là bản dịch của README tiếng Anh; bản tiếng Anh là bản chuẩn.*
 

--- a/readme/README.zh-CN.md
+++ b/readme/README.zh-CN.md
@@ -4,7 +4,13 @@
 
 ### 并行运行 100+ 个编码智能体
 
+<details>
+<summary>🌐 其他语言版本</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *本文档是英文版 README 的翻译,内容以英文版为准。*
 

--- a/readme/README.zh-TW.md
+++ b/readme/README.zh-TW.md
@@ -4,7 +4,13 @@
 
 ### 平行執行 100+ 個編碼代理程式
 
+<details>
+<summary>🌐 其他語言版本</summary>
+<br />
+
 [English](../README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md) | [한국어](README.ko.md) | [Français](README.fr.md) | [Español](README.es.md) | [Deutsch](README.de.md) | [Português](README.pt-BR.md) | [Italiano](README.it.md) | [Русский](README.ru.md) | [Türkçe](README.tr.md) | [Polski](README.pl.md) | [Nederlands](README.nl.md) | [Bahasa Indonesia](README.id.md) | [Čeština](README.cs.md) | [Tiếng Việt](README.vi.md)
+
+</details>
 
 *本文件為英文版 README 的翻譯,內容以英文版為準。*
 


### PR DESCRIPTION
Per Kiet's review: the 17-link row squished/overlapped at narrow widths. Now a `<details>` disclosure — one compact line (🌐 + a localized summary per translated file) that expands to the full native-name list. Link integrity re-verified (root links resolve; exactly one disclosure per file).

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the README language row into a `<details>` disclosure so the 17 links no longer squish or overlap at narrow widths.

- Each translated README now shows a localized summary label like "🌐 他の言語で読む" that expands to the full language list.
- Root and translated language links are unchanged and still resolve correctly.

<sup>Written for commit 4e520979aa92edb82f1ba90f6ffd2fe6cb92b742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the main README and translated README pages with collapsible language selectors.
  - Language links are now hidden by default and can be expanded using clearly labeled, localized controls.
  - Improved header readability and reduced visual clutter while preserving access to all available translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->