### PR TITLE
fix(desktop,workspace-client): fall back to GET queries on host-services older than 1.24

### DIFF
--- a/apps/desktop/src/renderer/lib/host-service-client.ts
+++ b/apps/desktop/src/renderer/lib/host-service-client.ts
@@ -1,10 +1,6 @@
 import type { AppRouter } from "@superset/host-service";
-import {
-	createTRPCClient,
-	httpBatchStreamLink,
-	TRPCClientError,
-} from "@trpc/client";
-import superjson from "superjson";
+import { createHostServiceLinks } from "@superset/workspace-client";
+import { createTRPCClient, TRPCClientError } from "@trpc/client";
 import { getHostServiceHeaders } from "./host-service-auth";
 
 const clientCache = new Map<
@@ -23,28 +19,10 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 	if (cached) return cached;
 
 	const client = createTRPCClient<AppRouter>({
-		links: [
-			// Streaming batch link: same-tick calls share one HTTP request and
-			// one CORS preflight, but each result streams as soon as it's ready
-			// — no slowest-in-batch latency (the reason #3879 unbatched the old
-			// buffering httpBatchLink). All renderer clients share Chromium's
-			// 6-connections-per-origin pool with every other host-service
-			// request, so sockets are the scarce resource here.
-			httpBatchStreamLink({
-				url: `${hostUrl}/trpc`,
-				transformer: superjson,
-				headers: () => getHostServiceHeaders(hostUrl),
-				// host-service is a local connection with no HTTP cache in front of
-				// it, so there's no upside to GET. Forcing POST puts query inputs in
-				// the request body instead of the URL — without this, a same-tick
-				// batch across many workspaces (terminalAgents.listByWorkspace,
-				// ports.getAll, etc.) can produce a GET URL long enough to blow past
-				// the server's HTTP header-size limit, failing even the CORS
-				// preflight before it reaches the route. See the identical fix on
-				// WorkspaceClientProvider in @superset/workspace-client.
-				methodOverride: "POST",
-			}),
-		],
+		links: createHostServiceLinks({
+			url: `${hostUrl}/trpc`,
+			headers: () => getHostServiceHeaders(hostUrl),
+		}),
 	});
 
 	clientCache.set(hostUrl, client);

