### PR TITLE
feat(admin): give the MRR tile a refresh button that breaks the cache

### DIFF
--- a/apps/admin/src/app/(dashboard)/components/MrrTile/MrrTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/MrrTile/MrrTile.tsx
@@ -14,7 +14,7 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { cn } from "@superset/ui/utils";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Area, AreaChart, XAxis, YAxis } from "recharts";
 
@@ -26,6 +26,14 @@ import { type MrrDatum, MrrTooltip } from "./MrrTooltip";
 
 const RANGE_DAYS = { "7d": 7, "35d": 35, "180d": 180 } as const;
 type RangeKey = keyof typeof RANGE_DAYS;
+
+/** Matches the server's reason for "a Sigma run is in flight". */
+const COMPUTING_REASON = "computing";
+
+interface MrrSeries {
+	points: { date: string; mrrUsd: number }[];
+	dataLoadTime: string | null;
+}
 
 // One daily-180d Stripe query serves every range; ranges differ only in
 // sampling: 7d shows days, 35d shows 7d intervals, 180d shows month ends.
@@ -57,18 +65,43 @@ export function MrrTile() {
 		},
 	} satisfies ChartConfig;
 	const [range, setRange] = useState<RangeKey>("7d");
+	const queryClient = useQueryClient();
 	const query = useQuery(
 		trpc.business.getMrr.queryOptions(undefined, {
 			refetchInterval: (q) =>
 				q.state.data && !q.state.data.available ? 10_000 : false,
 		}),
 	);
+	const refresh = useMutation(
+		trpc.business.refreshMrr.mutationOptions({
+			// Settled rather than success: the mutation reports the run it
+			// kicked, and the poll below is what lands it either way.
+			onSettled: () =>
+				queryClient.invalidateQueries({
+					queryKey: trpc.business.getMrr.queryKey(),
+				}),
+		}),
+	);
 
 	const unavailableReason =
 		query.data && !query.data.available ? query.data.reason : null;
+	const isComputing = unavailableReason === COMPUTING_REASON;
+	// Refreshing drops the cached figure, so the server answers "computing"
+	// for the ~minute Sigma takes. Hold the series already on screen through
+	// that rather than blanking the tile the moment someone asks to refresh
+	// it. Only across "computing" — a real failure should still surface.
+	const [lastSeries, setLastSeries] = useState<MrrSeries | null>(null);
+	if (query.data?.available && query.data.points !== lastSeries?.points) {
+		setLastSeries({
+			points: query.data.points,
+			dataLoadTime: query.data.dataLoadTime,
+		});
+	}
+	const series = query.data?.available || isComputing ? lastSeries : null;
+
 	// Server returns 180 daily points; range switches filter client-side.
 	const days = RANGE_DAYS[range];
