### PR TITLE
chore: drop BLAXEL_SANDBOX_IMAGE

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -181,7 +181,6 @@ jobs:
           BLAXEL_API_KEY: ${{ secrets.BLAXEL_API_KEY }}
           BLAXEL_WORKSPACE: ${{ secrets.BLAXEL_WORKSPACE }}
           BLAXEL_REGION: ${{ secrets.BLAXEL_REGION }}
-          BLAXEL_SANDBOX_IMAGE: ${{ secrets.BLAXEL_SANDBOX_IMAGE }}
           SENTRY_DSN_SANDBOX: ${{ secrets.SENTRY_DSN_SANDBOX }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_APP_SLUG: ${{ vars.GH_APP_SLUG }}
@@ -247,7 +246,6 @@ jobs:
             --env BLAXEL_API_KEY=$BLAXEL_API_KEY \
             --env BLAXEL_WORKSPACE=$BLAXEL_WORKSPACE \
             --env BLAXEL_REGION=$BLAXEL_REGION \
-            --env BLAXEL_SANDBOX_IMAGE=$BLAXEL_SANDBOX_IMAGE \
             --env SENTRY_DSN_SANDBOX=$SENTRY_DSN_SANDBOX \
             --env OPENAI_API_KEY=$OPENAI_API_KEY \
             --env GH_APP_SLUG=$GH_APP_SLUG)

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -144,7 +144,6 @@ jobs:
           BLAXEL_API_KEY: ${{ secrets.BLAXEL_API_KEY }}
           BLAXEL_WORKSPACE: ${{ secrets.BLAXEL_WORKSPACE }}
           BLAXEL_REGION: ${{ secrets.BLAXEL_REGION }}
