### PR TITLE
docs: correct the port-forwarding host-service floor to 1.26

### DIFF
--- a/apps/docs/content/docs/ports.mdx
+++ b/apps/docs/content/docs/ports.mdx
@@ -66,7 +66,7 @@ When a workspace lives on a [remote host](/remote-access), the sidebar lists por
 
 If a local process already uses the port, the row shows **local port busy**. Stop the local process from the row (when a Superset workspace started it), or pick **Use another port** to map the remote port to a free local port. The row then shows the mapping, for example `3000 → localhost:54321`.
 
-Forwarding needs a host on the current relay running host-service 1.25 or newer. For other hosts, forward the port yourself.
+Forwarding needs a host on the current relay running host-service 1.26 or newer. For other hosts, forward the port yourself.
 
 ### Forward a port yourself
 

--- a/apps/docs/content/docs/remote-access.mdx
+++ b/apps/docs/content/docs/remote-access.mdx
@@ -92,7 +92,7 @@ If a local process already uses the port, the row shows **local port busy** and 
 
 The remote server sees each forwarded connection as coming from its own loopback address — there is no real client IP. Only TCP is carried; anything UDP (WebRTC media, mDNS) does not ride the forward.
 
-Forwarding needs a host on the current relay running host-service 1.25 or newer. For a host you reach some other way, [forward a port yourself](/ports#forward-a-port-yourself) with SSH or Tailscale.
+Forwarding needs a host on the current relay running host-service 1.26 or newer. For a host you reach some other way, [forward a port yourself](/ports#forward-a-port-yourself) with SSH or Tailscale.
 
 Forwarded traffic passes through the Superset relay, like terminal traffic does. A browser talking to a forwarded dev server sends whatever it normally would — cookies, auth headers, query strings — so treat a forwarded port like the remote service it reaches, not like localhost.
 


### PR DESCRIPTION
Port forwarding (#6858) merged after v1.25.0 was cut, so the docs' "host-service 1.25 or newer" names a version without the feature — a 1.25 host shows the update-required row. Bumps both mentions to 1.26.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the documented port-forwarding version floor from host-service 1.25 to 1.26 in `ports.mdx` and `remote-access.mdx`. Port forwarding merged after v1.25.0 was cut, so a 1.25 host shows the update-required row instead of forwarding; the docs now point at the first release that actually carries the feature.

<sup>Written for commit 0e3ddc0d48436d3d661d9cb2c52cabbcb44c8649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated remote access requirements: port forwarding now requires host-service version 1.26 or newer.
  * Clarified the minimum required version in the ports and remote access documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->