### PR TITLE
fix(host-service): attribute PR merges to GitHub's merged_at

### DIFF
--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -146,8 +146,9 @@ export const pullRequests = sqliteTable(
 		reviewDecision: text("review_decision"),
 		checksStatus: text("checks_status").notNull().default("none"),
 		checksJson: text("checks_json").notNull().default("[]"),
-		// Set when the PR is first observed merged; never cleared. Anchors
-		// "merged in the last N days" windows on the workspaces board.
+		// GitHub's own merge time once a fetch has carried one, otherwise the
+		// time the merge was first observed; never cleared. Anchors "merged in
+		// the last N days" windows on the workspaces board.
 		mergedAt: integer("merged_at"),
 		lastFetchedAt: integer("last_fetched_at"),
 		error: text(),

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -86,10 +86,12 @@ function seedPullRequest(
 		reviewDecision?: string | null;
 		checksStatus?: string;
 		checksJson?: string;
+		mergedAt?: number | null;
 	},
 ) {
 	db.insert(schema.pullRequests)
 		.values({
+			mergedAt: pr.mergedAt ?? null,
 			id: pr.id,
 			projectId: PROJECT_ID,
 			repoProvider: "github",
@@ -187,14 +189,16 @@ function makePrNode(pr: {
 	headOwner?: string;
 	headRepo?: string;
 	title?: string;
+	state?: "open" | "closed";
+	mergedAt?: string | null;
 }) {
 	return {
 		number: pr.number,
 		title: pr.title ?? `PR ${pr.number}`,
 		html_url: `https://github.com/${REPO.owner}/${REPO.name}/pull/${pr.number}`,
-		state: "open",
+		state: pr.state ?? "open",
 		draft: false,
-		merged_at: null,
+		merged_at: pr.mergedAt ?? null,
 		updated_at: "2026-05-08T12:00:00Z",
 		head: {
 			ref: pr.headRef,
@@ -334,6 +338,273 @@ describe("PullRequestRuntimeManager direct checkout PR linking", () => {
 		await manager.refreshPullRequestsByWorkspaces(["ws"]);
 
 		expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
+	});
+});
+
+describe("PullRequestRuntimeManager mergedAt attribution", () => {
+	const MERGED_AT_ISO = "2026-05-01T10:00:00Z";
+	const MERGED_AT = Date.parse(MERGED_AT_ISO);
+	// First observed three days after the merge.
+	const OBSERVED_AT = Date.parse("2026-05-04T09:00:00Z");
+
+	function mergedPrExecGh(mergedAt: string | null, state: "open" | "closed") {
+		return async (args: string[]) => {
+			const path = args.find((arg) => arg.startsWith("repos/"));
+			if (path === `repos/${REPO.owner}/${REPO.name}/pulls`) {
+				return [
+					makePrNode({
+						number: 42,
+						headRef: "fix/sidebar",
+						headSha: "abc123",
+						state,
+						mergedAt,
+					}),
+				];
+			}
+			if (path?.endsWith("/reviews")) return [];
+			if (path?.endsWith("/check-runs")) return { check_runs: [] };
+			if (path?.endsWith("/statuses")) return [];
+			throw new Error(`unexpected gh call: ${args.join(" ")}`);
+		};
+	}
+
+	function seedLinkedWorkspace(db: HostDb, pullRequestId: string | null) {
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "fix/sidebar",
+			headSha: "abc123",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "fix/sidebar",
+			pullRequestId,
+		});
+	}
+
+	test("attributes a merge first observed on D+3 to GitHub's merged_at on day D", async () => {
+		setSystemTime(new Date(OBSERVED_AT));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			seedLinkedWorkspace(db, null);
+			const manager = createManager(db, {
+				execGh: mergedPrExecGh(MERGED_AT_ISO, "closed"),
+			});
+
+			await manager.refreshPullRequestsByWorkspaces(["ws"]);
+
+			const pr = getPrByNumber(db, 42);
+			expect(pr?.state).toBe("merged");
+			expect(pr?.mergedAt).toBe(MERGED_AT);
+			expect(new Date(pr?.mergedAt ?? 0).toISOString().slice(0, 10)).toBe(
+				"2026-05-01",
+			);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("uses merged_at when an existing open row transitions to merged", async () => {
+		setSystemTime(new Date(OBSERVED_AT));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			seedPullRequest(db, {
+				id: "pr-existing",
+				prNumber: 42,
+				headBranch: "fix/sidebar",
+				headSha: "abc123",
+				state: "open",
+			});
+			seedLinkedWorkspace(db, "pr-existing");
+			const manager = createManager(db, {
+				execGh: mergedPrExecGh(MERGED_AT_ISO, "closed"),
+			});
+
+			await manager.refreshPullRequestsByWorkspaces(["ws"]);
+
+			const pr = getPrById(db, "pr-existing");
+			expect(pr?.state).toBe("merged");
+			expect(pr?.mergedAt).toBe(MERGED_AT);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	// A row stamped at observation time before this fix heals when that PR
+	// head is fetched again, so GitHub's merged_at wins over what is stored.
+	test("repairs a stamped observation time with GitHub's merged_at", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
+			id: "pr-existing",
+			prNumber: 42,
+			headBranch: "fix/sidebar",
+			headSha: "abc123",
+			state: "merged",
+			mergedAt: OBSERVED_AT,
+		});
+		seedLinkedWorkspace(db, "pr-existing");
+		const manager = createManager(db, {
+			execGh: mergedPrExecGh(MERGED_AT_ISO, "closed"),
+		});
+
+		await manager.refreshPullRequestsByWorkspaces(["ws"]);
+
+		expect(getPrById(db, "pr-existing")?.mergedAt).toBe(MERGED_AT);
+	});
+
+	// The stored value is only a fallback: it survives when the source has no
+	// usable timestamp of its own.
+	test("keeps an existing mergedAt when the fetched merged_at is unparseable", async () => {
+		const STORED = Date.parse("2026-04-20T08:00:00Z");
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
+			id: "pr-existing",
+			prNumber: 42,
+			headBranch: "fix/sidebar",
+			headSha: "abc123",
+			state: "merged",
+			mergedAt: STORED,
+		});
+		seedLinkedWorkspace(db, "pr-existing");
+		const manager = createManager(db, {
+			execGh: mergedPrExecGh("not-a-date", "closed"),
+		});
+
+		await manager.refreshPullRequestsByWorkspaces(["ws"]);
+
+		const pr = getPrById(db, "pr-existing");
+		expect(pr?.state).toBe("merged");
+		expect(pr?.mergedAt).toBe(STORED);
+	});
+
+	test("leaves mergedAt null for a PR that is not merged", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedLinkedWorkspace(db, null);
+		const manager = createManager(db, {
+			execGh: mergedPrExecGh(null, "closed"),
+		});
+
+		await manager.refreshPullRequestsByWorkspaces(["ws"]);
+
+		const pr = getPrByNumber(db, 42);
+		expect(pr?.state).toBe("closed");
+		expect(pr?.mergedAt).toBeNull();
+	});
+
+	// GitHub says merged but the timestamp is unusable: keep the merged row
+	// visible to "merged in the last N days" windows by stamping observation
+	// time, the pre-existing contract for rows without a source timestamp.
+	test("falls back to observation time when merged_at is unparseable", async () => {
+		setSystemTime(new Date(OBSERVED_AT));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			seedLinkedWorkspace(db, null);
+			const manager = createManager(db, {
+				execGh: mergedPrExecGh("not-a-date", "closed"),
+			});
+
+			await manager.refreshPullRequestsByWorkspaces(["ws"]);
+
+			const pr = getPrByNumber(db, 42);
+			expect(pr?.state).toBe("merged");
+			expect(pr?.mergedAt).toBe(OBSERVED_AT);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("checkout link uses the caller's mergedAt when present", async () => {
+		setSystemTime(new Date(OBSERVED_AT));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			seedWorkspace(db, { id: "ws", branch: "pr/42" });
+			const manager = createManager(db);
+
+			const prId = await manager.linkWorkspaceToCheckoutPullRequest({
+				workspaceId: "ws",
+				projectId: PROJECT_ID,
+				pullRequest: {
+					number: 42,
+					url: "https://github.com/base-owner/base-repo/pull/42",
+					title: "Merged earlier",
+					state: "merged",
+					mergedAt: MERGED_AT_ISO,
+					headRefName: "fix/sidebar",
+					headRefOid: "abc123",
+					isCrossRepository: false,
+				},
+			});
+
+			expect(getPrById(db, prId ?? "")?.mergedAt).toBe(MERGED_AT);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("checkout link without a source timestamp stamps observation time", async () => {
+		setSystemTime(new Date(OBSERVED_AT));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			seedWorkspace(db, { id: "ws", branch: "pr/42" });
+			const manager = createManager(db);
+
+			const prId = await manager.linkWorkspaceToCheckoutPullRequest({
+				workspaceId: "ws",
+				projectId: PROJECT_ID,
+				pullRequest: {
+					number: 42,
+					url: "https://github.com/base-owner/base-repo/pull/42",
+					title: "Merged, no timestamp",
+					state: "merged",
+					headRefName: "fix/sidebar",
+					headRefOid: "abc123",
+					isCrossRepository: false,
+				},
+			});
+
+			expect(getPrById(db, prId ?? "")?.mergedAt).toBe(OBSERVED_AT);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("checkout link without a source timestamp keeps the existing mergedAt", async () => {
+		const STORED = Date.parse("2026-04-20T08:00:00Z");
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
+			id: "pr-existing",
+			prNumber: 42,
+			headBranch: "fix/sidebar",
+			headSha: "abc123",
+			state: "merged",
+			mergedAt: STORED,
+		});
+		seedWorkspace(db, { id: "ws", branch: "pr/42" });
+		const manager = createManager(db);
+
+		const prId = await manager.linkWorkspaceToCheckoutPullRequest({
+			workspaceId: "ws",
+			projectId: PROJECT_ID,
+			pullRequest: {
+				number: 42,
+				url: "https://github.com/base-owner/base-repo/pull/42",
+				title: "Merged, no timestamp",
+				state: "merged",
+				headRefName: "fix/sidebar",
+				headRefOid: "abc123",
+				isCrossRepository: false,
+			},
+		});
+
+		expect(prId).toBe("pr-existing");
+		expect(getPrById(db, "pr-existing")?.mergedAt).toBe(STORED);
 	});
 });
 

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -25,6 +25,7 @@ import {
 	fetchPullRequestMergeQueueStateFromGh,
 	fetchPullRequestReviewDecision,
 	fetchPullRequestReviewDecisionFromGh,
+	parseMergedAt,
 } from "./utils/github-query";
 import type {
 	GitHubPullRequestHeadRef,
@@ -94,7 +95,7 @@ export interface PullRequestStateSnapshot {
 	reviewDecision: ReviewDecision;
 	checksStatus: ChecksStatus;
 	checks: PullRequestCheck[];
-	/** First observed merged, epoch ms. Never cleared once set. */
+	/** GitHub merge time when available, observation time only as fallback; epoch ms. Never cleared once set. */
 	mergedAt: number | null;
 }
 
@@ -116,7 +117,7 @@ export interface WorkspacePullRequestHistoryEntry {
 	headBranch: string;
 	reviewDecision: ReviewDecision;
 	checksStatus: ChecksStatus;
-	/** First observed merged, epoch ms. Never cleared once set. */
+	/** GitHub merge time when available, observation time only as fallback; epoch ms. Never cleared once set. */
 	mergedAt: number | null;
 	/** Row refresh time, epoch ms — ordering, not GitHub's own clock. */
 	updatedAt: number;
@@ -163,6 +164,8 @@ export interface CheckoutPullRequestMetadata {
 	title: string;
 	state: "open" | "closed" | "merged";
 	isDraft?: boolean;
+	/** GitHub's `merged_at` (ISO 8601) when the caller has it. */
+	mergedAt?: string | null;
 	headRefName: string;
 	headRefOid: string;
 	headRepositoryOwner?: string | null;
@@ -522,6 +525,7 @@ export class PullRequestRuntimeManager {
 			isDraft,
 			headBranch: pullRequest.headRefName,
 			headSha: pullRequest.headRefOid,
+			mergedAt: parseMergedAt(pullRequest.mergedAt ?? null),
 			reviewDecision: coerceReviewDecision(existing?.reviewDecision ?? null),
 			checksStatus: coerceChecksStatus(existing?.checksStatus ?? null),
 			checksJson: JSON.stringify(existingChecks),
@@ -1039,6 +1043,7 @@ export class PullRequestRuntimeManager {
 		isDraft,
 		headBranch,
 		headSha,
+		mergedAt,
 		reviewDecision,
 		checksStatus,
 		checksJson,
@@ -1056,6 +1061,8 @@ export class PullRequestRuntimeManager {
 		isDraft: boolean;
 		headBranch: string;
 		headSha: string;
+		/** GitHub's merged_at as epoch ms; null when the source has none. */
+		mergedAt: number | null;
 		reviewDecision: ReviewDecision;
 		checksStatus: ChecksStatus;
 		checksJson: string;
@@ -1079,9 +1086,16 @@ export class PullRequestRuntimeManager {
 			reviewDecision,
 			checksStatus,
 			checksJson,
-			// Stamped at first merged observation (GitHub's node payload has no
-			// merge timestamp on this path); sticky thereafter.
-			mergedAt: existing?.mergedAt ?? (state === "merged" ? now : null),
+			// GitHub's merged_at wins, so a PR merged on day D but first seen on
+			// D+3 is attributed to D. A row stamped at observation time heals
+			// when that PR head is fetched again; fetches cover heads of
+			// unarchived active workspaces, so other rows keep what they have.
+			// The stored value is the fallback for a source with no usable
+			// timestamp; a merged row with neither takes the observation time,
+			// keeping every merged row visible to "merged in the last N days"
+			// windows.
+			mergedAt:
+				mergedAt ?? existing?.mergedAt ?? (state === "merged" ? now : null),
 			lastFetchedAt,
 			error,
 			updatedAt: now,
@@ -1441,6 +1455,7 @@ export class PullRequestRuntimeManager {
 				isDraft: node.isDraft,
 				headBranch: node.headRefName,
 				headSha: node.headRefOid,
+				mergedAt: node.mergedAt,
 				reviewDecision,
 				checksStatus: computeChecksStatus(checks),
 				checksJson: JSON.stringify(checks),

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -70,6 +70,7 @@ describe("GitHub pull request REST queries", () => {
 			headRepositoryOwner: { login: "superset-sh" },
 			headRepository: { name: "superset" },
 			updatedAt: "2026-05-08T12:00:00Z",
+			mergedAt: null,
 		});
 		expect(calls).toEqual([
 			{
@@ -91,6 +92,78 @@ describe("GitHub pull request REST queries", () => {
 				],
 			},
 		]);
+	});
+
+	// GitHub's merged_at is the authoritative merge time; the runtime persists
+	// it instead of stamping the sweep that first noticed the merge.
+	test("carries GitHub's merged_at as epoch ms on merged PRs", async () => {
+		const { execGh } = createExecGh([
+			[
+				{
+					number: 42,
+					title: "Merged earlier",
+					html_url: "https://github.com/superset-sh/superset/pull/42",
+					state: "closed",
+					draft: false,
+					merged_at: "2026-05-01T10:00:00Z",
+					updated_at: "2026-05-01T10:00:00Z",
+					head: {
+						ref: "fix/sidebar",
+						sha: "abc123",
+						repo: {
+							name: "superset",
+							owner: { login: "superset-sh" },
+						},
+					},
+					base: { repo: { full_name: "superset-sh/superset" } },
+				},
+			],
+		]);
+
+		const result = await fetchPullRequestByHeadFromGh(
+			execGh,
+			{ owner: "superset-sh", name: "superset" },
+			{ owner: "superset-sh", repo: "superset", branch: "fix/sidebar" },
+		);
+
+		expect(result?.state).toBe("MERGED");
+		expect(result?.mergedAt).toBe(Date.parse("2026-05-01T10:00:00Z"));
+	});
+
+	// GitHub reports merged via a non-null merged_at, so an unparseable value
+	// still means merged; only the timestamp is unknown.
+	test("drops an unparseable merged_at but keeps the merged state", async () => {
+		const { execGh } = createExecGh([
+			[
+				{
+					number: 42,
+					title: "Merged, bad clock",
+					html_url: "https://github.com/superset-sh/superset/pull/42",
+					state: "closed",
+					draft: false,
+					merged_at: "not-a-date",
+					updated_at: "2026-05-01T10:00:00Z",
+					head: {
+						ref: "fix/sidebar",
+						sha: "abc123",
+						repo: {
+							name: "superset",
+							owner: { login: "superset-sh" },
+						},
+					},
+					base: { repo: { full_name: "superset-sh/superset" } },
+				},
+			],
+		]);
+
+		const result = await fetchPullRequestByHeadFromGh(
+			execGh,
+			{ owner: "superset-sh", name: "superset" },
+			{ owner: "superset-sh", repo: "superset", branch: "fix/sidebar" },
+		);
+
+		expect(result?.state).toBe("MERGED");
+		expect(result?.mergedAt).toBeNull();
 	});
 
 	test("filters REST head candidates by exact upstream repository", async () => {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.test.ts
@@ -5,6 +5,7 @@ import {
 	fetchPullRequestChecksFromGh,
 	fetchPullRequestMergeQueueStateFromGh,
 	fetchPullRequestReviewDecisionFromGh,
+	parseMergedAt,
 } from "./github-query";
 
 interface GhCall {
@@ -515,5 +516,49 @@ describe("GitHub pull request REST queries", () => {
 		);
 
 		expect(result).toBe(false);
+	});
+});
+
+// Date.parse accepts far more than GitHub ever sends, and quietly turns the
+// excess into a merge time: a zone-less value is read as local time, so the
+// same payload lands on a different instant per host, and an impossible
+// calendar date rolls forward into a real one. Both would be stored as if
+// GitHub had reported them.
+describe("parseMergedAt", () => {
+	test("accepts the ISO 8601 UTC timestamps GitHub sends", () => {
+		expect(parseMergedAt("2026-05-01T10:00:00Z")).toBe(
+			Date.parse("2026-05-01T10:00:00Z"),
+		);
+		expect(parseMergedAt("2026-05-01T10:00:00.123Z")).toBe(
+			Date.parse("2026-05-01T10:00:00.123Z"),
+		);
+		// A real leap day stays a real leap day.
+		expect(parseMergedAt("2028-02-29T10:00:00Z")).toBe(
+			Date.parse("2028-02-29T10:00:00Z"),
+		);
+	});
+
+	test("rejects a calendar date that does not exist", () => {
+		// Date.parse rolls February 31st forward to March 3rd.
+		expect(Date.parse("2026-02-31T10:00:00Z")).not.toBeNaN();
+		expect(parseMergedAt("2026-02-31T10:00:00Z")).toBeNull();
+		expect(parseMergedAt("2026-04-31T00:00:00Z")).toBeNull();
+		expect(parseMergedAt("2026-02-29T10:00:00Z")).toBeNull();
+	});
+
+	test("rejects timestamps outside GitHub's format", () => {
+		// No zone marker: the instant would depend on the host's timezone.
+		expect(parseMergedAt("2026-05-01T10:00:00")).toBeNull();
+		expect(parseMergedAt("2026-05-01 10:00:00")).toBeNull();
+		expect(parseMergedAt("2026-05-01")).toBeNull();
+		expect(parseMergedAt("2026")).toBeNull();
+		expect(parseMergedAt("May 1, 2026")).toBeNull();
+		expect(parseMergedAt("Fri, 01 May 2026 10:00:00 GMT")).toBeNull();
+		expect(parseMergedAt("not-a-date")).toBeNull();
+	});
+
+	test("reports no merge time for an absent merged_at", () => {
+		expect(parseMergedAt(null)).toBeNull();
+		expect(parseMergedAt("")).toBeNull();
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -54,6 +54,15 @@ function normalizePullRequestState(
 	return state.toLowerCase() === "closed" ? "CLOSED" : "OPEN";
 }
 
+// GitHub's merged_at is the authoritative merge time. A non-null value means
+// merged even when it fails to parse; the state keeps that meaning and only
+// the timestamp is dropped.
+export function parseMergedAt(mergedAt: string | null): number | null {
+	if (!mergedAt) return null;
+	const parsed = Date.parse(mergedAt);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
 function normalizePullRequest(raw: unknown): GitHubPullRequestNode | null {
 	if (!isRecord(raw) || !isRecord(raw.head)) return null;
 	const headRepo = isRecord(raw.head.repo) ? raw.head.repo : null;
@@ -85,15 +94,13 @@ function normalizePullRequest(raw: unknown): GitHubPullRequestNode | null {
 	const headFullName = repoName
 		? `${ownerLogin}/${repoName}`.toLowerCase()
 		: null;
+	const mergedAt = typeof raw.merged_at === "string" ? raw.merged_at : null;
 
 	return {
 		number: raw.number,
 		title: raw.title,
 		url: raw.html_url,
-		state: normalizePullRequestState(
-			raw.state,
-			typeof raw.merged_at === "string" ? raw.merged_at : null,
-		),
+		state: normalizePullRequestState(raw.state, mergedAt),
 		isDraft: raw.draft === true,
 		headRefName: raw.head.ref,
 		headRefOid: raw.head.sha,
@@ -105,6 +112,7 @@ function normalizePullRequest(raw: unknown): GitHubPullRequestNode | null {
 			typeof raw.updated_at === "string"
 				? raw.updated_at
 				: new Date(0).toISOString(),
+		mergedAt: parseMergedAt(mergedAt),
 	};
 }
 

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/github-query.ts
@@ -54,13 +54,27 @@ function normalizePullRequestState(
 	return state.toLowerCase() === "closed" ? "CLOSED" : "OPEN";
 }
 
+// GitHub stamps merged_at as ISO 8601 UTC (`2026-05-01T10:00:00Z`), optionally
+// with fractional seconds.
+const MERGED_AT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
 // GitHub's merged_at is the authoritative merge time. A non-null value means
 // merged even when it fails to parse; the state keeps that meaning and only
 // the timestamp is dropped.
+//
+// Date.parse alone is far looser than the format above and silently invents a
+// merge time from a value GitHub never sent: it reads a missing zone marker as
+// local time, so the same payload lands on a different instant per host, and it
+// rolls impossible calendar dates forward, so `2026-02-31T10:00:00Z` would be
+// stored as March 3. Pin the format, then require the parse to render back to
+// the value we were given, which only a real calendar date does.
 export function parseMergedAt(mergedAt: string | null): number | null {
-	if (!mergedAt) return null;
+	if (!mergedAt || !MERGED_AT.test(mergedAt)) return null;
 	const parsed = Date.parse(mergedAt);
-	return Number.isNaN(parsed) ? null : parsed;
+	if (Number.isNaN(parsed)) return null;
+	return new Date(parsed).toISOString().startsWith(mergedAt.slice(0, 19))
+		? parsed
+		: null;
 }
 
 function normalizePullRequest(raw: unknown): GitHubPullRequestNode | null {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/index.ts
@@ -9,6 +9,7 @@ export {
 	fetchPullRequestMergeQueueStateFromGh,
 	fetchPullRequestReviewDecision,
 	fetchPullRequestReviewDecisionFromGh,
+	parseMergedAt,
 } from "./github-query";
 export type {
 	GitHubCheckContextNode,

--- a/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-query/types.ts
@@ -38,6 +38,8 @@ export interface GitHubPullRequestNode {
 	headRepositoryOwner: { login: string } | null;
 	headRepository: { name: string } | null;
 	updatedAt: string;
+	/** GitHub's `merged_at` parsed to epoch ms; null when absent or unparseable. */
+	mergedAt: number | null;
 }
 
 export type GitHubPullRequestReviewDecision =


### PR DESCRIPTION
## What & why

GitHub returns `merged_at` for merged pull requests, but the host service discarded it and stored the time Superset first observed the merge. A pull request merged on May 1 but first fetched on May 4 was therefore attributed to May 4.

This change:

- parses `merged_at` at the GitHub response boundary;
- carries it through all four pull-request fetch paths;
- stores a valid GitHub timestamp first, an existing timestamp second, and observation time only as a fallback.

New rows now use GitHub's merge time. Existing rows are corrected when that pull request is fetched again. Missing or invalid source values do not overwrite stored data.

This does not add a historical crawl or migration. The lifecycle plan in #6019 owns durable history and backfill.

## How I tested it

- Before the fix: 50 tests passed and 7 failed; the regression stored May 4 instead of GitHub's May 1 timestamp.
- Focused pull-request tests: 57 passed.
- Full host-service suite: 1,483 passed, 8 todo, 0 failed.
- Host-service typecheck and Biome checks passed.
- Fork CI passed Build, Test, Typecheck, Lint, Sherif, Version Sync, Vale, and all four CLI builds.

## Checklist

- [x] PR title follows conventional commits
- [x] Lint and typecheck pass
- [x] Allow edits from maintainers is enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pull request merge attribution so merged PRs are dated by GitHub's `merged_at` instead of when Superset first observed the merge.

- Stores GitHub's merge time first, an existing stored timestamp second, and observation time only as a fallback.
- Validates `merged_at` against GitHub's ISO 8601 UTC format so zone-less or impossible dates are rejected instead of silently stored.
- Repairs previously mis-stamped rows on their next fetch; a missing or unparseable source value never overwrites stored data.
- Existing rows without a source timestamp keep observation time so all merged PRs stay visible to "merged in the last N days" windows.

<sup>Written for commit 7f1404637fd70c1a259fb58605adf131ed1bd973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request merge-time tracking by prioritizing GitHub’s recorded merge timestamp.
  * Added a fallback timestamp when GitHub’s merge time is unavailable or invalid.
  * Preserved merged status even when the reported merge timestamp cannot be parsed.
  * Improved checkout-link metadata to include accurate merge timing when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->