### PR TITLE
fix(web): answer unauthenticated /api and /trpc with JSON 401, not a 307 redirect

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,19 +1,42 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { NextRequest } from "next/server";
 
+// The `next/headers` mock returns this shared Headers; the auth mock reads it,
+// so each test drives the actual Authorization path that `proxy` passes to
+// `auth.api.getSession({ headers: await headers() })`.
+const sessionHeaders = new Headers({ "content-type": "application/json" });
 mock.module("next/headers", () => ({
-	headers: () => new Headers({ "content-type": "application/json" }),
+	headers: () => sessionHeaders,
 }));
 
-// Proxy only needs auth.api.getSession; force it to return null so most
-// requests below are treated as unauthenticated (the failing CLI / remote-host
-// case from #7072). Valid-session cases override it per-test.
-const getSession = mock(async () => null);
+// getSession behaves like the real auth: a request bearing a valid Bearer
+// token resolves to an authenticated session, anything else is unauthenticated.
+// This exercises the Authorization plumbing instead of forcing a session.
+const getSession = mock(async ({ headers }: { headers?: Headers } = {}) => {
+	const auth = headers?.get("authorization") ?? "";
+	if (auth === "Bearer valid-token") {
+		return {
+			user: { email: "dev@app.superset.sh", deletionRequestedAt: null },
+		};
+	}
+	return null;
+});
 mock.module("@superset/auth/server", () => ({
 	auth: { api: { getSession } },
 }));
 
 const { default: proxy } = await import("./proxy");
