### PR TITLE
fix(usage): read the Claude Keychain login by account and keep Add account reachable

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/UsageView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/UsageView.tsx
@@ -45,23 +45,15 @@ import type { RestartSessionsPrompt } from "./components/RestartSessionsDialog";
 import { RestartSessionsDialog } from "./components/RestartSessionsDialog";
 import { formatResetIn, formatResetLabel } from "./utils/formatResetIn";
 import { switchSignInCommand } from "./utils/switchSignInCommand";
+import type { ManagedAgent, QuotaAgent } from "./utils/visibleQuotaAgents";
+import { isManagedAgent, visibleQuotaAgents } from "./utils/visibleQuotaAgents";
 
-type Agent = UsageAccount["agent"];
-
-const AGENTS: Agent[] = ["claude", "codex", "grok", "agy"];
-
-const AGENT_LABELS: Record<Agent, string> = {
+const AGENT_LABELS: Record<QuotaAgent, string> = {
 	claude: "Claude Code",
 	codex: "Codex",
 	grok: "Grok",
 	agy: "Antigravity",
 };
-
-type ManagedAgent = "claude" | "codex";
-
-function isManagedAgent(agent: Agent): agent is ManagedAgent {
-	return agent === "claude" || agent === "codex";
-}
 
 function meterColor(usedPercent: number): string {
 	if (usedPercent >= 90) return "bg-red-500";
@@ -542,9 +534,7 @@ export function UsageView({ hostUrl }: { hostUrl: string | null }) {
 					</Trans>
 				</div>
 			) : (
-				AGENTS.filter((agent) =>
-					accounts.some((account) => account.agent === agent),
-				).map((agent) => {
+				visibleQuotaAgents(accounts).map((agent) => {
 					const agentAccounts = accounts.filter(
 						(account) => account.agent === agent,
 					);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/index.ts
@@ -1,0 +1,6 @@
+export {
+	isManagedAgent,
+	type ManagedAgent,
+	type QuotaAgent,
+	visibleQuotaAgents,
+} from "./visibleQuotaAgents";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/visibleQuotaAgents.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/visibleQuotaAgents.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { visibleQuotaAgents } from "./visibleQuotaAgents";
+
+describe("visibleQuotaAgents", () => {
+	it("keeps the managed agents when the host has no logins at all", () => {
+		expect(visibleQuotaAgents([])).toEqual(["claude", "codex"]);
+	});
+
+	it("keeps Claude Code beside a lone Codex login so Add account stays reachable", () => {
+		expect(visibleQuotaAgents([{ agent: "codex" }])).toEqual([
+			"claude",
+			"codex",
+		]);
+	});
+
+	it("shows Grok and Antigravity only once they have a login", () => {
+		expect(visibleQuotaAgents([{ agent: "agy" }, { agent: "claude" }])).toEqual(
+			["claude", "codex", "agy"],
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/visibleQuotaAgents.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/visibleQuotaAgents.test.ts
@@ -13,9 +13,34 @@ describe("visibleQuotaAgents", () => {
 		]);
 	});
 
-	it("shows Grok and Antigravity only once they have a login", () => {
+	it("hides Grok and Antigravity while neither has a login", () => {
+		expect(visibleQuotaAgents([{ agent: "claude" }])).toEqual([
+			"claude",
+			"codex",
+		]);
+	});
+
+	it("shows Grok once it has a login", () => {
+		expect(visibleQuotaAgents([{ agent: "grok" }])).toEqual([
+			"claude",
+			"codex",
+			"grok",
+		]);
+	});
+
+	it("shows Antigravity once it has a login", () => {
 		expect(visibleQuotaAgents([{ agent: "agy" }, { agent: "claude" }])).toEqual(
 			["claude", "codex", "agy"],
 		);
+	});
+
+	it("orders every section by display order, not by account order", () => {
+		expect(
+			visibleQuotaAgents([
+				{ agent: "agy" },
+				{ agent: "grok" },
+				{ agent: "codex" },
+			]),
+		).toEqual(["claude", "codex", "grok", "agy"]);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/visibleQuotaAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/UsageView/utils/visibleQuotaAgents/visibleQuotaAgents.ts
@@ -1,0 +1,29 @@
+import type { UsageAccount } from "../../../../hooks/useHostUsageQuota";
+
+export type QuotaAgent = UsageAccount["agent"];
+
+/** Agents whose logins Superset can add, switch, and remove. */
+export type ManagedAgent = "claude" | "codex";
+
+const AGENT_ORDER: QuotaAgent[] = ["claude", "codex", "grok", "agy"];
+
+export function isManagedAgent(agent: QuotaAgent): agent is ManagedAgent {
+	return agent === "claude" || agent === "codex";
+}
+
+/**
+ * The quota panel's agent sections, in display order. Managed agents keep
+ * their section with no login on the host — that is where Add account
+ * lives, so hiding it would leave no way to sign in. Grok and Antigravity
+ * have no add flow, so an empty section would be a dead end; they appear
+ * once a login exists.
+ */
+export function visibleQuotaAgents(
+	accounts: ReadonlyArray<Pick<UsageAccount, "agent">>,
+): QuotaAgent[] {
+	return AGENT_ORDER.filter(
+		(agent) =>
+			isManagedAgent(agent) ||
+			accounts.some((account) => account.agent === agent),
+	);
+}

--- a/packages/host-service/src/trpc/router/usage/claude.ts
+++ b/packages/host-service/src/trpc/router/usage/claude.ts
@@ -8,16 +8,13 @@
  * token can trip Anthropic's token-reuse protection and sign the CLI out.
  */
 
-import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
-import { homedir, platform } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
-import { discoverClaudeProfiles, readKeychainSecret } from "./profiles";
+import { discoverClaudeProfiles, readKeychainSecrets } from "./profiles";
 import type { UsageAccount, UsageQuotaWindow } from "./types";
 
-const execFileAsync = promisify(execFile);
-
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
 const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 const CLAUDE_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile";
 const CLAUDE_OAUTH_BETA_HEADER = "oauth-2025-04-20";
@@ -83,23 +80,20 @@ async function readCredentialFile(
 	}
 }
 
+/** The default login's Keychain item: the freshest of the items sharing its
+ * service, since a sibling without a Claude login can sit beside it. */
 async function readKeychainCredential(): Promise<ClaudeOauthCredential | null> {
-	if (platform() !== "darwin") return null;
-	try {
-		const { stdout } = await execFileAsync(
-			"security",
-			["find-generic-password", "-s", "Claude Code-credentials", "-w"],
-			{ timeout: 5_000 },
-		);
-		return parseCredential(
-			stdout.trim(),
-			"keychain:Claude Code-credentials",
-			"Keychain",
-			null,
-		);
-	} catch {
-		return null;
-	}
+	const secrets = await readKeychainSecrets(CLAUDE_KEYCHAIN_SERVICE);
+	return pickFreshest(
+		secrets.map((secret) =>
+			parseCredential(
+				secret,
+				`keychain:${CLAUDE_KEYCHAIN_SERVICE}`,
+				"Keychain",
+				null,
+			),
+		),
+	);
 }
 
 function isLive(credential: ClaudeOauthCredential): boolean {
@@ -188,19 +182,21 @@ async function discoverClaudeCredentials(): Promise<{
 			profile.sourceLabel,
 			profile.configDir,
 		);
-		if (fromFile) return { ...fromFile, email: profile.email };
+		const candidates: Array<ClaudeOauthCredential | null> = [fromFile];
 		for (const service of profile.keychainServices) {
-			const secret = await readKeychainSecret(service);
-			if (!secret) continue;
-			const parsed = parseCredential(
-				secret,
-				profile.configDir,
-				profile.sourceLabel,
-				profile.configDir,
-			);
-			if (parsed) return { ...parsed, email: profile.email };
+			for (const secret of await readKeychainSecrets(service)) {
+				candidates.push(
+					parseCredential(
+						secret,
+						profile.configDir,
+						profile.sourceLabel,
+						profile.configDir,
+					),
+				);
+			}
 		}
-		return null;
+		const freshest = pickFreshest(candidates);
+		return freshest ? { ...freshest, email: profile.email } : null;
 	};
 
 	const profiles = await discoverClaudeProfiles();

--- a/packages/host-service/src/trpc/router/usage/profiles.test.ts
+++ b/packages/host-service/src/trpc/router/usage/profiles.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { claudeKeychainAccounts } from "./profiles";
+
+// Claude Code keys its Keychain items on these names; a miss reads a sibling
+// item (or nothing) and the login disappears from the quota panel.
+describe("claudeKeychainAccounts", () => {
+	it("uses $USER alone when it is set, as the CLI does", () => {
+		expect(claudeKeychainAccounts({ USER: "avi" }, () => "passwd")).toEqual([
+			"avi",
+		]);
+	});
+
+	it("without $USER probes the passwd name and Bun's 'unknown' identity", () => {
+		expect(claudeKeychainAccounts({}, () => "passwd")).toEqual([
+			"passwd",
+			"unknown",
+		]);
+		expect(claudeKeychainAccounts({ USER: "" }, () => "passwd")).toEqual([
+			"passwd",
+			"unknown",
+		]);
+	});
+
+	it("swaps an unusable name for the CLI's fixed fallback", () => {
+		expect(claudeKeychainAccounts({ USER: "not valid!" }, () => "x")).toEqual([
+			"claude-code-user",
+		]);
+		expect(
+			claudeKeychainAccounts({}, () => {
+				throw new Error("no passwd entry");
+			}),
+		).toEqual(["claude-code-user", "unknown"]);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/profiles.ts
+++ b/packages/host-service/src/trpc/router/usage/profiles.ts
@@ -12,13 +12,14 @@
  * - Credentials come from the dir's `.credentials.json` or its per-profile
  *   Keychain item: Claude Code hashes the literal CLAUDE_CONFIG_DIR string,
  *   so the service is `Claude Code-credentials-<sha256(literal)[0..8)>` and
- *   several path spellings must be probed (`~/x` vs absolute differ).
+ *   several path spellings must be probed (`~/x` vs absolute differ). Items
+ *   are keyed on the login user's account too — see readKeychainSecrets.
  */
 
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
-import { homedir, platform } from "node:os";
+import { homedir, platform, userInfo } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { resolveAmbientCodexHome } from "@superset/agent-setup";
@@ -141,21 +142,67 @@ export async function discoverClaudeProfiles(): Promise<ClaudeProfile[]> {
 	return profiles;
 }
 
-/** Reads one keychain service's secret; null when absent or non-darwin. */
-export async function readKeychainSecret(
-	service: string,
-): Promise<string | null> {
-	if (platform() !== "darwin") return null;
+const KEYCHAIN_ACCOUNT_PATTERN = /^[a-zA-Z0-9._-]+$/;
+const KEYCHAIN_ACCOUNT_FALLBACK = "claude-code-user";
+/** What Bun's os.userInfo() reports as the user name when USER is unset. */
+const BUN_USERINFO_FALLBACK = "unknown";
+
+/**
+ * The `-a` accounts Claude Code may file its Keychain items under, likeliest
+ * first. The CLI uses `$USER`, else `os.userInfo().username`, and swaps a
+ * name outside its pattern for a fixed fallback. Its native build runs on
+ * Bun, whose userInfo() reports "unknown" instead of the passwd name, so a
+ * CLI launched without USER (hand-built harness envs do this) keeps a
+ * separate "unknown" identity, while the npm build on Node uses the real
+ * name — without USER, both are probed.
+ */
+export function claudeKeychainAccounts(
+	env: NodeJS.ProcessEnv = process.env,
+	passwdName: () => string = () => userInfo().username,
+): string[] {
+	const validated = (name: string) =>
+		KEYCHAIN_ACCOUNT_PATTERN.test(name) ? name : KEYCHAIN_ACCOUNT_FALLBACK;
+	if (env.USER) return [validated(env.USER)];
+	let fromPasswd: string;
 	try {
-		const { stdout } = await execFileAsync(
-			"security",
-			["find-generic-password", "-s", service, "-w"],
-			{ timeout: 5_000 },
-		);
-		return stdout.trim() || null;
+		fromPasswd = validated(passwdName());
 	} catch {
-		return null;
+		fromPasswd = KEYCHAIN_ACCOUNT_FALLBACK;
 	}
+	return [...new Set([fromPasswd, BUN_USERINFO_FALLBACK])];
+}
+
+/**
+ * Every distinct secret filed under a Keychain service; empty off macOS.
+ * `security` returns one item per lookup, and a service can hold several:
+ * Claude Code keys each on an account name (see claudeKeychainAccounts),
+ * and a sibling identity — a CLI run without USER left an "unknown" item
+ * holding only MCP OAuth tokens — is what an unscoped lookup returns first,
+ * which made the real login vanish from the quota panel. The CLI's own
+ * accounts are probed first; the unscoped lookup then covers items an older
+ * client filed under a different name.
+ */
+export async function readKeychainSecrets(service: string): Promise<string[]> {
+	if (platform() !== "darwin") return [];
+	const secrets: string[] = [];
+	const scopes = [
+		...claudeKeychainAccounts().map((account) => ["-a", account]),
+		[],
+	];
+	for (const scope of scopes) {
+		try {
+			const { stdout } = await execFileAsync(
+				"security",
+				["find-generic-password", ...scope, "-s", service, "-w"],
+				{ timeout: 5_000 },
+			);
+			const secret = stdout.trim();
+			if (secret && !secrets.includes(secret)) secrets.push(secret);
+		} catch {
+			// No item under this scope.
+		}
+	}
+	return secrets;
 }
 
 interface CodexAuthShape {


### PR DESCRIPTION
## Summary
- The Usage tab showed no Claude row on a Mac whose Keychain holds a second `Claude Code-credentials` item under account `unknown`. The host now reads the item Claude Code itself uses (by account name) and keeps the freshest valid login among the items sharing the service.
- The quota panel hid the Claude Code and Codex sections entirely when the host found no login, taking the "No logins" empty state and the Add account button with them (regression from #6987). They now stay visible; Grok and Antigravity still appear only once a login exists.

## Why / Context
Claude Code keys its Keychain item on `$USER`, else `os.userInfo().username`. Its native build runs on Bun, and Bun's `userInfo()` reports the literal `unknown` whenever USER is unset (Node returns the passwd name), so any Claude Code launched without USER keeps a separate `unknown` identity in the Keychain. `security find-generic-password -s <service> -w` without `-a` returns whichever item comes first; on the affected machine that was the `unknown` item, which holds only MCP OAuth tokens, so `parseCredential` found no login and Claude was dropped from the quota list. With zero Claude accounts the panel then hid the section, so there was no Add account button either.

## How It Works
- `profiles.ts`: `claudeKeychainAccounts()` mirrors the CLI's derivation (`$USER`, else the passwd name; names outside the CLI's pattern collapse to `claude-code-user`) and, without USER, also yields `unknown` for the Bun case. `readKeychainSecrets(service)` probes those accounts with `-a`, then the unscoped lookup, and returns every distinct secret.
- `claude.ts`: the default login parses all returned secrets and keeps the freshest live credential via the existing `pickFreshest` rule; per-profile lookups do the same per service spelling.
- `visibleQuotaAgents`: managed agents (Claude Code, Codex) always render a section; Grok and Antigravity render once they have a login, since they have no add flow.

## Manual QA Checklist
- [x] Ran the patched `fetchClaudeAccounts()` with bun against the affected Mac's real Keychain (two items under the service, the `unknown` one first): returns the Claude Max login with status ok, three quota windows, and extra-usage spend. Before the change it returned nothing.
- [x] Reading each Keychain item directly confirmed the diagnosis: the unscoped lookup yields `{"mcpOAuth": …}` only; `-a $USER` yields the login.
- [ ] Renderer change not exercised in the running app (the affected machine runs a dev build from another worktree). Covered by unit tests; the rendering path is otherwise unchanged.

## Testing
- `bun run typecheck` (host-service and desktop)
- `bun run lint`
- `bun test src/trpc/router/usage` in `packages/host-service` (89 pass, including the new `profiles.test.ts`)
- `bun test visibleQuotaAgents` in `apps/desktop`

## Design Decisions
- **Probe by account rather than enumerate the Keychain**: `security dump-keychain` would list every item's account but dumps the whole keychain on each poll; probing the two or three names the CLI can actually use plus the unscoped fallback costs one extra `security` call and stays exact.
- **Keep Grok and Antigravity hidden when empty**: they have no add or switch flow, so an empty section would be a dead end. The managed agents get the section because that is where Add account lives.

## Known Limitations
- `removeClaudeProfile` still deletes scoped items by service only (first match). Per-profile services are hashed per config dir, so a second item there is unlikely, but the same shadowing could in principle apply.
- The stray `unknown` item itself is left in place. It is harmless to Superset now, but tools that read by service only will still hit it.

## Follow-ups
- The `unknown` identity is a Claude Code on Bun quirk (`os.userInfo().username` depends on USER). Worth reporting upstream; any agent Superset launched without USER would read that identity and appear signed out.

https://claude.ai/code/session_01D2sUAjSaSU9PBaiZzKRP59

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude usage detection on macOS when multiple `Claude Code-credentials` Keychain items exist. Previously, an unscoped lookup could select an MCP-only item and hide Claude; now the host selects the freshest valid login by account, while Claude Code and Codex sections keep Add account reachable without logins and Grok and Antigravity stay hidden until signed in.

**Bug Fixes**

- Applies the lookup to both default and per-profile logins, including Bun’s `unknown` account fallback.
- Adds coverage for account fallback and quota section visibility, including logged-in Grok and display ordering.

<sup>Written for commit e9f3ec647b40e84c6ceb97700f41fad152f08788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Usage settings now display managed agents consistently and include additional agents when an account login is detected.

- **Bug Fixes**
  - Improved Claude credential detection across account-specific and default Keychain entries.
  - The most recent usable Claude credential is now selected when multiple credentials are available.
  - Added fallback handling for environments with missing or unusable system usernames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->