### PR TITLE
fix(i18n): deterministic first render — no hydration mismatch for non-English users

### DIFF
--- a/packages/i18n/src/react.tsx
+++ b/packages/i18n/src/react.tsx
@@ -10,10 +10,16 @@ import {
 	type SupportedLocale,
 } from "./locales";
 
-// Activate at module scope so the first render is already localized;
-// activation notifies Lingui subscribers, so it must not run inside a render
-// pass (React can repeat or abandon renders).
-initI18n(inferLocale());
+// Activate the DEFAULT locale at module scope — deterministically the same
+// on the server and on the client's first render. Inferring the real locale
+// here localized the client's first render while the server had rendered
+// English, which threw a hydration mismatch on every translated client
+// string for every non-English user ("Search docs..." vs "Tìm trong tài
+// liệu..."). The provider switches to the inferred or chosen locale after
+// mount instead; the brief default-language flash on client chrome is the
+// price of hydration correctness, and server-component content (marketing
+// pages) is localized in the HTML itself and never hydrates.
+initI18n();
 
 export function I18nProvider({
 	children,


### PR DESCRIPTION
Fixes the console error Kiet hit on docs: `Hydration failed because the server rendered text didn't match the client` — server `Search docs...`, client `Tìm trong tài liệu...`.

**Mechanism**: module-scope activation inferred the locale in the browser (cookie/navigator) *before React hydrated*, so the client's first render was localized while the server had rendered the default. Every translated client-component string mismatched for every non-English user — the same class the production review measured as React #418s clustering on ja/ru/tr.

**Fix**: module scope activates the **default locale — identical on server and client** — and the provider switches to the inferred or chosen locale after mount (existing effect + keyed remount). Trade-off stated plainly: a brief default-language flash on client chrome for non-en users; content on marketing is RSC-localized in the served HTML and never hydrates, so what search engines and first paint see is unchanged. This is the standard resolution for statically-served client components (docs).

i18n tests 116/116.

https://claude.ai/code/session_012U97YWVsDvZwQkBaSGEmor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hydration mismatch that threw `Hydration failed because the server rendered text didn't match the client` for non-English users. The first client render now uses the same default locale as the server, and the provider switches to the inferred or chosen locale after mount.

Non-English users will see a brief default-language flash on client chrome. Marketing content is RSC-localized in the served HTML and never hydrates, so search engine and first-paint content are unchanged.

<sup>Written for commit be9923eb20fd0c8f2d30bad9fad28b11f9a1d784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization consistency between server-rendered content and the client’s initial display.
  * Locale detection and explicit locale selection now occur after the application loads, reducing potential rendering mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->