### PR TITLE
fix(desktop): render Nerd Font icons for any terminal font

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
@@ -139,6 +139,13 @@ describe("sanitizeTerminalFontFamily", () => {
 		);
 	});
 
+	test("escapes backslashes and quotes so any name serializes to valid CSS", () => {
+		restore = stubCanvas(() => equalWidths);
+		expect(sanitizeTerminalFontFamily("Trailing\\")).toBe(
+			`"Trailing\\\\", ${nerdTail()}, monospace`,
+		);
+	});
+
 	test("quotes families that are invalid as unquoted CSS idents", () => {
 		// "0xProto Nerd Font" starts with a digit — unquoted it invalidates the
 		// whole font-family value, so canvas `ctx.font` silently keeps its default

--- a/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
 	DEFAULT_TERMINAL_FONT_FAMILY,
+	NERD_FONT_FALLBACK_FAMILIES,
 	resolveTerminalAppearance,
 	sanitizeTerminalFontFamily,
 } from "./index";
+
+/** Quoted nerd-font fallback tail, minus families already in the stack. */
+function nerdTail(...present: string[]): string {
+	const lower = new Set(present.map((f) => f.toLowerCase()));
+	return NERD_FONT_FALLBACK_FAMILIES.filter((f) => !lower.has(f.toLowerCase()))
+		.map((f) => `"${f}"`)
+		.join(", ");
+}
 
 type MeasureFn = (text: string) => { width: number };
 
@@ -68,9 +77,13 @@ describe("sanitizeTerminalFontFamily", () => {
 		);
 	});
 
