### PR TITLE
fix(files): refuse to delete a file something still references

### DIFF
--- a/packages/trpc/src/router/file/file.ts
+++ b/packages/trpc/src/router/file/file.ts
@@ -243,6 +243,23 @@ export const fileRouter = {
 					message: "Only the uploader can delete a file",
 				});
 			}
+			// A published version is immutable and `attachments.file_id`
+			// cascades, so deleting an attached file would drop the attachment
+			// row and the bytes while the manifest still names them — the page
+			// then serves a hole. Republishing reuses one file id across every
+			// version whose bytes did not change, so a single delete can empty
+			// an asset out of the entire history at once.
+			const attached = await db
+				.select({ id: attachments.id })
+				.from(attachments)
+				.where(eq(attachments.fileId, row.id))
+				.limit(1);
+			if (attached.length > 0) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: "File is in use — delete what it is attached to instead",
+				});
+			}
 			await db.delete(files).where(eq(files.id, row.id));
 			await deleteObjects([fileOriginalKey(row.id)]).catch((error) => {
 				console.error("[files] failed to delete object", {


### PR DESCRIPTION
## Summary
- `file.delete` now refuses with `CONFLICT` when any `attachments` row still references the file.

## Why / Context
The procedure checked that the caller was the uploader, then deleted the row and the R2 object with **no attachment check**. `attachments.file_id` is `onDelete: "cascade"` and nothing rewrites the page manifest, so an uploader could delete an asset out from under a **published version**: the attachment row cascaded away, the bytes went with it, and the manifest kept naming both — the origin then served a hole where the image or video used to be.

It is worse than one version. The CLI reuses a file id across every version whose bytes did not change (sha256 reuse), so a single delete can empty an asset out of a page's entire history, including versions that are supposed to be immutable.

Found while auditing which router capabilities have no CLI/MCP surface — that missing surface is the only reason this is not reachable today, and SUPER-2087 plus the plugin MCP work would have exposed it.

## Testing
- `bun turbo run typecheck --filter=@superset/trpc`
- `bun test packages/trpc/src/router`
- `bunx biome check .`

No procedure test: the file router has none today (only `sniff.test.ts`), and exercising this needs a database, which `publish.integration.ts` shows is not wired into CI. The guard is a single query with an explicit refusal.

## Notes
Deleting a page still cleans up its assets — `page.delete` removes the attachment rows first and then the files nothing else references, so this only blocks deleting a file *while* something points at it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`file.delete` now refuses with a `CONFLICT` when any attachment still references the file, so deleting a file can no longer empty an asset out of a published version or its history.

**Why it matters**
- `attachments.file_id` cascades and nothing rewrites the page manifest, so the previous flow removed the attachment and the bytes while the manifest still named them.
- The CLI reuses one file id across versions whose bytes did not change, so a single delete could empty an asset from an entire page history.
- Deleting a page still cleans up its assets; this only blocks deleting a file while something points at it.

<sup>Written for commit 3cf0f8525ff2bb12806bebf17cab058e71d8ca75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented deletion of files that are still attached to other records.
  - Added a clear conflict message directing users to remove the attachment first.
  - Files without attachments continue to be deleted normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->