### PR TITLE
content: evergreen agent context-switching post and Orca vs Conductor compare page

### DIFF
--- a/apps/marketing/content/blog/switching-between-ai-coding-agents.mdx
+++ b/apps/marketing/content/blog/switching-between-ai-coding-agents.mdx
@@ -1,0 +1,114 @@
+---
+title: "Switching Between AI Coding Agents Without Losing Context"
+description: "Claude Code wedges, runs out of context, or turns out to be the wrong tool. Moving that session to another agent means moving the context. Here is what context actually is, why it does not travel, and the fork and resume commands every major agent CLI ships."
+author: kiet
+date: 2026-08-30
+category: Engineering
+relatedSlugs:
+  - parallel-coding-agents-guide
+  - agent-orchestration-not-another-agent
+  - working-with-worktrees-in-superset
+---
+
+You are forty minutes into a session. The agent knows your repo, the three files that matter, the approach you rejected twice, and the one test that keeps failing. Then it wedges. Or it burns through its context window. Or you realize it is simply the wrong tool for this particular job and a different model would have solved it in one turn.
+
+Starting over means explaining it again. So most people do the thing that feels cheaper: they keep pushing the stuck session, because re-teaching a fresh agent costs more than tolerating a bad one.
+
+That trade is the actual problem. Here is what context consists of, why it does not move between agents, and what each CLI gives you today.
+
+---
+
+## What "context" actually is
+
+"Context" gets used as one word for four different things, and they do not travel equally.
+
+**The conversation.** Every turn you and the agent exchanged. This is the biggest piece and the one people mean. Each harness stores it in its own place and its own shape: Claude Code under `~/.claude`, Codex under `~/.codex`, and so on, each keyed by a session id.
+
+**The working state.** The branch, the worktree, the files already edited, the dev server still running. This lives on disk rather than in the agent, so it transfers on its own. A second agent pointed at the same directory sees the same code.
+
+**The instructions.** `AGENTS.md`, `CLAUDE.md`, skills, MCP server config. Also on disk, also portable, and the most underrated of the four. Anything you teach an agent here survives not just a handoff but the agent itself.
+
+**The reasoning.** Why you rejected the first approach, which lead went nowhere. This one lives only in the transcript, and it hurts to lose, because the diff never shows it.
+
+Two of those four travel on their own. The fight is over the other two.
+
+---
+
+## Why the conversation does not travel
+
+No interchange format exists for agent sessions. Each vendor stores transcripts in its own schema, and none of them read each other's.
+
+That leaves two honest options, and they fail differently.
+
+**Native fork or resume** keeps full fidelity, because the harness reads its own store. It only works inside one harness. Claude cannot resume a Codex session.
+
+**Transcript replay** ports across harnesses by feeding the previous session's output to a new agent as text. That is lossy by construction, since you hand over a rendering rather than structured turns. It also happens to be the only approach that survives a change of tools.
+
+Use the first when you want another branch of the same conversation. Use the second when you are switching tools.
+
+---
+
+## The fork and resume commands
+
+Most agent CLIs ship a way to branch a session. The flags disagree with each other, which is the main reason people do not know the feature exists.
+
+| Agent | Fork an existing session |
+|---|---|
+| Claude Code | `claude --resume <sessionId> --fork-session` |
+| Codex | `codex fork <sessionId>` |
+| OpenCode | `opencode --session <sessionId> --fork` |
+| Grok | `grok --resume <sessionId> --fork-session` |
+| Pi | `pi --fork <sessionId>` |
+| Droid | `droid --fork <sessionId>` |
+
+We verified the first five by saying a codeword to the source session, forking it, and asking the fork to repeat the codeword back. Droid's flag comes from its documentation and we have not run it. OpenCode titles the new session "(fork #1)", which is a nice touch once you have a stack of them.
+
+A fork leaves the original running. That is the point: you get two branches of one conversation, so you can try the risky refactor in one and keep the working thread alive in the other.
+
+---
+
+## The scrollback trap
+
+If you want to move context to a *different* agent, you have to capture the old session's output. This is where the obvious approach quietly fails, and the failure is worth understanding because it applies to anything that scrapes a terminal.
+
+Every TUI agent draws to the **alternate screen buffer**. That is the same mechanism `vim` and `less` use, the reason your prompt reappears untouched when you quit them. The alternate screen keeps no scrollback. Nothing scrolls off, because nothing scrolls: the program redraws in place.
+
+So reading the terminal's visible buffer gives you one screen, no matter how large a line budget you ask for. We measured it against a pager showing 300 known lines:
+
+| Source | Alt-screen agent | Normal shell |
+|---|---|---|
+| Visible screen buffer, 800-line budget | 392 chars, **23** history lines | 4,991 chars, 300 lines |
+| Raw pty stream | 4,478 chars, **253** history lines | 4,993 chars, 300 lines |
+
+The 800-line budget is inert on the left. Worse, once the pager exits and restores the normal screen, the visible buffer holds **none** of the 300 lines, even though every byte went down the pty.
+
+The fix is to read the raw pty output rather than the rendered screen, which means something has to keep that stream while the session runs. If you are building this yourself, that is the piece to get right first. If a harness keeps its own conversation store, prefer it: structured turns beat a reconstructed screen every time.
+
+---
+
+## Practical patterns
+
+**Put durable knowledge in `AGENTS.md`, not in the chat.** Anything you find yourself re-explaining after a handoff belongs in a file. This is the highest-leverage habit here, because it makes every future switch cheaper and it survives the agent going away entirely.
+
+**Fork before anything irreversible.** A large refactor, a dependency bump, a migration. Forking costs nothing and gives you a thread to fall back to.
+
+**Switch tools on capability, not frustration.** A wedged agent is often a context-window problem, and a fresh session of the *same* agent fixes it. Change harness when you want a different model's strengths.
+
+**Hand over a summary, not a transcript.** When you do move across tools, asking the old session to write what it learned often beats replaying its raw output. You get the reasoning without the noise.
+
+---
+
+## How we handle it
+
+We ship this in [Superset](https://superset.sh) because we kept hitting it ourselves. Any agent terminal has two actions behind the fork icon: **Continue with another agent**, which starts a different harness seeded with the source session's recent output, and **Fork session**, which asks the agent for a native clone of its own session and leaves the original running.
+
+Both work from the CLI:
+
+```bash
+superset agents create --workspace W --agent codex  --from-terminal T
+superset agents create --workspace W --agent claude --fork-session S
+```
+
+The handoff reads the retained pty stream rather than the visible screen, for the reason above, and prefers a harness's own conversation store when one exists.
+
+The broader point stands whichever tool you use: the parts of context you keep on disk are the parts you never have to move. Everything else is a copy, and every copy loses something.

--- a/apps/marketing/content/blog/switching-between-ai-coding-agents.mdx
+++ b/apps/marketing/content/blog/switching-between-ai-coding-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Switching Between AI Coding Agents Without Losing Context"
-description: "Claude Code wedges, runs out of context, or turns out to be the wrong tool. Moving that session to another agent means moving the context. Here is what context actually is, why it does not travel, and the fork and resume commands every major agent CLI ships."
+description: "Claude Code wedges, runs out of context, or turns out to be the wrong tool. Moving that session to another agent means moving the context. Here is what context actually is, why it does not travel, and the fork commands every major agent CLI ships."
 author: kiet
 date: 2026-08-30
 category: Engineering
@@ -24,31 +24,31 @@ That trade is the actual problem. Here is what context consists of, why it does 
 
 **The conversation.** Every turn you and the agent exchanged. This is the biggest piece and the one people mean. Each harness stores it in its own place and its own shape: Claude Code under `~/.claude`, Codex under `~/.codex`, and so on, each keyed by a session id.
 
-**The working state.** The branch, the worktree, the files already edited, the dev server still running. This lives on disk rather than in the agent, so it transfers on its own. A second agent pointed at the same directory sees the same code.
+**The working state.** The branch, the worktree, the files already edited. This lives on disk rather than in the agent, so it transfers on its own: a second agent pointed at the same directory sees the same code. Process state is a different matter. A running dev server, its port, and anything held in memory belong to the process that started them, and the next agent inherits none of it.
 
 **The instructions.** `AGENTS.md`, `CLAUDE.md`, skills, MCP server config. Also on disk, also portable, and the most underrated of the four. Anything you teach an agent here survives not just a handoff but the agent itself.
 
 **The reasoning.** Why you rejected the first approach, which lead went nowhere. This one lives only in the transcript, and it hurts to lose, because the diff never shows it.
 
-Two of those four travel on their own. The fight is over the other two.
+The files and the instructions travel on their own. The fight is over the conversation and the reasoning.
 
 ---
 
 ## Why the conversation does not travel
 
-No interchange format exists for agent sessions. Each vendor stores transcripts in its own schema, and none of them read each other's.
+No vendor-neutral interchange format exists for agent sessions. Each vendor stores transcripts in its own schema, and by default none of them read another's. A few one-way importers have appeared, such as `grok import`, which pulls the current Claude Code conversation into Grok and prints a resume command. Check whether one exists for your pair before falling back to replay.
 
 That leaves two honest options, and they fail differently.
 
 **Native fork or resume** keeps full fidelity, because the harness reads its own store. It only works inside one harness. Claude cannot resume a Codex session.
 
-**Transcript replay** ports across harnesses by feeding the previous session's output to a new agent as text. That is lossy by construction, since you hand over a rendering rather than structured turns. It also happens to be the only approach that survives a change of tools.
+**Transcript replay** ports across harnesses by feeding the previous session's output to a new agent as text. That is lossy by construction, since you hand over a rendering rather than structured turns. It is the fallback when no importer covers your pair, which is still most pairs.
 
 Use the first when you want another branch of the same conversation. Use the second when you are switching tools.
 
 ---
 
-## The fork and resume commands
+## The fork commands
 
 Most agent CLIs ship a way to branch a session. The flags disagree with each other, which is the main reason people do not know the feature exists.
 
@@ -63,7 +63,7 @@ Most agent CLIs ship a way to branch a session. The flags disagree with each oth
 
 We verified the first five by saying a codeword to the source session, forking it, and asking the fork to repeat the codeword back. Droid's flag comes from its documentation and we have not run it. OpenCode titles the new session "(fork #1)", which is a nice touch once you have a stack of them.
 
-A fork leaves the original running. That is the point: you get two branches of one conversation, so you can try the risky refactor in one and keep the working thread alive in the other.
+A fork leaves the original untouched, and most CLIs fork from the saved session rather than a live process, so the source does not need to still be running. That is the point: you get two branches of one conversation, so you can try the risky refactor in one and keep the other intact.
 
 ---
 
@@ -71,7 +71,7 @@ A fork leaves the original running. That is the point: you get two branches of o
 
 If you want to move context to a *different* agent, you have to capture the old session's output. This is where the obvious approach quietly fails, and the failure is worth understanding because it applies to anything that scrapes a terminal.
 
-Every TUI agent draws to the **alternate screen buffer**. That is the same mechanism `vim` and `less` use, the reason your prompt reappears untouched when you quit them. The alternate screen keeps no scrollback. Nothing scrolls off, because nothing scrolls: the program redraws in place.
+Most fullscreen agent TUIs draw to the **alternate screen buffer**. That is the same mechanism `vim` and `less` use, the reason your prompt reappears untouched when you quit them. The alternate screen keeps no scrollback. Nothing scrolls off, because nothing scrolls: the program redraws in place. It depends on the mode, not the tool: Pi's default `regular` mode renders to the main buffer and keeps normal scrollback, while its fullscreen mode does not.
 
 So reading the terminal's visible buffer gives you one screen, no matter how large a line budget you ask for. We measured it against a pager showing 300 known lines:
 
@@ -95,6 +95,8 @@ The fix is to read the raw pty output rather than the rendered screen, which mea
 **Switch tools on capability, not frustration.** A wedged agent is often a context-window problem, and a fresh session of the *same* agent fixes it. Change harness when you want a different model's strengths.
 
 **Hand over a summary, not a transcript.** When you do move across tools, asking the old session to write what it learned often beats replaying its raw output. You get the reasoning without the noise.
+
+**Know what you are sending.** A transcript handoff ships your terminal output to a different vendor. Stripping control sequences is not redaction, so anything a command printed, including a token or a connection string, goes along with it. Summarize instead of replaying when the session touched credentials.
 
 ---
 

--- a/apps/marketing/content/compare/orca-vs-conductor.mdx
+++ b/apps/marketing/content/compare/orca-vs-conductor.mdx
@@ -18,7 +18,7 @@ keywords:
 
 Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source under MIT, cross-platform, and covers 25+ agents plus any custom CLI you add. Conductor is a proprietary macOS app focused on Claude Code, Codex, Cursor, and OpenCode, with a paid tier for cloud and team features.
 
-If you want the same worktree-per-task model without committing to either vendor's agent list, [Superset](/compare/superset-vs-conductor) is the agent-agnostic option.
+[Superset](/compare/superset-vs-conductor) runs the same worktree-per-task model and is the option to look at if you want other software to drive it, through an MCP server and a TypeScript SDK.
 
 ---
 

--- a/apps/marketing/content/compare/orca-vs-conductor.mdx
+++ b/apps/marketing/content/compare/orca-vs-conductor.mdx
@@ -16,7 +16,7 @@ keywords:
   - agent development environment
 ---
 
-Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source, cross-platform, and covers 25+ agents. Conductor is a proprietary macOS app focused on Claude Code, Codex, and Cursor, with a paid tier for cloud and team features.
+Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source, cross-platform, and covers 25+ agents. Conductor is a proprietary macOS app focused on Claude Code, Codex, Cursor, and OpenCode, with a paid tier for cloud and team features.
 
 If you want the same worktree-per-task model without committing to either vendor's agent list, [Superset](/compare/superset-vs-conductor) is the agent-agnostic option.
 
@@ -28,11 +28,11 @@ If you want the same worktree-per-task model without committing to either vendor
 |---|---|---|---|
 | **Platform** | macOS, Windows, Linux | macOS | macOS, Windows, Linux |
 | **License** | Open source | Proprietary | Source available |
-| **Agent coverage** | 25+ prebuilt agents | Claude Code, Codex, Cursor | Any CLI agent |
+| **Agent coverage** | 25+ prebuilt agents | Claude Code, Codex, Cursor, OpenCode | Any CLI agent |
 | **Isolation** | Git worktree per task | Git worktree per workspace | Git worktree per workspace |
 | **Remote work** | SSH remote worktrees | Cloud workspaces on paid tiers | Remote hosts and cloud workspaces |
 | **Task intake** | GitHub, Linear, GitHub Projects | GitHub, Linear | GitHub, Linear, Slack |
-| **Mobile** | Expo companion app in beta | Mobile app on Pro | iOS app |
+| **Mobile** | Expo companion app in beta | Announced, not released | iOS app |
 | **Pricing** | Free, open source | Free tier, Pro $50/mo, Teams $60/user/mo | Free tier, paid plans |
 
 ---
@@ -45,7 +45,7 @@ Its differentiator is breadth of agent support. Orca ships prebuilt configuratio
 
 ## What Is Conductor?
 
-Conductor is a native macOS app for running Claude Code, Codex, and Cursor in parallel, each agent on an isolated copy of your codebase.
+Conductor is a native macOS app for running Claude Code, Codex, Cursor, and OpenCode in parallel, each agent on an isolated copy of your codebase.
 
 Its differentiator is coordination and polish rather than breadth. Conductor spawns agent teams with named roles (Researcher, Builder, Reviewer, Reporter) across four coordination patterns: Supervisor, Pipeline, Consensus, and Swarm. It also manages context explicitly: when the window compacts, it extracts decisions, files, and tasks and reinjects them. The app leans on native macOS conventions, with a command palette and a session browser for resuming past conversations.
 
@@ -59,7 +59,7 @@ Orca runs on macOS, Windows, and Linux and is open source, so you can read it, f
 
 ### Agent Coverage
 
-Orca's 25+ prebuilt agents against Conductor's three is the starkest difference. If you switch models often, or you want an agent neither vendor has heard of, Orca's list and Superset's agent-agnostic model both handle it. Conductor's narrower list is a deliberate trade for a more opinionated experience on the agents it does support.
+Orca's 25+ prebuilt agents against Conductor's four is the starkest difference. If you switch models often, or you want an agent neither vendor has heard of, Orca's list and Superset's agent-agnostic model both handle it. Conductor's narrower list is a deliberate trade for a more opinionated experience on the agents it does support.
 
 ### Coordination Model
 
@@ -67,7 +67,7 @@ This is where Conductor pulls ahead. Named team roles and four coordination patt
 
 ### Pricing
 
-Orca is free and open source. Conductor has a free individual tier, with Pro at $50 per month adding cloud workspaces, multiplayer for up to five people, an API and a mobile app, and Teams at $60 per user per month. Whether that is worth it depends on how much you need the cloud and collaboration half.
+Orca is free and open source. Conductor has a free individual tier, with Pro at $50 per month adding Conductor Cloud workspace hours and multiplayer for up to five people, and Teams at $60 per user per month. It has announced a mobile app that has not shipped yet. Whether that is worth it depends on how much you need the cloud and collaboration half.
 
 ---
 
@@ -91,7 +91,7 @@ It adds the surfaces around orchestration: pull request review, an in-app browse
 
 ### Do Orca and Conductor both use Git worktrees?
 
-Yes. Both isolate each task or workspace in its own Git worktree so parallel agents never edit the same files. Superset uses the same model.
+Yes. Both give each workspace its own Git worktree, so agents in separate workspaces never edit the same files. Conductor also supports running more than one agent inside a single workspace when the work belongs on the same branch, and those agents do share files. Superset uses the same worktree-per-workspace model.
 
 ### Does Conductor run on Windows or Linux?
 
@@ -99,12 +99,12 @@ No. Conductor is a native macOS app. Orca and Superset both run on macOS, Window
 
 ### Which supports the most coding agents?
 
-Orca ships prebuilt configurations for more than 25 agents, against Conductor's Claude Code, Codex, and Cursor. Superset is agent-agnostic and runs any CLI agent.
+Orca ships prebuilt configurations for more than 25 agents, against Conductor's Claude Code, Codex, Cursor, and OpenCode. Superset is agent-agnostic and runs any CLI agent.
 
 ### Is Orca free?
 
-Yes. Orca is open source and free to run. Conductor has a free individual tier, with Pro at $50 per month and Teams at $60 per user per month for cloud workspaces, collaboration, API, and mobile.
+Yes. Orca is open source and free to run. Conductor has a free individual tier, with Pro at $50 per month and Teams at $60 per user per month for cloud workspace hours and collaboration.
 
 ### Can I use my existing Claude or Codex subscription?
 
-Yes, with all three. Orca, Conductor, and Superset run the agent CLIs on your machine under your own login, so you keep your existing plan rather than paying per token through the tool.
+Yes, with all three. In local workspaces, Orca, Conductor, and Superset run the agent CLIs on your machine under your own login, so you keep your existing plan rather than paying per token through the tool. Conductor Cloud is the exception to the local part: those sessions run in Conductor-managed Linux sandboxes rather than on your machine.

--- a/apps/marketing/content/compare/orca-vs-conductor.mdx
+++ b/apps/marketing/content/compare/orca-vs-conductor.mdx
@@ -16,7 +16,7 @@ keywords:
   - agent development environment
 ---
 
-Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source under MIT, cross-platform, and covers 25+ agents. Conductor is a proprietary macOS app focused on Claude Code, Codex, Cursor, and OpenCode, with a paid tier for cloud and team features.
+Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source under MIT, cross-platform, and covers 25+ agents plus any custom CLI you add. Conductor is a proprietary macOS app focused on Claude Code, Codex, Cursor, and OpenCode, with a paid tier for cloud and team features.
 
 If you want the same worktree-per-task model without committing to either vendor's agent list, [Superset](/compare/superset-vs-conductor) is the agent-agnostic option.
 
@@ -28,7 +28,7 @@ If you want the same worktree-per-task model without committing to either vendor
 |---|---|---|---|
 | **Platform** | macOS, Windows, Linux | macOS | macOS, Windows, Linux |
 | **License** | Open source | Proprietary | Source available |
-| **Agent coverage** | 25+ prebuilt agents | Claude Code, Codex, Cursor, OpenCode | Any CLI agent |
+| **Agent coverage** | 25+ prebuilt, plus custom CLI agents | Claude Code, Codex, Cursor, OpenCode | Any CLI agent |
 | **Isolation** | Git worktree per task | Git worktree per workspace | Git worktree per workspace |
 | **Remote work** | SSH remote worktrees | Cloud workspaces on paid tiers | Remote hosts and cloud workspaces |
 | **Task intake** | GitHub, Linear, GitHub Projects | GitHub, Linear | GitHub, Linear, Slack |
@@ -59,7 +59,7 @@ Orca runs on macOS, Windows, and Linux and is open source, so you can read it, f
 
 ### Agent Coverage
 
-Orca's 25+ prebuilt agents against Conductor's four is the starkest difference. If you switch models often, or you want an agent neither vendor has heard of, Orca's list and Superset's agent-agnostic model both handle it. Conductor's narrower list is a deliberate trade for a more opinionated experience on the agents it does support.
+Orca's 25+ prebuilt agents against Conductor's four is the starkest difference, and Orca also documents adding a custom CLI agent by name, binary, and default arguments. So if you switch models often, or want an agent no vendor has heard of, Orca and Superset both handle it and Conductor does not. Conductor's narrower list is a deliberate trade for a more opinionated experience on the agents it does support.
 
 ### Coordination Model
 
@@ -75,15 +75,15 @@ Orca is free and open source. Conductor has a free individual tier, with Pro at 
 
 Orca covers much of this ground already. It runs cross-platform and ships a design mode, SSH remote worktrees, PR and issue browsing, and mobile apps, so the honest gap is narrower than a feature list would suggest.
 
-Two things separate Superset from both. It takes any CLI agent rather than a prebuilt list, including one that shipped last week. And other software can drive it: Superset exposes an MCP server and a TypeScript SDK, so agents and your own scripts can create workspaces, launch agents, and read results, where Orca consumes MCP servers without exposing one and otherwise takes direction through its CLI. Superset also dispatches work from Slack and has an enterprise track with SSO, SCIM, and audit logs. See [Superset vs Orca](/compare/superset-vs-orca) and [Superset vs Conductor](/compare/superset-vs-conductor) for the head-to-heads.
+Against Conductor the gap is wide: any CLI agent, any platform. Against Orca it comes down to one thing, which is what can drive the tool from outside. Superset exposes an MCP server and a TypeScript SDK, so agents and your own scripts can create workspaces, launch agents, and read results as a first-class interface. Orca consumes MCP servers without exposing one, and otherwise takes direction through its CLI. Superset also dispatches work from Slack and has an enterprise track with SSO, SCIM, and audit logs. See [Superset vs Orca](/compare/superset-vs-orca) and [Superset vs Conductor](/compare/superset-vs-conductor) for the head-to-heads.
 
 ---
 
 ## Which Should You Choose?
 
-- **Choose Orca** if you want open source, cross-platform, the widest prebuilt agent list, and mobile on both iOS and Android.
+- **Choose Orca** if you want open source and free, the widest prebuilt agent list, and mobile on both iOS and Android.
 - **Choose Conductor** if you are on macOS, work primarily in Claude Code or Codex, and want structured multi-agent coordination with managed context.
-- **Choose Superset** if you want orchestration that other software can drive: any CLI agent, an MCP server and TypeScript SDK, Slack dispatch, and an enterprise track.
+- **Choose Superset** if you want orchestration other software can drive: an MCP server and TypeScript SDK, Slack dispatch, and an enterprise track with SSO and SCIM.
 
 ---
 
@@ -99,7 +99,7 @@ No. Conductor is a native macOS app. Orca and Superset both run on macOS, Window
 
 ### Which supports the most coding agents?
 
-Orca ships prebuilt configurations for more than 25 agents, against Conductor's Claude Code, Codex, Cursor, and OpenCode. Superset is agent-agnostic and runs any CLI agent.
+Orca ships prebuilt configurations for more than 25 agents and lets you add a custom CLI agent, against Conductor's Claude Code, Codex, Cursor, and OpenCode. Superset is agent-agnostic and runs any CLI agent. On this axis Orca and Superset are close; Conductor is the narrow one.
 
 ### Is Orca free?
 

--- a/apps/marketing/content/compare/orca-vs-conductor.mdx
+++ b/apps/marketing/content/compare/orca-vs-conductor.mdx
@@ -16,7 +16,7 @@ keywords:
   - agent development environment
 ---
 
-Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source, cross-platform, and covers 25+ agents. Conductor is a proprietary macOS app focused on Claude Code, Codex, Cursor, and OpenCode, with a paid tier for cloud and team features.
+Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source under MIT, cross-platform, and covers 25+ agents. Conductor is a proprietary macOS app focused on Claude Code, Codex, Cursor, and OpenCode, with a paid tier for cloud and team features.
 
 If you want the same worktree-per-task model without committing to either vendor's agent list, [Superset](/compare/superset-vs-conductor) is the agent-agnostic option.
 
@@ -32,16 +32,16 @@ If you want the same worktree-per-task model without committing to either vendor
 | **Isolation** | Git worktree per task | Git worktree per workspace | Git worktree per workspace |
 | **Remote work** | SSH remote worktrees | Cloud workspaces on paid tiers | Remote hosts and cloud workspaces |
 | **Task intake** | GitHub, Linear, GitHub Projects | GitHub, Linear | GitHub, Linear, Slack |
-| **Mobile** | Expo companion app in beta | Announced, not released | iOS app |
+| **Mobile** | iOS and Android | Announced, not released | iOS |
 | **Pricing** | Free, open source | Free tier, Pro $50/mo, Teams $60/user/mo | Free tier, paid plans |
 
 ---
 
 ## What Is Orca?
 
-Orca calls itself an Agent Development Environment: an open-source desktop app for macOS, Windows, and Linux that runs parallel agents in isolated worktrees, with terminals, editors, task workflows, and browser previews in one window.
+Orca calls itself an Agent Development Environment: an MIT-licensed desktop app for macOS, Windows, and Linux that runs parallel agents in isolated worktrees, with terminals, editors, task workflows, and browser previews in one window.
 
-Its differentiator is breadth of agent support. Orca ships prebuilt configurations for more than 25 agents, including Claude Code, Codex, OpenCode, Cursor CLI, GitHub Copilot, Gemini, Grok, Pi, Goose, Cline, Continue, Kilocode, and Qwen Code. Recent releases added SSH remote worktrees, a design mode, inline agent status in the sidebar, GitHub Projects in Tasks, and an account switcher that shows Claude and Codex quota with reset times.
+Its differentiator is breadth of agent support. Orca ships prebuilt configurations for more than 25 agents, including Claude Code, Codex, OpenCode, Cursor CLI, GitHub Copilot, Gemini, Grok, Pi, Goose, Cline, Continue, Kilocode, and Qwen Code. It also ships SSH remote worktrees, a design mode that opens a real Chromium window per worktree, GitHub PR, issue and Project boards alongside Linear, an account switcher showing Claude and Codex quota with reset times, and companion mobile apps for iOS and Android.
 
 ## What Is Conductor?
 
@@ -73,17 +73,17 @@ Orca is free and open source. Conductor has a free individual tier, with Pro at 
 
 ## Where Superset Fits
 
-Both tools tie you to their agent list: Orca's is long, Conductor's is short, but both are lists. Superset takes any CLI agent, including ones that shipped last week, and runs the same worktree-per-task model on macOS, Windows, and Linux.
+Orca covers much of this ground already. It runs cross-platform and ships a design mode, SSH remote worktrees, PR and issue browsing, and mobile apps, so the honest gap is narrower than a feature list would suggest.
 
-It adds the surfaces around orchestration: pull request review, an in-app browser with design mode, an MCP server so your agents can drive it, remote hosts, cloud workspaces, and an iOS app. See [Superset vs Orca](/compare/superset-vs-orca) and [Superset vs Conductor](/compare/superset-vs-conductor) for the head-to-heads.
+Two things separate Superset from both. It takes any CLI agent rather than a prebuilt list, including one that shipped last week. And other software can drive it: Superset exposes an MCP server and a TypeScript SDK, so agents and your own scripts can create workspaces, launch agents, and read results, where Orca consumes MCP servers without exposing one and otherwise takes direction through its CLI. Superset also dispatches work from Slack and has an enterprise track with SSO, SCIM, and audit logs. See [Superset vs Orca](/compare/superset-vs-orca) and [Superset vs Conductor](/compare/superset-vs-conductor) for the head-to-heads.
 
 ---
 
 ## Which Should You Choose?
 
-- **Choose Orca** if you want open source, cross-platform, and the widest agent list, and you are comfortable supervising agents yourself.
+- **Choose Orca** if you want open source, cross-platform, the widest prebuilt agent list, and mobile on both iOS and Android.
 - **Choose Conductor** if you are on macOS, work primarily in Claude Code or Codex, and want structured multi-agent coordination with managed context.
-- **Choose Superset** if you want agent-agnostic orchestration across any CLI agent, on any platform, with review, remote hosts, and mobile.
+- **Choose Superset** if you want orchestration that other software can drive: any CLI agent, an MCP server and TypeScript SDK, Slack dispatch, and an enterprise track.
 
 ---
 

--- a/apps/marketing/content/compare/orca-vs-conductor.mdx
+++ b/apps/marketing/content/compare/orca-vs-conductor.mdx
@@ -1,0 +1,110 @@
+---
+title: "Orca vs Conductor (2026): Agent Development Environments Compared"
+description: "Compare Orca and Conductor for running AI coding agents in parallel Git worktrees. Platform support, agent coverage, pricing, and where Superset fits as an agent-agnostic alternative."
+date: 2026-08-30
+lastUpdated: 2026-08-30
+type: "1v1"
+competitors:
+  - orca
+  - conductor
+keywords:
+  - orca vs conductor
+  - conductor vs orca
+  - orca alternative
+  - conductor alternative
+  - conductor competitors
+  - agent development environment
+---
+
+Orca and Conductor solve the same problem from opposite ends. Both run multiple AI coding agents at once, each in its own Git worktree, with review and merge in the app. Orca is open source, cross-platform, and covers 25+ agents. Conductor is a proprietary macOS app focused on Claude Code, Codex, and Cursor, with a paid tier for cloud and team features.
+
+If you want the same worktree-per-task model without committing to either vendor's agent list, [Superset](/compare/superset-vs-conductor) is the agent-agnostic option.
+
+---
+
+## At a Glance
+
+| | **Orca** | **Conductor** | **Superset** |
+|---|---|---|---|
+| **Platform** | macOS, Windows, Linux | macOS | macOS, Windows, Linux |
+| **License** | Open source | Proprietary | Source available |
+| **Agent coverage** | 25+ prebuilt agents | Claude Code, Codex, Cursor | Any CLI agent |
+| **Isolation** | Git worktree per task | Git worktree per workspace | Git worktree per workspace |
+| **Remote work** | SSH remote worktrees | Cloud workspaces on paid tiers | Remote hosts and cloud workspaces |
+| **Task intake** | GitHub, Linear, GitHub Projects | GitHub, Linear | GitHub, Linear, Slack |
+| **Mobile** | Expo companion app in beta | Mobile app on Pro | iOS app |
+| **Pricing** | Free, open source | Free tier, Pro $50/mo, Teams $60/user/mo | Free tier, paid plans |
+
+---
+
+## What Is Orca?
+
+Orca calls itself an Agent Development Environment: an open-source desktop app for macOS, Windows, and Linux that runs parallel agents in isolated worktrees, with terminals, editors, task workflows, and browser previews in one window.
+
+Its differentiator is breadth of agent support. Orca ships prebuilt configurations for more than 25 agents, including Claude Code, Codex, OpenCode, Cursor CLI, GitHub Copilot, Gemini, Grok, Pi, Goose, Cline, Continue, Kilocode, and Qwen Code. Recent releases added SSH remote worktrees, a design mode, inline agent status in the sidebar, GitHub Projects in Tasks, and an account switcher that shows Claude and Codex quota with reset times.
+
+## What Is Conductor?
+
+Conductor is a native macOS app for running Claude Code, Codex, and Cursor in parallel, each agent on an isolated copy of your codebase.
+
+Its differentiator is coordination and polish rather than breadth. Conductor spawns agent teams with named roles (Researcher, Builder, Reviewer, Reporter) across four coordination patterns: Supervisor, Pipeline, Consensus, and Swarm. It also manages context explicitly: when the window compacts, it extracts decisions, files, and tasks and reinjects them. The app leans on native macOS conventions, with a command palette and a session browser for resuming past conversations.
+
+---
+
+## Orca vs Conductor: Key Differences
+
+### Platform and License
+
+Orca runs on macOS, Windows, and Linux and is open source, so you can read it, fork it, and self-host the pieces you care about. Conductor is macOS only and proprietary. On this axis the choice often gets made for you: if your team is not all on Macs, Conductor is out.
+
+### Agent Coverage
+
+Orca's 25+ prebuilt agents against Conductor's three is the starkest difference. If you switch models often, or you want an agent neither vendor has heard of, Orca's list and Superset's agent-agnostic model both handle it. Conductor's narrower list is a deliberate trade for a more opinionated experience on the agents it does support.
+
+### Coordination Model
+
+This is where Conductor pulls ahead. Named team roles and four coordination patterns are a real feature, not a wrapper around parallel terminals, and its explicit context reinjection on compaction addresses a genuine failure mode. Orca's model is closer to a fleet of independent agents you supervise.
+
+### Pricing
+
+Orca is free and open source. Conductor has a free individual tier, with Pro at $50 per month adding cloud workspaces, multiplayer for up to five people, an API and a mobile app, and Teams at $60 per user per month. Whether that is worth it depends on how much you need the cloud and collaboration half.
+
+---
+
+## Where Superset Fits
+
+Both tools tie you to their agent list: Orca's is long, Conductor's is short, but both are lists. Superset takes any CLI agent, including ones that shipped last week, and runs the same worktree-per-task model on macOS, Windows, and Linux.
+
+It adds the surfaces around orchestration: pull request review, an in-app browser with design mode, an MCP server so your agents can drive it, remote hosts, cloud workspaces, and an iOS app. See [Superset vs Orca](/compare/superset-vs-orca) and [Superset vs Conductor](/compare/superset-vs-conductor) for the head-to-heads.
+
+---
+
+## Which Should You Choose?
+
+- **Choose Orca** if you want open source, cross-platform, and the widest agent list, and you are comfortable supervising agents yourself.
+- **Choose Conductor** if you are on macOS, work primarily in Claude Code or Codex, and want structured multi-agent coordination with managed context.
+- **Choose Superset** if you want agent-agnostic orchestration across any CLI agent, on any platform, with review, remote hosts, and mobile.
+
+---
+
+## Frequently Asked Questions
+
+### Do Orca and Conductor both use Git worktrees?
+
+Yes. Both isolate each task or workspace in its own Git worktree so parallel agents never edit the same files. Superset uses the same model.
+
+### Does Conductor run on Windows or Linux?
+
+No. Conductor is a native macOS app. Orca and Superset both run on macOS, Windows, and Linux.
+
+### Which supports the most coding agents?
+
+Orca ships prebuilt configurations for more than 25 agents, against Conductor's Claude Code, Codex, and Cursor. Superset is agent-agnostic and runs any CLI agent.
+
+### Is Orca free?
+
+Yes. Orca is open source and free to run. Conductor has a free individual tier, with Pro at $50 per month and Teams at $60 per user per month for cloud workspaces, collaboration, API, and mobile.
+
+### Can I use my existing Claude or Codex subscription?
+
+Yes, with all three. Orca, Conductor, and Superset run the agent CLIs on your machine under your own login, so you keep your existing plan rather than paying per token through the tool.


### PR DESCRIPTION
## Summary
- New blog post `switching-between-ai-coding-agents.mdx`: how to move a session between AI coding agents, what context is made of, and the fork/resume flags for six agent CLIs.
- New compare page `orca-vs-conductor.mdx`, targeting a competitor query cluster that currently has no dedicated page.

## Why / Context
This started as "should we turn changelog entries into blog posts?" Search Console says no, so this does the version the data supports instead.

Over the last 3 months on `sc-domain:superset.sh`:

| Bucket | Clicks | Impressions | Pages | Clicks/page |
|---|---|---|---|---|
| Compare pages | 5,689 | 230K | 71 | 80 |
| Blog | 716 | 38K | 7 | 102 |
| Changelog entries | 434 | 17K | 27 | 16 |

Changelog entries average 16 clicks and 616 impressions each, because nobody searches for a release announcement. The blog's 102 average is carried by one post (`git-worktrees-history-deep-dive`, 430 of 716 clicks) that ranks because "when was git worktree introduced" is a real recurring query. The two announcement-shaped blog posts flopped despite being six months old: `agent-orchestration-not-another-agent` has 1 click on 811 impressions, `how-to-get-hit` has 0 on 6.

So the lever is demand, not format. Both pages here target queries that already exist.

## How It Works

**Blog post.** Splits context into conversation, working state, instructions, and reasoning, and shows that two of the four travel on their own. Includes a fork/resume reference table for Claude Code, Codex, OpenCode, Grok, Pi, and Droid, which is not compiled anywhere else, and the alt-screen scrollback measurement from #6962 (visible buffer returns 23 history lines where the raw pty stream returns 253; after a pager exits the buffer holds none of 300 lines). Superset appears only in the last section.

**Compare page.** `orca vs conductor` already draws 331 impressions and 32 clicks with no dedicated page, and the competitor-vs-competitor pattern already exists (`conductor-vs-crystal`, `warp-vs-conductor`). The page also carries `conductor competitors` as a keyword, a query sitting at 1,883 impressions and 0 clicks.

## Manual QA Checklist
- [x] Both pages render 200 on a local marketing server (`next dev`, dummy env per the compare-pages recipe)
- [x] Compare page emits the At a Glance table and auto-generated FAQ JSON-LD (`FAQPage`)
- [x] Both appear on their index pages (`/compare`, `/blog`) and in the sitemap
- [x] Frontmatter matches existing convention for each content type
- [x] No em dashes; no literal `{` or bare `<lowercase` that would break MDX
- [x] Competitor facts checked against current sources on 2026-08-30

## Testing
- `bun run lint` (exit 0)
- `bun run --cwd apps/marketing lint:prose` (Vale: 0 errors, 0 warnings; 3 advisory suggestions kept deliberately, including `alex.ProfanityMaybe` firing on "trap" in "The scrollback trap")
- Render check over HTTP as above

## Design Decisions
- **Blog post leads with the problem, not the feature.** The evidence above says announcement-shaped writing does not earn clicks regardless of which directory it sits in, so the Superset section is last and the fork table is useful even to someone who never installs it.
- **No star count for Orca.** Sources disagree (one says 20k, our own note from 2026-08-24 says 52.6k), so the page cites neither rather than printing a number that may be wrong.
- **Conductor is given the win on coordination.** Its named team roles, four coordination patterns, and context reinjection on compaction are real advantages, and per our rule about competitor contrasts an invented differentiator would be worse than none.

## Known Limitations
- Neither page has a hero image. The blog index does show cover images, so this post will render without one until someone supplies it.
- Droid's fork flag is documented but unverified, and the post says so.

## Follow-ups
- The single largest untapped item from the same data is `conductor competitors` at 1,883 impressions and 0 clicks. `conductor-alternative.mdx` already targets that keyword and was last updated 2026-07-13, so it ranks but does not convert. Worth a refresh pass separately.

https://claude.ai/code/session_011zKUF9njL63tLUpHmCaGPv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two content pages targeting search queries that already draw impressions: an evergreen blog post on switching between AI coding agents and an Orca vs Conductor compare page.

- The post splits context into conversation, working state, instructions, and reasoning, and compiles fork/resume commands for six agent CLIs into a table not assembled anywhere else.
- It measures the alternate-screen scrollback trap: 23 history lines from the visible buffer versus 253 from the raw pty stream.
- The compare page targets `orca vs conductor` (331 impressions) and carries `conductor competitors` (1,883 impressions, 0 clicks).
- Review passes fixed Conductor facts against its docs and blog claims on portability, forking, and scrollback; the Orca pass rewrote the Superset positioning after Orca's docs showed it already covers PR review, design mode, remote hosts, mobile, and custom CLI agents.
- The surviving contrast against Orca is an exposed MCP server plus TypeScript SDK, Slack dispatch, and the enterprise track.
- Orca's star count is omitted because sources disagree (20k vs 52.6k); Droid's fork flag is documented but unverified, and the post says so.
- Neither page has a hero image; the blog post renders without one until supplied.

<sup>Written for commit a44ddc24401c41ee795f1c5f69a7fbfcf9157ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the guide for switching between AI coding agents, covering CLI forking, portable files and instructions, transcript replay, terminal buffering, vendor-specific imports, and credential-safety considerations.
  - Updated the Orca versus Conductor comparison with platform support, licensing, agent coverage, pricing, coordination models, mobile app availability, workspace isolation, subscription scope, and Superset’s positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->