### PR TITLE
fix(desktop): use workspace agent default for handoff

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalSessionHandoffMenu/TerminalSessionHandoffMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalSessionHandoffMenu/TerminalSessionHandoffMenu.tsx
@@ -25,6 +25,8 @@ import { AgentSelect } from "renderer/components/AgentSelect";
 import { useTerminalAgentBinding } from "renderer/hooks/host-service/useTerminalAgentBindings";
 import { useWorkspaceHostUrl } from "renderer/hooks/host-service/useWorkspaceHostUrl";
 import { useV2AgentConfigs } from "renderer/hooks/useV2AgentConfigs";
+import { AGENT_STORAGE_KEY } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
+import { resolveDefaultTargetConfigId } from "./resolveDefaultTargetConfigId";
 
 type Placement = "split-pane" | "new-tab";
 
@@ -79,6 +81,13 @@ export function TerminalSessionHandoffMenu({
 	const canFork = Boolean(
 		binding?.agentSessionId && sourceConfig?.forkArgs?.length,
 	);
+	const defaultTargetConfigId = resolveDefaultTargetConfigId(
+		configs.map((config) => config.id),
+		typeof window === "undefined"
+			? null
+			: window.localStorage.getItem(AGENT_STORAGE_KEY),
+		sourceConfig?.id,
+	);
 
 	// Fetched when the dialog opens rather than on Continue, so the size of
 	// what is about to be sent is on screen before the decision.
@@ -107,12 +116,8 @@ export function TerminalSessionHandoffMenu({
 
 	useEffect(() => {
 		if (action !== "handoff" || targetConfigId) return;
-		const defaultTarget =
-			configs.find((config) => config.id !== sourceConfig?.id) ??
-			sourceConfig ??
-			configs[0];
-		if (defaultTarget) setTargetConfigId(defaultTarget.id);
-	}, [action, configs, sourceConfig, targetConfigId]);
+		if (defaultTargetConfigId) setTargetConfigId(defaultTargetConfigId);
+	}, [action, defaultTargetConfigId, targetConfigId]);
 
 	if (!binding) return null;
 
@@ -121,11 +126,7 @@ export function TerminalSessionHandoffMenu({
 		setAction(nextAction);
 		setPlacement("split-pane");
 		if (nextAction === "handoff") {
-			const defaultTarget =
-				configs.find((config) => config.id !== sourceConfig?.id) ??
-				sourceConfig ??
-				configs[0];
-			setTargetConfigId(defaultTarget?.id ?? "");
+			setTargetConfigId(defaultTargetConfigId);
 		}
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalSessionHandoffMenu/resolveDefaultTargetConfigId.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalSessionHandoffMenu/resolveDefaultTargetConfigId.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { resolveDefaultTargetConfigId } from "./resolveDefaultTargetConfigId";
+
+describe("resolveDefaultTargetConfigId", () => {
+	test("uses the create-workspace agent preference when it is available", () => {
+		expect(
+			resolveDefaultTargetConfigId(
+				["claude-config", "codex-config"],
+				"claude-config",
+				"claude-config",
+			),
+		).toBe("claude-config");
+	});
+
+	test("falls back to another agent when the preference is unavailable", () => {
+		expect(
+			resolveDefaultTargetConfigId(
+				["claude-config", "codex-config"],
+				"remote-host-config",
+				"claude-config",
+			),
+		).toBe("codex-config");
+	});
+
+	test("falls back to the source agent when it is the only option", () => {
+		expect(
+			resolveDefaultTargetConfigId(["claude-config"], null, "claude-config"),
+		).toBe("claude-config");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalSessionHandoffMenu/resolveDefaultTargetConfigId.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalPaneHeaderExtras/components/TerminalSessionHandoffMenu/resolveDefaultTargetConfigId.ts
@@ -1,0 +1,14 @@
+export function resolveDefaultTargetConfigId(
+	configIds: readonly string[],
+	preferredConfigId: string | null,
+	sourceConfigId?: string,
+): string {
+	if (preferredConfigId && configIds.includes(preferredConfigId)) {
+		return preferredConfigId;
+	}
+	return (
+		configIds.find((configId) => configId !== sourceConfigId) ??
+		configIds[0] ??
+		""
+	);
+}


### PR DESCRIPTION
## What & why

Default the terminal session handoff target to the same agent selected in Create Workspace. If that host-specific config is unavailable, retain the existing fallback to another configured agent, then the source agent when it is the only option.

Adds focused coverage for the saved preference, unavailable-host fallback, and sole-agent fallback.

## How I tested it

- Focused Bun tests: 3 passed
- Persisted-key guardrail tests: 12 passed
- Biome check on changed files
- Desktop TypeScript check after generating normal route and icon artifacts
- CDP end-to-end in the matching worktree renderer on port 4245:
  - selected Codex in Create Workspace
  - opened the real workspace and a Codex terminal
  - opened Continue with another agent
  - confirmed the target remained Codex
  - confirmed the persisted preference and target used the identical config ID
  - observed no renderer exceptions or console.error events
  - restored the prior preference and removed the test terminal afterward

## Checklist

- [x] PR title follows conventional commits (type(scope): subject)
- [ ] bun run lint and bun run typecheck pass (targeted Biome and desktop TypeScript checks passed)
- [x] Allow edits from maintainers is checked on fork PRs (not a fork PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults terminal session handoff to the agent selected in Create Workspace instead of the first alternative agent. Falls back to the previous behavior when that preference isn't available.

<sup>Written for commit f9911aea4c113adf5f029c97c41476678048d2ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session handoff target selection by honoring the saved agent preference.
  * Added reliable fallback behavior when the preferred agent is unavailable, including source-agent-only scenarios.
  * Ensured the selected target remains consistent when opening the handoff dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->