### PR TITLE
test(agent-setup): stop rewriting the OpenCode plugin per test

### DIFF
--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -108,8 +108,13 @@ describe("agent-wrappers opencode", () => {
 	// definitely on disk. Nothing here needs a fresh module anyway: the plugin's
 	// re-entry guard lives on `globalThis`, not in module scope, and `beforeEach`
 	// clears it, so one cached import gives every test its own hooks.
+	/** The plugin hands back a map of OpenCode hooks, keyed by event name. */
+	type OpenCodeHooks = Record<
+		string,
+		(...args: unknown[]) => Promise<unknown> | unknown
+	>;
 	let pluginModule: Promise<{
-		SupersetNotifyPlugin: (input: unknown) => Promise<Record<string, never>>;
+		SupersetNotifyPlugin: (input: unknown) => Promise<OpenCodeHooks>;
 	}>;
 
 	const loadOpenCodePlugin = async () => {

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -102,16 +102,24 @@ const managedMastraHookCommand = getManagedNotifyHookCommand("mastracode");
 
 describe("agent-wrappers opencode", () => {
 	const originalTerminalId = process.env.SUPERSET_TERMINAL_ID;
-	let pluginImportCounter = 0;
+	// Written and imported once. A fresh file per test used to be the way to get
+	// a fresh module, but only the first dynamic import out of this directory
+	// ever resolved — the rest died on "Cannot find module" for a file that was
+	// definitely on disk. Nothing here needs a fresh module anyway: the plugin's
+	// re-entry guard lives on `globalThis`, not in module scope, and `beforeEach`
+	// clears it, so one cached import gives every test its own hooks.
+	let pluginModule: Promise<{
+		SupersetNotifyPlugin: (input: unknown) => Promise<Record<string, never>>;
+	}>;
 
 	const loadOpenCodePlugin = async () => {
-		mkdirSync(TEST_ROOT, { recursive: true });
-		const pluginPath = path.join(
-			TEST_ROOT,
-			`opencode-notify-${pluginImportCounter++}.mjs`,
-		);
-		writeFileSync(pluginPath, getOpenCodePluginContent("/tmp/notify.sh"));
-		return import(pathToFileURL(pluginPath).href);
+		if (!pluginModule) {
+			mkdirSync(TEST_ROOT, { recursive: true });
+			const pluginPath = path.join(TEST_ROOT, "opencode-notify.mjs");
+			writeFileSync(pluginPath, getOpenCodePluginContent("/tmp/notify.sh"));
+			pluginModule = import(pathToFileURL(pluginPath).href);
+		}
+		return pluginModule;
 	};
 
 	beforeEach(() => {


### PR DESCRIPTION
Two OpenCode plugin tests fail on `main`: `question.asked` and the legacy `permission.ask` hook.

Each of the three tests wrote a fresh `opencode-notify-N.mjs` into the temp root and dynamically imported it. Only the first import out of that directory ever resolved — the other two died with `Cannot find module` for a file that was definitely on disk. Reproduces in isolation, so it isn't cross-file mock pollution.

A fresh module was never needed. The plugin's re-entry guard is `globalThis.__supersetOpencodeNotifyPluginV9`, set *inside* the plugin function rather than at module scope, and `beforeEach` already clears it — so a single cached import hands every test its own hooks.

Before: 266 pass, 2 fail. After: **268 pass, 0 fail.**

Found while getting #7024 green; unrelated to it, so it's split out.

https://claude.ai/code/session_01XPfwELrTB6gvfbjBGzEmTb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two failing OpenCode plugin tests by reusing a single cached module import instead of rewriting the plugin file per test, and corrects the hook types so the tests typecheck.

The old approach only resolved the first dynamic import, so `question.asked` and the legacy `permission.ask` hook failed with "Cannot find module" even though the file existed. Because the re-entry guard lives on `globalThis`, one cached import gives each test its own hooks. The hooks are now typed as a callable map, since `Record<string, never>` made them non-callable and broke typechecking. Test results go from 266 pass/2 fail to 268 pass/0 fail. Found while working on #7024 but unrelated to it.

<sup>Written for commit 56d2d16ff5b1901c669981672b644f9c249f6a80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved OpenCode plugin test setup by reusing a shared generated module.
  * Preserved test isolation through existing reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->