### PR TITLE
fix(api): ship libvips with sharp so the API boots on Vercel

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -1,4 +1,6 @@
-import { join } from "node:path";
+import { realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, relative } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
@@ -11,9 +13,55 @@ if (process.env.NODE_ENV !== "production") {
 	});
 }
 
+/**
+ * The libvips shared library that sharp's prebuilt binary loads at runtime.
+ *
+ * `@img/sharp-<platform>` ships `sharp.node`, which loads libvips from the
+ * sibling package `@img/sharp-libvips-<platform>` through the binary's rpath,
+ * not through a `require()`. Next's file tracing resolves that package (its
+ * `package.json`, `versions.json` and the symlink beside the binary all reach
+ * the trace) but drops the shared library itself, so the Vercel function
+ * booted without it and every route importing `@superset/trpc` failed at
+ * module load (the 2026-09-01 outage). This includes the package's real
+ * directory, which is where the already-traced symlink points, so the rpath
+ * lookup lands on the library.
+ *
+ * Resolved from `packages/trpc`'s sharp rather than hard-coded, so it follows
+ * the sharp version and the build host's platform, which is also the platform
+ * whose `sharp.node` the tracer picks up: linux-x64 (glibc) on Vercel.
+ */
+function sharpLibvipsIncludes(): string[] {
+	const platform = `${process.platform}-${process.arch}`;
+	const require = createRequire(join(process.cwd(), "next.config.ts"));
+	try {
+		const sharpEntry = require.resolve("sharp", {
+			paths: [join(process.cwd(), "../../packages/trpc")],
+		});
+		const platformPackage = require.resolve(`@img/sharp-${platform}/package`, {
+			paths: [dirname(sharpEntry)],
+		});
+		const libvipsDir = realpathSync(
+			join(dirname(platformPackage), "..", `sharp-libvips-${platform}`),
+		);
+		return [`${relative(process.cwd(), libvipsDir)}/**`];
+	} catch (error) {
+		throw new Error(
+			`@img/sharp-${platform} and its libvips are not installed, so the API bundle cannot include the library sharp loads at runtime`,
+			{ cause: error },
+		);
+	}
+}
+
 const config: NextConfig = {
 	reactCompiler: true,
 	typescript: { ignoreBuildErrors: true },
+
+	// Every route: `@superset/trpc` is imported by the tRPC and MCP handlers
+	// and by two dozen integration and job routes, and a missed one is an
+	// outage. libvips is ~18MB, which the function bundle can afford.
+	outputFileTracingIncludes: {
+		"/**": sharpLibvipsIncludes(),
+	},
 
 	images: {
 		remotePatterns: [

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -37,10 +37,16 @@ if (process.env.NODE_ENV !== "production") {
 function sharpLibvipsIncludes(): string[] {
 	const platform = `${process.platform}-${process.arch}`;
 	const require = createRequire(join(process.cwd(), "next.config.ts"));
+	let sharpEntry: string;
 	try {
-		const sharpEntry = require.resolve("sharp", {
+		sharpEntry = require.resolve("sharp", {
 			paths: [join(process.cwd(), "../../packages/trpc")],
 		});
+	} catch {
+		// sharp is no longer a dependency of the router: nothing to ship.
+		return [];
+	}
+	try {
 		const platformPackage = require.resolve(`@img/sharp-${platform}/package`, {
 			paths: [dirname(sharpEntry)],
 		});

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -18,14 +18,18 @@ if (process.env.NODE_ENV !== "production") {
  *
  * `@img/sharp-<platform>` ships `sharp.node`, which loads libvips from the
  * sibling package `@img/sharp-libvips-<platform>` through the binary's rpath,
- * not through a `require()`. Next's file tracing resolves that package (its
- * `package.json`, `versions.json` and the symlink beside the binary all reach
- * the trace) but drops the shared library itself, so the Vercel function
- * booted without it and every route importing `@superset/trpc` failed at
- * module load (the 2026-09-01 outage). This includes the package's real
- * directory, which is where the already-traced symlink points, so the rpath
- * lookup lands on the library.
+ * not through a `require()`, so a JavaScript tracer cannot follow the edge.
+ * Turbopack special-cases sharp for exactly this, but its pattern
+ * (`/sharp-(\w+-\w+).node$`) predates sharp 0.35 renaming the binary to
+ * `sharp-<platform>-<version>.node`, so on Next 16.2.11 the library is left
+ * out and the Vercel function boots without it. Every route that imports
+ * `@superset/trpc` then failed at module load (the 2026-09-01 outage).
+ * Upstream fixed the pattern in vercel/next.js#94845 (Next 16.3). Until that
+ * upgrade this include does the same job; after it, the include is redundant
+ * and harmless.
  *
+ * It includes the package's real directory, which is where the already-traced
+ * symlink beside the binary points, so the rpath lookup lands on the library.
  * Resolved from `packages/trpc`'s sharp rather than hard-coded, so it follows
  * the sharp version and the build host's platform, which is also the platform
  * whose `sharp.node` the tracer picks up: linux-x64 (glibc) on Vercel.

--- a/packages/trpc/src/lib/upload.ts
+++ b/packages/trpc/src/lib/upload.ts
@@ -1,5 +1,4 @@
 import { TRPCError } from "@trpc/server";
-import sharp from "sharp";
 import { env } from "../env";
 import { userError } from "../i18n-error";
 import { deleteObjects, putObject } from "./r2";
@@ -46,6 +45,18 @@ export function imageUrlFor(pathname: string): string {
 }
 
 /**
+ * sharp is a native module, and this file is imported by the organization and
+ * user routers, so loading it at module scope makes its load failure every
+ * procedure's failure: on 2026-09-01 a bundle shipped without libvips and the
+ * whole API answered 500 until it was rolled back. Loaded here on first use,
+ * a broken sharp fails avatar and logo uploads and nothing else.
+ */
+async function loadSharp() {
+	const { default: sharp } = await import("sharp");
+	return sharp;
+}
+
+/**
  * Decodes the image and writes every variant. Shared with the backfill script
  * so a change to the sizes or the object layout cannot make fresh uploads and
  * migrated rows diverge.
@@ -60,6 +71,7 @@ export async function putImageVariants({
 	buffer: Buffer;
 	pathname: string;
 }): Promise<string> {
+	const sharp = await loadSharp();
 	let rendered: { name: string; body: Buffer }[];
 	try {
 		rendered = await Promise.all(


### PR DESCRIPTION
## What & why

Since #7061 the API has answered 500 to every request, until production was rolled back to the pre-#7061 deployment this afternoon. Vercel's runtime log for each of the three broken deployments:

```
Error: Could not load the "sharp" module using the linux-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.6: cannot open shared object file: No such file or directory
```

`sharp`'s prebuilt binary (`@img/sharp-linux-x64`) loads libvips from its sibling package `@img/sharp-libvips-linux-x64` through the binary's rpath, not through a `require()`, so a JavaScript tracer cannot follow the edge. Turbopack special-cases sharp for exactly this: when an addon path matches `/sharp-(\w+-\w+).node$` it adds the matching libvips package. sharp 0.35 renamed the binary to `sharp-linux-x64-0.35.4.node`, so the pattern never fires, and the route trace ends up with `sharp.node` plus libvips's `package.json`, `versions.json` and `lib/index.js`, but not the 18.6 MB shared library. Upstream fixed the pattern in vercel/next.js#94845 (merged 17 June, shipped in the 16.3 line); the API is on 16.2.11, whose Turbopack binary still carries the old pattern (checked with `strings`). Production-side confirmation: the first broken deployment's functions are 39.97 MB against 39.71 MB for the last good one, a quarter megabyte for sharp's JavaScript and binding and nothing for the library.

Two changes:

- **`apps/api/next.config.ts`**: an `outputFileTracingIncludes` entry that adds the libvips package's real directory to every route's trace. The symlink beside the binary (which the rpath resolves through) is already traced, so the real directory is all that is missing; including it through the symlink instead would declare a symlink and a directory at the same bundle path. This does by configuration what Turbopack's special case was supposed to do, and becomes redundant and harmless after an upgrade to Next 16.3. The path is resolved from `packages/trpc`'s `sharp` rather than hard-coded, so it tracks the sharp version and the host platform (linux-x64 on Vercel, which is also what the tracer picks up for `sharp.node`). Every route, because `@superset/trpc` is imported by the tRPC and MCP handlers and two dozen integration and job routes, and a missed one is an outage.
- **`packages/trpc/src/lib/upload.ts`**: `sharp` is now imported on first use instead of at module scope. This file is imported by the organization and user routers, which is why a native-module load failure took down every procedure rather than avatar and logo uploads. With the lazy import, the same failure is contained to the two upload mutations.

The rollback that is live right now is `api-h26xstmhv` (fa0c4f9c7). Merging this redeploys main with the fix.

## How I tested it

- `bun run lint` on both files and `bun run typecheck` in `packages/trpc` and `apps/api` are clean; `bun test` for the trpc lib and routers passes (14 tests).
- **Reproduced the gap locally.** On `origin/main` with the unmodified config, a clean `next build` for `apps/api` produces a route trace (`.next/server/app/api/trpc/[trpc]/route.js.nft.json`) that lists `sharp.node`, libvips's `package.json`, `versions.json` and `lib/index.js`, and the symlink beside the binary, but not `libvips-cpp.*`. Same shape on darwin-arm64 here as on linux-x64 in the failing deployments. With this change the trace lists the library.
- **Loaded sharp from the built function.** Ran `vercel build` locally against the `api` project settings (CLI 53.4.0; CI pins 50.22.1), then materialized the tRPC route's function from its `.vc-config.json` file map the way the Lambda filesystem sees it: regular files copied, symlinks recreated. Loading sharp from inside that tree decodes a PNG and writes a 64px WebP variant with libvips 8.18.6. Negative control: the same materialization minus the libvips library fails at load with sharp's `Could not load the "sharp" module` error, the one from the outage.
- **Verified on Linux.** The branch was built from a clean `git archive` in a `node:24-bookworm` container (linux-arm64, bun 1.3.14, isolated linker). The tRPC route's trace lists `libvips-cpp.so.8.18.6` in the real store directory; materializing the trace (693 files, 339 symlinks) and loading sharp from inside it works: `png 1x1, libvips 8.18.6, webp 94 bytes`, i.e. glibc's loader resolves `$ORIGIN/../../sharp-libvips-linux-arm64/lib` through the traced symlink. The negative control (same tree minus that file) fails with the production error text: `Could not load the "sharp" module using the linux-arm64 runtime | ERR_DLOPEN_FAILED: libvips-cpp.so.8.18.6: cannot open shared object file`.
- **Not verified: a real Vercel deployment.** This PR's preview would be the first run on linux-x64, and it is currently blocked by something unrelated: the preview API build fails env validation with `BLAXEL_REGION` and `BLAXEL_SANDBOX_IMAGE` undefined (`vars.*` in both deploy workflows). The 14:33 PDT production deploy still resolved them (`us-pdx-1`), another branch's preview API job passed at 15:19 and failed the same way at 15:31, and neither name is in the repo or environment variables now. Until that is restored, every preview API build fails, and so will the next production deploy of any branch. Once previews build, hit the preview's `/api/trpc/user.me?batch=1&input=%7B%7D` and expect a 401 JSON body rather than the HTML 500 page; the same check applies after merge.
- **Related: #7073** removes sharp from the function in favour of Cloudflare edge resizing (gated on a zone feature that is not enabled yet). The two are compatible: this PR makes today's code deploy; if #7073 lands first, the include resolves to nothing (the helper returns `[]` when sharp is not a dependency of `packages/trpc`).
- Bundle cost: libvips is ~18MB per function; the API's functions are ~40MB today.
- Independently re-derived by a second agent with read-only access; it reached the same commit and error, and added the Turbopack special-case finding above.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CDNPr763Cfk9SZBQTPrMb
