### PR TITLE
feat(shared,host-service): add Claude Fable 5.1 to the model pickers and pricing table

### DIFF
--- a/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
@@ -5,8 +5,8 @@ describe("matchModelRate", () => {
 	test("matches vendor-qualified ids from multi-model harnesses", () => {
 		const rate = matchModelRate("opencode", "anthropic/claude-sonnet-5");
 		expect(rate.approximate).toBe(false);
-		expect(rate.inputPerM).toBe(3);
-		expect(rate.outputPerM).toBe(15);
+		expect(rate.inputPerM).toBe(2);
+		expect(rate.outputPerM).toBe(10);
 	});
 
 	test("unknown models fall back to the cheapest rate, marked approximate", () => {
@@ -20,12 +20,21 @@ describe("matchModelRate", () => {
 		expect(rate.inputPerM).toBe(2);
 	});
 
-	test("prices Fable 5.1 cache reads at its own rate, not the usual 0.1x", () => {
+	test("prices Fable 5.1 and Mythos 5.1 cache reads at their own rate, not the usual 0.1x", () => {
 		const fable51 = matchModelRate("claude", "claude-fable-5-1");
 		const fable5 = matchModelRate("claude", "claude-fable-5");
 		expect(fable51).toMatchObject({
 			inputPerM: 10,
 			outputPerM: 50,
+			cacheReadPerM: 0.25,
+			approximate: false,
+		});
+		expect(matchModelRate("claude", "claude-mythos-5-1")).toMatchObject({
+			cacheReadPerM: 0.25,
+			approximate: false,
+		});
+		expect(matchModelRate("omp", "anthropic/claude-fable-5-1")).toMatchObject({
+			cacheReadPerM: 0.25,
 			approximate: false,
 		});
 		const cachedMillion = {
@@ -37,7 +46,11 @@ describe("matchModelRate", () => {
 		};
 		expect(costUsd(fable51, cachedMillion)).toBeCloseTo(0.25);
 		expect(costUsd(fable5, cachedMillion)).toBeCloseTo(1);
+		expect(
+			costUsd(matchModelRate("claude", "claude-mythos-5"), cachedMillion),
+		).toBeCloseTo(1);
 		expect(cacheSavingsUsd(fable51, cachedMillion)).toBeCloseTo(9.75);
+		expect(cacheSavingsUsd(fable5, cachedMillion)).toBeCloseTo(9);
 	});
 
 	test("uses Gemini Pro long-context tiers above 200k prompt tokens", () => {

--- a/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { matchModelRate } from "./pricing";
+import { cacheSavingsUsd, costUsd, matchModelRate } from "./pricing";
 
 describe("matchModelRate", () => {
 	test("matches vendor-qualified ids from multi-model harnesses", () => {
@@ -18,6 +18,26 @@ describe("matchModelRate", () => {
 		const rate = matchModelRate("grok", "grok-4.6");
 		expect(rate.approximate).toBe(false);
 		expect(rate.inputPerM).toBe(2);
+	});
+
+	test("prices Fable 5.1 cache reads at its own rate, not the usual 0.1x", () => {
+		const fable51 = matchModelRate("claude", "claude-fable-5-1");
+		const fable5 = matchModelRate("claude", "claude-fable-5");
+		expect(fable51).toMatchObject({
+			inputPerM: 10,
+			outputPerM: 50,
+			approximate: false,
+		});
+		const cachedMillion = {
+			uncachedInput: 0,
+			cachedInput: 1_000_000,
+			cacheWrite5m: 0,
+			cacheWrite1h: 0,
+			output: 0,
+		};
+		expect(costUsd(fable51, cachedMillion)).toBeCloseTo(0.25);
+		expect(costUsd(fable5, cachedMillion)).toBeCloseTo(1);
+		expect(cacheSavingsUsd(fable51, cachedMillion)).toBeCloseTo(9.75);
 	});
 
 	test("uses Gemini Pro long-context tiers above 200k prompt tokens", () => {

--- a/packages/host-service/src/trpc/router/usage/history/pricing.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.ts
@@ -8,11 +8,16 @@ import type { UsageAgent } from "../types";
  * Longest-prefix match on the lowercased model id; unknown models fall back
  * to the agent's cheapest rate and mark the result approximate.
  */
-export const PRICING_TABLE_UPDATED = "2026-08-16";
+export const PRICING_TABLE_UPDATED = "2026-09-01";
 
 export interface ModelRate {
 	inputPerM: number;
 	outputPerM: number;
+	/**
+	 * Cache-read price in USD per million tokens, for models priced off the
+	 * usual `CACHE_READ_MULTIPLIER` share of input.
+	 */
+	cacheReadPerM?: number;
 	longContext?: ModelRate;
 }
 
@@ -22,6 +27,9 @@ export const CACHE_WRITE_5M_MULTIPLIER = 1.25;
 export const CACHE_WRITE_1H_MULTIPLIER = 2;
 
 const CLAUDE_RATES: Record<string, ModelRate> = {
+	// Fable 5.1 keeps Fable 5's token price but cuts cache reads to $0.25/M
+	// (0.025x input) instead of the usual 0.1x.
+	"claude-fable-5-1": { inputPerM: 10, outputPerM: 50, cacheReadPerM: 0.25 },
 	"claude-fable-5": { inputPerM: 10, outputPerM: 50 },
 	"claude-mythos": { inputPerM: 10, outputPerM: 50 },
 	"claude-opus-5": { inputPerM: 5, outputPerM: 25 },
@@ -172,11 +180,16 @@ export interface TokenCounts {
 	output: number;
 }
 
+/** The model's own cache-read price, else the usual share of its input rate. */
+function cacheReadPerM(rate: ModelRate): number {
+	return rate.cacheReadPerM ?? rate.inputPerM * CACHE_READ_MULTIPLIER;
+}
+
 export function costUsd(rate: ModelRate, tokens: TokenCounts): number {
 	return (
 		(tokens.uncachedInput / 1e6) * rate.inputPerM +
 		(tokens.output / 1e6) * rate.outputPerM +
-		(tokens.cachedInput / 1e6) * rate.inputPerM * CACHE_READ_MULTIPLIER +
+		(tokens.cachedInput / 1e6) * cacheReadPerM(rate) +
 		(tokens.cacheWrite5m / 1e6) * rate.inputPerM * CACHE_WRITE_5M_MULTIPLIER +
 		(tokens.cacheWrite1h / 1e6) * rate.inputPerM * CACHE_WRITE_1H_MULTIPLIER
 	);
@@ -184,7 +197,5 @@ export function costUsd(rate: ModelRate, tokens: TokenCounts): number {
 
 /** Dollars saved by cache reads vs paying full input price for them. */
 export function cacheSavingsUsd(rate: ModelRate, tokens: TokenCounts): number {
-	return (
-		(tokens.cachedInput / 1e6) * rate.inputPerM * (1 - CACHE_READ_MULTIPLIER)
-	);
+	return (tokens.cachedInput / 1e6) * (rate.inputPerM - cacheReadPerM(rate));
 }

--- a/packages/host-service/src/trpc/router/usage/history/pricing.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.ts
@@ -27,9 +27,10 @@ export const CACHE_WRITE_5M_MULTIPLIER = 1.25;
 export const CACHE_WRITE_1H_MULTIPLIER = 2;
 
 const CLAUDE_RATES: Record<string, ModelRate> = {
-	// Fable 5.1 keeps Fable 5's token price but cuts cache reads to $0.25/M
-	// (0.025x input) instead of the usual 0.1x.
+	// Fable 5.1 and Mythos 5.1 keep Fable 5's token price but cut cache reads
+	// to $0.25/M (0.025x input) instead of the usual 0.1x.
 	"claude-fable-5-1": { inputPerM: 10, outputPerM: 50, cacheReadPerM: 0.25 },
+	"claude-mythos-5-1": { inputPerM: 10, outputPerM: 50, cacheReadPerM: 0.25 },
 	"claude-fable-5": { inputPerM: 10, outputPerM: 50 },
 	"claude-mythos": { inputPerM: 10, outputPerM: 50 },
 	"claude-opus-5": { inputPerM: 5, outputPerM: 25 },
@@ -39,17 +40,21 @@ const CLAUDE_RATES: Record<string, ModelRate> = {
 	"claude-opus-4-5": { inputPerM: 5, outputPerM: 25 },
 	// Opus 4.0/4.1 predate the price cut.
 	"claude-opus-4": { inputPerM: 15, outputPerM: 75 },
-	"claude-sonnet-5": { inputPerM: 3, outputPerM: 15 },
+	// Sonnet 5's launch price is permanent: the $3/$15 increase scheduled for
+	// 2026-09-01 was cancelled.
+	"claude-sonnet-5": { inputPerM: 2, outputPerM: 10 },
 	"claude-sonnet-4": { inputPerM: 3, outputPerM: 15 },
 	"claude-haiku-4-5": { inputPerM: 1, outputPerM: 5 },
 	"claude-3-5-haiku": { inputPerM: 0.8, outputPerM: 4 },
 };
 
 const CODEX_RATES: Record<string, ModelRate> = {
-	"gpt-5.6-sol": { inputPerM: 5, outputPerM: 30 },
+	// Sol's promotional price, published as lasting at least through
+	// 2026-11-21; the bare `gpt-5.6` id follows Sol.
+	"gpt-5.6-sol": { inputPerM: 4, outputPerM: 20 },
 	"gpt-5.6-terra": { inputPerM: 2, outputPerM: 12 },
 	"gpt-5.6-luna": { inputPerM: 0.2, outputPerM: 1.2 },
-	"gpt-5.6": { inputPerM: 5, outputPerM: 30 },
+	"gpt-5.6": { inputPerM: 4, outputPerM: 20 },
 	"gpt-5.3-codex": { inputPerM: 1.75, outputPerM: 14 },
 	"gpt-5.3": { inputPerM: 1.75, outputPerM: 14 },
 	"gpt-5-codex": { inputPerM: 1.25, outputPerM: 10 },

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -52,9 +52,10 @@ describe("AGENT_MODEL_SUPPORT", () => {
 });
 
 describe("SUPERSET_CHAT_MODELS", () => {
-	it("includes opus 5 and the GPT-5.6 Codex models", () => {
+	it("includes opus 5, fable 5.1 and the GPT-5.6 Codex models", () => {
 		const ids = SUPERSET_CHAT_MODELS.map((model) => model.id);
 		expect(ids).toContain("anthropic/claude-opus-5");
+		expect(ids).toContain("anthropic/claude-fable-5-1");
 		expect(ids).toContain("openai/gpt-5.6-sol");
 		expect(ids).toContain("openai/gpt-5.6-terra");
 		expect(ids).toContain("openai/gpt-5.6-luna");
@@ -112,6 +113,7 @@ describe("buildAgentModelArgs", () => {
 		// Aliases follow the CLI's newest model; teams standardising on one
 		// release need an id that stays put.
 		expect(ids).toContain("opus");
+		expect(ids).toContain("claude-fable-5-1");
 		expect(ids).toContain("claude-opus-4-8");
 		expect(ids).toContain("claude-opus-4-7");
 		expect(ids).toContain("claude-sonnet-4-6");
@@ -165,6 +167,18 @@ describe("buildAgentModelArgs", () => {
 		expect(buildAgentModelArgs("opencode", "anthropic/claude-fable-5")).toEqual(
 			["--model", "anthropic/claude-fable-5"],
 		);
+	});
+
+	it("includes fable 5.1 as a pinned claude release and for the models.dev harnesses", () => {
+		expect(buildAgentModelArgs("claude", "claude-fable-5-1")).toEqual([
+			"--model",
+			"claude-fable-5-1",
+		]);
+		for (const preset of ["opencode", "omp"]) {
+			expect(buildAgentModelArgs(preset, "anthropic/claude-fable-5-1")).toEqual(
+				["--model", "anthropic/claude-fable-5-1"],
+			);
+		}
 	});
 
 	it("includes every GPT-5.6 Codex model", () => {

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -126,6 +126,7 @@ describe("buildAgentModelArgs", () => {
 			models.find((model) => model.id === id)?.group;
 		expect(groupOf("opus")).toBe("Latest");
 		expect(groupOf("claude-opus-4-8")).toBe("Pinned releases");
+		expect(groupOf("claude-fable-5-1")).toBe("Pinned releases");
 		// The header carries the distinction, so labels stay bare.
 		expect(models.find((model) => model.id === "opus")?.label).toBe("Opus");
 	});

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -47,6 +47,11 @@ export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
 	{ id: "anthropic/claude-opus-5", label: "Opus 5", provider: "Anthropic" },
 	{ id: "anthropic/claude-opus-4-8", label: "Opus 4.8", provider: "Anthropic" },
 	{ id: "anthropic/claude-opus-4-7", label: "Opus 4.7", provider: "Anthropic" },
+	{
+		id: "anthropic/claude-fable-5-1",
+		label: "Fable 5.1",
+		provider: "Anthropic",
+	},
 	{ id: "anthropic/claude-fable-5", label: "Fable 5", provider: "Anthropic" },
 	{
 		id: "anthropic/claude-sonnet-4-6",
@@ -89,6 +94,7 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 			{ id: "opus", label: "Opus", group: LATEST_GROUP },
 			{ id: "sonnet", label: "Sonnet", group: LATEST_GROUP },
 			{ id: "haiku", label: "Haiku", group: LATEST_GROUP },
+			{ id: "claude-fable-5-1", label: "Fable 5.1", group: PINNED_GROUP },
 			{ id: "claude-fable-5", label: "Fable 5", group: PINNED_GROUP },
 			{ id: "claude-opus-5", label: "Opus 5", group: PINNED_GROUP },
 			{ id: "claude-sonnet-5", label: "Sonnet 5", group: PINNED_GROUP },
@@ -166,8 +172,10 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 			// openai ids verified against `opencode models` (2026-08-05), which
 			// no longer lists the old `openai/gpt-5`. anthropic ids follow the
 			// same models.dev catalog but need an authed anthropic provider to
-			// appear in that listing.
+			// appear in that listing; `claude-fable-5-1` was checked against
+			// models.dev directly (2026-09-01).
 			{ id: "anthropic/claude-opus-5", label: "Claude Opus 5" },
+			{ id: "anthropic/claude-fable-5-1", label: "Claude Fable 5.1" },
 			{ id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
 			{ id: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
 			{ id: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol" },
@@ -181,11 +189,13 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		models: [
 			// OMP accepts configured role aliases as well as exact
 			// provider/model selectors. Exact ids verified against
-			// `omp models --json` in OMP 18.0.1.
+			// `omp models --json` in OMP 18.0.1; `claude-fable-5-1` against the
+			// catalog bundled in OMP 18.1.2.
 			{ id: "@smol", label: "Configured fast model" },
 			{ id: "@slow", label: "Configured slow model" },
 			{ id: "@plan", label: "Configured plan model" },
 			{ id: "anthropic/claude-opus-5", label: "Claude Opus 5" },
+			{ id: "anthropic/claude-fable-5-1", label: "Claude Fable 5.1" },
 			{ id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
 			{
 				id: "anthropic/claude-sonnet-4-6",


### PR DESCRIPTION
## Summary
- Claude Fable 5.1 (`claude-fable-5-1`) is now selectable in the workspace-create picker for the claude preset (Pinned releases), in the opencode and OMP pickers, and in the Superset chat catalog. The claude `fable` alias already tracked it.
- The usage pricing table learns Fable 5.1's economics: the same $10/$50 per MTok as Fable 5, but cache reads at $0.25/MTok (0.025x input, where every other model is 0.1x). A per-model `cacheReadPerM` override carries that; Mythos 5.1 shares it.
- Two rows checked against the vendor pages while re-dating the table were corrected: Sonnet 5 is $2/$10 (the $3/$15 increase scheduled for 2026-09-01 was cancelled) and GPT-5.6 Sol is on $4/$20 promotional pricing through at least 2026-11-21.

## Why / Context
The model catalogs in `packages/shared/src/agent-models.ts` are hand-maintained, so Fable 5.1 was not offered anywhere. Usage cost estimates matched `claude-fable-5-1` transcripts to the `claude-fable-5` prefix, which is right on tokens but 4x too high on cache reads, and long agentic sessions are dominated by cache reads.

## How It Works
- `AGENT_MODEL_SUPPORT` and `SUPERSET_CHAT_MODELS` gain the new ids. The desktop picker, host-service's `validateAgentModelSelection`, and `buildAgentModelArgs` all derive from the catalog, so nothing else changes.
- `ModelRate.cacheReadPerM` is an optional absolute $/MTok cache-read price. `costUsd` and `cacheSavingsUsd` resolve it through one helper that falls back to `inputPerM × CACHE_READ_MULTIPLIER`. Only the Fable 5.1 and Mythos 5.1 rows set it.
- Ids were verified before being added: `claude-fable-5-1` is in the Claude Code 2.1.257 binary, and `anthropic/claude-fable-5-1` is in models.dev (opencode) and in the catalog bundled with OMP 18.1.2.

## Manual QA Checklist
- [x] `matchModelRate` resolves `claude-fable-5-1`, `claude-mythos-5-1`, and `anthropic/claude-fable-5-1` to the $0.25/MTok cache-read rate, while Fable 5 and Mythos 5 stay at $1/MTok (unit tests)
- [x] Fable 5.1 sits under "Pinned releases" in the claude picker, next to Fable 5 (catalog group pinned by test)
- [x] Sonnet 5 and GPT-5.6 Sol rates re-read from the Anthropic and OpenAI pricing pages on 2026-09-02
- [ ] Not exercised in the running desktop app: launching a workspace with each new id. The picker is data-driven and covered by tests, but the live launch path was not run.

## Testing
- `bun run lint` (the only diagnostic is a local, git-excluded `.github/hooks/superset-notify.json`, which is not in this PR)
- `bun run typecheck`
- `bun test packages/shared/src/agent-models.test.ts packages/host-service/src/trpc/router/usage/history/` (95 tests)
- `bun test packages/host-service/src/trpc/router/agents/agents.test.ts apps/desktop/src/renderer/components/AgentModelSelect/groupModelOptions.test.ts`

## Design Decisions
- **Absolute `cacheReadPerM` rather than a multiplier**: Anthropic publishes the cache-read price as $0.25/MTok and `longContext` is already an absolute override, so the table stays in the vendor's units.
- **Explicit `claude-mythos-5-1` row**: the longest-prefix matcher would otherwise price it off the bare `claude-mythos` row and report the match as exact.

## Known Limitations
- gpt-4.1, gpt-4o, and the Grok rows still use the 0.1x cache-read default although their vendors bill 0.25x to 0.5x. Not changed here.
- The chat catalog entry is inert today: `chat.getModels` has no in-repo consumer.
- The prefix matcher reports prefix-extended ids (a future `claude-fable-5-2`, say) as exact matches. A test tying picker ids to pricing keys would surface that; deferred.

## Follow-ups
- Add Fable 5.1 to the Copilot and cursor-agent pickers once their ids are confirmed against a logged-in CLI. Both list models server-side and reject unknown ids, so they were left out rather than guessed.
- The Slack integration's model picker never offered Fable and is unchanged.

https://claude.ai/code/session_01UwVi8ncK3E4L8LNGPT7t6r


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude Fable 5.1 to the model pickers and usage pricing, and corrects two outdated pricing rows.

**Pricing**
- Fable 5.1 and Mythos 5.1 cache reads are $0.25/MTok via a new `cacheReadPerM` override.
- Sonnet 5 drops to $2/$10 (the scheduled increase was cancelled) and GPT-5.6 Sol to $4/$20.

**Model pickers**
- Adds `claude-fable-5-1` to the claude preset, opencode, OMP, and Superset chat catalog.
- Copilot and cursor-agent pickers are left unchanged; their ids are confirmed server-side.

<sup>Written for commit b478ccd2eec9c10399b7cd04e5ba86da568ab144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Anthropic Claude Fable 5.1 to supported model catalogs and model selection options.
  - Added support for Fable 5.1 and Mythos 5.1 cache-read pricing.

- **Pricing Updates**
  - Updated Sonnet 5 pricing to $2 per million input tokens and $15 per million output tokens.
  - Updated GPT-5.6 and GPT-5.6 Sol pricing to $4/$20 per million tokens.
  - Added model-specific cache-read pricing, including $0.25 per million tokens for Fable 5.1 and Mythos 5.1.
  - Improved cached-token cost and savings calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->