### PR TITLE
fix(desktop): stop painting standalone red text with destructive-foreground

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/DashboardSidebarWorkspaceHoverCardContent.tsx
@@ -159,9 +159,7 @@ export function DashboardSidebarWorkspaceHoverCardContent({
 						{diffStats && (
 							<div className="flex items-center gap-1.5 text-xs font-mono shrink-0">
 								<span className="text-emerald-500">+{diffStats.additions}</span>
-								<span className="text-destructive-foreground">
-									-{diffStats.deletions}
-								</span>
+								<span className="text-destructive">-{diffStats.deletions}</span>
 							</div>
 						)}
 					</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/ChecksList/components/CheckItemRow/CheckItemRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/ChecksList/components/CheckItemRow/CheckItemRow.tsx
@@ -9,7 +9,7 @@ interface CheckItemRowProps {
 export function CheckItemRow({ check }: CheckItemRowProps) {
 	const statusConfig = {
 		success: { icon: LuCheck, className: "text-emerald-500" },
-		failure: { icon: LuX, className: "text-destructive-foreground" },
+		failure: { icon: LuX, className: "text-destructive" },
 		pending: { icon: LuLoaderCircle, className: "text-amber-500" },
 		skipped: { icon: LuMinus, className: "text-muted-foreground" },
 		cancelled: { icon: LuMinus, className: "text-muted-foreground" },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/ChecksSummary/ChecksSummary.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/ChecksSummary/ChecksSummary.tsx
@@ -24,7 +24,7 @@ export function ChecksSummary({ checks, status }: ChecksSummaryProps) {
 		},
 		failure: {
 			icon: LuX,
-			className: "text-destructive-foreground",
+			className: "text-destructive",
 		},
 		pending: {
 			icon: LuLoaderCircle,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/PullRequestStatusBadge/PullRequestStatusBadge.tsx
@@ -20,7 +20,7 @@ export function PullRequestStatusBadge({ state }: PullRequestStatusBadgeProps) {
 		open: "bg-emerald-500/15 text-emerald-500",
 		draft: "bg-muted text-muted-foreground",
 		merged: "bg-violet-500/15 text-violet-500",
-		closed: "bg-destructive/15 text-destructive-foreground",
+		closed: "bg-destructive/15 text-destructive",
 		queued: "bg-amber-500/15 text-amber-500",
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/ReviewStatus/ReviewStatus.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceHoverCardContent/components/ReviewStatus/ReviewStatus.tsx
@@ -23,7 +23,7 @@ export function ReviewStatus({
 				id: "dashboard.sidebar.reviewStatus.changesRequested",
 				message: "Changes requested",
 			}),
-			className: "bg-destructive/15 text-destructive-foreground",
+			className: "bg-destructive/15 text-destructive",
 		},
 		pending: {
 			label:

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/OrphanedBanner/OrphanedBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/OrphanedBanner/OrphanedBanner.tsx
@@ -7,7 +7,7 @@ interface OrphanedBannerProps {
 
 export function OrphanedBanner({ dirty, onDiscard }: OrphanedBannerProps) {
 	return (
-		<div className="flex items-center gap-2 border-b border-border bg-destructive/10 px-3 py-1.5 text-xs text-destructive-foreground">
+		<div className="flex items-center gap-2 border-b border-border bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
 			<span>
 				{dirty ? (
 					<Trans id="workspace.filePane.deletedOnDiskDirty">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/SaveErrorBanner/SaveErrorBanner.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/components/SaveErrorBanner/SaveErrorBanner.tsx
@@ -12,7 +12,7 @@ export function SaveErrorBanner({
 	onDismiss,
 }: SaveErrorBannerProps) {
 	return (
-		<div className="flex items-center gap-2 border-b border-border bg-destructive/10 px-3 py-1.5 text-xs text-destructive-foreground">
+		<div className="flex items-center gap-2 border-b border-border bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
 			<span className="flex-1 truncate select-text cursor-text">
 				<Trans id="workspace.filePane.saveFailed">Save failed: {message}</Trans>
 			</span>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/UploadingAttachmentPill/UploadingAttachmentPill.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/UploadingAttachmentPill/UploadingAttachmentPill.tsx
@@ -34,7 +34,7 @@ export function UploadingAttachmentPill({
 			)}
 			{isError && (
 				<div className="pointer-events-none absolute top-[7px] left-[7px] flex size-5 items-center justify-center rounded bg-destructive/70 transition-opacity group-hover:opacity-0">
-					<TriangleAlert className="size-3 text-destructive-foreground" />
+					<TriangleAlert className="size-3 text-destructive" />
 				</div>
 			)}
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/AttachmentCard/AttachmentCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/components/AttachmentCard/AttachmentCard.tsx
@@ -66,7 +66,7 @@ export function AttachmentCard({
 			)}
 		>
 			{isError ? (
-				<TriangleAlert className="size-4 text-destructive-foreground" />
+				<TriangleAlert className="size-4 text-destructive" />
 			) : (
 				<Loader2 className="size-4 animate-spin text-muted-foreground" />
 			)}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/WorkspaceHoverCard.tsx
@@ -167,9 +167,7 @@ export function WorkspaceHoverCardContent({
 						</div>
 						<div className="flex items-center gap-1.5 text-xs font-mono shrink-0">
 							<span className="text-emerald-500">+{pr.additions}</span>
-							<span className="text-destructive-foreground">
-								-{pr.deletions}
-							</span>
+							<span className="text-destructive">-{pr.deletions}</span>
 						</div>
 					</div>
 

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksList/components/CheckItemRow/CheckItemRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksList/components/CheckItemRow/CheckItemRow.tsx
@@ -9,7 +9,7 @@ interface CheckItemRowProps {
 export function CheckItemRow({ check }: CheckItemRowProps) {
 	const statusConfig = {
 		success: { icon: LuCheck, className: "text-emerald-500" },
-		failure: { icon: LuX, className: "text-destructive-foreground" },
+		failure: { icon: LuX, className: "text-destructive" },
 		pending: { icon: LuLoaderCircle, className: "text-amber-500" },
 		skipped: { icon: LuMinus, className: "text-muted-foreground" },
 		cancelled: { icon: LuMinus, className: "text-muted-foreground" },

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksSummary/ChecksSummary.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ChecksSummary/ChecksSummary.tsx
@@ -22,7 +22,7 @@ export function ChecksSummary({ checks, status }: ChecksSummaryProps) {
 		},
 		failure: {
 			icon: LuX,
-			className: "text-destructive-foreground",
+			className: "text-destructive",
 		},
 		pending: {
 			icon: LuLoaderCircle,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/PRStatusBadge/PRStatusBadge.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/PRStatusBadge/PRStatusBadge.tsx
@@ -7,7 +7,7 @@ export function PRStatusBadge({ state }: PRStatusBadgeProps) {
 		open: "bg-emerald-500/15 text-emerald-500",
 		draft: "bg-muted text-muted-foreground",
 		merged: "bg-violet-500/15 text-violet-500",
-		closed: "bg-destructive/15 text-destructive-foreground",
+		closed: "bg-destructive/15 text-destructive",
 	};
 
 	const labels = {

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ReviewStatus/ReviewStatus.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/WorkspaceListItem/components/WorkspaceHoverCard/components/ReviewStatus/ReviewStatus.tsx
@@ -14,7 +14,7 @@ export function ReviewStatus({
 		},
 		changes_requested: {
 			label: "Changes requested",
-			className: "bg-destructive/15 text-destructive-foreground",
+			className: "bg-destructive/15 text-destructive",
 		},
 		pending: {
 			label:

--- a/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspacesListView/WorkspaceRow/WorkspaceRow.tsx
@@ -149,7 +149,7 @@ export function WorkspaceRow({
 			{showDiffStats && (
 				<div className="flex items-center gap-1 text-[10px] font-mono shrink-0">
 					<span className="text-emerald-500">+{pr.additions}</span>
-					<span className="text-destructive-foreground">-{pr.deletions}</span>
+					<span className="text-destructive">-{pr.deletions}</span>
 				</div>
 			)}
 


### PR DESCRIPTION
## Summary
- `text-destructive-foreground` is the label colour for text sitting on a `bg-destructive` surface, so themes set it to their page background. Fifteen sites used it as a freestanding red and only looked right on the default dark theme, whose value happens to be pale pink. On Kintsugi the diff deletion counter rendered black on black; on the light theme it was near-white on white.
- Switch every standalone use to `text-destructive` so each theme gets its own red: the three diff deletion counters (workspace row, both sidebar hover cards), check-failure icons and summaries, closed-PR and changes-requested badges, attachment warning triangles, and the file-pane save-error and orphaned banners.
- The three real cases (ringtone delete button, delete-project button, window close hover) keep the `bg-destructive text-destructive-foreground` pair.

## Testing
- `bun run typecheck` (apps/desktop)
- `bunx biome check` on the 15 changed files
- No tests or snapshots reference the old class

## Notes
- On the default dark theme the counter shifts from pale pink `#ffcccc` to the theme's `#cc4444`.
- `+additions` stays hardcoded `text-emerald-500` because the theme schema has no success token. Adding one is a separate change.

https://claude.ai/code/session_01WNYfXfvbc1km7yfoRKk9b5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes standalone red text that used `text-destructive-foreground`, which themes set to their page background, so diff deletion counters, check-failure icons, closed-PR and changes-requested badges, attachment warnings, and file-pane error banners rendered black-on-black on Kintsugi and near-white-on-white on the light theme. Switches those fifteen sites to `text-destructive` so each theme provides its own red; the three real button and hover cases keep the `bg-destructive`/`text-destructive-foreground` pair.

- On the default dark theme, the counter color shifts from pale pink `#ffcccc` to the theme's `#cc4444`.
- The `+additions` counter stays hardcoded `text-emerald-500` because the theme schema has no success token.

<sup>Written for commit 6fc0b67fe9afb5700f243c5f5f9b8c9972baa8b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated destructive-state text and icon colors across workspace sidebar, pull request, review, check, file, and attachment views.
  * Improved visual consistency for closed pull requests, failed checks, requested changes, deletion counts, and file or upload errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->