### PR TITLE
fix(slack): forward attached images into spawned agent sessions

### DIFF
--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/forward-image-attachments.test.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/forward-image-attachments.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { SlackImageAsset } from "../slack-image-assets";
+import { forwardSlackImageAttachments } from "./forward-image-attachments";
+
+const IMAGE: SlackImageAsset = {
+	filename: "screenshot.png",
+	mediaType: "image/png",
+	base64Data: "aGVsbG8=",
+};
+
+function makeClient({
+	ids = ["11111111-1111-4111-8111-111111111111"],
+	onCall,
+	throws = false,
+}: {
+	ids?: string[];
+	onCall?: (args: Record<string, unknown>) => void;
+	throws?: boolean;
+} = {}) {
+	let index = 0;
+	const calls: Record<string, unknown>[] = [];
+
+	const client = {
+		callTool: async ({
+			arguments: args,
+		}: {
+			name: string;
+			arguments: Record<string, unknown>;
+		}) => {
+			if (throws) throw new Error("host unreachable");
+			calls.push(args);
+			onCall?.(args);
+			const attachmentId = ids[index++ % ids.length];
+			return { structuredContent: { attachmentId } };
+		},
+	} as unknown as Client;
+
+	return { client, calls };
+}
+
+describe("forwardSlackImageAttachments", () => {
+	test("passes arguments through untouched when the message had no images", async () => {
+		const { client, calls } = makeClient();
+		const args = { hostId: "host-1", workspaceId: "ws-1", agent: "claude" };
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args,
+			images: undefined,
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		expect(result).toBe(args);
+		expect(calls).toHaveLength(0);
+	});
+
+	test("passes through for tools that do not launch an agent", async () => {
+		const { client, calls } = makeClient();
+		const args = { hostId: "host-1", title: "a task" };
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "tasks_create",
+			args,
+			images: [IMAGE],
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		expect(result).toBe(args);
+		expect(calls).toHaveLength(0);
+	});
+
+	test("uploads the image and attaches its id on agents_create", async () => {
+		const { client, calls } = makeClient();
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args: { hostId: "host-1", workspaceId: "ws-1", agent: "claude" },
+			images: [IMAGE],
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({
+			hostId: "host-1",
+			data: IMAGE.base64Data,
+			mediaType: "image/png",
+			originalFilename: "screenshot.png",
+		});
+		expect(result.attachmentIds).toEqual([
+			"11111111-1111-4111-8111-111111111111",
+		]);
+	});
+
+	test("attaches into each agent launch entry on workspaces_create", async () => {
+		const { client } = makeClient();
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "workspaces_create",
+			args: {
+				hostId: "host-1",
+				name: "fix-bug",
+				agents: [
+					{ agent: "claude", prompt: "fix it" },
+					{ agent: "codex", prompt: "review it" },
+				],
+			},
+			images: [IMAGE],
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		const agents = result.agents as { attachmentIds: string[] }[];
+		expect(agents).toHaveLength(2);
+		for (const entry of agents) {
+			expect(entry.attachmentIds).toEqual([
+				"11111111-1111-4111-8111-111111111111",
+			]);
+		}
+	});
+
+	test("preserves attachment ids the caller already supplied", async () => {
+		const { client } = makeClient();
+		const existing = "22222222-2222-4222-8222-222222222222";
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args: {
+				hostId: "host-1",
+				workspaceId: "ws-1",
+				agent: "claude",
+				attachmentIds: [existing],
+			},
+			images: [IMAGE],
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		expect(result.attachmentIds).toEqual([
+			existing,
+			"11111111-1111-4111-8111-111111111111",
+		]);
+	});
+
+	test("uploads once per host and reuses the ids for a later launch", async () => {
+		const { client, calls } = makeClient();
+		const cache = new Map<string, string[]>();
+		const args = { hostId: "host-1", workspaceId: "ws-1", agent: "claude" };
+
+		const first = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args,
+			images: [IMAGE],
+			mcpClient: client,
+			cache,
+		});
+		const second = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args,
+			images: [IMAGE],
+			mcpClient: client,
+			cache,
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(second.attachmentIds).toEqual(
+			first.attachmentIds as unknown as string[],
+		);
+	});
+
+	test("uploads separately for a second host, since attachments are host-scoped", async () => {
+		const { client, calls } = makeClient({
+			ids: [
+				"11111111-1111-4111-8111-111111111111",
+				"33333333-3333-4333-8333-333333333333",
+			],
+		});
+		const cache = new Map<string, string[]>();
+
+		await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args: { hostId: "host-1", workspaceId: "ws-1", agent: "claude" },
+			images: [IMAGE],
+			mcpClient: client,
+			cache,
+		});
+		const second = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args: { hostId: "host-2", workspaceId: "ws-2", agent: "claude" },
+			images: [IMAGE],
+			mcpClient: client,
+			cache,
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(second.attachmentIds).toEqual([
+			"33333333-3333-4333-8333-333333333333",
+		]);
+	});
+
+	test("still launches the agent when the upload fails", async () => {
+		const { client } = makeClient({ throws: true });
+		const args = { hostId: "host-1", workspaceId: "ws-1", agent: "claude" };
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args,
+			images: [IMAGE],
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		expect(result).toBe(args);
+		expect(result.attachmentIds).toBeUndefined();
+	});
+
+	test("leaves arguments alone when the model named no host", async () => {
+		const { client, calls } = makeClient();
+		const args = { workspaceId: "ws-1", agent: "claude" };
+
+		const result = await forwardSlackImageAttachments({
+			toolName: "agents_create",
+			args,
+			images: [IMAGE],
+			mcpClient: client,
+			cache: new Map(),
+		});
+
+		expect(result).toBe(args);
+		expect(calls).toHaveLength(0);
+	});
+});

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/forward-image-attachments.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/forward-image-attachments.ts
@@ -1,0 +1,177 @@
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { SlackImageAsset } from "../slack-image-assets";
+
+/**
+ * MCP tool results carry their payload either as `structuredContent` or as a
+ * JSON string in the first text block, depending on the tool.
+ */
+function parseTextContent(content: unknown): Record<string, unknown> | null {
+	if (!Array.isArray(content)) return null;
+	const first = content.find(
+		(block): block is { type: "text"; text: string } =>
+			typeof block === "object" &&
+			block !== null &&
+			(block as { type?: unknown }).type === "text" &&
+			typeof (block as { text?: unknown }).text === "string",
+	);
+	if (!first) return null;
+	try {
+		return JSON.parse(first.text) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Tools that launch a coding agent, and so should carry the Slack message's
+ * images into the session they start.
+ */
+const ATTACHMENT_FORWARDING_TOOLS = new Set([
+	"agents_create",
+	"workspaces_create",
+]);
+
+/**
+ * Upload the Slack images to one host, once, reusing the ids for any later
+ * launch on that same host. Attachments are host-scoped, so the cache is keyed
+ * by host rather than shared across the run.
+ */
+async function uploadSlackImagesToHost({
+	hostId,
+	images,
+	mcpClient,
+	cache,
+}: {
+	hostId: string;
+	images: SlackImageAsset[];
+	mcpClient: Client;
+	cache: Map<string, string[]>;
+}): Promise<string[]> {
+	const cached = cache.get(hostId);
+	if (cached) {
+		return cached;
+	}
+
+	const attachmentIds: string[] = [];
+	for (const image of images) {
+		const result = await mcpClient.callTool({
+			name: "attachments_upload",
+			arguments: {
+				hostId,
+				data: image.base64Data,
+				mediaType: image.mediaType,
+				originalFilename: image.filename,
+			},
+		});
+
+		const data = (result.structuredContent ??
+			parseTextContent(result.content)) as {
+			attachmentId?: string;
+		} | null;
+
+		if (data?.attachmentId) {
+			attachmentIds.push(data.attachmentId);
+		}
+	}
+
+	cache.set(hostId, attachmentIds);
+	return attachmentIds;
+}
+
+/**
+ * Carry images attached to the Slack message into the agent session the model
+ * is about to spawn.
+ *
+ * Done here rather than as a tool the model calls, for two reasons: the model
+ * cannot reproduce the image bytes to pass them itself, and the target host is
+ * only known once it has chosen one. Forwarding unconditionally also means an
+ * attached screenshot reaches the session whether or not the model thought to
+ * mention it.
+ *
+ * A failed upload degrades to launching without the attachment rather than
+ * failing the spawn outright — losing the image is bad, losing the work the
+ * user asked for is worse.
+ */
+export async function forwardSlackImageAttachments({
+	toolName,
+	args,
+	images,
+	mcpClient,
+	cache,
+}: {
+	toolName: string;
+	args: Record<string, unknown>;
+	images: SlackImageAsset[] | undefined;
+	mcpClient: Client;
+	cache: Map<string, string[]>;
+}): Promise<Record<string, unknown>> {
+	if (
+		!images ||
+		images.length === 0 ||
+		!ATTACHMENT_FORWARDING_TOOLS.has(toolName)
+	) {
+		return args;
+	}
+
+	const hostId = typeof args.hostId === "string" ? args.hostId : null;
+	if (!hostId) {
+		return args;
+	}
+
+	let attachmentIds: string[];
+	try {
+		attachmentIds = await uploadSlackImagesToHost({
+			hostId,
+			images,
+			mcpClient,
+			cache,
+		});
+	} catch (error) {
+		console.warn(
+			"[slack-agent] Failed to forward Slack images to host:",
+			hostId,
+			error,
+		);
+		return args;
+	}
+
+	if (attachmentIds.length === 0) {
+		return args;
+	}
+
+	// `agents_create` takes the ids at the top level; `workspaces_create` takes
+	// them per entry in its `agents` launch sugar.
+	if (toolName === "agents_create") {
+		return {
+			...args,
+			attachmentIds: mergeAttachmentIds(args.attachmentIds, attachmentIds),
+		};
+	}
+
+	if (!Array.isArray(args.agents) || args.agents.length === 0) {
+		return args;
+	}
+
+	return {
+		...args,
+		agents: args.agents.map((entry) => {
+			if (typeof entry !== "object" || entry === null) {
+				return entry;
+			}
+
+			const launch = entry as Record<string, unknown>;
+			return {
+				...launch,
+				attachmentIds: mergeAttachmentIds(launch.attachmentIds, attachmentIds),
+			};
+		}),
+	};
+}
+
+function mergeAttachmentIds(existing: unknown, added: string[]): string[] {
+	const current = Array.isArray(existing)
+		? existing.filter((id): id is string => typeof id === "string")
+		: [];
+
+	return [...new Set([...current, ...added])];
+}

--- a/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
+++ b/apps/api/src/app/api/integrations/slack/events/utils/run-agent/run-agent.ts
@@ -5,6 +5,7 @@ import { env } from "@/env";
 import { DEFAULT_SLACK_MODEL } from "../../../constants";
 import type { AgentAction } from "../slack-blocks";
 import type { SlackImageAsset } from "../slack-image-assets";
+import { forwardSlackImageAttachments } from "./forward-image-attachments";
 import {
 	createSupersetMcpClient,
 	mcpToolToAnthropicTool,
@@ -330,6 +331,10 @@ const DENIED_SUPERSET_TOOLS = new Set([
 	"organization_members_list",
 	"tasks_statuses_list",
 	"hosts_list",
+	// Driven by `forwardSlackImageAttachments`, not by the model: an LLM cannot
+	// re-emit the bytes of an image it was shown, so exposing the upload tool
+	// would only invite calls it can't fill in.
+	"attachments_upload",
 ]);
 
 const SLACK_GET_CHANNEL_HISTORY_TOOL: Anthropic.Tool = {
@@ -404,6 +409,9 @@ Guidelines:
 - If an action fails, explain what went wrong and suggest alternatives
 - When answering questions that need up-to-date info, use web_search to find current information
 - Cite sources when sharing information from web search results
+
+Attachments:
+- Images attached to the Slack message are forwarded automatically to any agent you spawn — you do not need to describe them into the prompt or ask the user to re-send them
 
 Context gathering:
 - Thread context is automatically included if the mention is in a thread
@@ -507,6 +515,9 @@ export async function runSlackAgent(
 ): Promise<SlackAgentResult> {
 	const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
 	const actions: AgentAction[] = [];
+	// Host id -> attachment ids for this message's images, so a run that creates
+	// a workspace and then launches a second agent uploads them only once.
+	const attachmentUploadsByHost = new Map<string, string[]>();
 
 	let supersetMcp: Client | null = null;
 	let cleanupSuperset: (() => Promise<void>) | null = null;
@@ -652,9 +663,17 @@ ${agentContext}`;
 							continue;
 						}
 
+						const toolArguments = await forwardSlackImageAttachments({
+							toolName,
+							args: toolUse.input as Record<string, unknown>,
+							images: params.images,
+							mcpClient: supersetMcp,
+							cache: attachmentUploadsByHost,
+						});
+
 						const result = await supersetMcp.callTool({
 							name: toolName,
-							arguments: toolUse.input as Record<string, unknown>,
+							arguments: toolArguments,
 						});
 
 						resultContent = JSON.stringify(result.content);

--- a/apps/docs/content/docs/mcp-server.mdx
+++ b/apps/docs/content/docs/mcp-server.mdx
@@ -316,6 +316,12 @@ API keys grant full access to your organization. Keep them secret and never comm
 | `agents_list` | List agents configured on a host |
 | `agents_create` | Create (launch) an agent session in an existing workspace |
 
+### Attachments
+
+| Tool | Description |
+|------|-------------|
+| `attachments_upload` | Upload a file to a host and get the `attachmentId` that `agents_create` and `workspaces_create` accept in `attachmentIds` |
+
 ### Terminals
 
 | Tool | Description |

--- a/packages/mcp/src/tools/attachments/upload.ts
+++ b/packages/mcp/src/tools/attachments/upload.ts
@@ -1,0 +1,50 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { defineTool } from "../../define-tool";
+import { hostServiceCall } from "../../host-service-client";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "attachments_upload",
+		annotations: { destructiveHint: false },
+		description:
+			"Upload a file to a host's attachment storage and get back the `attachmentId` that `agents_create` and `workspaces_create` accept in `attachmentIds`. Attachments are host-scoped, so upload to the same hostId the workspace lives on. Intended for callers that already hold the bytes (an integration forwarding a user's upload); an agent cannot reproduce the bytes of a file it was merely shown.",
+		inputSchema: {
+			hostId: z
+				.string()
+				.min(1)
+				.describe("Host machineId to store the attachment on."),
+			data: z.string().min(1).describe("File contents, base64-encoded."),
+			mediaType: z
+				.string()
+				.min(1)
+				.describe("IANA media type, e.g. `image/png`."),
+			originalFilename: z
+				.string()
+				.optional()
+				.describe("Display filename preserved on the host."),
+		},
+		handler: async (input, ctx) => {
+			return hostServiceCall<{
+				attachmentId: string;
+				originalFilename?: string;
+				mediaType: string;
+				sizeBytes: number;
+			}>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: input.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"attachments.upload",
+				"mutation",
+				{
+					data: { kind: "base64", data: input.data },
+					mediaType: input.mediaType,
+					originalFilename: input.originalFilename,
+				},
+			);
+		},
+	});
+}

--- a/packages/mcp/src/tools/register.ts
+++ b/packages/mcp/src/tools/register.ts
@@ -6,6 +6,7 @@ import {
 
 import * as agentsCreate from "./agents/create";
 import * as agentsList from "./agents/list";
+import * as attachmentsUpload from "./attachments/upload";
 import * as automationsCreate from "./automations/create";
 import * as automationsDelete from "./automations/delete";
 import * as automationsGet from "./automations/get";
@@ -69,6 +70,7 @@ const REGISTRARS = [
 	workspacesDelete,
 	agentsCreate,
 	agentsList,
+	attachmentsUpload,
 	terminalsCreate,
 	terminalsList,
 	terminalsSend,


### PR DESCRIPTION
## What & why

Fixes #7097.

An image attached to a Slack message reaches the bot's own conversation but stops there. When the bot then spawns a workspace or agent, it passes a text-only prompt — so the session never sees the screenshot the user thought they attached. From the session's side this is invisible: the user believes they attached an image, the agent says nothing came through, and both are right.

`agents_create` and `workspaces_create` already accept `attachmentIds`, but nothing on this path could produce one. `packages/mcp/src/tools/` registered no attachment tool, so the host's `attachments.upload` mutation — which the CLI and the desktop/mobile clients both use — was unreachable from `apps/api`.

Two changes:

1. **`attachments_upload` MCP tool** (`packages/mcp/src/tools/attachments/upload.ts`) over the existing host mutation, same shape the CLI's `uploadAttachments` uses.
2. **Forward Slack images at the tool-call boundary** in `run-agent.ts`. When the originating message carried images and the model calls `agents_create` / `workspaces_create`, the images are uploaded to the `hostId` it chose and the resulting UUIDs merged into `attachmentIds`.

Doing the upload in the interception layer rather than exposing it to the model is deliberate, for two reasons: a model cannot re-emit the bytes of an image it was merely shown, and the target host is only known once it has picked one. Forwarding unconditionally also means an attached screenshot travels with the work whether or not the model thought to mention it — so `attachments_upload` is added to `DENIED_SUPERSET_TOOLS` rather than offered as something to call.

Two smaller notes:

- A failed upload degrades to launching without the attachment rather than failing the spawn. Losing the image is bad; losing the work the user asked for is worse. The failure is logged.
- Uploads are cached per host for the run, so a turn that creates a workspace and then launches a second agent on the same host uploads once.

## How I tested it

- `bun run lint` — clean.
- `bun run typecheck` — clean, 39/39 packages.
- New unit tests for the forwarding logic (`forward-image-attachments.test.ts`, 9 cases): pass-through when there are no images / the tool doesn't launch an agent / no host was named, top-level attach on `agents_create`, per-entry attach on `workspaces_create`, preserving caller-supplied ids, upload-once-per-host caching, separate upload for a second host, and still launching when the upload throws.
- `bun test src` in `apps/api` — 30 pass, 0 fail.

Not end-to-end tested against a live Slack workspace: that needs a Slack app install plus a connected host, which I don't have. The tests cover the argument rewriting, so the parts I could not exercise are the real `attachments_upload` round trip and the host resolving the id to a path.

One thing worth flagging on `bun run test`: `@superset/workspace-fs` fails under the full turbo run, but the failing set varies between runs (1–3 tests, all `FsWatcherManager` timing tests hitting 4–8s timeouts) and the package passes 101/101 when run alone. This branch does not touch `packages/workspace-fs`, and that package depends only on `@superset/typescript` — so it looks like a pre-existing flake under `--concurrency=2` load rather than anything here.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF3K6hJqzmxk6ZuzkXjEX8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7097. Images attached to a Slack message now reach the agent sessions the bot spawns, instead of stopping at the bot's own conversation.

- Adds the `attachments_upload` MCP tool, making the host's `attachments.upload` mutation reachable from `apps/api`.
- Uploads happen automatically at the tool-call boundary in `run-agent` rather than as a model-callable tool, since a model can't reproduce image bytes and the target host is only known once chosen.
- A failed upload degrades to launching without the attachment, and uploads are cached per host per run.

<sup>Written for commit 6ad6f038c3d44f0c5c69b4b02b7b1f7d049be77e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack-launched agents now automatically receive images attached to the originating message.
  * Added attachment uploading for MCP hosts, with support for reusing uploaded attachments across agent launches.
  * Existing attachment IDs are preserved and duplicate IDs are avoided.
* **Documentation**
  * Documented attachment uploads and how attachment IDs are used when launching agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->