### PR TITLE
fix(mobile): polyfill Intl.PluralRules, which Hermes does not ship

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,4 +1,6 @@
 import "react-native-get-random-values"; // MUST BE FIRST IMPORT
+// Before anything can render a plural — Hermes has no Intl.PluralRules.
+import "@/lib/intl-pluralrules";
 import "../global.css";
 
 import * as Sentry from "@sentry/react-native";

--- a/apps/mobile/lib/intl-pluralrules.ts
+++ b/apps/mobile/lib/intl-pluralrules.ts
@@ -1,0 +1,44 @@
+/**
+ * `Intl.PluralRules` for Hermes, which does not ship it.
+ *
+ * Hermes gives iOS most of Intl — `Collator`, `NumberFormat` and
+ * `DateTimeFormat` are all there — but `PluralRules` is missing. Lingui
+ * compiles every plural message to a runtime `new Intl.PluralRules(...)`, so
+ * without this each one throws "undefined cannot be used as a constructor" as
+ * it renders. There is no error boundary above these screens, so the throw
+ * takes the whole tree down rather than degrading to English or to the raw
+ * message.
+ *
+ * That is 23 messages on mobile surfaces today — search results, the commits
+ * list, hidden-line counts in a diff, the files-changed summary, pull request
+ * headlines and file counts, reasoning durations, test result counts.
+ *
+ * Imported for its side effects, before anything renders. `polyfill` installs
+ * only when the runtime is actually missing the API, so a future Hermes that
+ * grows one keeps its own.
+ *
+ * One data file per base language: plural categories do not vary by region, so
+ * `zh` serves zh-CN and zh-TW, and `pt` serves pt-BR. Keep in step with
+ * `SUPPORTED_LOCALES` in `packages/i18n/src/locales.ts`.
+ *
+ * The `.js` on each specifier is load-bearing: the package's `exports` map
+ * publishes `./polyfill.js` and `./locale-data/*`, so the extensionless form
+ * resolves in Metro but not in TypeScript.
+ */
+import "@formatjs/intl-pluralrules/polyfill.js";
+import "@formatjs/intl-pluralrules/locale-data/cs.js";
+import "@formatjs/intl-pluralrules/locale-data/de.js";
+import "@formatjs/intl-pluralrules/locale-data/en.js";
+import "@formatjs/intl-pluralrules/locale-data/es.js";
+import "@formatjs/intl-pluralrules/locale-data/fr.js";
+import "@formatjs/intl-pluralrules/locale-data/id.js";
+import "@formatjs/intl-pluralrules/locale-data/it.js";
+import "@formatjs/intl-pluralrules/locale-data/ja.js";
+import "@formatjs/intl-pluralrules/locale-data/ko.js";
+import "@formatjs/intl-pluralrules/locale-data/nl.js";
+import "@formatjs/intl-pluralrules/locale-data/pl.js";
+import "@formatjs/intl-pluralrules/locale-data/pt.js";
+import "@formatjs/intl-pluralrules/locale-data/ru.js";
+import "@formatjs/intl-pluralrules/locale-data/tr.js";
+import "@formatjs/intl-pluralrules/locale-data/vi.js";
+import "@formatjs/intl-pluralrules/locale-data/zh.js";

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,7 @@
 		"@better-auth/expo": "1.6.22",
 		"@expo/ui": "57.0.12",
 		"@expo/vector-icons": "15.1.1",
+		"@formatjs/intl-pluralrules": "6.3.13",
 		"@legendapp/list": "3.0.3",
 		"@lingui/core": "6.6.0",
 		"@lingui/react": "6.6.0",

--- a/bun.lock
+++ b/bun.lock
@@ -497,6 +497,7 @@
         "@better-auth/expo": "1.6.22",
         "@expo/ui": "57.0.12",
         "@expo/vector-icons": "15.1.1",
+        "@formatjs/intl-pluralrules": "6.3.13",
         "@legendapp/list": "3.0.3",
         "@lingui/core": "6.6.0",
         "@lingui/react": "6.6.0",
