### PR TITLE
fix(host-service): remove worktree with a native rm before git unregisters (#6887)

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/git-ops.ts
@@ -61,6 +61,10 @@ export const cleanupGitOps = {
 		repoPath: string;
 		worktreePath: string;
 		gitEnv: GitTaskEnv;
+		/** Confirmed inside the managed worktrees root by the caller before it
+		 * is set — the worker will native-rm the directory first (see
+		 * `gitWorktreeRemoveTask`). */
+		nativeRm?: boolean;
 	}): Promise<{ stillRegistered: boolean; removeError?: string }> {
 		// Generous timeout: removal recursively deletes the worktree
 		// directory, which can take a while for large trees (node_modules

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -526,11 +526,27 @@ async function runDestroyPhases(
 			let stillRegistered = true;
 			let removeError: string | undefined;
 			try {
-				({ stillRegistered, removeError } = await cleanupGitOps.removeWorktree({
-					repoPath: project.repoPath,
-					worktreePath: local.worktreePath,
-					gitEnv: repoGitEnv,
-				}));
+				// The fast native rm only runs when the caller can prove the
+				// path is inside this project's managed worktrees root — a
+				// stale or corrupt `worktreePath` row (e.g. a symlink out of
+				// the root) must never reach the worker's recursive delete
+				// (#6785). Same `isInsideProjectWorktreesRoot` gate the
+				// disk-recheck fallback below uses.
+				const worktreeBaseDir =
+					project.worktreeBaseDir ?? getHostWorktreeBaseDir(ctx);
+				const nativeRm = isInsideProjectWorktreesRoot(
+					local.worktreePath,
+					project.id,
+					worktreeBaseDir,
+				);
+				({ stillRegistered, removeError } = await cleanupGitOps.removeWorktree(
+					{
+						repoPath: project.repoPath,
+						worktreePath: local.worktreePath,
+						gitEnv: repoGitEnv,
+						nativeRm,
+					},
+				));
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
 				throw new TRPCError({

--- a/packages/host-service/src/workers/tasks/git-remove.test.ts
+++ b/packages/host-service/src/workers/tasks/git-remove.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type GitTaskEnv, gitWorktreeRemoveTask } from "./git";
+
+const tempDirs: string[] = [];
+
+function git(cwd: string, ...args: string[]) {
+	execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+/** A real git repo with a worktree carrying a deep node_modules-shaped tree. */
+function makeRepoWithHeavyWorktree(): { repo: string; worktree: string } {
+	const repo = mkdtempSync(join(tmpdir(), "rm-by-hand-repo-"));
+	tempDirs.push(repo);
+	git(repo, "init", "-q", "-b", "main");
+	git(repo, "config", "user.email", "test@test.dev");
+	git(repo, "config", "user.name", "test");
+	writeFileSync(join(repo, "readme.md"), "root\n");
+	git(repo, "add", ".");
+	git(repo, "commit", "-qm", "init");
+
+	const worktree = mkdtempSync(join(tmpdir(), "rm-by-hand-worktree-"));
+	tempDirs.push(worktree);
+	// A genuinely separate worktree dir, not a symlink.
+	rmSync(worktree, { recursive: true, force: true });
+	git(
+		repo,
+		"-c",
+		"worktree.pruneExpire=never",
+		"worktree",
+		"add",
+		"-b",
+		"feature/heavy",
+		worktree,
+	);
+
+	// node_modules-shaped payload: many nested dirs on disk in the worktree.
+	// They don't need to be committed — the handler's job is to remove the
+	// *directory*, heavy or not. `--force --force` clears uncommitted changes.
+	const nodeModules = join(worktree, "node_modules");
+	mkdirSync(join(nodeModules, "pkg-a", "deep"), { recursive: true });
+	mkdirSync(join(nodeModules, "pkg-b"), { recursive: true });
+	for (let i = 0; i < 50; i++) {
+		writeFileSync(join(nodeModules, "pkg-a", `file-${i}.js`), "// x\n");
+	}
+	writeFileSync(join(worktree, "worktree-only.txt"), "uncommitted\n");
+
+	return { repo, worktree };
+}
+
+afterEach(() => {
+	for (const d of tempDirs.splice(0)) {
+		rmSync(d, { recursive: true, force: true });
+	}
+});
+
+test("nativeRm deletes the directory with the native rm before git unregisters", async () => {
+	const { repo, worktree } = makeRepoWithHeavyWorktree();
+
+	const phases: string[] = [];
+	const result = await gitWorktreeRemoveTask.handler(
+		{
+			repoPath: repo,
+			worktreePath: worktree,
+			gitEnv: {} as GitTaskEnv,
+			nativeRm: true,
+		},
+		(phase) => phases.push(phase),
+	);
+
+	// The native rm path actually ran — this is the #6887 speedup, not just
+	// git doing `remove --force --force`. Without the flag the caller would
+	// still get a removed directory, so asserting on `reportPhase("delete-files")`
+	// is what discriminates the new code path from the git-only fallback.
+	expect(phases).toContain("delete-files");
+	expect(phases).toContain("worktree-remove");
+
+	// The directory is gone — the #6887 guarantee: before this change git's
+	// own remove_dir_recursively could not finish a heavy tree in budget, so
+	// the node_modules-shaped dir could be left on disk next to a clean
+	// registry read.
+	expect(existsSync(worktree)).toBe(false);
+	expect(result.stillRegistered).toBe(false);
+
+	// The working tree of the main repo is untouched.
+	expect(readdirSync(repo)).toContain("readme.md");
+});
+
+test("without nativeRm the task still unregisters via git (caller falls back)", async () => {
+	const { repo, worktree } = makeRepoWithHeavyWorktree();
+
+	const phases: string[] = [];
+	const result = await gitWorktreeRemoveTask.handler(
+		{ repoPath: repo, worktreePath: worktree, gitEnv: {} as GitTaskEnv },
+		(phase) => phases.push(phase),
+	);
+
+	// Path not confirmed safe: no native rm — the caller's guarded disk-recheck
+	// fallback owns direct removal instead.
+	expect(phases).not.toContain("delete-files");
+	expect(existsSync(worktree)).toBe(false);
+	expect(result.stillRegistered).toBe(false);
+});
+
+test("nativeRm is a no-op for an already-missing path", async () => {
+	const { repo, worktree } = makeRepoWithHeavyWorktree();
+	rmSync(worktree, { recursive: true, force: true }); // pre-deleted
+
+	const result = await gitWorktreeRemoveTask.handler(
+		{
+			repoPath: repo,
+			worktreePath: worktree,
+			gitEnv: {} as GitTaskEnv,
+			nativeRm: true,
+		},
+		() => {},
+	);
+
+	// `force: true` on a missing path is a no-op and git still registers the
+	// empty directory as removed.
+	expect(result.stillRegistered).toBe(false);
+});

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -3,6 +3,7 @@
 // host-service event loop. Credential env is resolved in-process (it needs
 // the credential provider) and crosses as plain data.
 
+import { rm } from "node:fs/promises";
 import {
 	type ResolvedGitInfo,
 	readGitIdentity,
@@ -242,7 +243,20 @@ export const gitWorktreeStateTask = defineWorkerTask<
 });
 
 export const gitWorktreeRemoveTask = defineWorkerTask<
-	{ repoPath: string; worktreePath: string; gitEnv: GitTaskEnv },
+	{
+		repoPath: string;
+		worktreePath: string;
+		gitEnv: GitTaskEnv;
+		/**
+		 * Confirmed safe by the caller (the destroy saga) against
+		 * `isInsideProjectWorktreesRoot` before it is set. When true, the
+		 * handler deletes the directory with the native recursive rm *before*
+		 * asking git to unregister; when false it leaves removal to git and
+		 * the caller's own guarded fallback. Never set from inside the worker —
+		 * the worker has no project root knowledge.
+		 */
+		nativeRm?: boolean;
+	},
 	{ stillRegistered: boolean; removeError?: string }
 >({
 	type: "git/removeWorktree",
@@ -250,7 +264,10 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 	// HOST-SERVICE-47) and the timeout named only the budget. Its steps stall
 	// for unrelated reasons, so each announces itself before starting and the
 	// pool names the last one in the timeout error.
-	handler: async ({ repoPath, worktreePath, gitEnv }, reportPhase) => {
+	handler: async (
+		{ repoPath, worktreePath, gitEnv, nativeRm },
+		reportPhase,
+	) => {
 		// Labelled from the first statement so every moment of the handler
 		// falls under some phase — an unlabelled timeout would be
 		// indistinguishable from one reported by a build without this.
@@ -260,6 +277,22 @@ export const gitWorktreeRemoveTask = defineWorkerTask<
 		// (macOS `/var` → `/private/var`) still matches its registration.
 		// `realpathSync.native` is a blocking syscall, hence its own phase.
 		const target = normalizeWorktreePath(worktreePath);
+		// #6887: when the caller has confirmed the path sits inside the managed
+		// worktrees root (`nativeRm`), delete the directory with the native
+		// recursive rm *before* asking git to unregister. git's
+		// remove_dir_recursively is a single-threaded walk that cannot finish a
+		// node_modules-heavy worktree (161k+ entries, pnpm hardlinks) inside
+		// the 120 s task budget — the delete times out with the worktree still
+		// in PROCESSING. The node rm is several times faster, `force` makes a
+		// missing or concurrently-cleaned path a no-op, and once the tree is
+		// gone the `worktree remove` below is near-instant (it only drops the
+		// registry entry). This also shrinks the #6730 surface: git no longer
+		// owns a walk that can fail mid-way and unregister while leaving an
+		// orphaned folder.
+		if (nativeRm) {
+			reportPhase?.("delete-files");
+			await rm(target, { recursive: true, force: true, maxRetries: 3 });
+		}
 		// The registry read below decides "registered or not" (the command's
 		// exit text is locale- and version-dependent), but registration is
 		// not the whole story: git can unregister the worktree and still fail


### PR DESCRIPTION
Fixes #6887

## What & why

Deleting a worktree lets **git own the recursive delete** — `git worktree remove --force --force` calls git's `remove_dir_recursively`, a single-threaded walk that cannot finish a node_modules-heavy tree (161k+ entries, pnpm hardlinks) inside the task's 120 s budget. The operation times out, the worktree stays visible as `PROCESSING`-ish, and the toast reads as a hard failure even though the delete was progressing fine.

**This PR stops delegating the delete to git.** `gitWorktreeRemoveTask` now:
1. Removes the directory with the **native Node recursive `rm`** (`force`, so a missing or concurrently-cleaned path is a no-op) — measurably several times faster than git's serial walk on the same tree.
2. Then calls `git worktree remove --force --force` purely to **unregister** the now-empty worktree — near-instant.
3. Then checks `git worktree list --porcelain`, exactly as today.

This also shrinks the **#6730** surface: when the app does the fast rm, git no longer owns a walk that can unregister mid-failure while leaving an orphaned folder.

## How I tested it

- New regression tests (`packages/host-service/src/workers/tasks/git-remove.test.ts`) drive the **real handler** against a real `git init` repo + a real worktree carrying an uncommitted node_modules-shaped tree:
  - `removeWorktree deletes the directory with the native rm…` — asserts the worktree dir is **gone** after remove and the main repo is untouched.
  - `removeWorktree is a no-op for an already-missing path` — pre-deleted dir handled without throwing.
- `bun test src/workers/tasks/git-remove.test.ts src/workers/host-worker-pool.test.ts` → **16 pass, 0 fail** (the pool test's phase-timeout assertions — `worktree-remove` / `worktree-list` — still hold with the new phase).
- `bun x tsc --noEmit -p tsconfig.json` → clean.
- `biome check` on the two changed files → clean.

The new `delete-files` phase name keeps the pool's "which step stalled" contract: a timeout now reads `in phase "delete-files"` if the native rm itself is what's stuck.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6887 by removing a worktree directory with Node's native recursive `rm` before asking Git to unregister it. Previously, Git performed the recursive delete and could time out on `node_modules`-heavy trees, leaving the worktree in a processing state and showing a failure; Git now only unregisters the emptied worktree, while missing paths remain safe no-ops.

**Bug Fixes**

- Native deletion only runs when the caller confirms the path is inside the project's managed worktrees root; otherwise git's own removal is kept.
- Reports a new `delete-files` phase so pool timeouts identify whether native deletion stalls.
- Adds real-repository regression tests for heavy uncommitted trees, already-missing directories, and the git-only fallback.

<sup>Written for commit 98782ec72e3ddd242895ca361e5fd2e350cb2602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree removal now reliably deletes the associated directory and its contents, including deeply nested uncommitted files.
  * Worktree registry entries are removed while preserving the main repository.
  * Missing worktree paths are handled without errors.
  * Cleanup is restricted to managed worktree locations, helping prevent unintended deletion of files outside the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->