+
+/** Drive proxy with the given auth header, threading it into the shared mock.
+ * Empties the Authorization header for the unauthenticated cases. */
+async function callProxy(
+	path: string,
+	{ auth }: { auth?: string } = {},
+): Promise<Response> {
+	if (auth) sessionHeaders.set("authorization", auth);
+	else sessionHeaders.delete("authorization");
+	return proxy(new NextRequest(path));
+}
 
 describe("proxy: unauthenticated API requests return JSON 401, never a sign-in redirect", () => {
 	beforeEach(() => {
@@ -21,11 +44,9 @@ describe("proxy: unauthenticated API requests return JSON 401, never a sign-in r
 	});
 
 	it("answers /api/trpc/* with a JSON 401 instead of a 307 redirect (#7072)", async () => {
-		const res = await proxy(
-			new NextRequest("https://app.superset.sh/api/trpc/user.me", {
-				headers: { authorization: "Bearer stale-token" },
-			}),
-		);
+		const res = await callProxy("https://app.superset.sh/api/trpc/user.me", {
+			auth: "Bearer stale-token",
+		});
 
 		expect(res.status).toBe(401);
 		expect(res.headers.get("content-type")).toContain("application/json");
@@ -33,18 +54,15 @@ describe("proxy: unauthenticated API requests return JSON 401, never a sign-in r
 		expect(body).toEqual({ error: "Unauthorized" });
 	});
 
-	it("answers bare /trpc/* with a JSON 401 too", async () => {
-		const res = await proxy(
-			new NextRequest("https://app.superset.sh/trpc/user.me?batch=1"),
-		);
+	it("answers the exact /trpc route with a JSON 401 too", async () => {
+		// coderabbit: exercise the pathname === "/trpc" branch (no trailing path).
+		const res = await callProxy("https://app.superset.sh/trpc?batch=1");
 
 		expect(res.status).toBe(401);
 	});
 
 	it("still redirects unauthenticated page routes to /sign-in", async () => {
-		const res = await proxy(
-			new NextRequest("https://app.superset.sh/dashboard"),
-		);
+		const res = await callProxy("https://app.superset.sh/dashboard");
 
 		// Not an API route: the historical page-redirect behaviour is preserved.
 		expect(res.status).toBe(307);
@@ -53,12 +71,8 @@ describe("proxy: unauthenticated API requests return JSON 401, never a sign-in r
 
 	it("does not treat /apiary or /trpcfoo as API routes (slash-delimited child only)", async () => {
 		// P2 (cubic) + coderabbit: only exact /api|/trpc or /api/|/trpc/ match.
-		const apiary = await proxy(
-			new NextRequest("https://app.superset.sh/apiary"),
-		);
-		const trpcfoo = await proxy(
-			new NextRequest("https://app.superset.sh/trpcfoo"),
-		);
+		const apiary = await callProxy("https://app.superset.sh/apiary");
+		const trpcfoo = await callProxy("https://app.superset.sh/trpcfoo");
 
 		// These are page routes — keep the historical /sign-in redirect, no JSON 401.
 		expect(apiary.status).toBe(307);
@@ -68,29 +82,21 @@ describe("proxy: unauthenticated API requests return JSON 401, never a sign-in r
 	});
 
 	it("leaves public API routes (e.g. /api/auth/desktop) reachable unauthenticated", async () => {
-		// P1 (cubic): /api/auth/desktop is the desktop OAuth start and is public;
-		// it must not fall into the JSON-401 gate.
-		const res = await proxy(
-			new NextRequest("https://app.superset.sh/api/auth/desktop"),
-		);
+		// P1 (cubic) + coderabbit: /api/auth/desktop is the public desktop-OAuth
+		// start; require a successful pass-through (200), so a 5xx would fail.
+		const res = await callProxy("https://app.superset.sh/api/auth/desktop");
 
-		expect(res.status).not.toBe(401);
-		expect(res.status).not.toBe(307);
+		expect(res.status).toBe(200);
 	});
 
-	it("passes a valid authenticated request through without 401 or redirect", async () => {
-		// coderabbit: a valid Bearer session must not be rejected by the gate.
-		getSession.mockReturnValueOnce({
-			user: { email: "dev@app.superset.sh", deletionRequestedAt: null },
+	it("passes a real valid Bearer request through without 401 or redirect", async () => {
+		// coderabbit: the Authorization header must drive auth lookup — a valid
+		// token resolves to a session, so the request is neither 401'd nor
+		// redirected (NextResponse.next() = 200).
+		const res = await callProxy("https://app.superset.sh/api/trpc/user.me", {
+			auth: "Bearer valid-token",
 		});
-		const res = await proxy(
-			new NextRequest("https://app.superset.sh/api/trpc/user.me", {
-				headers: { authorization: "Bearer valid-token" },
-			}),
-		);
 
-		expect(res.status).not.toBe(401);
-		expect(res.status).not.toBe(307);
-		expect(res.status).toBe(200); // NextResponse.next()
+		expect(res.status).toBe(200);
 	});
 });

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
+
+mock.module("next/headers", () => ({
+	headers: () => new Headers({ "content-type": "application/json" }),
+}));
+
+// Proxy only needs auth.api.getSession; force it to return null so most
+// requests below are treated as unauthenticated (the failing CLI / remote-host
+// case from #7072). Valid-session cases override it per-test.
+const getSession = mock(async () => null);
+mock.module("@superset/auth/server", () => ({
+	auth: { api: { getSession } },
+}));
+
+const { default: proxy } = await import("./proxy");
+
+describe("proxy: unauthenticated API requests return JSON 401, never a sign-in redirect", () => {
+	beforeEach(() => {
+		getSession.mockClear();
+	});
+
+	it("answers /api/trpc/* with a JSON 401 instead of a 307 redirect (#7072)", async () => {
+		const res = await proxy(
+			new NextRequest("https://app.superset.sh/api/trpc/user.me", {
+				headers: { authorization: "Bearer stale-token" },
+			}),
+		);
+
+		expect(res.status).toBe(401);
+		expect(res.headers.get("content-type")).toContain("application/json");
+		const body = await res.json();
+		expect(body).toEqual({ error: "Unauthorized" });
+	});
+
+	it("answers bare /trpc/* with a JSON 401 too", async () => {
+		const res = await proxy(
+			new NextRequest("https://app.superset.sh/trpc/user.me?batch=1"),
+		);
+
+		expect(res.status).toBe(401);
+	});
+
+	it("still redirects unauthenticated page routes to /sign-in", async () => {
+		const res = await proxy(
+			new NextRequest("https://app.superset.sh/dashboard"),
+		);
+
+		// Not an API route: the historical page-redirect behaviour is preserved.
+		expect(res.status).toBe(307);
+		expect(res.headers.get("location")).toContain("/sign-in");
+	});
+
+	it("does not treat /apiary or /trpcfoo as API routes (slash-delimited child only)", async () => {
+		// P2 (cubic) + coderabbit: only exact /api|/trpc or /api/|/trpc/ match.
+		const apiary = await proxy(
+			new NextRequest("https://app.superset.sh/apiary"),
+		);
+		const trpcfoo = await proxy(
+			new NextRequest("https://app.superset.sh/trpcfoo"),
+		);
+
+		// These are page routes — keep the historical /sign-in redirect, no JSON 401.
+		expect(apiary.status).toBe(307);
+		expect(apiary.headers.get("location")).toContain("/sign-in");
+		expect(trpcfoo.status).toBe(307);
+		expect(trpcfoo.headers.get("location")).toContain("/sign-in");
+	});
+
+	it("leaves public API routes (e.g. /api/auth/desktop) reachable unauthenticated", async () => {
+		// P1 (cubic): /api/auth/desktop is the desktop OAuth start and is public;
+		// it must not fall into the JSON-401 gate.
+		const res = await proxy(
+			new NextRequest("https://app.superset.sh/api/auth/desktop"),
+		);
+
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(307);
+	});
+
+	it("passes a valid authenticated request through without 401 or redirect", async () => {
+		// coderabbit: a valid Bearer session must not be rejected by the gate.
+		getSession.mockReturnValueOnce({
+			user: { email: "dev@app.superset.sh", deletionRequestedAt: null },
+		});
+		const res = await proxy(
+			new NextRequest("https://app.superset.sh/api/trpc/user.me", {
+				headers: { authorization: "Bearer valid-token" },
+			}),
+		);
+
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(307);
+		expect(res.status).toBe(200); // NextResponse.next()
+	});
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -16,8 +16,30 @@ export default async function proxy(req: NextRequest) {
 
 	const pathname = req.nextUrl.pathname;
 
+	// API routes must never redirect to /sign-in: clients (CLI, host-service,
+	// remote relay) parse the response body as JSON, so a 307 with a text/plain
+	// "Redirecting..." body surfaces as an opaque "Failed to parse JSON" in
+	// production for a stale or missing session (#7072). Answer with a JSON 401
+	// instead so the caller can diagnose and re-auth.
+	//
+	// Match the exact route or a slash-delimited child only — `/api-keys`,
+	// `/apiary`, `/trpcfoo` are page routes, not API routes, and must keep the
+	// page redirect.
+	const isApiRoute =
+		pathname === "/api" ||
+		pathname.startsWith("/api/") ||
+		pathname === "/trpc" ||
+		pathname.startsWith("/trpc/");
+
 	if (session && isAuthPageRoute(pathname)) {
 		return NextResponse.redirect(new URL("/", req.url));
+	}
+
+	// Public API routes (e.g. `/api/auth/desktop`, the desktop OAuth start)
+	// must stay reachable unauthenticated — exclude them so they don't fall
+	// into the JSON-401 gate.
+	if (!session && isApiRoute && !isPublicRoute(pathname)) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 	}
 
 	if (!session && !isPublicRoute(pathname)) {
@@ -28,8 +50,6 @@ export default async function proxy(req: NextRequest) {
 
 	// Pending-deletion accounts only get the recovery page; API routes stay
 	// reachable so the reactivate mutation itself can go through.
-	const isApiRoute =
-		pathname.startsWith("/api") || pathname.startsWith("/trpc");
 	if (
 		session?.user.deletionRequestedAt &&
 		!isApiRoute &&


### PR DESCRIPTION
Fixes #7072

## What & why

The web proxy redirected **every** unauthenticated request to `/sign-in` — including `/api/*` and `/trpc/*` — with a `307` and a `text/plain` body. CLI, host-service and remote-relay clients parse the response body as JSON, so for a stale or missing session they hit the opaque `Error: Failed to parse JSON`, `superset start` exits under systemd, and remote workspaces vanish.

`proxy.ts` already computed `isApiRoute`, but only **after** the session gate and only for the pending-deletion branch. This PR hoists that check above the session gate and answers `/api/*` and `/trpc/*` with a JSON `401` (`{ error: "Unauthorized" }`, status 401) when there is no session.

- **Page routes** keep the historical 307 redirect to `/sign-in`.
- The **pending-deletion** branch still uses `isApiRoute` untouched.
- API clients that were silently failing with a parse error now get a status + body they can meaningfully report, turning a future API auth failure into a one-line diagnosis instead of `Failed to parse JSON`.

(Note: this addresses the client-side symptom — the "never redirect API paths" hardening. The separate question of whether the logged-in browser path on `app.superset.sh` throws during Server Components render is a distinct, server-side concern the triage comment left open.)

## How I tested it

New integration test `apps/web/src/proxy.test.ts` drives the real proxy default export with a mocked null session, per the repo's `mock.module` pattern:

- `/api/trpc/user.me` with a Bearer header → **401**, `application/json`, body `{ error: "Unauthorized" }` (was 307)
- bare `/trpc/user.me?batch=1` → **401**
- `/dashboard` (page route) → **307** to `/sign-in`, unchanged behavior

Results:
- `bun test src/proxy.test.ts` → **3 pass**
- `bun test src/proxy-routes.test.ts` → **34 pass** (unchanged)
- `bun x tsc --noEmit -p tsconfig.json` → clean
- `biome check` on the two changed files → clean

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7072 so the web proxy answers unauthenticated `/api/*` and `/trpc/*` requests with a JSON 401 (`{ error: "Unauthorized" }`) instead of a 307 redirect to `/sign-in`. CLI, host-service, and remote-relay clients parse response bodies as JSON, so stale or missing sessions previously surfaced as an opaque `Failed to parse JSON`; they now get a clear auth failure. The API-route check matches the exact path or a slash-delimited child only, so page routes like `/apiary` and `/trpcfoo` keep the redirect, and public API routes like `/api/auth/desktop` stay reachable unauthenticated.

<sup>Written for commit 4fa8750f80d0fad9e182de6e27ded0de33f61a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unauthenticated API and tRPC requests now return a JSON `401 Unauthorized` response instead of redirecting to the sign-in page.
  - Unauthenticated page requests continue to redirect to the sign-in page.
  - Public authentication endpoints remain accessible without a session.
  - API route detection now avoids incorrectly classifying similarly named page paths as API routes.
  - Authenticated requests with a valid Bearer token continue successfully.

- **Tests**
  - Expanded coverage across API, tRPC, page, public authentication, and authenticated routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->