--- a/bun.lock
+++ b/bun.lock
@@ -1323,6 +1323,7 @@
       },
       "devDependencies": {
         "@superset/typescript": "workspace:*",
+        "@trpc/server": "11.16.0",
         "@types/node": "24.12.0",
         "@types/react": "19.2.14",
         "bun-types": "1.3.14",

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -332,7 +332,7 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		trpcServer({
 			router: appRouter,
 			// Renderer clients send every request (including queries) as POST —
-			// see WorkspaceClientProvider/host-service-client's methodOverride —
+			// see createHostServiceLinks in @superset/workspace-client —
 			// so a query with a large input (e.g. git.getDiffBulk's file-path
 			// list, or a same-tick batch across many workspaces) doesn't produce
 			// a GET URL long enough to blow past the header-size limit. Without

--- a/packages/workspace-client/package.json
+++ b/packages/workspace-client/package.json
@@ -15,6 +15,7 @@
 	},
 	"scripts": {
 		"clean": "git clean -xdf .cache .turbo dist node_modules",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {
@@ -29,6 +30,7 @@
 	},
 	"devDependencies": {
 		"@superset/typescript": "workspace:*",
+		"@trpc/server": "11.16.0",
 		"@types/node": "24.12.0",
 		"@types/react": "19.2.14",
 		"bun-types": "1.3.14",

--- a/packages/workspace-client/src/index.ts
+++ b/packages/workspace-client/src/index.ts
@@ -21,6 +21,11 @@ export {
 	type WorkspaceSnapshotPayload,
 } from "./lib/eventBus";
 export {
+	createHostServiceLinks,
+	type HostServiceLinkOptions,
+	isMethodOverrideRejection,
+} from "./lib/hostServiceLinks";
+export {
 	primeRelayAffinity,
 	type RelayAffinityProbe,
 } from "./lib/primeRelayAffinity";

--- a/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.test.ts
+++ b/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createTRPCClient, TRPCClientError, type TRPCLink } from "@trpc/client";
+import { initTRPC } from "@trpc/server";
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import superjson from "superjson";
+import {
+	createHostServiceLinks,
+	isMethodOverrideRejection,
+} from "./hostServiceLinks";
+
+const t = initTRPC.create({ transformer: superjson });
+const router = t.router({
+	settings: t.router({
+		agentConfigs: t.router({
+			list: t.procedure.query(() => [{ id: "claude" }]),
+			echo: t.procedure
+				.input((value: unknown) => value as { n: number })
+				.query(({ input }) => input),
+			boom: t.procedure.query(() => {
+				throw new Error("host exploded");
+			}),
+			reorder: t.procedure.mutation(() => "reordered"),
+		}),
+	}),
+});
+type TestRouter = typeof router;
+
+/**
+ * A host-service at a given version: pre-1.24.0 hosts run tRPC without
+ * `allowMethodOverride`, so a POSTed query is rejected per call with
+ * METHOD_NOT_SUPPORTED while mutations work as usual.
+ */
+function fakeHost(hostUrl: string, opts: { allowMethodOverride: boolean }) {
+	const methods: string[] = [];
+	hosts.set(hostUrl, (req) => {
+		methods.push(req.method);
+		return fetchRequestHandler({
+			endpoint: "/trpc",
+			req,
+			router,
+			allowMethodOverride: opts.allowMethodOverride,
+		});
+	});
+	const client = createTRPCClient<TestRouter>({
+		// The links are typed against host-service's AppRouter; the test
+		// router only needs to match the wire protocol.
+		links: createHostServiceLinks({
+			url: `${hostUrl}/trpc`,
+		}) as unknown as TRPCLink<TestRouter>[],
+	});
+	return { client, methods };
+}
+
+const hosts = new Map<string, (req: Request) => Promise<Response>>();
+const realFetch = globalThis.fetch;
+
+beforeAll(() => {
+	globalThis.fetch = (async (
+		input: string | URL | Request,
+		init?: RequestInit,
+	) => {
+		const req =
+			input instanceof Request ? input : new Request(String(input), init);
+		const host = hosts.get(new URL(req.url).origin);
+		if (!host) throw new Error(`no fake host for ${req.url}`);
+		return host(req);
+	}) as unknown as typeof fetch;
+});
+
+afterAll(() => {
+	globalThis.fetch = realFetch;
+});
+
+describe("createHostServiceLinks", () => {
+	test("queries a current host with POST", async () => {
+		const { client, methods } = fakeHost("http://modern.test", {
+			allowMethodOverride: true,
+		});
+
+		expect(await client.settings.agentConfigs.list.query()).toEqual([
+			{ id: "claude" },
+		]);
+		expect(methods).toEqual(["POST"]);
+	});
+
+	test("replays a query over GET when a pre-1.24 host rejects the POST", async () => {
+		const { client, methods } = fakeHost("http://legacy.test", {
+			allowMethodOverride: false,
+		});
+
+		expect(await client.settings.agentConfigs.list.query()).toEqual([
+			{ id: "claude" },
+		]);
+		expect(methods).toEqual(["POST", "GET"]);
+	});
+
+	test("remembers a legacy host so later queries skip the failing POST", async () => {
+		const first = fakeHost("http://remembered.test", {
+			allowMethodOverride: false,
+		});
+		await first.client.settings.agentConfigs.list.query();
+		expect(first.methods).toEqual(["POST", "GET"]);
+
+		await first.client.settings.agentConfigs.list.query();
+		expect(first.methods).toEqual(["POST", "GET", "GET"]);
+
+		// A fresh client for the same endpoint (another provider, a cache miss)
+		// inherits the fallback instead of paying the rejection again.
+		const second = fakeHost("http://remembered.test", {
+			allowMethodOverride: false,
+		});
+		expect(await second.client.settings.agentConfigs.list.query()).toEqual([
+			{ id: "claude" },
+		]);
+		expect(second.methods).toEqual(["GET"]);
+	});
+
+	test("replays every query in a rejected batch, with inputs intact", async () => {
+		const { client, methods } = fakeHost("http://batch.test", {
+			allowMethodOverride: false,
+		});
+
+		const [list, echoed] = await Promise.all([
+			client.settings.agentConfigs.list.query(),
+			client.settings.agentConfigs.echo.query({ n: 42 }),
+		]);
+
+		expect(list).toEqual([{ id: "claude" }]);
+		expect(echoed).toEqual({ n: 42 });
+		expect(methods).toEqual(["POST", "GET"]);
+	});
+
+	test("still sends mutations to a legacy host as POST", async () => {
+		const { client, methods } = fakeHost("http://legacy-mutation.test", {
+			allowMethodOverride: false,
+		});
+
+		expect(await client.settings.agentConfigs.reorder.mutate()).toBe(
+			"reordered",
+		);
+		expect(methods).toEqual(["POST"]);
+	});
+
+	test("does not retry a query that failed for any other reason", async () => {
+		const { client, methods } = fakeHost("http://faulty.test", {
+			allowMethodOverride: true,
+		});
+
+		await expect(client.settings.agentConfigs.boom.query()).rejects.toThrow(
+			"host exploded",
+		);
+		expect(methods).toEqual(["POST"]);
+	});
+});
+
+describe("isMethodOverrideRejection", () => {
+	test("ignores errors without the tRPC method-check code", () => {
+		expect(isMethodOverrideRejection(new Error("Failed to fetch"))).toBe(false);
+		expect(
+			isMethodOverrideRejection(TRPCClientError.from(new Error("boom"))),
+		).toBe(false);
+	});
+});

--- a/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.test.ts
+++ b/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.test.ts
@@ -151,9 +151,51 @@ describe("createHostServiceLinks", () => {
 		);
 		expect(methods).toEqual(["POST"]);
 	});
+
+	test("re-probes POST after the host restarts on the same endpoint", async () => {
+		const legacy = fakeHost("http://restarted.test", {
+			allowMethodOverride: false,
+		});
+		await legacy.client.settings.agentConfigs.list.query();
+		expect(legacy.methods).toEqual(["POST", "GET"]);
+
+		// The old process dies: the next request never reaches a server.
+		hosts.set("http://restarted.test", async () => {
+			throw new TypeError("Failed to fetch");
+		});
+		await expect(
+			legacy.client.settings.agentConfigs.list.query(),
+		).rejects.toThrow("Failed to fetch");
+
+		// The desktop respawns a current host-service on the same port; the
+		// client that fell back must not stay on GET for it.
+		const modern = fakeHost("http://restarted.test", {
+			allowMethodOverride: true,
+		});
+		expect(await legacy.client.settings.agentConfigs.list.query()).toEqual([
+			{ id: "claude" },
+		]);
+		expect(modern.methods).toEqual(["POST"]);
+	});
 });
 
 describe("isMethodOverrideRejection", () => {
+	test("matches tRPC's method-check rejection", () => {
+		const rejection = TRPCClientError.from({
+			error: {
+				message:
+					'Unsupported POST-request to query procedure at path "settings.agentConfigs.list"',
+				code: -32005,
+				data: {
+					code: "METHOD_NOT_SUPPORTED",
+					httpStatus: 405,
+					path: "settings.agentConfigs.list",
+				},
+			},
+		});
+		expect(isMethodOverrideRejection(rejection)).toBe(true);
+	});
+
 	test("ignores errors without the tRPC method-check code", () => {
 		expect(isMethodOverrideRejection(new Error("Failed to fetch"))).toBe(false);
 		expect(

--- a/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.ts
+++ b/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.ts
@@ -1,0 +1,75 @@
+import type { AppRouter } from "@superset/host-service/trpc";
+import {
+	httpBatchStreamLink,
+	retryLink,
+	splitLink,
+	TRPCClientError,
+	type TRPCLink,
+} from "@trpc/client";
+import superjson from "superjson";
+
+/**
+ * tRPC endpoints that rejected a POSTed query with METHOD_NOT_SUPPORTED.
+ * Module-level so every client pointed at the same host learns once, and a
+ * host that has fallen back stays on GET until reload.
+ */
+const legacyGetEndpoints = new Set<string>();
+
+export interface HostServiceLinkOptions {
+	/** The host's tRPC endpoint, e.g. `http://127.0.0.1:PORT/trpc`. */
+	url: string;
+	headers?: () => Record<string, string>;
+}
+
+/**
+ * True when a host answered a POSTed query with tRPC's method check — the
+ * server predates `allowMethodOverride` (host-service 1.24.0) and only takes
+ * queries as GET. Applies to remote hosts nobody updated and to a local
+ * host-service spawned by a stale CLI that the desktop then adopted.
+ */
+export function isMethodOverrideRejection(error: unknown): boolean {
+	return (
+		error instanceof TRPCClientError &&
+		error.data?.code === "METHOD_NOT_SUPPORTED"
+	);
+}
+
+/**
+ * The link chain every renderer host-service client uses.
+ *
+ * Streaming batch link: same-tick calls share one HTTP request and one CORS
+ * preflight, but each result streams as soon as it's ready — no
+ * slowest-in-batch latency (the reason #3879 unbatched the old buffering
+ * httpBatchLink). All renderer clients share Chromium's 6-connections-per-
+ * origin pool with every other host-service request, so sockets are the
+ * scarce resource here.
+ *
+ * Queries go out as POST: host-service has no HTTP cache in front of it, so
+ * there's no upside to GET, and a query with a large input (git.getDiffBulk's
+ * file-path list, a same-tick batch across many workspaces) can otherwise
+ * produce a GET URL long enough to blow past the server's header-size limit,
+ * failing even the CORS preflight before it reaches the route. Hosts older
+ * than 1.24.0 reject that override, so the first such rejection flips the
+ * endpoint to plain GET and replays the query there.
+ */
+export function createHostServiceLinks(
+	options: HostServiceLinkOptions,
+): TRPCLink<AppRouter>[] {
+	const { url, headers } = options;
+	const shared = { url, transformer: superjson, headers };
+	return [
+		retryLink({
+			retry: ({ op, error, attempts }) => {
+				if (attempts > 1 || op.type !== "query") return false;
+				if (!isMethodOverrideRejection(error)) return false;
+				legacyGetEndpoints.add(url);
+				return true;
+			},
+		}),
+		splitLink({
+			condition: () => legacyGetEndpoints.has(url),
+			true: httpBatchStreamLink(shared),
+			false: httpBatchStreamLink({ ...shared, methodOverride: "POST" }),
+		}),
+	];
+}

--- a/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.ts
+++ b/packages/workspace-client/src/lib/hostServiceLinks/hostServiceLinks.ts
@@ -10,10 +10,22 @@ import superjson from "superjson";
 
 /**
  * tRPC endpoints that rejected a POSTed query with METHOD_NOT_SUPPORTED.
- * Module-level so every client pointed at the same host learns once, and a
- * host that has fallen back stays on GET until reload.
+ * Module-level so every client pointed at the same host learns once. An
+ * entry is dropped on the next transport-level failure to that endpoint: the
+ * desktop respawns a replaced host-service on the same port, so a connection
+ * error is the signal that a newer process may now be answering there, and
+ * the next query re-probes POST instead of staying on GET for good.
  */
 const legacyGetEndpoints = new Set<string>();
+
+/**
+ * A failure that never got a server response — connection refused during a
+ * restart, a dropped stream. tRPC only populates `data` from a parsed error
+ * envelope, so its absence means the transport failed, not the server.
+ */
+function isConnectionError(error: unknown): boolean {
+	return error instanceof TRPCClientError && error.data == null;
+}
 
 export interface HostServiceLinkOptions {
 	/** The host's tRPC endpoint, e.g. `http://127.0.0.1:PORT/trpc`. */
@@ -60,6 +72,10 @@ export function createHostServiceLinks(
 	return [
 		retryLink({
 			retry: ({ op, error, attempts }) => {
+				if (isConnectionError(error)) {
+					legacyGetEndpoints.delete(url);
+					return false;
+				}
 				if (attempts > 1 || op.type !== "query") return false;
 				if (!isMethodOverrideRejection(error)) return false;
 				legacyGetEndpoints.add(url);

--- a/packages/workspace-client/src/lib/hostServiceLinks/index.ts
+++ b/packages/workspace-client/src/lib/hostServiceLinks/index.ts
@@ -1,0 +1,5 @@
+export {
+	createHostServiceLinks,
+	type HostServiceLinkOptions,
+	isMethodOverrideRejection,
+} from "./hostServiceLinks";

--- a/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
+++ b/packages/workspace-client/src/providers/WorkspaceClientProvider/WorkspaceClientProvider.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { httpBatchStreamLink, TRPCClientError } from "@trpc/client";
+import { TRPCClientError } from "@trpc/client";
 import { createContext, type ReactNode, useContext } from "react";
-import superjson from "superjson";
+import { createHostServiceLinks } from "../../lib/hostServiceLinks";
 import { workspaceTrpc } from "../../workspace-trpc";
 
 const STALE_TIME_MS = 5_000;
@@ -93,20 +93,7 @@ function getWorkspaceClients(
 	});
 
 	const trpcClient = workspaceTrpc.createClient({
-		links: [
-			httpBatchStreamLink({
-				url: `${hostUrl}/trpc`,
-				transformer: superjson,
-				headers: headers ?? (() => ({})),
-				// host-service is a local connection with no HTTP cache in front of
-				// it, so there's no upside to GET. Forcing POST puts query inputs in
-				// the request body instead of the URL — without this, a query with a
-				// large input (e.g. git.getDiffBulk's file-path list) can produce a
-				// GET URL long enough to blow past the server's HTTP header-size
-				// limit, failing even the CORS preflight before it reaches the route.
-				methodOverride: "POST",
-			}),
-		],
+		links: createHostServiceLinks({ url: `${hostUrl}/trpc`, headers }),
 	});
 
 	const getWsToken = wsToken ?? (() => null);


### PR DESCRIPTION
## Summary
- Fixes `Unsupported POST-request to query procedure at path "settings.agentConfigs.list"` on Settings > Agents (and the empty agent picker in the new-workspace composer) for users whose desktop talks to a host-service older than 1.24.
- Adds `createHostServiceLinks` in `@superset/workspace-client`, the one link chain both renderer host-service clients now use. It keeps POSTing queries to current hosts and falls back to GET for hosts that reject the override.

## Why / Context
#6658 (1.24.0) made both renderer links send every query as POST via `methodOverride`, so large inputs (bulk diff paths, same-tick batches across many workspaces) stay out of the URL. The same PR enabled `allowMethodOverride` in host-service. A host-service older than 1.24 still uses tRPC's default method map and rejects each POSTed query per call with `METHOD_NOT_SUPPORTED`. No call site uses a mutation; every consumer calls `.query()`.

Two ways a ≥1.24 desktop ends up on such a host:
- **Adopted local host.** The coordinator's `tryAdopt` takes any healthy host-service named in the org manifest with no version check. A host-service left running by an older CLI install (`superset-host`) or a second desktop channel becomes the local host that Settings > Agents queries.
- **Old remote host.** Remote hosts at 1.21 to 1.23 pass `MIN_HOST_SERVICE_VERSION` (1.21.0) but reject the override. The new-workspace composer lists agents from whichever host is selected.

## How It Works
`createHostServiceLinks` returns `[retryLink, splitLink]`:
- `splitLink` routes to a plain `httpBatchStreamLink` when the endpoint is in a module-level "legacy" set, otherwise to the same link with `methodOverride: "POST"`.
- `retryLink` catches the first `METHOD_NOT_SUPPORTED` on a query (never on a mutation, never a second time), adds the endpoint to the set, and replays the op, which now goes through the GET link.

The set is keyed by endpoint URL and shared by every client for that host, so a host pays the rejection once per renderer session. Mutations are unaffected. Current hosts never see a fallback.

## Manual QA
Real binaries, not a simulated server: `bin/superset-host` from the cli-v1.23.0 and cli-v1.25.1 release tarballs, booted by hand.

| Host | Pre-fix link | This PR |
|---|---|---|
| 1.23.0 | `METHOD_NOT_SUPPORTED`, the reported message | list loads; wire is POST then GET, later queries GET only |
| 1.25.1 | loads over POST | loads over POST, no fallback triggered |

End to end in the dev desktop: wrote org manifests pointing at the 1.23.0 host so the coordinator adopted it (log: `adopted existing host on port 48790`), then opened Settings > Agents with real clicks over CDP.
- [x] Before (client files at pre-fix state): red "Couldn't load agent settings: Unsupported POST-request to query procedure at path settings.agentConfigs.list"
- [x] After: Claude, Amp, Codex and the rest listed from the same 1.23.0 host

## Testing
- `bun test` in `packages/workspace-client` (22 pass; 7 new in `hostServiceLinks.test.ts`, which run the links against a real `fetchRequestHandler` with `allowMethodOverride` on and off). The three fallback tests fail when the fallback is removed.
- `bun run typecheck` in `packages/workspace-client` and `apps/desktop`
- biome check on changed files, `sherif`

## Design Decisions
- **Client-side fallback instead of a `MIN_HOST_SERVICE_VERSION` bump**: a bump only helps remote workspaces (it renders the incompatible-host state) and does nothing for an adopted local host or the composer's agent list. The fallback makes every surface work against old hosts with one extra round trip per session.
- **Remember the endpoint, don't gate the retry on it**: concurrent batches in flight when the first rejection lands each get their own retry; gating on "already marked" would surface the error for all but the first.
- **`@trpc/server` as a workspace-client devDependency**: only for the test's real handler. Also adds a `test` script so turbo runs this package's tests (the existing three suites already passed).

## Follow-ups
- `tryAdopt` still adopts a host-service of any version. Harmless for this error now, but a much older adopted host could lack newer procedures.

https://claude.ai/code/session_018GpzahQefv2y8yE4U8i6bn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Settings > Agents and the new-workspace agent picker failing with `Unsupported POST-request to query procedure` when the desktop talks to a host-service older than 1.24. Renderer clients now fall back to GET queries on the first `METHOD_NOT_SUPPORTED` rejection, so old hosts work without losing POST for current hosts.

**Details**
- Adds `createHostServiceLinks` in `@superset/workspace-client`, used by both renderer host-service clients.
- The first rejected query marks that host endpoint as legacy and replays it over GET; later queries go straight to GET, mutations stay POST.
- A transport-level failure clears the legacy mark, so the next query re-probes POST in case the host restarted on the same port.
- Costs one extra round trip per legacy host session.

<sup>Written for commit 8d992e9de33599779f086119f3dfeddfad9f14d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host-service compatibility by automatically retrying queries with GET when POST requests aren’t supported.
  * Preserved fallback behavior for subsequent and batched queries while keeping mutations on POST.
  * Re-probe POST after connection recovery or host restarts, preventing stale fallback behavior.

* **Tests**
  * Added coverage for request fallback, retries, batching, mutations, recovery scenarios, and non-retryable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->