### PR TITLE
chore(desktop): bump version to 1.25.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.25.0",
+	"version": "1.25.1",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -843,7 +843,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -940,7 +940,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",
@@ -1115,7 +1115,7 @@
     },
     "packages/pty-daemon": {
       "name": "@superset/pty-daemon",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "bin": {
         "pty-daemon": "./src/main.ts",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.25.0",
+	"version": "1.25.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.25.0",
+	"version": "1.25.1",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps package versions for the 1.25.1 release: `@superset/desktop`, `@superset/cli`, and `@superset/host-service` go to 1.25.1, and `@superset/pty-daemon` goes to 0.3.2. No behavior changes; `bun.lock` is updated to match.

<sup>Written for commit 108b9bf0901c61ff5192874cab285054eb1e88fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application and package versions for the latest release.
  * Published patch-level updates for the desktop app, CLI, host service, and terminal daemon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->