### PR TITLE
chore(ci): dispatchable job for the Vercel Blob to R2 image backfill

### DIFF
--- a/.github/workflows/backfill-images-to-r2.yml
+++ b/.github/workflows/backfill-images-to-r2.yml
@@ -1,0 +1,67 @@
+name: Backfill images to R2
+
+# One-off: moves avatars and organization logos off Vercel Blob into the public
+# R2 bucket. Runs here rather than from a laptop so the R2 write credentials
+# never leave the boundary that already holds them.
+#
+# SKIP_ENV_VALIDATION is what keeps this job small. The trpc env schema requires
+# 33 variables, so a validated run would need every production credential —
+# the Anthropic key, the GitHub App private key — to move some avatars. The
+# script reads only the database and R2, so only those are passed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run reads and decodes every image without writing anything"
+        type: choice
+        options:
+          - dry-run
+          - execute
+        default: dry-run
+      confirm:
+        description: 'Required for execute: type "backfill"'
+        type: string
+        default: ""
+
+concurrency:
+  group: backfill-images-to-r2
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill images
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Require confirmation to write
+        if: inputs.mode == 'execute' && inputs.confirm != 'backfill'
+        run: |
+          echo "::error::Refusing to write: re-run with confirm set to 'backfill'."
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run backfill (${{ inputs.mode }})
+        env:
+          SKIP_ENV_VALIDATION: "1"
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_PUBLIC_BUCKET: ${{ secrets.R2_PUBLIC_BUCKET }}
+          STATIC_URL: ${{ secrets.STATIC_URL }}
+        run: |
+          bun packages/trpc/scripts/migrate-images-to-r2.ts \
+            ${{ inputs.mode == 'dry-run' && '--dry-run' || '' }}

--- a/.github/workflows/backfill-images-to-r2.yml
+++ b/.github/workflows/backfill-images-to-r2.yml
@@ -28,11 +28,20 @@ concurrency:
   group: backfill-images-to-r2
   cancel-in-progress: false
 
+# Checkout is all the token is for. The job runs with production database and
+# R2 credentials in its environment, so it should not also hold a token that
+# can write to the repository.
+permissions:
+  contents: read
+
 jobs:
   backfill:
     name: Backfill images
     runs-on: ubuntu-latest
     environment: production
+    # Neither the per-object fetch nor the R2 writes set a timeout, so one hung
+    # connection would otherwise hold the runner for GitHub's six-hour default.
+    timeout-minutes: 60
 
     steps:
       - name: Require confirmation to write
@@ -43,6 +52,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -50,7 +61,11 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # Matches every other workflow here. sharp declares an install script,
+        # but it only checks for a prebuilt binary and falls back to building
+        # from source; the lockfile carries @img/sharp-linux-x64, so the check
+        # has nothing to do on this runner.
+        run: bun install --frozen --ignore-scripts
 
       - name: Run backfill (${{ inputs.mode }})
         env:


### PR DESCRIPTION
## What & why

The image backfill from #7061 has never run. It needs R2 write credentials, and those exist only in CI — so the options were to copy production write credentials onto a laptop, or to run the script where the credentials already live. This is the second.

Defaults to `dry-run`. A write run additionally requires typing `backfill` into a confirmation input, so a stray click cannot rewrite 1055 rows.

`SKIP_ENV_VALIDATION` is what keeps the job small. The trpc env schema requires 33 variables, so a validated run would need every production credential — the Anthropic key, the GitHub App private key — in order to move some avatars. The script reads the database and R2 and nothing else, so those are the only secrets passed. `@superset/db` already skips validation unconditionally, so only `DATABASE_URL` matters there.

## How I tested it

- Confirmed all seven referenced secrets resolve: `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `R2_PUBLIC_BUCKET` and `STATIC_URL` at `Production` scope, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` and `R2_ENDPOINT` at repo level.
- Ran the script's `--dry-run` locally against production: **1055 of 1055 rows movable, 0 unreadable, 0 failures**. That exercises every read path — the host filter, the fetch, and sharp decoding each object — without writing.
- YAML parses.

Not yet run through this workflow: `workflow_dispatch` only becomes triggerable once the file is on the default branch. The first run after merge will be a dry run.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manually triggered GitHub Actions workflow to run the Vercel Blob to R2 image backfill in CI, so R2 write credentials never leave the environment that already holds them. Defaults to `dry-run`; `execute` mode requires typing `backfill` into a confirmation input before writing.

- The job targets the `production` environment and passes only database and R2 secrets, with `SKIP_ENV_VALIDATION` skipping the other 33 trpc env variables.
- The runner gets `contents: read` with no persisted token, so it cannot write to the repository; a 60-minute timeout and `bun install --frozen --ignore-scripts` keep it in line with the other workflows.
- A concurrency group prevents overlapping runs.

<sup>Written for commit f86a0bf01187d805f4b09de633351e8a2f90da00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered migration workflow for moving avatars and organization logos to public storage.
  * Supports dry-run previews before migration begins.
  * Requires explicit confirmation before making changes.
  * Limits migrations to one active run at a time and applies a 60-minute execution limit.
  * Restricts the workflow to the permissions and credentials required for the migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->