### PR TITLE
fix(gmail): skip already-recorded messages so a history walk can finish

### DIFF
--- a/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
+++ b/apps/api/src/app/api/integrations/google/lib/syncMailbox.ts
@@ -1,5 +1,8 @@
 import { db } from "@superset/db/client";
-import type { SelectIntegrationConnection } from "@superset/db/schema";
+import {
+	automationEvents,
+	type SelectIntegrationConnection,
+} from "@superset/db/schema";
 import type { GmailMatchableEvent } from "@superset/shared/automation-matching";
 import {
 	type GmailMessage,
@@ -12,6 +15,7 @@ import {
 	parseAddresses,
 	patchGmailState,
 } from "@superset/trpc/integrations/google";
+import { and, eq, inArray } from "drizzle-orm";
 import {
 	ingestAutomationEvent,
 	type NormalizedDelivery,
@@ -53,9 +57,33 @@ export async function syncMailbox(
 		return { baseline: true, added: 0, recorded: 0, matched: 0 };
 	}
 
+	// Which of these were already recorded, so the fetch below is skipped for
+	// them. Without this, a history walk that cannot finish inside the
+	// function's time budget re-fetches every message on every push and the
+	// checkpoint write at the bottom never runs — the cursor wedges at its old
+	// value, each new email costs a full re-scan, and the re-scan only grows.
+	// One indexed query makes a re-walk nearly free, so runs complete and the
+	// cursor advances again.
+	const known = new Set<string>();
+	for (let i = 0; i < result.messages.length; i += 500) {
+		const chunk = result.messages.slice(i, i + 500).map((m) => m.id);
+		const rows = await db
+			.select({ id: automationEvents.externalEventId })
+			.from(automationEvents)
+			.where(
+				and(
+					eq(automationEvents.integrationConnectionId, connection.id),
+					eq(automationEvents.provider, "gmail"),
+					inArray(automationEvents.externalEventId, chunk),
+				),
+			);
+		for (const row of rows) known.add(row.id);
+	}
+
 	let recorded = 0;
 	let matched = 0;
 	for (const added of result.messages) {
+		if (known.has(added.id)) continue;
 		if (added.labelIds.some((label) => OUTGOING_LABELS.has(label))) continue;
 		const message = await getMessage(connection.id, added.id);
 		if (!message) continue;


### PR DESCRIPTION
Found live in production today, the first day Gmail ingestion actually worked (the watch had been publishing into an inaccessible GCP project since Aug 19 — fixed separately via the production secrets).

**The bug:** `syncMailbox` fetches every added message before the dedupe gets a say, and writes the history cursor only at the end of a run. A backlog too large to fetch inside the function's 60s budget wedges the cursor: every push re-walks the full history, re-fetches every message, times out before the checkpoint, and the walk only grows. New mail still lands (dedupe absorbs the re-reads) at the cost of a complete re-scan and a Gmail-quota storm per delivery — observed as the cursor pinned at 1289945 while a 324-message backlog re-scanned on every push.

**The fix:** one indexed query against the dedupe key (`integration_connection_id, provider, external_event_id`) names the messages already held; the `getMessage` fetch is skipped for them. A re-walk then costs a history list and nearly nothing else, runs complete, and the cursor advances again on its own — including healing the currently wedged production connection on the first delivery after deploy.

Cherry-picked from `feat/slack-trigger-parity` (7f6b998b2); the file is otherwise identical between the branches. Typecheck and lint green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gmail history walks getting stuck when the backlog is too large to fetch inside the function's 60-second time budget. `syncMailbox` now skips already-recorded messages, so re-walks finish and the history cursor advances again.

- Previously every push re-fetched the full backlog, timed out before writing the cursor, and the walk only grew.
- A single indexed query against the dedupe key (`integration_connection_id`, `provider`, `external_event_id`) names the messages already held.
- The currently wedged production connection heals on the first delivery after deploy.

<sup>Written for commit b6cf92bb63b522802741f231e06bcba4a5feb317. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented previously processed mailbox messages from being imported again.
  * Improved mailbox synchronization by avoiding duplicate event ingestion and unnecessary message retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->