### PR TITLE
chore(scripts): finish the Blob port — report, repoint avatars, drop dead pages

### DIFF
--- a/.github/workflows/blob-port.yml
+++ b/.github/workflows/blob-port.yml
@@ -1,0 +1,75 @@
+name: Finish the Blob port
+
+# Reports by default and changes nothing. The two mutating modes each need
+# their own confirmation, because both rewrite production rows.
+#
+# Deliberately does NOT take BLOB_READ_WRITE_TOKEN: a page version is
+# identified as unmigrated by comparing its storage key to the one the
+# registry would give it, and legacy avatars are repointed at an object
+# already in R2. Nothing here reads Vercel Blob.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "report changes nothing"
+        type: choice
+        options:
+          - report
+          - repoint-avatars
+          - delete-legacy-pages
+        default: report
+      confirm:
+        description: 'Required for either mutating mode: type "port"'
+        type: string
+        default: ""
+
+concurrency:
+  group: blob-port
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  port:
+    name: Blob port
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+
+    steps:
+      - name: Require confirmation to write
+        if: inputs.mode != 'report' && inputs.confirm != 'port'
+        run: |
+          echo "::error::Refusing to change rows: re-run with confirm set to 'port'."
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen --ignore-scripts
+
+      - name: Run (${{ inputs.mode }})
+        env:
+          SKIP_ENV_VALIDATION: "1"
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_PRIVATE_BUCKET: ${{ vars.R2_PRIVATE_BUCKET }}
+          R2_PUBLIC_BUCKET: ${{ secrets.R2_PUBLIC_BUCKET }}
+          STATIC_URL: ${{ secrets.STATIC_URL }}
+        run: |
+          bun packages/trpc/scripts/blob-port.ts \
+            ${{ inputs.mode == 'repoint-avatars' && '--repoint-avatars' || '' }} \
+            ${{ inputs.mode == 'delete-legacy-pages' && '--delete-legacy-pages' || '' }}

