### PR TITLE
fix(automations): four review findings on the trigger rows

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
@@ -99,7 +99,8 @@ export function ScheduleSentence({
 	// separately, or the row sits blank under the previous rule's next run.
 	const draftCleared = customDraft === "" && rrule !== "";
 	const showsProblem =
-		state.kind === "custom" && (draftCleared || (draftEdited && !!customProblem));
+		state.kind === "custom" &&
+		(draftCleared || (draftEdited && !!customProblem));
 
 	const showsTime = state.kind === "daily" || state.kind === "weekly";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
@@ -94,8 +94,12 @@ export function ScheduleSentence({
 	// ran); that is history, not an edit gone wrong, so only a changed draft
 	// gets the complaint.
 	const draftEdited = customDraft !== "" && customDraft !== rrule;
+	// Clearing a saved rule is an edit that cannot save, but it has no problem
+	// to report — an empty field parses as nothing at all — so it needs saying
+	// separately, or the row sits blank under the previous rule's next run.
+	const draftCleared = customDraft === "" && rrule !== "";
 	const showsProblem =
-		state.kind === "custom" && draftEdited && !!customProblem;
+		state.kind === "custom" && (draftCleared || (draftEdited && !!customProblem));
 
 	const showsTime = state.kind === "daily" || state.kind === "weekly";
 
@@ -165,9 +169,11 @@ export function ScheduleSentence({
 				    reads as a contradiction. */}
 			{showsProblem ? (
 				<span className="ml-1 truncate text-[13px] text-destructive">
-					{customProblem === "exhausted"
-						? "No upcoming runs — changes aren't saved"
-						: "Invalid recurrence rule — changes aren't saved"}
+					{draftCleared
+						? "Enter a recurrence rule — changes aren't saved"
+						: customProblem === "exhausted"
+							? "No upcoming runs — changes aren't saved"
+							: "Invalid recurrence rule — changes aren't saved"}
 				</span>
 			) : (
 				nextRun && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
@@ -94,13 +94,8 @@ export function ScheduleSentence({
 	// ran); that is history, not an edit gone wrong, so only a changed draft
 	// gets the complaint.
 	const draftEdited = customDraft !== "" && customDraft !== rrule;
-	// Clearing a saved rule is an edit that cannot save, but it has no problem
-	// to report — an empty field parses as nothing at all — so it needs saying
-	// separately, or the row sits blank under the previous rule's next run.
-	const draftCleared = customDraft === "" && rrule !== "";
 	const showsProblem =
-		state.kind === "custom" &&
-		(draftCleared || (draftEdited && !!customProblem));
+		state.kind === "custom" && draftEdited && !!customProblem;
 
 	const showsTime = state.kind === "daily" || state.kind === "weekly";
 
@@ -170,11 +165,9 @@ export function ScheduleSentence({
 				    reads as a contradiction. */}
 			{showsProblem ? (
 				<span className="ml-1 truncate text-[13px] text-destructive">
-					{draftCleared
-						? "Enter a recurrence rule — changes aren't saved"
-						: customProblem === "exhausted"
-							? "No upcoming runs — changes aren't saved"
-							: "Invalid recurrence rule — changes aren't saved"}
+					{customProblem === "exhausted"
+						? "No upcoming runs — changes aren't saved"
+						: "Invalid recurrence rule — changes aren't saved"}
 				</span>
 			) : (
 				nextRun && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/ScheduleSentence/ScheduleSentence.tsx
@@ -94,8 +94,13 @@ export function ScheduleSentence({
 	// ran); that is history, not an edit gone wrong, so only a changed draft
 	// gets the complaint.
 	const draftEdited = customDraft !== "" && customDraft !== rrule;
+	// Clearing a saved rule is an edit that cannot save, but it has no problem
+	// to report — an empty field parses as nothing at all — so it needs saying
+	// separately, or the row sits blank under the previous rule's next run.
+	const draftCleared = customDraft === "" && rrule !== "";
 	const showsProblem =
-		state.kind === "custom" && draftEdited && !!customProblem;
+		state.kind === "custom" &&
+		(draftCleared || (draftEdited && !!customProblem));
 
 	const showsTime = state.kind === "daily" || state.kind === "weekly";
 
@@ -165,9 +170,11 @@ export function ScheduleSentence({
 				    reads as a contradiction. */}
 			{showsProblem ? (
 				<span className="ml-1 truncate text-[13px] text-destructive">
-					{customProblem === "exhausted"
-						? "No upcoming runs — changes aren't saved"
-						: "Invalid recurrence rule — changes aren't saved"}
+					{draftCleared
+						? "Enter a recurrence rule — changes aren't saved"
+						: customProblem === "exhausted"
+							? "No upcoming runs — changes aren't saved"
+							: "Invalid recurrence rule — changes aren't saved"}
 				</span>
 			) : (
 				nextRun && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/TriggersEditor.tsx
@@ -13,10 +13,18 @@ import {
 import { Input } from "@superset/ui/input";
 import { Separator } from "@superset/ui/separator";
 import { useFeatureFlagPayload } from "posthog-js/react";
-import { type ReactNode, useMemo, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { LuPlus, LuTriangleAlert } from "react-icons/lu";
 import { useCurrentPlan } from "renderer/hooks/useCurrentPlan";
 import { providerFor, TRIGGER_PROVIDERS } from "../providers";
+import type { OptionGroupState } from "../providers/types";
 import { useProviderConnections } from "../providers/useProviderConnections";
 import { useProviderOptions } from "../providers/useProviderOptions";
 import { TriggerSentence } from "../TriggerSentence";
@@ -74,6 +82,19 @@ export function TriggersEditor({
 	// meant a new row was saved, refused, and dropped on the next render. Saving
 	// silently once it happened to become valid is no better: nothing tells you
 	// which edit crossed the line, or that anything was written at all.
+	const optionStateRef = useRef<Record<string, OptionGroupState>>({});
+	// Saving joins the bot to the public channels a Slack trigger watches, which
+	// flips `botMember` on the cached channel list. Without a refetch the
+	// membership warning outlives the save that fixed it.
+	const saveTriggers = useCallback(
+		async (next: DraftTrigger[]) => {
+			const result = await onChange(next);
+			optionStateRef.current.slack?.refetch();
+			return result;
+		},
+		[onChange],
+	);
+
 	const {
 		drafts,
 		dirty,
@@ -84,11 +105,16 @@ export function TriggersEditor({
 		add,
 		save,
 		discard,
-	} = useTriggerDrafts(triggers, onChange);
+	} = useTriggerDrafts(triggers, saveTriggers);
 	const { options, state: optionState } = useProviderOptions(
 		organizationId,
 		drafts,
 	);
+	// Read through a ref: the save handler is defined before this hook runs, and
+	// it only needs whichever refetch exists by the time a save resolves.
+	useEffect(() => {
+		optionStateRef.current = optionState;
+	}, [optionState]);
 
 	// Unlike problems, these show without waiting for a save attempt: they
 	// describe the world (a channel the bot is not in), not an unfinished edit,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/components/TokenField/TokenField.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/components/TokenField/TokenField.test.tsx
@@ -106,10 +106,19 @@ describe("TokenField committing", () => {
 		expect(field.values).toEqual(["alice", "bob", "carol"]);
 	});
 
-	test("strips a leading @, which is how people copy a handle", async () => {
-		const field = await setup();
+	test("strips a leading @ for logins, which is how people copy a handle", async () => {
+		const field = await setup([], { stripLeadingAt: true });
 		await field.typeAndCommit("@alice,");
 		expect(field.values).toEqual(["alice"]);
+	});
+
+	// Off by default: the same field takes branches and labels, and a branch
+	// may legitimately be called "@next" — stripping there stores a ref that
+	// does not exist.
+	test("keeps a leading @ where it can be part of the value", async () => {
+		const field = await setup();
+		await field.typeAndCommit("@next,");
+		expect(field.values).toEqual(["@next"]);
 	});
 
 	test("ignores a repeat rather than showing it twice", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/components/TokenField/TokenField.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/components/TokenField/TokenField.tsx
@@ -34,6 +34,7 @@ export function TokenField({
 	header,
 	onReset,
 	separators = SEPARATORS,
+	stripLeadingAt = false,
 }: {
 	values: string[];
 	onChange: (next: string[]) => void;
@@ -45,6 +46,12 @@ export function TokenField({
 	onReset?: () => void;
 	/** Defaults to commas and newlines; see SEPARATORS_WITH_SPACE. */
 	separators?: RegExp;
+	/**
+	 * Drops a leading "@" on commit. Only for logins, where the @ is display
+	 * sugar people paste along with the name — a branch may legitimately be
+	 * called "@next", and stripping it there stores a ref that does not exist.
+	 */
+	stripLeadingAt?: boolean;
 }) {
 	const [draft, setDraft] = useState("");
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -53,8 +60,12 @@ export function TokenField({
 	const commit = (text: string) => {
 		const added = text
 			.split(separators)
-			// People copy names with the @ still attached; it is not part of a login.
-			.map((part) => part.trim().replace(/^@/, ""))
+			.map((part) => {
+				const trimmed = part.trim();
+				// People copy names with the @ still attached; it is not part of a
+				// login. Values that can legitimately start with one keep it.
+				return stripLeadingAt ? trimmed.replace(/^@/, "") : trimmed;
+			})
 			.filter(Boolean);
 		if (added.length === 0) return false;
 		const next = [...values];

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/components/UserScopeChip/UserScopeChip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/github/components/UserScopeChip/UserScopeChip.tsx
@@ -85,6 +85,7 @@ export function UserScopeChip({
 			{isList ? (
 				<PopoverContent align="start" className="w-72 p-2">
 					<TokenField
+						stripLeadingAt
 						values={values}
 						onChange={(ids) => onChange({ mode: "list", ids })}
 						placeholder="GitHub username..."

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/schedule/schedule.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/schedule/schedule.test.tsx
@@ -176,6 +176,18 @@ describe("a custom row", () => {
 		expect(text).not.toContain("Next run Friday");
 	});
 
+	// Clearing the field is an edit that cannot save, but an empty rule has no
+	// parse error to report — without this it sat blank under the old next run.
+	test("says so when the rule is cleared rather than left invalid", async () => {
+		const { ui, view } = await row(CUSTOM, { nextRun: "Next run Friday" });
+		await act(async () => {
+			fireEvent.change(ui.getByRole("textbox"), { target: { value: "" } });
+		});
+		const text = view.container.textContent ?? "";
+		expect(text).toContain("Enter a recurrence rule — changes aren't saved");
+		expect(text).not.toContain("Next run Friday");
+	});
+
 	// A saved rule can be exhausted (a run-once schedule that already ran);
 	// that is history, not an edit gone wrong, so it is not complained about.
 	test("does not complain about the saved rule until it is edited", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/schedule/schedule.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/schedule/schedule.test.tsx
@@ -176,18 +176,6 @@ describe("a custom row", () => {
 		expect(text).not.toContain("Next run Friday");
 	});
 
-	// Clearing the field is an edit that cannot save, but an empty rule has no
-	// parse error to report — without this it sat blank under the old next run.
-	test("says so when the rule is cleared rather than left invalid", async () => {
-		const { ui, view } = await row(CUSTOM, { nextRun: "Next run Friday" });
-		await act(async () => {
-			fireEvent.change(ui.getByRole("textbox"), { target: { value: "" } });
-		});
-		const text = view.container.textContent ?? "";
-		expect(text).toContain("Enter a recurrence rule — changes aren't saved");
-		expect(text).not.toContain("Next run Friday");
-	});
-
 	// A saved rule can be exhausted (a run-once schedule that already ran);
 	// that is history, not an edit gone wrong, so it is not complained about.
 	test("does not complain about the saved rule until it is edited", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/webhook/WebhookSentence/WebhookSentence.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/providers/webhook/WebhookSentence/WebhookSentence.tsx
@@ -124,7 +124,12 @@ export function WebhookSentence({ triggerId, disabled }: WebhookSentenceProps) {
 			{token && (
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<button type="button" onClick={copyHeader} className={cn(CHIP)}>
+						<button
+							type="button"
+							disabled={disabled}
+							onClick={copyHeader}
+							className={cn(CHIP)}
+						>
 							<span className="truncate">Copy auth header</span>
 						</button>
 					</TooltipTrigger>


### PR DESCRIPTION
Four of the six review findings from #6709. Three sit in flag-gated trigger UI that no customer can reach while `automation-event-triggers` stays internal; the fourth ships unflagged — see the callout below.

| Fix | Symptom it removes |
|---|---|
| `WebhookSentence` copy button takes `disabled` | Token was copyable from a row the parent had disabled |
| `TokenField` `@`-strip is now opt-in | The field also takes branches and labels, so a branch named `@next` was silently stored as `next` — a ref that doesn't exist. On for logins, off elsewhere |
| Cleared custom RRULE reports itself | An emptied field parses to no problem at all, so the row sat blank under the *previous* rule's next run while being unsaveable |
| Slack options refetch after save | Saving auto-joins watched public channels, but the cached list kept `botMember: false`, so the membership warning outlived the save that fixed it |

Also adds one case to the schedule row spec for the cleared-rule path.

**One spec changed rather than added.** `TokenField` had a test asserting a leading `@` is always stripped — a deliberate decision about how people paste handles, not an accident. Rather than delete it, it now exercises the `stripLeadingAt` prop, with a companion case covering the branch value it used to mangle. The intent stays documented; only its scope narrows.

**⚠️ One change reaches customers.** The RRULE fix is in `ScheduleSentence`, and the Scheduled row bypasses the feature flag (`provider.kind === "schedule" || kinds.has(...)`), so it ships to everyone — prod holds 980 schedule triggers. It adds one string, `"Enter a recurrence rule — changes aren't saved"`, following the two already in that row. Copy review is owed on it after the fact.

**Not here:** the EmojiNameChip minor, and the Major finding that `useProviderOptions` folds an option-source failure into an empty array, so a provider outage renders as "nothing to choose yet". That one's a real correctness gap and wants its own change.

Desktop 3238 pass / 0 fail, lint clean, typecheck clean.

https://claude.ai/code/session_01JZADY3P3hZ7PitayKpGKLg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four review findings in the trigger rows, three behind the internal `automation-event-triggers` flag; the custom-RRULE fix ships unflagged, so its copy is worth a review pass.

**Bug Fixes**

- The webhook copy-token button now takes `disabled`, so a token can't be copied from a row the parent disabled.
- `TokenField` only strips a leading `@` when `stripLeadingAt` is set (on for logins); a value like `@next` keeps its `@` instead of being stored as `next`.
- `TriggersEditor` refetches Slack options after save — saving auto-joins watched public channels, and the cached list kept `botMember: false`, so the membership warning outlived its fix.
- Clearing a saved custom RRULE now says "Enter a recurrence rule — changes aren't saved" instead of a blank editor under the old rule's next run.

The `TokenField` spec now exercises `stripLeadingAt`; the schedule spec covers the cleared-rule message.

<sup>Written for commit 69f3e4b5c302de867e1367c5bea266617e210ee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear validation message when a custom schedule rule is emptied.
  * Slack trigger saves now refresh provider status, clearing outdated bot-membership warnings.
  * GitHub usernames remove a leading “@” when entered.
  * Other token values preserve “@” unless configured otherwise.
  * Disabled webhook copy buttons can no longer be activated.

* **Tests**
  * Added coverage for empty schedule rules and GitHub token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
