### PR TITLE
feat(marketing): /security page for vulnerability and abuse reports

### DIFF
--- a/apps/marketing/content/legal/security.mdx
+++ b/apps/marketing/content/legal/security.mdx
@@ -1,0 +1,22 @@
+---
+title: Security & Abuse
+description: How to report security vulnerabilities and abusive content to Superset.
+lastUpdated: 2026-08-30
+---
+
+## Reporting a security vulnerability
+
+If you believe you have found a security vulnerability in Superset — the desktop app, web app, mobile app, CLI, or any service we operate — email **security@superset.sh**. Include enough detail to reproduce the issue. We respond within 30 days, and usually much sooner.
+
+Please do not open public issues for security reports.
+
+Our compliance posture, certifications, and security documentation live in the [Superset Trust Center](https://trust.superset.sh).
+
+## Reporting abusive content
+
+Superset users can publish pages served under `pages.supersetusercontent.com`. If you encounter phishing, malware, or other abusive content on a page hosted there, report it to **security@superset.sh** with the page URL. We review abuse reports promptly and take down content that violates our [Terms of Service](/terms).
+
+## Scope
+
+- `superset.sh` and subdomains — our product and marketing surfaces
+- `supersetusercontent.com` and subdomains — user-published content, isolated from our product origins

--- a/apps/marketing/content/legal/security.mdx
+++ b/apps/marketing/content/legal/security.mdx
@@ -6,7 +6,7 @@ lastUpdated: 2026-08-30
 
 ## Reporting a security vulnerability
 
-If you believe you have found a security vulnerability in Superset — the desktop app, web app, mobile app, CLI, or any service we operate — email **security@superset.sh**. Include enough detail to reproduce the issue. We respond within 30 days, and usually much sooner.
+If you believe you have found a security vulnerability in Superset (the desktop app, web app, mobile app, CLI, or any service we operate), email **security@superset.sh**. Include enough detail to reproduce the issue. We respond within 30 days, and usually much sooner.
 
 Please do not open public issues for security reports.
 
@@ -18,5 +18,5 @@ Superset users can publish pages served under `pages.supersetusercontent.com`. I
 
 ## Scope
 
-- `superset.sh` and subdomains — our product and marketing surfaces
-- `supersetusercontent.com` and subdomains — user-published content, isolated from our product origins
+- `superset.sh` and subdomains: our product and marketing surfaces
+- `supersetusercontent.com` and subdomains: user-published content, isolated from our product origins

--- a/apps/marketing/content/legal/security.mdx
+++ b/apps/marketing/content/legal/security.mdx
@@ -14,7 +14,7 @@ Our compliance posture, certifications, and security documentation live in the [
 
 ## Reporting abusive content
 
-Superset users can publish pages served under `pages.supersetusercontent.com`. If you encounter phishing, malware, or other abusive content on a page hosted there, report it to **security@superset.sh** with the page URL. We review abuse reports promptly and take down content that violates our [Terms of Service](/terms).
+If you encounter phishing, malware, or other abusive content on a page hosted under `pages.supersetusercontent.com`, report it to **security@superset.sh** with the page URL. We review abuse reports promptly and take down content that violates our [Terms of Service](/terms).
 
 ## Scope
 

--- a/apps/marketing/src/app/[lang]/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/[lang]/components/Footer/Footer.tsx
@@ -147,9 +147,8 @@ const RESOURCE_LINKS: FooterLink[] = [
 
 const LEGAL_LINKS: FooterLink[] = [
 	{
-		href: COMPANY.TRUST_URL,
+		href: "/security",
 		label: <Trans id="marketing.footer.legal.security">Security</Trans>,
-		external: true,
 	},
 	{
 		href: "/terms",


### PR DESCRIPTION
## Summary
- Adds `superset.sh/security` (legal MDX page): how to report vulnerabilities and how to report abusive content on user-published pages (`pages.supersetusercontent.com`), both to security@superset.sh. Links the Trust Center for compliance material.
- Repoints the footer's legal "Security" link from the external trust center to `/security`; the page links trust.superset.sh in its first section, and the homepage SecuritySection / contact / enterprise pages still link the Trust Center directly.

## Why / Context
The Public Suffix List submission for `pages.supersetusercontent.com` (SUPER-2080, PR upcoming) requires an abuse contact that's easily reachable from our website — the trust center renders as a JS shell with no visible contact. Beyond PSL, hosting user-published HTML means we owe reporters a findable abuse channel anyway.

## Testing
- `bun turbo run typecheck --filter=@superset/marketing`
- biome on changed files
- Page renders via the existing `(legal)/[slug]` route (`getAllLegalSlugs` picks the new MDX up automatically); no new strings (footer reuses the existing `marketing.footer.legal.security` id), so no catalog changes.

## Notes
- Review point: the footer legal "Security" entry now goes to `/security` instead of trust.superset.sh — flag if you'd rather keep both links.
- security@superset.sh must exist before the PSL PR cites it (Satya: Google Admin → Groups).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/security` page for vulnerability and abuse reports and repoints the footer's legal "Security" link from the external Trust Center to `/security`.

- The page covers vulnerability reports for all Superset services and abuse reports for content on `pages.supersetusercontent.com`, both via `security@superset.sh`.
- Scope is documented for `superset.sh` and `supersetusercontent.com` subdomains.
- The Trust Center stays linked from the page, the homepage, and the contact page.
- `security@superset.sh` must exist before the Public Suffix List submission cites it.

<sup>Written for commit 2ac8f27268e0e9b1fa9113057e6c9a0bbfd58540. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Security page with instructions for reporting vulnerabilities and abusive content.
  * Included security contact information, response timelines, and links to compliance documentation.
  * Documented how to report phishing or malware hosted on Superset pages.
  * Clarified the domains covered by the security and abuse reporting policy.
  * Added a footer link to the Security page for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->