### PR TITLE
test(usage): isolate native history collectors

### DIFF
--- a/packages/host-service/src/trpc/router/usage/history/copilot-rows.ts
+++ b/packages/host-service/src/trpc/router/usage/history/copilot-rows.ts
@@ -1,0 +1,53 @@
+import type { UsageLogEntry } from "./parse";
+import { num } from "./parse";
+
+export interface CopilotUsageRow {
+	session_id: string | null;
+	model: string | null;
+	input_tokens: number | null;
+	output_tokens: number | null;
+	cache_read_tokens: number | null;
+	cache_write_tokens: number | null;
+	reasoning_tokens: number | null;
+	created_at: string | null;
+	cwd: string | null;
+	summary: string | null;
+}
+
+/** `created_at` is SQLite's `datetime('now')` — UTC without a zone marker. */
+function parseUtcTimestamp(raw: string | null): number {
+	if (!raw) return 0;
+	const parsed = Date.parse(`${raw.replace(" ", "T")}Z`);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function copilotRowsToEntries(
+	rows: CopilotUsageRow[],
+	cutoffMs: number,
+	out: UsageLogEntry[],
+	sessionLabels?: Map<string, string>,
+): void {
+	for (const row of rows) {
+		const timestampMs = parseUtcTimestamp(row.created_at);
+		if (!timestampMs || timestampMs < cutoffMs) continue;
+		const sessionId = row.session_id ?? "unknown";
+		if (row.summary && sessionLabels && !sessionLabels.has(sessionId)) {
+			sessionLabels.set(sessionId, row.summary);
+		}
+		out.push({
+			agent: "copilot",
+			model: row.model || "unknown",
+			timestampMs,
+			cwd: row.cwd ?? null,
+			sessionId,
+			// Cache reads/writes are separate columns (Anthropic-style), so
+			// input_tokens is taken as the non-cached count.
+			uncachedInput: num(row.input_tokens),
+			cachedInput: num(row.cache_read_tokens),
+			cacheWrite5m: num(row.cache_write_tokens),
+			cacheWrite1h: 0,
+			output: num(row.output_tokens),
+			reasoningOutput: num(row.reasoning_tokens),
+		});
+	}
+}

--- a/packages/host-service/src/trpc/router/usage/history/copilot.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/copilot.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { CopilotUsageRow } from "./copilot";
-import { copilotRowsToEntries } from "./copilot";
+import type { CopilotUsageRow } from "./copilot-rows";
+import { copilotRowsToEntries } from "./copilot-rows";
 import type { UsageLogEntry } from "./parse";
 
-// The sqlite read path itself can't run under bun (better-sqlite3 is
-// node-only); this covers the row mapping the query feeds.
+// Keep this test on the pure mapping module: the SQLite reader uses the
+// Node-only better-sqlite3 native binding, while the unit suite runs in Bun.
 
 function row(over: Partial<CopilotUsageRow> = {}): CopilotUsageRow {
 	return {

--- a/packages/host-service/src/trpc/router/usage/history/copilot.ts
+++ b/packages/host-service/src/trpc/router/usage/history/copilot.ts
@@ -8,63 +8,13 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
+import { type CopilotUsageRow, copilotRowsToEntries } from "./copilot-rows";
 import type { UsageLogEntry } from "./parse";
-import { num } from "./parse";
+
+export { type CopilotUsageRow, copilotRowsToEntries } from "./copilot-rows";
 
 export function copilotDbPath(): string {
 	return join(homedir(), ".copilot", "session-store.db");
-}
-
-export interface CopilotUsageRow {
-	session_id: string | null;
-	model: string | null;
-	input_tokens: number | null;
-	output_tokens: number | null;
-	cache_read_tokens: number | null;
-	cache_write_tokens: number | null;
-	reasoning_tokens: number | null;
-	created_at: string | null;
-	cwd: string | null;
-	summary: string | null;
-}
-
-/** `created_at` is SQLite's `datetime('now')` — UTC without a zone marker. */
-function parseUtcTimestamp(raw: string | null): number {
-	if (!raw) return 0;
-	const parsed = Date.parse(`${raw.replace(" ", "T")}Z`);
-	return Number.isFinite(parsed) ? parsed : 0;
-}
-
-/** Pure row → entry mapping, exported for tests (bun can't load sqlite). */
-export function copilotRowsToEntries(
-	rows: CopilotUsageRow[],
-	cutoffMs: number,
-	out: UsageLogEntry[],
-	sessionLabels?: Map<string, string>,
-): void {
-	for (const row of rows) {
-		const timestampMs = parseUtcTimestamp(row.created_at);
-		if (!timestampMs || timestampMs < cutoffMs) continue;
-		const sessionId = row.session_id ?? "unknown";
-		if (row.summary && sessionLabels && !sessionLabels.has(sessionId)) {
-			sessionLabels.set(sessionId, row.summary);
-		}
-		out.push({
-			agent: "copilot",
-			model: row.model || "unknown",
-			timestampMs,
-			cwd: row.cwd ?? null,
-			sessionId,
-			// Cache reads/writes are separate columns (Anthropic-style), so
-			// input_tokens is taken as the non-cached count.
-			uncachedInput: num(row.input_tokens),
-			cachedInput: num(row.cache_read_tokens),
-			cacheWrite5m: num(row.cache_write_tokens),
-			cacheWrite1h: 0,
-			output: num(row.output_tokens),
-			reasoningOutput: num(row.reasoning_tokens),
-		});
-	}
 }
 
 /** Returns 1 when the database was scanned, 0 when absent/unreadable. */

--- a/packages/host-service/src/trpc/router/usage/history/cursor-events.ts
+++ b/packages/host-service/src/trpc/router/usage/history/cursor-events.ts
@@ -1,0 +1,50 @@
+import type { UsageLogEntry } from "./parse";
+import { num } from "./parse";
+
+export interface CursorUsageEvent {
+	timestamp?: string;
+	model?: string;
+	conversationId?: string;
+	tokenUsage?: {
+		inputTokens?: number;
+		outputTokens?: number;
+		cacheReadTokens?: number;
+		cacheWriteTokens?: number;
+		totalCents?: number;
+	};
+	chargedCents?: number;
+}
+
+export function cursorEventsToEntries(
+	events: CursorUsageEvent[],
+	cutoffMs: number,
+): UsageLogEntry[] {
+	const entries: UsageLogEntry[] = [];
+	for (const event of events) {
+		const usage = event.tokenUsage;
+		if (!usage) continue;
+		const timestampMs = Number(event.timestamp);
+		if (!Number.isFinite(timestampMs) || timestampMs < cutoffMs) continue;
+		const cents = usage.totalCents ?? event.chargedCents;
+		const costUsd =
+			typeof cents === "number" && Number.isFinite(cents) && cents > 0
+				? cents / 100
+				: undefined;
+		entries.push({
+			agent: "cursor",
+			model: event.model || "unknown",
+			timestampMs,
+			cwd: null,
+			sessionId: event.conversationId || "unknown",
+			// Cursor reports cache reads separately from inputTokens.
+			uncachedInput: num(usage.inputTokens),
+			cachedInput: num(usage.cacheReadTokens),
+			cacheWrite5m: num(usage.cacheWriteTokens),
+			cacheWrite1h: 0,
+			output: num(usage.outputTokens),
+			reasoningOutput: 0,
+			...(costUsd !== undefined ? { costUsd } : {}),
+		});
+	}
+	return entries;
+}

--- a/packages/host-service/src/trpc/router/usage/history/cursor.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/cursor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { cursorEventsToEntries } from "./cursor";
+import { cursorEventsToEntries } from "./cursor-events";
 
 describe("cursorEventsToEntries", () => {
 	test("maps events with token usage into priced entries", () => {

--- a/packages/host-service/src/trpc/router/usage/history/cursor.ts
+++ b/packages/host-service/src/trpc/router/usage/history/cursor.ts
@@ -21,8 +21,10 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import Database from "better-sqlite3";
+import { type CursorUsageEvent, cursorEventsToEntries } from "./cursor-events";
 import type { UsageLogEntry } from "./parse";
-import { num } from "./parse";
+
+export { type CursorUsageEvent, cursorEventsToEntries } from "./cursor-events";
 
 const execFileAsync = promisify(execFile);
 
@@ -35,20 +37,6 @@ const FETCH_TIMEOUT_MS = 15_000;
 // for every render poll. Keyed per cutoff so range switches stay fresh.
 const EVENTS_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_LABEL_DB_OPENS = 200;
-
-export interface CursorUsageEvent {
-	timestamp?: string;
-	model?: string;
-	conversationId?: string;
-	tokenUsage?: {
-		inputTokens?: number;
-		outputTokens?: number;
-		cacheReadTokens?: number;
-		cacheWriteTokens?: number;
-		totalCents?: number;
-	};
-	chargedCents?: number;
-}
 
 export function cursorChatsDir(): string {
 	return join(homedir(), ".cursor", "chats");
@@ -144,41 +132,6 @@ let cachedEvents: {
 	fetchedAt: number;
 	events: CursorUsageEvent[];
 } | null = null;
-
-/** Pure event → entry mapping, exported for tests. */
-export function cursorEventsToEntries(
-	events: CursorUsageEvent[],
-	cutoffMs: number,
-): UsageLogEntry[] {
-	const entries: UsageLogEntry[] = [];
-	for (const event of events) {
-		const usage = event.tokenUsage;
-		if (!usage) continue;
-		const timestampMs = Number(event.timestamp);
-		if (!Number.isFinite(timestampMs) || timestampMs < cutoffMs) continue;
-		const cents = usage.totalCents ?? event.chargedCents;
-		const costUsd =
-			typeof cents === "number" && Number.isFinite(cents) && cents > 0
-				? cents / 100
-				: undefined;
-		entries.push({
-			agent: "cursor",
-			model: event.model || "unknown",
-			timestampMs,
-			cwd: null,
-			sessionId: event.conversationId || "unknown",
-			// Cursor reports cache reads separately from inputTokens.
-			uncachedInput: num(usage.inputTokens),
-			cachedInput: num(usage.cacheReadTokens),
-			cacheWrite5m: num(usage.cacheWriteTokens),
-			cacheWrite1h: 0,
-			output: num(usage.outputTokens),
-			reasoningOutput: 0,
-			...(costUsd !== undefined ? { costUsd } : {}),
-		});
-	}
-	return entries;
-}
 
 interface ChatDirIndex {
 	/** conversationId → md5-of-cwd segment. */


### PR DESCRIPTION
## What

- move Copilot row mapping into a native-free module
- move Cursor event mapping into a native-free module
- keep existing collector exports and production behavior unchanged

## Why

Bun unit tests should not load the Node-only `better-sqlite3` native binding just to exercise pure usage mapping logic.

## Test plan

- `bun run --cwd packages/host-service test` (1432 passed, 8 todo, 0 failed)
- `bun run --cwd packages/host-service typecheck`
- Biome checks for changed files
- CDP verification of the desktop usage page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the Copilot and Cursor usage row-to-entry mapping into separate `copilot-rows` and `cursor-events` modules so Bun unit tests no longer load the Node-only `better-sqlite3` binding. Production behavior and existing exports are unchanged.

<sup>Written for commit 7a62649d599d64b8091fea34eadac4269ae0a568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage history support for Copilot and Cursor activity.
  * Copilot records now include session labels, timestamps, token usage, and cache details.
  * Cursor records now capture token usage and applicable cost information.
* **Bug Fixes**
  * Invalid, incomplete, outdated, or non-billable usage events are excluded from history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->