### PR TITLE
fix(api): stop the automation sweep and retention jobs from stacking

### DIFF
--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -9,6 +9,7 @@ import { Client } from "@upstash/qstash";
 import { and, eq, lte } from "drizzle-orm";
 import { env } from "@/env";
 import { redispatchUndispatched } from "@/lib/automations/redispatchUndispatched";
+import { singleFlight } from "@/lib/singleFlight";
 import { verifyQstashRequest } from "@/lib/verifyQstash";
 
 export const dynamic = "force-dynamic";
@@ -37,6 +38,17 @@ function scheduleFromConfig(
 	const dtstart = new Date(config.dtstart);
 	if (Number.isNaN(dtstart.getTime())) return null;
 	return { rrule: config.rrule, dtstart, timezone: config.timezone };
+}
+
+/**
+ * One sweep at a time. Ticks arrive every minute whether or not the previous
+ * sweep finished, and a sweep that is still going is not worth joining.
+ */
+async function sweepUndispatched() {
+	const sweep = await singleFlight("automations.redispatch", () =>
+		redispatchUndispatched(),
+	);
+	return sweep.ran ? sweep.result : { skipped: true };
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -118,7 +130,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	if (planned.length === 0) {
 		// The event-handoff sweep still runs on a tick with no due schedules.
-		const redispatched = await redispatchUndispatched();
+		const redispatched = await sweepUndispatched();
 		return Response.json({
 			enqueued: 0,
 			unusable: unusable.length,
@@ -173,7 +185,7 @@ export async function POST(request: Request): Promise<Response> {
 	}
 
 	// The same tick retries event handoffs that never reached QStash.
-	const redispatched = await redispatchUndispatched();
+	const redispatched = await sweepUndispatched();
 
 	return Response.json({
 		enqueued: planned.length,

--- a/apps/api/src/app/api/automations/jobs/prune-payloads/route.ts
+++ b/apps/api/src/app/api/automations/jobs/prune-payloads/route.ts
@@ -1,9 +1,15 @@
-import { dbWs } from "@superset/db/client";
 import { sql } from "drizzle-orm";
 
+import { singleFlight } from "@/lib/singleFlight";
 import { verifyQstashRequest } from "@/lib/verifyQstash";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Matches enforce-retention. A batch measured 224 s in production, so on the
+ * platform default this route was killed before its first batch returned.
+ */
+export const maxDuration = 300;
 
 /**
  * Matches ingest.webhook_events. These are the same provider bodies, kept a
@@ -62,8 +68,10 @@ export async function POST(request: Request): Promise<Response> {
 	// scan re-skips everything it already cleared on every batch.
 	let cursor: string | null = null;
 
+	let skipped = false;
 	while (Date.now() - startedAt < TIME_BUDGET_MS && pruned < MAX_ROWS_PER_RUN) {
-		const result = await dbWs.execute(sql`
+		const attempt = await singleFlight("automations.prune-payloads", (tx) =>
+			tx.execute(sql`
 			WITH batch AS (
 				SELECT id, received_at
 				FROM automation_events
@@ -89,9 +97,14 @@ export async function POST(request: Request): Promise<Response> {
 			WHERE e.id = batch.id
 			  AND e.payload IS NOT NULL
 			RETURNING batch.received_at
-		`);
+		`),
+		);
+		if (!attempt.ran) {
+			skipped = true;
+			break;
+		}
 
-		const returned = result.rows as Array<{ received_at: string }>;
+		const returned = attempt.result.rows as Array<{ received_at: string }>;
 		pruned += returned.length;
 		batches++;
 		if (returned.length < BATCH_SIZE) break;
@@ -102,8 +115,12 @@ export async function POST(request: Request): Promise<Response> {
 	return Response.json({
 		pruned,
 		batches,
+		// Another run held the lock; its batches count for this tick.
+		skipped,
 		// Whether the run stopped on a limit rather than running out of work.
 		more:
-			pruned >= MAX_ROWS_PER_RUN || Date.now() - startedAt >= TIME_BUDGET_MS,
+			skipped ||
+			pruned >= MAX_ROWS_PER_RUN ||
+			Date.now() - startedAt >= TIME_BUDGET_MS,
 	});
 }

--- a/apps/api/src/app/api/ingest/jobs/enforce-retention/route.ts
+++ b/apps/api/src/app/api/ingest/jobs/enforce-retention/route.ts
@@ -1,6 +1,6 @@
-import { dbWs } from "@superset/db/client";
 import { type SQL, sql } from "drizzle-orm";
 
+import { singleFlight } from "@/lib/singleFlight";
 import { verifyQstashRequest } from "@/lib/verifyQstash";
 
 export const dynamic = "force-dynamic";
@@ -75,10 +75,13 @@ const TARGETS: RetentionTarget[] = [
 async function deleteAgedRows(
 	target: RetentionTarget,
 	deadline: number,
-): Promise<{ deleted: number; more: boolean }> {
+): Promise<{ deleted: number; more: boolean; skipped: boolean }> {
 	let deleted = 0;
 	while (Date.now() < deadline && deleted < MAX_ROWS_PER_TABLE) {
-		const result = await dbWs.execute(sql`
+		const attempt = await singleFlight(
+			`ingest.enforce-retention.${target.label}`,
+			(tx) =>
+				tx.execute(sql`
 			WITH batch AS (
 				SELECT ctid FROM ${target.relation}
 				WHERE ${target.receivedAt} < now() - ${`${RETAIN_DAYS} days`}::interval
@@ -89,12 +92,15 @@ async function deleteAgedRows(
 			DELETE FROM ${target.relation} t
 			USING batch WHERE t.ctid = batch.ctid
 			RETURNING 1
-		`);
-		const rows = result.rows.length;
+		`),
+		);
+		// Another run holds this table; its batches count for this tick.
+		if (!attempt.ran) return { deleted, more: true, skipped: true };
+		const rows = attempt.result.rows.length;
 		deleted += rows;
-		if (rows < BATCH_SIZE) return { deleted, more: false };
+		if (rows < BATCH_SIZE) return { deleted, more: false, skipped: false };
 	}
-	return { deleted, more: true };
+	return { deleted, more: true, skipped: false };
 }
 
 /**
@@ -129,7 +135,10 @@ export async function POST(request: Request): Promise<Response> {
 	// whole budget and leave the rest untouched. Moot at one target; not once a
 	// second joins, which is when it would be easy to miss.
 	const perTarget = Math.floor(TIME_BUDGET_MS / TARGETS.length);
-	const results: Record<string, { deleted: number; more: boolean }> = {};
+	const results: Record<
+		string,
+		{ deleted: number; more: boolean; skipped: boolean }
+	> = {};
 
 	for (const target of TARGETS) {
 		try {

--- a/apps/api/src/lib/automations/redispatchUndispatched.ts
+++ b/apps/api/src/lib/automations/redispatchUndispatched.ts
@@ -1,10 +1,24 @@
 import { dbWs } from "@superset/db/client";
 import { automationEvents } from "@superset/db/schema";
-import { and, asc, isNotNull, isNull, lt } from "drizzle-orm";
+import { and, asc, gt, isNotNull, isNull, lt } from "drizzle-orm";
 import { dispatchMatchingTriggers } from "./dispatchMatchingTriggers";
 
 /** Long enough that an in-flight delivery is not mistaken for a stuck one. */
 const GRACE_MS = 60_000;
+/**
+ * How far back the sweep looks. Two reasons it is bounded.
+ *
+ * Rows recorded before #6635 (2026-08-18) with nothing to dispatch were never
+ * marked, so about 1.2M of them sit at the left edge of the undispatched
+ * index forever. An unbounded sweep walks all of them, cold, on every tick
+ * before it reaches a row it can act on; in production that took four minutes
+ * a run and stacked two dozen runs deep. The bound turns the scan into a
+ * range that starts after them.
+ *
+ * It is also the retry ceiling. The sweep exists to retry a handoff that
+ * failed minutes ago; a run fired for a day-old event is worse than no run.
+ */
+const LOOKBACK_MS = 24 * 60 * 60 * 1000;
 const BATCH_SIZE = 200;
 
 /**
@@ -18,6 +32,7 @@ export async function redispatchUndispatched(): Promise<{
 	attempted: number;
 	failed: number;
 }> {
+	const now = Date.now();
 	const stuck = await dbWs
 		.select({
 			id: automationEvents.id,
@@ -29,7 +44,8 @@ export async function redispatchUndispatched(): Promise<{
 			and(
 				isNull(automationEvents.dispatchedAt),
 				isNotNull(automationEvents.dispatchInput),
-				lt(automationEvents.receivedAt, new Date(Date.now() - GRACE_MS)),
+				gt(automationEvents.receivedAt, new Date(now - LOOKBACK_MS)),
+				lt(automationEvents.receivedAt, new Date(now - GRACE_MS)),
 			),
 		)
 		.orderBy(asc(automationEvents.receivedAt))

--- a/apps/api/src/lib/singleFlight.ts
+++ b/apps/api/src/lib/singleFlight.ts
@@ -18,6 +18,13 @@ export type SingleFlightResult<T> = { ran: true; result: T } | { ran: false };
  * releases it as soon as Postgres rolls that transaction back. Batch work
  * should run on the transaction handed to `fn`, which keeps the lock and the
  * statement on one connection.
+ *
+ * Batch jobs take the lock per batch rather than around their whole loop.
+ * That keeps every transaction one statement long, which is what their batch
+ * sizes were chosen for, and still bounds the job to one batch in flight: a
+ * second invocation that lands between two batches wins the next lock, and
+ * the first then sees `ran: false` on its own next attempt and exits. One
+ * runner either way, never two.
  */
 export async function singleFlight<T>(
 	job: string,

--- a/apps/api/src/lib/singleFlight.ts
+++ b/apps/api/src/lib/singleFlight.ts
@@ -20,8 +20,8 @@ export type SingleFlightResult<T> = { ran: true; result: T } | { ran: false };
  * statement on one connection.
  *
  * Batch jobs take the lock per batch rather than around their whole loop.
- * That keeps every transaction one statement long, which is what their batch
- * sizes were chosen for, and still bounds the job to one batch in flight: a
+ * That keeps each batch transaction short, which is what their batch sizes
+ * were chosen for, and still bounds the job to one batch in flight: a
  * second invocation that lands between two batches wins the next lock, and
  * the first then sees `ran: false` on its own next attempt and exits. One
  * runner either way, never two.

--- a/apps/api/src/lib/singleFlight.ts
+++ b/apps/api/src/lib/singleFlight.ts
@@ -1,0 +1,34 @@
+import { dbWs } from "@superset/db/client";
+import { sql } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+
+export type SingleFlightResult<T> = { ran: true; result: T } | { ran: false };
+
+/**
+ * Runs `fn` under a job-scoped advisory lock, or reports `ran: false` without
+ * running it when another invocation already holds the lock.
+ *
+ * QStash fires the periodic job routes on a fixed cadence with no regard for
+ * whether the previous tick finished, and each of these jobs costs more per
+ * batch than its cadence, so left alone they stack: on 2026-09-02 production
+ * had 24 copies of the redispatch sweep, 6 of the payload pruner and 4 of the
+ * retention job running at once, every one pinning a backend for minutes.
+ *
+ * The lock is transaction-scoped, so a function the platform kills mid-batch
+ * releases it as soon as Postgres rolls that transaction back. Batch work
+ * should run on the transaction handed to `fn`, which keeps the lock and the
+ * statement on one connection.
+ */
+export async function singleFlight<T>(
+	job: string,
+	// biome-ignore lint/suspicious/noExplicitAny: Transaction type varies by client (Neon, PostgresJs, etc)
+	fn: (tx: PgTransaction<any, any, any>) => Promise<T>,
+): Promise<SingleFlightResult<T>> {
+	return dbWs.transaction(async (tx) => {
+		const { rows } = await tx.execute<{ locked: boolean }>(
+			sql`SELECT pg_try_advisory_xact_lock(hashtextextended(${`job:${job}`}::text, 0)) AS locked`,
+		);
+		if (!rows[0]?.locked) return { ran: false };
+		return { ran: true, result: await fn(tx) };
+	});
+}

--- a/packages/agent-setup/src/disabled-agent-hooks.test.ts
+++ b/packages/agent-setup/src/disabled-agent-hooks.test.ts
@@ -39,6 +39,10 @@ describe("shared disabled-agent-hooks state", () => {
 	});
 
 	it("treats a missing or corrupt file as nothing disabled", () => {
+		// Remove at the path the reader resolves, not just under TEST_HOME: a
+		// sibling file's top-level hook can leave SUPERSET_HOME_DIR pointing
+		// elsewhere in CI, and the previous test's write then survives afterEach.
+		fs.rmSync(getAgentHooksStateFilePath(), { force: true });
 		expect(readSharedDisabledAgentIds()).toEqual([]);
 
 		fs.writeFileSync(getAgentHooksStateFilePath(), "{not json");


### PR DESCRIPTION
Production has been hitting Neon's connection limits (Sentry API-22, API-24, API-2B; the 2 Sept Sazabi alert). Sampled on 2 Sept: 24 copies of the `automation_events` redispatch sweep running at once at up to 8 minutes each, 6 of `prune-payloads`, 4 of `enforce-retention`, together pinning ~34 backends for minutes, so ingest bursts then trip `max_client_conn`.

Two causes, both nominal to fix:

- **The sweep walks 1.2M rows it can never act on.** `redispatchUndispatched` filters on `dispatch_input IS NOT NULL`, but `automation_events_undispatched_idx` only covers `dispatched_at IS NULL`. Rows recorded before #6635 with nothing to dispatch were never marked, so ~1.2M of them (planner estimate) sit at the index's left edge and every run walks them cold before reaching anything actionable. The sweep now looks back 24 hours, which turns the scan into a range that starts after them (EXPLAIN on production: index range scan, ~42k rows estimated) and doubles as a retry ceiling: a run fired for a day-old event is worse than no run.
- **The jobs stack.** The three QStash-scheduled routes fire on cadences shorter than one batch takes, so every tick joins the previous ones. `singleFlight` takes a job-scoped `pg_try_advisory_xact_lock` and skips the tick when another invocation already holds it. The lock is transaction-scoped, so a function the platform kills mid-batch releases it on rollback, and batches run on the lock's own transaction so they hold one connection rather than two.

Also gives `prune-payloads` the same `maxDuration = 300` as `enforce-retention`: a batch measured 224 s in production, so on the platform default the route was killed before its first batch returned.

Deliberately not an index change. Rebuilding the partial index on a 101 GB table needs a lock the ingest path cannot afford right now; the bound gets the same scan without it. Stuck rows older than 24 hours are abandoned by the sweep; production currently has no GitHub or Linear event triggers, so nothing user-visible depends on them.

Verified with `tsc --noEmit` and `bun test src` in apps/api; biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents scheduled automation redispatch, payload pruning, and retention jobs from stacking by making overlapping invocations skip, reducing Neon connection pressure. The redispatch sweep now retries only actionable events from the previous 24 hours after a one-minute grace period, so older stuck rows are abandoned.

- Transaction-scoped advisory locks protect each job batch, and cleanup responses report `skipped` and `more` when a later tick must continue.
- `prune-payloads` now has a 300-second limit, matching `enforce-retention`.
- The agent setup test removes state at the path the reader resolves, preventing leaked state from sibling test hooks.

<sup>Written for commit 07a47fb6f167761b855998fc835776056aeeb0ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping automation evaluations, payload pruning, and retention runs from processing the same work concurrently.
  * Improved handling and reporting when a scheduled maintenance run is skipped because another run is already in progress.
  * Extended the payload-pruning time limit to allow larger cleanup batches to complete.
  * Limited redispatch checks to recent events, reducing unnecessary processing of older records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Also carries a one-line hardening of `packages/agent-setup/src/disabled-agent-hooks.test.ts`, which failed 3 of 4 CI runs on this PR and passes locally: the "missing file" case now removes the state file at the path the reader resolves, since a sibling file's top-level hook can leave `SUPERSET_HOME_DIR` pointing elsewhere in CI and the previous test's write then survives `afterEach`.
