### PR TITLE
docs(marketing): drop hostnames and the scope block from the security page

### DIFF
--- a/apps/marketing/content/legal/security.mdx
+++ b/apps/marketing/content/legal/security.mdx
@@ -1,7 +1,7 @@
 ---
 title: Security & Abuse
 description: How to report security vulnerabilities and abusive content to Superset.
-lastUpdated: 2026-08-30
+lastUpdated: 2026-08-31
 ---
 
 ## Reporting a security vulnerability
@@ -14,9 +14,6 @@ Our compliance posture, certifications, and security documentation live in the [
 
 ## Reporting abusive content
 
-If you encounter phishing, malware, or other abusive content on a page hosted under `pages.supersetusercontent.com`, report it to **security@superset.sh** with the page URL. We review abuse reports promptly and take down content that violates our [Terms of Service](/terms).
+If you encounter phishing, malware, or other abusive content, report it to **security@superset.sh**. We review abuse reports promptly and take down content that violates our [Terms of Service](/terms).
 
-## Scope
 
-- `superset.sh` and subdomains: our product and marketing surfaces
-- `supersetusercontent.com` and subdomains: user-published content, isolated from our product origins


### PR DESCRIPTION
The abuse paragraph named a hostname that the frame rename made stale on the live page; naming no hostname at all removes the drift class. Scope block dropped per Satya. Copy is Satya's own wording.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale hostname from the abuse reporting paragraph and drops the scope block from the security page, so the copy no longer drifts from the live page. Naming no hostname at all eliminates the drift class caused by the earlier frame rename.

<sup>Written for commit 7d36a8f0ce867794f226911f07231c8c1e26c183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the security policy’s last-updated date.
  * Simplified guidance for reporting abusive content.
  * Removed the listed domain scope from the security policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->