### PR TITLE
fix(sandbox): ship agent templates, make start.sh re-runnable, and report crashes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,9 @@ NEXT_PUBLIC_SENTRY_DSN_ADMIN=
 NEXT_PUBLIC_SENTRY_DSN_DOCS=
 NEXT_PUBLIC_SENTRY_DSN_API=
 SENTRY_DSN_DESKTOP=
+# Compiled into the desktop bundle and handed to the host service the desktop
+# spawns. Sandboxes cannot use this one — see SENTRY_DSN_SANDBOX below.
+SENTRY_DSN_HOST_SERVICE=
 
 # Sentry public integration — powers Sentry automation triggers (issue created,
 # resolved, assigned, ...). Optional: leave blank and the Sentry trigger simply
@@ -214,6 +217,11 @@ BLAXEL_API_KEY=
 BLAXEL_WORKSPACE=
 BLAXEL_REGION=us-pdx-1
 BLAXEL_SANDBOX_IMAGE=superset-hostsvc
+# Sandboxes get their own Sentry project, separate from the host-service one
+# (which means the host service on people's desktops). Set here rather than in
+# the desktop build because a sandbox is started by the API and never sees a
+# desktop bundle. Unset means sandbox crashes go unreported.
+SENTRY_DSN_SANDBOX=
 # Injected into sandboxes at the provider's edge so the agents can authenticate
 # without a real key ever existing inside one.
 OPENAI_API_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -132,6 +132,7 @@ NEXT_PUBLIC_SENTRY_DSN_ADMIN=
 NEXT_PUBLIC_SENTRY_DSN_DOCS=
 NEXT_PUBLIC_SENTRY_DSN_API=
 SENTRY_DSN_DESKTOP=
+SENTRY_DSN_HOST_SERVICE=
 
 # Sentry public integration — powers Sentry automation triggers (issue created,
 # resolved, assigned, ...). Optional: leave blank and the Sentry trigger simply
@@ -210,5 +211,8 @@ BLAXEL_API_KEY=fake-blaxel-api-key
 BLAXEL_WORKSPACE=fake-blaxel-workspace
 BLAXEL_REGION=us-pdx-1
 BLAXEL_SANDBOX_IMAGE=superset-hostsvc
+# Blank on purpose: Sentry is off in local dev, and the fake Blaxel key above
+# means no sandbox is ever provisioned here to report anything.
+SENTRY_DSN_SANDBOX=
 OPENAI_API_KEY=sk-fake-local-dev
 GH_APP_SLUG=superset-app

--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -242,3 +242,28 @@ enabled" even though routing works, so don't use those as a health check.
 Alpine) and only the pinned version ships prebuilds at all; better-sqlite3 must
 match what host-service was built against or it crashes on load. The image
 asserts the prebuild exists rather than letting something compile silently.
+
+**Local dev cannot exercise a sandbox, and the failure mode if you force it is
+silent.** `setup.local.sh` copies `.env.local.example` to `.env`, which sets
+`BLAXEL_API_KEY=fake-blaxel-api-key` — so provisioning fails at the provider and
+no sandbox is ever created. That part is loud and fine. The trap is what happens
+when someone supplies real Blaxel credentials to a local API to try a sandbox
+end-to-end: provisioning passes `SUPERSET_API_URL: env.NEXT_PUBLIC_API_URL`
+into the sandbox, and in local dev that value is `http://localhost:3001`. Inside
+the container `localhost` is the container, so the sandbox boots, serves, and
+looks healthy while every call it makes back to the API dials itself. Nothing
+reports an error at provision time. Treat sandboxes as a deployed-API-only
+surface, or tunnel a public URL and override `NEXT_PUBLIC_API_URL` for the
+provisioning process specifically.
+
+**Sandbox telemetry does not travel with the desktop build.** The host-service
+Sentry DSN is compiled into the desktop bundle at desktop build time
+(`apps/desktop/electron.vite.config.ts`) and handed to host-service when the
+desktop spawns it. A sandbox is started by the API and never sees a desktop
+bundle, so it can never receive that DSN — which is why sandbox startup crashes
+were invisible for as long as sandboxes have existed, rather than merely
+under-reported. Sandboxes now report to their own project via
+`SENTRY_DSN_SANDBOX` on the API, tagged with the cloud workspace id, image tag
+and provider. Keep the workspace id on both sides: a provisioning failure is
+recorded against the API and a runtime failure against the sandbox, and that id
+is the only thing that joins the two halves of one broken workspace.

