### PR TITLE
fix(desktop): keep sidebar usable after project close

### DIFF
--- a/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
+++ b/apps/desktop/src/renderer/lib/persisted-keys/persisted-key-registry.test-data.ts
@@ -186,6 +186,10 @@ export const PERSISTED_KEY_REGISTRY: ReadonlyArray<
 		["lastViewedWorkspaceId"],
 	],
 	[
+		"src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx",
+		["lastViewedWorkspaceId"],
+	],
+	[
 		"src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/richInputOpenStore.ts",
 		["superset.terminalRichInputOpen"],
 	],

--- a/apps/desktop/src/renderer/react-query/workspaces/utils/workspace-removal.test.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/utils/workspace-removal.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	getWorkspaceFocusTargetAfterRemoval,
+	removeProjectFromGroups,
 	removeWorkspaceFromGroups,
 } from "./workspace-removal";
 
@@ -61,5 +62,23 @@ describe("removeWorkspaceFromGroups", () => {
 				(item) => item.id,
 			),
 		).toEqual(["w1", "s1"]);
+	});
+});
+
+describe("removeProjectFromGroups", () => {
+	it("removes every workspace group for the closed project", () => {
+		const groupedProjects = [
+			{ project: { id: "p1" }, ...groups[0] },
+			{
+				project: { id: "p2" },
+				workspaces: [{ id: "w5", tabOrder: 1 }],
+				sections: [],
+				topLevelItems: [{ id: "w5", kind: "workspace" as const, tabOrder: 1 }],
+			},
+		];
+
+		expect(removeProjectFromGroups(groupedProjects, "p1")).toEqual([
+			groupedProjects[1],
+		]);
 	});
 });

--- a/apps/desktop/src/renderer/react-query/workspaces/utils/workspace-removal.ts
+++ b/apps/desktop/src/renderer/react-query/workspaces/utils/workspace-removal.ts
@@ -103,3 +103,9 @@ export function removeWorkspaceFromGroups<TGroup extends WorkspaceGroupLike>(
 		})
 		.filter(hasVisibleWorkspaces);
 }
