### PR TITLE
test(agent-setup): pin Claude system-default account switching

### DIFF
--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -58,6 +58,7 @@ const {
 	buildCodexWrapperExecLine,
 	buildCopilotWrapperExecLine,
 	buildWrapperScript,
+	createClaudeWrapper,
 	createClaudeSettingsJson,
 	createCodexHooksJson,
 	createCodexWrapper,
@@ -1157,6 +1158,40 @@ describe("agent-wrappers claude settings.json", () => {
 
 	afterEach(() => {
 		rmSync(TEST_ROOT, { recursive: true, force: true });
+	});
+
+	it("runs the generated wrapper on the system default after a profile switch", () => {
+		const supersetHome = path.join(TEST_ROOT, "superset");
+		const stateDir = path.join(supersetHome, "state");
+		const staleProfile = path.join(TEST_ROOT, "stale-profile");
+		const realBinDir = path.join(TEST_ROOT, "real-bin");
+		const realClaude = path.join(realBinDir, "claude");
+		const resolvedConfigDir = path.join(TEST_ROOT, "resolved-config-dir.txt");
+
+		mkdirSync(stateDir, { recursive: true });
+		mkdirSync(staleProfile);
+		mkdirSync(realBinDir);
+		writeFileSync(path.join(stateDir, "default-claude-config-dir"), "");
+		writeFileSync(
+			realClaude,
+			`#!/bin/bash
+printf '%s' "\${CLAUDE_CONFIG_DIR:-<unset>}" > "${resolvedConfigDir}"
+`,
+			{ mode: 0o755 },
+		);
+
+		createClaudeWrapper();
+		execFileSync(path.join(TEST_BIN_DIR, "claude"), ["--version"], {
+			env: {
+				PATH: `${TEST_BIN_DIR}:${realBinDir}:${process.env.PATH ?? ""}`,
+				SUPERSET_TERMINAL_ID: "terminal-1",
+				SUPERSET_HOME_DIR: supersetHome,
+				CLAUDE_CONFIG_DIR: staleProfile,
+				SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR: staleProfile,
+			},
+		});
+
+		expect(readFileSync(resolvedConfigDir, "utf-8")).toBe("<unset>");
 	});
 
 	it("creates Claude settings.json with hooks when no file exists", () => {


### PR DESCRIPTION
## What & why

Pins the generated Claude wrapper's real execution path for a Usage-tab switch from a secondary profile back to the system-default login.

The lower-level resolver already covered the environment mutation in isolation. This integration regression now creates the actual wrapper, starts it with a stale Superset-injected `CLAUDE_CONFIG_DIR`, publishes an empty default-account pointer, and proves the real Claude binary receives `CLAUDE_CONFIG_DIR` unset. That protects Keychain-backed macOS default logins from accidentally staying pinned to a signed-out profile.

## How I tested it

- `bun run lint`
- `bun run typecheck`
- `bun test packages/agent-setup/src/agent-wrappers.test.ts --test-name-pattern 'runs the generated wrapper on the system default after a profile switch'`
- `bun test packages/agent-setup/src/default-account-resolver.test.ts`

The full `agent-wrappers.test.ts` file also reaches and passes the new case, but two pre-existing OpenCode dynamic-import cases fail because their temporary modules disappear before the second and third imports. This change does not touch those cases.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integration test that verifies the generated Claude wrapper un-sets `CLAUDE_CONFIG_DIR` when switching back to the system-default login after a profile switch, preventing Keychain-backed macOS defaults from staying pinned to a signed-out profile.

<sup>Written for commit b91ce74a388fed5a49d9b63185fbcf8235461a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude now correctly uses the system’s default configuration after switching profiles, preventing stale profile settings from affecting generated wrappers.

* **Tests**
  * Added coverage to verify the corrected Claude configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->