### PR TITLE
feat(mobile): page viewer and ContentImage (SUPER-2079)

### DIFF
--- a/apps/mobile/app/(authenticated)/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/_layout.tsx
@@ -105,6 +105,10 @@ export default function AuthenticatedLayout() {
 				options={{ ...glassHeaderOptions, title: "" }}
 			/>
 			<Stack.Screen
+				name="page/[id]"
+				options={{ ...glassHeaderOptions, title: "" }}
+			/>
+			<Stack.Screen
 				name="workspace/[id]/commits"
 				options={{
 					presentation: "formSheet",

--- a/apps/mobile/app/(authenticated)/page/[id].tsx
+++ b/apps/mobile/app/(authenticated)/page/[id].tsx
@@ -1,0 +1,3 @@
+import { PageViewerScreen } from "@/screens/(authenticated)/page/[id]";
+
+export default PageViewerScreen;

--- a/apps/mobile/hooks/useSignOut/useSignOut.ts
+++ b/apps/mobile/hooks/useSignOut/useSignOut.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { Image } from "expo-image";
 import { useRouter } from "expo-router";
 import { useCallback, useState } from "react";
 import { signOut } from "@/lib/auth/client";
@@ -13,6 +14,7 @@ export function useSignOut() {
 		try {
 			await signOut();
 			queryClient.clear();
+			await Image.clearDiskCache().catch(() => {});
 			router.replace("/(auth)/sign-in");
 		} catch (error) {
 			console.error("[auth/signOut] Failed to sign out:", error);

--- a/apps/mobile/screens/(authenticated)/components/ContentImage/ContentImage.tsx
+++ b/apps/mobile/screens/(authenticated)/components/ContentImage/ContentImage.tsx
@@ -1,0 +1,34 @@
+import { Image as ExpoImage, type ImageProps } from "expo-image";
+import { withUniwind } from "uniwind";
+
+const StyledImage = withUniwind(ExpoImage);
+
+interface ContentImageProps extends Omit<ImageProps, "source"> {
+	url: string | null | undefined;
+	/**
+	 * The server's storage key for the bytes, when it names one
+	 * (`Superset-Storage-Key`, `storageKey` in API responses). It becomes the
+	 * disk-cache key, so a rotated ticket in the URL is never a fresh
+	 * download.
+	 */
+	storageKey?: string | null;
+	className?: string;
+}
+
+/** Every remote image the app renders goes through here, cached by identity, not URL. */
+export function ContentImage({
+	url,
+	storageKey,
+	className,
+	...props
+}: ContentImageProps) {
+	if (!url) return null;
+	return (
+		<StyledImage
+			className={className}
+			source={{ uri: url, ...(storageKey ? { cacheKey: storageKey } : {}) }}
+			cachePolicy="disk"
+			{...props}
+		/>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/components/ContentImage/index.ts
+++ b/apps/mobile/screens/(authenticated)/components/ContentImage/index.ts
@@ -1,0 +1,1 @@
+export { ContentImage } from "./ContentImage";

--- a/apps/mobile/screens/(authenticated)/components/OrganizationAvatar/OrganizationAvatar.tsx
+++ b/apps/mobile/screens/(authenticated)/components/OrganizationAvatar/OrganizationAvatar.tsx
@@ -1,7 +1,7 @@
-import { Image } from "expo-image";
 import { View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
+import { ContentImage } from "../ContentImage";
 
 export function OrganizationAvatar({
 	name,
@@ -20,10 +20,7 @@ export function OrganizationAvatar({
 				className="overflow-hidden rounded-md border border-foreground/10 bg-muted"
 				style={{ width: size, height: size }}
 			>
-				<Image
-					source={{ uri: logo }}
-					style={{ width: "100%", height: "100%" }}
-				/>
+				<ContentImage url={logo} style={{ width: "100%", height: "100%" }} />
 			</View>
 		);
 	}

--- a/apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
@@ -1,0 +1,81 @@
+import { useLingui } from "@lingui/react/macro";
+import { useQuery } from "@tanstack/react-query";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { ActivityIndicator, Linking, View } from "react-native";
+import { WebView } from "react-native-webview";
+import { withUniwind } from "uniwind";
+import { Text } from "@/components/ui/text";
+import { apiClient } from "@/lib/trpc/client";
+
+const StyledWebView = withUniwind(WebView);
+
+// A ticket is stable within its window (an hour for the served alias), so
+// reopening the page inside it reuses the URL — and WebKit's cache — instead
+// of minting a fresh one.
+const VIEW_URL_STALE_MS = 55 * 60 * 1000;
+
+/**
+ * A published page, loaded top-level from its own origin: its storage, CSP
+ * and video playback work exactly as on the web, cached by WebKit. The
+ * ticket rides the URL's path, so the WebView needs no headers and no
+ * cookies. Navigation stays on the page's origin; anything else opens in
+ * the browser.
+ */
+export function PageViewerScreen() {
+	const { t } = useLingui();
+	const { id } = useLocalSearchParams<{ id: string }>();
+
+	const page = useQuery({
+		queryKey: ["cloud", "page", "get", id],
+		enabled: !!id,
+		staleTime: VIEW_URL_STALE_MS,
+		networkMode: "always",
+		queryFn: () => apiClient.page.get.query({ id: id as string }),
+	});
+
+	const viewUrl = page.data?.viewUrl;
+	const pageOrigin = viewUrl ? new URL(viewUrl).origin : null;
+
+	return (
+		<View className="flex-1 bg-background">
+			<Stack.Screen options={{ title: page.data?.title ?? "" }} />
+			{page.isError ? (
+				<View className="flex-1 items-center justify-center gap-2 px-8">
+					<Text className="text-center font-medium">
+						{t({
+							id: "dashboard.pageViewer.pageOpenFailedTitle",
+							message: "This page could not be opened",
+						})}
+					</Text>
+					<Text className="text-center text-muted-foreground text-sm">
+						{t({
+							id: "dashboard.pageViewer.pageMissingDescription",
+							message:
+								"It may have been deleted, or it belongs to another organization.",
+						})}
+					</Text>
+				</View>
+			) : viewUrl ? (
+				<StyledWebView
+					ph-no-capture
+					className="flex-1 bg-background"
+					source={{ uri: viewUrl }}
+					allowsInlineMediaPlayback
+					mediaPlaybackRequiresUserAction={false}
+					setSupportMultipleWindows={false}
+					onShouldStartLoadWithRequest={(request) => {
+						if (pageOrigin && request.url.startsWith(pageOrigin)) return true;
+						if (request.url.startsWith("about:")) return true;
+						void Linking.openURL(request.url).catch(() => {});
+						return false;
+					}}
+					webviewDebuggingEnabled={__DEV__}
+				/>
+			) : (
+				<View className="flex-1 items-center justify-center">
+					<ActivityIndicator />
+				</View>
+			)}
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/page/[id]/index.ts
+++ b/apps/mobile/screens/(authenticated)/page/[id]/index.ts
@@ -1,0 +1,1 @@
+export { PageViewerScreen } from "./PageViewerScreen";

--- a/apps/mobile/screens/RootLayout/RootLayout.tsx
+++ b/apps/mobile/screens/RootLayout/RootLayout.tsx
@@ -6,6 +6,7 @@ import {
 	QueryClient,
 	QueryClientProvider,
 } from "@tanstack/react-query";
+import { Image } from "expo-image";
 import { getLocales } from "expo-localization";
 import { Stack } from "expo-router";
 import { ThemeProvider } from "expo-router/react-navigation";
@@ -16,6 +17,11 @@ import { useSession } from "@/lib/auth/client";
 import { NAV_THEME } from "@/lib/theme";
 
 Uniwind.setTheme("dark");
+
+// Bound the image disk cache (default is unlimited) so page thumbnails and
+// attachments cannot grow without limit; ContentImage keys entries by
+// storage key, so rotated ticket URLs never duplicate bytes.
+void Image.configureCache({ maxDiskSize: 512 * 1024 * 1024 });
 
 import { PostHogUserIdentifier } from "./components/PostHogUserIdentifier";
 import { PostHogProvider } from "./providers/PostHogProvider";

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Stránky"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Mohla být smazána nebo patří jiné organizaci."
 
@@ -6156,6 +6157,7 @@ msgstr "Tato stránka už neexistuje"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Tuto stránku se nepodařilo otevřít"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Seiten"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Sie wurde möglicherweise gelöscht oder gehört zu einer anderen Organisation."
 
@@ -6156,6 +6157,7 @@ msgstr "Diese Seite existiert nicht mehr"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Diese Seite konnte nicht geöffnet werden"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Pages"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "It may have been deleted, or it belongs to another organization."
 
@@ -6156,6 +6157,7 @@ msgstr "This page no longer exists"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "This page could not be opened"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Páginas"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Puede que se haya eliminado o que pertenezca a otra organización."
 
@@ -6156,6 +6157,7 @@ msgstr "Esta página ya no existe"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "No se pudo abrir esta página"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Pages"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Elle a peut-être été supprimée, ou elle appartient à une autre organisation."
 
@@ -6156,6 +6157,7 @@ msgstr "Cette page n'existe plus"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Impossible d'ouvrir cette page"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Halaman"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Mungkin sudah dihapus, atau milik organisasi lain."
 
@@ -6156,6 +6157,7 @@ msgstr "Halaman ini sudah tidak ada"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Halaman ini tidak bisa dibuka"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Pagine"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Potrebbe essere stata eliminata oppure appartiene a un'altra organizzazione."
 
@@ -6156,6 +6157,7 @@ msgstr "Questa pagina non esiste più"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Impossibile aprire questa pagina"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -6146,6 +6146,7 @@ msgstr "ページ"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "削除されたか、別の組織に属している可能性があります。"
 
@@ -6156,6 +6157,7 @@ msgstr "このページは存在しません"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "このページを開けませんでした"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -6146,6 +6146,7 @@ msgstr "페이지"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "삭제되었거나 다른 조직에 속한 페이지일 수 있습니다."
 
@@ -6156,6 +6157,7 @@ msgstr "이 페이지는 더 이상 존재하지 않습니다"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "이 페이지를 열 수 없습니다"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Pagina's"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Mogelijk is die verwijderd, of hoort die bij een andere organisatie."
 
@@ -6156,6 +6157,7 @@ msgstr "Deze pagina bestaat niet meer"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Deze pagina kon niet worden geopend"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Strony"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Mogła zostać usunięta lub należy do innej organizacji."
 
@@ -6156,6 +6157,7 @@ msgstr "Ta strona już nie istnieje"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Nie udało się otworzyć tej strony"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Páginas"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Ela pode ter sido excluída ou pertence a outra organização."
 
@@ -6156,6 +6157,7 @@ msgstr "Esta página não existe mais"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Não foi possível abrir esta página"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Страницы"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Возможно, она удалена или принадлежит другой организации."
 
@@ -6156,6 +6157,7 @@ msgstr "Этой страницы больше нет"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Не удалось открыть эту страницу"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Sayfalar"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Silinmiş olabilir veya başka bir kuruluşa ait olabilir."
 
@@ -6156,6 +6157,7 @@ msgstr "Bu sayfa artık mevcut değil"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Bu sayfa açılamadı"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -6146,6 +6146,7 @@ msgstr "Trang"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "Có thể nó đã bị xóa, hoặc thuộc về một tổ chức khác."
 
@@ -6156,6 +6157,7 @@ msgstr "Trang này không còn tồn tại"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "Không thể mở trang này"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -6146,6 +6146,7 @@ msgstr "页面"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "它可能已被删除，或属于另一个组织。"
 
@@ -6156,6 +6157,7 @@ msgstr "这个页面已不存在"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "无法打开这个页面"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -6146,6 +6146,7 @@ msgstr "頁面"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageMissingDescription"
 msgstr "它可能已被刪除，或屬於另一個組織。"
 
@@ -6156,6 +6157,7 @@ msgstr "這個頁面已不存在"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+#: ../../apps/mobile/screens/(authenticated)/page/[id]/PageViewerScreen.tsx
 msgid "dashboard.pageViewer.pageOpenFailedTitle"
 msgstr "無法開啟這個頁面"
 


### PR DESCRIPTION
**Links**
- Ticket: [SUPER-2079](https://linear.app/superset-sh/issue/SUPER-2079)
- Viewer spec: [Device Content Cache](https://app.superset.sh/page/device-content-cache-tc6594)
- Stacked on #7020 → #7019 → #6954.

## Summary
- The mobile page viewer: `/(authenticated)/page/<id>` loads `viewUrl` top-level in a WebView — the page's origin is first-party, so storage, CSP and **video playback** work exactly as on the web, cached by WebKit. Plus `ContentImage` (disk cache keyed by storage key), a 512 MB boot-time image-cache bound, and sign-out clearing.

## How It Works
- `page.get` → `viewUrl` carries the ticket in its path, so the WebView needs no headers or cookies; the query's `staleTime` (55 min) holds the URL inside the ticket's window so reopening reuses WebKit's cache instead of minting a fresh URL.
- `onShouldStartLoadWithRequest` keeps navigation on the page's own origin and hands anything else to the system browser. `allowsInlineMediaPlayback` + `mediaPlaybackRequiresUserAction={false}` are what let `<video>` inside a page play inline.
- `ContentImage` wraps expo-image with `cacheKey = storageKey` (`page.list` returns `thumbnailStorageKey`; the files layer returns `storageKey`), so a rotated ticket URL is never a fresh download on cellular. `OrganizationAvatar` adopts it as the first consumer; the pages grid and attachments use it when they land.
- Error copy reuses the desktop viewer's already-translated `dashboard.pageViewer.*` messages — zero new catalog strings.

## Manual QA Checklist
> End-to-end viewing is blocked on the deployed origin (SUPER-2080). Verify in the simulator once it's up:
- [ ] Deep link to `/(authenticated)/page/<id>` renders a page; a bogus id renders the error state
- [ ] A page with `<video>` plays inline and seeks
- [ ] External links in a page open in Safari, not the WebView
- [ ] Reopening a page within the hour does not refetch its assets (Network inspector)

## Testing
- `bun run typecheck` in `apps/mobile` — the one error is pre-existing on the base branch (`useCloudWorkspaceItems` / `tags`, from main's workspace-tags work; untouched here)
- `packages/i18n check` clean (reused ids)
- Not sim-verified yet: the viewer has nothing real to load until the Worker deploys — flagged rather than skipped silently

## Known Limitations
- No discovery UX on purpose — where pages appear on mobile is being designed separately; this screen is the deep-link target it will push to.
- `expo-video` intentionally absent: page video plays natively in the WebView; the dependency lands with the attachments UI (decision 10).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the mobile page viewer at `/(authenticated)/page/<id>`, loading published pages top-level in a WebView so the page's origin is first-party and storage, CSP, and inline video playback work as on the web. Also adds `ContentImage`, which caches remote images on disk by storage key instead of URL (SUPER-2079).

**Page viewer**
- The ticket rides the URL path, so the WebView needs no headers or cookies; a 55-minute stale time keeps the URL inside the ticket's window so reopening reuses WebKit's cache.
- Navigation stays on the page's origin; anything else opens in the system browser.
- Error copy reuses the desktop viewer's already-translated messages, and no discovery UX is included.
- End-to-end viewing is blocked until the deployed origin is updated (SUPER-2080), so the viewer was not sim-verified.

**ContentImage**
- Wraps `expo-image` with `cacheKey` = storage key, so a rotated ticket URL is never a fresh download.
- Bounds the image disk cache at 512 MB at boot and clears it on sign-out.
- `OrganizationAvatar` is the first consumer; the pages grid and attachments will use it when they land.
- Locale catalogs were regenerated to record the viewer's references to the reused error message ids.

<sup>Written for commit 57b6677f6542339892287ab08aa25fd90be0f88b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

