### PR TITLE
chore(scripts): print sample avatar URLs in the blob-port report

### DIFF
--- a/packages/trpc/scripts/blob-port.ts
+++ b/packages/trpc/scripts/blob-port.ts
@@ -74,6 +74,16 @@ console.log(
 	`avatars on the old variant URL: users ${legacyUsers.length}, organizations ${legacyOrgs.length}`,
 );
 
+// A few live URLs, so a run can be checked by fetching one rather than by
+// trusting the counts. Whether a rewritten row actually renders is exactly
+// what a count cannot tell you.
+const samples = await db
+	.select({ image: users.image })
+	.from(users)
+	.where(like(users.image, "%supersetusercontent%"))
+	.limit(3);
+for (const row of samples) console.log(`  sample: ${row.image}`);
+
 if (DELETE_PAGES && legacyPages.length > 0) {
 	for (const row of legacyPages) {
 		await db


### PR DESCRIPTION
Counts confirm rows were rewritten; they cannot confirm the rewritten URL renders. This prints a few live URLs so a run can be verified by fetching one.

Needed now to check that the repointed rows actually serve: the repoint points a transformation at a WebP source, and I want that proven rather than assumed.

https://claude.ai/code/session_01QAQLVm3xTUXsJhpPQo3Nuf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prints a few sample avatar URLs in the blob-port report so a run can be verified by fetching one. Counts only show rows were rewritten; they don't prove the rewritten URL renders, which is what matters after repointing thousands of rows to a WebP source.

<sup>Written for commit a47848e5c3f3931b92d8b747036495bbb2ed0c20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added logging of up to three live user image URLs for manual rendering checks during blob migration.
  * Existing migration counts and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->