### PR TITLE
fix(marketing): stop the locale proxy from swallowing /ingest, /monitoring and /md

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -507,6 +507,17 @@ jobs:
             /agent-orchestration /parallel-coding-agents /factory-2026 \
             /mcp-install /stats /team /starchart /the-production-run
 
+      # Non-page endpoints, checked without --localized because they serve
+      # markdown and text rather than an <html> document. These are the paths
+      # src/proxy.ts must NOT rewrite into the [lang] tree: the matcher there
+      # swallowed /ingest and /monitoring for four days in 2026-08 and nothing
+      # noticed, because the pages above all kept returning 200.
+      - name: Smoke test marketing non-page endpoints
+        run: |
+          bun scripts/smoke-routes.ts "https://${{ env.MARKETING_ALIAS }}" \
+            /md/page/pricing /ja/md/page/pricing /llms.txt /agents.md \
+            /index.md /robots.txt /sitemap.xml /.well-known/mcp
+
       - name: Save marketing success status
         run: |
           cat > marketing-status.env << EOF

--- a/apps/marketing/src/app/[lang]/md/[...path]/route.ts
+++ b/apps/marketing/src/app/[lang]/md/[...path]/route.ts
@@ -1,6 +1,7 @@
 import type { MessageDescriptor } from "@lingui/core";
-import { i18n, initI18n } from "@superset/i18n";
+import { i18n } from "@superset/i18n";
 import { COMPANY } from "@superset/shared/constants";