--- a/packages/trpc/scripts/blob-port.ts
+++ b/packages/trpc/scripts/blob-port.ts
@@ -1,0 +1,120 @@
+/**
+ * Finishes the move off Vercel Blob.
+ *
+ * Reports by default and changes nothing. Three things are counted, and the
+ * same three can be acted on:
+ *
+ *   pages   — a page version is migrated when its storage key equals the key
+ *             the registry would give it. Anything else is still a Blob
+ *             pathname, and its bytes disappear when the store is torn down.
+ *   avatars — the first backfill stored two fixed variants and pointed rows at
+ *             `<path>/256.webp`. Fresh uploads store the bytes once and point
+ *             at a transformation. Legacy rows are repointed at a
+ *             transformation over the 256 they already have, so every row ends
+ *             up one shape and every render gets AVIF.
+ *
+ *   bun --env-file=.env packages/trpc/scripts/blob-port.ts
+ *   bun --env-file=.env packages/trpc/scripts/blob-port.ts --repoint-avatars
+ *   bun --env-file=.env packages/trpc/scripts/blob-port.ts --delete-legacy-pages
+ */
+import { db } from "@superset/db/client";
+import { organizations, pageVersions, users } from "@superset/db/schema";
+import { pageVersionKey } from "@superset/shared/usercontent";
+import { and, eq, like, notLike } from "drizzle-orm";
+import { objectExists } from "../src/lib/r2";
+import { transformUrlFor } from "../src/lib/upload";
+
+const REPOINT = process.argv.includes("--repoint-avatars");
+const DELETE_PAGES = process.argv.includes("--delete-legacy-pages");
+
+/** Rows the first backfill wrote: a direct object, not a transformation. */
+const LEGACY_VARIANT = "%/256.webp";
+const TRANSFORMED = "%/cdn-cgi/image/%";
+
+const versions = await db
+	.select({
+		pageId: pageVersions.pageId,
+		version: pageVersions.version,
+		key: pageVersions.storageKey,
+	})
+	.from(pageVersions);
+
+const legacyPages = versions.filter(
+	(row) => row.key !== pageVersionKey(row.pageId, row.version),
+);
+console.log(
+	`page versions: ${versions.length}, still on Blob: ${legacyPages.length}`,
+);
+for (const row of legacyPages.slice(0, 20)) {
+	// Whether the bytes also exist in R2 decides if deleting the row loses anything.
+	const inR2 = await objectExists(pageVersionKey(row.pageId, row.version));
+	console.log(
+		`  ${row.pageId} v${row.version}  key=${row.key}  alsoInR2=${inR2}`,
+	);
+}
+if (legacyPages.length > 20)
+	console.log(`  … and ${legacyPages.length - 20} more`);
+
+const legacyUsers = await db
+	.select({ id: users.id, image: users.image })
+	.from(users)
+	.where(
+		and(like(users.image, LEGACY_VARIANT), notLike(users.image, TRANSFORMED)),
+	);
+const legacyOrgs = await db
+	.select({ id: organizations.id, logo: organizations.logo })
+	.from(organizations)
+	.where(
+		and(
+			like(organizations.logo, LEGACY_VARIANT),
+			notLike(organizations.logo, TRANSFORMED),
+		),
+	);
+console.log(
+	`avatars on the old variant URL: users ${legacyUsers.length}, organizations ${legacyOrgs.length}`,
+);
+
+if (DELETE_PAGES && legacyPages.length > 0) {
+	for (const row of legacyPages) {
+		await db
+			.delete(pageVersions)
+			.where(
+				and(
+					eq(pageVersions.pageId, row.pageId),
+					eq(pageVersions.version, row.version),
+				),
+			);
+	}
+	console.log(
+		`deleted ${legacyPages.length} page versions that only existed on Blob`,
+	);
+}
+
+if (REPOINT) {
+	let moved = 0;
+	for (const row of legacyUsers) {
+		if (!row.image) continue;
+		const key = new URL(row.image).pathname.replace(/^\//, "");
+		const updated = await db
+			.update(users)
+			.set({ image: transformUrlFor(key) })
+			.where(and(eq(users.id, row.id), eq(users.image, row.image)))
+			.returning({ id: users.id });
+		moved += updated.length;
+	}
+	for (const row of legacyOrgs) {
+		if (!row.logo) continue;
+		const key = new URL(row.logo).pathname.replace(/^\//, "");
+		const updated = await db
+			.update(organizations)
+			.set({ logo: transformUrlFor(key) })
+			.where(
+				and(eq(organizations.id, row.id), eq(organizations.logo, row.logo)),
+			)
+			.returning({ id: organizations.id });
+		moved += updated.length;
+	}
+	console.log(`repointed ${moved} rows at a transformation URL`);
+}
+
+if (!REPOINT && !DELETE_PAGES) console.log("(report only — nothing changed)");

--- a/packages/trpc/src/lib/upload.ts
+++ b/packages/trpc/src/lib/upload.ts
@@ -57,9 +57,15 @@ function objectKeysFor(pathname: string): string[] {
  * zone; without it the edge does not intercept `/cdn-cgi/image/` and the
  * request falls through to R2, which has no such key.
  */
+const TRANSFORM_OPTIONS = `width=${CANONICAL_WIDTH},height=${CANONICAL_WIDTH},fit=crop,format=auto`;
+
+/** A transformation URL over any object key in the public bucket. */
+export function transformUrlFor(key: string): string {
+	return `${staticBaseUrl()}/cdn-cgi/image/${TRANSFORM_OPTIONS}/${key}`;
+}
+
 export function imageUrlFor(pathname: string): string {
-	const options = `width=${CANONICAL_WIDTH},height=${CANONICAL_WIDTH},fit=crop,format=auto`;
-	return `${staticBaseUrl()}/cdn-cgi/image/${options}/${originalKey(pathname)}`;
+	return transformUrlFor(originalKey(pathname));
 }
 
 /**


### PR DESCRIPTION
## What & why

The last things tying us to Vercel Blob, so the 2026-10-02 teardown becomes a no-op instead of a tripwire.

**Reports by default and changes nothing.** Each mutating mode needs `confirm: port`.

### Pages

A page version is unmigrated iff its `storage_key` differs from the key the registry would give it (`pages/<pageId>/versions/<n>/index.html`). That comparison needs **no Blob token** — which matters, because it means finishing the port never requires the credential we're about to delete.

The report also says whether the bytes already exist in R2, so we can see whether deleting a row loses anything. Since these pages are internal and unlaunched, `--delete-legacy-pages` drops them rather than migrating them.

### Avatars

The first backfill stored two fixed variants and pointed rows at `<path>/256.webp`. Fresh uploads store the bytes once and point at a transformation. So there are two URL shapes in the DB, and the legacy ones serve WebP and can't produce other sizes.

`--repoint-avatars` points them at a transformation **over the 256 object they already have**. One shape everywhere, AVIF on every render, and no need to recover the Blob original.

The alternative was re-fetching originals from Blob before the store dies. I rejected it: the first backfill overwrote `users.image`, so the Blob URL is gone from the row and recovery means listing by prefix and guessing which object was current for anyone who uploaded twice. What that buys is a size above 256 — which the variant design never offered either (*"256 covers that at 4x, so nothing bigger earns its storage"*). Not worth the ambiguity.

### Refactor

`transformUrlFor` is extracted from `imageUrlFor`, so the transformation option string lives in one place instead of being retyped in a script that must not drift from it.

## How I tested it

- `bun run typecheck` and `bun run lint` — both pass.
- Workflow YAML parsed and asserted structurally (modes, env keys).
- Verified against the schema that `storageKey` is the discriminator, and that `pageVersionKey` is the canonical form the migration script itself writes.

**Not yet run.** The report mode is the first thing to run after merge, and its output decides whether either mutating mode is worth running at all.

## Follow-up, once the report is clean

Removing `@vercel/blob` from three manifests, `BLOB_READ_WRITE_TOKEN` from two schemas + two workflows + two templates, and deleting `migrate-pages-to-r2.ts`. Deliberately not in this PR — that removal is only safe once the report shows nothing depends on Blob.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

https://claude.ai/code/session_01QAQLVm3xTUXsJhpPQo3Nuf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finishes the move off Vercel Blob so the 2026-10-02 store teardown becomes a no-op. Adds a `blob-port` script and workflow that reports by default and requires typing `port` as confirmation to run either mutating mode.

**Script behavior**
- The report needs no Blob token: it compares each page version's `storage_key` to the key the registry would give it, and reports whether the bytes already exist in R2.
- Legacy avatars are repointed at a transformation over the 256 object they already have, giving every row one URL shape and AVIF on every render.
- Legacy page versions are deleted rather than migrated, since they're internal and unlaunched.
- Extracts `transformUrlFor` from `imageUrlFor` so the transformation option string lives in one place.

<sup>Written for commit df6d93fc41eea316353934bd85681dd7f04c9f7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved image transformation URL handling for more consistent media delivery.
  * Added migration reporting and maintenance tools to identify and clean up legacy image and page storage references.
  * Added safeguards requiring confirmation before storage changes are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->