### PR TITLE
fix(mobile): keep a Bluetooth route change from crashing dictation

### DIFF
--- a/apps/mobile/modules/composer/ios/ComposerDictation.swift
+++ b/apps/mobile/modules/composer/ios/ComposerDictation.swift
@@ -152,19 +152,28 @@ final class ComposerDictation {
 
     let input = engine.inputNode
     let format = input.outputFormat(forBus: 0)
-    // `installTap` raises an Objective-C exception — not a Swift error, so
-    // there is nothing to catch — when handed a degenerate format, which is
-    // what the input node reports while something else holds the microphone: a
-    // phone call, another recording app. Checking first turns a crash into the
-    // ordinary failure path.
+    // A degenerate format is what the input node reports while something else
+    // holds the microphone — a phone call, another recording app. Failing here
+    // is the cheap, deterministic version of the guard below.
     guard format.sampleRate > 0, format.channelCount > 0 else {
       throw NSError(domain: "ComposerDictation", code: 2)
     }
     pendingFrames = 0
     pendingPeak = 0
-    input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-      request.append(buffer)
-      self?.accumulate(buffer, sampleRate: format.sampleRate)
+    // `installTap` raises an Objective-C exception rather than throwing, and
+    // an uncaught one is a crash (MOBILE-5: "Failed to create tap due to
+    // format mismatch"). Two defences. No explicit format, because the node's
+    // format can change between reading it and installing the tap — a
+    // Bluetooth headset finishing its route switch after the session goes
+    // active — so nil lets the engine take the bus's format at the moment of
+    // the install, and the buffers carry the rate the meter needs. And the
+    // guard, so whatever AVFoundation still objects to lands on the ordinary
+    // failure path instead of taking the app down.
+    try ComposerExceptionGuard.run {
+      input.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
+        request.append(buffer)
+        self?.accumulate(buffer, sampleRate: buffer.format.sampleRate)
+      }
     }
 
     engine.prepare()

--- a/apps/mobile/modules/composer/ios/ComposerExceptionGuard.h
+++ b/apps/mobile/modules/composer/ios/ComposerExceptionGuard.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runs a block and reports an Objective-C exception as an error.
+///
+/// AVFoundation raises `NSException` from some entry points — installing an
+/// audio tap above all — and Swift cannot catch those: an uncaught one takes
+/// the process down. This is the one place they get turned into the ordinary
+/// failure path.
+@interface ComposerExceptionGuard : NSObject
+
++ (BOOL)run:(void (NS_NOESCAPE ^)(void))block error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/apps/mobile/modules/composer/ios/ComposerExceptionGuard.m
+++ b/apps/mobile/modules/composer/ios/ComposerExceptionGuard.m
@@ -1,0 +1,22 @@
+#import "ComposerExceptionGuard.h"
+
+@implementation ComposerExceptionGuard
+
++ (BOOL)run:(void (NS_NOESCAPE ^)(void))block error:(NSError **)error {
+  @try {
+    block();
+    return YES;
+  } @catch (NSException *exception) {
+    if (error) {
+      *error = [NSError errorWithDomain:@"ComposerDictation"
+                                   code:3
+                               userInfo:@{
+                                 NSLocalizedDescriptionKey : exception.reason ?: exception.name,
+                                 @"exception" : exception.name,
+                               }];
+    }
+    return NO;
+  }
+}
+
+@end


### PR DESCRIPTION
## What

Starting dictation with a Bluetooth headset could crash the app — Sentry [MOBILE-5](https://superset-sh.sentry.io/issues/MOBILE-5): fatal `NSException` "Failed to create tap due to format mismatch" from `installTapOnBus` in `ComposerDictation.beginRecording` (iPhone 16 Pro, iOS 26.6.1, TestFlight build 22).

## Why

`beginRecording` read `inputNode.outputFormat(forBus: 0)` and passed that format to `installTap`. A Bluetooth headset finishes its HFP route switch *after* `setActive(true)`, so the node's format changed between those two lines and AVFoundation raised an Objective-C exception, which Swift cannot catch. The existing guard only covered the 0 Hz "someone else holds the mic" case.

## How

- `installTap(…, format: nil)` — the engine takes the bus's format at the moment of the install; the level meter reads the sample rate off each buffer instead of the cached format.
- New `ComposerExceptionGuard` (`@try`/`@catch` → `NSError`) around the install, so anything AVFoundation still objects to becomes the existing "Could not start dictation" alert rather than a crash.

## Verification

- `xcodebuild -scheme Composer` compiles clean with the guard linked in (`pod install` registers the two new files).
- The route-change race can't be reproduced in the simulator (host mic, no Bluetooth switch). Worst case after this change is an alert, never a crash — worth a TestFlight run with AirPods.

Fixes MOBILE-5

https://claude.ai/code/session_0113rs2BkPf4Zb8Qxvfuq1Gq


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a crash when starting dictation with a Bluetooth headset whose route switch happens after the audio session goes active. AVFoundation raised an uncaught Objective-C exception when the tap format no longer matched the input node's format, so the app died instead of showing the usual failure alert.

- Installs the tap with `format: nil` so the engine takes the bus's format at install time.
- Reads the sample rate from each audio buffer instead of the format cached before the tap install.
- Wraps the tap install in a new `ComposerExceptionGuard` so any remaining AVFoundation exception becomes the existing "Could not start dictation" alert.

Fixes MOBILE-5.

<sup>Written for commit c13b657d295b469a15c1e774dc56f8fafdfb41db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice dictation reliability during audio route changes.
  * Prevented invalid recording formats and audio setup failures from causing app crashes.
  * Converted audio installation failures into standard, user-visible error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->