-	test("trusts all-generic monospace values without canvas", () => {
-		expect(sanitizeTerminalFontFamily("monospace")).toBe("monospace");
-		expect(sanitizeTerminalFontFamily("ui-monospace")).toBe("ui-monospace");
+	test("trusts generic monospace primaries without canvas, adding icon fallbacks after them", () => {
+		expect(sanitizeTerminalFontFamily("monospace")).toBe(
+			`monospace, ${nerdTail()}`,
+		);
+		expect(sanitizeTerminalFontFamily("ui-monospace")).toBe(
+			`ui-monospace, ${nerdTail()}`,
+		);
 	});
 
 	test("falls back when the primary family is a proportional generic", () => {
@@ -89,11 +102,11 @@ describe("sanitizeTerminalFontFamily", () => {
 		);
 	});
 
-	test("passes through a stack whose primary generic is monospace", () => {
+	test("keeps a generic monospace primary first, fallbacks after it", () => {
 		// The browser resolves the first generic, so "monospace, sans-serif"
-		// actually renders as monospace — safe.
+		// actually renders as monospace — safe; icon fallbacks slot in behind it.
 		expect(sanitizeTerminalFontFamily("monospace, sans-serif")).toBe(
-			"monospace, sans-serif",
+			`monospace, ${nerdTail()}, sans-serif`,
 		);
 	});
 
@@ -106,21 +119,60 @@ describe("sanitizeTerminalFontFamily", () => {
 		);
 	});
 
-	test("passes a monospace font through when the stack already ends with monospace", () => {
+	test("inserts nerd-font fallbacks before an existing monospace tail", () => {
 		restore = stubCanvas(() => equalWidths);
 		expect(sanitizeTerminalFontFamily('"JetBrains Mono", monospace')).toBe(
-			'"JetBrains Mono", monospace',
+			`"JetBrains Mono", ${nerdTail()}, monospace`,
 		);
 	});
 
-	test("appends a monospace fallback when the stack lacks one", () => {
-		// If the primary isn't installed, the browser otherwise falls back to a
-		// proportional default — appending "monospace" forces OS monospace.
+	test("appends nerd-font fallbacks and a monospace tail to a bare family", () => {
+		// The fallbacks keep PUA icons (eza --icons, starship) rendering when the
+		// chosen font lacks the glyphs; the generic tail keeps an uninstalled
+		// primary from resolving to a proportional default.
 		restore = stubCanvas(() => equalWidths);
 		expect(sanitizeTerminalFontFamily('"JetBrains Mono"')).toBe(
-			'"JetBrains Mono", monospace',
+			`"JetBrains Mono", ${nerdTail()}, monospace`,
 		);
-		expect(sanitizeTerminalFontFamily("Menlo")).toBe("Menlo, monospace");
+		expect(sanitizeTerminalFontFamily("Menlo")).toBe(
+			`"Menlo", ${nerdTail()}, monospace`,
+		);
+	});
+
+	test("quotes families that are invalid as unquoted CSS idents", () => {
+		// "0xProto Nerd Font" starts with a digit — unquoted it invalidates the
+		// whole font-family value, so canvas `ctx.font` silently keeps its default
+		// and the WebGL atlas rasterizes tofu for every icon (SUPER-1782).
+		restore = stubCanvas(() => equalWidths);
+		expect(sanitizeTerminalFontFamily("0xProto Nerd Font")).toBe(
+			`"0xProto Nerd Font", ${nerdTail()}, monospace`,
+		);
+	});
+
+	test("does not duplicate a chosen family that is already a fallback", () => {
+		restore = stubCanvas(() => equalWidths);
+		expect(sanitizeTerminalFontFamily("Hack Nerd Font")).toBe(
+			`"Hack Nerd Font", ${nerdTail("Hack Nerd Font")}, monospace`,
+		);
+	});
+
+	test("appends detected installed Nerd Fonts after the well-known fallbacks", () => {
+		restore = stubCanvas(() => equalWidths);
+		expect(
+			sanitizeTerminalFontFamily("Menlo", [
+				"0xProto Nerd Font Mono",
+				"Hack Nerd Font", // already a well-known fallback — not duplicated
+			]),
+		).toBe(`"Menlo", ${nerdTail()}, "0xProto Nerd Font Mono", monospace`);
+	});
+
+	test("includes detected installed Nerd Fonts in the default stack", () => {
+		expect(sanitizeTerminalFontFamily(null, ["0xProto Nerd Font Mono"])).toBe(
+			DEFAULT_TERMINAL_FONT_FAMILY.replace(
+				", monospace",
+				', "0xProto Nerd Font Mono", monospace',
+			),
+		);
 	});
 
 	test("falls back to default for a proportional primary family (quoted)", () => {
@@ -144,7 +196,7 @@ describe("sanitizeTerminalFontFamily", () => {
 		// Use a unique family so the module-level monospace cache doesn't mask
 		// the canvas error path.
 		expect(sanitizeTerminalFontFamily('"UnmeasurableFont-ABC-123"')).toBe(
-			'"UnmeasurableFont-ABC-123", monospace',
+			`"UnmeasurableFont-ABC-123", ${nerdTail()}, monospace`,
 		);
 	});
 });
@@ -182,7 +234,7 @@ describe("resolveTerminalAppearance", () => {
 		});
 
 		expect(appearance).toMatchObject({
-			fontFamily: "monospace",
+			fontFamily: `monospace, ${nerdTail()}`,
 			fontSize: 15.5,
 			lineHeight: 1.3,
 			letterSpacing: 0.5,

--- a/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
@@ -63,7 +63,9 @@ function serializeFontFamilyList(families: string[]): string {
 		.map((family) =>
 			GENERIC_FONT_FAMILIES.has(family.toLowerCase())
 				? family
-				: `"${family.replaceAll('"', '\\"')}"`,
+				: // Backslashes first, then quotes — a family ending in "\" would
+					// otherwise escape its own closing quote and invalidate the value.
+					`"${family.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`,
 		)
 		.join(", ");
 }

--- a/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
@@ -61,15 +61,20 @@ const GENERIC_FONT_FAMILIES = new Set([
 function serializeFontFamilyList(families: string[]): string {
 	return families
 		.map((family) =>
-			GENERIC_FONT_FAMILIES.has(family)
+			GENERIC_FONT_FAMILIES.has(family.toLowerCase())
 				? family
 				: `"${family.replaceAll('"', '\\"')}"`,
 		)
 		.join(", ");
 }
 
-export const DEFAULT_TERMINAL_FONT_FAMILIES = [
-	"JetBrains Mono",
+/**
+ * Icon-capable fallback families appended after the user's chosen font so
+ * Nerd Font glyphs (private-use-area icons from eza/starship/etc.) resolve
+ * even when the primary font lacks them. CSS font matching is per-character,
+ * so these only ever supply glyphs the earlier families are missing.
+ */
+export const NERD_FONT_FALLBACK_FAMILIES = [
 	"JetBrainsMono Nerd Font",
 	"MesloLGM Nerd Font",
 	"MesloLGM NF",
@@ -78,6 +83,13 @@ export const DEFAULT_TERMINAL_FONT_FAMILIES = [
 	"Hack Nerd Font",
 	"FiraCode Nerd Font",
 	"CaskaydiaCove Nerd Font",
+	"Symbols Nerd Font Mono",
+	"Symbols Nerd Font",
+] as const;
+
+export const DEFAULT_TERMINAL_FONT_FAMILIES = [
+	"JetBrains Mono",
+	...NERD_FONT_FALLBACK_FAMILIES,
 	"Menlo",
 	"Monaco",
 	"Courier New",
@@ -169,10 +181,17 @@ function isFontFamilyMonospace(family: string): boolean {
  */
 export function sanitizeTerminalFontFamily(
 	cssValue: string | null | undefined,
+	installedIconFonts: readonly string[] = [],
 ): string {
-	if (!cssValue || !cssValue.trim()) return DEFAULT_TERMINAL_FONT_FAMILY;
+	const defaultStack = () =>
+		buildIconCapableStack(
+			[...DEFAULT_TERMINAL_FONT_FAMILIES],
+			installedIconFonts,
+		);
+
+	if (!cssValue || !cssValue.trim()) return defaultStack();
 	const families = parseFontFamilyList(cssValue);
-	if (families.length === 0) return DEFAULT_TERMINAL_FONT_FAMILY;
+	if (families.length === 0) return defaultStack();
 
 	// Validate the actual CSS primary (first entry), not the first non-generic.
 	// A value like `sans-serif, "JetBrains Mono"` resolves to sans-serif in the
@@ -182,27 +201,70 @@ export function sanitizeTerminalFontFamily(
 	const primaryKey = primary.toLowerCase();
 
 	if (GENERIC_FONT_FAMILIES.has(primaryKey)) {
-		if (MONOSPACE_GENERIC_FAMILIES.has(primaryKey)) return cssValue;
-		console.warn(
-			`[terminal] Font stack "${cssValue}" has no monospace primary family; falling back to default terminal font.`,
-		);
-		return DEFAULT_TERMINAL_FONT_FAMILY;
-	}
-
-	if (!isFontFamilyMonospace(primary)) {
+		if (!MONOSPACE_GENERIC_FAMILIES.has(primaryKey)) {
+			console.warn(
+				`[terminal] Font stack "${cssValue}" has no monospace primary family; falling back to default terminal font.`,
+			);
+			return defaultStack();
+		}
+	} else if (!isFontFamilyMonospace(primary)) {
 		console.warn(
 			`[terminal] Font "${primary}" is not monospace; falling back to default terminal font.`,
 		);
-		return DEFAULT_TERMINAL_FONT_FAMILY;
+		return defaultStack();
 	}
-	// Ensure a generic monospace tail — if the configured primary isn't
-	// installed on this machine, the browser falls back to the OS monospace
-	// generic instead of a proportional default (mirrors VS Code's behavior
-	// in src/vs/workbench/contrib/terminal/browser/terminalConfigurationService.ts).
-	const hasMonoTail = families.some((f) =>
-		MONOSPACE_GENERIC_FAMILIES.has(f.toLowerCase()),
+	return buildIconCapableStack(families, installedIconFonts);
+}
+
+/**
+ * Re-serialize a validated family list with every non-generic name quoted,
+ * Nerd Font fallbacks merged in, and a generic monospace tail.
+ *
+ * Quoting: the persisted setting is a bare family name, and families that
+ * aren't valid unquoted CSS idents (e.g. the digit-led "0xProto Nerd Font")
+ * otherwise invalidate the whole font-family value — canvas `ctx.font` then
+ * silently keeps its previous value, so the WebGL glyph atlas rasterizes with
+ * the default sans-serif: every icon becomes tofu and cell metrics diverge
+ * (SUPER-1782).
+ *
+ * Fallbacks: CSS font matching is per-character, so appending icon-capable
+ * families after the user's choice only ever supplies glyphs the chosen font
+ * is missing — without them, picking any font dropped the default stack's
+ * Nerd Font tail and PUA icons went tofu. `installedIconFonts` extends the
+ * well-known names with Nerd Fonts actually installed on this machine.
+ *
+ * Generic tail: keeps an uninstalled primary from falling back to a
+ * proportional default (mirrors VS Code's terminalConfigurationService).
+ */
+function buildIconCapableStack(
+	families: string[],
+	installedIconFonts: readonly string[],
+): string {
+	const seen = new Set(families.map((f) => f.toLowerCase()));
+	const fallbacks: string[] = [];
+	for (const f of [...NERD_FONT_FALLBACK_FAMILIES, ...installedIconFonts]) {
+		const key = f.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		fallbacks.push(f);
+	}
+	// Insert before the generic tail, but never before the primary — a
+	// generic-monospace primary (e.g. bare "monospace") must stay first while
+	// still gaining the icon fallbacks after it.
+	const firstGenericIdx = families.findIndex((f) =>
+		GENERIC_FONT_FAMILIES.has(f.toLowerCase()),
 	);
-	return hasMonoTail ? cssValue : `${cssValue}, monospace`;
+	const insertAt =
+		firstGenericIdx === -1 ? families.length : Math.max(firstGenericIdx, 1);
+	const merged = [
+		...families.slice(0, insertAt),
+		...fallbacks,
+		...families.slice(insertAt),
+	];
+	if (!merged.some((f) => MONOSPACE_GENERIC_FAMILIES.has(f.toLowerCase()))) {
+		merged.push("monospace");
+	}
+	return serializeFontFamilyList(merged);
 }
 
 /** Reads localStorage theme cache for flash-free first paint. */
@@ -214,11 +276,15 @@ export function getDefaultTerminalAppearance(): TerminalAppearance {
 export function resolveTerminalAppearance(
 	theme: ITheme,
 	fontSettings: TerminalFontSettings = {},
+	installedIconFonts: readonly string[] = [],
 ): TerminalAppearance {
 	return {
 		theme,
 		background: theme.background ?? "#151110",
-		fontFamily: sanitizeTerminalFontFamily(fontSettings.terminalFontFamily),
+		fontFamily: sanitizeTerminalFontFamily(
+			fontSettings.terminalFontFamily,
+			installedIconFonts,
+		),
 		fontSize: fontSettings.terminalFontSize ?? DEFAULT_TERMINAL_FONT_SIZE,
 		lineHeight: fontSettings.terminalLineHeight ?? DEFAULT_TERMINAL_LINE_HEIGHT,
 		letterSpacing:

--- a/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+	detectInstalledNerdFontFamilies,
+	isNerdFontFamily,
+} from "./installed-nerd-fonts";
+
+describe("isNerdFontFamily", () => {
+	test("matches patched family names", () => {
+		expect(isNerdFontFamily("JetBrainsMono Nerd Font")).toBe(true);
+		expect(isNerdFontFamily("0xProto Nerd Font Mono")).toBe(true);
+		expect(isNerdFontFamily("MesloLGLDZ Nerd Font Mono")).toBe(true);
+		expect(isNerdFontFamily("MesloLGS NF")).toBe(true);
+		expect(isNerdFontFamily("JetBrainsMonoNL NFM")).toBe(true);
+	});
+
+	test("rejects proportional variants and regular fonts", () => {
+		expect(isNerdFontFamily("0xProto Nerd Font Propo")).toBe(false);
+		expect(isNerdFontFamily("JetBrainsMonoNL NFP")).toBe(false);
+		expect(isNerdFontFamily("JetBrains Mono")).toBe(false);
+		expect(isNerdFontFamily("Menlo")).toBe(false);
+		expect(isNerdFontFamily("Inter")).toBe(false);
+	});
+});
+
+describe("detectInstalledNerdFontFamilies", () => {
+	const fontData = (family: string) => ({
+		family,
+		fullName: family,
+		postscriptName: family.replaceAll(" ", ""),
+		style: "Regular",
+	});
+
+	test("filters, dedupes, and prefers Mono variants", async () => {
+		window.queryLocalFonts = async () =>
+			[
+				"Inter",
+				"0xProto Nerd Font",
+				"0xProto Nerd Font", // per-style duplicate
+				"0xProto Nerd Font Mono",
+				"0xProto Nerd Font Propo",
+				"MesloLGS NF",
+			].map(fontData);
+
+		const families = await detectInstalledNerdFontFamilies();
+		expect(families).toEqual([
+			"0xProto Nerd Font Mono",
+			"0xProto Nerd Font",
+			"MesloLGS NF",
+		]);
+
+		// Cached: a second call must not re-enumerate.
+		window.queryLocalFonts = async () => {
+			throw new Error("re-enumerated");
+		};
+		expect(await detectInstalledNerdFontFamilies()).toEqual(families);
+	});
+});

--- a/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.ts
@@ -1,0 +1,60 @@
+/**
+ * Detect Nerd Font families installed on this machine so the terminal font
+ * stack can fall back to them for private-use-area icon glyphs (SUPER-1782).
+ * The static NERD_FONT_FALLBACK_FAMILIES list only covers well-known names;
+ * users install arbitrarily named patches ("0xProto Nerd Font",
+ * "MesloLGLDZ Nerd Font Mono", …) that would otherwise never enter the stack.
+ */
+
+/** Nerd Fonts patcher family names: "X Nerd Font [Mono]" or short "X NF/NFM". */
+const NERD_FONT_NAME_PATTERN = /nerd font/i;
+const NERD_FONT_ABBREV_PATTERN = / NFM?$/i;
+/** Proportional variants — their icons break monospace cell metrics. */
+const PROPORTIONAL_VARIANT_PATTERN = /(?: propo| NFP)$/i;
+
+export function isNerdFontFamily(family: string): boolean {
+	if (PROPORTIONAL_VARIANT_PATTERN.test(family)) return false;
+	return (
+		NERD_FONT_NAME_PATTERN.test(family) || NERD_FONT_ABBREV_PATTERN.test(family)
+	);
+}
+
+/** Keep the CSS stack bounded when a user has many Nerd Fonts installed. */
+const MAX_DETECTED_FAMILIES = 8;
+
+let cached: Promise<string[]> | null = null;
+
+/**
+ * Enumerate installed Nerd Font families via the Local Font Access API.
+ * Resolves to [] when the API is unavailable or enumeration fails; the
+ * result is cached for the renderer's lifetime (font installs mid-session
+ * aren't visible to Chromium without a relaunch anyway).
+ */
+export function detectInstalledNerdFontFamilies(): Promise<string[]> {
+	cached ??= (async () => {
+		try {
+			const query = window.queryLocalFonts;
+			if (typeof query !== "function") return [];
+			const fonts = await query.call(window);
+
+			const seen = new Set<string>();
+			const families: string[] = [];
+			for (const font of fonts) {
+				const family = font.family;
+				if (!family) continue;
+				const key = family.toLowerCase();
+				if (seen.has(key)) continue;
+				seen.add(key);
+				if (isNerdFontFamily(family)) families.push(family);
+			}
+			// Mono variants first — their icons are drawn to fit a single cell.
+			families.sort(
+				(a, b) => Number(/mono$/i.test(b)) - Number(/mono$/i.test(a)),
+			);
+			return families.slice(0, MAX_DETECTED_FAMILIES);
+		} catch {
+			return [];
+		}
+	})();
+	return cached;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/hooks/useTerminalAppearance/useTerminalAppearance.ts
@@ -6,6 +6,7 @@ import {
 	resolveTerminalAppearance,
 	type TerminalAppearance,
 } from "renderer/lib/terminal/appearance";
+import { detectInstalledNerdFontFamilies } from "renderer/lib/terminal/appearance/installed-nerd-fonts";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTerminalTheme } from "renderer/stores/theme";
 
@@ -18,9 +19,17 @@ export function useTerminalAppearance(): TerminalAppearance {
 		queryFn: () => electronTrpcClient.settings.getFontSettings.query(),
 		staleTime: 30_000,
 	});
+	// Installed Nerd Fonts join the font stack as icon-glyph fallbacks; the
+	// enumeration is cached for the renderer's lifetime (module-level too, so
+	// the query never re-runs the OS enumeration).
+	const { data: installedIconFonts } = useQuery({
+		queryKey: ["installed-nerd-font-families"],
+		queryFn: detectInstalledNerdFontFamilies,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
 
 	return useMemo(() => {
 		const theme = terminalTheme ?? fallbackTheme;
-		return resolveTerminalAppearance(theme, fontSettings);
-	}, [terminalTheme, fontSettings]);
+		return resolveTerminalAppearance(theme, fontSettings, installedIconFonts);
+	}, [terminalTheme, fontSettings, installedIconFonts]);
 }


### PR DESCRIPTION
**Links**
- Issue: [SUPER-1782](https://linear.app/superset-sh/issue/SUPER-1782/nerd-font-glyphs-not-rendering-as-icons-in-terminal) (Discord report: icons render as empty boxes with default settings, Menlo, and JetBrains Mono)

## Summary
- Quote every family name when building the terminal font stack — a digit-led name like `0xProto Nerd Font` was invalid unquoted CSS and silently invalidated the whole stack (WebGL atlas fell back to `10px sans-serif`: every icon tofu, cell metrics broken).
- Keep private-use-area icons rendering for any chosen font by merging Nerd Font fallbacks into every stack: the well-known names (now including Symbols Nerd Font) plus the Nerd Fonts actually installed on the machine, detected via `queryLocalFonts`.

## Why / Context
Chromium performs no system font fallback for PUA codepoints — an icon glyph must come from a font explicitly in the declared `font-family` list. Two bugs guaranteed tofu:

1. **Unquoted stack.** The persisted setting is a bare family name and `sanitizeTerminalFontFamily` returned it unquoted. Families that aren't valid unquoted CSS idents (`0xProto Nerd Font`, `3270 Nerd Font`) invalidate the entire value; canvas `ctx.font` keeps its previous value, so the WebGL glyph atlas rasterized in sans-serif (`CSS.supports("font-family", "0xProto Nerd Font, monospace")` → `false`).
2. **Dropped fallbacks.** Picking any font in settings produced `<font>, monospace`, discarding the default stack's Nerd Font tail — so a non-Nerd primary (Menlo, JetBrains Mono, exactly what the reporter tried) could never render an icon even with a Nerd Font installed.

## How It Works
- `sanitizeTerminalFontFamily` is now one parse → validate → build pipeline. Every valid path goes through `buildIconCapableStack`: non-generic names quoted, icon fallbacks merged (deduped, inserted before the generic tail, never displacing the primary), and a generic monospace tail appended. The old raw pass-through returns are gone, and a latent case-sensitivity bug in `serializeFontFamilyList` is fixed.
- New `appearance/installed-nerd-fonts.ts` enumerates installed Nerd Font families once per renderer lifetime via `queryLocalFonts` (the same API the settings font picker already uses): Propo/NFP variants excluded (proportional icons break cell metrics), Mono variants sorted first, capped at 8.
- `useTerminalAppearance` feeds the detected families in via react-query; live terminals restyle through the existing `updateAppearance` path. The default (unset) stack gets the detected families too, so icons work out of the box with any installed Nerd Font, not just the hardcoded names.

CSS font matching is per-character, so fallbacks only ever supply glyphs the chosen font is missing — ASCII always renders in the user's chosen font.

## Manual QA Checklist
Verified in the dev app over CDP (screenshots on the Linear issue thread workflow; all six icon planes exercised: powerline, devicons, seti, Font Awesome, octicons, supplementary-plane material):
- [x] Font set to `0xProto Nerd Font` (invalid-unquoted name): previously double-spaced text + zero icons; now correct metrics and all icons render
- [x] Font set to `Menlo` (no nerd glyphs): icons render via detected installed Nerd Fonts, ASCII stays Menlo
- [x] Default settings (no font chosen): detected fonts merge into the default stack, icons render
- [x] Live terminals pick up a settings change without recreating the session (existing `updateAppearance` path)

## Testing
- `bun run typecheck` (desktop)
- `bun test src/renderer/lib/terminal/` — 340/340 (19 in the appearance suite, 8 new)
- Biome clean on changed files

## Known Limitations
- A machine with zero Nerd Fonts installed still shows tofu — no stack can supply missing glyphs. The settings page already warns when a chosen font isn't installed.

## Follow-ups
- Consider bundling Symbols Nerd Font (~2 MB) as a `@font-face` fallback like Ghostty/WezTerm, so icons work with no Nerd Font installed at all. Left out here: the app currently bundles no fonts, so that's a size/licensing decision.

https://claude.ai/code/session_01RqqJQQY4jyCBJvsqekDURb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SUPER-1782: Nerd Font icons no longer render as empty boxes when the terminal font is anything but the default.

Previously, selecting a font like `Menlo` dropped the Nerd Font fallbacks, and names that aren't valid CSS (like digit-led `0xProto Nerd Font` or ones ending in a backslash) invalidated the entire font stack, so the glyph atlas fell back to sans-serif. Now every family name is quoted and escaped, and every stack gets Nerd Font fallbacks — both the well-known names and Nerd Fonts installed on the machine, detected via `queryLocalFonts`. Icons render for any chosen font; ASCII text still renders in the user's font.

**Known limitation**
- A machine with no Nerd Fonts installed still can't render icons; the stack can't supply missing glyphs.

<sup>Written for commit a430a25fd4b39c521965f65bd717cddb36c2d076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Terminal rendering now provides more reliable icon and glyph support by detecting installed Nerd Fonts.
  * Font fallback handling preserves monospace formatting and avoids duplicate or invalid font names.
  * Supports additional Nerd Font naming variants while excluding incompatible proportional fonts.

* **Bug Fixes**
  * Improved terminal appearance when configured fonts are unavailable or contain special characters.
  * Added safer fallbacks when local font detection is unavailable or unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->