### PR TITLE
feat(auth): gate activation drip enrolment behind the experiment flag

### DIFF
--- a/packages/auth/src/lib/lifecycle.ts
+++ b/packages/auth/src/lib/lifecycle.ts
@@ -1,0 +1,42 @@
+import { PostHog } from "posthog-node";
+
+import { env } from "../env";
+
+export const ACTIVATION_CAMPAIGN_FLAG = "activation-email-campaign";
+
+const posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
+	host: env.NEXT_PUBLIC_POSTHOG_HOST,
+	flushAt: 1,
+	flushInterval: 0,
+});
+
+/**
+ * Arm for the activation-drip A/B. `getFeatureFlag` emits the
+ * `$feature_flag_called` exposure PostHog scores the experiment on, so a user
+ * enters the analysis only when this call succeeds.
+ *
+ * The flag must be MULTIVARIATE with variants keyed exactly `control` and
+ * `test`. Only `control` withholds the drip; a missing, disabled or boolean
+ * flag reads as `test`, so shipping this before the flag exists changes
+ * nothing — everyone keeps getting the campaign until someone creates the
+ * flag at 50/50.
+ *
+ * Fails OPEN for the same reason: the drip is what ships to everyone today, so
+ * a PostHog outage must not silently stop it. Those signups emit no exposure
+ * either, which keeps them out of both arms instead of polluting control.
+ */
+export async function getActivationVariant(
+	userId: string,
+): Promise<"control" | "test"> {
+	try {
+		const variant = await posthog.getFeatureFlag(
+			ACTIVATION_CAMPAIGN_FLAG,
+			userId,
+		);
+		await posthog.flush();
+		return variant === "control" ? "control" : "test";
+	} catch (error) {
+		console.error("[lifecycle] Failed to evaluate activation flag:", error);
+		return "test";
+	}
+}

--- a/packages/auth/src/lib/lifecycle.ts
+++ b/packages/auth/src/lib/lifecycle.ts
@@ -8,6 +8,9 @@ const posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	host: env.NEXT_PUBLIC_POSTHOG_HOST,
 	flushAt: 1,
 	flushInterval: 0,
