### PR TITLE
fix(desktop): keep tab selection local and sync sidebar state

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useTerminalAgentBindings/useTerminalAgentBindings.ts
@@ -59,6 +59,7 @@ export function useTerminalAgentBindings(
 	}, [queryClient, queryKey]);
 
 	useWorkspaceEvent("agent:lifecycle", workspaceId, invalidate, enabled);
+	useWorkspaceEvent("agent:bindings-changed", workspaceId, invalidate, enabled);
 	useWorkspaceEvent("terminal:lifecycle", workspaceId, invalidate, enabled);
 
 	return useMemo(() => {

--- a/apps/desktop/src/renderer/hooks/host-service/useWorkspaceEvent/useWorkspaceEvent.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useWorkspaceEvent/useWorkspaceEvent.ts
@@ -1,4 +1,5 @@
 import type {
+	AgentBindingsChangedPayload,
 	AgentLifecyclePayload,
 	GitChangedPayload,
 	PageWatchChangedPayload,
@@ -24,6 +25,12 @@ export function useWorkspaceEvent(
 	type: "fs:events",
 	workspaceId: string,
 	callback: (event: FsWatchEvent) => void,
+	enabled?: boolean,
+): void;
+export function useWorkspaceEvent(
+	type: "agent:bindings-changed",
+	workspaceId: string,
+	callback: (payload: AgentBindingsChangedPayload) => void,
 	enabled?: boolean,
 ): void;
 export function useWorkspaceEvent(
@@ -55,6 +62,7 @@ export function useWorkspaceEvent(
 		| "git:changed"
 		| "fs:events"
 		| "agent:lifecycle"
+		| "agent:bindings-changed"
 		| "terminal:lifecycle"
 		| "port:changed"
 		| "page-watch:changed",
@@ -63,6 +71,7 @@ export function useWorkspaceEvent(
 		| ((event: FsWatchEvent) => void)
 		| ((payload: GitChangedPayload) => void)
 		| ((payload: AgentLifecyclePayload) => void)
+		| ((payload: AgentBindingsChangedPayload) => void)
 		| ((payload: TerminalLifecyclePayload) => void)
 		| ((payload: PortChangedPayload) => void)
 		| ((payload: PageWatchChangedPayload) => void),
@@ -89,6 +98,15 @@ export function useWorkspaceEvent(
 				},
 			);
 			cleanups.push(removeListener, () => bus.unwatchFs(workspaceId));
+		} else if (type === "agent:bindings-changed") {
+			const removeListener = bus.on(
+				"agent:bindings-changed",
+				workspaceId,
+				(_wid, payload) => {
+					(handler as (payload: AgentBindingsChangedPayload) => void)(payload);
+				},
+			);
+			cleanups.push(removeListener);
 		} else if (type === "agent:lifecycle") {
 			const removeListener = bus.on(
 				"agent:lifecycle",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider/DashboardSidebarWorkspaceStatusProvider.tsx
@@ -243,6 +243,9 @@ export function DashboardSidebarWorkspaceStatusProvider({
 			};
 			cleanups.push(bus.on("agent:lifecycle", workspaceId, invalidateBindings));
 			cleanups.push(
+				bus.on("agent:bindings-changed", workspaceId, invalidateBindings),
+			);
+			cleanups.push(
 				bus.on("terminal:lifecycle", workspaceId, invalidateBindings),
 			);
 			cleanups.push(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/layout.tsx
@@ -27,6 +27,7 @@ import { usePortsDisplayMode } from "renderer/stores/inline-workspace-ports";
 import { useOpenNewWorkspaceModal } from "renderer/stores/new-workspace-modal";
 import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
 import { syncPersistedStoreAcrossWindows } from "renderer/stores/syncPersistedStoreAcrossWindows";
+import { useV2NotificationStore } from "renderer/stores/v2-notifications";
 import {
 	COLLAPSED_WORKSPACE_SIDEBAR_WIDTH,
 	DEFAULT_WORKSPACE_SIDEBAR_WIDTH,
@@ -67,10 +68,14 @@ function DashboardLayout() {
 		const stopSectionCollapseSync = syncPersistedStoreAcrossWindows(
 			useSidebarSectionsCollapseStore,
 		);
+		const stopAgentStateSync = syncPersistedStoreAcrossWindows(
+			useV2NotificationStore,
+		);
 
 		return () => {
 			stopWorkspaceSidebarSync();
 			stopSectionCollapseSync();
+			stopAgentStateSync();
 		};
 	}, []);
 	// Get current workspace from route to pre-select project in new workspace modal

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/useV2WorkspacePaneLayout.ts
@@ -6,8 +6,16 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useEffect, useMemo, useRef } from "react";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import {
+	applyRememberedV2PaneSelection,
+	rememberV2PaneSelection,
+} from "renderer/stores/v2-pane-selection";
 import type { PaneViewerData } from "../../types";
 import { dropUnavailablePanes } from "./utils/dropUnavailablePanes";
+import {
+	getSharedPaneLayoutSnapshot,
+	preserveLocalPaneSelection,
+} from "./utils/preserveLocalPaneSelection";
 
 const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
 	version: 1,
@@ -16,7 +24,7 @@ const EMPTY_STATE: WorkspaceState<PaneViewerData> = {
 };
 
 function getSnapshot(state: WorkspaceState<PaneViewerData>): string {
-	return JSON.stringify(state);
+	return getSharedPaneLayoutSnapshot(state);
 }
 
 export function useV2WorkspacePaneLayout() {
@@ -34,10 +42,14 @@ export function useV2WorkspacePaneLayout() {
 	// paint after every workspace switch, flashing its contents in one
 	// effect-cycle late.
 	const workspaceRuntime = useMemo(() => {
-		const seededLayout =
+		const persistedLayout =
 			(collections.v2WorkspaceLocalState.get(workspaceId)?.paneLayout as
 				| WorkspaceState<PaneViewerData>
 				| undefined) ?? EMPTY_STATE;
+		const seededLayout = applyRememberedV2PaneSelection(
+			workspaceId,
+			persistedLayout,
+		);
 		return {
 			workspaceId,
 			seededSnapshot: getSnapshot(seededLayout),
@@ -104,7 +116,11 @@ export function useV2WorkspacePaneLayout() {
 		}
 
 		syncStateRef.current.lastSyncedSnapshot = nextSnapshot;
-		store.getState().replaceState(persistedPaneLayout);
+		store
+			.getState()
+			.replaceState((current) =>
+				preserveLocalPaneSelection(current, persistedPaneLayout),
+			);
 	}, [persistedPaneLayout, store, isLayoutReady]);
 
 	useEffect(() => {
@@ -114,6 +130,7 @@ export function useV2WorkspacePaneLayout() {
 				tabs: nextStore.tabs,
 				activeTabId: nextStore.activeTabId,
 			};
+			rememberV2PaneSelection(workspaceId, nextWorkspaceState);
 			const nextSnapshot = getSnapshot(nextWorkspaceState);
 			if (nextSnapshot === syncStateRef.current.lastSyncedSnapshot) {
 				return;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection/index.ts
@@ -1,0 +1,4 @@
+export {
+	getSharedPaneLayoutSnapshot,
+	preserveLocalPaneSelection,
+} from "./preserveLocalPaneSelection";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection/preserveLocalPaneSelection.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection/preserveLocalPaneSelection.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+import type { LayoutNode, Pane, Tab, WorkspaceState } from "@superset/panes";
+import {
+	getSharedPaneLayoutSnapshot,
+	preserveLocalPaneSelection,
+} from "./preserveLocalPaneSelection";
+
+type Data = { value: string };
+
+function layout(...paneIds: string[]): LayoutNode {
+	const [first, ...rest] = paneIds;
+	if (!first) throw new Error("A tab needs at least one pane");
+	return rest.reduce<LayoutNode>(
+		(tree, paneId) => ({
+			type: "split",
+			direction: "horizontal",
+			first: tree,
+			second: { type: "pane", paneId },
+		}),
+		{ type: "pane", paneId: first },
+	);
+}
+
+function tab(id: string, paneIds: string[], activePaneId: string): Tab<Data> {
+	return {
+		id,
+		createdAt: 1,
+		activePaneId,
+		layout: layout(...paneIds),
+		panes: Object.fromEntries(
+			paneIds.map(
+				(paneId) =>
+					[paneId, { id: paneId, kind: "test", data: { value: paneId } }] as [
+						string,
+						Pane<Data>,
+					],
+			),
+		),
+	};
+}
+
+function state(
+	tabs: Tab<Data>[],
+	activeTabId: string | null,
+): WorkspaceState<Data> {
+	return { version: 1, tabs, activeTabId };
+}
+
+describe("preserveLocalPaneSelection", () => {
+	it("keeps the current window's active tab and panes during a shared update", () => {
+		const previous = state(
+			[
+				tab("tab-1", ["pane-1", "pane-2"], "pane-2"),
+				tab("tab-2", ["pane-3"], "pane-3"),
+			],
+			"tab-2",
+		);
+		const next = state(
+			[
+				tab("tab-1", ["pane-1", "pane-2", "pane-4"], "pane-4"),
+				tab("tab-2", ["pane-3"], "pane-3"),
+			],
+			"tab-1",
+		);
+
+		const merged = preserveLocalPaneSelection(previous, next);
+
+		expect(merged.activeTabId).toBe("tab-2");
+		expect(merged.tabs[0]?.activePaneId).toBe("pane-2");
+		expect(merged.tabs[0]?.panes["pane-4"]).toBeDefined();
+	});
+
+	it("selects a nearby survivor when the local tab or pane was removed", () => {
+		const previous = state(
+			[
+				tab("tab-1", ["pane-1"], "pane-1"),
+				tab("tab-2", ["pane-2", "pane-3", "pane-4"], "pane-3"),
+				tab("tab-3", ["pane-5"], "pane-5"),
+			],
+			"tab-2",
+		);
+		const next = state(
+			[tab("tab-1", ["pane-1"], "pane-1"), tab("tab-3", ["pane-5"], "pane-5")],
+			"tab-1",
+		);
+
+		const merged = preserveLocalPaneSelection(previous, next);
+
+		expect(merged.activeTabId).toBe("tab-3");
+	});
+
+	it("excludes active selections from the shared comparison snapshot", () => {
+		const first = state(
+			[tab("tab-1", ["pane-1", "pane-2"], "pane-1")],
+			"tab-1",
+		);
+		const second = state(
+			[tab("tab-1", ["pane-1", "pane-2"], "pane-2")],
+			"tab-1",
+		);
+
+		expect(getSharedPaneLayoutSnapshot(first)).toBe(
+			getSharedPaneLayoutSnapshot(second),
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection/preserveLocalPaneSelection.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection/preserveLocalPaneSelection.ts
@@ -1,0 +1,86 @@
+import type { LayoutNode, WorkspaceState } from "@superset/panes";
+
+function getPaneOrder(layout: LayoutNode): string[] {
+	if (layout.type === "pane") return [layout.paneId];
+	return [...getPaneOrder(layout.first), ...getPaneOrder(layout.second)];
+}
+
+function resolveLocalSelection(
+	previousOrder: string[],
+	previousActiveId: string | null,
+	nextOrder: string[],
+	nextFallbackId: string | null,
+): string | null {
+	const survivors = new Set(nextOrder);
+	if (previousActiveId && survivors.has(previousActiveId)) {
+		return previousActiveId;
+	}
+
+	const previousIndex = previousActiveId
+		? previousOrder.indexOf(previousActiveId)
+		: -1;
+	if (previousIndex !== -1) {
+		return (
+			previousOrder.slice(previousIndex + 1).find((id) => survivors.has(id)) ??
+			previousOrder
+				.slice(0, previousIndex)
+				.reverse()
+				.find((id) => survivors.has(id)) ??
+			(nextFallbackId && survivors.has(nextFallbackId)
+				? nextFallbackId
+				: (nextOrder[0] ?? null))
+		);
+	}
+
+	return nextFallbackId && survivors.has(nextFallbackId)
+		? nextFallbackId
+		: (nextOrder[0] ?? null);
+}
+
+/**
+ * Applies a shared pane-layout update without adopting another window's
+ * active tab or pane. Selections that still exist remain local; when a remote
+ * structural edit removes one, the nearest surviving local sibling wins.
+ */
+export function preserveLocalPaneSelection<TData>(
+	previous: WorkspaceState<TData>,
+	next: WorkspaceState<TData>,
+): WorkspaceState<TData> {
+	const previousTabs = new Map(previous.tabs.map((tab) => [tab.id, tab]));
+	const tabs = next.tabs.map((tab) => {
+		const previousTab = previousTabs.get(tab.id);
+		if (!previousTab) return tab;
+
+		return {
+			...tab,
+			activePaneId: resolveLocalSelection(
+				getPaneOrder(previousTab.layout),
+				previousTab.activePaneId,
+				getPaneOrder(tab.layout),
+				tab.activePaneId,
+			),
+		};
+	});
+
+	return {
+		...next,
+		tabs,
+		activeTabId: resolveLocalSelection(
+			previous.tabs.map((tab) => tab.id),
+			previous.activeTabId,
+			tabs.map((tab) => tab.id),
+			next.activeTabId,
+		),
+	};
+}
+
+/** Active selections are window-local and must not participate in sync. */
+export function getSharedPaneLayoutSnapshot<TData>(
+	state: WorkspaceState<TData>,
+): string {
+	return JSON.stringify({
+		...state,
+		activeTabId: null,
+		tabs: state.tabs.map((tab) => ({ ...tab, activePaneId: null })),
+	});
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/lifecycleEvents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/lifecycleEvents.ts
@@ -8,6 +8,7 @@ import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useRingtoneStore } from "renderer/stores/ringtone";
 import { useV2NotificationStore } from "renderer/stores/v2-notifications";
+import { applyRememberedV2PaneSelection } from "renderer/stores/v2-pane-selection";
 import { getV2NativeNotificationContent } from "./notificationContent";
 import {
 	isV2NotificationTargetVisible,
@@ -37,12 +38,15 @@ export function handleV2AgentLifecycleEvent({
 	volume: number;
 	muted: boolean;
 }): void {
+	const localPaneLayout = paneLayout
+		? applyRememberedV2PaneSelection(workspaceId, paneLayout)
+		: paneLayout;
 	const target = resolveV2NotificationTarget({
 		workspaceId,
 		payload,
-		paneLayout,
+		paneLayout: localPaneLayout,
 	});
-	markSeenIfTargetVisible({ payload, paneLayout, target });
+	markSeenIfTargetVisible({ payload, paneLayout: localPaneLayout, target });
 
 	// Only Stop and PermissionRequest deserve sound. Start fires per-prompt
 	// (the working spinner is feedback enough); Attached/Detached fire on
@@ -55,7 +59,7 @@ export function handleV2AgentLifecycleEvent({
 	) {
 		return;
 	}
-	if (shouldSuppress(target, paneLayout)) return;
+	if (shouldSuppress(target, localPaneLayout)) return;
 
 	const ringtoneId = useRingtoneStore.getState().selectedRingtoneId;
 	void playRingtone({ ringtoneId, volume, muted });
@@ -81,12 +85,15 @@ export function markV2AgentLifecycleTargetSeen({
 	payload: AgentLifecyclePayload;
 	paneLayout: WorkspaceState<PaneViewerData> | null | undefined;
 }): void {
+	const localPaneLayout = paneLayout
+		? applyRememberedV2PaneSelection(workspaceId, paneLayout)
+		: paneLayout;
 	const target = resolveV2NotificationTarget({
 		workspaceId,
 		payload,
-		paneLayout,
+		paneLayout: localPaneLayout,
 	});
-	markSeenIfTargetVisible({ payload, paneLayout, target });
+	markSeenIfTargetVisible({ payload, paneLayout: localPaneLayout, target });
 }
 
 export function handleV2TerminalLifecycleEvent({

--- a/apps/desktop/src/renderer/stores/v2-notifications/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-notifications/store.ts
@@ -14,7 +14,8 @@ export type V2NotificationSourceInput =
 	| V2NotificationSourceKey;
 
 /**
- * Renderer-local notification state. Terminal agent statuses
+ * Profile-local notification state, synchronized between open windows.
+ * Terminal agent statuses
  * (working/permission/idle/review) are DERIVED from host agent bindings —
  * see `renderer/hooks/host-service/useV2NotificationStatus` — so the only
  * facts stored here are about the user, not the agents:

--- a/apps/desktop/src/renderer/stores/v2-pane-selection/index.ts
+++ b/apps/desktop/src/renderer/stores/v2-pane-selection/index.ts
@@ -1,0 +1,5 @@
+export {
+	applyRememberedV2PaneSelection,
+	clearRememberedV2PaneSelectionsForTest,
+	rememberV2PaneSelection,
+} from "./store";

--- a/apps/desktop/src/renderer/stores/v2-pane-selection/store.test.ts
+++ b/apps/desktop/src/renderer/stores/v2-pane-selection/store.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { WorkspaceState } from "@superset/panes";
+import {
+	applyRememberedV2PaneSelection,
+	clearRememberedV2PaneSelectionsForTest,
+	rememberV2PaneSelection,
+} from "./store";
+
+function state(
+	activeTabId: string,
+	activePaneIds: [string, string][],
+): WorkspaceState<null> {
+	return {
+		version: 1,
+		activeTabId,
+		tabs: activePaneIds.map(([tabId, paneId]) => ({
+			id: tabId,
+			createdAt: 1,
+			activePaneId: paneId,
+			layout: { type: "pane", paneId },
+			panes: { [paneId]: { id: paneId, kind: "test", data: null } },
+		})),
+	};
+}
+
+afterEach(clearRememberedV2PaneSelectionsForTest);
+
+describe("v2 pane selection", () => {
+	it("overlays only the selection remembered for this renderer and workspace", () => {
+		rememberV2PaneSelection(
+			"workspace-1",
+			state("tab-2", [
+				["tab-1", "pane-1"],
+				["tab-2", "pane-2"],
+			]),
+		);
+		const shared = state("tab-1", [
+			["tab-1", "pane-1"],
+			["tab-2", "pane-2"],
+		]);
+
+		expect(
+			applyRememberedV2PaneSelection("workspace-1", shared).activeTabId,
+		).toBe("tab-2");
+		expect(
+			applyRememberedV2PaneSelection("workspace-2", shared).activeTabId,
+		).toBe("tab-1");
+	});
+
+	it("ignores remembered ids removed by a shared structural update", () => {
+		rememberV2PaneSelection(
+			"workspace-1",
+			state("tab-2", [["tab-2", "pane-2"]]),
+		);
+
+		expect(
+			applyRememberedV2PaneSelection(
+				"workspace-1",
+				state("tab-1", [["tab-1", "pane-1"]]),
+			).activeTabId,
+		).toBe("tab-1");
+	});
+});

--- a/apps/desktop/src/renderer/stores/v2-pane-selection/store.ts
+++ b/apps/desktop/src/renderer/stores/v2-pane-selection/store.ts
@@ -1,0 +1,59 @@
+import type { WorkspaceState } from "@superset/panes";
+
+interface V2PaneSelection {
+	activeTabId: string | null;
+	activePaneIds: Record<string, string | null>;
+}
+
+const MAX_REMEMBERED_WORKSPACES = 100;
+const selections = new Map<string, V2PaneSelection>();
+
+/**
+ * Remembers focus in this renderer only. Each Electron window has its own JS
+ * realm, so this state cannot leak focus to another window.
+ */
+export function rememberV2PaneSelection<TData>(
+	workspaceId: string,
+	state: WorkspaceState<TData>,
+): void {
+	selections.delete(workspaceId);
+	selections.set(workspaceId, {
+		activeTabId: state.activeTabId,
+		activePaneIds: Object.fromEntries(
+			state.tabs.map((tab) => [tab.id, tab.activePaneId]),
+		),
+	});
+
+	if (selections.size <= MAX_REMEMBERED_WORKSPACES) return;
+	const oldestWorkspaceId = selections.keys().next().value;
+	if (oldestWorkspaceId) selections.delete(oldestWorkspaceId);
+}
+
+/** Overlays this window's remembered focus onto a shared pane layout. */
+export function applyRememberedV2PaneSelection<TData>(
+	workspaceId: string,
+	state: WorkspaceState<TData>,
+): WorkspaceState<TData> {
+	const selection = selections.get(workspaceId);
+	if (!selection) return state;
+
+	const tabs = state.tabs.map((tab) => {
+		const activePaneId = selection.activePaneIds[tab.id];
+		return activePaneId && tab.panes[activePaneId]
+			? { ...tab, activePaneId }
+			: tab;
+	});
+	const activeTabId = selection.activeTabId;
+	return {
+		...state,
+		tabs,
+		activeTabId:
+			activeTabId && tabs.some((tab) => tab.id === activeTabId)
+				? activeTabId
+				: state.activeTabId,
+	};
+}
+
+export function clearRememberedV2PaneSelectionsForTest(): void {
+	selections.clear();
+}

--- a/packages/host-service/src/events/event-bus.test.ts
+++ b/packages/host-service/src/events/event-bus.test.ts
@@ -18,6 +18,33 @@ function createEventBus(): EventBus {
 	});
 }
 
+describe("EventBus agent binding events", () => {
+	it("broadcasts invalidation-only binding changes to every client", () => {
+		const eventBus = createEventBus();
+		const sentMessages: string[] = [];
+		const socket = {
+			readyState: 1,
+			send(data: string) {
+				sentMessages.push(data);
+			},
+			close() {},
+		};
+		eventBus.handleOpen(socket);
+
+		eventBus.broadcastAgentBindingsChanged({
+			workspaceId: "workspace-1",
+			occurredAt: 1_700_000_000_000,
+		});
+
+		expect(sentMessages).toHaveLength(1);
+		expect(JSON.parse(sentMessages[0] ?? "{}")).toEqual({
+			type: "agent:bindings-changed",
+			workspaceId: "workspace-1",
+			occurredAt: 1_700_000_000_000,
+		});
+	});
+});
+
 describe("EventBus port events", () => {
 	it("broadcasts port changes from the shared port manager and removes listeners on close", () => {
 		const eventBus = createEventBus();

--- a/packages/host-service/src/events/event-bus.ts
+++ b/packages/host-service/src/events/event-bus.ts
@@ -209,6 +209,20 @@ export class EventBus {
 	}
 
 	/**
+	 * Fan out binding mutations that are not lifecycle hooks. Renderers refetch
+	 * status from the host, but notification controllers do not treat this as an
+	 * agent completion event.
+	 */
+	broadcastAgentBindingsChanged(
+		message: Omit<
+			Extract<ServerMessage, { type: "agent:bindings-changed" }>,
+			"type"
+		>,
+	): void {
+		this.broadcast({ type: "agent:bindings-changed", ...message });
+	}
+
+	/**
 	 * Fan out terminal process lifecycle events to renderer clients. Agent hook
 	 * status can otherwise get stuck when a terminal exits while its pane is not
 	 * mounted and therefore cannot observe the terminal websocket `exit` packet.

--- a/packages/host-service/src/events/index.ts
+++ b/packages/host-service/src/events/index.ts
@@ -5,6 +5,7 @@ export {
 	mapEventType,
 } from "./map-event-type.ts";
 export type {
+	AgentBindingsChangedMessage,
 	AgentLifecycleMessage,
 	ClientMessage,
 	EventBusErrorMessage,

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -34,6 +34,18 @@ export interface AgentLifecycleMessage {
 	occurredAt: number;
 }
 
+/**
+ * Invalidation-only signal for host-owned agent bindings changed outside a
+ * lifecycle hook (for example, the sidebar's Clear Status action). This is
+ * intentionally separate from `agent:lifecycle`: consumers should refetch
+ * binding state without playing completion sounds or showing notifications.
+ */
+export interface AgentBindingsChangedMessage {
+	type: "agent:bindings-changed";
+	workspaceId: string;
+	occurredAt: number;
+}
+
 export interface TerminalLifecycleMessage {
 	type: "terminal:lifecycle";
 	workspaceId: string;
@@ -172,6 +184,7 @@ export type ServerMessage =
 	| FsEventsMessage
 	| GitChangedMessage
 	| AgentLifecycleMessage
+	| AgentBindingsChangedMessage
 	| TerminalLifecycleMessage
 	| PortChangedMessage
 	| WorkspaceChangedMessage

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
@@ -391,6 +391,10 @@ export const terminalAgentsRouter = router({
 				input.workspaceId,
 				input.terminalId,
 			);
+			ctx.eventBus.broadcastAgentBindingsChanged({
+				workspaceId: input.workspaceId,
+				occurredAt: Date.now(),
+			});
 			return { success: true };
 		}),
 

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -1,6 +1,7 @@
 export { useEventBus } from "./hooks/useEventBus";
 export { useGitChangeEvents } from "./hooks/useGitChangeEvents";
 export {
+	type AgentBindingsChangedPayload,
 	type AgentIdentity,
 	type AgentLifecyclePayload,
 	type EventBusHandle,

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -14,6 +14,7 @@ type EventType =
 	| "fs:events"
 	| "git:changed"
 	| "agent:lifecycle"
+	| "agent:bindings-changed"
 	| "terminal:lifecycle"
 	| "port:changed"
 	| "workspace:changed"
@@ -38,6 +39,10 @@ export interface AgentLifecyclePayload {
 	terminalId: string;
 	// Absent when the hook ran without `SUPERSET_AGENT_ID` set.
 	agent?: AgentIdentity;
+	occurredAt: number;
+}
+
+export interface AgentBindingsChangedPayload {
 	occurredAt: number;
 }
 
@@ -110,25 +115,27 @@ type EventListener<T extends EventType> = T extends "fs:events"
 		? (workspaceId: string, payload: GitChangedPayload) => void
 		: T extends "agent:lifecycle"
 			? (workspaceId: string, payload: AgentLifecyclePayload) => void
-			: T extends "terminal:lifecycle"
-				? (workspaceId: string, payload: TerminalLifecyclePayload) => void
-				: T extends "port:changed"
-					? (workspaceId: string, payload: PortChangedPayload) => void
-					: T extends "workspace:changed"
-						? (workspaceId: string, payload: WorkspaceChangedPayload) => void
-						: T extends "workspace:create-settled"
-							? (
-									workspaceId: string,
-									payload: WorkspaceCreateSettledPayload,
-								) => void
-							: T extends "project:changed"
-								? (projectId: string, payload: ProjectChangedPayload) => void
-								: T extends "page-watch:changed"
-									? (
-											workspaceId: string,
-											payload: PageWatchChangedPayload,
-										) => void
-									: never;
+			: T extends "agent:bindings-changed"
+				? (workspaceId: string, payload: AgentBindingsChangedPayload) => void
+				: T extends "terminal:lifecycle"
+					? (workspaceId: string, payload: TerminalLifecyclePayload) => void
+					: T extends "port:changed"
+						? (workspaceId: string, payload: PortChangedPayload) => void
+						: T extends "workspace:changed"
+							? (workspaceId: string, payload: WorkspaceChangedPayload) => void
+							: T extends "workspace:create-settled"
+								? (
+										workspaceId: string,
+										payload: WorkspaceCreateSettledPayload,
+									) => void
+								: T extends "project:changed"
+									? (projectId: string, payload: ProjectChangedPayload) => void
+									: T extends "page-watch:changed"
+										? (
+												workspaceId: string,
+												payload: PageWatchChangedPayload,
+											) => void
+										: never;
 
 interface ListenerEntry {
 	type: EventType;
@@ -228,6 +235,7 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 			message.type === "fs:events" ||
 			message.type === "git:changed" ||
 			message.type === "agent:lifecycle" ||
+			message.type === "agent:bindings-changed" ||
 			message.type === "terminal:lifecycle" ||
 			message.type === "port:changed" ||
 			message.type === "workspace:changed" ||
@@ -263,6 +271,11 @@ function handleMessage(state: ConnectionState, data: unknown): void {
 					...(message.agent ? { agent: message.agent } : {}),
 					occurredAt: message.occurredAt,
 				},
+			);
+		} else if (message.type === "agent:bindings-changed") {
+			(entry.callback as EventListener<"agent:bindings-changed">)(
+				message.workspaceId,
+				{ occurredAt: message.occurredAt },
 			);
 		} else if (message.type === "terminal:lifecycle") {
 			(entry.callback as EventListener<"terminal:lifecycle">)(


### PR DESCRIPTION
## What & why

Keep active v2 tab and pane selection local to each desktop window while continuing to sync structural pane-layout changes.

Also make sidebar agent/attention state update across windows immediately:

- exclude active tab and pane ids from shared layout snapshots
- preserve each renderer's valid local selection when structural updates arrive
- remember renderer-local selection for notification visibility checks
- rehydrate persisted attention state on cross-window storage events
- broadcast a notification-free `agent:bindings-changed` event for host-side status clears so every renderer refetches without playing a completion sound

## How I tested it

- `bun test` focused pane-selection, notification-store, and host event-bus suites: 15 passed / 30 assertions
- `bun run --cwd packages/workspace-client typecheck`
- `bun run --cwd packages/host-service typecheck`
- `bun run --cwd apps/desktop typecheck`
- Biome checks on all changed files and `git diff --check`
- CDP verification against the desktop dev app with two real Electron windows:
  - selecting Terminal in window A left window B on Browser
  - clearing sidebar attention in window A updated both windows in real time

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (targeted Biome checks and all affected package typechecks pass)
- [x] "Allow edits from maintainers" is not applicable because this branch is pushed to the upstream repository


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps active tab and pane selection local to each desktop window while still syncing structural pane-layout changes, and makes sidebar agent state update across windows immediately.

**Bug Fixes**
- Excludes active tab and pane ids from shared layout snapshots so switching tabs or panes no longer affects other windows.
- Preserves each window's local selection when structural updates arrive, choosing a nearby surviving tab or pane if the original is removed.
- Remembers renderer-local selection in a new store so notification visibility checks use the correct selection per window.
- Syncs the v2 notification store across windows so sidebar attention state updates everywhere.
- Broadcasts a notification-free `agent:bindings-changed` event on status clears so all renderers refetch bindings without playing a completion sound.

<sup>Written for commit e86429b7546e1de35ea52c52dfeed2225a59e025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