-          BLAXEL_SANDBOX_IMAGE: ${{ secrets.BLAXEL_SANDBOX_IMAGE }}
           SENTRY_DSN_SANDBOX: ${{ secrets.SENTRY_DSN_SANDBOX }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_APP_SLUG: ${{ vars.GH_APP_SLUG }}
@@ -222,7 +221,6 @@ jobs:
             --env BLAXEL_API_KEY=$BLAXEL_API_KEY \
             --env BLAXEL_WORKSPACE=$BLAXEL_WORKSPACE \
             --env BLAXEL_REGION=$BLAXEL_REGION \
-            --env BLAXEL_SANDBOX_IMAGE=$BLAXEL_SANDBOX_IMAGE \
             --env SENTRY_DSN_SANDBOX=$SENTRY_DSN_SANDBOX \
             --env OPENAI_API_KEY=$OPENAI_API_KEY \
             --env GH_APP_SLUG=$GH_APP_SLUG

--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -197,8 +197,8 @@ What it needs, roughly in order of how much it buys:
   push the branch, provision a fresh sandbox, restore the checkout. Slower,
   but it must exist for the cases where in-place fails.
 
-Note that the *image tag* is a deploy-time env var (`BLAXEL_SANDBOX_IMAGE`),
-so new sandboxes pick up a rebuilt image for free. It is only existing ones
+Note that the *image tag* lives on the environment row (`sourceRef`, seeded from
+the `SANDBOX_IMAGE_NAME` constant), so new sandboxes pick up a rebuilt image for free. It is only existing ones
 that strand — which is why this reads as fine right up until the first
 long-lived workspace.
 

--- a/packages/trpc/scripts/sandbox-smoke.ts
+++ b/packages/trpc/scripts/sandbox-smoke.ts
@@ -71,7 +71,7 @@ try {
 			id: "smoke",
 			provider: "blaxel",
 			sourceKind: "image",
-			sourceRef: process.env.BLAXEL_SANDBOX_IMAGE ?? SANDBOX_IMAGE_NAME,
+			sourceRef: SANDBOX_IMAGE_NAME,
 			envs: {},
 		},
 		workspaceEnv: {

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -1,4 +1,3 @@
-import { SANDBOX_IMAGE_NAME } from "@superset/shared/constants";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";
 
@@ -51,7 +50,6 @@ export const env = createEnv({
 		BLAXEL_API_KEY: z.string().min(1),
 		BLAXEL_WORKSPACE: z.string().min(1),
 		BLAXEL_REGION: z.string().min(1),
-		BLAXEL_SANDBOX_IMAGE: z.string().min(1).default(SANDBOX_IMAGE_NAME),
 		SENTRY_DSN_SANDBOX: z.string().optional(),
 		NEXT_PUBLIC_SENTRY_ENVIRONMENT: z
 			.enum(["development", "preview", "production"])

--- a/packages/trpc/src/router/environment/environment.ts
+++ b/packages/trpc/src/router/environment/environment.ts
@@ -1,10 +1,12 @@
 import { db, dbWs } from "@superset/db/client";
 import { cloudWorkspaces, environments } from "@superset/db/schema";
-import { SHARED_ENVIRONMENT_ORGANIZATION_ID } from "@superset/shared/constants";
+import {
+	SANDBOX_IMAGE_NAME,
+	SHARED_ENVIRONMENT_ORGANIZATION_ID,
+} from "@superset/shared/constants";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
-import { env } from "../../env";
 import { promoteSandboxToEnvironment } from "../../lib/blaxel";
 import { assertInternal, assertMember } from "../../lib/cloud-guards";
 import { jwtProcedure, userError } from "../../trpc";
@@ -103,7 +105,7 @@ export const environmentRouter = {
 					name: input.name,
 					provider: "blaxel",
 					sourceKind: "image",
-					sourceRef: env.BLAXEL_SANDBOX_IMAGE,
+					sourceRef: SANDBOX_IMAGE_NAME,
 				})
 				.returning();
 			return row;

--- a/scripts/sandbox/build-internal-environment.ts
+++ b/scripts/sandbox/build-internal-environment.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SandboxInstance, settings } from "@blaxel/core";
 
-const IMAGE = process.env.BLAXEL_SANDBOX_IMAGE ?? "superset-hostsvc";
+const IMAGE = "superset-hostsvc";
 const REGION = process.env.BLAXEL_REGION ?? "us-pdx-1";
 const SETUP = join(import.meta.dir, "internal-setup.sh");
 const WORKSPACE = process.env.SUPERSET_SANDBOX_WORKSPACE_PATH ?? "/workspace";

--- a/scripts/sandbox/seed-environments.ts
+++ b/scripts/sandbox/seed-environments.ts
@@ -16,7 +16,7 @@ const SHARED_ORGANIZATION = {
 } as const;
 
 export async function seedSharedEnvironments(
-	imageRef = process.env.BLAXEL_SANDBOX_IMAGE ?? SANDBOX_IMAGE_NAME,
+	imageRef = SANDBOX_IMAGE_NAME,
 ): Promise<{ imageRef: string }> {
 	await db
 		.insert(organizations)

--- a/scripts/sandbox/smoke.ts
+++ b/scripts/sandbox/smoke.ts
@@ -13,7 +13,7 @@ import {
 } from "../../packages/trpc/src/lib/blaxel";
 
 const NAME = process.env.SMOKE_SANDBOX_NAME ?? "ws-smoke-test";
-const IMAGE = process.env.BLAXEL_SANDBOX_IMAGE ?? "superset-hostsvc";
+const IMAGE = "superset-hostsvc";
 const keep = process.argv.includes("--keep");
 
 const main = async () => {


### PR DESCRIPTION
The image a sandbox boots from is the environment row's `sourceRef` — provisioning reads `environment.sourceRef` and never this variable. It survived in exactly two places: `environment.create` defaulting a new row's image, and the shared-environment seed. Both now use the `SANDBOX_IMAGE_NAME` constant directly.

Removed: the `env.ts` entry, both deploy workflows' `env:` + `--env` pass-through, the three scripts that fell back to it, and a stale sentence in `docs/cloud-sandbox-mismatches.md`.

**After merge:** delete the `BLAXEL_SANDBOX_IMAGE` repo secret — nothing reads it.

https://claude.ai/code/session_01HmfE4Qm77AwKUxJeFVMetY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `BLAXEL_SANDBOX_IMAGE` environment variable and the one-shot seed workflow that used it. Sandbox images now come from the `SANDBOX_IMAGE_NAME` constant, which provisioning already read from `environment.sourceRef`.

- Deletes the leftover `env.ts` entry, deploy workflow pass-throughs, fallback scripts, and a stale doc sentence.
- After merge, delete the `BLAXEL_SANDBOX_IMAGE` repo secret — nothing reads it.

<sup>Written for commit 70f72410ab6321d05445919dfa6d5a914270417b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Sandbox environments now consistently use the standard sandbox image.
  * Removed support for overriding the sandbox image through the `BLAXEL_SANDBOX_IMAGE` environment variable.
  * Updated preview and production deployments to no longer pass the removed configuration.
  * Updated sandbox provisioning, seeding, smoke tests, and documentation to reflect the standardized image configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->