-	const allPoints = query.data?.available ? query.data.points : [];
+	const allPoints = series?.points ?? [];
 	const enriched: MrrDatum[] = allPoints.map((p, i) => {
 		const prev = allPoints[i - days];
 		return {
@@ -95,12 +128,14 @@ export function MrrTile() {
 				message:
 					"Stripe's own Sigma MRR report, computed on demand via the Query Run API",
 			})}
-			lastRefresh={query.data?.available ? query.data.dataLoadTime : null}
+			lastRefresh={series?.dataLoadTime ?? null}
 			isLoading={query.isLoading}
+			onRefresh={() => refresh.mutate()}
+			isRefreshing={refresh.isPending || isComputing}
 			error={query.error}
 			empty={points.length === 0}
 			emptyLabel={
-				unavailableReason === "computing"
+				isComputing
 					? t({
 							id: "admin.mrr.computing",
 							message: "Computing in Stripe — up to a minute on first load",

--- a/packages/trpc/src/router/analytics/business.ts
+++ b/packages/trpc/src/router/analytics/business.ts
@@ -22,6 +22,16 @@ import { adminProcedure } from "../../trpc";
 // chart), executed on demand via the Query Run API — no dashboard scheduled
 // query involved. Requires an active Sigma subscription; a full secret key or
 // a restricted key with reporting_write + sigma_api_write.
+//
+// Deviates from the template in one place. The template's date spine is
+// exchange_rates_from_usd, which lands a day late and is then shifted back
+// another day, so the series stopped two days short of today even though the
+// subscription events behind it were current — the tile read as stuck. The
+// spine now runs to whichever of the two sources is newer, carrying the last
+// known rates forward across the days FX has not landed yet. It starts at the
+// first subscription change rather than at the first FX rate: SEQUENCE caps at
+// 10k elements and the FX table reaches back to 2010, which would have walked
+// the query into a hard failure some years out for rows that are all zero MRR.
 const STRIPE_QUERY_RUN_VERSION = "2026-04-22.preview";
 
 const MRR_SQL = `-- This template returns total monthly recurring revenue
@@ -42,11 +52,28 @@ sparse_mrrs AS (
   FROM sparse_mrr_changes
   ORDER BY currency, date DESC
 ),
-fx AS (
+sparse_fx AS (
   SELECT
     date - INTERVAL '1' DAY AS date,
     cast(JSON_PARSE(buy_currency_exchange_rates) AS MAP(VARCHAR, DOUBLE)) AS rate_per_usd
   FROM exchange_rates_from_usd
+),
+fx AS (
+  SELECT
+    spine.date,
+    LAST_VALUE(sparse_fx.rate_per_usd) IGNORE NULLS OVER (
+      ORDER BY spine.date ASC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS rate_per_usd
+  FROM UNNEST(SEQUENCE(
+    (SELECT MIN(date) FROM sparse_mrr_changes),
+    (SELECT GREATEST(
+      (SELECT MAX(date) FROM sparse_fx),
+      (SELECT CAST(MAX(date) AS TIMESTAMP) FROM sparse_mrr_changes)
+    )),
+    INTERVAL '1' DAY
+  )) AS spine(date)
+  LEFT JOIN sparse_fx ON sparse_fx.date = spine.date
 ),
 currencies AS (
   SELECT DISTINCT(currency) FROM subscription_item_change_events_v2_beta

--- a/packages/trpc/src/router/analytics/business.ts
+++ b/packages/trpc/src/router/analytics/business.ts
@@ -582,6 +582,27 @@ async function fetchMercuryCashFlow(): Promise<CashFlowResult> {
 export const businessRouter = {
 	getMrr: adminProcedure.query(() => fetchLatestSigmaMrr()),
 
+	// The tile's refresh button. The hourly job already keeps the entry warm,
+	// so the only reason to press this is to get past the cached figure —
+	// hence dropping the entry rather than just re-reading it. Dropping it is
+	// also what makes the tile's poll follow the new run: getMrr serves the
+	// cache before it ever looks at a pending run, so an entry left in place
+	// would leave this run uncollected until the next hourly job.
+	//
+	// Kicking the run is all this does. Sigma takes 30-60s and the tRPC route
+	// caps at 60s, so driving it to completion here would be a coin flip
+	// against the function timeout; the tile polls it down instead.
+	refreshMrr: adminProcedure.mutation(async () => {
+		const result = await advanceSigmaMrr({ ignoreCache: true });
+		// Only drop the cached figure once there is a run to replace it with,
+		// so a Stripe blip leaves the last good number on screen rather than
+		// trading it for an error.
+		if (!result.available && result.reason === MRR_COMPUTING_REASON) {
+			await clearMetricCache(MRR_CACHE_KEY);
+		}
+		return result;
+	}),
+
 	// Cohort survival: % of subscriptions started in a month still active k
 	// months later. Neon is authoritative for subscription state (D-10).
 	getChurnCohorts: adminProcedure


### PR DESCRIPTION
## What

Follow-up to #7084. The MRR tile is served from a 12h Redis entry that the hourly job keeps warm, so there was no way to ask for a recomputation short of waiting out the TTL — which is exactly what you want right after changing the query behind it.

## How

Adds `business.refreshMrr`. It kicks a Sigma run and drops the cached entry.

Dropping the entry is not just cosmetic — it's what makes the tile's existing poll follow the new run. `getMrr` serves the cache before it ever looks at a pending run, so an entry left in place would leave the freshly-kicked run uncollected until the next hourly job. The entry is only dropped once there *is* a run to replace it with, so a Stripe blip leaves the last good number on screen rather than trading it for an error.

Kicking the run is all the mutation does. Sigma takes 30-60s and `/api/trpc` sets `maxDuration = 60`, so driving it to completion server-side would be a coin flip against the function timeout. The tile's existing 10s poll (already there for cold starts) lands it instead.

On the client, `InsightTileFrame` already rendered `onRefresh`/`isRefreshing` as a spinning `LuRefreshCw` — `MrrTile` just never passed them, so this is mostly wiring, matching `TrendSeriesTile` / `HogQLLineTile` / `RetentionGridTile`.

One deliberate addition: the tile now holds the series already on screen across the `computing` state instead of blanking for the minute Sigma takes. Only across `computing` — any other unavailable reason still blanks to `Unavailable: <reason>` exactly as before, so a real failure doesn't hide behind stale numbers.

## Notes

- No new i18n strings: the button reuses the existing `admin.tile.refresh`, and `admin.mrr.computing`'s "on first load" copy stays accurate because a manual refresh no longer routes through the empty state.
- The button disables while a run is in flight, so it can't be leaned on to burn Sigma runs; `advanceSigmaMrr`'s claim already serialised concurrent callers anyway.

## Verification

`typecheck` on `packages/trpc` and `apps/admin`, `biome`, 125 `packages/trpc` tests, and the full i18n gate (`extract --clean` + `compile --strict` + stale-translation check + `git diff --exit-code -- locales`) all pass.

Not verified end-to-end by clicking it in a running admin app — the wiring is typechecked but nobody has pressed the button yet.

https://claude.ai/code/session_018FrUA5omygopkJUSLf78H3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the MRR tile a refresh button that kicks a Sigma run and breaks the 12h cached entry, and fixes the series stopping two days short of today.

**New Features**
- `business.refreshMrr` kicks a Sigma run and clears the cached entry, so the tile's existing 10s poll lands the new run.
- The entry is only dropped once there's a run to replace it, so a Stripe blip leaves the last good number on screen.
- The tile holds the series on screen during the ~minute Sigma computes instead of blanking; real failures still show `Unavailable`.

**Bug Fixes**
- The date spine now runs to whichever source is newer, forward-filling FX rates, so the series reaches today instead of stopping two days short.

<sup>Written for commit a6f87ce666d637c66d378030a7d614ace9152b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

