### PR TITLE
chore(ci): move the last repo variables to secrets

### DIFF
--- a/.github/workflows/blob-port.yml
+++ b/.github/workflows/blob-port.yml
@@ -66,7 +66,7 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_PRIVATE_BUCKET: ${{ vars.R2_PRIVATE_BUCKET }}
+          R2_PRIVATE_BUCKET: ${{ secrets.R2_PRIVATE_BUCKET }}
           R2_PUBLIC_BUCKET: ${{ secrets.R2_PUBLIC_BUCKET }}
           STATIC_URL: ${{ secrets.STATIC_URL }}
         run: |

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -67,8 +67,8 @@ jobs:
         working-directory: packages/cli
         env:
           RELAY_URL: ${{ secrets.RELAY_URL }}
-          SUPERSET_API_URL: ${{ vars.SUPERSET_API_URL }}
-          SUPERSET_WEB_URL: ${{ vars.SUPERSET_WEB_URL }}
+          SUPERSET_API_URL: ${{ secrets.SUPERSET_API_URL }}
+          SUPERSET_WEB_URL: ${{ secrets.SUPERSET_WEB_URL }}
         run: bun run build:dist --target=${{ matrix.target }}
 
       - name: Smoke test binary

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -18,7 +18,7 @@ jobs:
         uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
         continue-on-error: true
         with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: ${{ github.event.pull_request.head.ref }}
           api_key: ${{ secrets.NEON_API_KEY }}
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -48,7 +48,7 @@ jobs:
         id: create-branch
         uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # 6.3.1
         with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch_name: ${{ github.head_ref }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
@@ -65,7 +65,7 @@ jobs:
         run: |
           cat > database-status.env << EOF
           DATABASE_STATUS="✅"
-          DATABASE_LINK="<a href=\"https://console.neon.tech/app/projects/${{ vars.NEON_PROJECT_ID }}/branches/${{ steps.create-branch.outputs.branch_id }}/tables\">View Branch</a>"
+          DATABASE_LINK="<a href=\"https://console.neon.tech/app/projects/${{ secrets.NEON_PROJECT_ID }}/branches/${{ steps.create-branch.outputs.branch_id }}/tables\">View Branch</a>"
           DATABASE_URL="${{ steps.create-branch.outputs.db_url_pooled }}"
           DATABASE_URL_UNPOOLED="${{ steps.create-branch.outputs.db_url }}"
           BRANCH_ID="${{ steps.create-branch.outputs.branch_id }}"
@@ -183,7 +183,7 @@ jobs:
           BLAXEL_REGION: ${{ secrets.BLAXEL_REGION }}
           BLAXEL_SANDBOX_IMAGE: ${{ secrets.BLAXEL_SANDBOX_IMAGE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GH_APP_SLUG: ${{ vars.GH_APP_SLUG }}
+          GH_APP_SLUG: ${{ secrets.GH_APP_SLUG }}
         run: |
           vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
           vercel build --token=$VERCEL_TOKEN

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -84,7 +84,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_PRIVATE_BUCKET: ${{ vars.R2_PRIVATE_BUCKET }}
+          R2_PRIVATE_BUCKET: ${{ secrets.R2_PRIVATE_BUCKET }}
           R2_PUBLIC_BUCKET: ${{ secrets.R2_PUBLIC_BUCKET }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           USERCONTENT_URL: ${{ secrets.USERCONTENT_URL }}
@@ -146,7 +146,7 @@ jobs:
           BLAXEL_REGION: ${{ secrets.BLAXEL_REGION }}
           BLAXEL_SANDBOX_IMAGE: ${{ secrets.BLAXEL_SANDBOX_IMAGE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GH_APP_SLUG: ${{ vars.GH_APP_SLUG }}
+          GH_APP_SLUG: ${{ secrets.GH_APP_SLUG }}
         run: |
           vercel pull --yes --environment=production --token=$VERCEL_TOKEN
           vercel build --prod --token=$VERCEL_TOKEN

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -62,6 +62,10 @@ MY_VAR: ${{ secrets.MY_VAR }}     # the job's env: block
 
 Both reference `${{ secrets.MY_VAR }}`; the environment picks the value.
 
+A reusable workflow (`on: workflow_call`, e.g. `build-cli.yml`) inherits `vars`
+automatically but **not** `secrets` — the caller must pass `secrets: inherit`,
+or the value arrives empty.
+
 ## Checklist
 
 - [ ] `gh secret set`


### PR DESCRIPTION
`docs/environment-variables.md` says *"Always a secret, never a repo variable, even for something as unsecret as a bucket name — one mechanism means one place to look when a value goes missing."* Five variables predated that rule.

| variable | references |
|---|---|
| `R2_PRIVATE_BUCKET` | `blob-port.yml`, `deploy-production.yml` |
| `GH_APP_SLUG` | `deploy-production.yml`, `deploy-preview.yml` |
| `SUPERSET_API_URL` / `SUPERSET_WEB_URL` | `build-cli.yml` |
| `NEON_PROJECT_ID` | `deploy-preview.yml` ×2, `cleanup-preview.yml` |

Nine references, five workflows. The repo secrets are already set to the exact values the variables held, so no deploy changes behaviour.

**Two traps checked before switching, both clear:**
- `build-cli.yml` is `on: workflow_call`. Reusable workflows inherit `vars` automatically but *not* `secrets`. Both callers (`ci.yml`, `release-cli.yml`) already pass `secrets: inherit`, and it already reads `secrets.RELAY_URL` two lines above the two vars.
- `cleanup-preview.yml` declares no `environment:`, so on a fork PR it would lose a secret's value — but it already depends on `secrets.NEON_API_KEY`, so holding its project id as a variable bought nothing.

Added the `workflow_call` trap to the doc, since it is the one way this could have failed silently. Drop that hunk if you would rather keep the doc to the five-place checklist.

**After merge:** delete the five now-unreferenced repo variables, plus the dead `NEXT_PUBLIC_SENTRY_ENVIRONMENT` environment variables that #7074 superseded with secrets.

https://claude.ai/code/session_01HmfE4Qm77AwKUxJeFVMetY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the last five GitHub Actions repo variables (`R2_PRIVATE_BUCKET`, `GH_APP_SLUG`, `SUPERSET_API_URL`, `SUPERSET_WEB_URL`, `NEON_PROJECT_ID`) to secrets so all environment values live in one place. The secrets already hold the same values, so no workflow behavior changes.

**Migration**
- After merge, delete the five now-unreferenced repo variables and the dead `NEXT_PUBLIC_SENTRY_ENVIRONMENT` environment variables.
- `docs/environment-variables.md` now notes that reusable workflows inherit `vars` but not `secrets`, so callers must pass `secrets: inherit`.

<sup>Written for commit 171d0c7e5dadc3d5f74a30e99dc7f9855414a378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment workflows by sourcing required configuration securely from encrypted secrets.
  - Fixed configuration handling across preview, production, CLI build, and storage workflows.

- **Documentation**
  - Added guidance for passing secrets to reusable workflows so required values are available during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->