+
+export function removeProjectFromGroups<
+	TGroup extends { project: { id: string } },
+>(groups: readonly TGroup[], projectId: string): TGroup[] {
+	return groups.filter((group) => group.project.id !== projectId);
+}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -112,7 +112,21 @@ export function ProjectHeader({
 			const previousLastViewedWorkspaceId = localStorage.getItem(
 				"lastViewedWorkspaceId",
 			);
-			localStorage.removeItem("lastViewedWorkspaceId");
+			const shouldClearLastViewedWorkspace = previousGrouped.some(
+				(group) =>
+					group.project.id === id &&
+					(group.workspaces.some(
+						(workspace) => workspace.id === previousLastViewedWorkspaceId,
+					) ||
+						group.sections.some((section) =>
+							section.workspaces.some(
+								(workspace) => workspace.id === previousLastViewedWorkspaceId,
+							),
+						)),
+			);
+			if (shouldClearLastViewedWorkspace) {
+				localStorage.removeItem("lastViewedWorkspaceId");
+			}
 
 			// The workspace route cannot render after this mutation deletes it.
 			try {
@@ -146,7 +160,15 @@ export function ProjectHeader({
 				);
 			}
 			if (context?.previousWorkspaceId) {
-				void navigateToWorkspace(context.previousWorkspaceId, navigate);
+				void navigateToWorkspace(
+					context.previousWorkspaceId,
+					navigate,
+				).catch((navigationError) => {
+					console.error(
+						"[ProjectHeader] Failed to restore workspace after closing project failed",
+						navigationError,
+					);
+				});
 			}
 			toast.error(`Failed to close project: ${error.message}`);
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectHeader.tsx
@@ -27,6 +27,7 @@ import {
 import { ColorSelector } from "renderer/components/ColorSelector";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { useUpdateProject } from "renderer/react-query/projects/useUpdateProject";
+import { removeProjectFromGroups } from "renderer/react-query/workspaces/utils/workspace-removal";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { useProjectRename } from "renderer/screens/main/hooks/useProjectRename";
 import { STROKE_WIDTH } from "../constants";
@@ -51,6 +52,15 @@ interface ProjectHeaderProps {
 	onNewWorkspace: () => void;
 }
 
+type CloseProjectContext = {
+	previousWorkspaceId?: string;
+	previousGrouped?: ReturnType<
+		typeof electronTrpc.useUtils
+	>["workspaces"]["getAllGrouped"]["getData"] extends () => infer R
+		? R
+		: never;
+};
+
 export function ProjectHeader({
 	projectId,
 	projectName,
@@ -73,46 +83,71 @@ export function ProjectHeader({
 
 	const closeProject = electronTrpc.projects.close.useMutation({
 		onMutate: async ({ id }) => {
-			let shouldNavigate = false;
+			const workspaceId = params.workspaceId;
+			if (!workspaceId) return {};
 
-			if (params.workspaceId) {
-				try {
-					const currentWorkspace = await utils.workspaces.get.fetch({
-						id: params.workspaceId,
-					});
-					shouldNavigate = currentWorkspace?.projectId === id;
-				} catch (error) {
+			const currentWorkspace = await utils.workspaces.get
+				.fetch({
+					id: workspaceId,
+				})
+				.catch((error) => {
 					console.warn(
 						"[ProjectHeader] Failed to resolve current workspace before closing project",
 						error,
 					);
+					throw error;
+				});
+
+			if (currentWorkspace?.projectId !== id) return {};
+
+			await utils.workspaces.getAllGrouped.cancel();
+			const previousGrouped =
+				utils.workspaces.getAllGrouped.getData() ??
+				(await utils.workspaces.getAllGrouped.fetch());
+			utils.workspaces.getAllGrouped.setData(
+				undefined,
+				removeProjectFromGroups(previousGrouped, id),
+			);
+
+			const previousLastViewedWorkspaceId = localStorage.getItem(
+				"lastViewedWorkspaceId",
+			);
+			localStorage.removeItem("lastViewedWorkspaceId");
+
+			// The workspace route cannot render after this mutation deletes it.
+			try {
+				await navigate({ to: "/workspace" });
+			} catch (error) {
+				utils.workspaces.getAllGrouped.setData(undefined, previousGrouped);
+				if (previousLastViewedWorkspaceId) {
+					localStorage.setItem(
+						"lastViewedWorkspaceId",
+						previousLastViewedWorkspaceId,
+					);
 				}
+				throw error;
 			}
 
-			return { shouldNavigate };
+			return { previousWorkspaceId: workspaceId, previousGrouped };
 		},
-		onSuccess: async (data, { id }, context) => {
+		onSuccess: (data) => {
 			utils.workspaces.getAllGrouped.invalidate();
 			utils.projects.getRecents.invalidate();
-
-			if (context?.shouldNavigate) {
-				const groups = await utils.workspaces.getAllGrouped.fetch();
-				const otherWorkspace = groups
-					.flatMap((group) => group.workspaces)
-					.find((w) => w.projectId !== id);
-
-				if (otherWorkspace) {
-					navigateToWorkspace(otherWorkspace.id, navigate);
-				} else {
-					navigate({ to: "/workspace" });
-				}
-			}
 
 			if (data.terminalWarning) {
 				toast.warning(data.terminalWarning);
 			}
 		},
-		onError: (error) => {
+		onError: (error, _variables, context: CloseProjectContext | undefined) => {
+			if (context?.previousGrouped !== undefined) {
+				utils.workspaces.getAllGrouped.setData(
+					undefined,
+					context.previousGrouped,
+				);
+			}
+			if (context?.previousWorkspaceId) {
+				void navigateToWorkspace(context.previousWorkspaceId, navigate);
+			}
 			toast.error(`Failed to close project: ${error.message}`);
 		},
 	});


### PR DESCRIPTION
<!--
PR titles become the squash-merge commit subject, so use conventional commit format:
  feat(desktop): add copy-logs button to failed CI checks
  fix(web): guard against missing PR in workspace header
-->

## What & why

Fixed the app getting stuck after closing the active project. The sidebar is freezing if a user closes an active project.

It now removes that project from the sidebar cache and clears the stale workspace selection before navigating away, so the sidebar stays usable.

## How I tested it

I've replicated the bug, then verified it goes away after the fix.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closing the active project no longer leaves the desktop sidebar frozen. The sidebar now removes all of the closed project's workspace groups from its cache and clears a stale workspace selection before navigating to the workspace view.

**Behavior changes**
- If closing fails, the previous sidebar cache and workspace selection are restored and the user is sent back to the previous workspace.
- Adds test coverage for removing all workspace groups for a closed project.

<sup>Written for commit 64c255ce3c6a1be35cb0c2d882b6a41e9cbd72b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the close-project experience with immediate sidebar updates and navigation to the workspace view.
  * Added recovery handling to restore the previous project and workspace if closing fails.
  * Prevented closed projects from remaining visible in grouped workspace listings.
  * Improved handling of workspace-loading failures during project closure.
  * Ensured the last viewed workspace is cleared only when it belongs to the closed project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->