+import { initServerI18n } from "@/app/i18n-server";
 import { MCP_CAPABILITIES } from "@/app/[lang]/mcp-install/components/McpCapabilities/constants";
 import {
 	COMPARISON_SECTIONS,
@@ -20,10 +21,6 @@ import {
 } from "@/lib/llms";
 import { markdownNotFound } from "@/lib/markdown-not-found";
 import { getAllPeople } from "@/lib/people";
-
-// Route handlers render outside the root layout, so the shared i18n instance
-// is not seeded for them. Idempotent.
-initI18n();
 
 interface MarkdownPage {
 	title: string;
@@ -263,6 +260,12 @@ export async function GET(
 	_request: Request,
 	{ params }: { params: Promise<{ path: string[] }> },
 ) {
+	// Route handlers render outside the root layout, so the shared i18n
+	// instance is not seeded for them. This activates the language the URL
+	// names — /md/... is English, /ja/md/... is Japanese — and 404s an
+	// unsupported segment rather than silently serving English.
+	const locale = await initServerI18n();
+
 	const { path } = await params;
 	const [section, slug] = path;
 	const page =
@@ -271,17 +274,27 @@ export async function GET(
 		return markdownNotFound();
 	}
 
+	// The document a localized twin is the markdown of is the localized page,
+	// not the English one.
+	const canonical =
+		locale === "en"
+			? page.url
+			: page.url.replace(
+					COMPANY.MARKETING_URL,
+					`${COMPANY.MARKETING_URL}/${locale}`,
+				);
+
 	const lines = [
 		...buildFrontmatter({
 			title: page.title,
 			description: page.description ?? page.title,
-			canonical: page.url,
+			canonical,
 			lastUpdated: page.date,
 		}),
 		`# ${page.title}`,
 		"",
 		...(page.description ? [page.description, ""] : []),
-		`URL: ${page.url}`,
+		`URL: ${canonical}`,
 		...(page.date ? [`Date: ${page.date}`] : []),
 		...(page.author ? [`Author: ${page.author}`] : []),
 		"",

--- a/apps/marketing/src/app/[lang]/md/[...path]/route.ts
+++ b/apps/marketing/src/app/[lang]/md/[...path]/route.ts
@@ -1,5 +1,9 @@
 import type { MessageDescriptor } from "@lingui/core";
-import { i18n } from "@superset/i18n";
+import { i18n, isSupportedLocale } from "@superset/i18n";
+import {
+	initServerI18n as activateServerI18n,
+	preloadServerLocale,
+} from "@superset/i18n/server";
 import { COMPANY } from "@superset/shared/constants";
 import { MCP_CAPABILITIES } from "@/app/[lang]/mcp-install/components/McpCapabilities/constants";
 import {
@@ -8,7 +12,6 @@ import {
 	PRICING_FAQ_ITEMS,
 	PRICING_TIERS,
 } from "@/app/[lang]/pricing/constants";
-import { initServerI18n } from "@/app/i18n-server";
 import { getBlogPost } from "@/lib/blog";
 import { getCategoryPage } from "@/lib/category";
 import { getChangelogEntry } from "@/lib/changelog";
@@ -258,15 +261,22 @@ function loadPage(section: string, slug: string): MarkdownPage | undefined {
 
 export async function GET(
 	_request: Request,
-	{ params }: { params: Promise<{ path: string[] }> },
+	{ params }: { params: Promise<{ lang: string; path: string[] }> },
 ) {
 	// Route handlers render outside the root layout, so the shared i18n
-	// instance is not seeded for them. This activates the language the URL
-	// names — /md/... is English, /ja/md/... is Japanese — and 404s an
-	// unsupported segment rather than silently serving English.
-	const locale = await initServerI18n();
-
-	const { path } = await params;
+	// instance is not seeded for them. Activate the language the URL names —
+	// /md/... is English, /ja/md/... is Japanese.
+	//
+	// The locale comes from the route's own params rather than
+	// next/root-params: [lang] is a parent segment, so it is already in
+	// params here, and that works the same in a route handler as in a server
+	// component. app/i18n-server.ts reads root-params instead, which is a
+	// server-component API — using it here would risk 404ing every twin.
+	const { lang, path } = await params;
+	if (!isSupportedLocale(lang)) return markdownNotFound();
+	await preloadServerLocale(lang);
+	activateServerI18n(lang);
+	const locale = lang;
 	const [section, slug] = path;
 	const page =
 		path.length === 2 && section && slug ? loadPage(section, slug) : undefined;

--- a/apps/marketing/src/app/[lang]/md/[...path]/route.ts
+++ b/apps/marketing/src/app/[lang]/md/[...path]/route.ts
@@ -1,7 +1,6 @@
 import type { MessageDescriptor } from "@lingui/core";
 import { i18n } from "@superset/i18n";
 import { COMPANY } from "@superset/shared/constants";
-import { initServerI18n } from "@/app/i18n-server";
 import { MCP_CAPABILITIES } from "@/app/[lang]/mcp-install/components/McpCapabilities/constants";
 import {
 	COMPARISON_SECTIONS,
@@ -9,6 +8,7 @@ import {
 	PRICING_FAQ_ITEMS,
 	PRICING_TIERS,
 } from "@/app/[lang]/pricing/constants";
+import { initServerI18n } from "@/app/i18n-server";
 import { getBlogPost } from "@/lib/blog";
 import { getCategoryPage } from "@/lib/category";
 import { getChangelogEntry } from "@/lib/changelog";

--- a/apps/marketing/src/proxy.ts
+++ b/apps/marketing/src/proxy.ts
@@ -33,7 +33,16 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-	// Skip Next internals, API routes, and anything with a file extension
-	// (feeds, llms.txt, images, favicon) — those live at the root on purpose.
-	matcher: ["/((?!_next|api|.*\\..*).*)"],
+	// Skip Next internals, API routes, the two same-origin analytics proxies,
+	// and anything with a file extension (feeds, llms.txt, images, favicon) —
+	// those live at the root on purpose.
+	//
+	// `ingest` (PostHog, via next.config rewrites) and `monitoring` (Sentry's
+	// tunnelRoute) are extensionless, so without naming them here they get
+	// rewritten to /en/... and 404. That is silent: posthog-js still loads,
+	// because /ingest/static/*.js has a dot and slips through this matcher,
+	// and then every capture request dies. It cost four days of marketing
+	// analytics and Sentry reporting in 2026-08. apps/web and apps/api
+	// exclude both for the same reason.
+	matcher: ["/((?!_next|api|ingest|monitoring|.*\\..*).*)"],
 };


### PR DESCRIPTION
## What broke

`#7002` (localized URLs) added `apps/marketing/src/proxy.ts`. Its matcher skipped `_next`, `api`, and **anything containing a dot** — so every extensionless non-page path was rewritten to `/en/...` and 404'd.

Merged 2026-08-29 21:46 UTC. Marketing events stop at **21:49:59 UTC**.

| Path | Consequence |
|---|---|
| `/ingest/*` | All PostHog capture from `superset.sh` — pageviews, `download_clicked`, `download_started`, waitlist |
| `/monitoring` | Sentry's `tunnelRoute` — marketing error reporting equally dark |
| `/md/<section>/<slug>` | Markdown twins for agents returned an HTML 404 instead of the recoverable markdown 404 the route exists to serve |

Verified against production:

```
POST superset.sh/ingest/i/v0/e/  -> 404  x-matched-path: /404
POST superset.sh/monitoring      -> 404  x-matched-path: /[lang]/[slug]
GET  superset.sh/md/page/pricing -> 404  x-matched-path: /404   (content-type: text/html)
GET  superset.sh/ingest/static/array.js -> 200
```

**Why nobody noticed for four days.** `/ingest/static/*.js` has a dot, so it slipped through the matcher — posthog-js kept loading and initializing normally, then every capture request died. Nothing throws, nothing 500s, the pages all return 200. It surfaced only because a dashboard funnel read 0%.

## Scope

Marketing only. `apps/web` and `apps/api` already exclude both paths:

```
"/((?!_next|ingest|monitoring|[^?]*\\.(?:html?|css|…)).*)"
```

`admin` and `docs` have no proxy. Desktop and mobile point straight at PostHog (`NEXT_PUBLIC_POSTHOG_HOST` / `EXPO_PUBLIC_POSTHOG_HOST`), no Next routing in the path. All confirmed still reporting throughout the outage.

Marketing's matcher was written fresh for `#7002` rather than copying the established one, which is how `ingest` and `monitoring` got dropped.

## Changes

1. **`proxy.ts` matcher** names `ingest` and `monitoring` explicitly, with a comment on why the dot heuristic is not enough.
2. **`/md` moves under `[lang]`** instead of being exempted — the rewrite is then what makes it work. Bonus: the twins are now localized. `/ja/md/page/pricing` serves **Japanese** markdown, which it never did. The route seeds i18n via `initServerI18n()` like every other `[lang]` entry, and canonicals carry the locale prefix.
3. **Deploy gate** gets a second non-localized pass over the non-page endpoints. The gate already fails on 4xx — it just listed only pages, so it stayed green through the whole outage.

## Not fixed here

`.well-known/*` survives only because `.well-known` contains a dot. It works, but it is luck rather than intent.

Aug 29 → now analytics and Sentry data is unrecoverable.

https://claude.ai/code/session_01SduXRDYRusSKRKs6sFg31t

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the marketing locale proxy so extensionless service routes and markdown twins are no longer sent into the wrong page tree. This restores PostHog capture and Sentry reporting and makes markdown twins serve the requested locale.

- Excludes `ingest` and `monitoring` from locale rewriting.
- Reads the markdown route's locale from its own `[lang]` params, seeds route-handler i18n, and updates localized canonical and URL fields.
- Adds deploy-preview smoke tests for markdown, text, robots, sitemap, and MCP endpoints.

<sup>Written for commit cbab3257775850cbb1d2148d7f89145a5f0aff6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed localized markdown pages so canonical URLs correctly include the locale for non-English versions.
  - Unsupported locales for localized markdown pages now return a not-found response.
  - Prevented analytics and monitoring endpoints from being incorrectly rewritten as localized routes.
  - Corrected handling for marketing metadata, text, and service endpoints, including robots.txt, sitemap.xml, and well-known routes.

- **Tests**
  - Added deployment smoke tests covering marketing markdown, text, metadata, and service endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->