### PR TITLE
feat(agents): offer Codex's max and ultra reasoning efforts

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -1,6 +1,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	getAgentEffortSupport,
+	getAgentEfforts,
 	getAgentModelSupport,
 	getAgentModeSupport,
 } from "@superset/shared/agent-models";
@@ -214,6 +215,21 @@ export function PromptGroup({
 		EFFORT_STORAGE_KEY,
 		effortSupport ? selectedPresetId : null,
 	);
+	// Codex's top two efforts only exist on its GPT-5.6 models, so the offered
+	// list follows the model picker. A remembered effort the current model
+	// rejects stays stored but shows (and launches) as the agent default.
+	const effortOptions = useMemo(
+		() =>
+			selectedPresetId
+				? getAgentEfforts(selectedPresetId, selectedModel ?? undefined)
+				: [],
+		[selectedPresetId, selectedModel],
+	);
+	const effortForLaunch = effortOptions.some(
+		(option) => option.id === selectedEffort,
+	)
+		? selectedEffort
+		: null;
 	const modeSupport = selectedPresetId
 		? getAgentModeSupport(selectedPresetId)
 		: undefined;
@@ -374,7 +390,7 @@ export function PromptGroup({
 		projectId,
 		selectedAgent,
 		modelSupport ? selectedModel : null,
-		effortSupport ? selectedEffort : null,
+		effortForLaunch,
 		modeSupport ? selectedMode : null,
 		uploadAttachments,
 		promptContext,
@@ -649,7 +665,7 @@ export function PromptGroup({
 						)}
 						{effortSupport && (
 							<AgentModelSelect
-								models={effortSupport.efforts}
+								models={effortOptions}
 								value={selectedEffort}
 								onValueChange={setSelectedEffort}
 								defaultLabel={t({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -1,6 +1,7 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
 	getAgentEffortSupport,
+	getAgentEfforts,
 	getAgentModelSupport,
 	getAgentModeSupport,
 } from "@superset/shared/agent-models";
@@ -488,6 +489,21 @@ export function NewWorkspaceScreen({
 		EFFORT_STORAGE_KEY,
 		effortSupport ? selectedPresetId : null,
 	);
+	// Codex's top two efforts only exist on its GPT-5.6 models, so the offered
+	// list follows the model picker. A remembered effort the current model
+	// rejects stays stored but shows (and launches) as the agent default.
+	const effortOptions = useMemo(
+		() =>
+			selectedPresetId
+				? getAgentEfforts(selectedPresetId, selectedModel ?? undefined)
+				: [],
+		[selectedPresetId, selectedModel],
+	);
+	const effortForLaunch = effortOptions.some(
+		(option) => option.id === selectedEffort,
+	)
+		? selectedEffort
+		: null;
 	const modeSupport = selectedPresetId
 		? getAgentModeSupport(selectedPresetId)
 		: undefined;
@@ -535,7 +551,7 @@ export function NewWorkspaceScreen({
 		projectId,
 		selectedAgent,
 		modelSupport ? selectedModel : null,
-		effortSupport ? selectedEffort : null,
+		effortForLaunch,
 		modeSupport ? selectedMode : null,
 		uploadAttachments,
 		promptContext,
@@ -888,7 +904,7 @@ export function NewWorkspaceScreen({
 								)}
 								{effortSupport && (
 									<AgentModelSelect
-										models={effortSupport.efforts}
+										models={effortOptions}
 										value={selectedEffort}
 										onValueChange={setSelectedEffort}
 										defaultLabel={t({

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -685,13 +685,27 @@ describe("validateAgentEffortSelection", () => {
 
 	it("rejects an invalid effort with the supported values", () => {
 		try {
-			validateAgentEffortSelection("codex", "Codex", "max");
+			validateAgentEffortSelection("codex", "Codex", "extreme");
 			throw new Error("Expected validation to fail");
 		} catch (error) {
 			expect(error).toBeInstanceOf(TRPCError);
 			expect((error as TRPCError).code).toBe("BAD_REQUEST");
 			expect((error as Error).message).toBe(
-				'Unsupported reasoning effort "max" for Codex. Choose one of: low, medium, high, xhigh.',
+				'Unsupported reasoning effort "extreme" for Codex. Choose one of: low, medium, high, xhigh, max, ultra.',
+			);
+		}
+	});
+
+	it("rejects an effort the selected model does not accept", () => {
+		expect(() =>
+			validateAgentEffortSelection("codex", "Codex", "ultra", "gpt-5.6-sol"),
+		).not.toThrow();
+		try {
+			validateAgentEffortSelection("codex", "Codex", "ultra", "gpt-5.5");
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect((error as Error).message).toBe(
+				'Unsupported reasoning effort "ultra" for Codex with model gpt-5.5. Choose one of: low, medium, high, xhigh.',
 			);
 		}
 	});

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -5,6 +5,7 @@ import {
 	buildAgentModelArgs,
 	buildAgentModelEnv,
 	getAgentEffortSupport,
+	getAgentEfforts,
 	getAgentModelSupport,
 	getAgentModeSupport,
 	resolveAgentLaunchPresetId,
@@ -262,6 +263,7 @@ export function validateAgentEffortSelection(
 	presetId: string,
 	label: string,
 	effort: string | undefined,
+	model?: string,
 ): void {
 	if (!effort) return;
 
@@ -273,10 +275,13 @@ export function validateAgentEffortSelection(
 		});
 	}
 
-	if (!support.efforts.some((option) => option.id === effort)) {
+	// Some efforts only exist on some of the agent's models (Codex's max and
+	// ultra need GPT-5.6), so the accepted set follows the selected model.
+	const efforts = getAgentEfforts(presetId, model);
+	if (!efforts.some((option) => option.id === effort)) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
-			message: `Unsupported reasoning effort "${effort}" for ${label}. Choose one of: ${support.efforts.map((option) => option.id).join(", ")}.`,
+			message: `Unsupported reasoning effort "${effort}" for ${label}${model ? ` with model ${model}` : ""}. Choose one of: ${efforts.map((option) => option.id).join(", ")}.`,
 		});
 	}
 }
@@ -421,7 +426,12 @@ export function validateAgentLaunchOptions(
 		config.command,
 	);
 	validateAgentModelSelection(launchPresetId, config.label, input.model);
-	validateAgentEffortSelection(launchPresetId, config.label, input.effort);
+	validateAgentEffortSelection(
+		launchPresetId,
+		config.label,
+		input.effort,
+		input.model,
+	);
 	validateAgentModeSelection(launchPresetId, config.label, input.mode);
 }
 
@@ -450,7 +460,12 @@ export function buildTerminalAgentLaunch(
 		config.command,
 	);
 	validateAgentModelSelection(launchPresetId, config.label, input.model);
-	validateAgentEffortSelection(launchPresetId, config.label, input.effort);
+	validateAgentEffortSelection(
+		launchPresetId,
+		config.label,
+		input.effort,
+		input.model,
+	);
 	validateAgentModeSelection(launchPresetId, config.label, input.mode);
 	// Ahead of the per-field validators: passing both is its own mistake, and
 	// "this agent cannot fork" would send the caller after the wrong one.
@@ -478,7 +493,11 @@ export function buildTerminalAgentLaunch(
 
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
 	const modelArgs = buildAgentModelArgs(launchPresetId, input.model);
-	const effortArgs = buildAgentEffortArgs(launchPresetId, input.effort);
+	const effortArgs = buildAgentEffortArgs(
+		launchPresetId,
+		input.effort,
+		input.model,
+	);
 	const modeArgs = buildAgentModeArgs(launchPresetId, input.mode);
 	const command = buildAgentCommandString(
 		config,

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -8,6 +8,7 @@ import {
 	buildAgentModelArgs,
 	buildAgentModelEnv,
 	getAgentEffortSupport,
+	getAgentEfforts,
 	getAgentModelSupport,
 	getAgentModeSupport,
 	resolveAgentLaunchPresetId,
@@ -321,6 +322,52 @@ describe("buildAgentEffortArgs", () => {
 	it("returns [] for effort ids outside the preset's curated list", () => {
 		expect(buildAgentEffortArgs("claude", "bogus")).toEqual([]);
 		expect(buildAgentEffortArgs("copilot", "max")).toEqual([]);
+	});
+
+	it("drops an effort the selected model does not accept", () => {
+		expect(buildAgentEffortArgs("codex", "ultra", "gpt-5.6-sol")).toEqual([
+			"-c",
+			"model_reasoning_effort=ultra",
+		]);
+		expect(buildAgentEffortArgs("codex", "ultra", "gpt-5.5")).toEqual([]);
+	});
+});
+
+describe("getAgentEfforts", () => {
+	it("offers codex's top efforts only alongside the models that take them", () => {
+		expect(getAgentEfforts("codex", "gpt-5.6-sol").map((e) => e.id)).toEqual([
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+			"ultra",
+		]);
+		expect(getAgentEfforts("codex", "gpt-5.6-luna").map((e) => e.id)).toEqual([
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
+		]);
+		expect(getAgentEfforts("codex", "gpt-5.5").map((e) => e.id)).toEqual([
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+		]);
+	});
+
+	it("keeps the full list when the model is unset or uncurated", () => {
+		// Both launch on the agent's own default model.
+		expect(getAgentEfforts("codex").map((e) => e.id)).toContain("ultra");
+		expect(getAgentEfforts("codex", "gpt-9").map((e) => e.id)).toContain(
+			"ultra",
+		);
+	});
+
+	it("returns [] for presets without effort support", () => {
+		expect(getAgentEfforts("gemini")).toEqual([]);
 	});
 });
 

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -221,6 +221,16 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 	},
 ];
 
+export interface AgentEffortOption extends AgentModelOption {
+	/**
+	 * Model ids that accept this effort, when only some do. Absent means every
+	 * model the agent offers takes it. Codex's two top levels arrived with
+	 * GPT-5.6 and the models below it reject them, so the picker only offers
+	 * them next to a model that has them.
+	 */
+	models?: readonly string[];
+}
+
 export interface AgentEffortSupport {
 	presetId: string;
 	effortFlag: string;
@@ -230,7 +240,7 @@ export interface AgentEffortSupport {
 	 * `-c model_reasoning_effort=high`.
 	 */
 	effortValuePrefix?: string;
-	efforts: AgentModelOption[];
+	efforts: AgentEffortOption[];
 }
 
 export interface AgentModeOption extends AgentModelOption {
@@ -293,6 +303,16 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 			{ id: "medium", label: "Medium" },
 			{ id: "high", label: "High" },
 			{ id: "xhigh", label: "xHigh" },
+			// Per-model support taken from Codex's own model catalog
+			// (`supported_reasoning_levels`, codex-cli 0.149.1): every GPT-5.6
+			// model takes `max`, and `ultra` — max reasoning plus automatic
+			// task delegation — is Sol and Terra only.
+			{
+				id: "max",
+				label: "Max",
+				models: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+			},
+			{ id: "ultra", label: "Ultra", models: ["gpt-5.6-sol", "gpt-5.6-terra"] },
 		],
 	},
 	{
@@ -375,19 +395,44 @@ export function getAgentModeSupport(
 }
 
 /**
+ * Efforts the given preset offers for `model` — the full curated list minus
+ * any option the selected model rejects. An unset model (or an id outside the
+ * curated catalog, which `buildAgentModelArgs` drops so the launch runs the
+ * agent's own default) keeps the full list.
+ */
+export function getAgentEfforts(
+	presetId: string,
+	model?: string,
+): AgentEffortOption[] {
+	const support = getAgentEffortSupport(presetId);
+	if (!support) return [];
+	const selected = getAgentModelSupport(presetId)?.models.some(
+		(option) => option.id === model,
+	)
+		? model
+		: undefined;
+	return support.efforts.filter(
+		(effort) => !effort.models || !selected || effort.models.includes(selected),
+	);
+}
+
+/**
  * Argv tokens that select `effort` for the given preset, e.g.
  * `["--effort", "high"]` (codex: `["-c", "model_reasoning_effort=high"]`).
- * Same degrade-to-default contract as `buildAgentModelArgs`: unknown presets
- * or effort ids outside the curated list return `[]`.
+ * Same degrade-to-default contract as `buildAgentModelArgs`: unknown presets,
+ * effort ids outside the curated list, and efforts the selected model rejects
+ * return `[]`.
  */
 export function buildAgentEffortArgs(
 	presetId: string,
 	effort: string | undefined,
+	model?: string,
 ): string[] {
 	if (!effort) return [];
 	const support = getAgentEffortSupport(presetId);
 	if (!support) return [];
-	if (!support.efforts.some((option) => option.id === effort)) return [];
+	const efforts = getAgentEfforts(presetId, model);
+	if (!efforts.some((option) => option.id === effort)) return [];
 	return [support.effortFlag, `${support.effortValuePrefix ?? ""}${effort}`];
 }
 


### PR DESCRIPTION
The Codex effort picker in the new-workspace modal stopped at xhigh, so the two levels above it were unreachable even though codex-cli has accepted them for several releases.

They are not available on every model, which is why they arrive with a restriction rather than as two more flat entries. Codex's own model catalog (`supported_reasoning_levels` in `models_cache.json`) says:

| model | top level |
| --- | --- |
| gpt-5.6-sol, gpt-5.6-terra | `ultra` |
| gpt-5.6-luna | `max` |
| gpt-5.5, gpt-5.4 | `xhigh` |

The CLI does not police the pairing — `-c model_reasoning_effort=ultra` with `--model gpt-5.5` launches happily and dies on the first turn, which in a workspace means an agent that looks started and never answers.

So an effort option can now name the models that accept it, and the offered set follows the model picker. Absent `models` means every model takes it, which is every other entry in the catalog. An unset model keeps the full list — the launch omits `--model` and runs whatever default the CLI resolves — and so does an id outside the curated catalog, which `buildAgentModelArgs` already drops for the same reason.

A remembered effort the current model rejects stays in localStorage but reads as "Default effort" and launches as one, so switching from Sol to GPT-5.5 downgrades visibly instead of sending `ultra` along. The host validates the pair too, so `superset agents create --effort ultra --model gpt-5.5` gets the supported list back rather than a broken session.

Both new-workspace surfaces (the compact prompt group and the full screen) read the same list.

## Verification

biome, typecheck (shared, host-service, desktop), and the full suites for every touched package: shared 907 pass, host-service 1440 pass, desktop 3238 pass. Per-model gating and the launch-arg drop are covered by new tests in `agent-models.test.ts` and `agents.test.ts`; the host-service case that pinned `"max"` as an *invalid* Codex effort now uses `"extreme"`.

https://claude.ai/code/session_01JQ34D61zccarfUjbmdh477


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Codex's max and ultra reasoning efforts to the new-workspace modal, gated per model so unsupported combinations can't launch a broken agent.

- Effort options can now declare which models accept them; the offered set follows the model picker.
- Host validation and launch-arg building both reject an effort the selected model does not accept.
- A remembered effort the current model rejects is read as "Default effort" and launches as the default.

<sup>Written for commit 177cd70c7a4fa4708b2952634a6e25219c5dbd2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Effort options now adapt to the selected agent and model.
  - Added support for additional model-specific effort levels, including `max` and `ultra` where available.
  - Unsupported effort selections automatically fall back to the agent’s default.

- **Bug Fixes**
  - Prevented unsupported effort values from being submitted during workspace launches.
  - Improved validation messages to identify model-specific limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->