@@ -2082,6 +2083,14 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@formatjs/bigdecimal": ["@formatjs/bigdecimal@0.2.7", "", {}, "sha512-B4+XY/e4u5v261r3a37Kq2ax91gPZSKGyVpx8X5dygAggLlUz+6MeBpmAhaBFGB8WQ4JB1qD+QtKHk9aJkEb9Q=="],
+
+    "@formatjs/fast-memoize": ["@formatjs/fast-memoize@3.1.7", "", {}, "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA=="],
+
+    "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.8.13", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.7" } }, "sha512-kHEAFOkeJSPNi7c5PaKaRjxcBrJwzzt81ifUu+8uve1EDW/VJl83KsxmqgqNZLzcFEhSliZGvx3+pk/RH0IOmg=="],
+
+    "@formatjs/intl-pluralrules": ["@formatjs/intl-pluralrules@6.3.13", "", { "dependencies": { "@formatjs/bigdecimal": "0.2.7", "@formatjs/intl-localematcher": "0.8.13" } }, "sha512-78dxY4nu4BbB9J7WqqIFzr1EbhrbB6VE4KOGw4qlmX+IpS6YPM7tVYLLhDq7qOQCzq9+741iDMrgB1JlhHUM/Q=="],
 
     "@fuma-translate/react": ["@fuma-translate/react@1.0.2", "", { "peerDependencies": { "@types/react": "*", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@types/react"] }, "sha512-uOiOtBx3nRXR8Nu1GzBf1tApgF1FErDBTHxRIAQeyQdyOoZbrNRN6H4kDCWObY4qyGeGbHydG0DHzgeUgFDMIw=="],
 


### PR DESCRIPTION
## Summary

- Every plural message on a mobile surface throws while it renders. Hermes has no `Intl.PluralRules`, and Lingui compiles a plural to a runtime `new Intl.PluralRules(...)`.
- **This is not dev-only** — production builds use the same engine.
- Adds `@formatjs/intl-pluralrules` plus locale data, imported at the app entry before anything renders.

## Why / Context

Found while walking a workspace → pull request flow on a simulator. Opening a PR from a workspace red-boxes with:

```
Render Error
undefined cannot be used as a constructor.
  () => new Intl.PluralRules(_locales, { t...   index.mjs (82:31)
  <Trans /> → <TextImpl />
```

Probed the running app to confirm the gap rather than infer it:

```
Intl: object · PluralRules: undefined · NumberFormat: function · DateTimeFormat: function · Collator: function
```

Hermes ships most of Intl on Apple platforms. `PluralRules` is the hole, and the repo has no polyfill anywhere in `apps/` or `packages/`.

**Blast radius — 23 messages on mobile surfaces:**

`mobile.search.resultsOnHost`, `mobile.search.resultsInCloud`, `mobile.commits.count`, `mobile.diff.hiddenLines`, `mobile.diff.showHiddenLines`, `mobile.filesChanged.truncated`, `mobile.finishReview.commentsAttached`, `mobile.pullRequest.fileCount`, `mobile.pullRequest.filesChangedCount`, `mobile.pullRequest.headline.checksFailed`, `mobile.pullRequest.headline.checksNeedAction`, `mobile.reasoning.thoughtForSeconds`, `mobile.sources.usedCount`, `mobile.stackTrace.showMoreFrames`, `mobile.common.showMoreLines`, `mobile.workspaceActions.changesValue`, `mobile.accountPendingDeletion.descriptionDays`, and six `mobile.testResults.*` counters.

**Does this reach users?** Yes. `eas.json` has no `jsEngine` override on any profile, and neither does `app.config.ts`, so `development`, `preview` and `production` all build the same Hermes with the same missing API. And there is no error boundary anywhere in the mobile tree — in a release build the throw is unhandled, so the screen goes rather than degrading to the raw message.

## How It Works

`apps/mobile/lib/intl-pluralrules.ts` is a side-effect module imported from `app/_layout.tsx`, right after `react-native-get-random-values` and before anything can render. It pulls `@formatjs/intl-pluralrules/polyfill.js` — the conditional variant, which installs only when the runtime is actually missing the API, so a future Hermes that grows one keeps its own — followed by one locale-data file per base language.

Sixteen data files cover the seventeen `SUPPORTED_LOCALES`: plural categories do not vary by region, so `zh` serves zh-CN and zh-TW and `pt` serves pt-BR.

## Manual QA Checklist

Verified on an iPhone 17 simulator, iOS 26.5, by probing the live runtime:

- [x] Before: `typeof Intl.PluralRules` is `"undefined"`
- [x] After: `"function"`
- [x] English selects `1 → one`, `3 → other`
- [x] Russian selects `2 → few` (three-category language)
- [x] Czech selects `2 → few` (different rule set again)

Locale data genuinely loaded rather than a stub — a stub would answer `other` everywhere.

Not verified:

- [ ] Each of the 23 screens rendering cleanly end to end. The probe establishes the API is present and correct; I did not walk every surface.
- [ ] Android. The app is iOS-only today, and Hermes on Android ships Intl, so the conditional polyfill should no-op there.

## Testing

- `biome check` — clean
- `turbo run typecheck --filter=@superset/mobile` — clean in mobile's own files
- `bun test` — 47 pass

## Design Decisions

- **Conditional `polyfill.js`, not `polyfill-force.js`** — so the app defers to a native implementation the day Hermes ships one.
- **All locale data eagerly, not lazily by active locale** — the files are a few hundred bytes each and the locale can change at runtime from the settings picker; a lazy load would have to be awaited before the first plural renders.
- **The `.js` in each specifier is load-bearing.** The package's `exports` map publishes `./polyfill.js` and `./locale-data/*`; the extensionless form resolves in Metro but fails TypeScript with TS2882. Both agree on the `.js` form. There is a comment saying so, because it otherwise reads as a typo.
- **Lives in `apps/mobile`, not `packages/i18n`** — this is a Hermes gap, not an i18n one. Desktop and web have `Intl.PluralRules` natively.

## Risks / Rollout

- Risk: low. Additive; the polyfill no-ops on any runtime that already has the API.
- Rollback: revert the commit — behaviour returns to today's, which is the crash.

## Follow-ups

- There is no error boundary anywhere in the mobile tree, so any render throw takes the screen down with no telemetry beyond Sentry's global handler. Worth its own change.

https://claude.ai/code/session_015DLMgqtnPGus5Az8tGkoAX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Every plural message on a mobile surface was crashing during render because Hermes doesn't ship `Intl.PluralRules`, which Lingui requires at runtime. This adds `@formatjs/intl-pluralrules` as a side-effect import at the app entry, so plurals render correctly across all 23 currently affected messages. The polyfill installs conditionally (only when the API is missing) and includes locale data for all supported base languages.

**Notes**
- Imported before anything can render, in `app/_layout.tsx`.
- No migration or rollout steps needed; existing messages work as before.
- Also cleared up a follow-up: the mobile tree still has no error boundary, which remains as a separate issue.

<sup>Written for commit 7b7b2eb11550d1ef9da3adf23c8ac34d7151d148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pluralized messages failing to render on iOS devices using the Hermes runtime.
  * Improved mobile app stability by ensuring pluralization works across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->