### PR TITLE
feat: test imessage -> this is testing pr flow

### DIFF
--- a/packages/cli/src/commands/imessage/disable/command.ts
+++ b/packages/cli/src/commands/imessage/disable/command.ts
@@ -1,0 +1,19 @@
+import { string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { resolveImessageHost } from "../target";
+
+export default command({
+	description: "Turn the iMessage bridge off (keeps the allowlist)",
+	options: {
+		host: string().desc("Host to configure (default: this machine)"),
+	},
+	run: async ({ ctx, options }) => {
+		const target = await resolveImessageHost(ctx, options.host);
+		const current = await target.client.imessage.get.query();
+		const result = await target.client.imessage.set.mutate({
+			enabled: false,
+			handles: current.handles,
+		});
+		return { data: result, message: "iMessage bridge disabled" };
+	},
+});

--- a/packages/cli/src/commands/imessage/enable/command.ts
+++ b/packages/cli/src/commands/imessage/enable/command.ts
@@ -1,0 +1,34 @@
+import { CLIError, string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { resolveImessageHost } from "../target";
+
+export default command({
+	description:
+		"Enable the iMessage bridge for the given conversation handle(s)",
+	options: {
+		handle: string()
+			.variadic()
+			.required()
+			.desc(
+				"Allowlisted sender — a phone in E.164 (+15551234567) or an email. Repeatable; replaces the current allowlist. Your own iMessage address watches the Messages-to-yourself chat",
+			),
+		host: string().desc("Host to configure (default: this machine)"),
+	},
+	run: async ({ ctx, options }) => {
+		const target = await resolveImessageHost(ctx, options.host);
+		const result = await target.client.imessage.set.mutate({
+			enabled: true,
+			handles: options.handle,
+		});
+		if (result.status.state === "error") {
+			throw new CLIError(
+				`Bridge could not start: ${result.status.lastError}`,
+				"Grant Superset Full Disk Access (System Settings → Privacy & Security), then re-run",
+			);
+		}
+		return {
+			data: result,
+			message: `iMessage bridge ${result.status.state} — text ${result.handles.join(" or ")} to reach your agents`,
+		};
+	},
+});

--- a/packages/cli/src/commands/imessage/meta.ts
+++ b/packages/cli/src/commands/imessage/meta.ts
@@ -1,0 +1,4 @@
+export default {
+	description: "Text your Superset agents over iMessage (macOS)",
+	aliases: ["im"],
+};

--- a/packages/cli/src/commands/imessage/reply/command.ts
+++ b/packages/cli/src/commands/imessage/reply/command.ts
@@ -1,0 +1,23 @@
+import { positional, string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { resolveImessageHost } from "../target";
+
+export default command({
+	description:
+		"Text the user back over iMessage — agents use this to answer messages the bridge delivered",
+	options: {
+		to: string().desc(
+			"Allowlisted handle to text (default: the conversation the last message came from)",
+		),
+		host: string().desc("Host that runs the bridge (default: this machine)"),
+	},
+	args: [positional("body").required().desc("Message text")],
+	run: async ({ ctx, options, args }) => {
+		const target = await resolveImessageHost(ctx, options.host);
+		const result = await target.client.imessage.reply.mutate({
+			text: args.body as string,
+			to: options.to,
+		});
+		return { data: result, message: `Sent to ${result.to}` };
+	},
+});

--- a/packages/cli/src/commands/imessage/status/command.ts
+++ b/packages/cli/src/commands/imessage/status/command.ts
@@ -1,0 +1,22 @@
+import { string } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { resolveImessageHost } from "../target";
+
+export default command({
+	description: "Show the iMessage bridge's settings and state",
+	options: {
+		host: string().desc("Host to inspect (default: this machine)"),
+	},
+	run: async ({ ctx, options }) => {
+		const target = await resolveImessageHost(ctx, options.host);
+		const result = await target.client.imessage.get.query();
+		const lines = [
+			`state: ${result.status.state}`,
+			`handles: ${result.handles.join(", ") || "(none)"}`,
+			`active chat: ${result.status.activeChatIdentifier ?? "(none yet)"}`,
+		];
+		if (result.status.lastError)
+			lines.push(`error: ${result.status.lastError}`);
+		return { data: result, message: lines.join("\n") };
+	},
+});

--- a/packages/cli/src/commands/imessage/target.ts
+++ b/packages/cli/src/commands/imessage/target.ts
@@ -1,0 +1,27 @@
+import { CLIError } from "@superset/cli-framework";
+import { getHostId } from "@superset/shared/host-info";
+import type { CliContext } from "../../lib/command";
+import {
+	type ResolvedHostTarget,
+	resolveHostTarget,
+} from "../../lib/host-target";
+
+/**
+ * The bridge lives on the Mac that is signed into Messages — the local host
+ * unless --host points at another machine.
+ */
+export async function resolveImessageHost(
+	ctx: CliContext,
+	hostId: string | undefined,
+): Promise<ResolvedHostTarget> {
+	const organizationId = ctx.config.organizationId;
+	if (!organizationId) {
+		throw new CLIError("No active organization", "Run: superset auth login");
+	}
+	return resolveHostTarget({
+		requestedHostId: hostId ?? getHostId(),
+		organizationId,
+		userJwt: ctx.bearer,
+		api: ctx.api,
+	});
+}

--- a/packages/host-service/drizzle/0029_round_professor_monster.sql
+++ b/packages/host-service/drizzle/0029_round_professor_monster.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `host_settings` ADD `imessage_enabled` integer;--> statement-breakpoint
+ALTER TABLE `host_settings` ADD `imessage_handles` text;--> statement-breakpoint
+ALTER TABLE `host_settings` ADD `imessage_cursor` integer;

--- a/packages/host-service/drizzle/meta/0029_snapshot.json
+++ b/packages/host-service/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,1165 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ae062e4c-0323-4d80-922c-5fc9b9915f89",
+  "prevId": "5787b028-bb6a-4586-9d81-5f79e4a607dc",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fork_args_json": {
+          "name": "fork_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_claude_config_dir": {
+          "name": "default_claude_config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_codex_home": {
+          "name": "default_codex_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imessage_enabled": {
+          "name": "imessage_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imessage_handles": {
+          "name": "imessage_handles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imessage_cursor": {
+          "name": "imessage_cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_pull_requests": {
+      "name": "workspace_pull_requests",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_pull_requests_workspace_idx": {
+          "name": "workspace_pull_requests_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_pull_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspace_pull_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_pull_requests_pull_request_id_pull_requests_id_fk": {
+          "name": "workspace_pull_requests_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_pull_requests_workspace_id_pull_request_id_pk": {
+          "columns": [
+            "workspace_id",
+            "pull_request_id"
+          ],
+          "name": "workspace_pull_requests_workspace_id_pull_request_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_tag_settings": {
+      "name": "workspace_tag_settings",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_tag_settings_project_id_projects_id_fk": {
+          "name": "workspace_tag_settings_project_id_projects_id_fk",
+          "tableFrom": "workspace_tag_settings",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_tag_settings_project_id_tag_pk": {
+          "columns": [
+            "project_id",
+            "tag"
+          ],
+          "name": "workspace_tag_settings_project_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_tags": {
+      "name": "workspace_tags",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_tags_tag_idx": {
+          "name": "workspace_tags_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_tags_workspace_id_workspaces_id_fk": {
+          "name": "workspace_tags_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_tags",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_tags_workspace_id_tag_pk": {
+          "columns": [
+            "workspace_id",
+            "tag"
+          ],
+          "name": "workspace_tags_workspace_id_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1788045626690,
       "tag": "0028_funny_gideon",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1788229497965,
+      "tag": "0029_round_professor_monster",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -3,13 +3,21 @@ import { trpcServer } from "@hono/trpc-server";
 import { Octokit } from "@octokit/rest";
 import { ChatService } from "@superset/provider-auth/server";
 import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createApiClient } from "./api";
 import { createChatV3Mount, registerChatV3Routes } from "./chat-v3";
 import { createDb, type HostDb } from "./db";
+import { workspaces } from "./db/schema";
 import { EventBus, GitWatcher, registerEventBusRoute } from "./events";
+import { ImessageBridge, readChatDb, sendImessage } from "./imessage/index.ts";
+import {
+	getImessageSettings,
+	loadImessageCursor,
+	saveImessageCursor,
+} from "./imessage/settings";
 import { agentIsBusy, PageWatchManager } from "./page-watch/index.ts";
 import { registerForwardMuxRoute } from "./ports/forward-mux-route";
 import { portManager } from "./ports/port-manager";
@@ -229,11 +237,50 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 	});
 	pageWatch.subscribeToTerminalEvents(eventBus);
 
+	// Superset over iMessage (macOS): texts from allowlisted conversations in
+	// ~/Library/Messages/chat.db become agent follow-ups; agents text back via
+	// the `imessage.reply` procedure (`superset imessage reply`). Off-macOS the
+	// bridge constructs but never ticks.
+	const imessage = new ImessageBridge({
+		readChatDb: (sinceRowId, chatIdentifiers) =>
+			readChatDb(sinceRowId, chatIdentifiers),
+		sendMessage: (to, text) => sendImessage(to, text),
+		sendToTerminal: async ({ workspaceId, terminalId, text }) => {
+			const result = await writeFramedInputToSession({
+				terminalId,
+				workspaceId,
+				text,
+				submit: true,
+				db,
+				eventBus,
+			});
+			if ("error" in result) throw new Error(result.error);
+		},
+		listLiveAgents: () => terminalAgentStore.list(),
+		isTerminalAlive: isLiveTerminalSession,
+		hasAgent: (terminalId) => {
+			const binding = terminalAgentStore.get(terminalId);
+			return binding !== undefined && binding.endedAt === undefined;
+		},
+		getWorkspaceName: (workspaceId) => {
+			const row = db
+				.select({ name: workspaces.name })
+				.from(workspaces)
+				.where(eq(workspaces.id, workspaceId))
+				.get();
+			return row?.name || null;
+		},
+		loadCursor: () => loadImessageCursor(db),
+		saveCursor: (cursor) => saveImessageCursor(db, cursor),
+	});
+	imessage.applySettings(getImessageSettings(db));
+
 	const runtime = {
 		auth: chatService,
 		filesystem,
 		pullRequests: pullRequestRuntime,
 		pageWatch,
+		imessage,
 	};
 
 	// Startup sweeps run in the background so they don't block server
@@ -372,6 +419,11 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 			pageWatch.stop();
 		} catch (err) {
 			console.warn("[host-service] pageWatch.stop failed:", err);
+		}
+		try {
+			imessage.stop();
+		} catch (err) {
+			console.warn("[host-service] imessage.stop failed:", err);
 		}
 		try {
 			await chatV3.dispose();

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -124,6 +124,13 @@ export const hostSettings = sqliteTable("host_settings", {
 	// inject (CLAUDE_CONFIG_DIR / CODEX_HOME). Null = the system default login.
 	defaultClaudeConfigDir: text("default_claude_config_dir"),
 	defaultCodexHome: text("default_codex_home"),
+	// Superset over iMessage (macOS): 1 = bridge enabled.
+	imessageEnabled: integer("imessage_enabled"),
+	// JSON string[] of allowlisted 1:1 chat identifiers (E.164 phone / email).
+	imessageHandles: text("imessage_handles"),
+	// Last chat.db message ROWID the bridge processed; survives restarts so
+	// history is never replayed.
+	imessageCursor: integer("imessage_cursor"),
 });
 
 export const pullRequests = sqliteTable(

--- a/packages/host-service/src/imessage/README.md
+++ b/packages/host-service/src/imessage/README.md
@@ -13,10 +13,17 @@ superset imessage status
 ```
 
 Texting your **own** iMessage address watches the "Messages to yourself"
-chat, so a second Apple ID is not required. In the self-chat every device
-writes `is_from_me = 1`, which is why every message the bridge sends starts
-with an invisible U+2063 marker — that marker, not the sender column, is the
-loop guard (`selectInbound`).
+chat, so a second Apple ID is not required. Two self-chat facts drive the
+implementation (both observed live, not documented by Apple):
+
+- Messages keys the self-chat by whichever of your own addresses the sending
+  device picked — a text from your phone can land in a chat identified by
+  your phone number even though you allowlisted your email. Allowlisting any
+  own address therefore watches **all** of the Mac's own accounts
+  (`effectiveWatchList`).
+- Every device writes `is_from_me = 1` in the self-chat, which is why every
+  message the bridge sends starts with an invisible U+2063 marker — that
+  marker, not the sender column, is the loop guard (`selectInbound`).
 
 ## Message flow
 

--- a/packages/host-service/src/imessage/README.md
+++ b/packages/host-service/src/imessage/README.md
@@ -1,0 +1,47 @@
+# Superset over iMessage
+
+Text your Superset agents from your phone. The bridge (macOS only) polls
+`~/Library/Messages/chat.db` for new texts in allowlisted conversations,
+routes them to the most recent live agent terminal as framed input, and the
+agent texts back with `superset imessage reply`.
+
+## Setup
+
+```bash
+superset imessage enable --handle +15551234567   # or your own iMessage email
+superset imessage status
+```
+
+Texting your **own** iMessage address watches the "Messages to yourself"
+chat, so a second Apple ID is not required. In the self-chat every device
+writes `is_from_me = 1`, which is why every message the bridge sends starts
+with an invisible U+2063 marker — that marker, not the sender column, is the
+loop guard (`selectInbound`).
+
+## Message flow
+
+- Free text → delivered to the conversation's bound agent session, or the
+  most recently active live agent when none is bound (first routing sends a
+  one-time ack naming the agent and workspace).
+- `status` → per-agent summary (workspace, working/idle, recency).
+- `help` → usage.
+
+Agents reply through the `imessage.reply` procedure, which only ever sends
+to allowlisted conversations and is rate-limited to
+`MAX_SENDS_PER_MINUTE`. Inbound text is control-character-stripped before it
+touches a PTY (same reasoning as `page-watch/buildPrompt.ts`).
+
+## Requirements and failure modes
+
+- **Full Disk Access** for Superset — chat.db is TCC-protected. Read
+  failures surface in `superset imessage status` (state `error`) and stop
+  the poll loop after `MAX_CONSECUTIVE_FAILURES`.
+- **Automation permission** for Messages.app — the first send triggers the
+  TCC prompt (`osascript` sends via `applescript.ts`; text rides in argv, so
+  a message body can never inject AppleScript).
+- Sends target the 1:1 `participant` — group chats are not supported yet.
+
+State: allowlist and enablement live on `host_settings`
+(`imessage_enabled`, `imessage_handles`); `imessage_cursor` is the last
+processed chat.db ROWID, so restarts never replay history. Conversation →
+terminal bindings are in-memory and re-resolve after a restart.

--- a/packages/host-service/src/imessage/applescript.test.ts
+++ b/packages/host-service/src/imessage/applescript.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { buildSendArgs, sendImessage } from "./applescript.ts";
+import { OUTBOUND_MARKER } from "./messages.ts";
+
+describe("buildSendArgs", () => {
+	it("passes text and target as argv after --, never spliced into the script", () => {
+		const args = buildSendArgs("+15551234567", 'say "hi" & do bad things');
+		expect(args[0]).toBe("-e");
+		expect(args[2]).toBe("--");
+		expect(args[3]).toBe(`${OUTBOUND_MARKER}say "hi" & do bad things`);
+		expect(args[4]).toBe("+15551234567");
+		expect(args[1]).not.toContain("say");
+	});
+
+	it("marks every outbound message so the bridge never re-ingests it", () => {
+		const args = buildSendArgs("me@example.com", "done");
+		expect(args[3]?.startsWith(OUTBOUND_MARKER)).toBe(true);
+	});
+});
+
+describe("sendImessage", () => {
+	it("invokes osascript with the built args", async () => {
+		const calls: { file: string; args: string[] }[] = [];
+		await sendImessage("+15551234567", "hello", async (file, args) => {
+			calls.push({ file, args });
+			return { stdout: "", stderr: "" };
+		});
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.file).toBe("osascript");
+		expect(calls[0]?.args.at(-1)).toBe("+15551234567");
+	});
+});

--- a/packages/host-service/src/imessage/applescript.ts
+++ b/packages/host-service/src/imessage/applescript.ts
@@ -1,0 +1,48 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { OUTBOUND_MARKER, truncateOutbound } from "./messages";
+
+const execFileAsync = promisify(execFile);
+
+const SEND_TIMEOUT_MS = 15_000;
+
+/**
+ * The text and target ride in as argv — never spliced into the script — so a
+ * reply body can't inject AppleScript.
+ */
+const SEND_SCRIPT = [
+	"on run argv",
+	"  set theText to item 1 of argv",
+	"  set theTarget to item 2 of argv",
+	'  tell application "Messages"',
+	"    set theService to 1st account whose service type = iMessage",
+	"    send theText to participant theTarget of theService",
+	"  end tell",
+	"end run",
+].join("\n");
+
+export function buildSendArgs(to: string, text: string): string[] {
+	return [
+		"-e",
+		SEND_SCRIPT,
+		"--",
+		`${OUTBOUND_MARKER}${truncateOutbound(text)}`,
+		to,
+	];
+}
+
+export type ExecFileFn = (
+	file: string,
+	args: string[],
+	options: { timeout: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export async function sendImessage(
+	to: string,
+	text: string,
+	execFileFn: ExecFileFn = execFileAsync,
+): Promise<void> {
+	await execFileFn("osascript", buildSendArgs(to, text), {
+		timeout: SEND_TIMEOUT_MS,
+	});
+}

--- a/packages/host-service/src/imessage/attributed-body.test.ts
+++ b/packages/host-service/src/imessage/attributed-body.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { extractTextFromAttributedBody } from "./attributed-body.ts";
+
+/** typedstream fragment: ...NSString + 5 header bytes + length + utf8 body. */
+function blob(text: string, lengthEncoding: "short" | "u16" | "u32"): Buffer {
+	const body = Buffer.from(text, "utf8");
+	const header = Buffer.from("streamtyped garbage NSString", "latin1");
+	const skip = Buffer.from([0x01, 0x94, 0x84, 0x01, 0x2b]);
+	let length: Buffer;
+	if (lengthEncoding === "short") {
+		length = Buffer.from([body.length]);
+	} else if (lengthEncoding === "u16") {
+		length = Buffer.alloc(3);
+		length[0] = 0x81;
+		length.writeUInt16LE(body.length, 1);
+	} else {
+		length = Buffer.alloc(5);
+		length[0] = 0x82;
+		length.writeUInt32LE(body.length, 1);
+	}
+	const trailer = Buffer.from("iI NSDictionary trailing", "latin1");
+	return Buffer.concat([header, skip, length, body, trailer]);
+}
+
+describe("extractTextFromAttributedBody", () => {
+	it("reads a short-length body", () => {
+		expect(extractTextFromAttributedBody(blob("ship it", "short"))).toBe(
+			"ship it",
+		);
+	});
+
+	it("reads a two-byte length body", () => {
+		const text = "x".repeat(300);
+		expect(extractTextFromAttributedBody(blob(text, "u16"))).toBe(text);
+	});
+
+	it("reads a four-byte length body", () => {
+		const text = "y".repeat(70_000);
+		expect(extractTextFromAttributedBody(blob(text, "u32"))).toBe(text);
+	});
+
+	it("keeps multi-byte characters intact", () => {
+		expect(extractTextFromAttributedBody(blob("déployé 🚀", "short"))).toBe(
+			"déployé 🚀",
+		);
+	});
+
+	it("returns null without an NSString marker", () => {
+		expect(
+			extractTextFromAttributedBody(Buffer.from("streamtyped nothing here")),
+		).toBeNull();
+	});
+
+	it("returns null for empty or missing bodies", () => {
+		expect(extractTextFromAttributedBody(null)).toBeNull();
+		expect(extractTextFromAttributedBody(Buffer.alloc(0))).toBeNull();
+	});
+
+	it("returns null when the declared length overruns the buffer", () => {
+		const truncated = blob("hello world", "short").subarray(0, 40);
+		expect(extractTextFromAttributedBody(truncated)).toBeNull();
+	});
+});

--- a/packages/host-service/src/imessage/attributed-body.ts
+++ b/packages/host-service/src/imessage/attributed-body.ts
@@ -1,0 +1,41 @@
+/**
+ * Since macOS Ventura, Messages stores many bodies only in
+ * `message.attributedBody` — a NeXT "typedstream" archive — leaving
+ * `message.text` NULL (~12% of rows on a long-lived install). Full typedstream
+ * parsing is not needed to recover the plain text: the first NSString in the
+ * archive is the message body, preceded by a one/two/four-byte length.
+ */
+const NSSTRING_MARKER = Buffer.from("NSString");
+/** Bytes between the NSString class name and its length field. */
+const NSSTRING_HEADER_SKIP = 5;
+
+export function extractTextFromAttributedBody(
+	body: Uint8Array | null,
+): string | null {
+	if (!body || body.length === 0) return null;
+	const buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
+
+	const marker = buf.indexOf(NSSTRING_MARKER);
+	if (marker === -1) return null;
+
+	let at = marker + NSSTRING_MARKER.length + NSSTRING_HEADER_SKIP;
+	if (at >= buf.length) return null;
+
+	let length: number;
+	const lead = buf[at] as number;
+	if (lead === 0x81) {
+		if (at + 3 > buf.length) return null;
+		length = buf.readUInt16LE(at + 1);
+		at += 3;
+	} else if (lead === 0x82) {
+		if (at + 5 > buf.length) return null;
+		length = buf.readUInt32LE(at + 1);
+		at += 5;
+	} else {
+		length = lead;
+		at += 1;
+	}
+
+	if (length === 0 || at + length > buf.length) return null;
+	return buf.toString("utf8", at, at + length);
+}

--- a/packages/host-service/src/imessage/chat-db.ts
+++ b/packages/host-service/src/imessage/chat-db.ts
@@ -1,0 +1,99 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+// better-sqlite3, not `bun:sqlite`: the host service runs under Electron's
+// Node. Tests never import this module — the bridge takes a `readChatDb` dep.
+import Database from "better-sqlite3";
+import { extractTextFromAttributedBody } from "./attributed-body";
+import type { ChatDbSnapshot, InboundMessage } from "./types";
+
+/** Apple epoch (2001-01-01) → Unix epoch, and chat.db dates are nanoseconds. */
+const APPLE_EPOCH_OFFSET_S = 978_307_200;
+
+const MAX_ROWS_PER_READ = 50;
+
+export function defaultChatDbPath(): string {
+	return join(homedir(), "Library", "Messages", "chat.db");
+}
+
+interface RawRow {
+	rowId: number;
+	guid: string;
+	chatIdentifier: string;
+	senderHandle: string | null;
+	isFromMe: number;
+	itemType: number;
+	text: string | null;
+	attributedBody: Uint8Array | null;
+	date: number;
+}
+
+/**
+ * One-shot read of everything the bridge needs. Opens read-only and closes
+ * before returning: Messages.app owns this database, and a lingering handle
+ * has nothing to gain. NOT `immutable` — that flag ignores the write-ahead
+ * log, so a text received moments ago would read as absent.
+ *
+ * Throws when the file is unreadable — most commonly missing Full Disk
+ * Access, which the caller surfaces as a remedy rather than a crash.
+ */
+export function readChatDb(
+	sinceRowId: number,
+	chatIdentifiers: string[],
+	dbPath: string = defaultChatDbPath(),
+): ChatDbSnapshot {
+	const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+	try {
+		const maxRowId =
+			(
+				db.prepare("SELECT COALESCE(MAX(ROWID), 0) AS m FROM message").get() as
+					| { m: number }
+					| undefined
+			)?.m ?? 0;
+
+		const ownAccounts = (
+			db
+				.prepare(
+					"SELECT DISTINCT account_login AS login FROM chat WHERE account_login IS NOT NULL",
+				)
+				.all() as { login: string }[]
+		)
+			.map(({ login }) => login.replace(/^[EP]:/, ""))
+			.filter((login) => login.length > 0);
+
+		let rows: InboundMessage[] = [];
+		if (chatIdentifiers.length > 0) {
+			const placeholders = chatIdentifiers.map(() => "?").join(", ");
+			const raw = db
+				.prepare(
+					`SELECT m.ROWID AS rowId, m.guid AS guid, m.is_from_me AS isFromMe,
+						m.item_type AS itemType, m.text AS text,
+						m.attributedBody AS attributedBody, m.date AS date,
+						c.chat_identifier AS chatIdentifier, h.id AS senderHandle
+					FROM message m
+					JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+					JOIN chat c ON c.ROWID = cmj.chat_id
+					LEFT JOIN handle h ON h.ROWID = m.handle_id
+					WHERE m.ROWID > ? AND c.chat_identifier IN (${placeholders})
+					ORDER BY m.ROWID ASC
+					LIMIT ${MAX_ROWS_PER_READ}`,
+				)
+				.all(sinceRowId, ...chatIdentifiers) as RawRow[];
+
+			rows = raw.map((row) => ({
+				rowId: row.rowId,
+				guid: row.guid,
+				chatIdentifier: row.chatIdentifier,
+				senderHandle: row.senderHandle,
+				isFromMe: row.isFromMe === 1,
+				itemType: row.itemType,
+				text:
+					row.text ?? extractTextFromAttributedBody(row.attributedBody ?? null),
+				sentAt: Math.floor(row.date / 1_000_000) + APPLE_EPOCH_OFFSET_S * 1000,
+			}));
+		}
+
+		return { rows, maxRowId, ownAccounts };
+	} finally {
+		db.close();
+	}
+}

--- a/packages/host-service/src/imessage/imessage-bridge.test.ts
+++ b/packages/host-service/src/imessage/imessage-bridge.test.ts
@@ -43,21 +43,28 @@ function harness(
 		cursor?: number | null;
 		readError?: Error;
 		platform?: NodeJS.Platform;
+		ownAccounts?: string[];
 	} = {},
 ) {
 	const sent: { to: string; text: string }[] = [];
 	const delivered: { terminalId: string; text: string }[] = [];
 	const savedCursors: number[] = [];
+	const readCalls: string[][] = [];
 	let rows = options.rows ?? [];
 	let now = T0;
 
 	const bridge = new ImessageBridge({
-		readChatDb: (sinceRowId): ChatDbSnapshot => {
+		readChatDb: (sinceRowId, chatIdentifiers): ChatDbSnapshot => {
 			if (options.readError) throw options.readError;
+			readCalls.push(chatIdentifiers);
 			return {
-				rows: rows.filter((row) => row.rowId > sinceRowId),
+				rows: rows.filter(
+					(row) =>
+						row.rowId > sinceRowId &&
+						chatIdentifiers.includes(row.chatIdentifier),
+				),
 				maxRowId: options.maxRowId ?? 10,
-				ownAccounts: [SELF],
+				ownAccounts: options.ownAccounts ?? [SELF],
 			};
 		},
 		sendMessage: async (to, text) => {
@@ -85,6 +92,7 @@ function harness(
 		sent,
 		delivered,
 		savedCursors,
+		readCalls,
 		setRows(next: InboundMessage[]) {
 			rows = next;
 		},
@@ -160,6 +168,40 @@ describe("ImessageBridge", () => {
 		h.setRows([]);
 		await h.bridge.tick();
 		expect(h.savedCursors).toEqual([11]);
+	});
+
+	it("watches every own account once one is allowlisted", async () => {
+		// Messages keyed this user's self-chat by phone number even though the
+		// allowlist held the email — the bridge must widen to all own accounts.
+		const PHONE = "+15550001111";
+		const h = harness({
+			ownAccounts: [SELF, PHONE],
+			rows: [
+				inbound({ chatIdentifier: PHONE, isFromMe: true, text: "from phone" }),
+			],
+			agents: [liveAgent()],
+		});
+		h.bridge.applySettings({ enabled: true, handles: [SELF] });
+		await h.bridge.tick();
+		expect(h.readCalls.at(-1)).toEqual([SELF, PHONE]);
+		expect(h.delivered).toHaveLength(1);
+		expect(h.delivered[0]?.text).toContain("from phone");
+
+		// Replies may also target the sibling self-chat.
+		await expect(h.bridge.reply({ text: "done", to: PHONE })).resolves.toEqual({
+			to: PHONE,
+		});
+	});
+
+	it("does not widen the watch list for a non-self allowlist", async () => {
+		const h = harness({
+			ownAccounts: [SELF],
+			rows: [inbound({})],
+			agents: [liveAgent()],
+		});
+		h.bridge.applySettings({ enabled: true, handles: [HANDLE] });
+		await h.bridge.tick();
+		expect(h.readCalls.at(-1)).toEqual([HANDLE]);
 	});
 
 	it("does not tick off macOS", () => {

--- a/packages/host-service/src/imessage/imessage-bridge.test.ts
+++ b/packages/host-service/src/imessage/imessage-bridge.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import type { TerminalAgentBinding } from "../terminal-agents";
+import { ImessageBridge, MAX_SENDS_PER_MINUTE } from "./imessage-bridge.ts";
+import type { ChatDbSnapshot, InboundMessage } from "./types.ts";
+
+const T0 = 1_800_000_000_000;
+const HANDLE = "+15551234567";
+const SELF = "me@example.com";
+
+function inbound(overrides: Partial<InboundMessage>): InboundMessage {
+	return {
+		rowId: 11,
+		guid: "guid-11",
+		chatIdentifier: HANDLE,
+		senderHandle: HANDLE,
+		isFromMe: false,
+		itemType: 0,
+		text: "run the tests",
+		sentAt: T0,
+		...overrides,
+	};
+}
+
+function liveAgent(
+	overrides: Partial<TerminalAgentBinding> = {},
+): TerminalAgentBinding {
+	return {
+		terminalId: "term-1",
+		workspaceId: "ws-1",
+		agentId: "claude",
+		startedAt: T0 - 600_000,
+		lastEventAt: T0 - 60_000,
+		lastEventType: "Stop",
+		...overrides,
+	} as TerminalAgentBinding;
+}
+
+function harness(
+	options: {
+		rows?: InboundMessage[];
+		maxRowId?: number;
+		agents?: TerminalAgentBinding[];
+		cursor?: number | null;
+		readError?: Error;
+		platform?: NodeJS.Platform;
+	} = {},
+) {
+	const sent: { to: string; text: string }[] = [];
+	const delivered: { terminalId: string; text: string }[] = [];
+	const savedCursors: number[] = [];
+	let rows = options.rows ?? [];
+	let now = T0;
+
+	const bridge = new ImessageBridge({
+		readChatDb: (sinceRowId): ChatDbSnapshot => {
+			if (options.readError) throw options.readError;
+			return {
+				rows: rows.filter((row) => row.rowId > sinceRowId),
+				maxRowId: options.maxRowId ?? 10,
+				ownAccounts: [SELF],
+			};
+		},
+		sendMessage: async (to, text) => {
+			sent.push({ to, text });
+		},
+		sendToTerminal: async ({ terminalId, text }) => {
+			delivered.push({ terminalId, text });
+		},
+		listLiveAgents: () => options.agents ?? [],
+		isTerminalAlive: () => true,
+		hasAgent: () => true,
+		getWorkspaceName: () => "lavender-meal",
+		loadCursor: () => (options.cursor === undefined ? 10 : options.cursor),
+		saveCursor: (cursor) => {
+			savedCursors.push(cursor);
+		},
+		platform: options.platform ?? "darwin",
+		now: () => now,
+		setIntervalFn: (() => ({ unref() {} })) as unknown as typeof setInterval,
+		clearIntervalFn: (() => {}) as unknown as typeof clearInterval,
+	});
+
+	return {
+		bridge,
+		sent,
+		delivered,
+		savedCursors,
+		setRows(next: InboundMessage[]) {
+			rows = next;
+		},
+		advance(ms: number) {
+			now += ms;
+		},
+	};
+}
+
+function enable(h: ReturnType<typeof harness>) {
+	h.bridge.applySettings({ enabled: true, handles: [HANDLE, SELF] });
+}
+
+describe("ImessageBridge", () => {
+	it("initializes the cursor to the tail on first enable — no history replay", () => {
+		const h = harness({
+			cursor: null,
+			maxRowId: 42,
+			rows: [inbound({ rowId: 7 })],
+		});
+		enable(h);
+		expect(h.savedCursors).toEqual([42]);
+		expect(h.delivered).toHaveLength(0);
+	});
+
+	it("routes a task to the most recent live agent and acks once", async () => {
+		const h = harness({ rows: [inbound({})], agents: [liveAgent()] });
+		enable(h);
+		await h.bridge.tick();
+		expect(h.delivered).toHaveLength(1);
+		expect(h.delivered[0]?.terminalId).toBe("term-1");
+		expect(h.delivered[0]?.text).toContain("run the tests");
+		expect(h.sent).toHaveLength(1);
+		expect(h.sent[0]?.text).toContain("claude in lavender-meal");
+
+		// A follow-up to the bound session must not re-ack.
+		h.setRows([inbound({ rowId: 12, text: "also lint it" })]);
+		await h.bridge.tick();
+		expect(h.delivered).toHaveLength(2);
+		expect(h.sent).toHaveLength(1);
+	});
+
+	it("answers status without touching a terminal", async () => {
+		const h = harness({
+			rows: [inbound({ text: "status" })],
+			agents: [liveAgent()],
+		});
+		enable(h);
+		await h.bridge.tick();
+		expect(h.delivered).toHaveLength(0);
+		expect(h.sent).toHaveLength(1);
+		expect(h.sent[0]?.text).toContain("claude");
+	});
+
+	it("explains itself when no agent is live", async () => {
+		const h = harness({ rows: [inbound({})], agents: [] });
+		enable(h);
+		await h.bridge.tick();
+		expect(h.delivered).toHaveLength(0);
+		expect(h.sent[0]?.text).toContain("No agent is running");
+	});
+
+	it("persists the cursor past processed rows", async () => {
+		const h = harness({
+			rows: [inbound({ rowId: 11 })],
+			agents: [liveAgent()],
+		});
+		enable(h);
+		await h.bridge.tick();
+		expect(h.savedCursors).toEqual([11]);
+
+		// Nothing new and the tail is behind the cursor: no write.
+		h.setRows([]);
+		await h.bridge.tick();
+		expect(h.savedCursors).toEqual([11]);
+	});
+
+	it("does not tick off macOS", () => {
+		const h = harness({ platform: "linux" });
+		enable(h);
+		expect(h.bridge.status().state).toBe("unsupported-platform");
+	});
+
+	it("reports read failures and keeps ticking until the failure cap", async () => {
+		const h = harness({ readError: new Error("SQLITE_CANTOPEN") });
+		enable(h);
+		await h.bridge.tick();
+		expect(h.bridge.status().lastError).toContain("SQLITE_CANTOPEN");
+	});
+
+	it("replies only to allowlisted handles, defaulting to the active chat", async () => {
+		const h = harness({ rows: [inbound({})], agents: [liveAgent()] });
+		enable(h);
+		await h.bridge.tick();
+
+		const result = await h.bridge.reply({ text: "done" });
+		expect(result.to).toBe(HANDLE);
+		expect(h.sent.at(-1)?.text).toBe("done");
+
+		await expect(
+			h.bridge.reply({ text: "hi", to: "+19998887777" }),
+		).rejects.toThrow("not an allowlisted");
+	});
+
+	it("refuses to reply while disabled or with no active conversation", async () => {
+		const h = harness();
+		await expect(h.bridge.reply({ text: "hi" })).rejects.toThrow("disabled");
+		enable(h);
+		await expect(h.bridge.reply({ text: "hi" })).rejects.toThrow(
+			"No active iMessage conversation",
+		);
+	});
+
+	it("rate-limits outbound sends", async () => {
+		const h = harness({ rows: [inbound({})], agents: [liveAgent()] });
+		enable(h);
+		await h.bridge.tick();
+		for (let i = h.sent.length; i < MAX_SENDS_PER_MINUTE; i++) {
+			await h.bridge.reply({ text: `update ${i}` });
+		}
+		await expect(h.bridge.reply({ text: "one too many" })).rejects.toThrow(
+			"rate limit",
+		);
+		h.advance(61_000);
+		await expect(h.bridge.reply({ text: "fresh window" })).resolves.toEqual({
+			to: HANDLE,
+		});
+	});
+});

--- a/packages/host-service/src/imessage/imessage-bridge.ts
+++ b/packages/host-service/src/imessage/imessage-bridge.ts
@@ -1,0 +1,313 @@
+import type { TerminalAgentBinding } from "../terminal-agents";
+import {
+	buildAgentPrompt,
+	buildHelpReply,
+	buildNoAgentReply,
+	buildRoutedAck,
+	buildStatusReply,
+	parseInbound,
+	selectInbound,
+} from "./messages";
+import type {
+	ImessageBridgeDeps,
+	ImessageBridgeStatus,
+	ImessageSettings,
+} from "./types";
+
+export const TICK_INTERVAL_MS = 3_000;
+export const MAX_CONSECUTIVE_FAILURES = 5;
+/** Outbound cap per rolling minute — a stuck agent must not text-storm. */
+export const MAX_SENDS_PER_MINUTE = 10;
+const SEND_WINDOW_MS = 60_000;
+
+interface ConversationBinding {
+	workspaceId: string;
+	terminalId: string;
+}
+
+/**
+ * Texts from allowlisted iMessage conversations become follow-ups to the
+ * user's coding agents; agents text back via `superset imessage reply`
+ * (the `imessage.reply` host procedure). Same shape as PageWatchManager:
+ * constructed once in createApp, deps injected, `.stop()` on dispose.
+ */
+export class ImessageBridge {
+	private readonly deps: ImessageBridgeDeps;
+	private readonly now: () => number;
+	private readonly setIntervalFn: typeof setInterval;
+	private readonly clearIntervalFn: typeof clearInterval;
+	private readonly platform: NodeJS.Platform;
+
+	private settings: ImessageSettings = { enabled: false, handles: [] };
+	private cursor: number | null = null;
+	private readonly bindings = new Map<string, ConversationBinding>();
+	private activeChatIdentifier: string | null = null;
+	private lastError: string | null = null;
+	private failures = 0;
+	private sendTimestamps: number[] = [];
+
+	private ticker: ReturnType<typeof setInterval> | null = null;
+	private ticking = false;
+	private tickRequested = false;
+
+	constructor(deps: ImessageBridgeDeps) {
+		this.deps = deps;
+		this.now = deps.now ?? Date.now;
+		this.setIntervalFn = deps.setIntervalFn ?? setInterval;
+		this.clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
+		this.platform = deps.platform ?? process.platform;
+	}
+
+	applySettings(settings: ImessageSettings): void {
+		this.settings = {
+			enabled: settings.enabled,
+			handles: settings.handles.map((handle) => handle.trim()).filter(Boolean),
+		};
+		this.lastError = null;
+		this.failures = 0;
+
+		if (!this.shouldRun()) {
+			this.stopTicking();
+			return;
+		}
+
+		// First enable: start at the tail — the bridge answers new texts, it
+		// does not replay history.
+		this.cursor ??= this.deps.loadCursor();
+		if (this.cursor === null) {
+			try {
+				this.cursor = this.deps.readChatDb(
+					Number.MAX_SAFE_INTEGER,
+					[],
+				).maxRowId;
+				this.deps.saveCursor(this.cursor);
+			} catch (error) {
+				this.recordFailure(error, "open");
+				return;
+			}
+		}
+		this.ensureTicking();
+	}
+
+	status(): ImessageBridgeStatus {
+		return {
+			state:
+				this.platform !== "darwin" && this.settings.enabled
+					? "unsupported-platform"
+					: this.lastError !== null
+						? "error"
+						: this.ticker !== null
+							? "running"
+							: "disabled",
+			settings: this.settings,
+			activeChatIdentifier: this.activeChatIdentifier,
+			bindings: [...this.bindings.entries()].map(
+				([chatIdentifier, binding]) => ({ chatIdentifier, ...binding }),
+			),
+			lastError: this.lastError,
+		};
+	}
+
+	/**
+	 * Outbound reply — the `imessage.reply` procedure agents call. Only ever
+	 * texts an allowlisted conversation; an agent cannot use it to reach an
+	 * arbitrary number.
+	 */
+	async reply(input: { text: string; to?: string }): Promise<{ to: string }> {
+		if (!this.settings.enabled) {
+			throw new Error("iMessage bridge is disabled on this host");
+		}
+		const to = input.to ?? this.activeChatIdentifier;
+		if (!to) {
+			throw new Error(
+				"No active iMessage conversation — pass --to with an allowlisted handle",
+			);
+		}
+		if (!this.settings.handles.includes(to)) {
+			throw new Error(`${to} is not an allowlisted iMessage handle`);
+		}
+		await this.send(to, input.text);
+		return { to };
+	}
+
+	stop(): void {
+		this.stopTicking();
+		this.bindings.clear();
+	}
+
+	private shouldRun(): boolean {
+		return (
+			this.settings.enabled &&
+			this.settings.handles.length > 0 &&
+			this.platform === "darwin"
+		);
+	}
+
+	private ensureTicking(): void {
+		if (this.ticker) return;
+		this.ticker = this.setIntervalFn(() => {
+			void this.tick();
+		}, TICK_INTERVAL_MS);
+		this.ticker.unref?.();
+	}
+
+	private stopTicking(): void {
+		this.tickRequested = false;
+		if (this.ticker) {
+			this.clearIntervalFn(this.ticker);
+			this.ticker = null;
+		}
+	}
+
+	async tick(): Promise<void> {
+		if (this.ticking) {
+			this.tickRequested = true;
+			return;
+		}
+		this.ticking = true;
+		try {
+			await this.poll();
+		} finally {
+			this.ticking = false;
+		}
+
+		if (!this.tickRequested) return;
+		this.tickRequested = false;
+		if (this.ticker !== null) await this.tick();
+	}
+
+	private async poll(): Promise<void> {
+		if (!this.shouldRun() || this.cursor === null) return;
+
+		let snapshot: ReturnType<ImessageBridgeDeps["readChatDb"]>;
+		try {
+			snapshot = this.deps.readChatDb(this.cursor, this.settings.handles);
+		} catch (error) {
+			this.recordFailure(error, "read");
+			return;
+		}
+		this.failures = 0;
+
+		for (const message of selectInbound(snapshot)) {
+			try {
+				await this.handleInbound(message.chatIdentifier, message.text);
+			} catch (error) {
+				console.warn("[imessage] failed to handle inbound message", error);
+			}
+		}
+
+		// A non-empty batch may have been truncated at the read limit, so only
+		// advance past what was actually read; an empty batch can jump straight
+		// to the tail.
+		const nextCursor =
+			snapshot.rows.length > 0
+				? Math.max(this.cursor, ...snapshot.rows.map((row) => row.rowId))
+				: Math.max(this.cursor, snapshot.maxRowId);
+		if (nextCursor !== this.cursor) {
+			this.cursor = nextCursor;
+			this.deps.saveCursor(nextCursor);
+		}
+	}
+
+	private async handleInbound(
+		chatIdentifier: string,
+		text: string,
+	): Promise<void> {
+		this.activeChatIdentifier = chatIdentifier;
+		const action = parseInbound(text);
+
+		if (action.kind === "help") {
+			await this.send(chatIdentifier, buildHelpReply());
+			return;
+		}
+		if (action.kind === "status") {
+			await this.send(
+				chatIdentifier,
+				buildStatusReply(
+					this.deps.listLiveAgents(),
+					this.deps.getWorkspaceName,
+					this.now(),
+				),
+			);
+			return;
+		}
+
+		const target = this.resolveTarget(chatIdentifier);
+		if (!target) {
+			await this.send(chatIdentifier, buildNoAgentReply());
+			return;
+		}
+		await this.deps.sendToTerminal({
+			workspaceId: target.binding.workspaceId,
+			terminalId: target.binding.terminalId,
+			text: buildAgentPrompt(action.text),
+		});
+		if (target.isNew) {
+			const workspaceName =
+				this.deps.getWorkspaceName(target.binding.workspaceId) ?? "a workspace";
+			await this.send(
+				chatIdentifier,
+				buildRoutedAck(target.agentId, workspaceName),
+			);
+		}
+	}
+
+	private resolveTarget(chatIdentifier: string): {
+		binding: ConversationBinding;
+		agentId: string;
+		isNew: boolean;
+	} | null {
+		const existing = this.bindings.get(chatIdentifier);
+		if (
+			existing &&
+			this.deps.isTerminalAlive(existing.terminalId) &&
+			this.deps.hasAgent(existing.terminalId)
+		) {
+			return { binding: existing, agentId: "agent", isNew: false };
+		}
+		this.bindings.delete(chatIdentifier);
+
+		const candidates = this.deps
+			.listLiveAgents()
+			.filter(
+				(agent) =>
+					this.deps.isTerminalAlive(agent.terminalId) &&
+					this.deps.hasAgent(agent.terminalId),
+			)
+			.sort((a, b) => b.lastEventAt - a.lastEventAt);
+		const best: TerminalAgentBinding | undefined = candidates[0];
+		if (!best) return null;
+
+		const binding: ConversationBinding = {
+			workspaceId: best.workspaceId,
+			terminalId: best.terminalId,
+		};
+		this.bindings.set(chatIdentifier, binding);
+		return { binding, agentId: best.agentId, isNew: true };
+	}
+
+	private async send(to: string, text: string): Promise<void> {
+		const at = this.now();
+		this.sendTimestamps = this.sendTimestamps.filter(
+			(sentAt) => at - sentAt < SEND_WINDOW_MS,
+		);
+		if (this.sendTimestamps.length >= MAX_SENDS_PER_MINUTE) {
+			throw new Error(
+				`iMessage send rate limit hit (${MAX_SENDS_PER_MINUTE}/min) — dropping message`,
+			);
+		}
+		this.sendTimestamps.push(at);
+		await this.deps.sendMessage(to, text);
+	}
+
+	private recordFailure(error: unknown, stage: "open" | "read"): void {
+		this.failures += 1;
+		this.lastError = error instanceof Error ? error.message : String(error);
+		if (this.failures < MAX_CONSECUTIVE_FAILURES && stage !== "open") return;
+		console.error(
+			`[imessage] disabling bridge after ${stage} failure — likely missing Full Disk Access for chat.db`,
+			{ error: this.lastError },
+		);
+		this.stopTicking();
+	}
+}

--- a/packages/host-service/src/imessage/imessage-bridge.ts
+++ b/packages/host-service/src/imessage/imessage-bridge.ts
@@ -5,6 +5,7 @@ import {
 	buildNoAgentReply,
 	buildRoutedAck,
 	buildStatusReply,
+	effectiveWatchList,
 	parseInbound,
 	selectInbound,
 } from "./messages";
@@ -42,6 +43,8 @@ export class ImessageBridge {
 	private cursor: number | null = null;
 	private readonly bindings = new Map<string, ConversationBinding>();
 	private activeChatIdentifier: string | null = null;
+	/** The Mac's own Messages addresses, refreshed from every chat.db read. */
+	private ownAccounts: string[] = [];
 	private lastError: string | null = null;
 	private failures = 0;
 	private sendTimestamps: number[] = [];
@@ -71,20 +74,20 @@ export class ImessageBridge {
 			return;
 		}
 
-		// First enable: start at the tail — the bridge answers new texts, it
-		// does not replay history.
+		// Probe up front for the Mac's own addresses (self-chat watching must
+		// not wait a tick) and, on first enable, for the tail — the bridge
+		// answers new texts, it does not replay history.
 		this.cursor ??= this.deps.loadCursor();
-		if (this.cursor === null) {
-			try {
-				this.cursor = this.deps.readChatDb(
-					Number.MAX_SAFE_INTEGER,
-					[],
-				).maxRowId;
+		try {
+			const probe = this.deps.readChatDb(Number.MAX_SAFE_INTEGER, []);
+			this.ownAccounts = probe.ownAccounts;
+			if (this.cursor === null) {
+				this.cursor = probe.maxRowId;
 				this.deps.saveCursor(this.cursor);
-			} catch (error) {
-				this.recordFailure(error, "open");
-				return;
 			}
+		} catch (error) {
+			this.recordFailure(error, "open");
+			return;
 		}
 		this.ensureTicking();
 	}
@@ -123,7 +126,9 @@ export class ImessageBridge {
 				"No active iMessage conversation — pass --to with an allowlisted handle",
 			);
 		}
-		if (!this.settings.handles.includes(to)) {
+		if (
+			!effectiveWatchList(this.settings.handles, this.ownAccounts).includes(to)
+		) {
 			throw new Error(`${to} is not an allowlisted iMessage handle`);
 		}
 		await this.send(to, input.text);
@@ -181,11 +186,15 @@ export class ImessageBridge {
 
 		let snapshot: ReturnType<ImessageBridgeDeps["readChatDb"]>;
 		try {
-			snapshot = this.deps.readChatDb(this.cursor, this.settings.handles);
+			snapshot = this.deps.readChatDb(
+				this.cursor,
+				effectiveWatchList(this.settings.handles, this.ownAccounts),
+			);
 		} catch (error) {
 			this.recordFailure(error, "read");
 			return;
 		}
+		this.ownAccounts = snapshot.ownAccounts;
 		this.failures = 0;
 
 		for (const message of selectInbound(snapshot)) {

--- a/packages/host-service/src/imessage/index.ts
+++ b/packages/host-service/src/imessage/index.ts
@@ -1,0 +1,23 @@
+export { buildSendArgs, sendImessage } from "./applescript";
+export { extractTextFromAttributedBody } from "./attributed-body";
+export { defaultChatDbPath, readChatDb } from "./chat-db";
+export {
+	ImessageBridge,
+	MAX_CONSECUTIVE_FAILURES,
+	MAX_SENDS_PER_MINUTE,
+	TICK_INTERVAL_MS,
+} from "./imessage-bridge";
+export {
+	buildAgentPrompt,
+	MAX_OUTBOUND_CHARS,
+	OUTBOUND_MARKER,
+	parseInbound,
+	selectInbound,
+} from "./messages";
+export type {
+	ChatDbSnapshot,
+	ImessageBridgeDeps,
+	ImessageBridgeStatus,
+	ImessageSettings,
+	InboundMessage,
+} from "./types";

--- a/packages/host-service/src/imessage/messages.test.ts
+++ b/packages/host-service/src/imessage/messages.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import type { TerminalAgentBinding } from "../terminal-agents";
+import {
+	buildAgentPrompt,
+	buildStatusReply,
+	MAX_OUTBOUND_CHARS,
+	OUTBOUND_MARKER,
+	parseInbound,
+	selectInbound,
+	truncateOutbound,
+} from "./messages.ts";
+import type { ChatDbSnapshot, InboundMessage } from "./types.ts";
+
+const T0 = 1_800_000_000_000;
+
+function row(overrides: Partial<InboundMessage>): InboundMessage {
+	return {
+		rowId: 1,
+		guid: "guid-1",
+		chatIdentifier: "+15551234567",
+		senderHandle: "+15551234567",
+		isFromMe: false,
+		itemType: 0,
+		text: "hello",
+		sentAt: T0,
+		...overrides,
+	};
+}
+
+function snapshot(
+	rows: InboundMessage[],
+	ownAccounts: string[] = ["me@example.com"],
+): ChatDbSnapshot {
+	return { rows, maxRowId: 100, ownAccounts };
+}
+
+describe("selectInbound", () => {
+	it("accepts genuine inbound rows from a watched chat", () => {
+		const picked = selectInbound(snapshot([row({})]));
+		expect(picked).toHaveLength(1);
+		expect(picked[0]?.text).toBe("hello");
+	});
+
+	it("drops our own rows in a normal chat but keeps them in the self-chat", () => {
+		const picked = selectInbound(
+			snapshot([
+				row({ isFromMe: true }),
+				row({
+					rowId: 2,
+					chatIdentifier: "me@example.com",
+					isFromMe: true,
+					text: "from my phone",
+				}),
+			]),
+		);
+		expect(picked.map((m) => m.text)).toEqual(["from my phone"]);
+	});
+
+	it("drops marker-prefixed rows everywhere — that is the loop guard", () => {
+		const picked = selectInbound(
+			snapshot([
+				row({
+					chatIdentifier: "me@example.com",
+					isFromMe: true,
+					text: `${OUTBOUND_MARKER}done, tests pass`,
+				}),
+			]),
+		);
+		expect(picked).toHaveLength(0);
+	});
+
+	it("drops non-text items, empty bodies, and whitespace", () => {
+		const picked = selectInbound(
+			snapshot([
+				row({ itemType: 2 }),
+				row({ rowId: 2, text: null }),
+				row({ rowId: 3, text: "   " }),
+			]),
+		);
+		expect(picked).toHaveLength(0);
+	});
+});
+
+describe("parseInbound", () => {
+	it("recognizes commands case-insensitively", () => {
+		expect(parseInbound(" Status ").kind).toBe("status");
+		expect(parseInbound("s").kind).toBe("status");
+		expect(parseInbound("HELP").kind).toBe("help");
+		expect(parseInbound("?").kind).toBe("help");
+	});
+
+	it("treats anything else as a task", () => {
+		expect(parseInbound("run the tests")).toEqual({
+			kind: "task",
+			text: "run the tests",
+		});
+	});
+});
+
+describe("buildAgentPrompt", () => {
+	it("strips control characters so a text cannot escape the paste frame", () => {
+		const esc = String.fromCharCode(0x1b);
+		const prompt = buildAgentPrompt(`do it${esc}[201~rm -rf /`);
+		expect(prompt).not.toContain(esc);
+		expect(prompt).toContain('"do it [201~rm -rf /"');
+	});
+
+	it("tells the agent how to reply", () => {
+		expect(buildAgentPrompt("hi")).toContain("superset imessage reply");
+	});
+});
+
+describe("buildStatusReply", () => {
+	const agent = (overrides: Partial<TerminalAgentBinding>) =>
+		({
+			terminalId: "term-1",
+			workspaceId: "ws-1",
+			agentId: "claude",
+			startedAt: T0 - 600_000,
+			lastEventAt: T0 - 120_000,
+			lastEventType: "Start",
+			...overrides,
+		}) as TerminalAgentBinding;
+
+	it("summarizes agents most-recent first with busy state", () => {
+		const reply = buildStatusReply(
+			[
+				agent({ lastEventAt: T0 - 3_600_000, lastEventType: "Stop" }),
+				agent({
+					terminalId: "term-2",
+					workspaceId: "ws-2",
+					lastEventAt: T0 - 60_000,
+				}),
+			],
+			(id) => (id === "ws-2" ? "lavender-meal" : null),
+			T0,
+		);
+		const lines = reply.split("\n");
+		expect(lines[0]).toContain("lavender-meal");
+		expect(lines[0]).toContain("working");
+		expect(lines[1]).toContain("idle");
+	});
+
+	it("explains when nothing is running", () => {
+		expect(buildStatusReply([], () => null, T0)).toContain("No agents running");
+	});
+});
+
+describe("truncateOutbound", () => {
+	it("caps at the outbound limit with an ellipsis", () => {
+		const out = truncateOutbound("z".repeat(MAX_OUTBOUND_CHARS + 50));
+		expect(out).toHaveLength(MAX_OUTBOUND_CHARS);
+		expect(out.endsWith("…")).toBe(true);
+	});
+});

--- a/packages/host-service/src/imessage/messages.test.ts
+++ b/packages/host-service/src/imessage/messages.test.ts
@@ -3,6 +3,7 @@ import type { TerminalAgentBinding } from "../terminal-agents";
 import {
 	buildAgentPrompt,
 	buildStatusReply,
+	effectiveWatchList,
 	MAX_OUTBOUND_CHARS,
 	OUTBOUND_MARKER,
 	parseInbound,
@@ -78,6 +79,32 @@ describe("selectInbound", () => {
 			]),
 		);
 		expect(picked).toHaveLength(0);
+	});
+});
+
+describe("effectiveWatchList", () => {
+	it("widens to all own accounts when any own address is allowlisted", () => {
+		expect(
+			effectiveWatchList(
+				["me@example.com"],
+				["me@example.com", "+15550001111"],
+			),
+		).toEqual(["me@example.com", "+15550001111"]);
+	});
+
+	it("leaves a non-self allowlist untouched", () => {
+		expect(effectiveWatchList(["+15551234567"], ["me@example.com"])).toEqual([
+			"+15551234567",
+		]);
+	});
+
+	it("dedupes when the allowlist already carries own accounts", () => {
+		expect(
+			effectiveWatchList(
+				["me@example.com", "+15550001111"],
+				["me@example.com", "+15550001111"],
+			),
+		).toEqual(["me@example.com", "+15550001111"]);
 	});
 });
 

--- a/packages/host-service/src/imessage/messages.test.ts
+++ b/packages/host-service/src/imessage/messages.test.ts
@@ -171,6 +171,16 @@ describe("buildStatusReply", () => {
 	it("explains when nothing is running", () => {
 		expect(buildStatusReply([], () => null, T0)).toContain("No agents running");
 	});
+
+	it("caps the list on hosts with many live sessions", () => {
+		const many = Array.from({ length: 20 }, (_, i) =>
+			agent({ terminalId: `term-${i}`, lastEventAt: T0 - i * 1000 }),
+		);
+		const reply = buildStatusReply(many, () => "ws", T0);
+		const lines = reply.split("\n");
+		expect(lines).toHaveLength(9);
+		expect(lines.at(-1)).toBe("…and 12 more");
+	});
 });
 
 describe("truncateOutbound", () => {

--- a/packages/host-service/src/imessage/messages.ts
+++ b/packages/host-service/src/imessage/messages.ts
@@ -1,0 +1,119 @@
+import { agentIsBusy } from "../page-watch/index.ts";
+import type { TerminalAgentBinding } from "../terminal-agents";
+import type { ChatDbSnapshot, InboundMessage } from "./types";
+
+/**
+ * Invisible separator prepended to every message the bridge sends. In the
+ * self-chat every device writes `is_from_me = 1`, so this marker — not the
+ * sender column — is what keeps the bridge from ingesting its own replies
+ * and looping.
+ */
+export const OUTBOUND_MARKER = "⁣";
+
+/** Texting surface, not a terminal — keep replies inside iMessage limits. */
+export const MAX_OUTBOUND_CHARS = 1600;
+
+// Control characters would reach the PTY verbatim. A body carrying the
+// bracketed-paste terminator would close the paste early and land the rest as
+// keystrokes.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: removing them is the point
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
+
+function quote(text: string): string {
+	return text.replace(CONTROL_CHARS, " ").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Rows worth acting on. The self-chat accepts both directions (see
+ * OUTBOUND_MARKER); any other watched chat only trusts genuine inbound rows.
+ */
+export function selectInbound(
+	snapshot: ChatDbSnapshot,
+): (InboundMessage & { text: string })[] {
+	const own = new Set(snapshot.ownAccounts);
+	const out: (InboundMessage & { text: string })[] = [];
+	for (const row of snapshot.rows) {
+		if (row.itemType !== 0) continue;
+		const text = row.text?.trim();
+		if (!text) continue;
+		if (text.startsWith(OUTBOUND_MARKER)) continue;
+		if (row.isFromMe && !own.has(row.chatIdentifier)) continue;
+		out.push({ ...row, text });
+	}
+	return out;
+}
+
+export type InboundAction =
+	| { kind: "status" }
+	| { kind: "help" }
+	| { kind: "task"; text: string };
+
+export function parseInbound(text: string): InboundAction {
+	const word = text.trim().toLowerCase();
+	if (word === "status" || word === "s") return { kind: "status" };
+	if (word === "help" || word === "?") return { kind: "help" };
+	return { kind: "task", text: text.trim() };
+}
+
+export function buildAgentPrompt(text: string): string {
+	return [
+		`iMessage from your user: "${quote(text)}"`,
+		"",
+		"Act on it, then text back with:",
+		'  superset imessage reply "your message"',
+		"Reply like a text message — a sentence or two, no markdown. Send one",
+		"when you finish or when you are blocked on something only they can",
+		"answer.",
+	].join("\n");
+}
+
+export function buildHelpReply(): string {
+	return [
+		"Superset over iMessage:",
+		'• Text anything to steer your most recent agent ("run the tests", "ship it").',
+		'• "status" — what your agents are doing.',
+		'• "help" — this message.',
+	].join("\n");
+}
+
+function formatAgo(ms: number): string {
+	const minutes = Math.floor(ms / 60_000);
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function buildStatusReply(
+	agents: TerminalAgentBinding[],
+	workspaceNameOf: (workspaceId: string) => string | null,
+	now: number,
+): string {
+	if (agents.length === 0) {
+		return "No agents running. Start one in Superset, then text your task here.";
+	}
+	const lines = agents
+		.slice()
+		.sort((a, b) => b.lastEventAt - a.lastEventAt)
+		.map((agent) => {
+			const workspace =
+				workspaceNameOf(agent.workspaceId) ?? agent.workspaceId.slice(0, 8);
+			const activity = agentIsBusy(agent.lastEventType) ? "working" : "idle";
+			return `• ${agent.agentId} in ${workspace} — ${activity} (${formatAgo(now - agent.lastEventAt)})`;
+		});
+	return lines.join("\n");
+}
+
+export function buildRoutedAck(agentId: string, workspaceName: string): string {
+	return `Sent to ${agentId} in ${workspaceName} — it will text back here.`;
+}
+
+export function buildNoAgentReply(): string {
+	return 'No agent is running in Superset right now. Start one, then text again. ("status" shows what\'s live.)';
+}
+
+export function truncateOutbound(text: string): string {
+	if (text.length <= MAX_OUTBOUND_CHARS) return text;
+	return `${text.slice(0, MAX_OUTBOUND_CHARS - 1)}…`;
+}

--- a/packages/host-service/src/imessage/messages.ts
+++ b/packages/host-service/src/imessage/messages.ts
@@ -43,6 +43,21 @@ export function selectInbound(
 	return out;
 }
 
+/**
+ * Messages keys the self-chat by whichever of the user's own addresses the
+ * sending device picked (phone number vs iCloud email), so allowlisting one
+ * own address must watch them all — otherwise a text from the phone lands in
+ * a sibling chat the bridge filters out.
+ */
+export function effectiveWatchList(
+	handles: string[],
+	ownAccounts: string[],
+): string[] {
+	const isSelfMode = handles.some((handle) => ownAccounts.includes(handle));
+	if (!isSelfMode) return handles;
+	return [...new Set([...handles, ...ownAccounts])];
+}
+
 export type InboundAction =
 	| { kind: "status" }
 	| { kind: "help" }

--- a/packages/host-service/src/imessage/messages.ts
+++ b/packages/host-service/src/imessage/messages.ts
@@ -100,6 +100,9 @@ function formatAgo(ms: number): string {
 	return `${Math.floor(hours / 24)}d ago`;
 }
 
+/** A long-lived host tracks dozens of sessions; a text lists the recent few. */
+export const MAX_STATUS_AGENTS = 8;
+
 export function buildStatusReply(
 	agents: TerminalAgentBinding[],
 	workspaceNameOf: (workspaceId: string) => string | null,
@@ -108,15 +111,16 @@ export function buildStatusReply(
 	if (agents.length === 0) {
 		return "No agents running. Start one in Superset, then text your task here.";
 	}
-	const lines = agents
-		.slice()
-		.sort((a, b) => b.lastEventAt - a.lastEventAt)
-		.map((agent) => {
-			const workspace =
-				workspaceNameOf(agent.workspaceId) ?? agent.workspaceId.slice(0, 8);
-			const activity = agentIsBusy(agent.lastEventType) ? "working" : "idle";
-			return `• ${agent.agentId} in ${workspace} — ${activity} (${formatAgo(now - agent.lastEventAt)})`;
-		});
+	const sorted = agents.slice().sort((a, b) => b.lastEventAt - a.lastEventAt);
+	const lines = sorted.slice(0, MAX_STATUS_AGENTS).map((agent) => {
+		const workspace =
+			workspaceNameOf(agent.workspaceId) ?? agent.workspaceId.slice(0, 8);
+		const activity = agentIsBusy(agent.lastEventType) ? "working" : "idle";
+		return `• ${agent.agentId} in ${workspace} — ${activity} (${formatAgo(now - agent.lastEventAt)})`;
+	});
+	if (sorted.length > MAX_STATUS_AGENTS) {
+		lines.push(`…and ${sorted.length - MAX_STATUS_AGENTS} more`);
+	}
 	return lines.join("\n");
 }
 

--- a/packages/host-service/src/imessage/settings.ts
+++ b/packages/host-service/src/imessage/settings.ts
@@ -1,0 +1,65 @@
+import { eq } from "drizzle-orm";
+import type { HostDb } from "../db";
+import { hostSettings } from "../db/schema";
+import type { ImessageSettings } from "./types";
+
+const HOST_SETTINGS_ID = 1;
+
+function parseHandles(raw: string | null | undefined): string[] {
+	if (!raw) return [];
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((entry): entry is string => typeof entry === "string");
+	} catch {
+		return [];
+	}
+}
+
+export function getImessageSettings(db: HostDb): ImessageSettings {
+	const row = db
+		.select({
+			enabled: hostSettings.imessageEnabled,
+			handles: hostSettings.imessageHandles,
+		})
+		.from(hostSettings)
+		.where(eq(hostSettings.id, HOST_SETTINGS_ID))
+		.get();
+	return {
+		enabled: row?.enabled === 1,
+		handles: parseHandles(row?.handles),
+	};
+}
+
+export function setImessageSettings(
+	db: HostDb,
+	settings: ImessageSettings,
+): void {
+	const values = {
+		imessageEnabled: settings.enabled ? 1 : 0,
+		imessageHandles: JSON.stringify(settings.handles),
+	};
+	db.insert(hostSettings)
+		.values({ id: HOST_SETTINGS_ID, ...values })
+		.onConflictDoUpdate({ target: hostSettings.id, set: values })
+		.run();
+}
+
+export function loadImessageCursor(db: HostDb): number | null {
+	const row = db
+		.select({ cursor: hostSettings.imessageCursor })
+		.from(hostSettings)
+		.where(eq(hostSettings.id, HOST_SETTINGS_ID))
+		.get();
+	return row?.cursor ?? null;
+}
+
+export function saveImessageCursor(db: HostDb, cursor: number): void {
+	db.insert(hostSettings)
+		.values({ id: HOST_SETTINGS_ID, imessageCursor: cursor })
+		.onConflictDoUpdate({
+			target: hostSettings.id,
+			set: { imessageCursor: cursor },
+		})
+		.run();
+}

--- a/packages/host-service/src/imessage/types.ts
+++ b/packages/host-service/src/imessage/types.ts
@@ -1,0 +1,73 @@
+import type { TerminalAgentBinding } from "../terminal-agents";
+
+/** One row read from chat.db, already reduced to what routing needs. */
+export interface InboundMessage {
+	rowId: number;
+	guid: string;
+	/** 1:1 chat identifier — the other party's handle, or the user's own
+	 * address for the "Messages to yourself" chat. */
+	chatIdentifier: string;
+	senderHandle: string | null;
+	isFromMe: boolean;
+	itemType: number;
+	text: string | null;
+	sentAt: number;
+}
+
+export interface ChatDbSnapshot {
+	rows: InboundMessage[];
+	maxRowId: number;
+	/** Addresses the Mac's own Messages accounts are signed in as. A watched
+	 * chat with one of these identifiers is the self-chat, where every device
+	 * writes `is_from_me = 1` and sender filtering must rely on the outbound
+	 * marker instead. */
+	ownAccounts: string[];
+}
+
+export interface ImessageSettings {
+	enabled: boolean;
+	/** Allowlisted 1:1 chat identifiers (phone in E.164 or email). */
+	handles: string[];
+}
+
+export type ImessageBridgeState =
+	| "disabled"
+	| "running"
+	| "unsupported-platform"
+	| "error";
+
+export interface ImessageBridgeStatus {
+	state: ImessageBridgeState;
+	settings: ImessageSettings;
+	/** Chat the last accepted inbound came from; default target for replies. */
+	activeChatIdentifier: string | null;
+	bindings: {
+		chatIdentifier: string;
+		workspaceId: string;
+		terminalId: string;
+	}[];
+	lastError: string | null;
+}
+
+export interface ImessageBridgeDeps {
+	/** One call per tick; opens chat.db read-only and closes it. Throws when
+	 * the DB is unreadable (missing Full Disk Access, no Messages history). */
+	readChatDb(sinceRowId: number, chatIdentifiers: string[]): ChatDbSnapshot;
+	/** Deliver one iMessage. Implementations prepend OUTBOUND_MARKER. */
+	sendMessage(to: string, text: string): Promise<void>;
+	sendToTerminal(input: {
+		workspaceId: string;
+		terminalId: string;
+		text: string;
+	}): Promise<void>;
+	listLiveAgents(): TerminalAgentBinding[];
+	isTerminalAlive(terminalId: string): boolean;
+	hasAgent(terminalId: string): boolean;
+	getWorkspaceName(workspaceId: string): string | null;
+	loadCursor(): number | null;
+	saveCursor(cursor: number): void;
+	platform?: NodeJS.Platform;
+	now?: () => number;
+	setIntervalFn?: typeof setInterval;
+	clearIntervalFn?: typeof clearInterval;
+}

--- a/packages/host-service/src/trpc/router/imessage/imessage.ts
+++ b/packages/host-service/src/trpc/router/imessage/imessage.ts
@@ -1,0 +1,52 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { MAX_OUTBOUND_CHARS } from "../../../imessage/index.ts";
+import {
+	getImessageSettings,
+	setImessageSettings,
+} from "../../../imessage/settings";
+import { protectedProcedure, router } from "../../index";
+
+const setInputSchema = z.object({
+	enabled: z.boolean(),
+	handles: z
+		.array(z.string().trim().min(3).max(320))
+		.max(5, "Allowlist at most 5 handles"),
+});
+
+const replyInputSchema = z.object({
+	text: z.string().trim().min(1).max(MAX_OUTBOUND_CHARS),
+	to: z.string().trim().min(3).max(320).optional(),
+});
+
+export const imessageRouter = router({
+	get: protectedProcedure.query(({ ctx }) => ({
+		...getImessageSettings(ctx.db),
+		status: ctx.runtime.imessage.status(),
+	})),
+
+	set: protectedProcedure.input(setInputSchema).mutation(({ ctx, input }) => {
+		setImessageSettings(ctx.db, input);
+		ctx.runtime.imessage.applySettings(input);
+		return {
+			...getImessageSettings(ctx.db),
+			status: ctx.runtime.imessage.status(),
+		};
+	}),
+
+	status: protectedProcedure.query(({ ctx }) => ctx.runtime.imessage.status()),
+
+	reply: protectedProcedure
+		.input(replyInputSchema)
+		.mutation(async ({ ctx, input }) => {
+			try {
+				return await ctx.runtime.imessage.reply(input);
+			} catch (error) {
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message:
+						error instanceof Error ? error.message : "Could not send iMessage",
+				});
+			}
+		}),
+});

--- a/packages/host-service/src/trpc/router/imessage/index.ts
+++ b/packages/host-service/src/trpc/router/imessage/index.ts
@@ -1,0 +1,1 @@
+export { imessageRouter } from "./imessage";

--- a/packages/host-service/src/trpc/router/router.ts
+++ b/packages/host-service/src/trpc/router/router.ts
@@ -10,6 +10,7 @@ import { gitRouter } from "./git";
 import { githubRouter } from "./github";
 import { healthRouter } from "./health";
 import { hostRouter } from "./host";
+import { imessageRouter } from "./imessage";
 import { issuesRouter } from "./issues";
 import { notificationsRouter } from "./notifications";
 import { pageWatchRouter } from "./page-watch";
@@ -37,6 +38,7 @@ export const appRouter = router({
 	filesystem: filesystemRouter,
 	git: gitRouter,
 	github: githubRouter,
+	imessage: imessageRouter,
 	issues: issuesRouter,
 	notifications: notificationsRouter,
 	pullRequests: pullRequestsRouter,

--- a/packages/host-service/src/types.ts
+++ b/packages/host-service/src/types.ts
@@ -4,6 +4,7 @@ import type { AppRouter } from "@superset/trpc";
 import type { TRPCClient } from "@trpc/client";
 import type { HostDb } from "./db";
 import type { EventBus } from "./events";
+import type { ImessageBridge } from "./imessage/index.ts";
 import type { PageWatchManager } from "./page-watch/index.ts";
 import type { WorkspaceFilesystemManager } from "./runtime/filesystem";
 import type { GitCredentialProvider, GitFactory } from "./runtime/git";
@@ -18,6 +19,7 @@ export interface HostServiceRuntime {
 	filesystem: WorkspaceFilesystemManager;
 	pullRequests: PullRequestRuntimeManager;
 	pageWatch: PageWatchManager;
+	imessage: ImessageBridge;
 }
 
 export interface HostServiceContext {


### PR DESCRIPTION
this is testing pr flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS-only iMessage bridge so you can text your Superset agents from your phone. Before, agents were only reachable from the Superset UI and CLI; now texts from allowlisted conversations are polled from `~/Library/Messages/chat.db` and delivered to the most recent live agent terminal, with replies sent back via a new `superset imessage reply` command.

**New Features**
- New CLI commands: `superset imessage enable`, `disable`, `status`, and `reply`.
- The bridge watches the Messages self-chat, so a second Apple ID is not needed.
- Outbound sends are rate-limited and prefixed with an invisible marker so the bridge never ingests its own replies.
- `status` and `help` texts are answered directly without touching a terminal.

**Migration**
- `host_settings` gains `imessage_enabled`, `imessage_handles`, and `imessage_cursor`; the cursor starts at the tail so history is never replayed.
- Enabling the bridge requires Full Disk Access for Superset; read failures surface in `superset imessage status`.

<sup>Written for commit acfdd300ccdb727f487064374abb56441d32d451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