--- a/packages/host-service/src/sentry.ts
+++ b/packages/host-service/src/sentry.ts
@@ -2,6 +2,31 @@ import * as Sentry from "@sentry/node";
 
 let initialized = false;
 
+/**
+ * A cloud sandbox reports to its own Sentry project, and its failures split
+ * across two of them: provisioning fails in the API, the runtime fails in
+ * here, and a user sees one broken workspace either way. `cloud_workspace_id`
+ * is what stitches the two halves back together, so it is the tag that makes
+ * the separate projects safe rather than a nicety.
+ *
+ * Read from the environment rather than passed in: these are the same values
+ * the sandbox already configures itself from on boot, and threading them
+ * through `initSentry`'s signature would make every local host carry sandbox
+ * parameters it has no use for.
+ */
+function sandboxTags(): Record<string, string> {
+	if (process.env.SUPERSET_HOST_RUN_MODE !== "sandbox") return {};
+	const workspaceId = process.env.SUPERSET_SANDBOX_WORKSPACE_ID;
+	const imageTag = process.env.SUPERSET_SANDBOX_IMAGE_TAG;
+	const provider = process.env.SUPERSET_SANDBOX_PROVIDER;
+	return {
+		run_mode: "sandbox",
+		...(workspaceId ? { cloud_workspace_id: workspaceId } : {}),
+		...(imageTag ? { image_tag: imageTag } : {}),
+		...(provider ? { provider } : {}),
+	};
+}
+
 export function initSentry(options: { organizationId?: string }): void {
 	if (initialized) return;
 	const dsn = process.env.HOST_SERVICE_SENTRY_DSN;
@@ -24,6 +49,7 @@ export function initSentry(options: { organizationId?: string }): void {
 				...(options.organizationId
 					? { organization_id: options.organizationId }
 					: {}),
+				...sandboxTags(),
 			},
 		},
 	});

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -42,6 +42,16 @@ export const env = createEnv({
 		BLAXEL_WORKSPACE: z.string().min(1),
 		BLAXEL_REGION: z.string().min(1),
 		BLAXEL_SANDBOX_IMAGE: z.string().min(1),
+		// Sandboxes report to their own Sentry project, not the host-service one:
+		// that project means the host service on people's desktops, and `release`
+		// means opposite things on the two surfaces — a version users happen to
+		// have installed versus one we deploy and converge. Optional so that a
+		// deployment without it still provisions, just blindly.
+		//
+		// It has to live here rather than travel with the desktop bundle the way
+		// SENTRY_DSN_HOST_SERVICE does: a sandbox is started by the API and never
+		// sees a desktop build, which is why sandbox crashes have been invisible.
+		SENTRY_DSN_SANDBOX: z.string().optional(),
 		// GitHub App credentials
 		GH_APP_ID: z.string().min(1),
 		GH_APP_PRIVATE_KEY: z.string().min(1),

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -140,6 +140,19 @@ export async function provisionSandbox(args: {
 	// sandbox, and it is not awaited. The script needs a second or two; the
 	// client discovers the result by polling the health endpoint it already
 	// polls, so there is nothing to wait for here.
+	//
+	// Deliberately no `keepAlive`: it suppresses the provider's automatic
+	// standby, so the sandbox would bill continuously and never sleep. A sandbox
+	// is meant to wake on inbound traffic.
+	//
+	// And deliberately no `restartOnFailure`. Nothing supervises this process —
+	// the platform supervises its own agent, not ours — so a restart is the
+	// obvious reflex, but we have never observed host-service exit. Restarting
+	// an unexplained exit converts a bug we would investigate into a wobble
+	// nobody sees, and it does nothing for the failure we have actually hit: a
+	// missing environment variable throws identically five times and dies
+	// anyway. Worth revisiting once startup errors reach Sentry, which today
+	// they do not — until then a restart loop would be silent.
 	await sandbox.process.exec({
 		name: "host-service",
 		command: "/app/start.sh",

--- a/packages/trpc/src/router/cloud-workspace/provision.ts
+++ b/packages/trpc/src/router/cloud-workspace/provision.ts
@@ -119,6 +119,20 @@ export async function provisionCloudWorkspace(
 					// silently serving the baked repo's code.
 					SUPERSET_SANDBOX_REPO_URL: clone.cloneUrl,
 					...(clone.token ? { SUPERSET_SANDBOX_GIT_TOKEN: clone.token } : {}),
+					// Telemetry. Without a DSN in here `captureFatalStartupError`
+					// is a no-op and a sandbox that dies on boot tells us nothing
+					// — the failure mode that made the last investigation manual.
+					// The tags let one Sentry issue name the workspace and the
+					// image it came from, and correlate with a provisioning
+					// failure recorded against the same id on the API side.
+					...(env.SENTRY_DSN_SANDBOX
+						? {
+								HOST_SERVICE_SENTRY_DSN: env.SENTRY_DSN_SANDBOX,
+								HOST_SERVICE_SENTRY_ENVIRONMENT: "sandbox",
+							}
+						: {}),
+					SUPERSET_SANDBOX_IMAGE_TAG: env.BLAXEL_SANDBOX_IMAGE,
+					SUPERSET_SANDBOX_PROVIDER: row.provider,
 				},
 			}),
 			nameWrite,

--- a/scripts/sandbox/image.ts
+++ b/scripts/sandbox/image.ts
@@ -154,6 +154,17 @@ export const sandboxImage = ImageInstance.fromRegistry("node:24-bookworm-slim")
 		"/app/drizzle",
 		"hostsvc-drizzle",
 	)
+	// Agent lifecycle hook templates. host-service resolves these as
+	// `agent-templates` beside its own bundle, which from /app/host-service.js
+	// is /app/agent-templates; the CLI tarball does the same into lib/. Without
+	// them every hook writer soft-fails and a sandbox gets wrappers with no
+	// hooks — agents run but never report starting, finishing, or asking a
+	// question, which is how this shipped unnoticed since the image was built.
+	.addLocalDir(
+		"packages/agent-setup/templates",
+		"/app/agent-templates",
+		"agent-templates",
+	)
 	// The supervisor resolves the daemon as ../../../pty-daemon/dist relative
 	// to its own source path, which from /app/host-service.js lands at /.
 	.addLocalDir("packages/pty-daemon/dist", "/pty-daemon/dist", "ptyd-dist")

--- a/scripts/sandbox/start.sh
+++ b/scripts/sandbox/start.sh
@@ -35,22 +35,39 @@ fi
 # Getting this wrong is silent rather than loud: fetching the requested branch
 # from the wrong origin leaves a sandbox serving somebody else's code, so the
 # URLs are compared rather than assumed to match.
-if [ -n "$REPO_URL" ]; then
+# Exactly once per sandbox, and never again.
+#
+# Both branches below are destructive to work in progress: the clone path wipes
+# the directory, and the fetch path moves the branch onto the remote's head,
+# which orphans commits an agent made and hadn't pushed. That was survivable
+# only because nothing ever ran this script twice. It now restarts — the
+# provider restarts it on failure, and updating host-service re-runs it — so
+# the repository bootstrap is fenced behind a marker and every later run falls
+# straight through to serving.
+#
+# The marker is written only after the bootstrap succeeds, so a run interrupted
+# midway retries on the next start rather than leaving a half-checked-out
+# workspace nothing will ever repair.
+BOOTSTRAP_MARKER=/data/.workspace-bootstrapped
+
+if [ -n "$REPO_URL" ] && [ ! -f "$BOOTSTRAP_MARKER" ]; then
   BAKED_URL=$(git -C "$WORKSPACE" remote get-url origin 2>/dev/null || echo "")
   if [ -n "${SUPERSET_SANDBOX_GIT_TOKEN:-}" ]; then
     export GIT_ASKPASS=/app/git-askpass.sh
   fi
   if [ "$BAKED_URL" = "$REPO_URL" ] && [ -d "$WORKSPACE/.git" ]; then
     (
-      cd "$WORKSPACE" || exit 0
+      cd "$WORKSPACE" || exit 1
       git fetch --depth 1 origin "$BRANCH" >/dev/null 2>&1 &&
         git checkout -q -B "$BRANCH" FETCH_HEAD >/dev/null 2>&1
-    )
+    ) && touch "$BOOTSTRAP_MARKER"
   else
     rm -rf "$WORKSPACE"
-    git clone --depth 1 --single-branch --branch "$BRANCH" "$REPO_URL" "$WORKSPACE" \
+    if git clone --depth 1 --single-branch --branch "$BRANCH" "$REPO_URL" "$WORKSPACE" \
       >/dev/null 2>&1 ||
-      git clone --depth 1 "$REPO_URL" "$WORKSPACE" >/dev/null 2>&1
+      git clone --depth 1 "$REPO_URL" "$WORKSPACE" >/dev/null 2>&1; then
+      touch "$BOOTSTRAP_MARKER"
+    fi
   fi
   unset GIT_ASKPASS
 fi


### PR DESCRIPTION
Cloud sandboxes had three independent defects, all of which would still be
broken the day after an image rebuild.

The image never copied packages/agent-setup/templates, so every boot logged
"agent hooks will NOT work on this host" and eight setup actions failed. Agents
ran but never reported starting, finishing, or asking a question — for as long
as sandboxes have existed. host-service resolves them as `agent-templates`
beside its own bundle, so they now land at /app/agent-templates, the same
placement the CLI tarball uses.

start.sh was not safe to run twice. Both of its branches destroy work in
progress — the clone path wipes the directory, the fetch path moves the branch
onto the remote's head and orphans commits an agent made and hadn't pushed.
That was survivable only while nothing ever ran the script twice, which stops
being true the moment anything restarts it or updates in place. The repository
bootstrap is now fenced behind a marker written only on success, so an
interrupted first run retries and every later run falls through to serving.

Finally, sandbox crashes were invisible, and not because provisioning forgot a
variable: the host-service Sentry DSN is compiled into the desktop bundle at
desktop build time and handed over when the desktop spawns a host. A sandbox is
started by the API and never sees a desktop build, so it could never receive
one. Sandboxes now report to their own project via SENTRY_DSN_SANDBOX on the
API — separate because that project means the host service on people's
desktops, and because `release` means opposite things on the two surfaces: a
version users happen to have installed versus one we deploy and converge.
Events carry the cloud workspace id, image tag and provider; the workspace id
is what joins a provisioning failure recorded against the API to a runtime
failure recorded against the sandbox.

Notably absent: restartOnFailure. Nothing supervises host-service, so a restart
is the obvious reflex — but it has never been observed to exit. The container
is healthy throughout the investigation above; what looked like a crash was the
desktop calling procedures a 12-day-old image had never heard of. Restarting an
unexplained exit would convert a bug worth investigating into a wobble nobody
sees, and it does nothing for the failure actually hit since: a missing
environment variable throws identically five times and dies anyway. Worth
revisiting once startup errors reach Sentry, which they do not yet.

Verified against a real sandbox provisioned from the live image and torn down
afterwards. Full host-service suite (1439 pass) and trpc suite (122 pass) green.

https://claude.ai/code/https://claude.ai/code/session_01HmfE4Qm77AwKUxJeFVMetY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate Sentry configuration for host services and cloud sandboxes.
  - Sandbox error reports now include workspace, image, provider, and run-mode context.
  - Sandbox builds now include agent setup templates for more reliable hook execution.

- **Bug Fixes**
  - Improved sandbox startup so interrupted repository setup can retry safely.
  - Prevented repeated repository initialization on subsequent starts.

- **Documentation**
  - Documented sandbox telemetry configuration and local-development limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->