+	// This is awaited inside the signup hook, and the SDK default is 10s — long
+	// enough that a slow PostHog would stall signup rather than fail open.
+	requestTimeout: 3000,
 });
 
 /**

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -35,6 +35,7 @@ import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
 import { jwksAdapter } from "./lib/cached-jwks";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
+import { getActivationVariant } from "./lib/lifecycle";
 import { loadCustomSessionData } from "./lib/load-custom-session-data";
 import { invitationRateLimit } from "./lib/rate-limit";
 import { resend } from "./lib/resend";
@@ -296,10 +297,9 @@ export const auth = betterAuth({
 							.where(eq(authSchema.sessions.userId, user.id));
 					}
 
-					// Lifecycle emails ship to every signup. The A/B (experiment
-					// 387868) was retired inconclusive: at ~143 signups/day the
-					// diluted intent-to-treat effect would need years to resolve.
-					// Kill switch for the nudges is the Resend automation toggle.
+					// The welcome email is unconditional in BOTH arms. Gating it is
+					// what invalidated experiment 387868: a6beb048b changed the control
+					// condition mid-flight and the run became unreadable.
 					try {
 						const { error } = await resend.emails.send({
 							from: "Superset <noreply@superset.sh>",
@@ -320,18 +320,26 @@ export const auth = betterAuth({
 						);
 					}
 
-					try {
-						const { error } = await resend.events.send({
-							event: "user.signed_up",
-							email: user.email,
-							payload: { userId: user.id, name: user.name },
-						});
-						if (error) throw new Error(error.message);
-					} catch (error) {
-						console.error(
-							`[lifecycle] Failed to emit signup event for ${user.id}:`,
-							error,
-						);
+					// Only drip enrolment is randomised. Nothing differs between arms
+					// until the first nudge (>=23h after signup), so "not activated at
+					// 22h" stays a pre-treatment covariate and the analysis can restrict
+					// to it without selection bias — the undiluted effect needs ~3.2k per
+					// arm rather than ~80k. Kill switch for the nudges is still the
+					// Resend automation toggle.
+					if ((await getActivationVariant(user.id)) === "test") {
+						try {
+							const { error } = await resend.events.send({
+								event: "user.signed_up",
+								email: user.email,
+								payload: { userId: user.id, name: user.name },
+							});
+							if (error) throw new Error(error.message);
+						} catch (error) {
+							console.error(
+								`[lifecycle] Failed to emit signup event for ${user.id}:`,
+								error,
+							);
+						}
 					}
 				},
 			},

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -323,9 +323,16 @@ export const auth = betterAuth({
 					// Only drip enrolment is randomised. Nothing differs between arms
 					// until the first nudge (>=23h after signup), so "not activated at
 					// 22h" stays a pre-treatment covariate and the analysis can restrict
-					// to it without selection bias — the undiluted effect needs ~3.2k per
-					// arm rather than ~80k. Kill switch for the nudges is still the
-					// Resend automation toggle.
+					// to it without selection bias. Kill switch for the nudges is still
+					// the Resend automation toggle.
+					//
+					// CAUTION: `user.signed_up` triggers BOTH activation-drip and
+					// habit-drip, so withholding it withholds both. That is only safe
+					// while habit-drip stays disabled. Before re-arming habit-drip with
+					// this flag on, split enrolment into its own event (emit
+					// `user.signed_up` unconditionally, add an activation-only event and
+					// repoint activation-drip's trigger at it in sync-automations.ts),
+					// or control users silently drop out of the habit campaign too.
 					if ((await getActivationVariant(user.id)) === "test") {
 						try {
 							const { error } = await resend.events.send({


### PR DESCRIPTION
## What & why

Restores the activation-drip A/B gate so experiment 387868 can be re-run, and fixes the reason the last run was unreadable.

`getActivationVariant` was deleted in #6535 when the campaign shipped to 100%. This brings it back and gates **only** drip enrolment (the `user.signed_up` Resend event). The welcome email stays unconditional in both arms — gating it in `a6beb048b` is what invalidated 387868 by moving the control condition mid-flight, and that trap is now recorded in a comment.

**The analysis change.** Randomising at signup diluted the last run ~3x, because most signups activate before the first nudge ever sends; a true +2pp lift read as ~0.63pp, needing ~80k per arm (~3 years). But nothing differs between arms until that first nudge fires, which is at least 23h after signup. So "not activated at 22h" is a *pre-treatment* covariate, and restricting the analysis to that subgroup carries no selection bias. Measured against the real baseline for that population — **9.6%** (57/596 nudge recipients with ≥4 days follow-up) — the undiluted effect needs **~3.8k per arm**, or roughly 3.5 months at current volume. That avoids rebuilding the drip's scheduling around our own cron, which is what randomising at day 2 would have required (Resend automations have no branch step).

Two deliberate changes from the original helper:

- **Fails OPEN to `test`.** The old version returned `control` on error, which silently withheld the campaign during a PostHog outage *and* miscounted those users as control. A failed call emits no `$feature_flag_called`, so they now land in neither arm rather than polluting one.
- **A missing, disabled or boolean flag also reads as `test`**, so this ships as a no-op. The flag must be multivariate with variants keyed exactly `control`/`test` — a boolean at 50% rollout would read as all-`test`. That's documented in the file.

**This is behaviourally inert on merge.** Flag `activation-email-campaign` (781011) is disabled, with its 50/50 variants preserved. Starting the experiment is flipping it on, not deploying.

## How I tested it

- `bun run --cwd packages/auth typecheck` — clean
- `bunx biome check` on both files — clean
- `bun test` in `packages/auth` — 8 pass, 0 fail
- Verified flag 781011's live state directly (was `active: true` at 50/50 — merging without disabling it first would have started the experiment immediately; it is now `active: false`)

No UI surface, so no screenshots.

Not deployed-and-verified end to end: the flag is off, so the `control` path is unexercised in production until we turn it on. That's deliberate — the 48h check on the corrected activation-drip comes first.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs — n/a, not a fork

---

Context: the corrected `activation-drip` went live earlier today (`01a059d5-…`), replacing a drifted draft that had been sending installed users the "Get the desktop app" nudge since 20 Aug — 375 sends of `01-first-agent` against 2 of `01b-first-prompt` over 4.5 days. Baseline insight: https://us.posthog.com/project/264803/insights/AfPEj1qk

https://claude.ai/code/session_01NNJx4iLBUGs2kVBzso9Wym

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the activation-drip A/B gate so experiment 387868 can be re-run, and fixes what made the last run unreadable.

- Only drip enrolment (the `user.signed_up` Resend event) is randomised; the welcome email stays unconditional in both arms — gating it mid-flight is what invalidated the last run.
- The flag fails open to `test` instead of returning `control` on error, so a PostHog outage no longer withholds the campaign, and those users land in neither arm (no exposure is emitted).
- A missing, disabled, or boolean flag also reads as `test`, so this merge is behaviourally inert — the experiment starts when flag `activation-email-campaign` is turned on at 50/50.
- Restricting the analysis to users not activated within 22h of signup excludes 45% of signups and cuts the sample needed from ~80k to ~5.7k per arm.
- The PostHog call has a 3s timeout so a slow PostHog can't stall signup.
- `user.signed_up` also triggers habit-drip, so the control arm drops out of that campaign too — safe only while habit-drip stays disabled, which is recorded as a caution at the gate.

<sup>Written for commit bb18bc4983279ed81fbfc62928eddd5dbe67ba15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added activation campaign variant assignment, placing new sign-ups in either a control or test experience.
  - Added exposure tracking for campaign evaluations, with fallback behavior when the evaluation service is unavailable.

- **Behavior Updates**
  - Sign-up campaign events are now emitted only for users assigned to the test variant.
  - Welcome emails continue to be sent for all newly created users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->