### PR TITLE
fix(host-service): bind a resumed agent session's id at launch

### DIFF
--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -9,8 +9,10 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../../../db";
 import * as schema from "../../../db/schema";
+import { TerminalAgentStore } from "../../../terminal-agents";
 import { setDefaultAccountSelection } from "../usage/default-account";
 import {
+	bindResumedSession,
 	buildAgentCommandString,
 	buildTerminalAgentLaunch,
 	validateAgentEffortSelection,
@@ -733,5 +735,96 @@ describe("validateAgentModeSelection", () => {
 		expect(() =>
 			validateAgentModeSelection("claude", "Claude", "plan"),
 		).toThrow("Claude does not support a launch mode override");
+	});
+});
+
+describe("bindResumedSession", () => {
+	function seedCodexConfig(db: HostDb) {
+		db.insert(schema.hostAgentConfigs)
+			.values({
+				id: "00000000-0000-0000-0000-00000000000c",
+				presetId: "codex",
+				label: "Codex",
+				command: "codex",
+				argsJson: "[]",
+				promptTransport: "argv",
+				promptArgsJson: JSON.stringify(["--"]),
+				resumeArgsJson: JSON.stringify(["resume"]),
+				forkArgsJson: JSON.stringify(["fork", "{sessionId}"]),
+				envJson: "{}",
+				displayOrder: 0,
+			})
+			.run();
+	}
+
+	const WORKSPACE_ID = "11111111-1111-1111-1111-111111111111";
+	const TERMINAL_ID = "22222222-2222-2222-2222-222222222222";
+
+	it("binds the resumed session id without waiting for a hook", () => {
+		const db = createTestDb();
+		seedCodexConfig(db);
+		const store = new TerminalAgentStore();
+
+		bindResumedSession(
+			{ db, terminalAgentStore: store },
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "codex",
+				prompt: "",
+				resumeSessionId: "01a058a7-3990-7921-bb87-66c7370b999e",
+			},
+			TERMINAL_ID,
+		);
+
+		expect(store.list()).toMatchObject([
+			{
+				terminalId: TERMINAL_ID,
+				agentId: "codex",
+				agentSessionId: "01a058a7-3990-7921-bb87-66c7370b999e",
+				lastEventType: "Attached",
+			},
+		]);
+	});
+
+	it("leaves a fresh (non-resumed) launch unbound", () => {
+		const db = createTestDb();
+		seedCodexConfig(db);
+		const store = new TerminalAgentStore();
+
+		bindResumedSession(
+			{ db, terminalAgentStore: store },
+			{ workspaceId: WORKSPACE_ID, agent: "codex", prompt: "go" },
+			TERMINAL_ID,
+		);
+
+		expect(store.list()).toEqual([]);
+	});
+
+	it("keeps the bound id when the wrapper's launch report arrives without one", () => {
+		const db = createTestDb();
+		seedCodexConfig(db);
+		const store = new TerminalAgentStore();
+
+		bindResumedSession(
+			{ db, terminalAgentStore: store },
+			{
+				workspaceId: WORKSPACE_ID,
+				agent: "codex",
+				prompt: "",
+				resumeSessionId: "01a058a7-3990-7921-bb87-66c7370b999e",
+			},
+			TERMINAL_ID,
+		);
+		store.recordEvent({
+			terminalId: TERMINAL_ID,
+			workspaceId: WORKSPACE_ID,
+			eventType: "Attached",
+			agentId: "codex",
+			occurredAt: Date.now(),
+		});
+
+		expect(store.list()[0]?.agentSessionId).toBe(
+			"01a058a7-3990-7921-bb87-66c7370b999e",
+		);
 	});
 });

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -1,3 +1,4 @@
+import { isBuiltinAgentId } from "@superset/shared/agent-catalog";
 import { FORK_SESSION_ID_TOKEN } from "@superset/shared/agent-definition";
 import {
 	buildAgentEffortArgs,
@@ -499,8 +500,37 @@ export function buildTerminalAgentLaunch(
 	};
 }
 
