### PR TITLE
fix(accounts): stop tests clobbering the real account pointers, and give Codex session sharing

### DIFF
--- a/apps/desktop/test-setup.ts
+++ b/apps/desktop/test-setup.ts
@@ -9,6 +9,7 @@
  * DO NOT mock internal code here - tests should use real implementations
  * or mock at the individual test level when necessary.
  */
+import "../../scripts/test-preload.ts";
 import { beforeEach, mock } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,8 @@
+[test]
+# Isolates SUPERSET_HOME_DIR so a test can never write the developer's real
+# ~/.superset. See scripts/test-preload.ts for what went wrong without it.
+preload = ["./scripts/test-preload.ts"]
+
 [install]
 linker = "isolated" # Prevent hoisting from resolving `path-scurry@2` to `lru-cache@6` (missing `LRUCache`), which breaks the `@superset/desktop` postinstall native rebuild.
 exact = true

--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -278,8 +278,11 @@ export function createCodexWrapper(): void {
 	const notifyPath = getNotifyScriptPath();
 	const script = buildWrapperScript(
 		"codex",
-		buildDefaultAccountResolver("CODEX_HOME", "default-codex-home") +
-			buildCodexWrapperExecLine(notifyPath),
+		buildDefaultAccountResolver(
+			"CODEX_HOME",
+			"default-codex-home",
+			"SUPERSET_AMBIENT_CODEX_HOME",
+		) + buildCodexWrapperExecLine(notifyPath),
 		{ agentId: "codex" },
 	);
 	createWrapper("codex", script);

--- a/packages/agent-setup/src/agent-wrappers-common.ts
+++ b/packages/agent-setup/src/agent-wrappers-common.ts
@@ -125,8 +125,10 @@ export function buildDefaultAccountResolver(
   superset_default_account="$(cat ${pointer} 2>/dev/null)"
   if [ -n "$superset_default_account" ] && [ -d "$superset_default_account" ]; then
     export ${envVar}="$superset_default_account"
+    export SUPERSET_DEFAULT_${envVar}="$superset_default_account"
   else
     unset ${envVar}
+    unset SUPERSET_DEFAULT_${envVar}
   fi
 fi
 

--- a/packages/agent-setup/src/agent-wrappers-common.ts
+++ b/packages/agent-setup/src/agent-wrappers-common.ts
@@ -117,8 +117,19 @@ function buildRealBinaryResolver(): string {
 export function buildDefaultAccountResolver(
 	envVar: string,
 	pointerName: string,
+	ambientEnvVar?: string,
 ): string {
 	const pointer = `"$SUPERSET_HOME_DIR/state/${pointerName}"`;
+	const restoreSystemDefault = ambientEnvVar
+		? `if [ -n "\${${ambientEnvVar}}" ]; then
+    export ${envVar}="\${${ambientEnvVar}}"
+    export SUPERSET_DEFAULT_${envVar}="\${${ambientEnvVar}}"
+  else
+    unset ${envVar}
+    unset SUPERSET_DEFAULT_${envVar}
+  fi`
+		: `unset ${envVar}
+  unset SUPERSET_DEFAULT_${envVar}`;
 	return `if [ -n "$SUPERSET_TERMINAL_ID" ] && [ -n "$SUPERSET_HOME_DIR" ] \\
   && { [ -z "\${${envVar}}" ] || [ "\${${envVar}}" = "\${SUPERSET_DEFAULT_${envVar}}" ]; } \\
   && [ -f ${pointer} ]; then
@@ -127,8 +138,7 @@ export function buildDefaultAccountResolver(
     export ${envVar}="$superset_default_account"
     export SUPERSET_DEFAULT_${envVar}="$superset_default_account"
   else
-    unset ${envVar}
-    unset SUPERSET_DEFAULT_${envVar}
+    ${restoreSystemDefault}
   fi
 fi
 

--- a/packages/agent-setup/src/ambient-codex-home.test.ts
+++ b/packages/agent-setup/src/ambient-codex-home.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { resolveAmbientCodexHome } from "./provider-profiles";
 
@@ -6,16 +8,19 @@ describe("resolveAmbientCodexHome", () => {
 	const HOME = "/home/tester";
 	let previousCodexHome: string | undefined;
 	let previousInjected: string | undefined;
+	let previousAmbient: string | undefined;
 
 	beforeEach(() => {
 		previousCodexHome = process.env.CODEX_HOME;
 		previousInjected = process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		previousAmbient = process.env.SUPERSET_AMBIENT_CODEX_HOME;
 	});
 
 	afterEach(() => {
 		for (const [key, value] of [
 			["CODEX_HOME", previousCodexHome],
 			["SUPERSET_DEFAULT_CODEX_HOME", previousInjected],
+			["SUPERSET_AMBIENT_CODEX_HOME", previousAmbient],
 		] as const) {
 			if (value === undefined) delete process.env[key];
 			else process.env[key] = value;
@@ -25,12 +30,14 @@ describe("resolveAmbientCodexHome", () => {
 	it("falls back to ~/.codex when nothing is set", () => {
 		delete process.env.CODEX_HOME;
 		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
 		expect(resolveAmbientCodexHome(HOME)).toBe(path.join(HOME, ".codex"));
 	});
 
 	it("honours a CODEX_HOME the user set themselves", () => {
 		process.env.CODEX_HOME = "/home/tester/my-codex";
 		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
 		expect(resolveAmbientCodexHome(HOME)).toBe("/home/tester/my-codex");
 	});
 
@@ -41,12 +48,45 @@ describe("resolveAmbientCodexHome", () => {
 		// masquerade as the system default and share config out of itself.
 		process.env.CODEX_HOME = "/home/tester/.codex-work";
 		process.env.SUPERSET_DEFAULT_CODEX_HOME = "/home/tester/.codex-work";
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
 		expect(resolveAmbientCodexHome(HOME)).toBe(path.join(HOME, ".codex"));
+	});
+
+	it("normalizes the injected value before comparing it", () => {
+		process.env.CODEX_HOME = "/home/tester/.codex-work/../.codex-work";
+		process.env.SUPERSET_DEFAULT_CODEX_HOME = "/home/tester/.codex-work";
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
+		expect(resolveAmbientCodexHome(HOME)).toBe(path.join(HOME, ".codex"));
+	});
+
+	it("recognizes a symlink spelling of the injected value", () => {
+		const root = mkdtempSync(path.join(tmpdir(), "superset-codex-ambient-"));
+		try {
+			const profile = path.join(root, "profile");
+			const alias = path.join(root, "profile-alias");
+			mkdirSync(profile);
+			symlinkSync(profile, alias);
+			process.env.CODEX_HOME = alias;
+			process.env.SUPERSET_DEFAULT_CODEX_HOME = profile;
+			delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
+			expect(resolveAmbientCodexHome(HOME)).toBe(path.join(HOME, ".codex"));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("recovers a preserved custom default behind an injected profile", () => {
+		process.env.CODEX_HOME = "/home/tester/.codex-work";
+		process.env.SUPERSET_DEFAULT_CODEX_HOME =
+			"/home/tester/.codex-work/../.codex-work";
+		process.env.SUPERSET_AMBIENT_CODEX_HOME = "/home/tester/my-codex";
+		expect(resolveAmbientCodexHome(HOME)).toBe("/home/tester/my-codex");
 	});
 
 	it("still honours a user override that differs from the injected value", () => {
 		process.env.CODEX_HOME = "/home/tester/my-codex";
 		process.env.SUPERSET_DEFAULT_CODEX_HOME = "/home/tester/.codex-work";
+		process.env.SUPERSET_AMBIENT_CODEX_HOME = "/home/tester/original-codex";
 		expect(resolveAmbientCodexHome(HOME)).toBe("/home/tester/my-codex");
 	});
 });

--- a/packages/agent-setup/src/ambient-codex-home.test.ts
+++ b/packages/agent-setup/src/ambient-codex-home.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import { resolveAmbientCodexHome } from "./provider-profiles";
+
+describe("resolveAmbientCodexHome", () => {
+	const HOME = "/home/tester";
+	let previousCodexHome: string | undefined;
+	let previousInjected: string | undefined;
+
+	beforeEach(() => {
+		previousCodexHome = process.env.CODEX_HOME;
+		previousInjected = process.env.SUPERSET_DEFAULT_CODEX_HOME;
+	});
+
+	afterEach(() => {
+		for (const [key, value] of [
+			["CODEX_HOME", previousCodexHome],
+			["SUPERSET_DEFAULT_CODEX_HOME", previousInjected],
+		] as const) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	it("falls back to ~/.codex when nothing is set", () => {
+		delete process.env.CODEX_HOME;
+		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		expect(resolveAmbientCodexHome(HOME)).toBe(path.join(HOME, ".codex"));
+	});
+
+	it("honours a CODEX_HOME the user set themselves", () => {
+		process.env.CODEX_HOME = "/home/tester/my-codex";
+		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		expect(resolveAmbientCodexHome(HOME)).toBe("/home/tester/my-codex");
+	});
+
+	it("ignores Superset's own injected value", () => {
+		// Every Superset terminal and agent launch exports the selected account
+		// as CODEX_HOME. A host-service (or any tool) started from such a
+		// terminal inherits it; trusting it would make the selected profile
+		// masquerade as the system default and share config out of itself.
+		process.env.CODEX_HOME = "/home/tester/.codex-work";
+		process.env.SUPERSET_DEFAULT_CODEX_HOME = "/home/tester/.codex-work";
+		expect(resolveAmbientCodexHome(HOME)).toBe(path.join(HOME, ".codex"));
+	});
+
+	it("still honours a user override that differs from the injected value", () => {
+		process.env.CODEX_HOME = "/home/tester/my-codex";
+		process.env.SUPERSET_DEFAULT_CODEX_HOME = "/home/tester/.codex-work";
+		expect(resolveAmbientCodexHome(HOME)).toBe("/home/tester/my-codex");
+	});
+});

--- a/packages/agent-setup/src/default-account-resolver.test.ts
+++ b/packages/agent-setup/src/default-account-resolver.test.ts
@@ -21,6 +21,21 @@ function resolve(env: Record<string, string | undefined>): string {
 	});
 }
 
+function resolveWithTwin(env: Record<string, string | undefined>): string {
+	const script = `${buildDefaultAccountResolver(
+		"CLAUDE_CONFIG_DIR",
+		"default-claude-config-dir",
+	)}printf "%s|%s" "\${CLAUDE_CONFIG_DIR:-<unset>}" "\${SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR:-<unset>}"`;
+	const cleanEnv: Record<string, string> = { PATH: process.env.PATH ?? "" };
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== undefined) cleanEnv[key] = value;
+	}
+	return execFileSync("bash", ["-c", script], {
+		env: cleanEnv,
+		encoding: "utf-8",
+	});
+}
+
 function makeHome(pointer: string | null): {
 	home: string;
 	profile: string;
@@ -57,6 +72,19 @@ describe("buildDefaultAccountResolver", () => {
 		).toBe(profile);
 	});
 
+	it("updates the injection marker when it adopts a new pointer", () => {
+		const { home, profile } = makeHome(null);
+		writeFileSync(join(home, "state", "default-claude-config-dir"), profile);
+		expect(
+			resolveWithTwin({
+				SUPERSET_TERMINAL_ID: "t1",
+				SUPERSET_HOME_DIR: home,
+				CLAUDE_CONFIG_DIR: "/tmp/old-spawn-time-default",
+				SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR: "/tmp/old-spawn-time-default",
+			}),
+		).toBe(`${profile}|${profile}`);
+	});
+
 	it("clears a stale injected value when the pointer says system default", () => {
 		const { home, profile } = makeHome("");
 		expect(
@@ -67,6 +95,18 @@ describe("buildDefaultAccountResolver", () => {
 				SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR: profile,
 			}),
 		).toBe("<unset>");
+	});
+
+	it("clears the injection marker with the injected value", () => {
+		const { home, profile } = makeHome("");
+		expect(
+			resolveWithTwin({
+				SUPERSET_TERMINAL_ID: "t1",
+				SUPERSET_HOME_DIR: home,
+				CLAUDE_CONFIG_DIR: profile,
+				SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR: profile,
+			}),
+		).toBe("<unset>|<unset>");
 	});
 
 	it("never overrides a value the user exported by hand", () => {

--- a/packages/agent-setup/src/default-account-resolver.test.ts
+++ b/packages/agent-setup/src/default-account-resolver.test.ts
@@ -36,6 +36,22 @@ function resolveWithTwin(env: Record<string, string | undefined>): string {
 	});
 }
 
+function resolveCodexWithTwin(env: Record<string, string | undefined>): string {
+	const script = `${buildDefaultAccountResolver(
+		"CODEX_HOME",
+		"default-codex-home",
+		"SUPERSET_AMBIENT_CODEX_HOME",
+	)}printf "%s|%s" "\${CODEX_HOME:-<unset>}" "\${SUPERSET_DEFAULT_CODEX_HOME:-<unset>}"`;
+	const cleanEnv: Record<string, string> = { PATH: process.env.PATH ?? "" };
+	for (const [key, value] of Object.entries(env)) {
+		if (value !== undefined) cleanEnv[key] = value;
+	}
+	return execFileSync("bash", ["-c", script], {
+		env: cleanEnv,
+		encoding: "utf-8",
+	});
+}
+
 function makeHome(pointer: string | null): {
 	home: string;
 	profile: string;
@@ -107,6 +123,36 @@ describe("buildDefaultAccountResolver", () => {
 				SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR: profile,
 			}),
 		).toBe("<unset>|<unset>");
+	});
+
+	it("restores the ambient Codex home when switching to system default", () => {
+		const { home, profile } = makeHome(null);
+		const ambient = join(home, "custom-codex");
+		writeFileSync(join(home, "state", "default-codex-home"), "");
+		expect(
+			resolveCodexWithTwin({
+				SUPERSET_TERMINAL_ID: "t1",
+				SUPERSET_HOME_DIR: home,
+				CODEX_HOME: profile,
+				SUPERSET_DEFAULT_CODEX_HOME: profile,
+				SUPERSET_AMBIENT_CODEX_HOME: ambient,
+			}),
+		).toBe(`${ambient}|${ambient}`);
+	});
+
+	it("adopts a later Codex profile over an injected ambient default", () => {
+		const { home, profile } = makeHome(null);
+		const ambient = join(home, "custom-codex");
+		writeFileSync(join(home, "state", "default-codex-home"), profile);
+		expect(
+			resolveCodexWithTwin({
+				SUPERSET_TERMINAL_ID: "t1",
+				SUPERSET_HOME_DIR: home,
+				CODEX_HOME: ambient,
+				SUPERSET_DEFAULT_CODEX_HOME: ambient,
+				SUPERSET_AMBIENT_CODEX_HOME: ambient,
+			}),
+		).toBe(`${profile}|${profile}`);
 	});
 
 	it("never overrides a value the user exported by hand", () => {

--- a/packages/agent-setup/src/index.ts
+++ b/packages/agent-setup/src/index.ts
@@ -70,6 +70,7 @@ export {
 	type ProfileProvisionReport,
 	provisionClaudeProfile,
 	provisionCodexProfile,
+	resolveAmbientCodexHome,
 } from "./provider-profiles";
 
 export { getCommandShellArgs, getShellArgs, getShellEnv };

--- a/packages/agent-setup/src/provider-profiles.ts
+++ b/packages/agent-setup/src/provider-profiles.ts
@@ -263,12 +263,35 @@ const CODEX_SHARED_DIRS = ["prompts"] as const;
  */
 const CODEX_SHARED_FILES = ["config.toml", "AGENTS.md"] as const;
 
+/**
+ * The Codex home the CLI uses with no Superset involvement.
+ *
+ * `CODEX_HOME` is honoured only when the user set it themselves. Superset
+ * injects that same variable into every terminal and agent launch from the
+ * Usage tab's account pointer, and any process started from such a terminal
+ * inherits it — a host-service restarted from a Superset terminal included.
+ * Trusting it there is circular: the selected profile would masquerade as the
+ * system default, so provisioning would share config *out of* the profile and
+ * `discoverCodexHomes` would label it `selection: null`. The
+ * `SUPERSET_DEFAULT_CODEX_HOME` twin exists precisely to mark our own
+ * injection, so an inherited value is recognisable and ignored.
+ */
+export function resolveAmbientCodexHome(
+	homeDir: string = os.homedir(),
+): string {
+	const fromEnv = process.env.CODEX_HOME?.trim();
+	const supersetInjected = process.env.SUPERSET_DEFAULT_CODEX_HOME?.trim();
+	if (!fromEnv || fromEnv === supersetInjected) {
+		return path.join(homeDir, ".codex");
+	}
+	return path.resolve(fromEnv);
+}
+
 function defaultCodexHome(homeDir: string, homeDirOverridden: boolean): string {
 	// An overridden homeDir (tests) must win over the ambient CODEX_HOME, or
 	// the provision would share from the real machine's Codex home.
 	if (homeDirOverridden) return path.join(homeDir, ".codex");
-	const fromEnv = process.env.CODEX_HOME?.trim();
-	return fromEnv ? path.resolve(fromEnv) : path.join(homeDir, ".codex");
+	return resolveAmbientCodexHome(homeDir);
 }
 
 /** Brings one Codex home up to date with the default one. */

--- a/packages/agent-setup/src/provider-profiles.ts
+++ b/packages/agent-setup/src/provider-profiles.ts
@@ -274,17 +274,24 @@ const CODEX_SHARED_FILES = ["config.toml", "AGENTS.md"] as const;
  * system default, so provisioning would share config *out of* the profile and
  * `discoverCodexHomes` would label it `selection: null`. The
  * `SUPERSET_DEFAULT_CODEX_HOME` twin exists precisely to mark our own
- * injection, so an inherited value is recognisable and ignored.
+ * injection. `SUPERSET_AMBIENT_CODEX_HOME` preserves the actual default when
+ * that default was itself a custom CODEX_HOME, so a nested host-service can
+ * distinguish the selected profile from the user's real home.
  */
 export function resolveAmbientCodexHome(
 	homeDir: string = os.homedir(),
 ): string {
 	const fromEnv = process.env.CODEX_HOME?.trim();
 	const supersetInjected = process.env.SUPERSET_DEFAULT_CODEX_HOME?.trim();
-	if (!fromEnv || fromEnv === supersetInjected) {
-		return path.join(homeDir, ".codex");
+	const preservedAmbient = process.env.SUPERSET_AMBIENT_CODEX_HOME?.trim();
+	if (
+		fromEnv &&
+		(!supersetInjected || canonical(fromEnv) !== canonical(supersetInjected))
+	) {
+		return path.resolve(fromEnv);
 	}
-	return path.resolve(fromEnv);
+	if (preservedAmbient) return path.resolve(preservedAmbient);
+	return path.join(homeDir, ".codex");
 }
 
 function defaultCodexHome(homeDir: string, homeDirOverridden: boolean): string {

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { TRPCError } from "@trpc/server";
@@ -530,6 +530,28 @@ describe("buildTerminalAgentLaunch", () => {
 describe("buildTerminalAgentLaunch default account env", () => {
 	// tmpdir always exists, which is all resolveDefaultAccountEnv checks.
 	const existingDir = tmpdir();
+
+	// setDefaultAccountSelection also publishes the host-wide pointer files
+	// under SUPERSET_HOME_DIR, which agent launches read on every start. Give
+	// each case its own home: without one these writes land in the real
+	// ~/.superset and repoint the developer's Codex and Claude accounts at
+	// $TMPDIR. scripts/test-preload.ts keeps that off the real home even if
+	// this hook is lost; the per-test dir also keeps the cases independent.
+	let previousSupersetHome: string | undefined;
+	let supersetHome = "";
+
+	beforeEach(() => {
+		previousSupersetHome = process.env.SUPERSET_HOME_DIR;
+		supersetHome = mkdtempSync(join(tmpdir(), "agents-default-account-"));
+		process.env.SUPERSET_HOME_DIR = supersetHome;
+	});
+
+	afterEach(() => {
+		if (previousSupersetHome === undefined)
+			delete process.env.SUPERSET_HOME_DIR;
+		else process.env.SUPERSET_HOME_DIR = previousSupersetHome;
+		rmSync(supersetHome, { recursive: true, force: true });
+	});
 
 	function seedClaude(db: HostDb, env: Record<string, string> = {}) {
 		db.insert(schema.hostAgentConfigs)

--- a/packages/host-service/src/trpc/router/usage/account-provisioning.ts
+++ b/packages/host-service/src/trpc/router/usage/account-provisioning.ts
@@ -9,13 +9,17 @@ import { existsSync } from "node:fs";
 import {
 	provisionClaudeProfile,
 	provisionCodexProfile,
+	resolveAmbientCodexHome,
 } from "@superset/agent-setup";
 import type { HostDb } from "../../../db/index.ts";
 import {
 	getDefaultAccountSelections,
 	syncDefaultAccountPointers,
 } from "./default-account.ts";
-import { shareClaudeSessionState } from "./session-share.ts";
+import {
+	shareClaudeSessionState,
+	shareCodexSessionState,
+} from "./session-share.ts";
 
 /**
  * Everything a Claude account needs on this host: the shared session state
@@ -25,6 +29,17 @@ import { shareClaudeSessionState } from "./session-share.ts";
 export async function provisionClaudeAccount(configDir: string): Promise<void> {
 	shareClaudeSessionState(configDir);
 	await provisionClaudeProfile(configDir);
+}
+
+/**
+ * The Codex twin. Both agents get session sharing: an account switch that
+ * keeps `--resume` for Claude but drops `codex resume` is the same bug twice.
+ * The share target is the same home `discoverCodexHomes` calls the system
+ * default, so the account the UI labels default is the one sessions pool into.
+ */
+export async function provisionCodexAccount(codexHome: string): Promise<void> {
+	shareCodexSessionState(codexHome, resolveAmbientCodexHome());
+	await provisionCodexProfile(codexHome);
 }
 
 /**
@@ -49,7 +64,7 @@ export async function provisionSelectedAccounts(db: HostDb): Promise<void> {
 		]);
 	}
 	if (codexHome && existsSync(codexHome)) {
-		targets.push([codexHome, () => provisionCodexProfile(codexHome)]);
+		targets.push([codexHome, () => provisionCodexAccount(codexHome)]);
 	}
 	for (const [dir, provision] of targets) {
 		try {

--- a/packages/host-service/src/trpc/router/usage/account-provisioning.ts
+++ b/packages/host-service/src/trpc/router/usage/account-provisioning.ts
@@ -6,6 +6,8 @@
  */
 
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
 	provisionClaudeProfile,
 	provisionCodexProfile,
@@ -27,7 +29,7 @@ import {
  * config surfaces agent-setup owns (skills, plugins, settings, MCP servers).
  */
 export async function provisionClaudeAccount(configDir: string): Promise<void> {
-	shareClaudeSessionState(configDir);
+	shareClaudeSessionState(configDir, join(homedir(), ".claude"));
 	await provisionClaudeProfile(configDir);
 }
 

--- a/packages/host-service/src/trpc/router/usage/default-account.test.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import type { HostDb } from "../../../db/index.ts";
 import {
 	getDefaultAccountSelections,
+	resolveDefaultAccountEnv,
 	syncDefaultAccountPointer,
 	syncDefaultAccountPointers,
 } from "./default-account.ts";
@@ -31,9 +32,15 @@ function mockDb(defaultClaudeConfigDir: string | null | undefined): HostDb {
 describe("host-wide default account pointers", () => {
 	let home: string;
 	let previousHome: string | undefined;
+	let previousCodexHome: string | undefined;
+	let previousInjectedCodexHome: string | undefined;
+	let previousAmbientCodexHome: string | undefined;
 
 	beforeEach(() => {
 		previousHome = process.env.SUPERSET_HOME_DIR;
+		previousCodexHome = process.env.CODEX_HOME;
+		previousInjectedCodexHome = process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		previousAmbientCodexHome = process.env.SUPERSET_AMBIENT_CODEX_HOME;
 		home = mkdtempSync(join(tmpdir(), "superset-default-account-"));
 		process.env.SUPERSET_HOME_DIR = home;
 	});
@@ -41,6 +48,14 @@ describe("host-wide default account pointers", () => {
 	afterEach(() => {
 		if (previousHome === undefined) delete process.env.SUPERSET_HOME_DIR;
 		else process.env.SUPERSET_HOME_DIR = previousHome;
+		for (const [key, value] of [
+			["CODEX_HOME", previousCodexHome],
+			["SUPERSET_DEFAULT_CODEX_HOME", previousInjectedCodexHome],
+			["SUPERSET_AMBIENT_CODEX_HOME", previousAmbientCodexHome],
+		] as const) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
 		rmSync(home, { recursive: true, force: true });
 	});
 
@@ -87,5 +102,33 @@ describe("host-wide default account pointers", () => {
 		expect(() =>
 			getDefaultAccountSelections(mockDb("/Users/kietho/.claude-work")),
 		).toThrow();
+	});
+
+	it("preserves a custom ambient Codex home beside an injected profile", () => {
+		const customDefault = join(home, "custom-codex");
+		const selected = join(home, ".codex-work");
+		mkdirSync(selected);
+		process.env.CODEX_HOME = customDefault;
+		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
+		syncDefaultAccountPointer("codex", selected);
+
+		expect(resolveDefaultAccountEnv(mockDb(undefined), "codex")).toEqual({
+			SUPERSET_AMBIENT_CODEX_HOME: customDefault,
+			CODEX_HOME: selected,
+			SUPERSET_DEFAULT_CODEX_HOME: selected,
+		});
+	});
+
+	it("preserves the ambient Codex home when the system default is selected", () => {
+		const customDefault = join(home, "custom-codex");
+		process.env.CODEX_HOME = customDefault;
+		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
+		syncDefaultAccountPointer("codex", null);
+
+		expect(resolveDefaultAccountEnv(mockDb(undefined), "codex")).toEqual({
+			SUPERSET_AMBIENT_CODEX_HOME: customDefault,
+		});
 	});
 });

--- a/packages/host-service/src/trpc/router/usage/default-account.test.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.test.ts
@@ -130,6 +130,7 @@ describe("host-wide default account pointers", () => {
 		expect(resolveDefaultAccountEnv(mockDb(undefined), "codex")).toEqual({
 			SUPERSET_AMBIENT_CODEX_HOME: customDefault,
 			CODEX_HOME: customDefault,
+			SUPERSET_DEFAULT_CODEX_HOME: customDefault,
 		});
 	});
 });

--- a/packages/host-service/src/trpc/router/usage/default-account.test.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.test.ts
@@ -129,6 +129,7 @@ describe("host-wide default account pointers", () => {
 
 		expect(resolveDefaultAccountEnv(mockDb(undefined), "codex")).toEqual({
 			SUPERSET_AMBIENT_CODEX_HOME: customDefault,
+			CODEX_HOME: customDefault,
 		});
 	});
 });

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -270,7 +270,11 @@ export function resolveDefaultAccountEnv(
 		const ambientCodex = ambientCodexHome();
 		const ambient = { SUPERSET_AMBIENT_CODEX_HOME: ambientCodex };
 		if (!selections.codexHome || !existsSync(selections.codexHome)) {
-			return { ...ambient, CODEX_HOME: ambientCodex };
+			return {
+				...ambient,
+				CODEX_HOME: ambientCodex,
+				SUPERSET_DEFAULT_CODEX_HOME: ambientCodex,
+			};
 		}
 		return {
 			...ambient,

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -11,12 +11,13 @@ import {
 	linkSync,
 	mkdirSync,
 	readFileSync,
+	realpathSync,
 	renameSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { HostDb } from "../../../db/index.ts";
 import { hostSettings } from "../../../db/schema.ts";
 
@@ -34,6 +35,34 @@ const POINTER_NAMES: Record<SwitchableAccountAgent, string> = {
  */
 function supersetHomeDir(): string {
 	return process.env.SUPERSET_HOME_DIR?.trim() || join(homedir(), ".superset");
+}
+
+/**
+ * Mirror of agent-setup's resolveAmbientCodexHome. New terminals preserve the
+ * user's real Codex home separately from the profile Superset injects, so a
+ * nested host-service can recover it without importing agent-setup here.
+ */
+function ambientCodexHome(): string {
+	const fromEnv = process.env.CODEX_HOME?.trim();
+	const supersetInjected = process.env.SUPERSET_DEFAULT_CODEX_HOME?.trim();
+	const preservedAmbient = process.env.SUPERSET_AMBIENT_CODEX_HOME?.trim();
+	if (
+		fromEnv &&
+		(!supersetInjected ||
+			canonicalAccountHome(fromEnv) !== canonicalAccountHome(supersetInjected))
+	) {
+		return resolve(fromEnv);
+	}
+	if (preservedAmbient) return resolve(preservedAmbient);
+	return join(homedir(), ".codex");
+}
+
+function canonicalAccountHome(target: string): string {
+	try {
+		return realpathSync(target);
+	} catch {
+		return resolve(target);
+	}
 }
 
 function defaultAccountPointerPath(agent: SwitchableAccountAgent): string {
@@ -237,12 +266,15 @@ export function resolveDefaultAccountEnv(
 			SUPERSET_DEFAULT_CLAUDE_CONFIG_DIR: selections.claudeConfigDir,
 		};
 	}
-	if (
-		presetId === "codex" &&
-		selections.codexHome &&
-		existsSync(selections.codexHome)
-	) {
+	if (presetId === "codex") {
+		const ambient = {
+			SUPERSET_AMBIENT_CODEX_HOME: ambientCodexHome(),
+		};
+		if (!selections.codexHome || !existsSync(selections.codexHome)) {
+			return ambient;
+		}
 		return {
+			...ambient,
 			CODEX_HOME: selections.codexHome,
 			SUPERSET_DEFAULT_CODEX_HOME: selections.codexHome,
 		};

--- a/packages/host-service/src/trpc/router/usage/default-account.ts
+++ b/packages/host-service/src/trpc/router/usage/default-account.ts
@@ -267,11 +267,10 @@ export function resolveDefaultAccountEnv(
 		};
 	}
 	if (presetId === "codex") {
-		const ambient = {
-			SUPERSET_AMBIENT_CODEX_HOME: ambientCodexHome(),
-		};
+		const ambientCodex = ambientCodexHome();
+		const ambient = { SUPERSET_AMBIENT_CODEX_HOME: ambientCodex };
 		if (!selections.codexHome || !existsSync(selections.codexHome)) {
-			return ambient;
+			return { ...ambient, CODEX_HOME: ambientCodex };
 		}
 		return {
 			...ambient,

--- a/packages/host-service/src/trpc/router/usage/profile-remove.test.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-remove.test.ts
@@ -56,10 +56,12 @@ describe("assertRemovableProfileDir", () => {
 describe("assertRemovableProfileDir with Codex account injection", () => {
 	let previousCodexHome: string | undefined;
 	let previousInjectedHome: string | undefined;
+	let previousAmbientHome: string | undefined;
 
 	beforeEach(() => {
 		previousCodexHome = process.env.CODEX_HOME;
 		previousInjectedHome = process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		previousAmbientHome = process.env.SUPERSET_AMBIENT_CODEX_HOME;
 	});
 
 	afterEach(() => {
@@ -68,12 +70,29 @@ describe("assertRemovableProfileDir with Codex account injection", () => {
 		if (previousInjectedHome === undefined)
 			delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
 		else process.env.SUPERSET_DEFAULT_CODEX_HOME = previousInjectedHome;
+		if (previousAmbientHome === undefined)
+			delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
+		else process.env.SUPERSET_AMBIENT_CODEX_HOME = previousAmbientHome;
 	});
 
 	it("allows removal of a profile Superset injected into CODEX_HOME", () => {
 		const profile = join(homedir(), ".codex-injected-profile");
 		process.env.CODEX_HOME = profile;
 		process.env.SUPERSET_DEFAULT_CODEX_HOME = profile;
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
+		expect(assertRemovableProfileDir(profile)).toBe(profile);
+	});
+
+	it("protects a preserved custom default while allowing the injected profile", () => {
+		const profile = join(homedir(), ".codex-injected-profile");
+		const customDefault = join(homedir(), ".codex-user-default");
+		process.env.CODEX_HOME = profile;
+		process.env.SUPERSET_DEFAULT_CODEX_HOME = profile;
+		process.env.SUPERSET_AMBIENT_CODEX_HOME = customDefault;
+
+		expect(() => assertRemovableProfileDir(customDefault)).toThrow(
+			/system-default/,
+		);
 		expect(assertRemovableProfileDir(profile)).toBe(profile);
 	});
 
@@ -81,6 +100,7 @@ describe("assertRemovableProfileDir with Codex account injection", () => {
 		const customDefault = join(homedir(), ".codex-user-default");
 		process.env.CODEX_HOME = customDefault;
 		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		delete process.env.SUPERSET_AMBIENT_CODEX_HOME;
 		expect(() => assertRemovableProfileDir(customDefault)).toThrow(
 			/system-default/,
 		);

--- a/packages/host-service/src/trpc/router/usage/profile-remove.test.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-remove.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
 	existsSync,
 	mkdirSync,
@@ -50,6 +50,40 @@ describe("assertRemovableProfileDir", () => {
 	it("accepts a profile dir under the home dir", () => {
 		const dir = join(homedir(), ".claude-unittest-profile");
 		expect(assertRemovableProfileDir(dir)).toBe(dir);
+	});
+});
+
+describe("assertRemovableProfileDir with Codex account injection", () => {
+	let previousCodexHome: string | undefined;
+	let previousInjectedHome: string | undefined;
+
+	beforeEach(() => {
+		previousCodexHome = process.env.CODEX_HOME;
+		previousInjectedHome = process.env.SUPERSET_DEFAULT_CODEX_HOME;
+	});
+
+	afterEach(() => {
+		if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+		else process.env.CODEX_HOME = previousCodexHome;
+		if (previousInjectedHome === undefined)
+			delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		else process.env.SUPERSET_DEFAULT_CODEX_HOME = previousInjectedHome;
+	});
+
+	it("allows removal of a profile Superset injected into CODEX_HOME", () => {
+		const profile = join(homedir(), ".codex-injected-profile");
+		process.env.CODEX_HOME = profile;
+		process.env.SUPERSET_DEFAULT_CODEX_HOME = profile;
+		expect(assertRemovableProfileDir(profile)).toBe(profile);
+	});
+
+	it("still protects a CODEX_HOME the user set themselves", () => {
+		const customDefault = join(homedir(), ".codex-user-default");
+		process.env.CODEX_HOME = customDefault;
+		delete process.env.SUPERSET_DEFAULT_CODEX_HOME;
+		expect(() => assertRemovableProfileDir(customDefault)).toThrow(
+			/system-default/,
+		);
 	});
 });
 

--- a/packages/host-service/src/trpc/router/usage/profile-remove.ts
+++ b/packages/host-service/src/trpc/router/usage/profile-remove.ts
@@ -10,6 +10,7 @@ import { rm } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
+import { resolveAmbientCodexHome } from "@superset/agent-setup";
 import { keychainServicesForConfigDir } from "./profiles";
 
 const execFileAsync = promisify(execFile);
@@ -22,8 +23,8 @@ function protectedDirs(): Set<string> {
 		join(home, ".config", "claude"),
 		join(home, ".config"),
 		join(home, ".codex"),
+		resolveAmbientCodexHome(home),
 	]);
-	if (process.env.CODEX_HOME) dirs.add(resolve(process.env.CODEX_HOME));
 	return dirs;
 }
 

--- a/packages/host-service/src/trpc/router/usage/profiles.ts
+++ b/packages/host-service/src/trpc/router/usage/profiles.ts
@@ -21,6 +21,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { resolveAmbientCodexHome } from "@superset/agent-setup";
 
 const execFileAsync = promisify(execFile);
 
@@ -162,13 +163,19 @@ interface CodexAuthShape {
 }
 
 /**
- * Codex homes: `$CODEX_HOME` (default `~/.codex`) plus any `~/.codex*`
- * dot-dir carrying an `auth.json` with a token — the common multi-account
- * convention is one CODEX_HOME dir per account.
+ * Codex homes: the ambient home (`~/.codex`, or a `CODEX_HOME` the user set
+ * themselves — see resolveAmbientCodexHome for why Superset's own injected
+ * value is ignored) plus any `~/.codex*` dot-dir carrying an `auth.json` with
+ * a token. The common multi-account convention is one CODEX_HOME dir per
+ * account.
+ *
+ * The first entry is the system default, and `fetchCodexAccounts` gives it
+ * `selection: null`. It is listed even without an `auth.json` so the
+ * add-account poller has a baseline to compare a fresh `codex login` against.
  */
 export async function discoverCodexHomes(): Promise<CodexHome[]> {
 	const home = homedir();
-	const defaultHome = process.env.CODEX_HOME ?? join(home, ".codex");
+	const defaultHome = resolveAmbientCodexHome(home);
 	const homes = new Map<string, CodexHome>([
 		[defaultHome, { home: defaultHome, sourceLabel: tildeLabel(defaultHome) }],
 	]);

--- a/packages/host-service/src/trpc/router/usage/session-share.test.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.test.ts
@@ -342,6 +342,23 @@ describe("shareCodexSessionState", () => {
 		);
 	});
 
+	it("drains numbered history captures in generation order", () => {
+		const { profile, main } = makeDirs();
+		for (let generation = 0; generation <= 10; generation += 1) {
+			const suffix = generation === 0 ? "" : `-${generation}`;
+			writeFileSync(
+				join(profile, `history.jsonl.superset-merge${suffix}`),
+				`${generation}\n`,
+			);
+		}
+
+		shareCodexSessionState(profile, main);
+
+		expect(
+			readFileSync(join(main, "history.jsonl"), "utf-8").trim().split("\n"),
+		).toEqual(Array.from({ length: 11 }, (_, generation) => `${generation}`));
+	});
+
 	it("re-links a history file the CLI replaced with a real file", () => {
 		const { profile, main } = makeDirs();
 		shareCodexSessionState(profile, main);

--- a/packages/host-service/src/trpc/router/usage/session-share.test.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.test.ts
@@ -105,6 +105,21 @@ describe("sameFilesystem", () => {
 		).toBe("session");
 		expect(lstatOrNull(join(profile, "sessions.superset-merge"))).toBeNull();
 	});
+
+	it("restores an interrupted session tree when recovery crosses devices", () => {
+		const { profile, main } = makeDirs();
+		const pending = join(profile, "sessions.superset-merge");
+		mkdirSync(pending);
+		writeFileSync(join(pending, "rollout.jsonl"), "session");
+
+		mergeAndLinkSessionDir(profile, main, "sessions", () => false);
+
+		expect(lstatSync(join(profile, "sessions")).isDirectory()).toBe(true);
+		expect(
+			readFileSync(join(profile, "sessions", "rollout.jsonl"), "utf8"),
+		).toBe("session");
+		expect(lstatOrNull(pending)).toBeNull();
+	});
 });
 
 describe("shareClaudeSessionState", () => {
@@ -383,6 +398,13 @@ describe("shareCodexSessionState", () => {
 		expect(
 			shareableProfileDir(join(home, ".codex-work"), main, [".codex"]),
 		).toBe(join(home, ".codex-work"));
+	});
+
+	it("allows ~/.codex to share into a user-defined Codex main home", () => {
+		const home = homedir();
+		expect(
+			shareableProfileDir(join(home, ".codex"), "/tmp/custom-codex-main", []),
+		).toBe(join(home, ".codex"));
 	});
 
 	it("never touches auth.json, so accounts keep separate credentials", () => {

--- a/packages/host-service/src/trpc/router/usage/session-share.test.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.test.ts
@@ -1,27 +1,40 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import {
+	closeSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	openSync,
 	readdirSync,
 	readFileSync,
 	readlinkSync,
+	rmSync,
 	symlinkSync,
 	unlinkSync,
 	writeFileSync,
+	writeSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+	mergeAndLinkSessionDir,
+	sameFilesystem,
 	shareableProfileDir,
 	shareClaudeSessionState,
 	shareCodexSessionState,
 } from "./session-share";
 
 const CLAUDE_HOMES = [".claude", ".config/claude"];
+const roots = new Set<string>();
+
+afterEach(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true });
+	roots.clear();
+});
 
 function makeDirs(): { profile: string; main: string } {
 	const root = mkdtempSync(join(tmpdir(), "claude-session-share-"));
+	roots.add(root);
 	const profile = join(root, "profile");
 	const main = join(root, "main");
 	mkdirSync(profile);
@@ -66,6 +79,31 @@ describe("shareableProfileDir", () => {
 				CLAUDE_HOMES,
 			),
 		).toBe(join(home, ".claude-work"));
+	});
+});
+
+describe("sameFilesystem", () => {
+	it("detects when a rename would cross filesystem devices", () => {
+		expect(
+			sameFilesystem("profile", "main", (path) =>
+				path === "profile" ? 41 : 42,
+			),
+		).toBe(false);
+		expect(sameFilesystem("profile", "main", () => 41)).toBe(true);
+	});
+
+	it("leaves an existing session tree visible when devices differ", () => {
+		const { profile, main } = makeDirs();
+		mkdirSync(join(profile, "sessions"));
+		writeFileSync(join(profile, "sessions", "rollout.jsonl"), "session");
+
+		mergeAndLinkSessionDir(profile, main, "sessions", () => false);
+
+		expect(lstatSync(join(profile, "sessions")).isSymbolicLink()).toBe(false);
+		expect(
+			readFileSync(join(profile, "sessions", "rollout.jsonl"), "utf8"),
+		).toBe("session");
+		expect(lstatOrNull(join(profile, "sessions.superset-merge"))).toBeNull();
 	});
 });
 
@@ -171,6 +209,11 @@ describe("shareClaudeSessionState", () => {
 		expect(readFileSync(join(main, "history.jsonl"), "utf-8")).toBe(
 			'{"m":1}\n{"p":1}\n',
 		);
+		// Re-provisioning drains only bytes written since the last cursor.
+		shareClaudeSessionState(profile, main);
+		expect(readFileSync(join(main, "history.jsonl"), "utf-8")).toBe(
+			'{"m":1}\n{"p":1}\n',
+		);
 	});
 
 	it("leaves config surfaces to agent-setup provisioning", () => {
@@ -268,6 +311,35 @@ describe("shareCodexSessionState", () => {
 		expect(
 			isLinkTo(join(profile, "history.jsonl"), join(main, "history.jsonl")),
 		).toBe(true);
+	});
+
+	it("drains a write made through an fd opened before the history swap", () => {
+		const { profile, main } = makeDirs();
+		const profileHistory = join(profile, "history.jsonl");
+		writeFileSync(profileHistory, '{"t":"before-switch"}\n');
+		const oldFd = openSync(profileHistory, "a");
+
+		shareCodexSessionState(profile, main);
+		writeSync(oldFd, '{"t":"in-flight"}\n');
+		closeSync(oldFd);
+
+		// The old inode remains durable and the next normal provision drains the
+		// late append without duplicating the bytes already imported.
+		shareCodexSessionState(profile, main);
+		const merged = readFileSync(join(main, "history.jsonl"), "utf-8");
+		expect(merged.match(/before-switch/g)).toHaveLength(1);
+		expect(merged.match(/in-flight/g)).toHaveLength(1);
+		expect(
+			readFileSync(join(profile, "history.jsonl.superset-merge"), "utf-8"),
+		).toContain("in-flight");
+		expect(
+			readFileSync(
+				join(profile, "history.jsonl.superset-merge.offset"),
+				"utf-8",
+			),
+		).toBe(
+			`${Buffer.byteLength('{"t":"before-switch"}\n{"t":"in-flight"}\n')}\n`,
+		);
 	});
 
 	it("re-links a history file the CLI replaced with a real file", () => {

--- a/packages/host-service/src/trpc/router/usage/session-share.test.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.test.ts
@@ -18,6 +18,8 @@ import {
 	shareCodexSessionState,
 } from "./session-share";
 
+const CLAUDE_HOMES = [".claude", ".config/claude"];
+
 function makeDirs(): { profile: string; main: string } {
 	const root = mkdtempSync(join(tmpdir(), "claude-session-share-"));
 	const profile = join(root, "profile");
@@ -43,20 +45,26 @@ describe("shareableProfileDir", () => {
 	it("refuses the default homes and the main home itself", () => {
 		const home = homedir();
 		const main = join(home, ".claude");
-		expect(shareableProfileDir(home, main)).toBeNull();
-		expect(shareableProfileDir(join(home, ".claude"), main)).toBeNull();
+		expect(shareableProfileDir(home, main, CLAUDE_HOMES)).toBeNull();
 		expect(
-			shareableProfileDir(join(home, ".config", "claude"), main),
+			shareableProfileDir(join(home, ".claude"), main, CLAUDE_HOMES),
 		).toBeNull();
 		expect(
-			shareableProfileDir("/tmp/custom-main", "/tmp/custom-main"),
+			shareableProfileDir(join(home, ".config", "claude"), main, CLAUDE_HOMES),
+		).toBeNull();
+		expect(
+			shareableProfileDir("/tmp/custom-main", "/tmp/custom-main", CLAUDE_HOMES),
 		).toBeNull();
 	});
 
 	it("accepts an ordinary profile dir", () => {
 		const home = homedir();
 		expect(
-			shareableProfileDir(join(home, ".claude-work"), join(home, ".claude")),
+			shareableProfileDir(
+				join(home, ".claude-work"),
+				join(home, ".claude"),
+				CLAUDE_HOMES,
+			),
 		).toBe(join(home, ".claude-work"));
 	});
 });
@@ -149,7 +157,7 @@ describe("shareClaudeSessionState", () => {
 		const { profile, main } = makeDirs();
 		const alias = join(profile, "..", "main-alias");
 		symlinkSync(main, alias);
-		expect(shareableProfileDir(alias, main)).toBeNull();
+		expect(shareableProfileDir(alias, main, CLAUDE_HOMES)).toBeNull();
 	});
 
 	it("appends the profile's prompt history to main's", () => {

--- a/packages/host-service/src/trpc/router/usage/session-share.test.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.test.ts
@@ -8,6 +8,7 @@ import {
 	readdirSync,
 	readFileSync,
 	readlinkSync,
+	realpathSync,
 	rmSync,
 	symlinkSync,
 	unlinkSync,
@@ -400,11 +401,9 @@ describe("shareCodexSessionState", () => {
 		).toBe(join(home, ".codex-work"));
 	});
 
-	it("allows ~/.codex to share into a user-defined Codex main home", () => {
-		const home = homedir();
-		expect(
-			shareableProfileDir(join(home, ".codex"), "/tmp/custom-codex-main", []),
-		).toBe(join(home, ".codex"));
+	it("allows a fixed Codex home to share into a user-defined main home", () => {
+		const { profile, main } = makeDirs();
+		expect(shareableProfileDir(profile, main, [])).toBe(realpathSync(profile));
 	});
 
 	it("never touches auth.json, so accounts keep separate credentials", () => {

--- a/packages/host-service/src/trpc/router/usage/session-share.test.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.test.ts
@@ -7,11 +7,16 @@ import {
 	readFileSync,
 	readlinkSync,
 	symlinkSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { shareableProfileDir, shareClaudeSessionState } from "./session-share";
+import {
+	shareableProfileDir,
+	shareClaudeSessionState,
+	shareCodexSessionState,
+} from "./session-share";
 
 function makeDirs(): { profile: string; main: string } {
 	const root = mkdtempSync(join(tmpdir(), "claude-session-share-"));
@@ -195,5 +200,105 @@ describe("shareClaudeSessionState", () => {
 		expect(lstatSync(join(profile, "daemon")).isSymbolicLink()).toBe(false);
 		expect(readdirSync(main)).not.toContain(".claude.json");
 		expect(readdirSync(main)).not.toContain(".credentials.json");
+	});
+});
+
+describe("shareCodexSessionState", () => {
+	it("links a fresh Codex home's rollout dirs and history into main", () => {
+		const { profile, main } = makeDirs();
+		shareCodexSessionState(profile, main);
+		for (const name of ["sessions", "archived_sessions", "shell_snapshots"]) {
+			expect(isLinkTo(join(profile, name), join(main, name))).toBe(true);
+			expect(lstatSync(join(main, name)).isDirectory()).toBe(true);
+		}
+		expect(
+			isLinkTo(join(profile, "history.jsonl"), join(main, "history.jsonl")),
+		).toBe(true);
+	});
+
+	it("merges both accounts' rollouts into one resumable tree", () => {
+		const { profile, main } = makeDirs();
+		// Codex keys rollouts by date, so the two accounts land side by side in
+		// the same day directory — the case `codex resume` has to see whole.
+		mkdirSync(join(profile, "sessions", "2026", "08", "31"), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(profile, "sessions", "2026", "08", "31", "rollout-work.jsonl"),
+			"work",
+		);
+		mkdirSync(join(main, "sessions", "2026", "08", "31"), { recursive: true });
+		writeFileSync(
+			join(main, "sessions", "2026", "08", "31", "rollout-personal.jsonl"),
+			"personal",
+		);
+		shareCodexSessionState(profile, main);
+
+		expect(isLinkTo(join(profile, "sessions"), join(main, "sessions"))).toBe(
+			true,
+		);
+		const day = join(main, "sessions", "2026", "08", "31");
+		expect(readdirSync(day).sort()).toEqual([
+			"rollout-personal.jsonl",
+			"rollout-work.jsonl",
+		]);
+		// Both are reachable through the profile's own path, which is what the
+		// CLI will be pointed at by CODEX_HOME.
+		expect(
+			readdirSync(join(profile, "sessions", "2026", "08", "31")).sort(),
+		).toEqual(["rollout-personal.jsonl", "rollout-work.jsonl"]);
+	});
+
+	it("appends an existing Codex prompt history instead of dropping it", () => {
+		const { profile, main } = makeDirs();
+		writeFileSync(join(profile, "history.jsonl"), '{"t":"from-profile"}\n');
+		writeFileSync(join(main, "history.jsonl"), '{"t":"from-main"}\n');
+		shareCodexSessionState(profile, main);
+		const merged = readFileSync(join(main, "history.jsonl"), "utf-8");
+		expect(merged).toContain("from-main");
+		expect(merged).toContain("from-profile");
+		expect(
+			isLinkTo(join(profile, "history.jsonl"), join(main, "history.jsonl")),
+		).toBe(true);
+	});
+
+	it("re-links a history file the CLI replaced with a real file", () => {
+		const { profile, main } = makeDirs();
+		shareCodexSessionState(profile, main);
+		// A rename-over-symlink forks the log; the next provision must heal it
+		// rather than leave the two accounts writing separate histories.
+		unlinkSync(join(profile, "history.jsonl"));
+		writeFileSync(join(profile, "history.jsonl"), '{"t":"forked"}\n');
+		shareCodexSessionState(profile, main);
+		expect(
+			isLinkTo(join(profile, "history.jsonl"), join(main, "history.jsonl")),
+		).toBe(true);
+		expect(readFileSync(join(main, "history.jsonl"), "utf-8")).toContain(
+			"forked",
+		);
+	});
+
+	it("refuses to share the default Codex home into itself", () => {
+		const home = homedir();
+		const main = join(home, ".codex");
+		expect(shareableProfileDir(home, main, [".codex"])).toBeNull();
+		expect(shareableProfileDir(main, main, [".codex"])).toBeNull();
+		expect(
+			shareableProfileDir(join(home, ".codex-work"), main, [".codex"]),
+		).toBe(join(home, ".codex-work"));
+	});
+
+	it("never touches auth.json, so accounts keep separate credentials", () => {
+		const { profile, main } = makeDirs();
+		writeFileSync(join(profile, "auth.json"), '{"account":"work"}');
+		writeFileSync(join(main, "auth.json"), '{"account":"personal"}');
+		shareCodexSessionState(profile, main);
+		expect(lstatSync(join(profile, "auth.json")).isSymbolicLink()).toBe(false);
+		expect(readFileSync(join(profile, "auth.json"), "utf-8")).toBe(
+			'{"account":"work"}',
+		);
+		expect(readFileSync(join(main, "auth.json"), "utf-8")).toBe(
+			'{"account":"personal"}',
+		);
 	});
 });

--- a/packages/host-service/src/trpc/router/usage/session-share.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.ts
@@ -84,7 +84,10 @@ const CLAUDE_SHARE: SessionShareSpec = {
 const CODEX_SHARE: SessionShareSpec = {
 	dirs: ["sessions", "archived_sessions", "shell_snapshots"],
 	historyFiles: ["history.jsonl"],
-	providerHomes: [".codex", ".config/codex"],
+	// A user-defined CODEX_HOME can make ~/.codex a secondary account. The
+	// actual mainHome is excluded separately, so no other fixed home belongs
+	// here.
+	providerHomes: [],
 };
 
 const MERGE_SUFFIX = ".superset-merge";
@@ -186,7 +189,13 @@ export function mergeAndLinkSessionDir(
 	// else — src may already be a symlink by now.
 	if (lstatOrNull(pending)?.isDirectory()) {
 		mkdirSync(dst, { recursive: true });
-		if (!onSameFilesystem(pending, dst)) return;
+		if (!onSameFilesystem(pending, dst)) {
+			// A prior process may have stopped after the rename but before linking.
+			// Put the tree back when cross-device recovery cannot finish, otherwise
+			// the CLI's original session path remains missing.
+			if (!lstatOrNull(src)) renameSync(pending, src);
+			return;
+		}
 		moveTreeInto(pending, dst);
 	}
 	const info = lstatOrNull(src);

--- a/packages/host-service/src/trpc/router/usage/session-share.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.ts
@@ -106,7 +106,7 @@ function canonical(path: string): string {
 export function shareableProfileDir(
 	configDir: string,
 	mainHome: string,
-	providerHomes: readonly string[] = CLAUDE_SHARE.providerHomes,
+	providerHomes: readonly string[],
 ): string | null {
 	const resolved = canonical(configDir);
 	const home = homedir();
@@ -281,21 +281,30 @@ function shareSessionState(
 	}
 }
 
+/**
+ * `mainHome` is required on both of these, with no default aimed at the real
+ * `~/.claude` / `~/.codex`. A defaulted one-argument call reads as harmless
+ * and is not: it renames the caller's live session trees into their actual
+ * home. account-provisioning.ts is the single place that decides what "main"
+ * is, and for Codex that answer has to be resolveAmbientCodexHome() rather
+ * than a hardcoded `~/.codex`, so the share targets the same home
+ * discoverCodexHomes calls the system default.
+ */
 export function shareClaudeSessionState(
 	configDir: string,
-	mainHome: string = join(homedir(), ".claude"),
+	mainHome: string,
 ): void {
 	shareSessionState(configDir, mainHome, CLAUDE_SHARE);
 }
 
 /**
- * The Codex twin of shareClaudeSessionState, so `codex resume` keeps working
- * across an account switch. Without it a switch stranded every rollout in the
- * home the previous account used.
+ * The Codex twin, so `codex resume` keeps working across an account switch.
+ * Without it a switch stranded every rollout in the home the previous account
+ * used.
  */
 export function shareCodexSessionState(
 	codexHome: string,
-	mainHome: string = join(homedir(), ".codex"),
+	mainHome: string,
 ): void {
 	shareSessionState(codexHome, mainHome, CODEX_SHARE);
 }

--- a/packages/host-service/src/trpc/router/usage/session-share.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.ts
@@ -225,8 +225,15 @@ function historyPendingPaths(profile: string, name: string): string[] {
 			if (!entry.name.startsWith(`${prefix}-`)) return false;
 			return /^\d+$/.test(entry.name.slice(prefix.length + 1));
 		})
-		.map((entry) => join(profile, entry.name))
-		.sort();
+		.map((entry) => entry.name)
+		.sort((left, right) => {
+			const leftGeneration =
+				left === prefix ? 0 : Number(left.slice(prefix.length + 1));
+			const rightGeneration =
+				right === prefix ? 0 : Number(right.slice(prefix.length + 1));
+			return leftGeneration - rightGeneration;
+		})
+		.map((entry) => join(profile, entry));
 }
 
 function nextHistoryPendingPath(src: string): string {

--- a/packages/host-service/src/trpc/router/usage/session-share.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.ts
@@ -1,23 +1,26 @@
 /**
- * Shares session state between a secondary Claude profile dir and the
- * default `~/.claude` home via symlinks, so every login sees one
- * conversation history — switching accounts stops meaning losing
- * `--resume` and the prompt history.
+ * Shares session state between a secondary provider profile dir and that
+ * provider's default home (`~/.claude`, `~/.codex`) via symlinks, so every
+ * login sees one conversation history — switching accounts stops meaning
+ * losing `--resume` and the prompt history.
  *
- * Only surfaces a symlink can survive are shared here: directories, and
- * `history.jsonl`, which the CLI appends to in place. Config files like
- * settings.json and `.claude.json` are written with write-tmp-then-rename —
+ * Only surfaces a symlink can survive are shared here: directories, and the
+ * append-in-place history logs. Config files like settings.json,
+ * `.claude.json`, and config.toml are written with write-tmp-then-rename —
  * a rename would replace the symlink with a real file and silently fork the
  * config — so those (plus skills, plugins, MCP servers) belong to
  * agent-setup's ledger-based profile provisioning, not to this module.
- * Identity (`.claude.json`, credential stores) and runtime dirs (daemon/,
- * cache/, telemetry/, backups/) always stay per-profile.
+ * Identity (`.claude.json`, `auth.json`, credential stores) and runtime dirs
+ * (daemon/, cache/, telemetry/, backups/) always stay per-profile.
  *
  * Existing real state is merged, not clobbered. Session trees are renamed
- * aside, the symlink lands immediately, and files then move into `~/.claude`
- * one by one: renames preserve inodes, so a live session's open transcripts
- * stay valid and its paths resolve through the new link. The prompt history
- * is appended. Anything that cannot merge safely is left where it is.
+ * aside, the symlink lands immediately, and files then move into the main
+ * home one by one: renames preserve inodes, so a live session's open
+ * transcripts stay valid and its paths resolve through the new link. The
+ * prompt history is appended. A history file the CLI later replaces outright
+ * (rename-over-symlink) is re-merged and re-linked on the next provision, so
+ * the share is self-healing. Anything that cannot merge safely is left where
+ * it is.
  */
 
 import {
@@ -39,21 +42,50 @@ import {
 import { homedir, platform } from "node:os";
 import { join, resolve } from "node:path";
 
-/** Session-scoped state keyed by session UUID or cwd slug: safe to merge
- * file-by-file, since two profiles' sessions collide no more than two
- * concurrent sessions in one dir already do. */
-const SESSION_DIRS = [
-	"projects",
-	"sessions",
-	"session-env",
-	"file-history",
-	"shell-snapshots",
-	"todos",
-	"paste-cache",
-	"tasks",
-	"plans",
-	"transcripts",
-];
+/**
+ * What one provider keeps that is safe to share. `dirs` are session-scoped
+ * state keyed by session UUID or cwd slug: safe to merge file-by-file, since
+ * two profiles' sessions collide no more than two concurrent sessions in one
+ * dir already do. `historyFiles` are line-delimited logs the CLI appends to
+ * in place. `providerHomes` are that provider's own default homes, which are
+ * the share's source and so can never be its target.
+ */
+interface SessionShareSpec {
+	dirs: readonly string[];
+	historyFiles: readonly string[];
+	providerHomes: readonly string[];
+}
+
+const CLAUDE_SHARE: SessionShareSpec = {
+	dirs: [
+		"projects",
+		"sessions",
+		"session-env",
+		"file-history",
+		"shell-snapshots",
+		"todos",
+		"paste-cache",
+		"tasks",
+		"plans",
+		"transcripts",
+	],
+	historyFiles: ["history.jsonl"],
+	providerHomes: [".claude", ".config/claude"],
+};
+
+/**
+ * Codex keys rollouts by date under `sessions/`, so two accounts' sessions
+ * interleave in one tree exactly as two same-day sessions already do, and
+ * `codex resume` sees every one of them. `auth.json` stays per-account, and
+ * `config.toml` / `AGENTS.md` / `prompts/` belong to agent-setup's ledger
+ * (they are rewritten with tmp-then-rename). `shell_snapshots` uses an
+ * underscore here; Claude's spells the same dir with a hyphen.
+ */
+const CODEX_SHARE: SessionShareSpec = {
+	dirs: ["sessions", "archived_sessions", "shell_snapshots"],
+	historyFiles: ["history.jsonl"],
+	providerHomes: [".codex", ".config/codex"],
+};
 
 const MERGE_SUFFIX = ".superset-merge";
 
@@ -74,15 +106,15 @@ function canonical(path: string): string {
 export function shareableProfileDir(
 	configDir: string,
 	mainHome: string,
+	providerHomes: readonly string[] = CLAUDE_SHARE.providerHomes,
 ): string | null {
 	const resolved = canonical(configDir);
 	const home = homedir();
 	const excluded = new Set(
 		[
 			home,
-			join(home, ".claude"),
 			join(home, ".config"),
-			join(home, ".config", "claude"),
+			...providerHomes.map((relative) => join(home, relative)),
 			mainHome,
 		].map(canonical),
 	);
@@ -187,9 +219,13 @@ function appendHistoryRecords(dst: string, content: Buffer): void {
 	);
 }
 
-function mergeAndLinkHistory(profile: string, main: string): void {
-	const src = join(profile, "history.jsonl");
-	const dst = join(main, "history.jsonl");
+function mergeAndLinkHistory(
+	profile: string,
+	main: string,
+	name: string,
+): void {
+	const src = join(profile, name);
+	const dst = join(main, name);
 	const pending = `${src}${MERGE_SUFFIX}`;
 	if (lstatOrNull(pending)?.isFile()) {
 		appendHistoryRecords(dst, readFileSync(pending));
@@ -218,20 +254,23 @@ function mergeAndLinkHistory(profile: string, main: string): void {
  * Best-effort per entry: one unmergeable path must not stop the rest, and a
  * partially shared profile is strictly better than an unshared one.
  */
-export function shareClaudeSessionState(
+function shareSessionState(
 	configDir: string,
-	mainHome: string = join(homedir(), ".claude"),
+	mainHome: string,
+	spec: SessionShareSpec,
 ): void {
 	// Windows symlinks need elevation; profiles are a macOS/Linux feature.
 	if (platform() === "win32") return;
-	const profile = shareableProfileDir(configDir, mainHome);
+	const profile = shareableProfileDir(configDir, mainHome, spec.providerHomes);
 	if (!profile) return;
 	const main = resolve(mainHome);
 	const steps: Array<() => void> = [
-		...SESSION_DIRS.map(
+		...spec.dirs.map(
 			(name) => () => mergeAndLinkSessionDir(profile, main, name),
 		),
-		() => mergeAndLinkHistory(profile, main),
+		...spec.historyFiles.map(
+			(name) => () => mergeAndLinkHistory(profile, main, name),
+		),
 	];
 	for (const step of steps) {
 		try {
@@ -240,4 +279,23 @@ export function shareClaudeSessionState(
 			// Skipped entry; retried on the next switch to this profile.
 		}
 	}
+}
+
+export function shareClaudeSessionState(
+	configDir: string,
+	mainHome: string = join(homedir(), ".claude"),
+): void {
+	shareSessionState(configDir, mainHome, CLAUDE_SHARE);
+}
+
+/**
+ * The Codex twin of shareClaudeSessionState, so `codex resume` keeps working
+ * across an account switch. Without it a switch stranded every rollout in the
+ * home the previous account used.
+ */
+export function shareCodexSessionState(
+	codexHome: string,
+	mainHome: string = join(homedir(), ".codex"),
+): void {
+	shareSessionState(codexHome, mainHome, CODEX_SHARE);
 }

--- a/packages/host-service/src/trpc/router/usage/session-share.ts
+++ b/packages/host-service/src/trpc/router/usage/session-share.ts
@@ -37,7 +37,7 @@ import {
 	rmdirSync,
 	statSync,
 	symlinkSync,
-	unlinkSync,
+	writeFileSync,
 } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join, resolve } from "node:path";
@@ -88,6 +88,7 @@ const CODEX_SHARE: SessionShareSpec = {
 };
 
 const MERGE_SUFFIX = ".superset-merge";
+const HISTORY_OFFSET_SUFFIX = ".offset";
 
 /** Real path when the dir exists (a symlink alias of a protected dir must
  * compare equal to it), plain resolution otherwise. */
@@ -129,6 +130,21 @@ function lstatOrNull(path: string) {
 	}
 }
 
+/** Renames are only atomic within one filesystem. Check before swapping the
+ * profile path for a symlink: an EXDEV after that swap would hide the real
+ * session tree in the pending directory. */
+export function sameFilesystem(
+	left: string,
+	right: string,
+	deviceOf: (path: string) => number | bigint = (path) => statSync(path).dev,
+): boolean {
+	try {
+		return deviceOf(left) === deviceOf(right);
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Moves every file under `srcDir` into `dstDir`, creating dirs as needed.
  * Conflicts (a path that already exists in `dstDir`) are left behind in
@@ -157,10 +173,11 @@ function moveTreeInto(srcDir: string, dstDir: string): void {
 	}
 }
 
-function mergeAndLinkSessionDir(
+export function mergeAndLinkSessionDir(
 	profile: string,
 	main: string,
 	name: string,
+	onSameFilesystem: (left: string, right: string) => boolean = sameFilesystem,
 ): void {
 	const src = join(profile, name);
 	const dst = join(main, name);
@@ -169,6 +186,7 @@ function mergeAndLinkSessionDir(
 	// else — src may already be a symlink by now.
 	if (lstatOrNull(pending)?.isDirectory()) {
 		mkdirSync(dst, { recursive: true });
+		if (!onSameFilesystem(pending, dst)) return;
 		moveTreeInto(pending, dst);
 	}
 	const info = lstatOrNull(src);
@@ -177,6 +195,12 @@ function mergeAndLinkSessionDir(
 	mkdirSync(dst, { recursive: true });
 	if (!info) {
 		symlinkSync(dst, src);
+		return;
+	}
+	if (!onSameFilesystem(src, dst)) {
+		console.warn(
+			`[host-service] leaving ${src} unshared because ${dst} is on another filesystem`,
+		);
 		return;
 	}
 	// Swap first, merge after: the path is only ever missing for the instant
@@ -190,6 +214,61 @@ function mergeAndLinkSessionDir(
 		return;
 	}
 	moveTreeInto(pending, dst);
+}
+
+function historyPendingPaths(profile: string, name: string): string[] {
+	const prefix = `${name}${MERGE_SUFFIX}`;
+	return readdirSync(profile, { withFileTypes: true })
+		.filter((entry) => {
+			if (!entry.isFile()) return false;
+			if (entry.name === prefix) return true;
+			if (!entry.name.startsWith(`${prefix}-`)) return false;
+			return /^\d+$/.test(entry.name.slice(prefix.length + 1));
+		})
+		.map((entry) => join(profile, entry.name))
+		.sort();
+}
+
+function nextHistoryPendingPath(src: string): string {
+	const base = `${src}${MERGE_SUFFIX}`;
+	if (!lstatOrNull(base)) return base;
+	for (let generation = 1; ; generation += 1) {
+		const candidate = `${base}-${generation}`;
+		if (!lstatOrNull(candidate)) return candidate;
+	}
+}
+
+function readHistoryOffset(pending: string, length: number): number {
+	try {
+		const parsed = Number.parseInt(
+			readFileSync(`${pending}${HISTORY_OFFSET_SUFFIX}`, "utf8"),
+			10,
+		);
+		return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= length
+			? parsed
+			: 0;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Copies bytes not imported on an earlier provision, but deliberately keeps
+ * the renamed inode and cursor. A CLI may have opened the old history path
+ * immediately before the symlink swap; a later append then lands on that
+ * inode. Keeping it makes the late write durable, and the next host boot or
+ * account switch drains it instead of losing it to an unlink.
+ *
+ * Cursor updates happen after the append. A crash can therefore duplicate a
+ * record on retry, but can never advance past bytes that were not attempted.
+ */
+function drainPendingHistory(pending: string, dst: string): void {
+	const content = readFileSync(pending);
+	const offset = readHistoryOffset(pending, content.length);
+	appendHistoryRecords(dst, content.subarray(offset));
+	writeFileSync(`${pending}${HISTORY_OFFSET_SUFFIX}`, `${content.length}\n`, {
+		mode: 0o600,
+	});
 }
 
 /** Appends line-delimited records, inserting a newline first when the
@@ -226,19 +305,19 @@ function mergeAndLinkHistory(
 ): void {
 	const src = join(profile, name);
 	const dst = join(main, name);
-	const pending = `${src}${MERGE_SUFFIX}`;
-	if (lstatOrNull(pending)?.isFile()) {
-		appendHistoryRecords(dst, readFileSync(pending));
-		unlinkSync(pending);
+	mkdirSync(main, { recursive: true });
+	if (!lstatOrNull(dst)) appendFileSync(dst, "");
+	for (const pending of historyPendingPaths(profile, name)) {
+		drainPendingHistory(pending, dst);
 	}
 	const info = lstatOrNull(src);
 	if (info?.isSymbolicLink()) return;
 	if (info && !info.isFile()) return;
-	if (!lstatOrNull(dst)) appendFileSync(dst, "");
 	if (!info) {
 		symlinkSync(dst, src);
 		return;
 	}
+	const pending = nextHistoryPendingPath(src);
 	renameSync(src, pending);
 	try {
 		symlinkSync(dst, src);
@@ -246,8 +325,7 @@ function mergeAndLinkHistory(
 		renameSync(pending, src);
 		return;
 	}
-	appendHistoryRecords(dst, readFileSync(pending));
-	unlinkSync(pending);
+	drainPendingHistory(pending, dst);
 }
 
 /**

--- a/packages/host-service/src/trpc/router/usage/usage.ts
+++ b/packages/host-service/src/trpc/router/usage/usage.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { provisionCodexProfile } from "@superset/agent-setup";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { projects, workspaces } from "../../../db/schema";
@@ -11,7 +10,10 @@ import {
 } from "../../../workers/tasks/usage";
 import { protectedProcedure, queryProcedure, router } from "../../index";
 import { offLoop } from "../../off-loop";
-import { provisionClaudeAccount } from "./account-provisioning";
+import {
+	provisionClaudeAccount,
+	provisionCodexAccount,
+} from "./account-provisioning";
 import { fetchAgyAccounts } from "./agy-quota";
 import { fetchClaudeAccounts, readDefaultLoginEmail } from "./claude";
 import { fetchCodexAccounts } from "./codex";
@@ -163,7 +165,7 @@ export const usageRouter = router({
 				try {
 					await (input.agent === "claude"
 						? provisionClaudeAccount(input.selection)
-						: provisionCodexProfile(input.selection));
+						: provisionCodexAccount(input.selection));
 				} catch (error) {
 					console.warn(
 						`[host-service] provisioning ${input.agent} account ${input.selection} failed (continuing):`,
@@ -247,7 +249,7 @@ export const usageRouter = router({
 			}
 			await (input.agent === "claude"
 				? provisionClaudeAccount(input.selection)
-				: provisionCodexProfile(input.selection));
+				: provisionCodexAccount(input.selection));
 			return { success: true as const };
 		}),
 

--- a/packages/host-service/test/setup-env.ts
+++ b/packages/host-service/test/setup-env.ts
@@ -1,3 +1,8 @@
+// Isolates SUPERSET_HOME_DIR. `bun test` run inside this package reads this
+// bunfig, not the root one, so the guard has to be re-entered here — and this
+// package is where the pointer writers live.
+import "../../../scripts/test-preload.ts";
+
 // Populate the env vars `src/env.ts` validates at module load so test runtimes
 // that boot host-service via `createApp` (instead of `serve.ts`) can import
 // modules that transitively load the validated env. Real values come from

--- a/packages/host-service/test/superset-home-isolation.test.ts
+++ b/packages/host-service/test/superset-home-isolation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Canary for scripts/test-preload.ts. This file deliberately sets nothing up:
+ * if the preload is dropped from a bunfig, or a run loads this package's tests
+ * without it, these fail instead of the suite quietly writing the developer's
+ * real ~/.superset — which is how the default agent-account pointers got
+ * clobbered before (see scripts/test-preload.ts).
+ */
+describe("Superset home isolation", () => {
+	it("points SUPERSET_HOME_DIR somewhere other than the real home", () => {
+		const isolated = process.env.SUPERSET_HOME_DIR;
+		expect(isolated).toBeTruthy();
+		expect(resolve(isolated as string)).not.toBe(
+			resolve(join(homedir(), ".superset")),
+		);
+	});
+
+	it("resolves the account pointer dir inside the isolated home", async () => {
+		const { syncDefaultAccountPointer } = await import(
+			"../src/trpc/router/usage/default-account.ts"
+		);
+		syncDefaultAccountPointer("codex", null);
+		const { existsSync } = await import("node:fs");
+		expect(
+			existsSync(
+				join(
+					process.env.SUPERSET_HOME_DIR as string,
+					"state",
+					"default-codex-home",
+				),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/host-service/test/superset-home-isolation.test.ts
+++ b/packages/host-service/test/superset-home-isolation.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "bun:test";
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+
+function canonical(target: string): string {
+	try {
+		return realpathSync(target);
+	} catch {
+		return resolve(target);
+	}
+}
 
 /**
  * Canary for scripts/test-preload.ts. This file deliberately sets nothing up:
@@ -12,13 +21,21 @@ import { join, resolve } from "node:path";
 describe("Superset home isolation", () => {
 	function requireIsolatedHome(): string {
 		const isolated = process.env.SUPERSET_HOME_DIR;
+		const preloadHome = Reflect.get(
+			globalThis,
+			Symbol.for("superset.test.supersetHome"),
+		);
+		if (!isolated || typeof preloadHome !== "string") {
+			throw new Error("SUPERSET_HOME_DIR is not isolated for tests");
+		}
+		const canonicalHome = canonical(isolated);
 		if (
-			!isolated ||
-			resolve(isolated) === resolve(join(homedir(), ".superset"))
+			canonicalHome !== canonical(preloadHome) ||
+			canonicalHome === canonical(join(homedir(), ".superset"))
 		) {
 			throw new Error("SUPERSET_HOME_DIR is not isolated for tests");
 		}
-		return isolated;
+		return canonicalHome;
 	}
 
 	it("points SUPERSET_HOME_DIR somewhere other than the real home", () => {

--- a/packages/host-service/test/superset-home-isolation.test.ts
+++ b/packages/host-service/test/superset-home-isolation.test.ts
@@ -10,28 +10,33 @@ import { join, resolve } from "node:path";
  * clobbered before (see scripts/test-preload.ts).
  */
 describe("Superset home isolation", () => {
-	it("points SUPERSET_HOME_DIR somewhere other than the real home", () => {
+	function requireIsolatedHome(): string {
 		const isolated = process.env.SUPERSET_HOME_DIR;
-		expect(isolated).toBeTruthy();
-		expect(resolve(isolated as string)).not.toBe(
-			resolve(join(homedir(), ".superset")),
-		);
+		if (
+			!isolated ||
+			resolve(isolated) === resolve(join(homedir(), ".superset"))
+		) {
+			throw new Error("SUPERSET_HOME_DIR is not isolated for tests");
+		}
+		return isolated;
+	}
+
+	it("points SUPERSET_HOME_DIR somewhere other than the real home", () => {
+		expect(requireIsolatedHome()).toBeTruthy();
 	});
 
 	it("resolves the account pointer dir inside the isolated home", async () => {
+		// Validate before importing or calling the pointer writer. If the preload
+		// disappears, this canary must fail without reproducing the real-home
+		// clobber it exists to prevent.
+		const isolated = requireIsolatedHome();
 		const { syncDefaultAccountPointer } = await import(
 			"../src/trpc/router/usage/default-account.ts"
 		);
 		syncDefaultAccountPointer("codex", null);
 		const { existsSync } = await import("node:fs");
-		expect(
-			existsSync(
-				join(
-					process.env.SUPERSET_HOME_DIR as string,
-					"state",
-					"default-codex-home",
-				),
-			),
-		).toBe(true);
+		expect(existsSync(join(isolated, "state", "default-codex-home"))).toBe(
+			true,
+		);
 	});
 });

--- a/packages/ui/test-setup.ts
+++ b/packages/ui/test-setup.ts
@@ -8,6 +8,7 @@
  * component tests keep asserting the source copy. Mirrors
  * `apps/desktop/test-setup.ts`.
  */
+import "../../scripts/test-preload.ts";
 import { mock } from "bun:test";
 
 type MessageDescriptor = {

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -1,0 +1,35 @@
+/**
+ * Test preload: give every test run its own Superset home.
+ *
+ * Production code resolves `~/.superset` from `SUPERSET_HOME_DIR` (see
+ * agent-setup's resolveSupersetHomeDir and the mirror in the usage router's
+ * default-account.ts). A test that calls such code with the variable unset
+ * writes to the developer's REAL home. That is not hypothetical: the default
+ * agent-account tests wrote `$TMPDIR` into the live
+ * `~/.superset/state/default-codex-home` pointer, which every Superset
+ * terminal and agent launch then injected as `CODEX_HOME`, so Codex ran
+ * signed out with none of its session history and re-logins landed in a
+ * directory macOS periodically purges.
+ *
+ * Setting it here — before any test module loads — makes that whole class of
+ * accident impossible rather than something each test file has to remember.
+ *
+ * The override is unconditional, and that is the point. Every Superset
+ * terminal exports `SUPERSET_HOME_DIR=~/.superset`, and that is where the
+ * team runs `bun test`, so the variable is not merely unset-and-forgotten —
+ * it arrives already aimed at the real home. A `??=` default would be a
+ * no-op in exactly the environment that needs it. Tests wanting a specific
+ * home still set one in their own `beforeEach`, which runs after this.
+ *
+ * Loaded from the root bunfig.toml and re-entered by each package preload
+ * that has one; `test/superset-home-isolation.test.ts` fails loudly if a run
+ * ever loses it.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.SUPERSET_HOME_DIR = mkdtempSync(
+	join(tmpdir(), "superset-test-home-"),
+);

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -33,6 +33,11 @@ import { join } from "node:path";
 
 const testSupersetHome = mkdtempSync(join(tmpdir(), "superset-test-home-"));
 process.env.SUPERSET_HOME_DIR = testSupersetHome;
+Reflect.set(
+	globalThis,
+	Symbol.for("superset.test.supersetHome"),
+	testSupersetHome,
+);
 
 // Test processes are short-lived, but a full local run creates enough state
 // here to make relying on the OS's eventual temp cleanup needlessly noisy.

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -26,10 +26,28 @@
  * ever loses it.
  */
 
-import { mkdtempSync } from "node:fs";
+import { afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-process.env.SUPERSET_HOME_DIR = mkdtempSync(
-	join(tmpdir(), "superset-test-home-"),
-);
+const testSupersetHome = mkdtempSync(join(tmpdir(), "superset-test-home-"));
+process.env.SUPERSET_HOME_DIR = testSupersetHome;
+
+// Test processes are short-lived, but a full local run creates enough state
+// here to make relying on the OS's eventual temp cleanup needlessly noisy.
+// The exit hook is synchronous because Node/Bun cannot await async work once
+// process shutdown has begun; best-effort cleanup must never mask test status.
+function cleanupTestSupersetHome(): void {
+	try {
+		rmSync(testSupersetHome, { recursive: true, force: true });
+	} catch {
+		// The temp directory may already have been removed by a test.
+	}
+}
+
+// Bun's test runner does not consistently emit Node's process exit event, so
+// use its lifecycle hook as the primary cleanup and retain exit as a fallback
+// for alternate runners that load the same preload.
+afterAll(cleanupTestSupersetHome);
+process.once("exit", cleanupTestSupersetHome);


### PR DESCRIPTION
Reported as "logins aren't working as expected and sessions access aren't transferred when switching account, same with codex". It turned out not to be a Usage-tab bug. The tab was showing the truth and agents were running somewhere else entirely.

## What was happening

`agents.test.ts`'s `buildTerminalAgentLaunch default account env` block called `setDefaultAccountSelection` with a throwaway in-memory DB but no `SUPERSET_HOME_DIR` isolation. `syncDefaultAccountPointer` resolves the real home, so running the host-service suite wrote the developer's live `~/.superset/state/`:

| pointer | value the tests left behind |
|---|---|
| `default-codex-home` | `$TMPDIR` (from `existingDir = tmpdir()`) |
| `default-claude-config-dir` | empty (the last case sets claude to `null`) |

Every Superset terminal and agent launch injects that codex pointer as `CODEX_HOME`. On the reporting machine:

- `~/.superset/state/default-codex-home` was `/var/folders/…/T` while the org DB's `host_settings` row was null for both. The UI writes DB and pointer together, so the two disagreeing is what proved this was a direct pointer write rather than anything a user did.
- Live terminals were exporting `CODEX_HOME=/var/folders/…/T`.
- `$TMPDIR/auth.json` existed with a valid token: a real `codex login`, done because Codex looked signed out, landing in a directory macOS periodically purges.
- `$TMPDIR/sessions` held 3 rollouts against `~/.codex/sessions`' 1697. That is the missing session access.

The Claude pointer being blanked is the other half: a selected Claude account silently reverts to the system login.

## Changes

**1. Tests can no longer write the real `~/.superset`** (`scripts/test-preload.ts`)

Every test run gets its own Superset home, wired in from the root `bunfig.toml` and re-entered by the host-service preload, since a package-local `bun test` reads that bunfig rather than the root one.

The override is unconditional and that is the point. Superset terminals already export `SUPERSET_HOME_DIR=~/.superset`, and that is where we run tests, so the variable is not unset-and-forgotten, it arrives already aimed at the real home. A `??=` default is a no-op in exactly the environment that needs it. I found this because the canary caught my first attempt.

`test/superset-home-isolation.test.ts` is that canary and fails if a run ever loses the preload. The offending describe block also gets a per-test home, which makes those cases independent rather than sharing one pointer file.

**2. We no longer trust our own injected `CODEX_HOME`** (`resolveAmbientCodexHome`)

`discoverCodexHomes` and `defaultCodexHome` both read `process.env.CODEX_HOME` to decide which home Codex uses with no override, and anything started from a Superset terminal inherits our injected value, a host-service restarted from one included. That is circular: the selected profile masquerades as the system default, so `fetchCodexAccounts` labels it `selection: null` and dedupes the real default away, and provisioning shares config out of the profile into itself.

It also let an unvalidated env value become a selectable account. The default entry skips the `auth.json` check every other candidate gets, so `setDefaultAccount`'s "only accept a discovered login" guard vouched for it. A user-set `CODEX_HOME` is still honoured; only one equal to `SUPERSET_DEFAULT_CODEX_HOME` is ignored.

**3. Codex gets session sharing** (`shareCodexSessionState`)

Claude profiles had `shareClaudeSessionState`; Codex had nothing, so a switch stranded every rollout in the previous account's home and `codex resume` came up empty. This is the second half of the report and a real gap independent of the pointer bug.

`session-share.ts` is now provider-agnostic via `SessionShareSpec`. Codex shares `sessions/`, `archived_sessions/`, `shell_snapshots/` and `history.jsonl`. Rollouts are keyed by date, so two accounts interleave in one tree exactly as two same-day sessions already do. `auth.json` stays per-account; `config.toml` / `AGENTS.md` / `prompts/` stay with agent-setup's ledger since they are rewritten tmp-then-rename and would fork through a symlink.

## Verification

- host-service **1447 pass, 0 fail** (145 files); agent-setup **272 pass, 0 fail**. Typecheck, biome and sherif clean.
- A full host-service run now leaves the real pointers byte-identical with unchanged mtimes. Before this, the same run rewrote them.
- The guard is load-bearing: with the preload stubbed out, the canary fails.
- The new tests can fail: emptying `CODEX_SHARE.dirs` reds 2 of the Codex share tests, and restoring the old unconditional env trust reds the circularity test.

## Not covered here

- A default pointer naming a dir that matches no discovered account is invisible in the UI. `getQuota` marks `isDefault` by equality, so a stale value shows zero accounts as default with no way to see or clear it. That is why the tab showed a healthy `~/.codex` with no default marker.
- If the pointer file is absent, every org host-service races `migrateDefaultAccountPointer` with its own legacy `host_settings` value and first-to-link wins host-wide.
- `profile-remove.ts:26` still protects the raw `process.env.CODEX_HOME`, which errs safe but can block removing a legitimate profile.

Anyone who ran the host-service suite has the bad pointers on disk. Re-pick the Claude account in the Usage tab; Codex returns to `~/.codex` once `default-codex-home` is empty or repointed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops host-service tests from clobbering the real `~/.superset` account pointers, which left Codex signed out with no session history, and lets Codex sessions survive an account switch.

**Bug Fixes**
- Every test run gets an isolated `SUPERSET_HOME_DIR` via a preload script; a canary test fails if that isolation is lost.
- Superset's own injected `CODEX_HOME` is no longer trusted as the system default — the real ambient home is preserved in `SUPERSET_AMBIENT_CODEX_HOME` and restored when the system default is selected, so the selected profile can't masquerade as it.
- Removing a Codex profile Superset injected is no longer blocked as if it were the system default.
- Session sharing no longer defaults its target home, and only swaps a session tree when both homes sit on one filesystem.
- History merges keep a cursor, so a late append through an fd opened before the swap drains on the next provision, in capture-generation order; a log the CLI replaced outright is re-linked.
- If you ran the host-service suite, `~/.superset/state/default-codex-home` may point at a temp dir; clearing it (or re-picking the Claude account in the Usage tab) returns Codex to `~/.codex`.

**New Features**
- `shareCodexSessionState` symlink-merges `sessions/`, `archived_sessions/`, `shell_snapshots/`, and `history.jsonl` into the default Codex home so `codex resume` works across accounts, matching Claude's existing sharing.

<sup>Written for commit a301de2ba5170eb2b82cf02232121cbf1b022703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex session sharing, preserving rollout data and prompt history across configured accounts.
  * Improved Codex home detection with support for user overrides, custom defaults, and safer fallbacks.

* **Bug Fixes**
  * Preserved credentials and existing history during account setup.
  * Prevented unsafe session merges across different filesystems.
  * Restored session data reliably after cross-filesystem recovery.
  * Isolated automated tests from the local Superset home directory and cleaned up temporary data.

* **Tests**
  * Added coverage for Codex home resolution, session sharing, account provisioning, profile removal, and test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->