### PR TITLE
fix(trpc): carry the MRR series past the FX table's lag

### DIFF
--- a/packages/trpc/src/router/analytics/business.ts
+++ b/packages/trpc/src/router/analytics/business.ts
@@ -22,6 +22,16 @@ import { adminProcedure } from "../../trpc";
 // chart), executed on demand via the Query Run API — no dashboard scheduled
 // query involved. Requires an active Sigma subscription; a full secret key or
 // a restricted key with reporting_write + sigma_api_write.
+//
+// Deviates from the template in one place. The template's date spine is
+// exchange_rates_from_usd, which lands a day late and is then shifted back
+// another day, so the series stopped two days short of today even though the
+// subscription events behind it were current — the tile read as stuck. The
+// spine now runs to whichever of the two sources is newer, carrying the last
+// known rates forward across the days FX has not landed yet. It starts at the
+// first subscription change rather than at the first FX rate: SEQUENCE caps at
+// 10k elements and the FX table reaches back to 2010, which would have walked
+// the query into a hard failure some years out for rows that are all zero MRR.
 const STRIPE_QUERY_RUN_VERSION = "2026-04-22.preview";
 
 const MRR_SQL = `-- This template returns total monthly recurring revenue
@@ -42,11 +52,28 @@ sparse_mrrs AS (
   FROM sparse_mrr_changes
   ORDER BY currency, date DESC
 ),
-fx AS (
+sparse_fx AS (
   SELECT
     date - INTERVAL '1' DAY AS date,
     cast(JSON_PARSE(buy_currency_exchange_rates) AS MAP(VARCHAR, DOUBLE)) AS rate_per_usd
   FROM exchange_rates_from_usd
+),
+fx AS (
+  SELECT
+    spine.date,
+    LAST_VALUE(sparse_fx.rate_per_usd) IGNORE NULLS OVER (
+      ORDER BY spine.date ASC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS rate_per_usd
+  FROM UNNEST(SEQUENCE(
+    (SELECT MIN(date) FROM sparse_mrr_changes),
+    (SELECT GREATEST(
+      (SELECT MAX(date) FROM sparse_fx),
+      (SELECT CAST(MAX(date) AS TIMESTAMP) FROM sparse_mrr_changes)
+    )),
+    INTERVAL '1' DAY
+  )) AS spine(date)
+  LEFT JOIN sparse_fx ON sparse_fx.date = spine.date
 ),
 currencies AS (
   SELECT DISTINCT(currency) FROM subscription_item_change_events_v2_beta


### PR DESCRIPTION
## What

The admin MRR tile was showing MRR from two days ago — $15,845 while Stripe said $16,150 — and looked like it was failing to update.

The refresh pipeline was fine. #6931's fix is holding: the Redis entry was being rewritten hourly (`2026-09-02T01:00:27Z` at the time of diagnosis, which is the "Sep 1, 6:00 PM" the tile displayed). It was faithfully caching a query that had already thrown the last two days away.

The Sigma template builds its date spine from `exchange_rates_from_usd`, then shifts it back a day (`date - INTERVAL '1' DAY`). Running diagnostics against live Sigma:

| max_fx_date | max_event_date | today (engine, UTC) |
|---|---|---|
| 2026-08-31 | 2026-09-01 | 2026-09-02 |

FX lands a day late, the template subtracts another, so the `CROSS JOIN` ceilings the series at Aug 30 — while the subscription change events driving MRR were current through Sep 1 the whole time. Because MRR is a running total, losing the tail days doesn't merely shorten the chart, it makes the headline figure wrong as a *current* number.

## How

Split the FX CTE into `sparse_fx` and forward-fill the last known rates over a spine that runs to whichever of the two sources is newer.

The spine is bounded by the data rather than by `CURRENT_DATE` on purpose: Sigma's `CURRENT_DATE` is UTC while `local_event_timestamp` is the account's local time, so a `CURRENT_DATE` bound would paint a phantom "tomorrow" point every evening Pacific.

It starts at the first subscription change rather than the first FX rate — `SEQUENCE` caps at 10k elements and the FX table reaches back to 2010-01-07 (6,082 days and counting), which would have walked the query into a hard failure roughly a decade out, over rows that are all zero MRR anyway.

## Verification

Ran the patched SQL against live Sigma; the series now reaches Sep 1:

```
"2026-08-30 00:00:00.000","15845.00"
"2026-08-31 00:00:00.000","15905.00"
"2026-09-01 00:00:00.000","16130.00"
```

Fed that CSV through `parseMrrCsv` verbatim: 180 clean points, no NaN, no malformed dates, last point `{"date":"2026-09-01","mrrUsd":16130}`. Confirmed the spine-start bound produces byte-identical output to the unbounded version. `typecheck`, `biome`, and 125 `packages/trpc` tests pass.

The remaining ~$20 against Stripe's dashboard is Sigma's own snapshot lag, not a bug: the newest event in the snapshot was `2026-09-01 14:07` local. **This tile will always trail the Stripe dashboard by that lag** — it should not be expected to match to the dollar.

## Deploy note

The cached entry holds the old 178-point payload for its 12h TTL, but the hourly job runs with `ignoreCache: true`, so the tile self-corrects within an hour of deploy — no manual key flush needed.

https://claude.ai/code/session_018FrUA5omygopkJUSLf78H3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The admin MRR tile no longer stops two days short because the Sigma query's FX-based date spine lags behind subscription events. The query now carries the latest known FX rates forward and extends the series through the newer data source; MRR can still trail Stripe by Sigma's snapshot lag.

**Rollout**

- The spine starts at the first subscription change to avoid exceeding Sigma's 10,000-element `SEQUENCE` limit.
- The hourly refresh replaces the stale cached payload within an hour, so no manual cache flush is needed.

<sup>Written for commit 722f5a3c36cb9d0ba2bbdcb894bafb26c9a831ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