+/**
+ * Bind a resumed session's id to its fresh terminal at launch instead of
+ * waiting for a hook. Harnesses differ on when they first report a session
+ * id: Claude's SessionStart fires at launch, but Codex's TUI fires nothing
+ * until the first turn (verified on codex-cli 0.151), so a resumed pane the
+ * user has not prompted yet would carry no id — and dying again would leave
+ * its restored conversation with no resume candidate. `codex resume <id>`
+ * keeps the same rollout id, so the id we launched with is the id to bind.
+ * Forks are excluded: they mint a new session id we cannot know here.
+ */
+export function bindResumedSession(
+	ctx: Pick<HostServiceContext, "db" | "terminalAgentStore">,
+	input: AgentRunInput,
+	terminalId: string,
+): void {
+	if (!input.resumeSessionId) return;
+	const presetId = resolveHostAgentConfig(ctx.db, input.agent)?.presetId;
+	if (!presetId || !isBuiltinAgentId(presetId)) return;
+
+	ctx.terminalAgentStore.recordEvent({
+		terminalId,
+		workspaceId: input.workspaceId,
+		eventType: "Attached",
+		agentId: presetId,
+		agentSessionId: input.resumeSessionId,
+		occurredAt: Date.now(),
+	});
+}
+
 async function runTerminalAgent(
-	ctx: { db: HostDb; eventBus: import("../../../events").EventBus },
+	ctx: Pick<HostServiceContext, "db" | "eventBus" | "terminalAgentStore">,
 	input: AgentRunInput,
 ): Promise<AgentRunResult> {
 	const { fullCommand, label } = buildTerminalAgentLaunch(ctx.db, input);
@@ -517,6 +547,8 @@ async function runTerminalAgent(
 	if ("error" in result) {
 		throw toTerminalSessionError(result);
 	}
+
+	bindResumedSession(ctx, input, result.terminalId);
 
 	return {
 		kind: "terminal",


### PR DESCRIPTION
## Summary
- Auto-resume for Codex was effectively single-shot. A codex pane that auto-resumed carried no `agentSessionId`, so if it died again before the user's next prompt, its restored conversation had no resume candidate and no "Resuming Codex…" pill.
- `runTerminalAgent` now binds the session id it just launched with, instead of waiting for a lifecycle hook to report one.

## Why / Context
A terminal becomes a resume candidate only if its agent binding carries an `agentSessionId`, and that id arrives from a lifecycle hook. Harnesses disagree on when they first send one:

- Claude's `SessionStart` fires at launch, so claude bindings carry an id from `Attached` onward.
- Codex's TUI fires nothing until the first turn. Verified on codex-cli 0.151: an idle TUI under a real pty in a trusted worktree, watched for 25s, delivered exactly one event, the wrapper's own synthetic launch report, with `"sessionId": ""`. (`codex exec` does fire `SessionStart` with the real id; only the TUI defers.)

Bindings on my machine show the split:

```
claude   Attached  has-id      codex     Attached  NO-ID
claude   Start     has-id      codex     Start     NO-ID
claude   Stop      has-id      codex     Stop      has-id
```

The resumed-pane case is the one that loses real work: the host launched that terminal with `resume <id>`, so it knew the id, and then dropped it.

## How It Works
`bindResumedSession` records an `Attached` event into the `TerminalAgentStore` right after the terminal is created, carrying `input.resumeSessionId`.

- Only on resume. Forks mint a new provider-side id we cannot know at launch, so they are excluded.
- Only for builtin preset ids, since `TerminalAgentId` cannot hold a custom slug.
- `Attached`, not `Start`, so the seed reads as session liveness and does not fake working state. The store's existing rule that `Attached` preserves prior lifecycle state then keeps the id when the wrapper's synthetic `SessionStart` lands ~2s later without one.

`codex resume <id>` keeps the same rollout id, verified by sending a follow-up into a resumed pane and watching it report the same id, so the launched-with id is the right one to bind.

This is agent-agnostic: it keys off `resumeSessionId`, so all 17 resume-capable harnesses get it. For harnesses that already report at launch (claude, mastracode) the real hook overwrites the seed within seconds and nothing changes.

## Manual QA

Done against the running host on a scratch workspace, before the fix:

- [x] Launched a codex agent, let it take a turn, confirmed the binding captured `agent_session_id`
- [x] `kill -9` on the terminal's shell to simulate a crash, binding flipped to `end_reason = terminal-exited`
- [x] `terminalAgents.resumeCandidate` returned `resumeSupported: true`
- [x] `terminalAgents.resume` relaunched `codex … resume <id>` with the transcript restored
- [x] Confirmed the resumed terminal's binding had an empty `agent_session_id`, the bug this fixes
- [x] Confirmed a follow-up prompt into the resumed pane reported the same rollout id

Not yet re-run end to end against a host build carrying this commit. The seeding path is covered by the unit tests below.

## Testing
- `bun run typecheck` (host-service)
- `bunx biome check`
- `bun test` (host-service): 1442 pass, 0 fail
- 3 new tests in `agents.test.ts` against a real in-memory host db and a real `TerminalAgentStore`: a resumed launch binds the id, a fresh launch stays unbound, and the wrapper's id-less launch report does not clobber it. Confirmed they fail against the unfixed code (stubbing the seed turns 2 of 3 red).

## Known Limitations
A brand-new codex pane killed before its first prompt still has no id and will not resume. There is no conversation to restore there, and closing it would mean teaching the wrapper to scrape codex's rollout directory, which is well outside this change.

## Risks / Rollout
- Risk: low. One `recordEvent` call on a path that previously wrote nothing, gated on `resumeSessionId`. A wrong id would be replaced by the harness's first real hook event.
- Rollback: revert the commit; behavior returns to hook-only binding.

https://claude.ai/code/session_01XbdkBBA2ASXGLPHXFBf5ZB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-resumed Codex sessions losing their session id at relaunch. Previously, a Codex pane that auto-resumed carried no `agentSessionId` until the first turn, so if it died again before the user prompted, it lost its resume candidate. Now `runTerminalAgent` binds the resumed session id at launch.

- Binds the rolled-out `resumeSessionId` to the terminal's agent binding immediately after creation, using an `Attached` event.
- Only applies to resumed sessions of builtin preset agents; fresh launches and forks are left unbound.
- Harnesses that already report a session id at launch (e.g. Claude) overwrite the seed quickly, so behavior is unchanged for them.

<sup>Written for commit c894c18ff62b3dee4ca69e2e51ca8af01513cd3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resumed terminal sessions so they remain correctly associated with their original session.
  * Prevented fresh terminal launches from being incorrectly marked as resumed.
  * Preserved existing session associations when later launch information is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->