### PR TITLE
perf(web): stop re-optimizing images Cloudflare already optimized

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -28,10 +28,6 @@ const config: NextConfig = {
 				protocol: "https",
 				hostname: "*.public.blob.vercel-storage.com",
 			},
-			{
-				protocol: "https",
-				hostname: "static.supersetusercontent.com",
-			},
 		],
 	},
 

--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -33,10 +33,6 @@ const config: NextConfig = {
 			},
 			{
 				protocol: "https",
-				hostname: "static.supersetusercontent.com",
-			},
-			{
-				protocol: "https",
 				hostname: "unavatar.io",
 			},
 		],

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -143,10 +143,6 @@ const config: NextConfig = {
 				protocol: "https",
 				hostname: "*.public.blob.vercel-storage.com",
 			},
-			{
-				protocol: "https",
-				hostname: "static.supersetusercontent.com",
-			},
 		],
 	},
 

--- a/apps/web/src/app/accept-invitation/[invitationId]/page.tsx
+++ b/apps/web/src/app/accept-invitation/[invitationId]/page.tsx
@@ -98,10 +98,15 @@ export default async function AcceptInvitationPage({
 			<div className="max-w-lg space-y-6 text-center">
 				{invitation.organization.logo && (
 					<div className="relative mx-auto h-16 w-16">
+						{/* unoptimized: the URL is already a 256px square, resized and
+						    re-encoded by Cloudflare and cached at its edge. Without
+						    this, Vercel's optimizer fetches that and re-encodes it a
+						    second time, for a logo rendered at 64px. */}
 						<Image
 							src={invitation.organization.logo}
 							alt={invitation.organization.name}
 							fill
+							unoptimized
 							className="rounded-lg object-contain"
 						/>
 					</div>


### PR DESCRIPTION
## What & why

The invitation page rendered an organization logo through `next/image`. That component doesn't serve the `src` it is given — it rewrites the URL to `/_next/image?url=…&w=…&q=…`, served by Vercel's optimizer. So the real request path was:

```
browser → Cloudflare (superset.sh) → Vercel optimizer → Cloudflare /cdn-cgi/image/ → R2
```

Two CDNs and **two** image transformations for a logo displayed at 64px, whose source is already a 256px square WebP that Cloudflare resized, re-encoded, and cached. The second pass bought nothing and cost a network hop, a billable Vercel image optimization stacked on the billable Cloudflare one, and a re-encode of already-lossy output.

`unoptimized` makes `next/image` render the URL as given. Nothing else changes — the sizing was already correct.

## Also

`static.supersetusercontent.com` is removed from `remotePatterns` in `web`, `admin` and `marketing`. After this change nothing renders that host through the optimizer, and leaving the entry there is an invitation to reintroduce the same problem by writing the obvious thing.

`*.public.blob.vercel-storage.com` is deliberately left: it predates this work and older content may still reference Blob URLs.

## How I tested it

- `bun run typecheck` and `bun run lint` — both pass. (First attempt used a plain `<img>`; biome's `lint/performance/noImgElement` rejected it, and `unoptimized` is the better fix anyway since it keeps the component and needs no suppression.)
- Checked every `next/image` usage in `web`, `admin` and `marketing`: this was the **only** one pointing at an image we upload. The others are static marketing assets and GitHub/unavatar URLs, which still optimize normally.
- Confirmed no shared package under `packages/` imports `next/image`.

Not verified in a browser — this is a rendering path behind an invitation link. The change is `unoptimized` on one component, and the URL it renders is the same one the desktop and web apps already display directly today.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

https://claude.ai/code/session_01QAQLVm3xTUXsJhpPQo3Nuf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `next/image` from re-optimizing organization logos on the invitation page. The logo URL is already a 256px WebP that Cloudflare resized and cached, but `next/image` was rewriting it to Vercel's optimizer for a second pass. Adding `unoptimized` makes it render the URL directly, removing a network hop, a billable optimization, and a re-encode.

- Removes `static.supersetusercontent.com` from `remotePatterns` in `web`, `admin`, and `marketing` configs; nothing uses that host through the optimizer anymore.

<sup>Written for commit 264a3e190f3e4f00d183af87e0be166c1c5a844d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated remote image handling across the admin, marketing, and web apps.
  * Invitation acceptance pages now reliably display organization logos without image optimization issues.
  * Removed support for loading images from the deprecated static image host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->