### PR TITLE
feat(sdk): expose terminal agent lifecycle status

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -947,12 +947,23 @@ superset terminals create --workspace ws_…
 		{ flag: "--workspace <id>", required: true, description: "Workspace UUID." },
 		{ flag: "--host <id>", description: "Host the workspace lives on (default: this machine)." },
 	]}
-	output={`{
-  sessions: Array<TerminalSession>;
+output={`{
+  sessions: Array<TerminalSession & {
+    agentStatus?: {
+      agentId: string;
+      sessionId?: string;
+      definitionId?: string;
+      startedAt: number;
+      lastEventType: "Start" | "Stop" | "PermissionRequest" | "Failed" | "Attached" | "Detached";
+      lastEventAt: number;
+    };
+  }>;
 }`}
 >
 List the live terminal sessions in a workspace. Presence in the list means the
-PTY exists, not that an agent inside it is working or idle.
+PTY exists. When Superset has identified a live agent inside it, `agentStatus`
+reports the same normalized lifecycle state used by the workspace board;
+`PermissionRequest` means the agent needs attention.
 </Command>
 
 <Command

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -265,6 +265,26 @@ const { terminalId } = await client.terminals.create({
 });
 ```
 
+### `terminals.list({ hostId, workspaceId })`
+
+List the live terminal sessions in a workspace. When Superset has identified
+an agent in a terminal, its row includes `agentStatus` with the agent and
+session identity and the latest normalized lifecycle event. A
+`PermissionRequest` event means the agent is waiting for input or approval.
+
+```ts
+const { sessions } = await client.terminals.list({
+  hostId: '<machineId>',
+  workspaceId: '<uuid>',
+});
+
+for (const terminal of sessions) {
+  if (terminal.agentStatus?.lastEventType === 'PermissionRequest') {
+    console.log(`${terminal.agentStatus.agentId} needs attention`);
+  }
+}
+```
+
 ---
 
 ## automations

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -138,9 +138,10 @@ export const terminalRouter = router({
 				workspaceId: input?.workspaceId,
 			});
 			const agentsByTerminal = new Map(
-				ctx.terminalAgentStore
-					.list()
-					.map((binding) => [binding.terminalId, binding] as const),
+				(input?.workspaceId
+					? ctx.terminalAgentStore.listByWorkspace(input.workspaceId)
+					: []
+				).map((binding) => [binding.terminalId, binding] as const),
 			);
 
 			return {

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -133,11 +133,38 @@ export const terminalRouter = router({
 				})
 				.optional(),
 		)
-		.query(async ({ ctx, input }) => ({
-			sessions: await listLiveTerminalSessions(ctx.db, {
+		.query(async ({ ctx, input }) => {
+			const sessions = await listLiveTerminalSessions(ctx.db, {
 				workspaceId: input?.workspaceId,
-			}),
-		})),
+			});
+			const agentsByTerminal = new Map(
+				ctx.terminalAgentStore
+					.list()
+					.map((binding) => [binding.terminalId, binding] as const),
+			);
+
+			return {
+				sessions: sessions.map((session) => {
+					const binding = agentsByTerminal.get(session.terminalId);
+					if (!binding) return session;
+					return {
+						...session,
+						agentStatus: {
+							agentId: binding.agentId,
+							...(binding.agentSessionId
+								? { sessionId: binding.agentSessionId }
+								: {}),
+							...(binding.definitionId
+								? { definitionId: binding.definitionId }
+								: {}),
+							startedAt: binding.startedAt,
+							lastEventAt: binding.lastEventAt,
+							lastEventType: binding.lastEventType,
+						},
+					};
+				}),
+			};
+		}),
 
 	hasRunningProcess: protectedProcedure
 		.input(

--- a/packages/host-service/test/integration/terminal.integration.test.ts
+++ b/packages/host-service/test/integration/terminal.integration.test.ts
@@ -92,7 +92,7 @@ describe("terminal router integration", () => {
 		).rejects.toBeInstanceOf(TRPCClientError);
 	});
 
-	test("createSession sends the configured shell to the daemon instead of inherited bash", async () => {
+	test("createSession uses the configured shell and list includes live agent status", async () => {
 		const tmp = mkdtempSync(join(tmpdir(), "host-service-terminal-shell-"));
 		const socketPath = join(tmp, "pty-daemon.sock");
 		const fakeFishPath = join(tmp, "fish");
@@ -145,6 +145,25 @@ describe("terminal router integration", () => {
 			expect(meta.argv[1]).toBe("--init-command");
 			expect(meta.env?.SHELL).toBe(fakeFishPath);
 			expect(meta.env?.SUPERSET_TERMINAL_ID).toBe(terminalId);
+
+			await scenario.host.unauthenticatedTrpc.notifications.hook.mutate({
+				terminalId,
+				eventType: "request_user_input",
+				agent: { agentId: "codex", sessionId: "thread-123" },
+			});
+			const listedWithAgent = await scenario.host.trpc.terminal.list.query({
+				workspaceId: scenario.workspaceId,
+			});
+			const terminal = listedWithAgent.sessions.find(
+				(session) => session.terminalId === terminalId,
+			);
+			expect(terminal?.agentStatus).toMatchObject({
+				agentId: "codex",
+				sessionId: "thread-123",
+				lastEventType: "PermissionRequest",
+			});
+			expect(terminal?.agentStatus?.startedAt).toBeNumber();
+			expect(terminal?.agentStatus?.lastEventAt).toBeNumber();
 		} finally {
 			await scenario.host.trpc.terminal.killSession
 				.mutate({

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -94,6 +94,8 @@ import {
 	TaskUpdateParams,
 } from "./resources/tasks";
 import {
+	TerminalAgentLifecycleEventType,
+	TerminalAgentStatus,
 	TerminalCloseParams,
 	TerminalCloseResult,
 	TerminalCreateParams,
@@ -1282,6 +1284,8 @@ export declare namespace Superset {
 
 	export {
 		Terminals,
+		TerminalAgentLifecycleEventType,
+		TerminalAgentStatus,
 		TerminalCreateParams,
 		TerminalCreateResult,
 		TerminalListParams,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -55,6 +55,8 @@ export {
 	Tasks,
 	type TaskUpdateParams,
 	type TerminalCloseParams,
+	type TerminalAgentLifecycleEventType,
+	type TerminalAgentStatus,
 	type TerminalCloseResult,
 	type TerminalCreateParams,
 	type TerminalCreateResult,

--- a/packages/sdk/src/resources/index.ts
+++ b/packages/sdk/src/resources/index.ts
@@ -30,6 +30,8 @@ export {
 } from "./organization";
 export { type Project, type ProjectListResponse, Projects } from "./projects";
 export {
+	type TerminalAgentLifecycleEventType,
+	type TerminalAgentStatus,
 	type TerminalCloseParams,
 	type TerminalCloseResult,
 	type TerminalCreateParams,

--- a/packages/sdk/src/resources/terminals.ts
+++ b/packages/sdk/src/resources/terminals.ts
@@ -121,6 +121,25 @@ export interface TerminalSummary {
 	exitCode: number;
 	attached: boolean;
 	title: string | null;
+	/** Present when Superset has identified a live agent in this terminal. */
+	agentStatus?: TerminalAgentStatus;
+}
+
+export type TerminalAgentLifecycleEventType =
+	| "Start"
+	| "Stop"
+	| "PermissionRequest"
+	| "Failed"
+	| "Attached"
+	| "Detached";
+
+export interface TerminalAgentStatus {
+	agentId: string;
+	sessionId?: string;
+	definitionId?: string;
+	startedAt: number;
+	lastEventAt: number;
+	lastEventType: TerminalAgentLifecycleEventType;
 }
 
 export interface TerminalListResult {
@@ -185,6 +204,8 @@ export declare namespace Terminals {
 		TerminalListParams,
 		TerminalListResult,
 		TerminalSummary,
+		TerminalAgentStatus,
+		TerminalAgentLifecycleEventType,
 		TerminalSendParams,
 		TerminalSendResult,
 		TerminalReadParams,


### PR DESCRIPTION
## FOR TODD — 1 decision, 0 actions

**Decision:** expose the existing normalized lifecycle record on `terminals.list`, rather than add a second status endpoint.

I recommend this because the terminal is already the public CLI/SDK object consumers use to read and send messages, while the host service remains the single owner of agent-state normalization.

## What & why

Superset already knows when Claude, Codex, and other supported agents are working or waiting for attention, and the workspace board renders that state. CLI and SDK consumers could only see that the PTY existed, though, so they could not distinguish a working agent from one waiting for input.

This adds an optional `agentStatus` field to each live terminal returned by `terminal.list` / `terminals.list()`. It exposes agent/session identity, timestamps, and the latest normalized lifecycle event. In particular, `PermissionRequest` gives integrations the same needs-attention signal used by the workspace board.

The response is joined from the existing `TerminalAgentStore`; this does not introduce another detector or status model. The CLI and SDK reference docs describe the additive field.

Downstream context: [todd-studio/workstation#252](https://github.com/todd-studio/workstation/issues/252)

## How I tested it

- `bun test test/integration/terminal.integration.test.ts --test-name-pattern "createSession uses the configured shell and list includes live agent status"` — passed
- Full terminal integration file — 8 passed; the process-group disposal test timed out once and passed when rerun alone
- `bun run typecheck` in `packages/host-service` — passed
- `bun run typecheck` in `packages/sdk` — passed
- `bun run build` in `packages/sdk` — passed
- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun run test` — not fully green: two dynamic-import tests in the untouched `@superset/agent-setup` package could not find their shared temporary module after another suite removed it; the same failures remained under the repository-pinned Bun 1.3.14

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the terminal agent's lifecycle status on `terminals.list` responses, so SDK and CLI consumers can tell when a supported agent is working or waiting for input instead of only knowing the PTY exists.

- Adds an optional `agentStatus` field with agent identity, timestamps, and the latest normalized lifecycle event, populated only when listing a specific workspace; workspace-wide listings still return just PTY presence.
- `PermissionRequest` signals the agent needs attention, matching what the workspace board displays.
- Reads from the existing `TerminalAgentStore`; no new detector or status model is introduced.
- Exports `TerminalAgentStatus` and `TerminalAgentLifecycleEventType` from the SDK and documents the field in the CLI and SDK reference docs.

<sup>Written for commit da713eb00a1ab5330bd01106f6ab49d1946cebd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal listings now include live agent status when an agent is detected, including identity, session details, lifecycle state, and timestamps.
  * Permission requests are clearly identified when an agent needs input or approval.
  * SDK users can access new terminal-agent status types and lifecycle event values.

* **Documentation**
  * Updated CLI and SDK references to describe agent status fields.
  * Added an example showing how to detect terminals awaiting permission and identify the agent involved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->