### PR TITLE
fix(browser): keep sign-in popups in the pane's session

### DIFF
--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -391,150 +391,193 @@ async function main() {
 						.filter((target) => target.type === "webview")
 						.map((target) => target.id),
 				);
-				let actionError: string | null = null;
-				await g.eval(`window.__handle = null; ${script}; 1`).catch((error) => {
-					actionError = error instanceof Error ? error.message : String(error);
-				});
-				await sleep(
-					OBSERVE_MS ??
-						(name === "nested" || name === "selfClosing" ? 3000 : 2000),
-				);
+				const createdPopups = new Map<string, CdpTarget>();
+				const createdPanes = new Map<string, CdpTarget>();
+				try {
+					let actionError: string | null = null;
+					await g
+						.eval(`window.__handle = null; ${script}; 1`)
+						.catch((error) => {
+							actionError =
+								error instanceof Error ? error.message : String(error);
+						});
+					await sleep(
+						OBSERVE_MS ??
+							(name === "nested" || name === "selfClosing" ? 3000 : 2000),
+					);
 
-				const after = await targets();
-				const live = after.filter(
-					(target) => target.type === "page" && !pageIdsBefore.has(target.id),
-				);
-				const createdPanes = after.filter(
-					(target) =>
-						target.type === "webview" && !paneIdsBefore.has(target.id),
-				);
-				const opener: Array<boolean | null> = [];
-				const jar: Array<boolean | null> = [];
-				const windowNames: Array<string | null> = [];
-				const observationErrors: string[] = [];
-				for (const p of live) {
-					if (!p.webSocketDebuggerUrl) {
-						observationErrors.push(`popup ${p.id} has no debugger URL`);
-						continue;
+					const after = await targets();
+					const live = after.filter(
+						(target) => target.type === "page" && !pageIdsBefore.has(target.id),
+					);
+					const livePanes = after.filter(
+						(target) =>
+							target.type === "webview" && !paneIdsBefore.has(target.id),
+					);
+					for (const target of live) createdPopups.set(target.id, target);
+					for (const target of livePanes) createdPanes.set(target.id, target);
+					const opener: Array<boolean | null> = [];
+					const jar: Array<boolean | null> = [];
+					const windowNames: Array<string | null> = [];
+					const observationErrors: string[] = [];
+					for (const p of live) {
+						if (!p.webSocketDebuggerUrl) {
+							observationErrors.push(`popup ${p.id} has no debugger URL`);
+							continue;
+						}
+						const c = await Cdp.connect(p.webSocketDebuggerUrl).catch(
+							(error) => {
+								observationErrors.push(`popup ${p.id}: ${String(error)}`);
+								return null;
+							},
+						);
+						if (!c) continue;
+						try {
+							await c.send("Runtime.enable");
+							// Probe the popup directly. This also covers about:blank, which never
+							// loads the fixture's window.__info snapshot.
+							opener.push(
+								await c.eval<boolean>("!!window.opener").catch(() => null),
+							);
+							jar.push(
+								await c
+									.eval<boolean>('document.cookie.includes("paneprobe=1")')
+									.catch(() => null),
+							);
+							windowNames.push(
+								await c.eval<string>("window.name").catch(() => null),
+							);
+						} finally {
+							c.close();
+						}
 					}
-					const c = await Cdp.connect(p.webSocketDebuggerUrl).catch((error) => {
-						observationErrors.push(`popup ${p.id}: ${String(error)}`);
-						return null;
-					});
-					if (!c) continue;
-					try {
-						await c.send("Runtime.enable");
-						// Probe the popup directly. This also covers about:blank, which never
-						// loads the fixture's window.__info snapshot.
-						opener.push(
-							await c.eval<boolean>("!!window.opener").catch(() => null),
-						);
-						jar.push(
-							await c
-								.eval<boolean>('document.cookie.includes("paneprobe=1")')
-								.catch(() => null),
-						);
-						windowNames.push(
-							await c.eval<string>("window.name").catch(() => null),
-						);
-					} finally {
-						c.close();
-					}
-				}
-				const handle = await g
-					.eval<string>("String(window.__handle)")
-					.catch(() => "?");
+					const handle = await g
+						.eval<string>("String(window.__handle)")
+						.catch(() => "?");
 
-				const bad: string[] = [];
-				if (actionError) bad.push(`action failed: ${actionError}`);
-				bad.push(...observationErrors);
-				if (live.length !== want.popups)
-					bad.push(`popups ${live.length}!=${want.popups}`);
-				if (createdPanes.length !== want.panes)
-					bad.push(`panes +${createdPanes.length}!=+${want.panes}`);
-				if (want.opener !== undefined) {
-					if (
-						opener.length !== live.length ||
-						opener.some((value) => value !== want.opener)
-					) {
-						bad.push(`opener ${formatObservations(opener)}!=${want.opener}`);
+					const bad: string[] = [];
+					if (actionError) bad.push(`action failed: ${actionError}`);
+					bad.push(...observationErrors);
+					if (live.length !== want.popups)
+						bad.push(`popups ${live.length}!=${want.popups}`);
+					if (livePanes.length !== want.panes)
+						bad.push(`panes +${livePanes.length}!=+${want.panes}`);
+					if (want.opener !== undefined) {
+						if (
+							opener.length !== live.length ||
+							opener.some((value) => value !== want.opener)
+						) {
+							bad.push(`opener ${formatObservations(opener)}!=${want.opener}`);
+						}
 					}
-				}
-				if (want.jar !== undefined) {
-					if (
-						jar.length !== live.length ||
-						jar.some((value) => value !== want.jar)
-					) {
-						bad.push(`jar ${formatObservations(jar)}!=${want.jar}`);
+					if (want.jar !== undefined) {
+						if (
+							jar.length !== live.length ||
+							jar.some((value) => value !== want.jar)
+						) {
+							bad.push(`jar ${formatObservations(jar)}!=${want.jar}`);
+						}
 					}
-				}
-				if (want.names) {
-					const gotNames = windowNames
-						.filter((value): value is string => value != null)
-						.sort();
-					const wantedNames = [...want.names].sort();
-					if (
-						gotNames.length !== live.length ||
-						JSON.stringify(gotNames) !== JSON.stringify(wantedNames)
-					) {
-						bad.push(
-							`names ${JSON.stringify(windowNames)}!=${JSON.stringify(want.names)}`,
-						);
+					if (want.names) {
+						const gotNames = windowNames
+							.filter((value): value is string => value != null)
+							.sort();
+						const wantedNames = [...want.names].sort();
+						if (
+							gotNames.length !== live.length ||
+							JSON.stringify(gotNames) !== JSON.stringify(wantedNames)
+						) {
+							bad.push(
+								`names ${JSON.stringify(windowNames)}!=${JSON.stringify(want.names)}`,
+							);
+						}
 					}
-				}
-				if (want.handle !== undefined) {
-					const got = handle === "HANDLE";
-					if (got !== want.handle) bad.push(`handle ${handle}`);
-				}
-				if (bad.length)
-					failures.push(`${name}: ${bad.join(", ")} (${want.note})`);
+					if (want.handle !== undefined) {
+						const got = handle === "HANDLE";
+						if (got !== want.handle) bad.push(`handle ${handle}`);
+					}
+					if (bad.length)
+						failures.push(`${name}: ${bad.join(", ")} (${want.note})`);
 
-				console.log(
-					`${name.padEnd(19)}${String(live.length).padEnd(8)}${formatObservations(opener).padEnd(12)}${formatObservations(jar).padEnd(10)}${formatObservations(windowNames).padEnd(20)}${handle.padEnd(8)}+${createdPanes.length}     ${bad.length ? `FAIL ${bad.join(", ")}` : "ok"}`,
-				);
+					console.log(
+						`${name.padEnd(19)}${String(live.length).padEnd(8)}${formatObservations(opener).padEnd(12)}${formatObservations(jar).padEnd(10)}${formatObservations(windowNames).padEnd(20)}${handle.padEnd(8)}+${livePanes.length}     ${bad.length ? `FAIL ${bad.join(", ")}` : "ok"}`,
+					);
+				} catch (error) {
+					failures.push(`${name}: case failed unexpectedly: ${String(error)}`);
+				} finally {
+					await targets()
+						.then((current) => {
+							for (const target of current) {
+								if (target.type === "page" && !pageIdsBefore.has(target.id)) {
+									createdPopups.set(target.id, target);
+								}
+								if (
+									target.type === "webview" &&
+									!paneIdsBefore.has(target.id)
+								) {
+									createdPanes.set(target.id, target);
+								}
+							}
+						})
+						.catch((error) => {
+							failures.push(
+								`${name}: could not enumerate targets for cleanup: ${String(error)}`,
+							);
+						});
 
-				for (const p of live) {
-					if (!p.webSocketDebuggerUrl) {
-						failures.push(
-							`${name}: could not close popup ${p.id}: no debugger URL`,
+					for (const p of createdPopups.values()) {
+						if (!p.webSocketDebuggerUrl) {
+							failures.push(
+								`${name}: could not close popup ${p.id}: no debugger URL`,
+							);
+							continue;
+						}
+						const c = await Cdp.connect(p.webSocketDebuggerUrl).catch(
+							(error) => {
+								failures.push(
+									`${name}: could not connect to popup for cleanup: ${String(error)}`,
+								);
+								return null;
+							},
 						);
-						continue;
+						await c?.send("Page.close").catch((error) => {
+							failures.push(
+								`${name}: could not close popup ${p.id}: ${String(error)}`,
+							);
+						});
+						c?.close();
 					}
-					const c = await Cdp.connect(p.webSocketDebuggerUrl).catch((error) => {
-						failures.push(
-							`${name}: could not connect to popup for cleanup: ${String(error)}`,
-						);
-						return null;
-					});
-					await c?.send("Page.close").catch((error) => {
-						failures.push(
-							`${name}: could not close popup ${p.id}: ${String(error)}`,
-						);
-					});
-					c?.close();
-				}
-				for (let index = 0; index < createdPanes.length; index += 1) {
-					await closeFocusedPane(host).catch((error) => {
-						failures.push(
-							`${name}: could not close created pane: ${String(error)}`,
-						);
-					});
-				}
-				await sleep(800);
-				const remainingIds = new Set(
-					(await targets()).map((target) => target.id),
-				);
-				for (const createdPane of createdPanes) {
-					if (remainingIds.has(createdPane.id)) {
-						failures.push(
-							`${name}: created pane ${createdPane.id} remained after cleanup`,
-						);
+					for (let index = 0; index < createdPanes.size; index += 1) {
+						await closeFocusedPane(host).catch((error) => {
+							failures.push(
+								`${name}: could not close created pane: ${String(error)}`,
+							);
+						});
 					}
-				}
-				for (const popup of live) {
-					if (remainingIds.has(popup.id)) {
-						failures.push(`${name}: popup ${popup.id} remained after cleanup`);
-					}
+					await sleep(800);
+					await targets()
+						.then((current) => {
+							const remainingIds = new Set(current.map((target) => target.id));
+							for (const createdPane of createdPanes.values()) {
+								if (remainingIds.has(createdPane.id)) {
+									failures.push(
+										`${name}: created pane ${createdPane.id} remained after cleanup`,
+									);
+								}
+							}
+							for (const popup of createdPopups.values()) {
+								if (remainingIds.has(popup.id)) {
+									failures.push(
+										`${name}: popup ${popup.id} remained after cleanup`,
+									);
+								}
+							}
+						})
+						.catch((error) => {
+							failures.push(
+								`${name}: could not verify target cleanup: ${String(error)}`,
+							);
+						});
 				}
 			}
 
@@ -555,20 +598,27 @@ async function main() {
 				`\npostMessage callbacks delivered to opener: ${msgs.length}`,
 			);
 		} finally {
-			await g.send("Page.navigate", { url: originalPaneUrl }).catch((error) => {
-				failures.push(`could not restore pane URL: ${String(error)}`);
-			});
-			await sleep(1500);
-			const restored = (await targets()).find(
-				(target) => target.id === pane.id,
-			);
-			if (restored?.url !== originalPaneUrl) {
-				failures.push(
-					`pane URL not restored: ${restored?.url ?? "missing"} != ${originalPaneUrl}`,
+			try {
+				await g
+					.send("Page.navigate", { url: originalPaneUrl })
+					.catch((error) => {
+						failures.push(`could not restore pane URL: ${String(error)}`);
+					});
+				await sleep(1500);
+				const restored = (await targets()).find(
+					(target) => target.id === pane.id,
 				);
+				if (restored?.url !== originalPaneUrl) {
+					failures.push(
+						`pane URL not restored: ${restored?.url ?? "missing"} != ${originalPaneUrl}`,
+					);
+				}
+			} catch (error) {
+				failures.push(`could not verify pane restoration: ${String(error)}`);
+			} finally {
+				g.close();
+				host.close();
 			}
-			g.close();
-			host.close();
 		}
 
 		if (failures.length) {

--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -18,8 +18,13 @@
  * Dependency-free (Bun WebSocket + fetch).
  */
 
-const PORT = process.env.RENDERER_REMOTE_DEBUG_PORT ?? "9222";
+const PORT = process.env.RENDERER_REMOTE_DEBUG_PORT;
+const VITE_PORT = process.env.DESKTOP_VITE_PORT;
 const FIXTURE_PORT = Number(process.env.POPUP_FIXTURE_PORT ?? "8797");
+const ONLY_CASE = process.env.POPUP_CASE;
+const OBSERVE_MS = process.env.POPUP_OBSERVE_MS
+	? Number(process.env.POPUP_OBSERVE_MS)
+	: null;
 const ORIGIN = `http://localhost:${FIXTURE_PORT}`;
 
 const OAUTH = `${ORIGIN}/popup?client_id=a&redirect_uri=${encodeURIComponent(
@@ -58,6 +63,10 @@ interface Expectation {
 	panes: number;
 	/** Whether the popup must still see its opener. */
 	opener?: boolean;
+	/** Whether every live popup must share the opener's cookie jar. */
+	jar?: boolean;
+	/** Exact live window names, sorted because CDP target order is unspecified. */
+	names?: string[];
 	/** Whether `window.open` must hand the page a usable handle. */
 	handle?: boolean;
 	note: string;
@@ -68,6 +77,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: [""],
 		handle: true,
 		note: "window.open() with no arguments",
 	},
@@ -75,6 +86,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: [""],
 		handle: true,
 		note: "about:blank with a fragment",
 	},
@@ -82,6 +95,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: [""],
 		handle: true,
 		note: "bare window.open of a sign-in URL (Deel's shape)",
 	},
@@ -89,6 +104,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: [""],
 		handle: true,
 		note: "sign-in URL with a _blank name",
 	},
@@ -96,6 +113,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: ["authwin"],
 		handle: true,
 		note: "sign-in URL, named, no features",
 	},
@@ -103,6 +122,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: ["authpopup"],
 		handle: true,
 		note: "window.open with features (Firebase's shape)",
 	},
@@ -110,6 +131,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: [""],
 		handle: true,
 		note: "OIDC hybrid response_type",
 	},
@@ -117,6 +140,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 1,
 		panes: 0,
 		opener: false,
+		jar: true,
+		names: ["n"],
 		handle: false,
 		note: "noopener severs the opener and nulls the handle, per spec",
 	},
@@ -124,6 +149,8 @@ const EXPECT: Record<string, Expectation> = {
 		popups: 2,
 		panes: 0,
 		opener: true,
+		jar: true,
+		names: ["inner", "outer"],
 		handle: true,
 		note: "a popup opening its own popup (Google's consent step)",
 	},
@@ -178,6 +205,7 @@ const POPUP = (q: URLSearchParams) => `<!doctype html><meta charset="utf-8">
 </script>`;
 
 interface CdpTarget {
+	id: string;
 	type: string;
 	url: string;
 	webSocketDebuggerUrl?: string;
@@ -249,14 +277,48 @@ const targets = async (): Promise<CdpTarget[]> =>
 	(await (
 		await fetch(`http://127.0.0.1:${PORT}/json/list`)
 	).json()) as CdpTarget[];
-const popupsNow = async () =>
-	(await targets()).filter(
-		(t) => t.type === "page" && !/^https?:\/\/localhost:\d+\/#/.test(t.url),
-	);
-const panesNow = async () =>
-	(await targets()).filter((t) => t.type === "webview");
+function formatObservations(values: Array<boolean | string | null>): string {
+	return values.length ? values.map((value) => value ?? "?").join(",") : "-";
+}
+
+async function closeFocusedPane(renderer: Cdp): Promise<void> {
+	// The split action focuses the new pane. Drive the host's real CLOSE_PANE
+	// hotkey rather than Page.close on the guest target: the latter destroys a
+	// WebContents without updating the renderer's pane layout.
+	const isMac = process.platform === "darwin";
+	const modifiers = isMac ? 4 : 2 | 8; // Meta, or Control + Shift.
+	await renderer.send("Input.dispatchKeyEvent", {
+		type: "rawKeyDown",
+		key: isMac ? "w" : "W",
+		code: "KeyW",
+		windowsVirtualKeyCode: 87,
+		modifiers,
+	});
+	await renderer.send("Input.dispatchKeyEvent", {
+		type: "keyUp",
+		key: isMac ? "w" : "W",
+		code: "KeyW",
+		windowsVirtualKeyCode: 87,
+		modifiers,
+	});
+}
 
 async function main() {
+	if (!PORT || !VITE_PORT) {
+		console.error(
+			"FAIL: set RENDERER_REMOTE_DEBUG_PORT explicitly and load this workspace's DESKTOP_VITE_PORT from .env.",
+		);
+		return 1;
+	}
+	if (ONLY_CASE && !(ONLY_CASE in CASES)) {
+		console.error(`FAIL: unknown POPUP_CASE ${ONLY_CASE}`);
+		return 1;
+	}
+	if (OBSERVE_MS !== null && (!Number.isFinite(OBSERVE_MS) || OBSERVE_MS < 0)) {
+		console.error("FAIL: POPUP_OBSERVE_MS must be a non-negative number.");
+		return 1;
+	}
+
 	const server = Bun.serve({
 		port: FIXTURE_PORT,
 		fetch(req) {
@@ -271,7 +333,24 @@ async function main() {
 	});
 
 	try {
-		const pane = (await panesNow())[0];
+		const allTargets = await targets();
+		const rendererOrigin = new URL(`http://localhost:${VITE_PORT}`).origin;
+		const renderer = allTargets.find(
+			(target) =>
+				target.type === "page" &&
+				target.webSocketDebuggerUrl &&
+				target.url.startsWith(`${rendererOrigin}/`),
+		);
+		if (!renderer) {
+			console.error(
+				`FAIL: no renderer for ${rendererOrigin} on CDP port ${PORT}.`,
+			);
+			return 1;
+		}
+
+		const pane = allTargets.find(
+			(target) => target.type === "webview" && target.webSocketDebuggerUrl,
+		);
 		if (!pane?.webSocketDebuggerUrl) {
 			console.error(
 				`FAIL: no browser pane found on port ${PORT}.\n` +
@@ -279,89 +358,218 @@ async function main() {
 			);
 			return 1;
 		}
-
-		const g = await Cdp.connect(pane.webSocketDebuggerUrl);
-		await g.send("Page.enable");
-		await g.send("Runtime.enable");
-		await g.send("Page.navigate", { url: `${ORIGIN}/` });
-		await sleep(2500);
-
-		const failures: string[] = [];
+		const originalPaneUrl = pane.url;
 		console.log(
-			`${"case".padEnd(19)}${"popups".padEnd(8)}${"opener".padEnd(8)}${"jar".padEnd(6)}${"handle".padEnd(8)}panes  verdict`,
+			`Renderer ${renderer.url}; pane ${pane.id} initially ${originalPaneUrl}`,
 		);
 
-		for (const [name, script] of Object.entries(CASES)) {
-			const want = EXPECT[name];
-			if (!want) continue;
-			const panesBefore = (await panesNow()).length;
-			await g.eval(`window.__handle = null; ${script}; 1`).catch(() => {});
-			await sleep(name === "nested" || name === "selfClosing" ? 3000 : 2000);
-
-			const live = await popupsNow();
-			const panesAfter = (await panesNow()).length;
-			let opener: boolean | null = null;
-			let jar: boolean | null = null;
-			for (const p of live) {
-				if (!p.webSocketDebuggerUrl) continue;
-				const c = await Cdp.connect(p.webSocketDebuggerUrl);
-				await c.send("Runtime.enable");
-				// Read the opener off the popup itself rather than the fixture's
-				// snapshot: an `about:blank` popup never loads the fixture, and
-				// relying on that snapshot silently skipped the assertion for the
-				// two blank cases.
-				const has = await c.eval<boolean>("!!window.opener").catch(() => null);
-				if (has !== null) opener = opener === false ? false : has;
-				const info = await c
-					.eval<{ sharesCookieJar: boolean } | null>("window.__info ?? null")
-					.catch(() => null);
-				if (info) jar = info.sharesCookieJar;
-				c.close();
-			}
-			const handle = await g
-				.eval<string>("String(window.__handle)")
-				.catch(() => "?");
-
-			const bad: string[] = [];
-			if (live.length !== want.popups)
-				bad.push(`popups ${live.length}!=${want.popups}`);
-			if (panesAfter - panesBefore !== want.panes)
-				bad.push(`panes +${panesAfter - panesBefore}!=+${want.panes}`);
-			if (
-				want.opener !== undefined &&
-				opener !== null &&
-				opener !== want.opener
-			)
-				bad.push(`opener ${opener}!=${want.opener}`);
-			// Every popup that keeps its opener must also keep the pane's jar.
-			if (want.opener === true && jar === false)
-				bad.push("cookie jar not shared");
-			if (want.handle !== undefined) {
-				const got = handle === "HANDLE";
-				if (got !== want.handle) bad.push(`handle ${handle}`);
-			}
-			if (bad.length)
-				failures.push(`${name}: ${bad.join(", ")} (${want.note})`);
+		const g = await Cdp.connect(pane.webSocketDebuggerUrl);
+		const host = await Cdp.connect(renderer.webSocketDebuggerUrl as string);
+		const failures: string[] = [];
+		try {
+			await g.send("Page.enable");
+			await g.send("Runtime.enable");
+			await g.send("Page.navigate", { url: `${ORIGIN}/` });
+			await sleep(2500);
 
 			console.log(
-				`${name.padEnd(19)}${String(live.length).padEnd(8)}${String(opener ?? "-").padEnd(8)}${String(jar ?? "-").padEnd(6)}${handle.padEnd(8)}+${panesAfter - panesBefore}     ${bad.length ? `FAIL ${bad.join(", ")}` : "ok"}`,
+				`${"case".padEnd(19)}${"popups".padEnd(8)}${"opener".padEnd(12)}${"jar".padEnd(10)}${"name".padEnd(20)}${"handle".padEnd(8)}panes  verdict`,
 			);
 
-			for (const p of live) {
-				if (!p.webSocketDebuggerUrl) continue;
-				const c = await Cdp.connect(p.webSocketDebuggerUrl).catch(() => null);
-				await c?.send("Page.close").catch(() => {});
-				c?.close();
-			}
-			await sleep(800);
-		}
+			for (const [name, script] of Object.entries(CASES)) {
+				if (ONLY_CASE && name !== ONLY_CASE) continue;
+				const want = EXPECT[name];
+				if (!want) continue;
+				const before = await targets();
+				const pageIdsBefore = new Set(
+					before
+						.filter((target) => target.type === "page")
+						.map((target) => target.id),
+				);
+				const paneIdsBefore = new Set(
+					before
+						.filter((target) => target.type === "webview")
+						.map((target) => target.id),
+				);
+				let actionError: string | null = null;
+				await g.eval(`window.__handle = null; ${script}; 1`).catch((error) => {
+					actionError = error instanceof Error ? error.message : String(error);
+				});
+				await sleep(
+					OBSERVE_MS ??
+						(name === "nested" || name === "selfClosing" ? 3000 : 2000),
+				);
 
-		const msgs = await g.eval<string[]>("window.__msgs ?? []").catch(() => []);
-		if (!msgs.some((m) => m.startsWith("ok:"))) {
-			failures.push("no postMessage reached the opener");
+				const after = await targets();
+				const live = after.filter(
+					(target) => target.type === "page" && !pageIdsBefore.has(target.id),
+				);
+				const createdPanes = after.filter(
+					(target) =>
+						target.type === "webview" && !paneIdsBefore.has(target.id),
+				);
+				const opener: Array<boolean | null> = [];
+				const jar: Array<boolean | null> = [];
+				const windowNames: Array<string | null> = [];
+				const observationErrors: string[] = [];
+				for (const p of live) {
+					if (!p.webSocketDebuggerUrl) {
+						observationErrors.push(`popup ${p.id} has no debugger URL`);
+						continue;
+					}
+					const c = await Cdp.connect(p.webSocketDebuggerUrl).catch((error) => {
+						observationErrors.push(`popup ${p.id}: ${String(error)}`);
+						return null;
+					});
+					if (!c) continue;
+					try {
+						await c.send("Runtime.enable");
+						// Probe the popup directly. This also covers about:blank, which never
+						// loads the fixture's window.__info snapshot.
+						opener.push(
+							await c.eval<boolean>("!!window.opener").catch(() => null),
+						);
+						jar.push(
+							await c
+								.eval<boolean>('document.cookie.includes("paneprobe=1")')
+								.catch(() => null),
+						);
+						windowNames.push(
+							await c.eval<string>("window.name").catch(() => null),
+						);
+					} finally {
+						c.close();
+					}
+				}
+				const handle = await g
+					.eval<string>("String(window.__handle)")
+					.catch(() => "?");
+
+				const bad: string[] = [];
+				if (actionError) bad.push(`action failed: ${actionError}`);
+				bad.push(...observationErrors);
+				if (live.length !== want.popups)
+					bad.push(`popups ${live.length}!=${want.popups}`);
+				if (createdPanes.length !== want.panes)
+					bad.push(`panes +${createdPanes.length}!=+${want.panes}`);
+				if (want.opener !== undefined) {
+					if (
+						opener.length !== live.length ||
+						opener.some((value) => value !== want.opener)
+					) {
+						bad.push(`opener ${formatObservations(opener)}!=${want.opener}`);
+					}
+				}
+				if (want.jar !== undefined) {
+					if (
+						jar.length !== live.length ||
+						jar.some((value) => value !== want.jar)
+					) {
+						bad.push(`jar ${formatObservations(jar)}!=${want.jar}`);
+					}
+				}
+				if (want.names) {
+					const gotNames = windowNames
+						.filter((value): value is string => value != null)
+						.sort();
+					const wantedNames = [...want.names].sort();
+					if (
+						gotNames.length !== live.length ||
+						JSON.stringify(gotNames) !== JSON.stringify(wantedNames)
+					) {
+						bad.push(
+							`names ${JSON.stringify(windowNames)}!=${JSON.stringify(want.names)}`,
+						);
+					}
+				}
+				if (want.handle !== undefined) {
+					const got = handle === "HANDLE";
+					if (got !== want.handle) bad.push(`handle ${handle}`);
+				}
+				if (bad.length)
+					failures.push(`${name}: ${bad.join(", ")} (${want.note})`);
+
+				console.log(
+					`${name.padEnd(19)}${String(live.length).padEnd(8)}${formatObservations(opener).padEnd(12)}${formatObservations(jar).padEnd(10)}${formatObservations(windowNames).padEnd(20)}${handle.padEnd(8)}+${createdPanes.length}     ${bad.length ? `FAIL ${bad.join(", ")}` : "ok"}`,
+				);
+
+				for (const p of live) {
+					if (!p.webSocketDebuggerUrl) {
+						failures.push(
+							`${name}: could not close popup ${p.id}: no debugger URL`,
+						);
+						continue;
+					}
+					const c = await Cdp.connect(p.webSocketDebuggerUrl).catch((error) => {
+						failures.push(
+							`${name}: could not connect to popup for cleanup: ${String(error)}`,
+						);
+						return null;
+					});
+					await c?.send("Page.close").catch((error) => {
+						failures.push(
+							`${name}: could not close popup ${p.id}: ${String(error)}`,
+						);
+					});
+					c?.close();
+				}
+				for (let index = 0; index < createdPanes.length; index += 1) {
+					await closeFocusedPane(host).catch((error) => {
+						failures.push(
+							`${name}: could not close created pane: ${String(error)}`,
+						);
+					});
+				}
+				await sleep(800);
+				const remainingIds = new Set(
+					(await targets()).map((target) => target.id),
+				);
+				for (const createdPane of createdPanes) {
+					if (remainingIds.has(createdPane.id)) {
+						failures.push(
+							`${name}: created pane ${createdPane.id} remained after cleanup`,
+						);
+					}
+				}
+				for (const popup of live) {
+					if (remainingIds.has(popup.id)) {
+						failures.push(`${name}: popup ${popup.id} remained after cleanup`);
+					}
+				}
+			}
+
+			const msgs = await g
+				.eval<string[]>("window.__msgs ?? []")
+				.catch(() => []);
+			const expectsCallback = Object.entries(EXPECT).some(
+				([name, expectation]) =>
+					(!ONLY_CASE || name === ONLY_CASE) &&
+					expectation.opener === true &&
+					name !== "noArgs" &&
+					name !== "blankFragment",
+			);
+			if (expectsCallback && !msgs.some((m) => m.startsWith("ok:"))) {
+				failures.push("no postMessage reached the opener");
+			}
+			console.log(
+				`\npostMessage callbacks delivered to opener: ${msgs.length}`,
+			);
+		} finally {
+			await g.send("Page.navigate", { url: originalPaneUrl }).catch((error) => {
+				failures.push(`could not restore pane URL: ${String(error)}`);
+			});
+			await sleep(1500);
+			const restored = (await targets()).find(
+				(target) => target.id === pane.id,
+			);
+			if (restored?.url !== originalPaneUrl) {
+				failures.push(
+					`pane URL not restored: ${restored?.url ?? "missing"} != ${originalPaneUrl}`,
+				);
+			}
+			g.close();
+			host.close();
 		}
-		console.log(`\npostMessage callbacks delivered to opener: ${msgs.length}`);
-		g.close();
 
 		if (failures.length) {
 			console.error(`\nFAIL (${failures.length}):`);

--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -551,9 +551,8 @@ async function main() {
 						});
 						c?.close();
 					}
-					let previousCreatedPaneCount: number | null = null;
-					while (true) {
-						const liveCreatedPaneCount = await targets()
+					const countLiveCreatedPanes = () =>
+						targets()
 							.then(
 								(current) =>
 									current.filter(
@@ -568,17 +567,8 @@ async function main() {
 								);
 								return null;
 							});
-						if (!liveCreatedPaneCount) break;
-						if (
-							previousCreatedPaneCount !== null &&
-							liveCreatedPaneCount >= previousCreatedPaneCount
-						) {
-							failures.push(
-								`${name}: created pane count did not decrease during cleanup`,
-							);
-							break;
-						}
-						previousCreatedPaneCount = liveCreatedPaneCount;
+					let liveCreatedPaneCount = await countLiveCreatedPanes();
+					while (liveCreatedPaneCount) {
 						const closed = await closeFocusedPane(host)
 							.then(() => true)
 							.catch((error) => {
@@ -588,7 +578,27 @@ async function main() {
 								return false;
 							});
 						if (!closed) break;
-						await sleep(800);
+
+						const countBeforeClose = liveCreatedPaneCount;
+						let countAfterClose: number | null = countBeforeClose;
+						for (
+							let attempt = 0;
+							attempt < 10 &&
+							countAfterClose !== null &&
+							countAfterClose >= countBeforeClose;
+							attempt += 1
+						) {
+							await sleep(500);
+							countAfterClose = await countLiveCreatedPanes();
+						}
+						if (countAfterClose === null) break;
+						if (countAfterClose >= countBeforeClose) {
+							failures.push(
+								`${name}: created pane count did not decrease during cleanup`,
+							);
+							break;
+						}
+						liveCreatedPaneCount = countAfterClose;
 					}
 					await sleep(800);
 					await targets()

--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -67,6 +67,8 @@ interface Expectation {
 	jar?: boolean;
 	/** Exact live window names, sorted because CDP target order is unspecified. */
 	names?: string[];
+	/** Exact postMessage callbacks this case must deliver to the opener. */
+	messages?: string[];
 	/** Whether `window.open` must hand the page a usable handle. */
 	handle?: boolean;
 	note: string;
@@ -97,6 +99,7 @@ const EXPECT: Record<string, Expectation> = {
 		opener: true,
 		jar: true,
 		names: [""],
+		messages: ["ok:(anon)"],
 		handle: true,
 		note: "bare window.open of a sign-in URL (Deel's shape)",
 	},
@@ -106,6 +109,7 @@ const EXPECT: Record<string, Expectation> = {
 		opener: true,
 		jar: true,
 		names: [""],
+		messages: ["ok:(anon)"],
 		handle: true,
 		note: "sign-in URL with a _blank name",
 	},
@@ -115,6 +119,7 @@ const EXPECT: Record<string, Expectation> = {
 		opener: true,
 		jar: true,
 		names: ["authwin"],
+		messages: ["ok:authwin"],
 		handle: true,
 		note: "sign-in URL, named, no features",
 	},
@@ -124,6 +129,7 @@ const EXPECT: Record<string, Expectation> = {
 		opener: true,
 		jar: true,
 		names: ["authpopup"],
+		messages: ["ok:authpopup"],
 		handle: true,
 		note: "window.open with features (Firebase's shape)",
 	},
@@ -133,6 +139,7 @@ const EXPECT: Record<string, Expectation> = {
 		opener: true,
 		jar: true,
 		names: [""],
+		messages: ["ok:(anon)"],
 		handle: true,
 		note: "OIDC hybrid response_type",
 	},
@@ -151,12 +158,14 @@ const EXPECT: Record<string, Expectation> = {
 		opener: true,
 		jar: true,
 		names: ["inner", "outer"],
+		messages: ["ok:outer"],
 		handle: true,
 		note: "a popup opening its own popup (Google's consent step)",
 	},
 	selfClosing: {
 		popups: 0,
 		panes: 0,
+		messages: ["ok:c"],
 		handle: true,
 		note: "window.close() from inside the popup",
 	},
@@ -303,6 +312,39 @@ async function closeFocusedPane(renderer: Cdp): Promise<void> {
 	});
 }
 
+async function focusPaneTarget(
+	renderer: Cdp,
+	target: CdpTarget,
+): Promise<void> {
+	const point = await renderer.eval<{ x: number; y: number } | null>(`(() => {
+		const targetUrl = ${JSON.stringify(target.url)};
+		const element = [...document.querySelectorAll("webview")].find((candidate) =>
+			candidate.getURL?.() === targetUrl || candidate.getAttribute("src") === targetUrl
+		);
+		if (!element) return null;
+		const rect = element.getBoundingClientRect();
+		// Click the host-rendered pane header just above the fixed webview. A
+		// click inside the guest does not bubble to the pane's focus handler.
+		return { x: rect.left + rect.width / 2, y: Math.max(0, rect.top - 10) };
+	})()`);
+	if (!point) throw new Error(`could not locate pane target ${target.id}`);
+	await renderer.send("Input.dispatchMouseEvent", {
+		type: "mousePressed",
+		x: point.x,
+		y: point.y,
+		button: "left",
+		clickCount: 1,
+	});
+	await renderer.send("Input.dispatchMouseEvent", {
+		type: "mouseReleased",
+		x: point.x,
+		y: point.y,
+		button: "left",
+		clickCount: 1,
+	});
+	await sleep(200);
+}
+
 async function main() {
 	if (!PORT || !VITE_PORT) {
 		console.error(
@@ -375,6 +417,7 @@ async function main() {
 			console.log(
 				`${"case".padEnd(19)}${"popups".padEnd(8)}${"opener".padEnd(12)}${"jar".padEnd(10)}${"name".padEnd(20)}${"handle".padEnd(8)}panes  verdict`,
 			);
+			let callbacksDelivered = 0;
 
 			for (const [name, script] of Object.entries(CASES)) {
 				if (ONLY_CASE && name !== ONLY_CASE) continue;
@@ -392,11 +435,10 @@ async function main() {
 						.map((target) => target.id),
 				);
 				const createdPopups = new Map<string, CdpTarget>();
-				const createdPanes = new Map<string, CdpTarget>();
 				try {
 					let actionError: string | null = null;
 					await g
-						.eval(`window.__handle = null; ${script}; 1`)
+						.eval(`window.__handle = null; window.__msgs = []; ${script}; 1`)
 						.catch((error) => {
 							actionError =
 								error instanceof Error ? error.message : String(error);
@@ -415,7 +457,6 @@ async function main() {
 							target.type === "webview" && !paneIdsBefore.has(target.id),
 					);
 					for (const target of live) createdPopups.set(target.id, target);
-					for (const target of livePanes) createdPanes.set(target.id, target);
 					const opener: Array<boolean | null> = [];
 					const jar: Array<boolean | null> = [];
 					const windowNames: Array<string | null> = [];
@@ -454,6 +495,15 @@ async function main() {
 					const handle = await g
 						.eval<string>("String(window.__handle)")
 						.catch(() => "?");
+					const caseMessages = await g
+						.eval<string[]>("window.__msgs ?? []")
+						.catch((error) => {
+							observationErrors.push(
+								`could not read opener callbacks: ${String(error)}`,
+							);
+							return [];
+						});
+					callbacksDelivered += caseMessages.length;
 
 					const bad: string[] = [];
 					if (actionError) bad.push(`action failed: ${actionError}`);
@@ -492,6 +542,17 @@ async function main() {
 							);
 						}
 					}
+					if (want.messages) {
+						const gotMessages = [...caseMessages].sort();
+						const wantedMessages = [...want.messages].sort();
+						if (
+							JSON.stringify(gotMessages) !== JSON.stringify(wantedMessages)
+						) {
+							bad.push(
+								`messages ${JSON.stringify(caseMessages)}!=${JSON.stringify(want.messages)}`,
+							);
+						}
+					}
 					if (want.handle !== undefined) {
 						const got = handle === "HANDLE";
 						if (got !== want.handle) bad.push(`handle ${handle}`);
@@ -507,19 +568,12 @@ async function main() {
 				} finally {
 					await targets()
 						.then((current) => {
-							// Replace the observation snapshot only after enumeration succeeds.
-							// If it fails, retain recorded targets as a cleanup fallback.
+							// Replace the popup snapshot only after enumeration succeeds. If it
+							// fails, retain recorded popup targets as a cleanup fallback.
 							createdPopups.clear();
-							createdPanes.clear();
 							for (const target of current) {
 								if (target.type === "page" && !pageIdsBefore.has(target.id)) {
 									createdPopups.set(target.id, target);
-								}
-								if (
-									target.type === "webview" &&
-									!paneIdsBefore.has(target.id)
-								) {
-									createdPanes.set(target.id, target);
 								}
 							}
 						})
@@ -529,37 +583,30 @@ async function main() {
 							);
 						});
 
+					const popupCleanupErrors = new Map<string, string>();
 					for (const p of createdPopups.values()) {
 						if (!p.webSocketDebuggerUrl) {
-							failures.push(
-								`${name}: could not close popup ${p.id}: no debugger URL`,
-							);
+							popupCleanupErrors.set(p.id, "no debugger URL");
 							continue;
 						}
 						const c = await Cdp.connect(p.webSocketDebuggerUrl).catch(
 							(error) => {
-								failures.push(
-									`${name}: could not connect to popup for cleanup: ${String(error)}`,
-								);
+								popupCleanupErrors.set(p.id, String(error));
 								return null;
 							},
 						);
 						await c?.send("Page.close").catch((error) => {
-							failures.push(
-								`${name}: could not close popup ${p.id}: ${String(error)}`,
-							);
+							popupCleanupErrors.set(p.id, String(error));
 						});
 						c?.close();
 					}
-					const countLiveCreatedPanes = () =>
+					const listLiveCreatedPanes = () =>
 						targets()
-							.then(
-								(current) =>
-									current.filter(
-										(target) =>
-											target.type === "webview" &&
-											!paneIdsBefore.has(target.id),
-									).length,
+							.then((current) =>
+								current.filter(
+									(target) =>
+										target.type === "webview" && !paneIdsBefore.has(target.id),
+								),
 							)
 							.catch((error) => {
 								failures.push(
@@ -567,9 +614,10 @@ async function main() {
 								);
 								return null;
 							});
-					let liveCreatedPaneCount = await countLiveCreatedPanes();
-					while (liveCreatedPaneCount) {
-						const closed = await closeFocusedPane(host)
+					let liveCreatedPanes = await listLiveCreatedPanes();
+					while (liveCreatedPanes?.length) {
+						const closed = await focusPaneTarget(host, liveCreatedPanes[0])
+							.then(() => closeFocusedPane(host))
 							.then(() => true)
 							.catch((error) => {
 								failures.push(
@@ -579,42 +627,53 @@ async function main() {
 							});
 						if (!closed) break;
 
-						const countBeforeClose = liveCreatedPaneCount;
-						let countAfterClose: number | null = countBeforeClose;
+						const countBeforeClose = liveCreatedPanes.length;
+						let panesAfterClose: CdpTarget[] | null = liveCreatedPanes;
 						for (
 							let attempt = 0;
 							attempt < 10 &&
-							countAfterClose !== null &&
-							countAfterClose >= countBeforeClose;
+							panesAfterClose !== null &&
+							panesAfterClose.length >= countBeforeClose;
 							attempt += 1
 						) {
 							await sleep(500);
-							countAfterClose = await countLiveCreatedPanes();
+							panesAfterClose = await listLiveCreatedPanes();
 						}
-						if (countAfterClose === null) break;
-						if (countAfterClose >= countBeforeClose) {
+						if (panesAfterClose === null) break;
+						if (panesAfterClose.length >= countBeforeClose) {
 							failures.push(
 								`${name}: created pane count did not decrease during cleanup`,
 							);
 							break;
 						}
-						liveCreatedPaneCount = countAfterClose;
+						if (panesAfterClose.length === 0) {
+							// A closed webview can briefly disappear and be recreated under a
+							// new target id while the renderer commits its pane state.
+							await sleep(1500);
+							panesAfterClose = await listLiveCreatedPanes();
+							if (panesAfterClose === null) break;
+						}
+						liveCreatedPanes = panesAfterClose;
 					}
 					await sleep(800);
 					await targets()
 						.then((current) => {
 							const remainingIds = new Set(current.map((target) => target.id));
-							for (const createdPane of createdPanes.values()) {
-								if (remainingIds.has(createdPane.id)) {
+							for (const target of current) {
+								if (
+									target.type === "webview" &&
+									!paneIdsBefore.has(target.id)
+								) {
 									failures.push(
-										`${name}: created pane ${createdPane.id} remained after cleanup`,
+										`${name}: created pane ${target.id} remained after cleanup`,
 									);
 								}
 							}
 							for (const popup of createdPopups.values()) {
 								if (remainingIds.has(popup.id)) {
+									const cleanupError = popupCleanupErrors.get(popup.id);
 									failures.push(
-										`${name}: popup ${popup.id} remained after cleanup`,
+										`${name}: popup ${popup.id} remained after cleanup${cleanupError ? ` (${cleanupError})` : ""}`,
 									);
 								}
 							}
@@ -627,21 +686,8 @@ async function main() {
 				}
 			}
 
-			const msgs = await g
-				.eval<string[]>("window.__msgs ?? []")
-				.catch(() => []);
-			const expectsCallback = Object.entries(EXPECT).some(
-				([name, expectation]) =>
-					(!ONLY_CASE || name === ONLY_CASE) &&
-					expectation.opener === true &&
-					name !== "noArgs" &&
-					name !== "blankFragment",
-			);
-			if (expectsCallback && !msgs.some((m) => m.startsWith("ok:"))) {
-				failures.push("no postMessage reached the opener");
-			}
 			console.log(
-				`\npostMessage callbacks delivered to opener: ${msgs.length}`,
+				`\npostMessage callbacks delivered to opener: ${callbacksDelivered}`,
 			);
 		} finally {
 			try {

--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -507,6 +507,10 @@ async function main() {
 				} finally {
 					await targets()
 						.then((current) => {
+							// Replace the observation snapshot only after enumeration succeeds.
+							// If it fails, retain recorded targets as a cleanup fallback.
+							createdPopups.clear();
+							createdPanes.clear();
 							for (const target of current) {
 								if (target.type === "page" && !pageIdsBefore.has(target.id)) {
 									createdPopups.set(target.id, target);
@@ -547,12 +551,44 @@ async function main() {
 						});
 						c?.close();
 					}
-					for (let index = 0; index < createdPanes.size; index += 1) {
-						await closeFocusedPane(host).catch((error) => {
+					let previousCreatedPaneCount: number | null = null;
+					while (true) {
+						const liveCreatedPaneCount = await targets()
+							.then(
+								(current) =>
+									current.filter(
+										(target) =>
+											target.type === "webview" &&
+											!paneIdsBefore.has(target.id),
+									).length,
+							)
+							.catch((error) => {
+								failures.push(
+									`${name}: could not recount panes for cleanup: ${String(error)}`,
+								);
+								return null;
+							});
+						if (!liveCreatedPaneCount) break;
+						if (
+							previousCreatedPaneCount !== null &&
+							liveCreatedPaneCount >= previousCreatedPaneCount
+						) {
 							failures.push(
-								`${name}: could not close created pane: ${String(error)}`,
+								`${name}: created pane count did not decrease during cleanup`,
 							);
-						});
+							break;
+						}
+						previousCreatedPaneCount = liveCreatedPaneCount;
+						const closed = await closeFocusedPane(host)
+							.then(() => true)
+							.catch((error) => {
+								failures.push(
+									`${name}: could not close created pane: ${String(error)}`,
+								);
+								return false;
+							});
+						if (!closed) break;
+						await sleep(800);
 					}
 					await sleep(800);
 					await targets()

--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -290,29 +290,7 @@ function formatObservations(values: Array<boolean | string | null>): string {
 	return values.length ? values.map((value) => value ?? "?").join(",") : "-";
 }
 
-async function closeFocusedPane(renderer: Cdp): Promise<void> {
-	// The split action focuses the new pane. Drive the host's real CLOSE_PANE
-	// hotkey rather than Page.close on the guest target: the latter destroys a
-	// WebContents without updating the renderer's pane layout.
-	const isMac = process.platform === "darwin";
-	const modifiers = isMac ? 4 : 2 | 8; // Meta, or Control + Shift.
-	await renderer.send("Input.dispatchKeyEvent", {
-		type: "rawKeyDown",
-		key: isMac ? "w" : "W",
-		code: "KeyW",
-		windowsVirtualKeyCode: 87,
-		modifiers,
-	});
-	await renderer.send("Input.dispatchKeyEvent", {
-		type: "keyUp",
-		key: isMac ? "w" : "W",
-		code: "KeyW",
-		windowsVirtualKeyCode: 87,
-		modifiers,
-	});
-}
-
-async function focusPaneTarget(
+async function closePaneTarget(
 	renderer: Cdp,
 	target: CdpTarget,
 ): Promise<void> {
@@ -323,23 +301,24 @@ async function focusPaneTarget(
 		);
 		if (!element) return null;
 		const rect = element.getBoundingClientRect();
-		// Click the host-rendered pane header just above the fixed webview. A
-		// click inside the guest does not bubble to the pane's focus handler.
+		// The host-rendered pane header sits just above the fixed webview.
 		return { x: rect.left + rect.width / 2, y: Math.max(0, rect.top - 10) };
 	})()`);
 	if (!point) throw new Error(`could not locate pane target ${target.id}`);
+	// PaneHeader scopes a middle click to this pane's context.actions.close.
+	// Unlike the global close hotkey, a miss cannot close some other active pane.
 	await renderer.send("Input.dispatchMouseEvent", {
 		type: "mousePressed",
 		x: point.x,
 		y: point.y,
-		button: "left",
+		button: "middle",
 		clickCount: 1,
 	});
 	await renderer.send("Input.dispatchMouseEvent", {
 		type: "mouseReleased",
 		x: point.x,
 		y: point.y,
-		button: "left",
+		button: "middle",
 		clickCount: 1,
 	});
 	await sleep(200);
@@ -616,8 +595,7 @@ async function main() {
 							});
 					let liveCreatedPanes = await listLiveCreatedPanes();
 					while (liveCreatedPanes?.length) {
-						const closed = await focusPaneTarget(host, liveCreatedPanes[0])
-							.then(() => closeFocusedPane(host))
+						const closed = await closePaneTarget(host, liveCreatedPanes[0])
 							.then(() => true)
 							.catch((error) => {
 								failures.push(

--- a/apps/desktop/scripts/cdp-smoke-popups.ts
+++ b/apps/desktop/scripts/cdp-smoke-popups.ts
@@ -1,0 +1,378 @@
+/**
+ * Smoke test for browser-pane popups against a running dev build.
+ *
+ *   RENDERER_REMOTE_DEBUG_PORT=9222 bun run dev:desktop   # then, with a
+ *   # browser pane open in a workspace (Cmd+Shift+B):
+ *   bun run apps/desktop/scripts/cdp-smoke-popups.ts
+ *
+ * Covers the contract in `main/lib/browser/popup-window.ts`: a `window.open`
+ * that a sign-in flow depends on becomes a real popup window that keeps
+ * `window.opener`, the window name, the pane's cookie jar and `window.close()`,
+ * while an ordinary `target="_blank"` link still opens as a split pane.
+ *
+ * Regressions here are close to invisible in unit tests: the pieces that break
+ * (opener identity, session inheritance, whether Electron hands the URL to the
+ * system browser) only exist in a real Electron window. See SUPER-1272.
+ *
+ * Serves its own fixture, so it needs no network. Exits 0 on PASS, 1 on FAIL.
+ * Dependency-free (Bun WebSocket + fetch).
+ */
+
+const PORT = process.env.RENDERER_REMOTE_DEBUG_PORT ?? "9222";
+const FIXTURE_PORT = Number(process.env.POPUP_FIXTURE_PORT ?? "8797");
+const ORIGIN = `http://localhost:${FIXTURE_PORT}`;
+
+const OAUTH = `${ORIGIN}/popup?client_id=a&redirect_uri=${encodeURIComponent(
+	`${ORIGIN}/cb`,
+)}&response_type=code&scope=email`;
+
+/** Each case runs in the pane; `rec` stores what `window.open` handed back. */
+const CASES: Record<string, string> = {
+	noArgs: `rec(window.open())`,
+	blankFragment: `rec(window.open("about:blank#state=1"))`,
+	oauthBare: `rec(window.open(${JSON.stringify(OAUTH)}))`,
+	oauthBlankTarget: `rec(window.open(${JSON.stringify(OAUTH)}, "_blank"))`,
+	oauthNamed: `rec(window.open(${JSON.stringify(OAUTH)}, "authwin"))`,
+	withFeatures: `rec(window.open(${JSON.stringify(
+		`${ORIGIN}/popup`,
+	)}, "authpopup", "width=500,height=600"))`,
+	oidcHybrid: `rec(window.open(${JSON.stringify(
+		`${ORIGIN}/popup?client_id=a&redirect_uri=b&response_type=${encodeURIComponent("code id_token")}`,
+	)}))`,
+	noopener: `rec(window.open(${JSON.stringify(OAUTH)}, "n", "noopener"))`,
+	nested: `rec(window.open(${JSON.stringify(
+		`${ORIGIN}/popup?nest=1`,
+	)}, "outer", "width=500,height=500"))`,
+	selfClosing: `rec(window.open(${JSON.stringify(
+		`${ORIGIN}/popup?close=1`,
+	)}, "c", "width=400,height=400"))`,
+	blankLink: `document.getElementById("lnk").click()`,
+	plainScriptedOpen: `rec(window.open(${JSON.stringify(`${ORIGIN}/popup`)}))`,
+	disallowedScheme: `rec(window.open("file:///etc/passwd"))`,
+};
+
+interface Expectation {
+	/** Popup windows expected to exist while the case is live. */
+	popups: number;
+	/** Extra split panes the case should create. */
+	panes: number;
+	/** Whether the popup must still see its opener. */
+	opener?: boolean;
+	/** Whether `window.open` must hand the page a usable handle. */
+	handle?: boolean;
+	note: string;
+}
+
+const EXPECT: Record<string, Expectation> = {
+	noArgs: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "window.open() with no arguments",
+	},
+	blankFragment: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "about:blank with a fragment",
+	},
+	oauthBare: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "bare window.open of a sign-in URL (Deel's shape)",
+	},
+	oauthBlankTarget: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "sign-in URL with a _blank name",
+	},
+	oauthNamed: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "sign-in URL, named, no features",
+	},
+	withFeatures: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "window.open with features (Firebase's shape)",
+	},
+	oidcHybrid: {
+		popups: 1,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "OIDC hybrid response_type",
+	},
+	noopener: {
+		popups: 1,
+		panes: 0,
+		opener: false,
+		handle: false,
+		note: "noopener severs the opener and nulls the handle, per spec",
+	},
+	nested: {
+		popups: 2,
+		panes: 0,
+		opener: true,
+		handle: true,
+		note: "a popup opening its own popup (Google's consent step)",
+	},
+	selfClosing: {
+		popups: 0,
+		panes: 0,
+		handle: true,
+		note: "window.close() from inside the popup",
+	},
+	blankLink: {
+		popups: 0,
+		panes: 1,
+		note: "a plain target=_blank link still opens a split pane",
+	},
+	plainScriptedOpen: {
+		popups: 0,
+		panes: 1,
+		handle: false,
+		note: "KNOWN GAP: indistinguishable from a _blank link, so null + a pane",
+	},
+	disallowedScheme: {
+		popups: 0,
+		panes: 0,
+		handle: false,
+		note: "file: is refused outright",
+	},
+};
+
+const FIXTURE = `<!doctype html><meta charset="utf-8"><title>popup fixture</title>
+<body style="font:14px system-ui;background:#111;color:#eee;padding:20px">
+<a id="lnk" href="${ORIGIN}/popup" target="_blank">blank link</a>
+<script>
+  window.__handle = null; window.__msgs = [];
+  window.rec = (w) => { window.__handle = (w === null ? "NULL" : "HANDLE"); };
+  addEventListener("message", (e) => window.__msgs.push(String(e.data)));
+  document.cookie = "paneprobe=1; path=/";
+</script>`;
+
+const POPUP = (q: URLSearchParams) => `<!doctype html><meta charset="utf-8">
+<body style="font:13px ui-monospace;background:#022;color:#9fd;padding:16px">
+<script>
+  window.__info = {
+    hasOpener: !!window.opener,
+    name: window.name,
+    // Same origin as the pane: proves the popup inherited its cookie jar
+    // rather than landing in a separate session (the SUPER-1272 symptom).
+    sharesCookieJar: document.cookie.includes("paneprobe=1"),
+  };
+  try { if (window.opener) window.opener.postMessage("ok:" + (window.name || "(anon)"), "*"); } catch {}
+  ${q.get("nest") === "1" ? `setTimeout(() => window.open("${ORIGIN}/popup?inner=1", "inner", "width=380,height=380"), 500);` : ""}
+  ${q.get("close") === "1" ? "setTimeout(() => window.close(), 800);" : ""}
+</script>`;
+
+interface CdpTarget {
+	type: string;
+	url: string;
+	webSocketDebuggerUrl?: string;
+}
+
+class Cdp {
+	private id = 0;
+	private pending = new Map<
+		number,
+		{ resolve: (v: unknown) => void; reject: (e: Error) => void }
+	>();
+	private constructor(private ws: WebSocket) {
+		ws.addEventListener("message", (ev) => {
+			const m = JSON.parse(String(ev.data)) as {
+				id?: number;
+				result?: unknown;
+				error?: { message: string };
+			};
+			if (m.id == null) return;
+			const p = this.pending.get(m.id);
+			if (!p) return;
+			this.pending.delete(m.id);
+			m.error ? p.reject(new Error(m.error.message)) : p.resolve(m.result);
+		});
+	}
+	static async connect(url: string): Promise<Cdp> {
+		const ws = new WebSocket(url);
+		await new Promise<void>((res, rej) => {
+			ws.addEventListener("open", () => res(), { once: true });
+			ws.addEventListener("error", () => rej(new Error("ws error")), {
+				once: true,
+			});
+		});
+		return new Cdp(ws);
+	}
+	send<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+		const id = ++this.id;
+		return new Promise<T>((resolve, reject) => {
+			this.pending.set(id, {
+				resolve: resolve as (v: unknown) => void,
+				reject,
+			});
+			this.ws.send(JSON.stringify({ id, method, params }));
+			setTimeout(() => {
+				if (this.pending.delete(id)) reject(new Error(`timeout: ${method}`));
+			}, 20_000);
+		});
+	}
+	async eval<T>(expression: string): Promise<T> {
+		const r = await this.send<{
+			result?: { value?: T };
+			exceptionDetails?: { text: string };
+		}>("Runtime.evaluate", {
+			expression,
+			awaitPromise: true,
+			returnByValue: true,
+			userGesture: true,
+		});
+		if (r.exceptionDetails) throw new Error(r.exceptionDetails.text);
+		return r.result?.value as T;
+	}
+	close() {
+		this.ws.close();
+	}
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const targets = async (): Promise<CdpTarget[]> =>
+	(await (
+		await fetch(`http://127.0.0.1:${PORT}/json/list`)
+	).json()) as CdpTarget[];
+const popupsNow = async () =>
+	(await targets()).filter(
+		(t) => t.type === "page" && !/^https?:\/\/localhost:\d+\/#/.test(t.url),
+	);
+const panesNow = async () =>
+	(await targets()).filter((t) => t.type === "webview");
+
+async function main() {
+	const server = Bun.serve({
+		port: FIXTURE_PORT,
+		fetch(req) {
+			const u = new URL(req.url);
+			const body = u.pathname.startsWith("/popup")
+				? POPUP(u.searchParams)
+				: FIXTURE;
+			return new Response(body, {
+				headers: { "content-type": "text/html; charset=utf-8" },
+			});
+		},
+	});
+
+	try {
+		const pane = (await panesNow())[0];
+		if (!pane?.webSocketDebuggerUrl) {
+			console.error(
+				`FAIL: no browser pane found on port ${PORT}.\n` +
+					"Open a workspace and press Cmd+Shift+B, then re-run.",
+			);
+			return 1;
+		}
+
+		const g = await Cdp.connect(pane.webSocketDebuggerUrl);
+		await g.send("Page.enable");
+		await g.send("Runtime.enable");
+		await g.send("Page.navigate", { url: `${ORIGIN}/` });
+		await sleep(2500);
+
+		const failures: string[] = [];
+		console.log(
+			`${"case".padEnd(19)}${"popups".padEnd(8)}${"opener".padEnd(8)}${"jar".padEnd(6)}${"handle".padEnd(8)}panes  verdict`,
+		);
+
+		for (const [name, script] of Object.entries(CASES)) {
+			const want = EXPECT[name];
+			if (!want) continue;
+			const panesBefore = (await panesNow()).length;
+			await g.eval(`window.__handle = null; ${script}; 1`).catch(() => {});
+			await sleep(name === "nested" || name === "selfClosing" ? 3000 : 2000);
+
+			const live = await popupsNow();
+			const panesAfter = (await panesNow()).length;
+			let opener: boolean | null = null;
+			let jar: boolean | null = null;
+			for (const p of live) {
+				if (!p.webSocketDebuggerUrl) continue;
+				const c = await Cdp.connect(p.webSocketDebuggerUrl);
+				await c.send("Runtime.enable");
+				// Read the opener off the popup itself rather than the fixture's
+				// snapshot: an `about:blank` popup never loads the fixture, and
+				// relying on that snapshot silently skipped the assertion for the
+				// two blank cases.
+				const has = await c.eval<boolean>("!!window.opener").catch(() => null);
+				if (has !== null) opener = opener === false ? false : has;
+				const info = await c
+					.eval<{ sharesCookieJar: boolean } | null>("window.__info ?? null")
+					.catch(() => null);
+				if (info) jar = info.sharesCookieJar;
+				c.close();
+			}
+			const handle = await g
+				.eval<string>("String(window.__handle)")
+				.catch(() => "?");
+
+			const bad: string[] = [];
+			if (live.length !== want.popups)
+				bad.push(`popups ${live.length}!=${want.popups}`);
+			if (panesAfter - panesBefore !== want.panes)
+				bad.push(`panes +${panesAfter - panesBefore}!=+${want.panes}`);
+			if (
+				want.opener !== undefined &&
+				opener !== null &&
+				opener !== want.opener
+			)
+				bad.push(`opener ${opener}!=${want.opener}`);
+			// Every popup that keeps its opener must also keep the pane's jar.
+			if (want.opener === true && jar === false)
+				bad.push("cookie jar not shared");
+			if (want.handle !== undefined) {
+				const got = handle === "HANDLE";
+				if (got !== want.handle) bad.push(`handle ${handle}`);
+			}
+			if (bad.length)
+				failures.push(`${name}: ${bad.join(", ")} (${want.note})`);
+
+			console.log(
+				`${name.padEnd(19)}${String(live.length).padEnd(8)}${String(opener ?? "-").padEnd(8)}${String(jar ?? "-").padEnd(6)}${handle.padEnd(8)}+${panesAfter - panesBefore}     ${bad.length ? `FAIL ${bad.join(", ")}` : "ok"}`,
+			);
+
+			for (const p of live) {
+				if (!p.webSocketDebuggerUrl) continue;
+				const c = await Cdp.connect(p.webSocketDebuggerUrl).catch(() => null);
+				await c?.send("Page.close").catch(() => {});
+				c?.close();
+			}
+			await sleep(800);
+		}
+
+		const msgs = await g.eval<string[]>("window.__msgs ?? []").catch(() => []);
+		if (!msgs.some((m) => m.startsWith("ok:"))) {
+			failures.push("no postMessage reached the opener");
+		}
+		console.log(`\npostMessage callbacks delivered to opener: ${msgs.length}`);
+		g.close();
+
+		if (failures.length) {
+			console.error(`\nFAIL (${failures.length}):`);
+			for (const f of failures) console.error(`  - ${f}`);
+			return 1;
+		}
+		console.log("\nPASS: every popup shape behaved as specified.");
+		return 0;
+	} finally {
+		server.stop(true);
+	}
+}
+
+process.exit(await main());

--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, shell } from "electron";
 import { env } from "main/env.main";
+import { isBrowserPanePopup } from "main/lib/browser/popup-window";
 import { loadReactDevToolsExtension } from "main/lib/extensions";
 import { PLATFORM } from "shared/constants";
 import { makeAppId } from "shared/utils";
@@ -44,6 +45,13 @@ export async function makeAppSetup(
 	app.on("web-contents-created", (_, contents) => {
 		if (contents.getType() === "webview") return;
 		contents.on("will-navigate", (event, url) => {
+			// A popup a browser pane opened navigates in place: it is a real
+			// `window.open` window (an OAuth sign-in, typically) that has to stay
+			// on the pane's session. Handing it to the system browser strands the
+			// sign-in in a different cookie jar than the pane that started it
+			// (SUPER-1272). Checked here rather than above because the popup is
+			// marked on `did-create-window`, after this listener is attached.
+			if (isBrowserPanePopup(contents)) return;
 			// Always prevent in-app navigation for external URLs
 			if (url.startsWith("http://") || url.startsWith("https://")) {
 				event.preventDefault();

--- a/apps/desktop/src/main/lib/browser/browser-manager.test.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.test.ts
@@ -415,12 +415,17 @@ describe("window.open handling", () => {
 		expect(opts).not.toHaveProperty("height");
 	});
 
-	test("a popup does not pin a partition, so it inherits the pane session", () => {
+	test("a popup pins no webPreferences, so it inherits the opener's", () => {
 		const wc = register("pane-partition");
 		const result = wc.windowOpen?.(openDetails({ disposition: "new-window" }));
-		const prefs = result?.overrideBrowserWindowOptions?.webPreferences;
-		expect(prefs).not.toHaveProperty("partition");
-		expect(prefs).toMatchObject({ nodeIntegration: false, sandbox: true });
+		// Inheritance already guarantees no-Node and context isolation. Pinning
+		// a value that later diverges from the guest (sandbox especially) makes
+		// Electron isolate the child in its own process, which nulls
+		// window.opener and silently breaks the sign-in handshake. Not setting
+		// a partition is part of the same rule: the popup shares the pane's jar.
+		expect(
+			result?.overrideBrowserWindowOptions?.webPreferences,
+		).toBeUndefined();
 	});
 
 	test("an about:blank popup is allowed — auth flows open one then navigate it", () => {
@@ -449,14 +454,17 @@ describe("window.open handling", () => {
 		expect(emitted).toEqual(["https://example.com/docs"]);
 	});
 
-	test("about:blank tabs are dropped rather than opening an empty pane", () => {
+	test("a bare about:blank open is allowed, not denied as an empty tab", () => {
+		// window.open("about:blank") passes no features, so Chromium reports a
+		// tab. Denying it returns null to the caller, which auth libraries that
+		// open-then-navigate read as a blocked popup.
 		const wc = register("pane-blank-tab");
 		const emitted: string[] = [];
 		browserManager.on("new-window:pane-blank-tab", (url: string) => {
 			emitted.push(url);
 		});
 		expect(wc.windowOpen?.(openDetails({ url: "about:blank" }))?.action).toBe(
-			"deny",
+			"allow",
 		);
 		expect(emitted).toEqual([]);
 	});

--- a/apps/desktop/src/main/lib/browser/browser-manager.test.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.test.ts
@@ -28,11 +28,16 @@ const PNG_IMAGE: FakeImage = {
 	toJPEG: () => Buffer.from("jpeg"),
 };
 
+type WindowOpenHandler = (
+	details: Electron.HandlerDetails,
+) => Electron.WindowOpenHandlerResponse;
+
 interface FakeWebContents {
 	throttlingCalls: boolean[];
 	isDestroyed: () => boolean;
 	setBackgroundThrottling: (allowed: boolean) => void;
-	setWindowOpenHandler: () => void;
+	setWindowOpenHandler: (handler: WindowOpenHandler) => void;
+	windowOpen: WindowOpenHandler | null;
 	on: () => void;
 	off: () => void;
 	getURL: () => string;
@@ -58,7 +63,10 @@ function makeWc(): { wc: FakeWebContents; id: number } {
 		setBackgroundThrottling: (allowed: boolean) => {
 			throttlingCalls.push(allowed);
 		},
-		setWindowOpenHandler: () => {},
+		setWindowOpenHandler: (handler: WindowOpenHandler) => {
+			wc.windowOpen = handler;
+		},
+		windowOpen: null,
 		on: () => {},
 		off: () => {},
 		getURL: () => "https://example.com",
@@ -363,5 +371,110 @@ describe("forced CDP detach", () => {
 		session.detach();
 		browserManager.off("agent-active", handler);
 		expect(states).toEqual([["pane-state"], []]);
+	});
+});
+
+describe("window.open handling", () => {
+	function openDetails(
+		overrides: Partial<Electron.HandlerDetails>,
+	): Electron.HandlerDetails {
+		return {
+			url: "https://accounts.google.com/o/oauth2/auth",
+			frameName: "",
+			features: "",
+			disposition: "foreground-tab",
+			referrer: { url: "", policy: "default" },
+			...overrides,
+		} as Electron.HandlerDetails;
+	}
+
+	test("a real popup opens natively, so it keeps its opener and cookie jar", () => {
+		const wc = register("pane-popup");
+		const result = wc.windowOpen?.(
+			openDetails({
+				disposition: "new-window",
+				features: "width=500,height=600",
+			}),
+		);
+		expect(result?.action).toBe("allow");
+		// A sign-in popup must not outlive the page that opened it.
+		expect(result?.outlivesOpener).toBe(false);
+	});
+
+	test("geometry is left to Electron's own parse of the features string", () => {
+		const wc = register("pane-geometry");
+		const opts = wc.windowOpen?.(
+			openDetails({
+				disposition: "new-window",
+				features: "width=500,height=600",
+			}),
+		)?.overrideBrowserWindowOptions;
+		// These options outrank Electron's features parse, so re-deriving the
+		// geometry here would override Chromium rather than defer to it.
+		expect(opts).not.toHaveProperty("width");
+		expect(opts).not.toHaveProperty("height");
+	});
+
+	test("a popup does not pin a partition, so it inherits the pane session", () => {
+		const wc = register("pane-partition");
+		const result = wc.windowOpen?.(openDetails({ disposition: "new-window" }));
+		const prefs = result?.overrideBrowserWindowOptions?.webPreferences;
+		expect(prefs).not.toHaveProperty("partition");
+		expect(prefs).toMatchObject({ nodeIntegration: false, sandbox: true });
+	});
+
+	test("an about:blank popup is allowed — auth flows open one then navigate it", () => {
+		const wc = register("pane-blank-popup");
+		const emitted: string[] = [];
+		browserManager.on("new-window:pane-blank-popup", (url: string) => {
+			emitted.push(url);
+		});
+		const result = wc.windowOpen?.(
+			openDetails({ url: "about:blank", disposition: "new-window" }),
+		);
+		expect(result?.action).toBe("allow");
+		expect(emitted).toEqual([]);
+	});
+
+	test("a target=_blank link still opens as a split pane", () => {
+		const wc = register("pane-link");
+		const emitted: string[] = [];
+		browserManager.on("new-window:pane-link", (url: string) => {
+			emitted.push(url);
+		});
+		const result = wc.windowOpen?.(
+			openDetails({ url: "https://example.com/docs", frameName: "_blank" }),
+		);
+		expect(result?.action).toBe("deny");
+		expect(emitted).toEqual(["https://example.com/docs"]);
+	});
+
+	test("about:blank tabs are dropped rather than opening an empty pane", () => {
+		const wc = register("pane-blank-tab");
+		const emitted: string[] = [];
+		browserManager.on("new-window:pane-blank-tab", (url: string) => {
+			emitted.push(url);
+		});
+		expect(wc.windowOpen?.(openDetails({ url: "about:blank" }))?.action).toBe(
+			"deny",
+		);
+		expect(emitted).toEqual([]);
+	});
+
+	test("a disallowed scheme is denied outright, popup or not", () => {
+		const wc = register("pane-scheme");
+		const emitted: string[] = [];
+		browserManager.on("new-window:pane-scheme", (url: string) => {
+			emitted.push(url);
+		});
+		expect(
+			wc.windowOpen?.(openDetails({ url: "file:///etc/passwd" }))?.action,
+		).toBe("deny");
+		expect(
+			wc.windowOpen?.(
+				openDetails({ url: "file:///etc/passwd", disposition: "new-window" }),
+			)?.action,
+		).toBe("deny");
+		expect(emitted).toEqual([]);
 	});
 });

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -17,7 +17,7 @@ import {
 import { DesignModeController } from "./design-mode-controller";
 import { captureDesignModeScreenshot } from "./design-mode-screenshot";
 import { buildDesignModeScript } from "./design-mode-script";
-import { isPopupDisposition, markBrowserPanePopup } from "./popup-window";
+import { markBrowserPanePopup, shouldOpenAsPopup } from "./popup-window";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -875,7 +875,10 @@ class BrowserManager extends EventEmitter {
 	 * Decide what a guest's `window.open` should do.
 	 *
 	 * A `target="_blank"` link (a tab disposition) keeps the pane behaviour: deny
-	 * the native window and let the renderer open the URL as a split.
+	 * the native window and let the renderer open the URL as a split. The one
+	 * exception is an OAuth authorization URL, which arrives with the same
+	 * disposition when a site opens sign-in via a bare `window.open(url)` but
+	 * cannot survive losing its opener — see `shouldOpenAsPopup`.
 	 *
 	 * A real popup has to stay a real popup. `window.open(url, name, "width=…")`
 	 * is how "Sign in with Google" flows work (Firebase `signInWithPopup`, Google
@@ -891,7 +894,7 @@ class BrowserManager extends EventEmitter {
 		details: Electron.HandlerDetails,
 	): Electron.WindowOpenHandlerResponse {
 		if (!isAllowedGuestUrl(details.url)) return { action: "deny" };
-		if (isPopupDisposition(details.disposition)) {
+		if (shouldOpenAsPopup(details)) {
 			return {
 				action: "allow",
 				// The default, but worth stating: a sign-in popup must not

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -131,13 +131,13 @@ function popupWindowOptions(): Electron.BrowserWindowConstructorOptions {
 		autoHideMenuBar: true,
 		// A sign-in window has no business going fullscreen.
 		fullscreenable: false,
-		webPreferences: {
-			// Arbitrary remote content: no app preload, no Node.
-			nodeIntegration: false,
-			contextIsolation: true,
-			sandbox: true,
-			webviewTag: false,
-		},
+		// `webPreferences` is deliberately not set. Electron inherits the
+		// opener's security preferences and refuses to relax them, so the popup
+		// is already no-Node and context-isolated. Restating them here would be
+		// worse than redundant: if a value we pin ever diverges from the guest's
+		// (`sandbox` especially), Electron isolates the child in its own process
+		// and `window.opener` comes back null, silently breaking the one thing
+		// this popup exists to preserve.
 	};
 }
 
@@ -903,11 +903,7 @@ class BrowserManager extends EventEmitter {
 				overrideBrowserWindowOptions: popupWindowOptions(),
 			};
 		}
-		// `about:blank` carries nothing worth a split pane. An auth flow that
-		// opens one before navigating it is a popup, handled above.
-		if (details.url !== "about:blank") {
-			this.emit(`new-window:${paneId}`, details.url);
-		}
+		this.emit(`new-window:${paneId}`, details.url);
 		return { action: "deny" };
 	}
 

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -17,6 +17,7 @@ import {
 import { DesignModeController } from "./design-mode-controller";
 import { captureDesignModeScreenshot } from "./design-mode-screenshot";
 import { buildDesignModeScript } from "./design-mode-script";
+import { isPopupDisposition, markBrowserPanePopup } from "./popup-window";
 
 interface ConsoleEntry {
 	level: "log" | "warn" | "error" | "info" | "debug";
@@ -99,6 +100,47 @@ function isAllowedGuestUrl(url: string): boolean {
 	}
 }
 
+/** Shared by panes and by the popups they open. Returns a detach function. */
+function attachNavigationGuard(wc: Electron.WebContents): () => void {
+	const handler = (event: Electron.Event, url: string) => {
+		if (!isAllowedGuestUrl(url)) event.preventDefault();
+	};
+	wc.on("will-navigate", handler);
+	wc.on("will-redirect", handler);
+	return () => {
+		try {
+			wc.off("will-navigate", handler);
+			wc.off("will-redirect", handler);
+		} catch {
+			// webContents may be destroyed
+		}
+	};
+}
+
+/**
+ * Window options for a popup opened from a guest pane.
+ *
+ * Geometry is deliberately left out: Electron already parses `width`/`height`/
+ * `x`/`y` from the `features` string, and options returned here outrank that
+ * parse — setting them would only re-derive what Chromium worked out, and drift
+ * from it. `partition` is left out for a different reason: the popup inherits
+ * the opener's session, and that shared cookie jar is the point of allowing it.
+ */
+function popupWindowOptions(): Electron.BrowserWindowConstructorOptions {
+	return {
+		autoHideMenuBar: true,
+		// A sign-in window has no business going fullscreen.
+		fullscreenable: false,
+		webPreferences: {
+			// Arbitrary remote content: no app preload, no Node.
+			nodeIntegration: false,
+			contextIsolation: true,
+			sandbox: true,
+			webviewTag: false,
+		},
+	};
+}
+
 /**
  * Resolve address-bar input to a URL the guest may load, or throw if it names
  * an explicit disallowed scheme (`file:`, `chrome:`, `data:`, `javascript:`,
@@ -156,6 +198,7 @@ class BrowserManager extends EventEmitter {
 	private contextMenuListeners = new Map<string, () => void>();
 	private beforeInputListeners = new Map<string, () => void>();
 	private navigationListeners = new Map<string, () => void>();
+	private popupListeners = new Map<string, () => void>();
 	private cdpDetachers = new Map<string, () => void>();
 	// Ref-count of in-flight agent work per pane (a live CDP session, a
 	// screenshot capture). While present the guest renderer stays
@@ -181,6 +224,7 @@ class BrowserManager extends EventEmitter {
 				this.contextMenuListeners,
 				this.beforeInputListeners,
 				this.navigationListeners,
+				this.popupListeners,
 			]) {
 				const cleanup = map.get(paneId);
 				if (cleanup) {
@@ -201,12 +245,7 @@ class BrowserManager extends EventEmitter {
 			// throttled+hidden guest stops presenting frames and CDP input and
 			// screenshots silently break.
 			this.applyThrottling(paneId, wc);
-			wc.setWindowOpenHandler(({ url }) => {
-				if (url && url !== "about:blank") {
-					this.emit(`new-window:${paneId}`, url);
-				}
-				return { action: "deny" as const };
-			});
+			this.setupWindowOpen(paneId, wc);
 			this.setupConsoleCapture(paneId, wc);
 			this.setupContextMenu(paneId, wc);
 			this.setupBeforeInput(paneId, wc);
@@ -224,6 +263,7 @@ class BrowserManager extends EventEmitter {
 			this.contextMenuListeners,
 			this.beforeInputListeners,
 			this.navigationListeners,
+			this.popupListeners,
 		]) {
 			const cleanup = map.get(paneId);
 			if (cleanup) {
@@ -811,19 +851,82 @@ class BrowserManager extends EventEmitter {
 	// the guest itself, so the policy holds whether the load came from the
 	// toolbar, a link, or a raw CDP `Page.navigate` (which skips sanitizeUrl).
 	private setupNavigationGuard(paneId: string, wc: Electron.WebContents): void {
-		const handler = (event: Electron.Event, url: string) => {
-			if (!isAllowedGuestUrl(url)) event.preventDefault();
+		this.navigationListeners.set(paneId, attachNavigationGuard(wc));
+	}
+
+	private setupWindowOpen(paneId: string, wc: Electron.WebContents): void {
+		wc.setWindowOpenHandler((details) =>
+			this.resolveWindowOpen(paneId, details),
+		);
+		const onCreated = (window: Electron.BrowserWindow) => {
+			this.configurePopupWindow(paneId, window);
 		};
-		wc.on("will-navigate", handler);
-		wc.on("will-redirect", handler);
-		this.navigationListeners.set(paneId, () => {
+		wc.on("did-create-window", onCreated);
+		this.popupListeners.set(paneId, () => {
 			try {
-				wc.off("will-navigate", handler);
-				wc.off("will-redirect", handler);
+				wc.off("did-create-window", onCreated);
 			} catch {
 				// webContents may be destroyed
 			}
 		});
+	}
+
+	/**
+	 * Decide what a guest's `window.open` should do.
+	 *
+	 * A `target="_blank"` link (a tab disposition) keeps the pane behaviour: deny
+	 * the native window and let the renderer open the URL as a split.
+	 *
+	 * A real popup has to stay a real popup. `window.open(url, name, "width=…")`
+	 * is how "Sign in with Google" flows work (Firebase `signInWithPopup`, Google
+	 * Identity Services, Auth0): the popup hands its result back through
+	 * `window.opener` and then closes itself. Re-opening that URL as a detached
+	 * pane drops both the opener and the window name, so the flow can never
+	 * complete — the reported symptom is Google bouncing the callback to
+	 * `accounts.google.com/CookieMismatch` (SUPER-1272). Allowing the window also
+	 * keeps it on the opener's session, so it shares the pane's cookie jar.
+	 */
+	private resolveWindowOpen(
+		paneId: string,
+		details: Electron.HandlerDetails,
+	): Electron.WindowOpenHandlerResponse {
+		if (!isAllowedGuestUrl(details.url)) return { action: "deny" };
+		if (isPopupDisposition(details.disposition)) {
+			return {
+				action: "allow",
+				// The default, but worth stating: a sign-in popup must not
+				// outlive the page that opened it.
+				outlivesOpener: false,
+				overrideBrowserWindowOptions: popupWindowOptions(),
+			};
+		}
+		// `about:blank` carries nothing worth a split pane. An auth flow that
+		// opens one before navigating it is a popup, handled above.
+		if (details.url !== "about:blank") {
+			this.emit(`new-window:${paneId}`, details.url);
+		}
+		return { action: "deny" };
+	}
+
+	/**
+	 * A popup loads arbitrary web content in the pane's session, so it gets the
+	 * pane's scheme guard, and the same window-open policy so the nested consent
+	 * window Google opens mid-flow stays a popup too.
+	 */
+	private configurePopupWindow(
+		paneId: string,
+		window: Electron.BrowserWindow,
+	): void {
+		const wc = window.webContents;
+		markBrowserPanePopup(wc);
+		const detachGuard = attachNavigationGuard(wc);
+		wc.setWindowOpenHandler((details) =>
+			this.resolveWindowOpen(paneId, details),
+		);
+		wc.on("did-create-window", (child) => {
+			this.configurePopupWindow(paneId, child);
+		});
+		window.on("closed", detachGuard);
 	}
 
 	private setupContextMenu(paneId: string, wc: Electron.WebContents): void {

--- a/apps/desktop/src/main/lib/browser/popup-window.test.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
 	isBrowserPanePopup,
+	isOAuthAuthorizationUrl,
 	isPopupDisposition,
 	markBrowserPanePopup,
+	shouldOpenAsPopup,
 } from "./popup-window";
 
 describe("isPopupDisposition", () => {
@@ -41,5 +43,70 @@ describe("browser pane popup registry", () => {
 		markBrowserPanePopup(a);
 		expect(isBrowserPanePopup(a)).toBe(true);
 		expect(isBrowserPanePopup(b)).toBe(false);
+	});
+});
+
+describe("isOAuthAuthorizationUrl", () => {
+	// The exact parameter set Deel's "Sign in with Google" opens with, captured
+	// from the running app. It arrives as `foreground-tab` with an empty
+	// frameName and empty features, indistinguishable from a `_blank` link, so
+	// the URL is the only signal left.
+	const DEEL_GOOGLE =
+		"https://accounts.google.com/o/oauth2/v2/auth?scope=email+profile&response_type=code&redirect_uri=https%3A%2F%2Fapp.deel.com%2Flogin%2Fgoogle&response_mode=query&prompt=select_account&client_id=x&state=y";
+
+	test("recognises a real provider authorization request", () => {
+		expect(isOAuthAuthorizationUrl(DEEL_GOOGLE)).toBe(true);
+	});
+
+	test("is provider-agnostic rather than a hostname allowlist", () => {
+		expect(
+			isOAuthAuthorizationUrl(
+				"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=a&redirect_uri=b&response_type=code",
+			),
+		).toBe(true);
+		expect(
+			isOAuthAuthorizationUrl(
+				"https://example.okta.com/oauth2/v1/authorize?client_id=a&redirect_uri=b&response_type=token",
+			),
+		).toBe(true);
+	});
+
+	test("an ordinary link is not an authorization request", () => {
+		expect(isOAuthAuthorizationUrl("https://example.com/docs")).toBe(false);
+		expect(isOAuthAuthorizationUrl("https://example.com/?client_id=a")).toBe(
+			false,
+		);
+		expect(isOAuthAuthorizationUrl("not a url")).toBe(false);
+		expect(isOAuthAuthorizationUrl("about:blank")).toBe(false);
+	});
+});
+
+describe("shouldOpenAsPopup", () => {
+	test("a Chromium popup disposition is enough on its own", () => {
+		expect(
+			shouldOpenAsPopup({
+				disposition: "new-window",
+				url: "https://example.com/anything",
+			}),
+		).toBe(true);
+	});
+
+	test("a bare window.open of a sign-in URL still becomes a popup", () => {
+		// Deel's shape: no name, no features, so Chromium reports a tab.
+		expect(
+			shouldOpenAsPopup({
+				disposition: "foreground-tab",
+				url: "https://accounts.google.com/o/oauth2/v2/auth?client_id=a&redirect_uri=b&response_type=code",
+			}),
+		).toBe(true);
+	});
+
+	test("an ordinary target=_blank link still opens as a split pane", () => {
+		expect(
+			shouldOpenAsPopup({
+				disposition: "foreground-tab",
+				url: "https://example.com/docs",
+			}),
+		).toBe(false);
 	});
 });

--- a/apps/desktop/src/main/lib/browser/popup-window.test.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.test.ts
@@ -146,9 +146,33 @@ describe("isOAuthAuthorizationUrl: response_type value space", () => {
 		`https://idp.example.com/authorize?client_id=a&redirect_uri=b&response_type=${rt}`;
 
 	test("accepts the defined single and hybrid response types", () => {
-		for (const rt of ["code", "token", "id_token", "none", "code%20id_token"]) {
+		for (const rt of [
+			"code",
+			"token",
+			"id_token",
+			"none",
+			"code%20id_token",
+			"token%20id_token",
+			"token%20code%20id_token",
+		]) {
 			expect(isOAuthAuthorizationUrl(url(rt))).toBe(true);
 		}
+	});
+
+	test("rejects invalid combinations and empty required values", () => {
+		for (const rt of ["none%20code", "code%20code", "code%20unknown"]) {
+			expect(isOAuthAuthorizationUrl(url(rt))).toBe(false);
+		}
+		expect(
+			isOAuthAuthorizationUrl(
+				"https://idp.example.com/authorize?client_id=&redirect_uri=b&response_type=code",
+			),
+		).toBe(false);
+		expect(
+			isOAuthAuthorizationUrl(
+				"https://idp.example.com/authorize?client_id=a&redirect_uri=&response_type=code",
+			),
+		).toBe(false);
 	});
 
 	test("an unrelated URL carrying the same parameter names is not a sign-in", () => {

--- a/apps/desktop/src/main/lib/browser/popup-window.test.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.test.ts
@@ -110,3 +110,48 @@ describe("shouldOpenAsPopup", () => {
 		).toBe(false);
 	});
 });
+
+describe("blank popups (open-then-navigate auth libraries)", () => {
+	test('a bare window.open("about:blank") is a popup, not a denied tab', () => {
+		// No features, so Chromium reports a tab. Denying it would hand the
+		// caller null, which reads as a blocked popup.
+		expect(
+			shouldOpenAsPopup({ disposition: "foreground-tab", url: "about:blank" }),
+		).toBe(true);
+	});
+
+	test("still a popup when Chromium already calls it one", () => {
+		expect(
+			shouldOpenAsPopup({ disposition: "new-window", url: "about:blank" }),
+		).toBe(true);
+	});
+});
+
+describe("isOAuthAuthorizationUrl: response_type value space", () => {
+	const url = (rt: string) =>
+		`https://idp.example.com/authorize?client_id=a&redirect_uri=b&response_type=${rt}`;
+
+	test("accepts the defined single and hybrid response types", () => {
+		for (const rt of ["code", "token", "id_token", "none", "code%20id_token"]) {
+			expect(isOAuthAuthorizationUrl(url(rt))).toBe(true);
+		}
+	});
+
+	test("an unrelated URL carrying the same parameter names is not a sign-in", () => {
+		// The false positive a presence-only check would have accepted.
+		expect(isOAuthAuthorizationUrl(url("json"))).toBe(false);
+		expect(
+			isOAuthAuthorizationUrl(
+				"https://example.com/report?client_id=a&redirect_uri=b&response_type=csv",
+			),
+		).toBe(false);
+	});
+
+	test("only http(s) URLs qualify", () => {
+		expect(
+			isOAuthAuthorizationUrl(
+				"file:///tmp/x?client_id=a&redirect_uri=b&response_type=code",
+			),
+		).toBe(false);
+	});
+});

--- a/apps/desktop/src/main/lib/browser/popup-window.test.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.test.ts
@@ -125,6 +125,20 @@ describe("blank popups (open-then-navigate auth libraries)", () => {
 			shouldOpenAsPopup({ disposition: "new-window", url: "about:blank" }),
 		).toBe(true);
 	});
+
+	test("a fragment or query on about:blank does not lose the popup", () => {
+		// Measured: matching the bare string exactly returned null to the caller
+		// AND left an empty split pane behind.
+		for (const url of [
+			"about:blank#state=abc",
+			"about:blank?x=1",
+			"about:srcdoc",
+		]) {
+			expect(shouldOpenAsPopup({ disposition: "foreground-tab", url })).toBe(
+				true,
+			);
+		}
+	});
 });
 
 describe("isOAuthAuthorizationUrl: response_type value space", () => {

--- a/apps/desktop/src/main/lib/browser/popup-window.test.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isBrowserPanePopup,
+	isPopupDisposition,
+	markBrowserPanePopup,
+} from "./popup-window";
+
+describe("isPopupDisposition", () => {
+	test("treats Chromium's popup disposition as a popup", () => {
+		expect(isPopupDisposition("new-window")).toBe(true);
+	});
+
+	test("leaves link targets as tabs, so they still open as split panes", () => {
+		expect(isPopupDisposition("foreground-tab")).toBe(false);
+		expect(isPopupDisposition("background-tab")).toBe(false);
+		expect(isPopupDisposition("default")).toBe(false);
+		expect(isPopupDisposition("other")).toBe(false);
+	});
+});
+
+describe("browser pane popup registry", () => {
+	// The app-wide `web-contents-created` guard in electron-app/factories/app
+	// sends http(s) `will-navigate` to the system browser. It consults this
+	// registry so a pane's sign-in popup navigates in place instead of being
+	// kicked out to Chrome, which would split the session across two browsers.
+	const contents = () => ({}) as unknown as Electron.WebContents;
+
+	test("an unmarked webContents is not a pane popup", () => {
+		expect(isBrowserPanePopup(contents())).toBe(false);
+	});
+
+	test("a marked webContents is recognised", () => {
+		const wc = contents();
+		markBrowserPanePopup(wc);
+		expect(isBrowserPanePopup(wc)).toBe(true);
+	});
+
+	test("marking one popup does not mark another", () => {
+		const a = contents();
+		const b = contents();
+		markBrowserPanePopup(a);
+		expect(isBrowserPanePopup(a)).toBe(true);
+		expect(isBrowserPanePopup(b)).toBe(false);
+	});
+});

--- a/apps/desktop/src/main/lib/browser/popup-window.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.ts
@@ -29,17 +29,53 @@ export function isPopupDisposition(
  * has none of these, so the split-pane path keeps that traffic.
  */
 export function isOAuthAuthorizationUrl(url: string): boolean {
-	let params: URLSearchParams;
+	let parsed: URL;
 	try {
-		params = new URL(url).searchParams;
+		parsed = new URL(url);
 	} catch {
 		return false;
 	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
+	const params = parsed.searchParams;
 	return (
 		params.has("client_id") &&
 		params.has("redirect_uri") &&
-		params.has("response_type")
+		hasAuthorizationResponseType(params)
 	);
+}
+
+/**
+ * `response_type` restricted to the values the specs actually define (RFC 6749
+ * section 3.1.1, plus the OIDC hybrid combinations, which are space-delimited
+ * and order-independent). Checking the value space rather than merely the
+ * parameter's presence keeps an unrelated URL that happens to carry these three
+ * parameter names on the split-pane path, without resorting to a list of
+ * provider hostnames that would go stale and would miss self-hosted identity
+ * providers.
+ */
+const AUTHORIZATION_RESPONSE_TYPES = new Set([
+	"code",
+	"token",
+	"id_token",
+	"none",
+]);
+
+function hasAuthorizationResponseType(params: URLSearchParams): boolean {
+	const raw = params.get("response_type")?.trim();
+	if (!raw) return false;
+	const values = raw.split(/\s+/);
+	return values.every((value) => AUTHORIZATION_RESPONSE_TYPES.has(value));
+}
+
+/**
+ * `window.open("about:blank")`, then assigning `location` once the request is
+ * ready, is how several auth libraries dodge popup blockers. Chromium reports
+ * it as a tab when no features are passed, so without this it would be denied
+ * and `window.open` would hand the page `null` — indistinguishable, to the
+ * caller, from a blocked popup.
+ */
+function isBlankPopupUrl(url: string): boolean {
+	return url === "about:blank";
 }
 
 /**
@@ -52,6 +88,7 @@ export function shouldOpenAsPopup(
 ): boolean {
 	return (
 		isPopupDisposition(details.disposition) ||
+		isBlankPopupUrl(details.url) ||
 		isOAuthAuthorizationUrl(details.url)
 	);
 }

--- a/apps/desktop/src/main/lib/browser/popup-window.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.ts
@@ -1,0 +1,38 @@
+/**
+ * Classification for a guest pane's `window.open`.
+ *
+ * Chromium decides the disposition itself: a scripted `window.open(url, name,
+ * "width=…,height=…")` is a popup (`new-window`), while a `target="_blank"`
+ * link is a tab (`foreground-tab`/`background-tab`). We keep tabs as split
+ * panes and let popups stay real popups — see `resolveWindowOpen` in
+ * browser-manager.
+ */
+export function isPopupDisposition(
+	disposition: Electron.HandlerDetails["disposition"],
+): boolean {
+	return disposition === "new-window";
+}
+
+/**
+ * Popups opened from a browser pane.
+ *
+ * The app-wide `web-contents-created` guard sends any http(s) `will-navigate`
+ * in a non-webview `webContents` to the system browser. A pane's popup is a
+ * `BrowserWindow`, so it matches that rule — which would kick a "Sign in with
+ * Google" window out to Chrome, stranding the session in a different browser's
+ * cookie jar from the pane that started it (SUPER-1272). These popups must
+ * navigate in place instead; that is the entire point of allowing them.
+ *
+ * A `WeakSet` so an entry dies with its `webContents`. Registration happens on
+ * `did-create-window`, which Electron fires before the popup's first
+ * `will-navigate`, so the guard always sees the mark in time.
+ */
+const panePopupContents = new WeakSet<Electron.WebContents>();
+
+export function markBrowserPanePopup(contents: Electron.WebContents): void {
+	panePopupContents.add(contents);
+}
+
+export function isBrowserPanePopup(contents: Electron.WebContents): boolean {
+	return panePopupContents.has(contents);
+}

--- a/apps/desktop/src/main/lib/browser/popup-window.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.ts
@@ -14,6 +14,49 @@ export function isPopupDisposition(
 }
 
 /**
+ * An OAuth 2.0 / OpenID Connect authorization request (RFC 6749 section 4.1.1).
+ *
+ * Needed because Chromium cannot tell us the thing we actually want to know.
+ * Measured in Electron 41: a scripted `window.open(url)` with no name and no
+ * features, and a plain `<a target="_blank">` click, arrive *identically* —
+ * disposition `foreground-tab`, empty `frameName`, empty `features`. Sites that
+ * open sign-in that way (Deel does) would otherwise land in a split pane, lose
+ * `window.opener`, and never complete the handshake.
+ *
+ * Keyed on the parameters every authorization endpoint carries rather than a
+ * list of provider hostnames, so it covers any identity provider without a
+ * vendor allowlist to maintain. A `target="_blank"` link to an ordinary page
+ * has none of these, so the split-pane path keeps that traffic.
+ */
+export function isOAuthAuthorizationUrl(url: string): boolean {
+	let params: URLSearchParams;
+	try {
+		params = new URL(url).searchParams;
+	} catch {
+		return false;
+	}
+	return (
+		params.has("client_id") &&
+		params.has("redirect_uri") &&
+		params.has("response_type")
+	);
+}
+
+/**
+ * Whether a guest's `window.open` should become a real popup window rather than
+ * a split pane: either Chromium already called it a popup, or it is a sign-in
+ * handshake that cannot survive losing its opener.
+ */
+export function shouldOpenAsPopup(
+	details: Pick<Electron.HandlerDetails, "disposition" | "url">,
+): boolean {
+	return (
+		isPopupDisposition(details.disposition) ||
+		isOAuthAuthorizationUrl(details.url)
+	);
+}
+
+/**
  * Popups opened from a browser pane.
  *
  * The app-wide `web-contents-created` guard sends any http(s) `will-navigate`

--- a/apps/desktop/src/main/lib/browser/popup-window.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.ts
@@ -75,7 +75,16 @@ function hasAuthorizationResponseType(params: URLSearchParams): boolean {
  * caller, from a blocked popup.
  */
 function isBlankPopupUrl(url: string): boolean {
-	return url === "about:blank";
+	try {
+		// Any `about:` URL, not just the bare string: `about:blank#state` is a
+		// real pattern (libraries stash handshake state in the fragment), and
+		// matching exactly missed it, which both returned null to the caller and
+		// left an empty split pane behind. Nothing under `about:` is worth a
+		// pane, so routing the whole scheme here fixes both halves.
+		return new URL(url).protocol === "about:";
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/apps/desktop/src/main/lib/browser/popup-window.ts
+++ b/apps/desktop/src/main/lib/browser/popup-window.ts
@@ -38,8 +38,8 @@ export function isOAuthAuthorizationUrl(url: string): boolean {
 	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return false;
 	const params = parsed.searchParams;
 	return (
-		params.has("client_id") &&
-		params.has("redirect_uri") &&
+		Boolean(params.get("client_id")?.trim()) &&
+		Boolean(params.get("redirect_uri")?.trim()) &&
 		hasAuthorizationResponseType(params)
 	);
 }
@@ -55,16 +55,21 @@ export function isOAuthAuthorizationUrl(url: string): boolean {
  */
 const AUTHORIZATION_RESPONSE_TYPES = new Set([
 	"code",
-	"token",
 	"id_token",
 	"none",
+	"token",
+	"code id_token",
+	"code token",
+	"id_token token",
+	"code id_token token",
 ]);
 
 function hasAuthorizationResponseType(params: URLSearchParams): boolean {
 	const raw = params.get("response_type")?.trim();
 	if (!raw) return false;
 	const values = raw.split(/\s+/);
-	return values.every((value) => AUTHORIZATION_RESPONSE_TYPES.has(value));
+	if (new Set(values).size !== values.length) return false;
+	return AUTHORIZATION_RESPONSE_TYPES.has(values.sort().join(" "));
 }
 
 /**


### PR DESCRIPTION
**Links**
- Issue: [SUPER-1272](https://linear.app/superset-sh/issue/SUPER-1272/browser-doesnt-work-well-with-popups) (reported in Discord by nitinl)

## Summary
- "Sign in with Google" never completed in the in-app browser. Popup OAuth flows now open as real popup windows on the pane's own session, instead of being flattened into a split pane or kicked out to the system browser.
- Two separate defects on the same path, both required for the flow to work end to end.

## Why / Context

The reported symptom is Google's cookie mismatch page. The underlying cause is that a `window.open` sign-in popup was never a popup:

**Defect 1: popups were denied outright.** `setWindowOpenHandler` denied *every* `window.open` and re-emitted the URL, which both renderer surfaces opened as a new split pane. A detached pane has no `window.opener` and no window name, so popup OAuth (Firebase `signInWithPopup`, Google Identity Services, Auth0) can never hand its result back to the page that started it. It also denied `about:blank` popups, which is how several auth libraries open the window before navigating it, so `window.open` returned `null` and tripped `auth/popup-blocked`.

**Defect 2: allowed popups got kicked to Chrome.** The app-wide guard in `electron-app/factories/app/setup.ts` sends any http(s) `will-navigate` in a non-webview `webContents` to the system browser. A popup is a `BrowserWindow`, not a webview, so fixing defect 1 alone made things look fixed while the sign-in URL opened in **Chrome**: the popup sat on `about:blank` forever while the user signed in in a different browser, landing the cookies in a different jar than the pane that started the flow. This is the half that actually produces the reported "cookie mismatch" behaviour, and it is invisible to unit tests.

## How It Works

- `resolveWindowOpen` gates on Chromium's own disposition. `new-window` (a scripted `window.open(url, name, "width=...")`) returns `action: "allow"`, so Electron creates a real window that keeps `window.opener`, the window name, and `window.close()`. Tab dispositions (`target="_blank"`) keep the existing split-pane behaviour, so that UX is unchanged.
- Popups inherit the opener's session. `partition` is deliberately never set in `overrideBrowserWindowOptions`, which is what keeps the popup's cookies in the pane's jar.
- Geometry is left to Electron, which already parses `width`/`height`/`x`/`y` from the `features` string and is outranked by `overrideBrowserWindowOptions`. Hand-rolling it would override Chromium rather than defer to it.
- A `WeakSet` of pane-popup `webContents` (`popup-window.ts`) lets the app-wide guard skip these windows. The check lives inside the `will-navigate` listener rather than at `web-contents-created`, because the mark is added on `did-create-window`, which Electron fires after creation but before the popup's first navigation.
- Popups get the pane's scheme guard and the same window-open policy, so the nested consent window Google opens mid-flow stays a popup too, and they load remote content with no preload, no Node, sandboxed.

## Manual QA Checklist

Verified over CDP against the dev app on this branch (renderer `localhost:4885`, dedicated debug port), driving a real mouse click on a real "Sign in with Google" button inside the guest webview. Baseline captured by reverting to the old deny-all path and repeating the identical journey.

| Observation | Before (deny-all) | After |
|---|---|---|
| `window.open` | `BLOCKED (returned null)` | returned a handle |
| `postMessage` to opener | none | `auth-ok:authpopup` delivered |
| Real popup window | 0 | 1, `name="authpopup"`, `opener=true` |
| Split panes created | popup flattened into a 2nd pane | none |
| Who fetched the OAuth URL | n/a | the app itself, not the system browser |
| Popup geometry | n/a | `outer=500x600`, matching the `features` string |

- [x] Popup sign-in completes: opener receives the callback
- [x] Popup opens on the pane's session (no `partition` override)
- [x] `target="_blank"` link still opens as a split pane (unchanged)
- [x] `about:blank` popup is allowed rather than returning null
- [x] Disallowed schemes (`file:`) still denied, popup or not
- [x] App launches without errors, pane restores across restart

Not covered: a real Google account sign-in end to end. See Known Limitations.

## Update: widened after testing a real account

Testing against a live Deel account found the disposition gate alone was not enough. Deel opens Google sign-in with a bare `window.open(url)` (no name, no features). Measured in Electron 41:

| call shape | disposition | frameName | features |
|---|---|---|---|
| `window.open(url)` (Deel) | `foreground-tab` | `''` | `''` |
| `window.open(url, name, "width=...")` (Firebase) | `new-window` | `'authpopup'` | `location=yes,...` |
| `window.open(url, name)` | `foreground-tab` | `'authwin'` | `''` |
| `<a target="_blank">` | `foreground-tab` | `''` | `''` |

Rows 1 and 4 are **indistinguishable**, so disposition cannot decide on its own. Gating only on `new-window` sent Google's account chooser to a split pane, where it lost `window.opener` and Deel's callback bounced back to `/login`.

The gate now also matches the shape of the URL: an OAuth 2.0 authorization request carries `client_id` + `redirect_uri` + `response_type` (RFC 6749 4.1.1). Keyed on those parameters rather than provider hostnames, so it covers any identity provider with no vendor allowlist to maintain. An ordinary `target="_blank"` link has none of them and still opens as a split pane, so that behaviour is unchanged.

**Verified end to end with a real Google account against `app.deel.com`:** the account chooser opens as a real popup window, the handshake completes, the popup closes itself, and the pane lands authenticated on Deel.

Worth noting for the open UA question below: Google raised **no** "browser or app may not be secure" wall in this flow, despite the pane presenting an `Electron/41.10.3` user agent.

## Edge-case sweep

Now a committed, repeatable smoke test: `apps/desktop/scripts/cdp-smoke-popups.ts`, alongside the existing `cdp-smoke-integrations.ts`. It serves its own fixture, drives thirteen `window.open` shapes through a live browser pane, and asserts popup count, opener identity, cookie-jar sharing, the returned handle, and pane count for each. Latest run: 13/13, 7 postMessage callbacks delivered.

```
case               popups  opener  jar   handle  panes  verdict
noArgs             1       true    -     HANDLE  +0     ok
blankFragment      1       true    -     HANDLE  +0     ok
oauthBare          1       true    true  HANDLE  +0     ok
oauthBlankTarget   1       true    true  HANDLE  +0     ok
oauthNamed         1       true    true  HANDLE  +0     ok
withFeatures       1       true    true  HANDLE  +0     ok
oidcHybrid         1       true    true  HANDLE  +0     ok
noopener           1       false   true  NULL    +0     ok
nested             2       true    true  HANDLE  +0     ok
selfClosing        0       -       -     HANDLE  +0     ok
blankLink          0       -       -     null    +1     ok
plainScriptedOpen  0       -       -     NULL    +1     ok
disallowedScheme   0       -       -     NULL    +0     ok
```

The `jar` column is the one that matters most: the popup reads a cookie the pane set, a direct check of the property whose absence was the reported symptom. `blankLink` and `disallowedScheme` are pinned as expected-negative so a future change cannot quietly turn every link into an OS window or let `file:` through.


Nine real `window.open` shapes driven through the running app. One misbehaved and is fixed; the rest now have measurements behind them.

| shape | handle | popup | `window.opener` | panes |
|---|---|---|---|---|
| `window.open()` (no args) | handle | 1 | intact | unchanged |
| `window.open("about:blank#state")` | handle | 1 | intact | unchanged (was: null + stray pane) |
| `window.open(oauthUrl, "_blank")` | handle | 1 | intact | unchanged |
| `window.open(oauthUrl, "name")` | handle | 1 | intact | unchanged |
| `window.open(oauthUrl, n, "noopener")` | null | 1 | none | unchanged (spec-correct) |
| OIDC hybrid `response_type=code id_token` | handle | 1 | intact | unchanged |
| nested popup opened from a popup | handle | 2 | intact | unchanged |
| `window.close()` from a popup | handle | 0 | n/a | unchanged |
| plain `<a target="_blank">` | n/a | 0 | n/a | split pane |


## Testing
- `bun run typecheck`
- `bun run lint` (6882 files, clean)
- `bun test src/main` (647 pass, 0 fail; 12 new tests across `popup-window.test.ts` and `browser-manager.test.ts`)
- `bun turbo run build --filter=@superset/desktop`
- `bun run --cwd packages/i18n check` (no new strings, no catalog changes)

The new tests are pinned in both directions: forcing `isPopupDisposition` to `false` (the old behaviour) fails exactly the three popup tests while the split-pane tests keep passing.

## Design Decisions
- **Gate on disposition, not on URL patterns or window name.** `new-window` is Chromium's own "this is a popup" determination, so it matches what a real browser does and needs no allowlist of auth providers. This is also what Ferdium landed for the same bug ([ferdium-app#2412](https://github.com/ferdium/ferdium-app/pull/2412), after [#1420](https://github.com/ferdium/ferdium-app/issues/1420) "oAuth window opens in browser"), arrived at independently here and cross-checked afterwards.
- **Exempt via a registry rather than loosening the global guard.** The app-wide "external URLs go to the system browser" rule is worth keeping for everything else; only pane popups need the carve-out.
- **One commit, not two.** Either half alone leaves the flow broken, so splitting would only produce a knowingly-broken intermediate revision.

## Known Limitations
- Tested end to end with a real Google account against Deel (see above). Not exercised against every provider; the OAuth detection is parameter-based, so a provider whose authorization endpoint omits `response_type` or `redirect_uri` would still fall through to the split-pane path.
- **A bare `window.open(url)` to a non-sign-in URL still returns `null` while the URL opens as a split pane** (`plainScriptedOpen` above). The page is told its popup was blocked even though we did open something, so a site that calls `w.focus()` on the result will throw. Pre-existing rather than new: before this PR *every* `window.open` behaved this way, sign-in included.

  I looked at closing it properly and do not think it can be done within this PR's scope. Four routes, all dead ends:

  1. **`createWindow` on `WindowOpenHandlerResponse`** — the right answer in principle, since a pane's webview could *be* the opened window and keep both the opener and the split-pane UX. It must return a `WebContents` synchronously, and panes are renderer-owned `<webview>` elements created asynchronously, so main cannot produce one in time. Would require moving panes to main-process `WebContentsView`s.
  2. **A preload that patches `window.open` in the guest** — with `contextIsolation` on, a preload runs in an isolated world and cannot touch the page's `window.open`. Turning it off for arbitrary web content is not a trade worth making.
  3. **Smuggling a marker through `frameName` or `features` from a main-world injection** — mutates page-observable state (`window.name`), risks flipping Chromium's own disposition computation, and any page that captures `window.open` first defeats it.
  4. **Treating every `foreground-tab` as a popup** — turns every `target="_blank"` link into an OS window, which is a worse regression than the bug.

  So it stays a documented gap, pinned by the smoke test so it cannot silently change, rather than a hack. The real fix is the panes-in-main architecture change.
- **Separate, still open: the "This browser or app may not be secure" wall.** The app sets no user-agent override, so panes present the default Electron UA and Google may reject it (`disallowed_useragent`). That is a different failure from this one and is deliberately out of scope. It did not trigger in the Deel flow, so it may be narrower than feared. Worth noting for whoever picks it up: UA spoofing is reportedly no longer a fix ([ferdium-app#2324](https://github.com/ferdium/ferdium-app/issues/2324), Jan 2026: "changing the user agent seems to no longer work no matter the value"), so the real answer is likely the system browser plus a loopback OAuth redirect. Our popup is now a real `BrowserWindow` rather than a webview, which may change Google's verdict on its own; untested.

## Follow-ups
- Optional polish: Ferdium also sets `parent: mainWindow` so a sign-in window cannot get lost behind the app. Skipped here because `BrowserManager` has no handle to the owning window and `outlivesOpener: false` already ties the popup's lifetime to its opener.

## Risks / Rollout
- Risk: low and contained to the in-app browser pane. The behaviour change is scoped to `window.open` with a popup disposition; `target="_blank"` links, the address bar, and CDP navigation are untouched. Popups keep the pane's scheme guard, so they cannot reach `file:`/`chrome:`.
- Rollout: ships with the desktop app, no flag, no migration, no API coupling.
- Rollback: revert this commit. Popups return to opening as split panes.

https://claude.ai/code/session_01QQV2Jd8VXMYgjRFQSeRNJH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sign-in popups in the in-app browser so OAuth flows like "Sign in with Google" complete in the pane's own session instead of failing on Google's cookie mismatch page (SUPER-1272).

- Scripted `window.open` popups now open as real popup windows, keeping `window.opener`, the window name, and the opener's cookie session; a bare `window.open(url)` of an OAuth authorization URL is detected by parameter shape (`client_id`, `redirect_uri`, `response_type`, with `response_type` validated against spec-defined values) rather than by disposition, which cannot distinguish it from a `target="_blank"` link.
- Popups are exempt from the app-wide rule that sends navigations to the system browser, which previously landed sign-in cookies in a different browser's cookie jar.
- `about:` popups are allowed so auth libraries can open a window before navigating it; popups inherit the pane's scheme guard, and `file:` and `chrome:` URLs stay denied.
- Ordinary `target="_blank"` links still open as split panes.

**Testing**
- Adds `cdp-smoke-popups.ts`, a dependency-free smoke test driving thirteen `window.open` shapes through a live pane, asserting popup count, opener identity, cookie-jar sharing, returned handle, exact opener callbacks, and pane count. Its fail-safe cleanup closes each test-created pane through its own header action and verifies current target deltas, so a missed target cannot close a pre-existing pane and recreated webviews cannot escape.

<sup>Written for commit 04fc2efda658007e9782531088b21d21c63ce858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser panes now support sign-in and other compatible popup flows directly within the app.
  * Popups preserve the originating pane’s session, opener relationship, and navigation protections.
  * Blank-page, nested-popup, and supported OAuth flows are handled consistently.

* **Bug Fixes**
  * Prevented valid popup navigation from being incorrectly redirected to the system browser.
  * Continued blocking unsupported tab-opening behaviors and disallowed URL schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


