### PR TITLE
Rename the worktree dir along with the branch

### DIFF
--- a/packages/host-service/src/terminal/harness-transcript.ts
+++ b/packages/host-service/src/terminal/harness-transcript.ts
@@ -40,14 +40,22 @@ export interface HarnessTranscript {
  * Claude Code stores one JSONL file per session under a directory named after
  * the working directory with every `/` and `.` replaced by `-`.
  */
+export function claudeProjectDirName(worktreePath: string): string {
+	return worktreePath.replaceAll(/[/.]/g, "-");
+}
+
 function claudeTranscriptPath(
 	worktreePath: string,
 	sessionId: string,
 	configDir: string,
 ): string | null {
 	if (!/^[\w-]+$/.test(sessionId)) return null;
-	const encoded = worktreePath.replaceAll(/[/.]/g, "-");
-	const path = join(configDir, "projects", encoded, `${sessionId}.jsonl`);
+	const path = join(
+		configDir,
+		"projects",
+		claudeProjectDirName(worktreePath),
+		`${sessionId}.jsonl`,
+	);
 	return existsSync(path) ? path : null;
 }
 

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -16,6 +16,10 @@ import {
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
+import {
+	hasRecordedAgentHistory,
+	moveWorkspaceWorktree,
+} from "../workspace-creation/shared/move-worktree";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
 import type {
 	ChangedFile,
@@ -460,7 +464,23 @@ export const gitRouter = router({
 			}
 
 			await git.raw(["branch", "-m", input.oldName, input.newName]);
-			return { name: input.newName };
+
+			// The directory was named after the branch at creation, so follow
+			// the rename with it — but only while nothing has filed anything
+			// under the old path. A refusal is not an error: the branch is
+			// renamed either way, and a stale directory name is cosmetic.
+			let movedTo: string | null = null;
+			if (
+				!(await hasRecordedAgentHistory(ctx, input.workspaceId, worktreePath))
+			) {
+				const result = await moveWorkspaceWorktree({
+					ctx,
+					workspaceId: input.workspaceId,
+					newLeafName: input.newName,
+				});
+				if (result.moved) movedTo = result.worktreePath;
+			}
+			return { name: input.newName, worktreePath: movedTo };
 		}),
 
 	discardChanges: protectedProcedure

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/move-worktree.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/move-worktree.ts
@@ -1,0 +1,253 @@
+/**
+ * Renaming the worktree directory to follow its branch.
+ *
+ * The directory is named after the branch that existed when the workspace
+ * was created, so every later branch rename drifts it. Moving it is safe
+ * exactly while nothing has recorded the old path — which is why the two
+ * halves here are separate: `moveWorkspaceWorktree` is the mechanic, and
+ * `hasRecordedAgentHistory` is the gate late callers must consult first.
+ */
+
+import { existsSync, mkdirSync, rmdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { eq } from "drizzle-orm";
+import {
+	projects,
+	terminalAgentBindings,
+	workspaces,
+} from "../../../../db/schema";
+import { invalidateLabelCache } from "../../../../ports/static-ports";
+import { createGitEnvResolver } from "../../../../runtime/git";
+import { claudeProjectDirName } from "../../../../terminal/harness-transcript";
+import type { HostServiceContext } from "../../../../types";
+import { getHostWorkerPool } from "../../../../workers/host-worker-pool";
+import {
+	type GitTaskEnv,
+	gitWorktreeMoveTask,
+} from "../../../../workers/tasks/git";
+import { updateLocalWorkspace } from "../../../../workspaces/local-workspace-store";
+import { getHostWorktreeBaseDir } from "../../settings/worktree-location";
+import { discoverClaudeProfiles } from "../../usage/profiles";
+import {
+	isInsideProjectWorktreesRoot,
+	safeResolveWorktreePath,
+} from "./worktree-paths";
+
+export type MoveWorktreeResult =
+	| { moved: true; worktreePath: string }
+	| { moved: false; reason: MoveWorktreeRefusal };
+
+export type MoveWorktreeRefusal =
+	/** Destination is where the worktree already lives. */
+	| "unchanged"
+	/** Session workspace, main checkout, or a worktree adopted from outside
+	 * the managed root — not ours to relocate. */
+	| "not-managed"
+	/** Something already occupies the destination. `git worktree move` would
+	 * move the worktree *inside* it rather than failing, so this is checked
+	 * here and not left to git. */
+	| "destination-exists"
+	/** git refuses outright, with no --force override. */
+	| "has-submodules"
+	/** Needs `move -f -f`; deliberately not forced under the user. */
+	| "locked"
+	| "move-failed";
+
+/**
+ * Moves a workspace's worktree to `<project worktrees root>/<newLeafName>`
+ * and repoints the row at it.
+ *
+ * Callers own the decision of *when* this is safe — see
+ * `hasRecordedAgentHistory`. Every refusal is a normal outcome, not an
+ * error: the branch rename that prompted the move has already succeeded and
+ * a stale directory name is cosmetic, so nothing here throws.
+ *
+ * Refusals are silent to the user for that reason, but not to the log —
+ * reporting them here rather than at each call site is what keeps the same
+ * refusal from being observable through one entry point and invisible
+ * through another.
+ */
+export async function moveWorkspaceWorktree(args: {
+	ctx: HostServiceContext;
+	workspaceId: string;
+	newLeafName: string;
+}): Promise<MoveWorktreeResult> {
+	const result = await attemptMove(args);
+	// `unchanged` and `not-managed` are the ordinary shape of most calls —
+	// anything else means a rename the user asked for did not fully land.
+	if (
+		!result.moved &&
+		result.reason !== "unchanged" &&
+		result.reason !== "not-managed"
+	) {
+		console.warn("[moveWorkspaceWorktree] worktree dir kept its old name", {
+			workspaceId: args.workspaceId,
+			reason: result.reason,
+		});
+	}
+	return result;
+}
+
+async function attemptMove(args: {
+	ctx: HostServiceContext;
+	workspaceId: string;
+	newLeafName: string;
+}): Promise<MoveWorktreeResult> {
+	const { ctx, workspaceId, newLeafName } = args;
+
+	const workspace = ctx.db.query.workspaces
+		.findFirst({ where: eq(workspaces.id, workspaceId) })
+		.sync();
+	if (!workspace?.projectId || workspace.type !== "worktree") {
+		return { moved: false, reason: "not-managed" };
+	}
+
+	const project = ctx.db.query.projects
+		.findFirst({ where: eq(projects.id, workspace.projectId) })
+		.sync();
+	if (!project?.repoPath) return { moved: false, reason: "not-managed" };
+
+	const worktreeBaseDir =
+		project.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
+	const from = workspace.worktreePath;
+	// Adopted worktrees living outside the managed root belong to whoever
+	// made them; the same check keeps a corrupt row from moving the main
+	// checkout.
+	if (!isInsideProjectWorktreesRoot(from, project.id, worktreeBaseDir)) {
+		return { moved: false, reason: "not-managed" };
+	}
+
+	let to: string;
+	try {
+		to = safeResolveWorktreePath(project.id, newLeafName, worktreeBaseDir);
+	} catch {
+		return { moved: false, reason: "move-failed" };
+	}
+	if (to === from) return { moved: false, reason: "unchanged" };
+	if (existsSync(to)) return { moved: false, reason: "destination-exists" };
+
+	// A branch with a slash nests the directory, and git will not create the
+	// intermediate levels for us.
+	try {
+		mkdirSync(dirname(to), { recursive: true });
+	} catch {
+		return { moved: false, reason: "move-failed" };
+	}
+
+	// Env resolution stays on the event loop (it needs the credential
+	// provider); the git subprocess runs in the worker pool.
+	const repoPath = project.repoPath;
+	let gitEnv: GitTaskEnv;
+	try {
+		gitEnv = await createGitEnvResolver(ctx.credentials)(repoPath);
+	} catch (err) {
+		console.warn("[moveWorkspaceWorktree] failed to open project repo", err);
+		return { moved: false, reason: "move-failed" };
+	}
+
+	const runMove = (input: { from: string; to: string }) =>
+		getHostWorkerPool().run(
+			gitWorktreeMoveTask,
+			{ repoPath, gitEnv, ...input },
+			{ timeoutMs: 60_000 },
+		);
+
+	let result: Awaited<ReturnType<typeof runMove>>;
+	try {
+		result = await runMove({ from, to });
+	} catch (err) {
+		console.warn("[moveWorkspaceWorktree] git worktree move failed", err);
+		return { moved: false, reason: "move-failed" };
+	}
+	if (!result.moved) return { moved: false, reason: result.reason };
+
+	const updated = updateLocalWorkspace(ctx, workspaceId, { worktreePath: to });
+	if (!updated) {
+		// Disk moved but the row did not; put it back rather than leave the
+		// workspace pointing at a path that no longer exists.
+		await runMove({ from: to, to: from }).catch((err) =>
+			console.warn("[moveWorkspaceWorktree] rollback failed", {
+				workspaceId,
+				from,
+				to,
+				err,
+			}),
+		);
+		return { moved: false, reason: "move-failed" };
+	}
+
+	invalidateLabelCache(workspaceId);
+	pruneEmptyParent(dirname(from), project.id, worktreeBaseDir);
+	return { moved: true, worktreePath: to };
+}
+
+/** Moving out of `<root>/feature/foo` leaves `<root>/feature` behind. */
+function pruneEmptyParent(
+	parent: string,
+	projectId: string,
+	worktreeBaseDir: string | null,
+): void {
+	if (!isInsideProjectWorktreesRoot(parent, projectId, worktreeBaseDir)) return;
+	try {
+		rmdirSync(parent);
+	} catch {}
+}
+
+/**
+ * Whether an agent has left anything behind that is keyed to this
+ * worktree's path. Claude Code stores its transcripts under a directory
+ * named after the cwd, and resume resolves a session through that name, so
+ * moving the worktree after an agent has run there silently strands both.
+ *
+ * Live terminals are deliberately not part of this: a shell keeps working
+ * across the rename (the inode follows) and only its cached `$PWD` goes
+ * stale, which the next `cd` fixes.
+ */
+export async function hasRecordedAgentHistory(
+	ctx: Pick<HostServiceContext, "db">,
+	workspaceId: string,
+	worktreePath: string,
+): Promise<boolean> {
+	const binding = ctx.db
+		.select({ terminalId: terminalAgentBindings.terminalId })
+		.from(terminalAgentBindings)
+		.where(eq(terminalAgentBindings.workspaceId, workspaceId))
+		.get();
+	// Bindings cascade away with their terminal sessions, so a reaped
+	// terminal can leave transcripts with no row to point at them.
+	if (binding) return true;
+
+	const encoded = claudeProjectDirName(worktreePath);
+	for (const home of await claudeHomes()) {
+		if (existsSync(join(home, "projects", encoded))) return true;
+	}
+	return false;
+}
+
+/**
+ * Every config dir whose `projects/` could hold this path's transcripts —
+ * the defaults, `CLAUDE_CONFIG_DIR` (a comma list), and the per-account
+ * profiles, which keep transcripts inside the profile.
+ *
+ * Codex needs no equivalent: its rollouts are filed by date and session id,
+ * so a moved worktree never orphans them.
+ */
+async function claudeHomes(): Promise<string[]> {
+	const home = homedir();
+	const homes = new Set([
+		join(home, ".claude"),
+		join(home, ".config", "claude"),
+	]);
+	for (const dir of (process.env.CLAUDE_CONFIG_DIR ?? "").split(",")) {
+		if (dir.trim()) homes.add(dir.trim());
+	}
+	try {
+		for (const profile of await discoverClaudeProfiles()) {
+			homes.add(profile.configDir);
+		}
+	} catch (err) {
+		console.warn("[hasRecordedAgentHistory] profile discovery failed", err);
+	}
+	return [...homes];
+}

--- a/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/utils/ai-workspace-names.ts
@@ -20,6 +20,7 @@ import type { HostDb } from "../../../../db";
 import type { HostServiceContext } from "../../../../types";
 import { updateLocalWorkspace } from "../../../../workspaces/local-workspace-store";
 import { resolveHostAgentConfig } from "../../agents/agents";
+import { moveWorkspaceWorktree } from "../shared/move-worktree";
 import { listBranchNames } from "./list-branch-names";
 import { deduplicateBranchName } from "./sanitize-branch";
 
@@ -390,6 +391,13 @@ interface ApplyGeneratedNamesArgs {
 	renameTitle: boolean;
 	/** Replace the git branch name with an AI-picked one. Skip when the user typed a branch. */
 	renameBranch: boolean;
+	/**
+	 * Rename the worktree directory to follow the new branch. Only safe
+	 * while nothing has recorded the old path — true at create time, where
+	 * no terminal or agent has started yet; late callers must consult
+	 * `hasRecordedAgentHistory` first.
+	 */
+	moveWorktreeDir?: boolean;
 }
 
 interface ApplyAiRenameArgs extends ApplyGeneratedNamesArgs {
@@ -428,8 +436,9 @@ export async function applyAiWorkspaceRename(
  *
  * `renameTitle` / `renameBranch` let callers preserve user-typed
  * values: skip replacing whichever side the user supplied directly.
- * The worktree directory keeps its creation-time name — renaming it
- * under running terminals/agents would break their recorded paths.
+ * The worktree directory follows the branch only when the caller passes
+ * `moveWorktreeDir` — renaming it under running terminals/agents would
+ * break their recorded paths.
  */
 export async function applyGeneratedWorkspaceNames(
 	args: ApplyGeneratedNamesArgs & { names: GeneratedWorkspaceNames },
@@ -444,6 +453,7 @@ export async function applyGeneratedWorkspaceNames(
 		names: aiNames,
 		renameTitle,
 		renameBranch,
+		moveWorktreeDir = false,
 	} = args;
 
 	if (!renameTitle && !renameBranch) return null;
@@ -495,5 +505,12 @@ export async function applyGeneratedWorkspaceNames(
 		);
 		return null;
 	}
+
+	// After the row patch: the move repoints `worktreePath` on the same row,
+	// and a failure there must not cost us the name that already landed.
+	if (gitRenamed && moveWorktreeDir) {
+		await moveWorkspaceWorktree({ ctx, workspaceId, newLeafName: deduped });
+	}
+
 	return { name: updated.name, branch: updated.branch };
 }

--- a/packages/host-service/src/trpc/router/workspaces/workspaces.ts
+++ b/packages/host-service/src/trpc/router/workspaces/workspaces.ts
@@ -50,6 +50,7 @@ import {
 	requireLocalProject,
 	requireProjectRepoPath,
 } from "../workspace-creation/shared/local-project";
+import { hasRecordedAgentHistory } from "../workspace-creation/shared/move-worktree";
 import { startSetupTerminalIfPresent } from "../workspace-creation/shared/setup-terminal";
 import {
 	addWorktreeWithSparseCheckout,
@@ -1086,7 +1087,7 @@ export const workspacesRouter = router({
 			// bounded by its own timeouts, so this usually adds well under a
 			// second on top of the git work; the rename itself (`branch -m`
 			// plus a row update) is milliseconds. The worktree directory
-			// keeps its creation-time name.
+			// follows the branch here — nothing has opened it yet.
 			if (!alreadyExists && aiNamesPromise && worktreePath !== undefined) {
 				const names = await aiNamesPromise;
 				if (names) {
@@ -1101,6 +1102,7 @@ export const workspacesRouter = router({
 							names,
 							renameTitle: true,
 							renameBranch: aiCanRenameBranch,
+							moveWorktreeDir: true,
 						});
 						if (applied) {
 							// Keep the original row object: it carries the create txid.
@@ -1318,18 +1320,28 @@ export const workspacesRouter = router({
 					message: "Local project not found for workspace",
 				});
 			}
-			void applyAiWorkspaceRename({
-				ctx,
-				workspaceId: input.workspaceId,
-				repoPath: project.repoPath ?? "",
-				worktreePath: local.worktreePath,
-				oldBranchName: local.branch,
-				oldWorkspaceName: local.name || local.branch,
-				prompt: input.prompt,
-				namingInstructions: project.namingInstructions,
-				renameTitle: true,
-				renameBranch: true,
-			}).catch((err) => {
+			// A late rename, unlike the one during create: the directory may
+			// follow only if no agent has filed anything under the old path.
+			void (async () => {
+				const moveWorktreeDir = !(await hasRecordedAgentHistory(
+					ctx,
+					input.workspaceId,
+					local.worktreePath,
+				));
+				await applyAiWorkspaceRename({
+					ctx,
+					workspaceId: input.workspaceId,
+					repoPath: project.repoPath ?? "",
+					worktreePath: local.worktreePath,
+					oldBranchName: local.branch,
+					oldWorkspaceName: local.name || local.branch,
+					prompt: input.prompt,
+					namingInstructions: project.namingInstructions,
+					renameTitle: true,
+					renameBranch: true,
+					moveWorktreeDir,
+				});
+			})().catch((err) => {
 				console.warn("[workspaces.aiRename] failed", err);
 			});
 			return { success: true as const };

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -280,6 +280,36 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 	},
 });
 
+export const gitWorktreeMoveTask = defineWorkerTask<
+	{ repoPath: string; from: string; to: string; gitEnv: GitTaskEnv },
+	{ moved: true } | { moved: false; reason: "has-submodules" | "locked" }
+>({
+	type: "git/moveWorktree",
+	handler: async ({ repoPath, from, to, gitEnv }) => {
+		const git = createUserSimpleGit(repoPath).env(gitEnv);
+		try {
+			// Move from git's canonical path so a symlinked stored path
+			// (macOS `/var` → `/private/var`) still matches its registration.
+			await git.raw(["worktree", "move", normalizeWorktreePath(from), to]);
+			return { moved: true };
+		} catch (err) {
+			// Two refusals are ordinary answers rather than failures: git
+			// rejects a worktree containing submodules outright (there is no
+			// --force for it), and a locked one without `-f -f`, which we
+			// decline to do under the user. Anything else is unexplained and
+			// throws.
+			const message = err instanceof Error ? err.message : String(err);
+			if (message.includes("submodule")) {
+				return { moved: false, reason: "has-submodules" };
+			}
+			if (message.includes("locked working tree")) {
+				return { moved: false, reason: "locked" };
+			}
+			throw err;
+		}
+	},
+});
+
 export const gitDeleteBranchTask = defineWorkerTask<
 	{ repoPath: string; branch: string; gitEnv: GitTaskEnv },
 	{ deleted: boolean }
@@ -308,5 +338,6 @@ export const gitTasks = [
 	gitIdentityTask,
 	gitWorktreeStateTask,
 	gitWorktreeRemoveTask,
+	gitWorktreeMoveTask,
 	gitDeleteBranchTask,
 ];


### PR DESCRIPTION
## Summary

The worktree directory is named after the branch that existed at creation, so every later branch rename drifts it — this repo's own workspace sits at `painted-freedom` on a branch called `rename-worktree-dir`. This follows the rename with `git worktree move` wherever that is safe.

It is safe exactly while nothing has recorded the old path. Claude Code files transcripts under a directory named after the cwd and resumes sessions through that name, so moving a worktree after an agent has run there strands both the transcript lookup (`harness-transcript.ts`) and auto-resume. So:

- **Create-time AI naming always moves.** Nothing is attached yet by construction — the rename already runs before terminals and agents start. This is where the drift is manufactured, and it costs nothing to fix there.
- **The two late entry points gate first.** `git.renameBranch` and `workspaces.aiRename` check `terminal_agent_bindings`, then fall back to looking for the Claude transcript directory on disk — bindings cascade away with their terminal sessions, so the on-disk check is the durable half.

Live terminals deliberately do not block a move: a shell keeps working across the rename (the inode follows) and only its cached `$PWD` goes stale, which the next `cd` fixes.

The move refuses on anything not ours to relocate (session workspaces, the main checkout, adopted worktrees outside the managed root), on an occupied destination, and on git's own refusals. Two of those are worth calling out, both confirmed against git 2.50 rather than assumed:

- `git worktree move` into an **existing directory nests inside it and exits 0** rather than failing, so the destination check cannot be left to git.
- **Worktrees containing submodules cannot be moved at all** — there is no `--force` for it. `mv` + `git worktree repair` is not a way around this: repair fixes the worktree's own gitdir pointer and leaves the submodule gitlink stale, breaking the submodule.

Refusals are silent to the user — the branch rename succeeded either way and a stale folder name is cosmetic — and logged once inside the helper, so the same refusal cannot be observable through one entry point and invisible through another.

The git subprocess runs in the host worker pool (`gitWorktreeMoveTask`) rather than on the event loop, per the `no-main-loop-blocking` ratchet.

## Test plan

Verified with a throwaway integration harness against real repos (not committed — say the word if it should be):

- [x] Directory moves, row repoints, uncommitted **and** untracked work survive, `git worktree list` agrees
- [x] Slashed branch name (`satya/scoped`) nests correctly, with intermediate dirs created
- [x] A seeded agent binding leaves the directory alone; the branch still renames
- [x] Occupied destination refuses instead of silently nesting inside the occupant
- [x] Adopted worktree outside the managed root is untouched
- [x] Full `packages/host-service` suite: 1439 pass, 0 fail
- [x] `scripts/lint.sh` clean; host-service and desktop typecheck clean

Not included: surfacing the submodule refusal in the UI. A user with submodules will never see the directory follow a rename and won't learn why — worth deciding on separately, and the rename dialog is the honest place for it rather than a toast on success.

https://claude.ai/code/session_01PFAzkRUhnDniMCXuxM5xSi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follows branch renames with the worktree directory, so the folder no longer keeps its creation-time name and drifts from the branch. The move is skipped when an agent has recorded the old path, and refusals are silent — the branch rename always lands.

**When the move happens**
- Create-time AI naming always moves, since nothing has recorded the old path yet.
- Late entry points (`git.renameBranch`, `workspaces.aiRename`) check the Claude transcript directory and terminal agent bindings first, and skip the move when either exists.
- Live terminals never block the move: a shell survives the rename and only its cached `$PWD` goes stale.

**What refuses the move**
- Anything outside the managed root: session workspaces, the main checkout, adopted worktrees.
- An occupied destination, checked explicitly because `git worktree move` nests into an existing directory instead of failing.
- Worktrees containing submodules, which git refuses outright with no `--force` or repair workaround.
- Locked worktrees, deliberately not forced under the user.

<sup>Written for commit ef56d7c293fbd06335d4fc7de440e9d66e38824a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renaming a branch or workspace can now automatically rename its associated worktree directory.
  * Worktree moves are skipped when existing agent history could be affected.
  * Branch rename results now indicate whether the worktree path changed.
* **Bug Fixes**
  * Worktree move failures no longer prevent the branch rename from completing.
  * Safeguards prevent moves for locked, occupied, unmanaged, or submodule-based worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->