### PR TITLE
feat(agent-setup): report agent launch from the wrapper so terminals bind at boot

### DIFF
--- a/packages/agent-setup/src/agent-wrappers-common.ts
+++ b/packages/agent-setup/src/agent-wrappers-common.ts
@@ -4,7 +4,7 @@ import { SUPERSET_MANAGED_BINARIES } from "./agent-setup-targets";
 import { NOTIFY_SCRIPT_NAME } from "./notify-hook";
 import { getBinDir } from "./paths";
 
-export const WRAPPER_MARKER = "# Superset agent-wrapper v3";
+export const WRAPPER_MARKER = "# Superset agent-wrapper v4";
 export { SUPERSET_MANAGED_BINARIES };
 
 /** Path (under SUPERSET_HOME_DIR) of the runtime notify hook script. */
@@ -151,6 +151,43 @@ export interface BuildWrapperScriptOptions {
 	agentId?: string;
 }
 
+/**
+ * Shell block that reports the agent launch to the host so the terminal gets
+ * an agent binding the moment a harness starts — not on its first native hook.
+ * Some harnesses defer their SessionStart hook until the first turn (Codex
+ * creates its rollout lazily, so an idle or resumed TUI fires nothing) and
+ * some have no session hooks at all (vibe); the wrapper is the one launch-time
+ * signal every harness shares. The report is delayed and liveness-gated so
+ * `--help`-style probes that exit right away never bind a pane, and the
+ * subshell survives `exec` — after it, the captured pid IS the agent process.
+ * Harnesses with working native SessionStart hooks fire too; the host upsert
+ * makes the duplicate harmless and lets them attach the real session id.
+ */
+function buildLaunchReportBlock(): string {
+	return `_superset_skip_launch_report=""
+for _superset_arg in "$@"; do
+  # Tokens past \`--\` are prompt text, never flags.
+  [ "$_superset_arg" = "--" ] && break
+  case "$_superset_arg" in
+    --help|-h|--version|-V|-v)
+      _superset_skip_launch_report="1"
+      break
+      ;;
+  esac
+done
+if [ -z "$_superset_skip_launch_report" ] && [ -n "$SUPERSET_TERMINAL_ID" ] \\
+  && [ -n "$SUPERSET_HOME_DIR" ] && [ -x "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" ]; then
+  _superset_launch_pid=$$
+  (
+    sleep 2
+    kill -0 "$_superset_launch_pid" 2>/dev/null || exit 0
+    exec "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" '{"hook_event_name":"SessionStart"}'
+  ) >/dev/null 2>&1 </dev/null &
+fi
+
+`;
+}
+
 export function buildWrapperScript(
 	binaryName: string,
 	execLine: string,
@@ -159,6 +196,7 @@ export function buildWrapperScript(
 	const exportAgentId = options.agentId
 		? `export SUPERSET_AGENT_ID="${options.agentId}"\n\n`
 		: "";
+	const launchReport = options.agentId ? buildLaunchReportBlock() : "";
 	return `#!/bin/bash
 ${WRAPPER_MARKER}
 # Superset wrapper for ${binaryName}
@@ -170,7 +208,7 @@ if [ -z "$REAL_BIN" ]; then
   exit 127
 fi
 
-${exportAgentId}${execLine}
+${exportAgentId}${launchReport}${execLine}
 `;
 }
 

--- a/packages/agent-setup/src/agent-wrappers-launch-report.test.ts
+++ b/packages/agent-setup/src/agent-wrappers-launch-report.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { writeFileIfChanged } from "./write-file-if-changed";
+
+// No mock.module here on purpose: buildWrapperScript is pure string
+// generation, and the behavioral cases below execute the generated script
+// with a self-contained fake PATH/home, so the real ./paths module is fine.
+const { buildWrapperScript } = await import("./agent-wrappers-common");
+
+/**
+ * The launch report waits this long before checking the agent is still
+ * alive. Tests that assert the report fired (or didn't) must outlast it.
+ */
+const REPORT_DELAY_MS = 2000;
+
+interface Scenario {
+	root: string;
+	supersetHome: string;
+	notifyLog: string;
+	wrapperPath: string;
+}
+
+/**
+ * Builds an isolated scenario: a fake agent binary on PATH, a fake
+ * notify.sh that records its payload, and a generated wrapper for it.
+ */
+function setupScenario(binaryBody: string): Scenario {
+	const root = mkdtempSync(path.join(tmpdir(), "wrapper-launch-report-"));
+	const binDir = path.join(root, "bin");
+	const supersetHome = path.join(root, "superset-home");
+	const hooksDir = path.join(supersetHome, "hooks");
+	mkdirSync(binDir, { recursive: true });
+	mkdirSync(hooksDir, { recursive: true });
+
+	const notifyLog = path.join(root, "notify.log");
+	writeFileIfChanged(
+		path.join(hooksDir, "notify.sh"),
+		`#!/bin/bash\nprintf '%s|%s\\n' "$SUPERSET_AGENT_ID" "$1" >> "${notifyLog}"\n`,
+		0o755,
+	);
+	writeFileIfChanged(
+		path.join(binDir, "testagent"),
+		`#!/bin/bash\n${binaryBody}\n`,
+		0o755,
+	);
+
+	const wrapperPath = path.join(root, "wrapper");
+	writeFileIfChanged(
+		wrapperPath,
+		buildWrapperScript("testagent", `exec "$REAL_BIN" "$@"`, {
+			agentId: "testagent",
+		}),
+		0o755,
+	);
+
+	return { root, supersetHome, notifyLog, wrapperPath };
+}
+
+async function runWrapper(
+	scenario: Scenario,
+	args: string[],
+	envOverrides: Record<string, string> = {},
+): Promise<void> {
+	const proc = Bun.spawn({
+		cmd: ["bash", scenario.wrapperPath, ...args],
+		env: {
+			...process.env,
+			PATH: `${path.dirname(scenario.wrapperPath)}:${path.join(scenario.root, "bin")}:${process.env.PATH ?? ""}`,
+			SUPERSET_TERMINAL_ID: "terminal-test",
+			SUPERSET_HOME_DIR: scenario.supersetHome,
+			...envOverrides,
+		},
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	await proc.exited;
+}
+
+function readNotifyLog(scenario: Scenario): string {
+	return existsSync(scenario.notifyLog)
+		? readFileSync(scenario.notifyLog, "utf-8")
+		: "";
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("wrapper launch report", () => {
+	it("emits SessionStart at launch and skips help/version/fast-exit/non-Superset runs", async () => {
+		// The report is liveness-gated behind a real 2s delay, so run every
+		// scenario concurrently to keep the suite fast.
+		const longRun = `sleep ${(REPORT_DELAY_MS + 1200) / 1000}`;
+		const running = setupScenario(longRun);
+		const fastExit = setupScenario("exit 0");
+		const helpFlag = setupScenario(longRun);
+		const afterDashDash = setupScenario(longRun);
+		const outsideSuperset = setupScenario(longRun);
+
+		await Promise.all([
+			runWrapper(running, ["chat"]),
+			runWrapper(fastExit, []),
+			runWrapper(helpFlag, ["--help"]),
+			// Tokens past `--` are prompt text, never flags.
+			runWrapper(afterDashDash, ["--", "--help"]),
+			runWrapper(outsideSuperset, [], {
+				SUPERSET_TERMINAL_ID: "",
+				SUPERSET_TAB_ID: "",
+			}),
+		]);
+		// The fast-exit wrapper returns immediately; give its (never-firing)
+		// report window time to elapse before asserting absence.
+		await sleep(REPORT_DELAY_MS + 600);
+
+		expect(readNotifyLog(running)).toContain(
+			'testagent|{"hook_event_name":"SessionStart"}',
+		);
+		expect(readNotifyLog(afterDashDash)).toContain(
+			'testagent|{"hook_event_name":"SessionStart"}',
+		);
+		expect(readNotifyLog(fastExit)).toBe("");
+		expect(readNotifyLog(helpFlag)).toBe("");
+		expect(readNotifyLog(outsideSuperset)).toBe("");
+	}, 15000);
+
+	it("only injects the launch report for wrappers with an agent identity", () => {
+		const withAgent = buildWrapperScript("claude", 'exec "$REAL_BIN" "$@"', {
+			agentId: "claude",
+		});
+		const withoutAgent = buildWrapperScript("tool", 'exec "$REAL_BIN" "$@"');
+
+		expect(withAgent).toContain('{"hook_event_name":"SessionStart"}');
+		// Must be armed before the agent replaces the shell.
+		expect(
+			withAgent.indexOf('{"hook_event_name":"SessionStart"}'),
+		).toBeLessThan(withAgent.indexOf('exec "$REAL_BIN"'));
+		expect(withoutAgent).not.toContain("SessionStart");
+	});
+});

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -251,7 +251,7 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).not.toContain("-c 'notify=");
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
 
-		expect(wrapper).toContain("# Superset agent-wrapper v3");
+		expect(wrapper).toContain("# Superset agent-wrapper v4");
 
 		// Native hooks remain enabled, but the process-scoped TUI session log is
 		// the reliable Start signal for installed Codex TUI builds.

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -58,6 +58,77 @@ describe("TerminalAgentStore", () => {
 		expect(binding?.agentId).toBe("claude");
 	});
 
+	it("Attached refreshes the binding without downgrading an active working state", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			agentId: "codex",
+			agentSessionId: "s1",
+			occurredAt: 100,
+		});
+		// The wrapper's launch report is delayed and can land after the first
+		// prompt already marked the agent working; it must not flip the
+		// working indicator back to idle.
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "codex",
+			occurredAt: 200,
+		});
+
+		const binding = store.get("t1");
+		expect(binding?.lastEventType).toBe("Start");
+		expect(binding?.lastEventAt).toBe(200);
+		expect(binding?.agentSessionId).toBe("s1");
+	});
+
+	it("Attached preserves a pending PermissionRequest state", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "PermissionRequest",
+			agentId: "codex",
+			agentSessionId: "s1",
+			occurredAt: 100,
+		});
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "codex",
+			agentSessionId: "s1",
+			occurredAt: 200,
+		});
+
+		expect(store.get("t1")?.lastEventType).toBe("PermissionRequest");
+	});
+
+	it("Attached with a new session id overrides the previous session's working state", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			agentId: "codex",
+			agentSessionId: "s1",
+			occurredAt: 100,
+		});
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "codex",
+			agentSessionId: "s2",
+			occurredAt: 200,
+		});
+
+		const binding = store.get("t1");
+		expect(binding?.lastEventType).toBe("Attached");
+		expect(binding?.agentSessionId).toBe("s2");
+		expect(binding?.startedAt).toBe(200);
+	});
+
 	it("deletes the binding on Detached/exit/error", () => {
 		store.recordEvent({
 			terminalId: "t1",

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -84,25 +84,36 @@ describe("TerminalAgentStore", () => {
 		expect(binding?.agentSessionId).toBe("s1");
 	});
 
-	it("Attached preserves a pending PermissionRequest state", () => {
-		store.recordEvent({
-			terminalId: "t1",
-			workspaceId: WORKSPACE,
-			eventType: "PermissionRequest",
-			agentId: "codex",
-			agentSessionId: "s1",
-			occurredAt: 100,
-		});
-		store.recordEvent({
-			terminalId: "t1",
-			workspaceId: WORKSPACE,
-			eventType: "Attached",
-			agentId: "codex",
-			agentSessionId: "s1",
-			occurredAt: 200,
-		});
+	it("Attached preserves every same-session lifecycle state, not just working ones", () => {
+		// Stop must survive: an Attached lastEventType would erase the row's
+		// resume-candidate status; Failed must survive so the failure stays
+		// surfaced.
+		for (const [i, lastEventType] of [
+			"PermissionRequest",
+			"Stop",
+			"Failed",
+		].entries()) {
+			const terminalId = `t-preserve-${i}`;
+			store.recordEvent({
+				terminalId,
+				workspaceId: WORKSPACE,
+				eventType: lastEventType,
+				agentId: "codex",
+				agentSessionId: "s1",
+				occurredAt: 100,
+			});
+			store.recordEvent({
+				terminalId,
+				workspaceId: WORKSPACE,
+				eventType: "Attached",
+				agentId: "codex",
+				agentSessionId: "s1",
+				occurredAt: 200,
+			});
 
-		expect(store.get("t1")?.lastEventType).toBe("PermissionRequest");
+			expect(store.get(terminalId)?.lastEventType).toBe(lastEventType);
+			expect(store.get(terminalId)?.lastEventAt).toBe(200);
+		}
 	});
 
 	it("Attached with a new session id overrides the previous session's working state", () => {

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -146,16 +146,13 @@ export class TerminalAgentStore extends EventEmitter {
 			agentSessionId !== undefined &&
 			prior.agentSessionId !== agentSessionId;
 
-		// "Attached" is a session-liveness signal, not working state. The
-		// wrapper's launch report is delayed and can land after the first
-		// prompt already marked the agent working — keep the working state
-		// unless the event belongs to a different session.
-		const preservedWorkingState =
-			eventType === "Attached" &&
-			prior !== undefined &&
-			!sessionChanged &&
-			(prior.lastEventType === "Start" ||
-				prior.lastEventType === "PermissionRequest")
+		// "Attached" is a session-liveness signal, not lifecycle progress. The
+		// wrapper's launch report is delayed and can land after the session
+		// already advanced past it (working, a Stop that makes the row a
+		// resume candidate, a surfaced Failed) — keep the prior state unless
+		// the event belongs to a different session.
+		const preservedLifecycleState =
+			eventType === "Attached" && prior !== undefined && !sessionChanged
 				? prior.lastEventType
 				: undefined;
 
@@ -168,7 +165,7 @@ export class TerminalAgentStore extends EventEmitter {
 			startedAt:
 				prior !== undefined && !sessionChanged ? prior.startedAt : occurredAt,
 			lastEventAt: occurredAt,
-			lastEventType: preservedWorkingState ?? eventType,
+			lastEventType: preservedLifecycleState ?? eventType,
 		};
 
 		this.byTerminal.set(terminalId, next);

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -146,6 +146,19 @@ export class TerminalAgentStore extends EventEmitter {
 			agentSessionId !== undefined &&
 			prior.agentSessionId !== agentSessionId;
 
+		// "Attached" is a session-liveness signal, not working state. The
+		// wrapper's launch report is delayed and can land after the first
+		// prompt already marked the agent working — keep the working state
+		// unless the event belongs to a different session.
+		const preservedWorkingState =
+			eventType === "Attached" &&
+			prior !== undefined &&
+			!sessionChanged &&
+			(prior.lastEventType === "Start" ||
+				prior.lastEventType === "PermissionRequest")
+				? prior.lastEventType
+				: undefined;
+
 		const next: TerminalAgentBinding = {
 			terminalId,
 			workspaceId,
@@ -155,7 +168,7 @@ export class TerminalAgentStore extends EventEmitter {
 			startedAt:
 				prior !== undefined && !sessionChanged ? prior.startedAt : occurredAt,
 			lastEventAt: occurredAt,
-			lastEventType: eventType,
+			lastEventType: preservedWorkingState ?? eventType,
 		};
 
 		this.byTerminal.set(terminalId, next);


### PR DESCRIPTION
## Problem

A freshly launched agent pane can sit with no `terminalAgentBindings` row — and therefore none of the binding-gated pane controls — until its first Stop or an attach. Worst right after a session handoff: the new pane is exactly the one a user wants to chain from.

Root cause (proven empirically, not delivery): Codex 0.150.1 creates its session rollout lazily, so the native `SessionStart` hook registered in `~/.codex/hooks.json` fires only with the **first turn**. An idle Codex TUI booted for 10s with `--enable hooks --dangerously-bypass-hook-trust` fires nothing; `codex resume` fires nothing at launch either. Vibe has no session hooks at all (its hooks.toml supports only `before_tool`/`post_agent_turn`). Every hook POST that did fire got a 200 — the gap is upstream of the wire.

## Fix

- **Wrapper launch report** (`buildWrapperScript`, all 12 agent wrappers, marker v3→v4): a backgrounded subshell waits 2s, checks the agent process is still alive (`kill -0` on the pid that survives `exec`), then fires `{"hook_event_name":"SessionStart"}` through notify.sh. Skips `--help/-h/--version/-V/-v` (before `--`) and runs only inside Superset terminals, so version probes and fast exits never bind a pane. Server-side, SessionStart→`Attached` already creates the binding; harnesses with working native SessionStart still fire it and attach the real session id via upsert.
- **Store guard**: an `Attached` for the same agent session no longer downgrades an active `Start`/`PermissionRequest` — the delayed report must not flip a working agent to idle.

Per-harness: all 12 wrapper harnesses (claude, amp, codex, gemini, mastracode, opencode, copilot, vibe, kimi, grok, cursor-agent, droid) now report at launch via the wrapper; omp/pi have no wrappers but their extensions already fire `session_start` at session boot. Known limits: long-running non-session subcommands (`claude mcp add`, `codex login`) bind until they exit; direct-binary launches that bypass the wrapper rely on native hooks only.

## Verification

- Both new tests proven failing before the fix. `packages/agent-setup`: 268/268 + tsc clean. `packages/host-service`: 1407/1407 + typecheck clean.
- Real app over CDP: launching `codex` in a dev-app terminal produced a `codex | Attached` binding **2.5s after Enter, while Codex was still at its trust prompt** (no session, no native hook possible); the pane tab swapped to the Codex icon (the binding-gated UI on main); `/quit` ended the binding as `detached`.

https://claude.ai/code/session_01HR6rXRzQM6p8epeyer3XqG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent terminals now get their agent binding at boot instead of waiting for the harness's first native hook, which Codex defers until the first turn and vibe never fires at launch.

- All 12 agent wrappers emit a synthetic SessionStart through notify.sh 2s after launch, gated on the agent process still being alive and running inside a Superset terminal, so `--help`/`--version` probes and fast exits never bind a pane.
- Harnesses with working native hooks still fire their real SessionStart; the host upsert keeps the duplicate harmless and attaches the real session id.
- A delayed `Attached` event no longer rewrites any same-session lifecycle state — Start, PermissionRequest, Stop, or Failed — and only refreshes `lastEventAt`, so a late launch report can't hide a failure or erase a resume candidate.
- Known limits: long-running non-session subcommands (`claude mcp add`, `codex login`) bind until they exit, and direct-binary launches that bypass the wrapper rely on native hooks only.
- Verified in the dev app: launching codex produced an Attached binding 2.5s after Enter while Codex was still at its trust prompt.

<sup>Written for commit abb242f8e421e85920da0e2419f251d6a2e2fb3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added launch reporting for eligible long-running agent sessions, improving host visibility into session starts.
  - Reports are automatically skipped for help, version, short-lived commands, and unsupported environments.

- **Bug Fixes**
  - Preserved all existing session lifecycle states when an attachment event occurs, including permission requests, stops, and failures.
  - Correctly refreshed session activity during reattachment without overwriting the current lifecycle status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->