### PR TITLE
fix(auth,desktop): stop moving people into the organization they joined last

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -149,10 +149,32 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 			try {
 				// Window-local switch: warm the new org's collections, then flip the
 				// UI. The registry and the cloud org header follow from
-				// activeOrganizationId changing. The shared login session is NOT
-				// mutated, so other windows are unaffected. On failure the UI stays put.
+				// activeOrganizationId changing. Windows that are already open are
+				// unaffected — they seeded once and own their org from then on. On
+				// failure the UI stays put.
 				await preloadCollections(organizationId);
 				setActiveOrganizationId(organizationId);
+				// Record the choice on the server as well. A window that opens with
+				// no org of its own seeds from the login session, and a session that
+				// is never told about a switch keeps handing out the org the server
+				// guessed for it — which is how a window-local-only switcher kept
+				// dropping people back into an organization they had already left
+				// behind. Every other switch path (create, leave, web, mobile) goes
+				// through set-active for the same reason.
+				//
+				// Best effort and unawaited: this window has already moved, and the
+				// only cost of a failure is the seed for the next new window.
+				void authClient.organization
+					.setActive({ organizationId })
+					.then(({ error }) => {
+						if (error) throw error;
+					})
+					.catch((error) => {
+						console.error(
+							"[collections-provider] Failed to record the active organization:",
+							error,
+						);
+					});
 			} catch (error) {
 				console.error(
 					"[collections-provider] Failed to switch organization:",

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/CollectionsProvider.tsx
@@ -67,6 +67,12 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 	// A ref, not state: nothing renders differently while a switch is in
 	// flight, it only stops two switches overlapping.
 	const switchInFlightRef = useRef(false);
+	// Set-active writes are chained rather than fired straight off, because the
+	// server keeps whichever one *completes* last. Two quick switches racing
+	// could otherwise leave the account remembering the organization you
+	// switched away from. Every link ends resolved so one failure cannot stall
+	// the rest.
+	const recordActiveOrganizationRef = useRef<Promise<void>>(Promise.resolve());
 
 	// Per-window active org. The window registry (main process) is the source of
 	// truth: each window holds its own org, so switching in one window never
@@ -164,17 +170,20 @@ export function CollectionsProvider({ children }: { children: ReactNode }) {
 				//
 				// Best effort and unawaited: this window has already moved, and the
 				// only cost of a failure is the seed for the next new window.
-				void authClient.organization
-					.setActive({ organizationId })
-					.then(({ error }) => {
-						if (error) throw error;
-					})
-					.catch((error) => {
-						console.error(
-							"[collections-provider] Failed to record the active organization:",
-							error,
-						);
-					});
+				recordActiveOrganizationRef.current =
+					recordActiveOrganizationRef.current
+						.then(async () => {
+							const { error } = await authClient.organization.setActive({
+								organizationId,
+							});
+							if (error) throw error;
+						})
+						.catch((error) => {
+							console.error(
+								"[collections-provider] Failed to record the active organization:",
+								error,
+							);
+						});
 			} catch (error) {
 				console.error(
 					"[collections-provider] Failed to switch organization:",

--- a/packages/auth/src/lib/load-custom-session-data.ts
+++ b/packages/auth/src/lib/load-custom-session-data.ts
@@ -27,7 +27,7 @@ export interface CustomSessionData {
 	planOrganizationId: string | null;
 	plan: string | null;
 	/** The organization the user last switched to; the fallback a new session
-	 * resumes from before the newest membership is considered. */
+	 * resumes from before any membership guess is considered. */
 	lastActiveOrganizationId: string | null;
 	onboardedAt: Date | null;
 	deletionRequestedAt: Date | null;
@@ -91,8 +91,12 @@ export async function loadCustomSessionData({
 				 WHERE organization_id = ${activeOrganizationId}::uuid LIMIT 1),
 				(SELECT m.organization_id FROM memberships m, last_active l
 				 WHERE m.organization_id = l.organization_id LIMIT 1),
+				-- Oldest membership, not newest: the last resort has to be an
+				-- answer that does not move as the user joins more
+				-- organizations. Keep it in step with findFallbackMembership in
+				-- resolve-session-organization-state, id tie-break included.
 				(SELECT organization_id FROM memberships
-				 ORDER BY created_at DESC LIMIT 1)
+				 ORDER BY created_at ASC, id ASC LIMIT 1)
 			) AS organization_id
 		)
 		SELECT

--- a/packages/auth/src/lib/resolve-session-organization-state.test.ts
+++ b/packages/auth/src/lib/resolve-session-organization-state.test.ts
@@ -75,10 +75,10 @@ describe("resolveSessionOrganizationState", () => {
 		getLastActiveOrganization.mockImplementation(async () => null);
 	});
 
-	it("falls back to the most recent membership when the user has never switched", async () => {
+	it("falls back to the longest-held membership when the user has never switched", async () => {
 		listMemberships.mockImplementation(async () => [
-			createMember("org-1"),
-			createMember("org-2", {
+			createMember("org-joined-last"),
+			createMember("org-joined-first", {
 				createdAt: new Date("2026-03-20T00:00:00.000Z"),
 			}),
 		]);
@@ -91,14 +91,31 @@ describe("resolveSessionOrganizationState", () => {
 			deps,
 		);
 
-		expect(result.activeOrganizationId).toBe("org-1");
-		expect(result.membership?.organizationId).toBe("org-1");
+		expect(result.activeOrganizationId).toBe("org-joined-first");
+		expect(result.membership?.organizationId).toBe("org-joined-first");
 		expect(updateSessionActiveOrganization).toHaveBeenCalledWith({
 			sessionId: "session-1",
 			previousActiveOrganizationId: null,
-			nextActiveOrganizationId: "org-1",
+			nextActiveOrganizationId: "org-joined-first",
 		});
 		expect(getSessionActiveOrganization).not.toHaveBeenCalled();
+	});
+
+	it("breaks a created-at tie on id, matching the SQL fallback", async () => {
+		listMemberships.mockImplementation(async () => [
+			createMember("org-b", { id: "member-b" }),
+			createMember("org-a", { id: "member-a" }),
+		]);
+
+		const result = await resolveSessionOrganizationState(
+			{
+				userId: "user-1",
+				session: { id: "session-1", activeOrganizationId: null },
+			},
+			deps,
+		);
+
+		expect(result.activeOrganizationId).toBe("org-a");
 	});
 
 	it("resumes the organization the user last switched to when the session has none", async () => {
@@ -130,7 +147,7 @@ describe("resolveSessionOrganizationState", () => {
 	it("ignores a last active organization the user is no longer a member of", async () => {
 		listMemberships.mockImplementation(async () => [
 			createMember("org-newest"),
-			createMember("org-older", {
+			createMember("org-oldest", {
 				createdAt: new Date("2026-03-20T00:00:00.000Z"),
 			}),
 		]);
@@ -144,7 +161,7 @@ describe("resolveSessionOrganizationState", () => {
 			deps,
 		);
 
-		expect(result.activeOrganizationId).toBe("org-newest");
+		expect(result.activeOrganizationId).toBe("org-oldest");
 	});
 
 	it("keeps the session's own organization without consulting the last active one", async () => {
@@ -168,7 +185,7 @@ describe("resolveSessionOrganizationState", () => {
 		expect(updateSessionActiveOrganization).not.toHaveBeenCalled();
 	});
 
-	it("replaces stale active org ids with the most recent valid membership", async () => {
+	it("replaces stale active org ids with the longest-held valid membership", async () => {
 		listMemberships.mockImplementation(async () => [
 			createMember("org-2"),
 			createMember("org-1", {
@@ -187,12 +204,12 @@ describe("resolveSessionOrganizationState", () => {
 			deps,
 		);
 
-		expect(result.activeOrganizationId).toBe("org-2");
-		expect(result.membership?.organizationId).toBe("org-2");
+		expect(result.activeOrganizationId).toBe("org-1");
+		expect(result.membership?.organizationId).toBe("org-1");
 		expect(updateSessionActiveOrganization).toHaveBeenCalledWith({
 			sessionId: "session-1",
 			previousActiveOrganizationId: "org-missing",
-			nextActiveOrganizationId: "org-2",
+			nextActiveOrganizationId: "org-1",
 		});
 	});
 
@@ -227,7 +244,7 @@ describe("resolveSessionOrganizationState", () => {
 			}),
 		]);
 		updateSessionActiveOrganization.mockImplementation(async () => false);
-		getSessionActiveOrganization.mockImplementation(async () => "org-2");
+		getSessionActiveOrganization.mockImplementation(async () => "org-1");
 
 		const result = await resolveSessionOrganizationState(
 			{
@@ -237,8 +254,8 @@ describe("resolveSessionOrganizationState", () => {
 			deps,
 		);
 
-		expect(result.activeOrganizationId).toBe("org-2");
-		expect(result.membership?.organizationId).toBe("org-2");
+		expect(result.activeOrganizationId).toBe("org-1");
+		expect(result.membership?.organizationId).toBe("org-1");
 		expect(getSessionActiveOrganization).toHaveBeenCalledWith("session-1");
 	});
 });

--- a/packages/auth/src/lib/resolve-session-organization-state.ts
+++ b/packages/auth/src/lib/resolve-session-organization-state.ts
@@ -70,6 +70,31 @@ const defaultResolveSessionOrganizationDeps: ResolveSessionOrganizationDeps = {
 	},
 };
 
+/**
+ * The organization the user has belonged to longest — the last resort when
+ * nothing else says where this user wants to be.
+ *
+ * It used to be the *newest* membership, which is not a stable answer: it moves
+ * the moment somebody adds you to another organization, so a session that had
+ * to guess silently relocated people into whatever they had joined most
+ * recently. The oldest membership only changes if you leave it.
+ *
+ * `createdAt` ties are real — sign-up auto-enrolment adds several memberships
+ * in one pass — so break them on id, the same way the SQL fallback in
+ * `load-custom-session-data` does, or the two disagree about the same user.
+ */
+function findFallbackMembership(
+	memberships: SelectMember[],
+): SelectMember | undefined {
+	return memberships.reduce<SelectMember | undefined>((oldest, item) => {
+		if (!oldest) return item;
+		const itemTime = item.createdAt.getTime();
+		const oldestTime = oldest.createdAt.getTime();
+		if (itemTime !== oldestTime) return itemTime < oldestTime ? item : oldest;
+		return item.id < oldest.id ? item : oldest;
+	}, undefined);
+}
+
 export async function resolveSessionOrganizationState(
 	{
 		userId,
@@ -95,9 +120,9 @@ export async function resolveSessionOrganizationState(
 
 	// Session first: it is the only thing that knows about an organization this
 	// session was explicitly switched to. Then the user's last switch, so a new
-	// session resumes where the last one left off. The newest membership is the
-	// last resort, for a user who has never switched at all — reaching it for
-	// anyone else is what silently moved people between organizations.
+	// session resumes where the last one left off. Only then a guess, for a user
+	// who has never switched at all — reaching it for anyone else is what
+	// silently moved people between organizations.
 	let nextMembership = previousActiveOrganizationId
 		? allMemberships.find(
 				(item) => item.organizationId === previousActiveOrganizationId,
@@ -112,7 +137,7 @@ export async function resolveSessionOrganizationState(
 				? allMemberships.find(
 						(item) => item.organizationId === lastActiveOrganizationId,
 					)
-				: undefined) ?? allMemberships[0];
+				: undefined) ?? findFallbackMembership(allMemberships);
 	}
 
 	const nextActiveOrganizationId = nextMembership?.organizationId ?? null;
@@ -143,7 +168,10 @@ export async function resolveSessionOrganizationState(
 			? allMemberships.find(
 					(item) => item.organizationId === activeOrganizationId,
 				)
-			: undefined) ?? (!activeOrganizationId ? allMemberships[0] : undefined);
+			: undefined) ??
+		(!activeOrganizationId
+			? findFallbackMembership(allMemberships)
+			: undefined);
 
 	return {
 		activeOrganizationId,


### PR DESCRIPTION
Every once in a while the desktop app dropped me from the Superset organization into the organization I most recently joined. #6957 was supposed to have fixed that class of bug; it didn't, for two reasons.

**The desktop never told the server about a switch.** `CollectionsProvider.switchOrganization` is window-local by design — local state plus the main-process window registry — and #6957's persistence hangs off `/organization/set-active`. Create-organization, leave-organization, web and mobile all call that route; the organization dropdown, which is where people actually switch, does not. So `users.last_active_organization_id` stayed NULL and the resolver kept falling through to its guess.

**The guess was the newest membership.** That is not a stable answer: it moves the moment somebody adds you to another organization. It is also written back onto the session row, so it then re-seeds every window that starts without an org of its own — a new window, or reopening after the last window closed (which clears the restore list). Windows persist their own org across relaunches, which is why this presented as intermittent rather than constant.

## Changes

- `switchOrganization` now also fires `authClient.organization.setActive`, best effort and unawaited: the window has already moved, and the only cost of a failure is the seed for the next new window. Windows that are already open are unaffected — they seed once at mount and own their org from then on.
- The last resort is now the **oldest** membership, the only choice that does not move as you join more organizations. Both implementations change together — `resolveSessionOrganizationState` and the `active` CTE in `load-custom-session-data` that the plan lookup shares — with an `id` tie-break, since sign-up auto-enrolment creates several memberships in one pass and `created_at` ties are real.

Resolution order is unchanged otherwise: session organization → the user's last switch → the guess. A session already stamped with a guess still wins over the remembered value, deliberately — a browser and a desktop app are allowed to sit in different organizations. Those sessions heal on the first switch after this ships.

## Verification

- `packages/auth`: 8/8. Three tests pinned the old newest-membership behaviour and were rewritten; one new test pins the id tie-break that keeps the TypeScript and SQL fallbacks in agreement.
- `apps/desktop`: 3086/3086.
- Typecheck and biome clean in both packages.
- Ran both fallback implementations against the 10 real multi-organization users on a database branch (read-only). They agree on the oldest membership for every one.

https://claude.ai/code/session_017EAxV43BZjTSBeC1vF6UQJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop app dropping users into the organization they most recently joined instead of the one they switched to. The dropdown switch never told the server about a change, and the session fallback guessed the newest membership; the switch is now recorded and the fallback uses the oldest membership.

- The desktop's organization dropdown now calls the set-active route so the server remembers the switch; it runs best-effort and unawaited because the window has already moved, and the writes are chained so two quick switches cannot race.
- A session with no recorded switch now falls back to the user's longest-held membership in both the resolver and the shared SQL query, breaking ties on id so the two paths agree.
- The old newest-membership guess moved whenever someone added the user to a new organization and, once written to the session row, re-seeded every window that opened without its own organization.
- Resolution order is unchanged: the session's own organization wins, then the last recorded switch, then the fallback guess.
- Sessions already stamped with the old guess keep it until the user switches again, since a browser and desktop app may intentionally sit in different organizations.

<sup>Written for commit b0f7c8e3c89cf95b57b90107c7fa3708085579fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Active organization selections are saved across sessions, so newly opened windows start in the selected organization.
  - Rapid organization switches are synchronized in order to keep the active selection consistent.

- **Bug Fixes**
  - Improved recovery when an organization selection is missing or outdated by choosing the longest-held membership.
  - Added deterministic tie-breaking when memberships share the same creation time.
  - Local organization switching remains available even if server synchronization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->