### PR TITLE
fix(desktop,mobile): stop polling cloud sandboxes; cloud rows get PR chips from the cloud table

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -1,4 +1,5 @@
 import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useKnownHosts } from "renderer/hooks/known-hosts/useKnownHosts";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
@@ -109,6 +110,21 @@ export function useHostWorkspacesSource(
 	} = useKnownHosts();
 	const { targets: sandboxes, isReady: sandboxesReady } = useSandboxAccess();
 
+	// Only the open workspace's sandbox is a host here. The provider suspends a
+	// sandbox after a few seconds without an inbound request and counts this
+	// hook's poll as one, so every sandbox in the fan-out is a sandbox kept
+	// awake — and billed — for as long as the app is open. Nothing in the
+	// sidebar needs a sandbox's served row (the cloud row carries name and
+	// branch; a sandbox's rows only add live git state for the one workspace
+	// someone is inside), so the route param is the whole "open" signal.
+	const { workspaceId: openWorkspaceId } = useParams({ strict: false });
+	const openSandbox = useMemo(
+		() =>
+			sandboxes.find((sandbox) => sandbox.workspaceId === openWorkspaceId) ??
+			null,
+		[sandboxes, openWorkspaceId],
+	);
+
 	const targets = useMemo(() => {
 		const all = deriveHostWorkspacesQueryTargets({
 			activeHostUrl,
@@ -116,7 +132,7 @@ export function useHostWorkspacesSource(
 			machineId,
 			relayUrl,
 			fallbackOrganizationId: knownHostsOrgId,
-			sandboxes,
+			openSandbox,
 		});
 		return scopedHostId === undefined
 			? all
@@ -127,7 +143,7 @@ export function useHostWorkspacesSource(
 		knownHostsOrgId,
 		machineId,
 		relayUrl,
-		sandboxes,
+		openSandbox,
 		scopedHostId,
 	]);
 
@@ -226,15 +242,10 @@ export function useHostWorkspacesSource(
 	// Live updates: each reachable host's workspace:changed patches its own
 	// cached list without a refetch.
 	//
-	// Not for sandboxes. The provider counts a held connection as activity, so
-	// subscribing here would keep every cloud workspace's VM awake for as long
-	// as the app is open — ten in the sidebar, ten warm machines, whether or not
-	// anyone is looking at them. And there is nothing to be gained: a sandbox
-	// holds exactly one workspace whose identity the cloud row owns; the only
-	// field read off its served row is the branch, which has a fallback and can
-	// only change while someone is inside it — when the open workspace's own
-	// subscribers hold a socket anyway. Sandboxes are polled, and connected to
-	// only while open.
+	// Not for the sandbox either. It is only a target while its workspace is
+	// open, and then the workspace's own subscribers hold a socket to it
+	// anyway; a second one here would only duplicate them. The 30s poll
+	// covers its single row.
 	useEffect(() => {
 		const cleanups: Array<() => void> = [];
 		for (const target of targets) {

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -111,12 +111,10 @@ export function useHostWorkspacesSource(
 	const { targets: sandboxes, isReady: sandboxesReady } = useSandboxAccess();
 
 	// Only the open workspace's sandbox is a host here. The provider suspends a
-	// sandbox after a few seconds without an inbound request and counts this
-	// hook's poll as one, so every sandbox in the fan-out is a sandbox kept
-	// awake — and billed — for as long as the app is open. Nothing in the
-	// sidebar needs a sandbox's served row (the cloud row carries name and
-	// branch; a sandbox's rows only add live git state for the one workspace
-	// someone is inside), so the route param is the whole "open" signal.
+	// sandbox after ~15s without an inbound request and this poll counts as
+	// one, so every sandbox in the fan-out is one kept awake (and billed) for
+	// as long as the app is open. The sidebar renders cloud rows from the cloud
+	// row, so nothing else needs a sandbox's served rows.
 	const { workspaceId: openWorkspaceId } = useParams({ strict: false });
 	const openSandbox = useMemo(
 		() =>
@@ -242,10 +240,8 @@ export function useHostWorkspacesSource(
 	// Live updates: each reachable host's workspace:changed patches its own
 	// cached list without a refetch.
 	//
-	// Not for the sandbox either. It is only a target while its workspace is
-	// open, and then the workspace's own subscribers hold a socket to it
-	// anyway; a second one here would only duplicate them. The 30s poll
-	// covers its single row.
+	// Not for the sandbox: while its workspace is open, the workspace's own
+	// subscribers already hold a socket to it, and the poll covers its one row.
 	useEffect(() => {
 		const cleanups: Array<() => void> = [];
 		for (const target of targets) {

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -95,6 +95,7 @@ export function getHostWorkspacesQueryKey(
 /**
  * One target per known host: the local host always (direct URL), remote
  * hosts via relay when online, and a null-URL placeholder when offline.
+ * Plus, at most, the one sandbox behind the workspace that is open.
  */
 export function deriveHostWorkspacesQueryTargets({
 	activeHostUrl,
@@ -102,7 +103,7 @@ export function deriveHostWorkspacesQueryTargets({
 	machineId,
 	relayUrl,
 	fallbackOrganizationId,
-	sandboxes = [],
+	openSandbox = null,
 }: {
 	activeHostUrl: string | null;
 	hosts: HostRowForTargets[];
@@ -110,12 +111,16 @@ export function deriveHostWorkspacesQueryTargets({
 	relayUrl: string;
 	/** Org for the synthesized local target — see derivePullRequestQueryTargets. */
 	fallbackOrganizationId?: string | null;
-	/** Cloud workspaces whose sandbox currently has a brokered address. */
-	sandboxes?: Array<{
+	/**
+	 * The sandbox behind the open cloud workspace, once it has a brokered
+	 * address. Never the whole cloud list: the provider counts every request
+	 * as activity, so a sandbox in the fan-out is a sandbox that never sleeps.
+	 */
+	openSandbox?: {
 		workspaceId: string;
 		organizationId: string;
 		url: string;
-	}>;
+	} | null;
 }): HostWorkspacesQueryTarget[] {
 	const targets: HostWorkspacesQueryTarget[] = hosts.map((host) => {
 		const isLocal = host.machineId === machineId;
@@ -147,11 +152,11 @@ export function deriveHostWorkspacesQueryTargets({
 		});
 	}
 
-	for (const sandbox of sandboxes) {
+	if (openSandbox) {
 		targets.push({
-			machineId: sandbox.workspaceId,
-			organizationId: sandbox.organizationId,
-			hostUrl: sandbox.url,
+			machineId: openSandbox.workspaceId,
+			organizationId: openSandbox.organizationId,
+			hostUrl: openSandbox.url,
 			isLocal: false,
 			isSandbox: true,
 		});

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -111,11 +111,7 @@ export function deriveHostWorkspacesQueryTargets({
 	relayUrl: string;
 	/** Org for the synthesized local target — see derivePullRequestQueryTargets. */
 	fallbackOrganizationId?: string | null;
-	/**
-	 * The sandbox behind the open cloud workspace, once it has a brokered
-	 * address. Never the whole cloud list: the provider counts every request
-	 * as activity, so a sandbox in the fan-out is a sandbox that never sleeps.
-	 */
+	/** The open cloud workspace's sandbox — never the whole cloud list, see useHostWorkspacesSource. */
 	openSandbox?: {
 		workspaceId: string;
 		organizationId: string;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -1,10 +1,17 @@
 import { useLingui } from "@lingui/react/macro";
 import { useLiveQuery } from "@tanstack/react-db";
 import { useMemo } from "react";
+import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId";
 import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
+import {
+	type CloudPullRequestRef,
+	cloudPullRequestRefKey,
+	useSidebarCloudPullRequests,
+} from "../../hooks/useSidebarCloudPullRequests";
 import type { DashboardSidebarWorkspace } from "../../types";
 import { DashboardSidebarSectionHeader } from "../DashboardSidebarSectionHeader";
 import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem";
@@ -18,9 +25,10 @@ import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem"
  *
  * The cloud row owns the workspace's identity — it is what created, named and
  * lists it. The row inside the sandbox exists only so host-service has
- * something to serve panes against, so its name is ignored here; live git
- * state (branch) still comes from the sandbox, which is the only thing that
- * knows it.
+ * something to serve panes against, so its name is ignored here. Its branch
+ * is read only for the workspace that is open (the only sandbox the fan-out
+ * addresses); every other row shows the branch it was created on. Pull
+ * requests come from the cloud table, since asking a sandbox would wake it.
  */
 export function DashboardSidebarCloudSection({
 	isCollapsed,
@@ -50,12 +58,48 @@ export function DashboardSidebarCloudSection({
 					isHidden: local.sidebarState.isHidden,
 					pinnedAt: local.sidebarState.pinnedAt,
 					tabOrder: local.sidebarState.tabOrder,
+					suppressedPullRequestUrl: local.sidebarState.suppressedPullRequestUrl,
 				})),
 		[collections],
 	);
 
-	const rows = useMemo<DashboardSidebarWorkspace[]>(() => {
+	// Every cloud workspace clones the one cloud repository, so that is the
+	// repository every row's branch is matched against.
+	const organizationId = useActiveOrganizationId();
+	const { data: cloudRepo } = cloudTrpc.cloudWorkspace.repo.useQuery(
+		{ organizationId: organizationId ?? "" },
+		{
+			enabled: organizationId !== null && cloudWorkspaces.length > 0,
+			staleTime: Number.POSITIVE_INFINITY,
+		},
+	);
+	const cloudRepoFullName = cloudRepo
+		? `${cloudRepo.owner}/${cloudRepo.name}`
+		: null;
+
+	const branchById = useMemo(() => {
 		const servedById = new Map(hostWorkspaces.map((row) => [row.id, row]));
+		return new Map(
+			cloudWorkspaces.map((cloud) => [
+				cloud.id,
+				servedById.get(cloud.id)?.branch ?? cloud.branch,
+			]),
+		);
+	}, [cloudWorkspaces, hostWorkspaces]);
+
+	const pullRequestRefs = useMemo<CloudPullRequestRef[]>(
+		() =>
+			cloudRepoFullName
+				? cloudWorkspaces.map((cloud) => ({
+						repoFullName: cloudRepoFullName,
+						headBranch: branchById.get(cloud.id) ?? cloud.branch,
+					}))
+				: [],
+		[branchById, cloudRepoFullName, cloudWorkspaces],
+	);
+	const cloudPullRequests = useSidebarCloudPullRequests(pullRequestRefs);
+
+	const rows = useMemo<DashboardSidebarWorkspace[]>(() => {
 		const localById = new Map(
 			localStateRows.map((row) => [row.workspaceId, row]),
 		);
@@ -73,7 +117,16 @@ export function DashboardSidebarCloudSection({
 					(localById.get(right.id)?.tabOrder ?? 0),
 			)
 			.map((cloud) => {
-				const served = servedById.get(cloud.id);
+				const branch = branchById.get(cloud.id) ?? cloud.branch;
+				const pullRequest = cloudRepoFullName
+					? (cloudPullRequests.byRef.get(
+							cloudPullRequestRefKey({
+								repoFullName: cloudRepoFullName,
+								headBranch: branch,
+							}),
+						) ?? null)
+					: null;
+				const suppressedUrl = localById.get(cloud.id)?.suppressedPullRequestUrl;
 				return {
 					id: cloud.id,
 					// Grouping is by section here, and the sandbox's project id means
@@ -90,8 +143,11 @@ export function DashboardSidebarCloudSection({
 					// its list has answered.
 					lastActivityAt: served?.lastActivityAt ?? null,
 					name: cloud.name,
-					branch: served?.branch ?? cloud.branch,
-					pullRequest: null,
+					branch,
+					pullRequest:
+						pullRequest && pullRequest.url !== suppressedUrl
+							? pullRequest
+							: null,
 					repoUrl: null,
 					branchExistsOnRemote: true,
 					previewUrl: null,
@@ -117,7 +173,13 @@ export function DashboardSidebarCloudSection({
 							: null,
 				};
 			});
-	}, [cloudWorkspaces, hostWorkspaces, localStateRows]);
+	}, [
+		branchById,
+		cloudPullRequests.byRef,
+		cloudRepoFullName,
+		cloudWorkspaces,
+		localStateRows,
+	]);
 
 	if (rows.length === 0) return null;
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -76,25 +76,22 @@ export function DashboardSidebarCloudSection({
 		? `${cloudRepo.owner}/${cloudRepo.name}`
 		: null;
 
-	const branchById = useMemo(() => {
-		const servedById = new Map(hostWorkspaces.map((row) => [row.id, row]));
-		return new Map(
-			cloudWorkspaces.map((cloud) => [
-				cloud.id,
-				servedById.get(cloud.id)?.branch ?? cloud.branch,
-			]),
-		);
-	}, [cloudWorkspaces, hostWorkspaces]);
+	// Only the open workspace's sandbox is in the fan-out, so this holds at
+	// most one row.
+	const servedById = useMemo(
+		() => new Map(hostWorkspaces.map((row) => [row.id, row])),
+		[hostWorkspaces],
+	);
 
 	const pullRequestRefs = useMemo<CloudPullRequestRef[]>(
 		() =>
 			cloudRepoFullName
 				? cloudWorkspaces.map((cloud) => ({
 						repoFullName: cloudRepoFullName,
-						headBranch: branchById.get(cloud.id) ?? cloud.branch,
+						headBranch: servedById.get(cloud.id)?.branch ?? cloud.branch,
 					}))
 				: [],
-		[branchById, cloudRepoFullName, cloudWorkspaces],
+		[servedById, cloudRepoFullName, cloudWorkspaces],
 	);
 	const cloudPullRequests = useSidebarCloudPullRequests(pullRequestRefs);
 
@@ -116,7 +113,8 @@ export function DashboardSidebarCloudSection({
 					(localById.get(right.id)?.tabOrder ?? 0),
 			)
 			.map((cloud) => {
-				const branch = branchById.get(cloud.id) ?? cloud.branch;
+				const served = servedById.get(cloud.id);
+				const branch = served?.branch ?? cloud.branch;
 				const pullRequest = cloudRepoFullName
 					? (cloudPullRequests.byRef.get(
 							cloudPullRequestRefKey({
@@ -173,7 +171,7 @@ export function DashboardSidebarCloudSection({
 				};
 			});
 	}, [
-		branchById,
+		servedById,
 		cloudPullRequests.byRef,
 		cloudRepoFullName,
 		cloudWorkspaces,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -25,10 +25,9 @@ import { DashboardSidebarWorkspaceItem } from "../DashboardSidebarWorkspaceItem"
  *
  * The cloud row owns the workspace's identity — it is what created, named and
  * lists it. The row inside the sandbox exists only so host-service has
- * something to serve panes against, so its name is ignored here. Its branch
- * is read only for the workspace that is open (the only sandbox the fan-out
- * addresses); every other row shows the branch it was created on. Pull
- * requests come from the cloud table, since asking a sandbox would wake it.
+ * something to serve panes against, so its name is ignored here. Only the
+ * open workspace's sandbox is in the fan-out, so every other row shows the
+ * branch it was created on; pull requests come from the cloud table.
  */
 export function DashboardSidebarCloudSection({
 	isCollapsed,
@@ -63,8 +62,7 @@ export function DashboardSidebarCloudSection({
 		[collections],
 	);
 
-	// Every cloud workspace clones the one cloud repository, so that is the
-	// repository every row's branch is matched against.
+	// Every cloud workspace clones the one cloud repository.
 	const organizationId = useActiveOrganizationId();
 	const { data: cloudRepo } = cloudTrpc.cloudWorkspace.repo.useQuery(
 		{ organizationId: organizationId ?? "" },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -68,7 +68,8 @@ export function DashboardSidebarCloudSection({
 		{ organizationId: organizationId ?? "" },
 		{
 			enabled: organizationId !== null && cloudWorkspaces.length > 0,
-			staleTime: Number.POSITIVE_INFINITY,
+			// Finite so an App installed mid-session is picked up.
+			staleTime: 5 * 60_000,
 		},
 	);
 	const cloudRepoFullName = cloudRepo

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -128,6 +128,7 @@ export function DashboardSidebarWorkspaceItem({
 		workspaceName: name,
 		branch,
 		pullRequestUrl: pullRequest?.url ?? null,
+		isCloudWorkspace: hostType === "cloud",
 		isMainWorkspace,
 		isPinned: workspace.isPinned,
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/DashboardSidebarWorkspaceItem.tsx
@@ -127,6 +127,7 @@ export function DashboardSidebarWorkspaceItem({
 		isSessionWorkspace,
 		workspaceName: name,
 		branch,
+		pullRequestUrl: pullRequest?.url ?? null,
 		isMainWorkspace,
 		isPinned: workspace.isPinned,
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -285,9 +285,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleRemovePullRequest = async () => {
-		// The chip is sourced from the cloud table, so the decision lives in
-		// local sidebar state and takes effect at once. The host keeps its own
-		// copy for the views it serves, when it can be reached.
+		// Local state hides the chip at once; the host keeps its own copy when reachable.
 		if (pullRequestUrl) {
 			setWorkspaceSuppressedPullRequest(workspaceId, projectId, pullRequestUrl);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -46,6 +46,8 @@ interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	branch: string;
 	/** The chip currently shown, so "Remove PR link" knows which PR to hide. */
 	pullRequestUrl?: string | null;
+	/** Cloud rows source their chip from the cloud table, not their host. */
+	isCloudWorkspace?: boolean;
 	isMainWorkspace?: boolean;
 	isPinned?: boolean;
 }
@@ -57,6 +59,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 	workspaceName,
 	branch,
 	pullRequestUrl = null,
+	isCloudWorkspace = false,
 	isMainWorkspace = false,
 	isPinned = false,
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
@@ -285,12 +288,12 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleRemovePullRequest = async () => {
-		// Local state hides the chip at once; the host keeps its own copy when reachable.
-		if (pullRequestUrl) {
+		// A cloud row's chip is local state; its sandbox is told too when open.
+		if (isCloudWorkspace && pullRequestUrl) {
 			setWorkspaceSuppressedPullRequest(workspaceId, projectId, pullRequestUrl);
 		}
 		if (!workspaceHostUrl) {
-			if (!pullRequestUrl) {
+			if (!isCloudWorkspace) {
 				showHostServiceUnavailableToast(hostService, {
 					action: "removePrLink",
 				});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -44,6 +44,8 @@ interface UseDashboardSidebarWorkspaceItemActionsOptions {
 	isSessionWorkspace?: boolean;
 	workspaceName: string;
 	branch: string;
+	/** The chip currently shown, so "Remove PR link" knows which PR to hide. */
+	pullRequestUrl?: string | null;
 	isMainWorkspace?: boolean;
 	isPinned?: boolean;
 }
@@ -54,6 +56,7 @@ export function useDashboardSidebarWorkspaceItemActions({
 	isSessionWorkspace = false,
 	workspaceName,
 	branch,
+	pullRequestUrl = null,
 	isMainWorkspace = false,
 	isPinned = false,
 }: UseDashboardSidebarWorkspaceItemActionsOptions) {
@@ -88,8 +91,12 @@ export function useDashboardSidebarWorkspaceItemActions({
 		clearManualUnread(workspaceId);
 		markWorkspaceTerminalsSeen();
 	};
-	const { createSection, moveWorkspaceToSection, setWorkspacePinned } =
-		useDashboardSidebarState();
+	const {
+		createSection,
+		moveWorkspaceToSection,
+		setWorkspacePinned,
+		setWorkspaceSuppressedPullRequest,
+	} = useDashboardSidebarState();
 
 	const [isRenaming, setIsRenaming] = useState(false);
 	const [renameValue, setRenameValue] = useState(workspaceName);
@@ -278,10 +285,18 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleRemovePullRequest = async () => {
+		// The chip is sourced from the cloud table, so the decision lives in
+		// local sidebar state and takes effect at once. The host keeps its own
+		// copy for the views it serves, when it can be reached.
+		if (pullRequestUrl) {
+			setWorkspaceSuppressedPullRequest(workspaceId, projectId, pullRequestUrl);
+		}
 		if (!workspaceHostUrl) {
-			showHostServiceUnavailableToast(hostService, {
-				action: "removePrLink",
-			});
+			if (!pullRequestUrl) {
+				showHostServiceUnavailableToast(hostService, {
+					action: "removePrLink",
+				});
+			}
 			return;
 		}
 		try {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets.ts
@@ -32,7 +32,6 @@ export function derivePullRequestQueryTargets({
 	relayUrl,
 	workspaces,
 	fallbackOrganizationId,
-	sandboxes = [],
 }: {
 	activeHostUrl: string | null;
 	hosts: PullRequestQueryHostRow[];
@@ -45,12 +44,6 @@ export function derivePullRequestQueryTargets({
 	 * under "" and re-keys once hosts arrive, cold-starting the entry.
 	 */
 	fallbackOrganizationId?: string | null;
-	/** Cloud workspaces whose sandbox currently has a brokered address. */
-	sandboxes?: Array<{
-		workspaceId: string;
-		organizationId: string;
-		url: string;
-	}>;
 }): PullRequestQueryTarget[] {
 	const workspaceIdsByHostId = new Map<string, string[]>();
 	for (const workspace of workspaces) {
@@ -110,20 +103,8 @@ export function derivePullRequestQueryTargets({
 		}
 	}
 
-	// A sandbox is its own host, addressed by the cloud workspace's id — the
-	// rows it serves were restated under that id by the workspace fan-out.
-	for (const sandbox of sandboxes) {
-		const workspaceIds = workspaceIdsByHostId.get(sandbox.workspaceId);
-		if (!workspaceIds || workspaceIds.length === 0) continue;
-		targets.push({
-			organizationId: sandbox.organizationId,
-			machineId: sandbox.workspaceId,
-			hostType: "cloud",
-			hostUrl: sandbox.url,
-			workspaceIds,
-		});
-	}
-
+	// Cloud workspaces never get a target: their sandbox is not a host row, and
+	// asking it every ten seconds is what kept every sandbox awake all day.
 	return targets;
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/derivePullRequestQueryTargets.ts
@@ -103,8 +103,6 @@ export function derivePullRequestQueryTargets({
 		}
 	}
 
-	// Cloud workspaces never get a target: their sandbox is not a host row, and
-	// asking it every ten seconds is what kept every sandbox awake all day.
 	return targets;
 }
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -14,7 +14,6 @@ import {
 } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { useSandboxAccess } from "renderer/routes/_authenticated/providers/SandboxAccessProvider";
 import {
 	deriveTagFolders,
 	useTagFolderContext,
@@ -257,7 +256,6 @@ export function useDashboardSidebarData() {
 	);
 
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
-	const { targets: sandboxes } = useSandboxAccess();
 	const hostWorkspacesById = useMemo(
 		() => new Map(hostWorkspaces.map((workspace) => [workspace.id, workspace])),
 		[hostWorkspaces],
@@ -430,7 +428,6 @@ export function useDashboardSidebarData() {
 					(workspace) => workspace.projectId !== null,
 				),
 				fallbackOrganizationId: knownHostsOrgId,
-				sandboxes,
 			}),
 		[
 			activeHostUrl,
@@ -438,7 +435,6 @@ export function useDashboardSidebarData() {
 			knownHostsOrgId,
 			machineId,
 			relayUrl,
-			sandboxes,
 			visibleSidebarWorkspaces,
 		],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -260,7 +260,17 @@ export function useDashboardSidebarData() {
 		[collections],
 	);
 
-	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	const { workspaces: allHostWorkspaces, cache: hostWorkspacesCache } =
+		useHostWorkspaces();
+	// Cloud workspaces render in the Cloud section only, whatever placement
+	// their local-state row carries.
+	const hostWorkspaces = useMemo(
+		() =>
+			allHostWorkspaces.filter(
+				(workspace) => !hostWorkspacesCache.isSandboxHost(workspace.hostId),
+			),
+		[allHostWorkspaces, hostWorkspacesCache],
+	);
 	const hostWorkspacesById = useMemo(
 		() => new Map(hostWorkspaces.map((workspace) => [workspace.id, workspace])),
 		[hostWorkspaces],
@@ -452,8 +462,10 @@ export function useDashboardSidebarData() {
 		[repoFullNameByProjectId, visibleSidebarWorkspaces],
 	);
 	const cloudPullRequests = useSidebarCloudPullRequests(cloudPullRequestRefs);
-	// Only an organization without the GitHub App falls back to asking each host.
-	const useHostPullRequests = cloudPullRequests.hasInstallation === false;
+	// An organization without the GitHub App falls back to asking each host, as
+	// does one whose cloud lookup is failing.
+	const useHostPullRequests =
+		cloudPullRequests.hasInstallation === false || cloudPullRequests.isError;
 
 	const pullRequestQueryTargets = useMemo<PullRequestQueryTarget[]>(
 		() =>
@@ -518,13 +530,23 @@ export function useDashboardSidebarData() {
 			}
 			return rows;
 		}
+		const suppressedUrlByWorkspaceId = new Map(
+			visibleSidebarWorkspaces.map((workspace) => [
+				workspace.id,
+				workspace.suppressedPullRequestUrl,
+			]),
+		);
 		for (const query of pullRequestQueries) {
 			const data = query.data;
 			if (!data) continue;
 			for (const row of data.workspaces) {
+				const suppressedUrl = suppressedUrlByWorkspaceId.get(row.workspaceId);
 				rows.push({
 					workspaceId: row.workspaceId,
-					pullRequest: row.pullRequest,
+					pullRequest:
+						row.pullRequest && row.pullRequest.url === suppressedUrl
+							? null
+							: row.pullRequest,
 				});
 			}
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -425,10 +425,8 @@ export function useDashboardSidebarData() {
 		sidebarWorkspaces,
 	]);
 
-	// Pull-request chips come from the cloud table, matched on the project's
-	// repository and the row's branch: one request for every row on screen,
-	// and no host — or sandbox — asked. A workspace whose project has no
-	// GitHub remote has nothing to match on and gets no chip from here.
+	// Chips come from the cloud table, matched on the project's repository and
+	// the row's branch — one request for every row on screen, no host asked.
 	const repoFullNameByProjectId = useMemo(
 		() =>
 			new Map(
@@ -454,8 +452,7 @@ export function useDashboardSidebarData() {
 		[repoFullNameByProjectId, visibleSidebarWorkspaces],
 	);
 	const cloudPullRequests = useSidebarCloudPullRequests(cloudPullRequestRefs);
-	// Only an organization without the GitHub App falls back to asking each
-	// host; a host it cannot reach keeps its cached chips either way.
+	// Only an organization without the GitHub App falls back to asking each host.
 	const useHostPullRequests = cloudPullRequests.hasInstallation === false;
 
 	const pullRequestQueryTargets = useMemo<PullRequestQueryTarget[]>(
@@ -512,7 +509,6 @@ export function useDashboardSidebarData() {
 						headBranch: workspace.branch,
 					}),
 				);
-				// "Remove PR link" hides that one PR; a different PR still shows.
 				if (
 					!pullRequest ||
 					pullRequest.url === workspace.suppressedPullRequestUrl

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -25,11 +25,6 @@ import type {
 	DashboardSidebarWorkspace,
 } from "../../types";
 import {
-	type CloudPullRequestRef,
-	cloudPullRequestRefKey,
-	useSidebarCloudPullRequests,
-} from "../useSidebarCloudPullRequests";
-import {
 	buildDashboardSidebarPinnedWorkspaces,
 	buildDashboardSidebarProjects,
 	buildDashboardSidebarSessions,
@@ -320,8 +315,6 @@ export function useDashboardSidebarData() {
 					sectionId: sidebarWorkspaces.sidebarState.sectionId,
 					isHidden: sidebarWorkspaces.sidebarState.isHidden,
 					pinnedAt: sidebarWorkspaces.sidebarState.pinnedAt,
-					suppressedPullRequestUrl:
-						sidebarWorkspaces.sidebarState.suppressedPullRequestUrl,
 				})),
 		[collections],
 	);
@@ -347,7 +340,6 @@ export function useDashboardSidebarData() {
 						tags: workspace.tags,
 						isHidden: localState.isHidden,
 						pinnedAt: localState.pinnedAt,
-						suppressedPullRequestUrl: localState.suppressedPullRequestUrl,
 					},
 				];
 			}),
@@ -400,7 +392,6 @@ export function useDashboardSidebarData() {
 					// Auto-included mains have no local-state row; pinning one
 					// creates a row first (see setWorkspacePinned).
 					pinnedAt: null as number | null,
-					suppressedPullRequestUrl: null as string | null,
 				})),
 		[hostWorkspaces],
 	);
@@ -435,38 +426,6 @@ export function useDashboardSidebarData() {
 		sidebarWorkspaces,
 	]);
 
-	// Chips come from the cloud table, matched on the project's repository and
-	// the row's branch — one request for every row on screen, no host asked.
-	const repoFullNameByProjectId = useMemo(
-		() =>
-			new Map(
-				sidebarProjects.map((project) => [
-					project.id,
-					project.githubOwner && project.githubRepoName
-						? `${project.githubOwner}/${project.githubRepoName}`
-						: null,
-				]),
-			),
-		[sidebarProjects],
-	);
-	const cloudPullRequestRefs = useMemo<CloudPullRequestRef[]>(
-		() =>
-			visibleSidebarWorkspaces.flatMap((workspace) => {
-				const repoFullName = workspace.projectId
-					? repoFullNameByProjectId.get(workspace.projectId)
-					: null;
-				return repoFullName
-					? [{ repoFullName, headBranch: workspace.branch }]
-					: [];
-			}),
-		[repoFullNameByProjectId, visibleSidebarWorkspaces],
-	);
-	const cloudPullRequests = useSidebarCloudPullRequests(cloudPullRequestRefs);
-	// An organization without the GitHub App falls back to asking each host, as
-	// does one whose cloud lookup is failing.
-	const useHostPullRequests =
-		cloudPullRequests.hasInstallation === false || cloudPullRequests.isError;
-
 	const pullRequestQueryTargets = useMemo<PullRequestQueryTarget[]>(
 		() =>
 			derivePullRequestQueryTargets({
@@ -496,7 +455,7 @@ export function useDashboardSidebarData() {
 			refetchInterval: 10_000,
 			// Unreachable host: keep the query mounted so cached chips stay
 			// rendered through the outage; fetches resume when the URL returns.
-			enabled: useHostPullRequests && target.hostUrl !== null,
+			enabled: target.hostUrl !== null,
 			queryFn: async () => {
 				if (!target.hostUrl) return { workspaces: [] };
 				const client = getHostServiceClientByUrl(target.hostUrl);
@@ -509,55 +468,18 @@ export function useDashboardSidebarData() {
 
 	const pullRequestRows = useMemo<PullRequestWorkspaceRow[]>(() => {
 		const rows: PullRequestWorkspaceRow[] = [];
-		if (!useHostPullRequests) {
-			for (const workspace of visibleSidebarWorkspaces) {
-				const repoFullName = workspace.projectId
-					? repoFullNameByProjectId.get(workspace.projectId)
-					: null;
-				if (!repoFullName) continue;
-				const pullRequest = cloudPullRequests.byRef.get(
-					cloudPullRequestRefKey({
-						repoFullName,
-						headBranch: workspace.branch,
-					}),
-				);
-				if (
-					!pullRequest ||
-					pullRequest.url === workspace.suppressedPullRequestUrl
-				)
-					continue;
-				rows.push({ workspaceId: workspace.id, pullRequest });
-			}
-			return rows;
-		}
-		const suppressedUrlByWorkspaceId = new Map(
-			visibleSidebarWorkspaces.map((workspace) => [
-				workspace.id,
-				workspace.suppressedPullRequestUrl,
-			]),
-		);
 		for (const query of pullRequestQueries) {
 			const data = query.data;
 			if (!data) continue;
 			for (const row of data.workspaces) {
-				const suppressedUrl = suppressedUrlByWorkspaceId.get(row.workspaceId);
 				rows.push({
 					workspaceId: row.workspaceId,
-					pullRequest:
-						row.pullRequest && row.pullRequest.url === suppressedUrl
-							? null
-							: row.pullRequest,
+					pullRequest: row.pullRequest,
 				});
 			}
 		}
 		return rows;
-	}, [
-		cloudPullRequests.byRef,
-		pullRequestQueries,
-		repoFullNameByProjectId,
-		useHostPullRequests,
-		visibleSidebarWorkspaces,
-	]);
+	}, [pullRequestQueries]);
 
 	const refreshWorkspacePullRequest = useCallback(
 		async (workspaceId: string) => {
@@ -565,13 +487,6 @@ export function useDashboardSidebarData() {
 				(candidate) => candidate.id === workspaceId,
 			);
 			if (!workspace) return;
-			if (!useHostPullRequests) {
-				if (!pullRequestRefreshGate.shouldRefresh(workspaceId, Date.now())) {
-					return;
-				}
-				await cloudPullRequests.refetch();
-				return;
-			}
 			const target = pullRequestQueryTargets.find(
 				(candidate) => candidate.machineId === workspace.hostId,
 			);
@@ -588,13 +503,7 @@ export function useDashboardSidebarData() {
 				queryKey: getDashboardSidebarPullRequestQueryKey(target),
 			});
 		},
-		[
-			cloudPullRequests.refetch,
-			pullRequestQueryTargets,
-			queryClient,
-			useHostPullRequests,
-			visibleSidebarWorkspaces,
-		],
+		[pullRequestQueryTargets, queryClient, visibleSidebarWorkspaces],
 	);
 
 	const pullRequestsByWorkspaceId =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useDashboardSidebarData/useDashboardSidebarData.ts
@@ -25,6 +25,11 @@ import type {
 	DashboardSidebarWorkspace,
 } from "../../types";
 import {
+	type CloudPullRequestRef,
+	cloudPullRequestRefKey,
+	useSidebarCloudPullRequests,
+} from "../useSidebarCloudPullRequests";
+import {
 	buildDashboardSidebarPinnedWorkspaces,
 	buildDashboardSidebarProjects,
 	buildDashboardSidebarSessions,
@@ -305,6 +310,8 @@ export function useDashboardSidebarData() {
 					sectionId: sidebarWorkspaces.sidebarState.sectionId,
 					isHidden: sidebarWorkspaces.sidebarState.isHidden,
 					pinnedAt: sidebarWorkspaces.sidebarState.pinnedAt,
+					suppressedPullRequestUrl:
+						sidebarWorkspaces.sidebarState.suppressedPullRequestUrl,
 				})),
 		[collections],
 	);
@@ -330,6 +337,7 @@ export function useDashboardSidebarData() {
 						tags: workspace.tags,
 						isHidden: localState.isHidden,
 						pinnedAt: localState.pinnedAt,
+						suppressedPullRequestUrl: localState.suppressedPullRequestUrl,
 					},
 				];
 			}),
@@ -382,6 +390,7 @@ export function useDashboardSidebarData() {
 					// Auto-included mains have no local-state row; pinning one
 					// creates a row first (see setWorkspacePinned).
 					pinnedAt: null as number | null,
+					suppressedPullRequestUrl: null as string | null,
 				})),
 		[hostWorkspaces],
 	);
@@ -416,6 +425,39 @@ export function useDashboardSidebarData() {
 		sidebarWorkspaces,
 	]);
 
+	// Pull-request chips come from the cloud table, matched on the project's
+	// repository and the row's branch: one request for every row on screen,
+	// and no host — or sandbox — asked. A workspace whose project has no
+	// GitHub remote has nothing to match on and gets no chip from here.
+	const repoFullNameByProjectId = useMemo(
+		() =>
+			new Map(
+				sidebarProjects.map((project) => [
+					project.id,
+					project.githubOwner && project.githubRepoName
+						? `${project.githubOwner}/${project.githubRepoName}`
+						: null,
+				]),
+			),
+		[sidebarProjects],
+	);
+	const cloudPullRequestRefs = useMemo<CloudPullRequestRef[]>(
+		() =>
+			visibleSidebarWorkspaces.flatMap((workspace) => {
+				const repoFullName = workspace.projectId
+					? repoFullNameByProjectId.get(workspace.projectId)
+					: null;
+				return repoFullName
+					? [{ repoFullName, headBranch: workspace.branch }]
+					: [];
+			}),
+		[repoFullNameByProjectId, visibleSidebarWorkspaces],
+	);
+	const cloudPullRequests = useSidebarCloudPullRequests(cloudPullRequestRefs);
+	// Only an organization without the GitHub App falls back to asking each
+	// host; a host it cannot reach keeps its cached chips either way.
+	const useHostPullRequests = cloudPullRequests.hasInstallation === false;
+
 	const pullRequestQueryTargets = useMemo<PullRequestQueryTarget[]>(
 		() =>
 			derivePullRequestQueryTargets({
@@ -445,7 +487,7 @@ export function useDashboardSidebarData() {
 			refetchInterval: 10_000,
 			// Unreachable host: keep the query mounted so cached chips stay
 			// rendered through the outage; fetches resume when the URL returns.
-			enabled: target.hostUrl !== null,
+			enabled: useHostPullRequests && target.hostUrl !== null,
 			queryFn: async () => {
 				if (!target.hostUrl) return { workspaces: [] };
 				const client = getHostServiceClientByUrl(target.hostUrl);
@@ -458,6 +500,28 @@ export function useDashboardSidebarData() {
 
 	const pullRequestRows = useMemo<PullRequestWorkspaceRow[]>(() => {
 		const rows: PullRequestWorkspaceRow[] = [];
+		if (!useHostPullRequests) {
+			for (const workspace of visibleSidebarWorkspaces) {
+				const repoFullName = workspace.projectId
+					? repoFullNameByProjectId.get(workspace.projectId)
+					: null;
+				if (!repoFullName) continue;
+				const pullRequest = cloudPullRequests.byRef.get(
+					cloudPullRequestRefKey({
+						repoFullName,
+						headBranch: workspace.branch,
+					}),
+				);
+				// "Remove PR link" hides that one PR; a different PR still shows.
+				if (
+					!pullRequest ||
+					pullRequest.url === workspace.suppressedPullRequestUrl
+				)
+					continue;
+				rows.push({ workspaceId: workspace.id, pullRequest });
+			}
+			return rows;
+		}
 		for (const query of pullRequestQueries) {
 			const data = query.data;
 			if (!data) continue;
@@ -469,7 +533,13 @@ export function useDashboardSidebarData() {
 			}
 		}
 		return rows;
-	}, [pullRequestQueries]);
+	}, [
+		cloudPullRequests.byRef,
+		pullRequestQueries,
+		repoFullNameByProjectId,
+		useHostPullRequests,
+		visibleSidebarWorkspaces,
+	]);
 
 	const refreshWorkspacePullRequest = useCallback(
 		async (workspaceId: string) => {
@@ -477,6 +547,13 @@ export function useDashboardSidebarData() {
 				(candidate) => candidate.id === workspaceId,
 			);
 			if (!workspace) return;
+			if (!useHostPullRequests) {
+				if (!pullRequestRefreshGate.shouldRefresh(workspaceId, Date.now())) {
+					return;
+				}
+				await cloudPullRequests.refetch();
+				return;
+			}
 			const target = pullRequestQueryTargets.find(
 				(candidate) => candidate.machineId === workspace.hostId,
 			);
@@ -493,7 +570,13 @@ export function useDashboardSidebarData() {
 				queryKey: getDashboardSidebarPullRequestQueryKey(target),
 			});
 		},
-		[pullRequestQueryTargets, queryClient, visibleSidebarWorkspaces],
+		[
+			cloudPullRequests.refetch,
+			pullRequestQueryTargets,
+			queryClient,
+			useHostPullRequests,
+			visibleSidebarWorkspaces,
+		],
 	);
 
 	const pullRequestsByWorkspaceId =

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/index.ts
@@ -1,0 +1,6 @@
+export {
+	type CloudPullRequestRef,
+	cloudPullRequestRefKey,
+	type SidebarCloudPullRequests,
+	useSidebarCloudPullRequests,
+} from "./useSidebarCloudPullRequests";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/toSidebarPullRequest.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/toSidebarPullRequest.ts
@@ -51,11 +51,7 @@ function toChecksStatus(
 		: "none";
 }
 
-/**
- * The cloud table's row, in the shape the sidebar chip already renders from
- * the host. The host knows a fifth state, `queued` (merge queue), which the
- * webhooks do not carry; a queued PR shows as open here.
- */
+/** The host's chip shape; `queued` (merge queue) is host-only, so it shows as open here. */
 export function toSidebarPullRequest(
 	row: CloudPullRequestRow,
 ): DashboardSidebarWorkspacePullRequest {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/toSidebarPullRequest.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/toSidebarPullRequest.ts
@@ -14,9 +14,9 @@ function toCheckStatus(check: {
 	if (check.status.toLowerCase() !== "completed") return "pending";
 	switch (check.conclusion?.toLowerCase()) {
 		case "success":
-		case "neutral":
 			return "success";
 		case "skipped":
+		case "neutral":
 			return "skipped";
 		case "cancelled":
 			return "cancelled";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/toSidebarPullRequest.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/toSidebarPullRequest.ts
@@ -1,0 +1,83 @@
+import type { RouterOutputs } from "@superset/trpc";
+import type {
+	DashboardSidebarWorkspacePullRequest,
+	DashboardSidebarWorkspacePullRequestCheck,
+} from "../../types";
+
+export type CloudPullRequestRow =
+	RouterOutputs["integration"]["github"]["getByBranches"]["pullRequests"][number];
+
+function toCheckStatus(check: {
+	status: string;
+	conclusion: string | null;
+}): DashboardSidebarWorkspacePullRequestCheck["status"] {
+	if (check.status.toLowerCase() !== "completed") return "pending";
+	switch (check.conclusion?.toLowerCase()) {
+		case "success":
+		case "neutral":
+			return "success";
+		case "skipped":
+			return "skipped";
+		case "cancelled":
+			return "cancelled";
+		case null:
+		case undefined:
+			return "pending";
+		default:
+			return "failure";
+	}
+}
+
+function toReviewDecision(
+	value: string | null,
+): DashboardSidebarWorkspacePullRequest["reviewDecision"] {
+	switch (value) {
+		case "APPROVED":
+			return "approved";
+		case "CHANGES_REQUESTED":
+			return "changes_requested";
+		case "REVIEW_REQUIRED":
+			return "pending";
+		default:
+			return null;
+	}
+}
+
+function toChecksStatus(
+	value: string,
+): DashboardSidebarWorkspacePullRequest["checksStatus"] {
+	return value === "success" || value === "failure" || value === "pending"
+		? value
+		: "none";
+}
+
+/**
+ * The cloud table's row, in the shape the sidebar chip already renders from
+ * the host. The host knows a fifth state, `queued` (merge queue), which the
+ * webhooks do not carry; a queued PR shows as open here.
+ */
+export function toSidebarPullRequest(
+	row: CloudPullRequestRow,
+): DashboardSidebarWorkspacePullRequest {
+	const state =
+		row.state === "merged" || row.mergedAt
+			? "merged"
+			: row.state === "closed"
+				? "closed"
+				: row.isDraft
+					? "draft"
+					: "open";
+	return {
+		url: row.url,
+		number: row.number,
+		title: row.title,
+		state,
+		reviewDecision: toReviewDecision(row.reviewDecision),
+		checksStatus: toChecksStatus(row.checksStatus),
+		checks: row.checks.map((check) => ({
+			name: check.name,
+			status: toCheckStatus(check),
+			url: check.detailsUrl ?? null,
+		})),
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/useSidebarCloudPullRequests.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/useSidebarCloudPullRequests.ts
@@ -26,19 +26,13 @@ export interface SidebarCloudPullRequests {
 	refetch: () => Promise<unknown>;
 }
 
-/**
- * Sidebar pull-request chips from the cloud `github_pull_requests` table,
- * fed by the App's webhooks. One request for every row on screen instead of
- * one poll per host — and, for a cloud workspace, the only source there is:
- * asking its sandbox would wake it.
- */
+/** Sidebar chips from the cloud `github_pull_requests` table: one request for every row on screen. */
 export function useSidebarCloudPullRequests(
 	refs: CloudPullRequestRef[],
 ): SidebarCloudPullRequests {
 	const organizationId = useActiveOrganizationId();
 
-	// Deduplicated and sorted so the query input (and so its key) only changes
-	// when the set of rows actually changes, not on every rebuild of the list.
+	// Deduplicated and sorted so the query key only changes with the set of rows.
 	const stableRefs = useMemo(() => {
 		const byKey = new Map<string, CloudPullRequestRef>();
 		for (const ref of refs) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/useSidebarCloudPullRequests.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/useSidebarCloudPullRequests.ts
@@ -1,0 +1,81 @@
+import { useCallback, useMemo } from "react";
+import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId";
+import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import type { DashboardSidebarWorkspacePullRequest } from "../../types";
+import { toSidebarPullRequest } from "./toSidebarPullRequest";
+
+const CLOUD_PULL_REQUESTS_REFETCH_INTERVAL_MS = 30_000;
+
+export interface CloudPullRequestRef {
+	repoFullName: string;
+	headBranch: string;
+}
+
+export function cloudPullRequestRefKey(ref: CloudPullRequestRef): string {
+	return `${ref.repoFullName.toLowerCase()}\n${ref.headBranch}`;
+}
+
+export interface SidebarCloudPullRequests {
+	/** Chip per ref key (see cloudPullRequestRefKey); absent = no PR known. */
+	byRef: Map<string, DashboardSidebarWorkspacePullRequest>;
+	/**
+	 * Null until the first answer. False means the organization has no
+	 * GitHub App installation, so the cloud table can never know its PRs.
+	 */
+	hasInstallation: boolean | null;
+	refetch: () => Promise<unknown>;
+}
+
+/**
+ * Sidebar pull-request chips from the cloud `github_pull_requests` table,
+ * fed by the App's webhooks. One request for every row on screen instead of
+ * one poll per host — and, for a cloud workspace, the only source there is:
+ * asking its sandbox would wake it.
+ */
+export function useSidebarCloudPullRequests(
+	refs: CloudPullRequestRef[],
+): SidebarCloudPullRequests {
+	const organizationId = useActiveOrganizationId();
+
+	// Deduplicated and sorted so the query input (and so its key) only changes
+	// when the set of rows actually changes, not on every rebuild of the list.
+	const stableRefs = useMemo(() => {
+		const byKey = new Map<string, CloudPullRequestRef>();
+		for (const ref of refs) {
+			byKey.set(cloudPullRequestRefKey(ref), {
+				repoFullName: ref.repoFullName,
+				headBranch: ref.headBranch,
+			});
+		}
+		return [...byKey.entries()]
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([, ref]) => ref);
+	}, [refs]);
+
+	const query = cloudTrpc.integration.github.getByBranches.useQuery(
+		{ organizationId: organizationId ?? "", refs: stableRefs },
+		{
+			enabled: organizationId !== null,
+			refetchInterval: CLOUD_PULL_REQUESTS_REFETCH_INTERVAL_MS,
+			staleTime: 10_000,
+			placeholderData: (previous) => previous,
+		},
+	);
+
+	const byRef = useMemo(() => {
+		const map = new Map<string, DashboardSidebarWorkspacePullRequest>();
+		for (const row of query.data?.pullRequests ?? []) {
+			map.set(cloudPullRequestRefKey(row), toSidebarPullRequest(row));
+		}
+		return map;
+	}, [query.data]);
+
+	const refetch = query.refetch;
+	const refetchStable = useCallback(() => refetch(), [refetch]);
+
+	return {
+		byRef,
+		hasInstallation: query.data?.hasInstallation ?? null,
+		refetch: refetchStable,
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/useSidebarCloudPullRequests.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarCloudPullRequests/useSidebarCloudPullRequests.ts
@@ -5,6 +5,8 @@ import type { DashboardSidebarWorkspacePullRequest } from "../../types";
 import { toSidebarPullRequest } from "./toSidebarPullRequest";
 
 const CLOUD_PULL_REQUESTS_REFETCH_INTERVAL_MS = 30_000;
+/** Matches the procedure's input bound. */
+const MAX_REFS_PER_QUERY = 500;
 
 export interface CloudPullRequestRef {
 	repoFullName: string;
@@ -23,6 +25,7 @@ export interface SidebarCloudPullRequests {
 	 * GitHub App installation, so the cloud table can never know its PRs.
 	 */
 	hasInstallation: boolean | null;
+	isError: boolean;
 	refetch: () => Promise<unknown>;
 }
 
@@ -43,7 +46,8 @@ export function useSidebarCloudPullRequests(
 		}
 		return [...byKey.entries()]
 			.sort(([left], [right]) => left.localeCompare(right))
-			.map(([, ref]) => ref);
+			.map(([, ref]) => ref)
+			.slice(0, MAX_REFS_PER_QUERY);
 	}, [refs]);
 
 	const query = cloudTrpc.integration.github.getByBranches.useQuery(
@@ -52,7 +56,18 @@ export function useSidebarCloudPullRequests(
 			enabled: organizationId !== null,
 			refetchInterval: CLOUD_PULL_REQUESTS_REFETCH_INTERVAL_MS,
 			staleTime: 10_000,
-			placeholderData: (previous) => previous,
+			// Keep chips up while the row set changes, but never carry another
+			// organization's answer across a switch.
+			placeholderData: (previous, previousQuery) => {
+				const previousInput = (
+					previousQuery?.queryKey as
+						| [unknown, { input?: { organizationId?: string } }?]
+						| undefined
+				)?.[1]?.input;
+				return previousInput?.organizationId === organizationId
+					? previous
+					: undefined;
+			},
 		},
 	);
 
@@ -70,6 +85,7 @@ export function useSidebarCloudPullRequests(
 	return {
 		byRef,
 		hasInstallation: query.data?.hasInstallation ?? null,
+		isError: query.isError,
 		refetch: refetchStable,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
@@ -65,10 +65,9 @@ function V2WorkspaceLayout() {
 				: null,
 		[hostWorkspaces, workspaceId],
 	);
-	// The open workspace's sandbox joins the fan-out as its own host (and only
-	// the open one: polled, a sandbox never sleeps), so a cloud workspace is
-	// found the same way as any other — but it has no v2_hosts row for the
-	// remote version gate to check.
+	// The open workspace's sandbox joins the fan-out as its own host, so a
+	// cloud workspace is found the same way as any other — but it has no
+	// v2_hosts row for the remote version gate to check.
 	const { targets: sandboxes } = useSandboxAccess();
 	const isCloud = sandboxes.some(
 		(sandbox) => sandbox.workspaceId === workspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/layout.tsx
@@ -65,7 +65,8 @@ function V2WorkspaceLayout() {
 				: null,
 		[hostWorkspaces, workspaceId],
 	);
-	// A sandbox joins the fan-out as its own host, so a cloud workspace is
+	// The open workspace's sandbox joins the fan-out as its own host (and only
+	// the open one: polled, a sandbox never sleeps), so a cloud workspace is
 	// found the same way as any other — but it has no v2_hosts row for the
 	// remote version gate to check.
 	const { targets: sandboxes } = useSandboxAccess();

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -967,6 +967,37 @@ export function useDashboardSidebarState() {
 		[collections, hostWorkspaces, tagFolderContext],
 	);
 
+	/**
+	 * "Remove PR link" for a chip sourced from the cloud table. Null clears
+	 * it. A row without local state (an auto-included main) gets one, the way
+	 * pinning does — the decision has to live somewhere.
+	 */
+	const setWorkspaceSuppressedPullRequest = useCallback(
+		(
+			workspaceId: string,
+			projectId: string | null,
+			pullRequestUrl: string | null,
+		) => {
+			if (!collections.v2WorkspaceLocalState.get(workspaceId)) {
+				if (pullRequestUrl === null) return;
+				if (projectId !== null) {
+					ensureSidebarProjectRecord(collections, projectId);
+				}
+				ensureSidebarWorkspaceRecord(
+					collections,
+					hostWorkspaces,
+					tagFolderContext,
+					workspaceId,
+					projectId,
+				);
+			}
+			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+				draft.sidebarState.suppressedPullRequestUrl = pullRequestUrl;
+			});
+		},
+		[collections, hostWorkspaces, tagFolderContext],
+	);
+
 	const reorderPinnedWorkspaces = useCallback(
 		(
 			orderedPins: Array<{ workspaceId: string; projectId: string | null }>,
@@ -1068,6 +1099,7 @@ export function useDashboardSidebarState() {
 		renameSection,
 		setSectionColor,
 		setWorkspacePinned,
+		setWorkspaceSuppressedPullRequest,
 		toggleProjectCollapsed,
 		toggleSectionCollapsed,
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -967,11 +967,7 @@ export function useDashboardSidebarState() {
 		[collections, hostWorkspaces, tagFolderContext],
 	);
 
-	/**
-	 * "Remove PR link" for a chip sourced from the cloud table. Null clears
-	 * it. A row without local state (an auto-included main) gets one, the way
-	 * pinning does — the decision has to live somewhere.
-	 */
+	// A row without local state (an auto-included main) gets one, as pinning does.
 	const setWorkspaceSuppressedPullRequest = useCallback(
 		(
 			workspaceId: string,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -148,9 +148,8 @@ export const workspaceLocalStateSchema = z.object({
 		// Epoch ms when the user pinned this workspace to the sidebar's Pinned
 		// section; null = not pinned. Ordering is pinnedAt ascending.
 		pinnedAt: z.number().int().nullable().default(null),
-		// "Remove PR link" for a chip sourced from the cloud pull-request table:
-		// that PR stays hidden on this row, a different PR still shows. The
-		// host keeps its own copy of the same decision for the views it serves.
+		// "Remove PR link" for cloud-sourced chips: that PR stays hidden, a
+		// different PR still shows.
 		suppressedPullRequestUrl: z.string().nullable().default(null),
 	}),
 	paneLayout: paneWorkspaceStateSchema,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -148,6 +148,10 @@ export const workspaceLocalStateSchema = z.object({
 		// Epoch ms when the user pinned this workspace to the sidebar's Pinned
 		// section; null = not pinned. Ordering is pinnedAt ascending.
 		pinnedAt: z.number().int().nullable().default(null),
+		// "Remove PR link" for a chip sourced from the cloud pull-request table:
+		// that PR stays hidden on this row, a different PR still shows. The
+		// host keeps its own copy of the same decision for the views it serves.
+		suppressedPullRequestUrl: z.string().nullable().default(null),
 	}),
 	paneLayout: paneWorkspaceStateSchema,
 	viewedFiles: z.array(z.string()).default([]),
@@ -190,6 +194,7 @@ const SIDEBAR_STATE_DEFAULTS = {
 	activeTab: "changes",
 	isHidden: false,
 	pinnedAt: null,
+	suppressedPullRequestUrl: null,
 } as const;
 
 const WORKSPACE_LOCAL_STATE_OPTIONAL_DEFAULTS = {

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/SandboxAccessProvider/SandboxAccessProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/SandboxAccessProvider/SandboxAccessProvider.tsx
@@ -27,11 +27,12 @@ const SandboxAccessContext = createContext<SandboxAccessValue | null>(null);
  * Keeps a live address for every ready cloud workspace.
  *
  * A sandbox has no `v2_hosts` row and no stable URL — it is reachable only
- * through a token this brokers, and that token expires. Minting for all of
- * them (rather than only the open one) is what lets the rest of the app treat
- * a sandbox as just another host: the workspace, pull-request, agent-status
- * and diff-stat fan-outs are all keyed by host address, so once a sandbox has
- * one they light up with no cloud-specific code.
+ * through a token this brokers, and that token expires. Minting talks to the
+ * Superset API, not to the sandbox, so holding an address for every ready
+ * workspace costs nothing at the provider: it is what makes "is this id a
+ * cloud workspace" a synchronous question, and lets the workspace fan-out
+ * address the open one the instant it opens. The addresses are not used to
+ * reach a sandbox that is not open — every request wakes it.
  */
 export function SandboxAccessProvider({ children }: { children: ReactNode }) {
 	const { workspaces: cloudWorkspaces, organizationId } = useCloudWorkspaces();

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/SandboxAccessProvider/SandboxAccessProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/SandboxAccessProvider/SandboxAccessProvider.tsx
@@ -28,11 +28,8 @@ const SandboxAccessContext = createContext<SandboxAccessValue | null>(null);
  *
  * A sandbox has no `v2_hosts` row and no stable URL — it is reachable only
  * through a token this brokers, and that token expires. Minting talks to the
- * Superset API, not to the sandbox, so holding an address for every ready
- * workspace costs nothing at the provider: it is what makes "is this id a
- * cloud workspace" a synchronous question, and lets the workspace fan-out
- * address the open one the instant it opens. The addresses are not used to
- * reach a sandbox that is not open — every request wakes it.
+ * Superset API, not the sandbox, so addressing every ready workspace wakes
+ * nothing; the fan-out only uses the open one's address.
  */
 export function SandboxAccessProvider({ children }: { children: ReactNode }) {
 	const { workspaces: cloudWorkspaces, organizationId } = useCloudWorkspaces();

--- a/apps/mobile/hooks/useCloudWorkspaceItems/index.ts
+++ b/apps/mobile/hooks/useCloudWorkspaceItems/index.ts
@@ -2,6 +2,5 @@ export {
 	type CloudWorkspaceItem,
 	type CloudWorkspaceItemsValue,
 	type CloudWorkspaceStatus,
-	sandboxWorkspacesQuery,
 	useCloudWorkspaceItems,
 } from "./useCloudWorkspaceItems";

--- a/apps/mobile/hooks/useCloudWorkspaceItems/useCloudWorkspaceItems.ts
+++ b/apps/mobile/hooks/useCloudWorkspaceItems/useCloudWorkspaceItems.ts
@@ -1,4 +1,4 @@
-import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
 	type CloudWorkspaceRow,
@@ -11,10 +11,7 @@ import {
 	type HostWorkspacesCacheOps,
 } from "@/hooks/useHostWorkspaces";
 import { type SandboxTarget, useSandboxAccess } from "@/hooks/useSandboxAccess";
-import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { getSandboxAccess } from "@/lib/sandbox-access";
-
-const SERVED_REFETCH_INTERVAL_MS = 30_000;
 
 export type CloudWorkspaceStatus = CloudWorkspaceRow["status"];
 
@@ -23,46 +20,23 @@ export interface CloudWorkspaceItem extends HostWorkspaceItem {
 }
 
 /**
- * The row a sandbox serves for its own workspace, restated under the cloud
- * workspace's id: the sandbox reports the machine id of the container it
- * happens to run in, which addresses nothing from here.
- */
-export function sandboxWorkspacesQuery(target: SandboxTarget) {
-	return {
-		queryKey: getHostWorkspacesQueryKey(target.workspaceId, target.url),
-		refetchInterval: SERVED_REFETCH_INTERVAL_MS,
-		retry: 1,
-		networkMode: "always" as const,
-		queryFn: async (): Promise<HostWorkspaceRow[]> => {
-			const rows = await getHostServiceClientByUrl(
-				target.url,
-			).workspace.list.query();
-			return rows.map((row) => ({ ...row, hostId: target.workspaceId }));
-		},
-	};
-}
-
-/**
- * A cloud row rendered as a list item before its sandbox serves anything —
- * while it provisions, after it failed, or in the beat between `ready` and
- * host-service answering. The cloud row is the workspace's identity (it is
- * what created, named and lists it); the sandbox's own row only adds live git
- * state once it exists.
+ * A cloud row rendered as a list item. The cloud row is the workspace's
+ * identity (it is what created, named and lists it) and carries the branch it
+ * was created on; the sandbox's own row is only consulted once the workspace
+ * is opened (useWorkspaceHost), never from the list — the provider counts
+ * every request as activity, so a list that asked each sandbox for its row
+ * kept all of them awake for as long as Home was on screen.
  *
- * Two fields are invented while the sandbox isn't serving, and both are load
- * bearing only in what they prevent: `worktreeExists: true` keeps the list
- * from filtering the row as a stale shell, and `worktreePath: ""` satisfies
- * the shape — nothing reads a path off a list row (the workspace screen's
- * attachment target uses the served row, which has the real one). `type` is
- * not invented: the sandbox self-seeds its workspace as `main`. Anything new
- * that reads more than that off a home-list row has to decide what an
- * unserved sandbox should answer.
+ * Two fields are invented, and both are load bearing only in what they
+ * prevent: `worktreeExists: true` keeps the list from filtering the row as a
+ * stale shell, and `worktreePath: ""` satisfies the shape — nothing reads a
+ * path off a list row (the workspace screen's attachment target uses the
+ * served row, which has the real one). `type` is not invented: the sandbox
+ * self-seeds its workspace as `main`. `hostReachable` is false because the
+ * list never asks; row decoration that needs the host (diff stats) waits for
+ * the workspace to be opened.
  */
-function itemFromCloudRow(
-	cloud: CloudWorkspaceRow,
-	served: HostWorkspaceRow | undefined,
-	hostReachable: boolean,
-): CloudWorkspaceItem {
+function itemFromCloudRow(cloud: CloudWorkspaceRow): CloudWorkspaceItem {
 	return {
 		id: cloud.id,
 		organizationId: cloud.organizationId,
@@ -70,21 +44,21 @@ function itemFromCloudRow(
 		projectId: "",
 		hostId: cloud.id,
 		name: cloud.name,
-		branch: served?.branch ?? cloud.branch,
+		branch: cloud.branch,
 		type: "main",
 		createdByUserId: cloud.createdByUserId ?? null,
 		taskId: null,
-		tags: served?.tags ?? [],
+		tags: [],
 		createdAt: cloud.createdAt,
-		updatedAt: served?.updatedAt ?? cloud.updatedAt,
-		// Agent activity is stamped by the sandbox host; unknown until it serves.
-		lastActivityAt: served?.lastActivityAt ?? null,
-		worktreePath: served?.worktreePath ?? "",
-		worktreeExists: served ? served.worktreeExists : true,
-		projectName: served?.projectName ?? null,
+		updatedAt: cloud.updatedAt,
+		// Agent activity is stamped by the sandbox host; unknown until opened.
+		lastActivityAt: null,
+		worktreePath: "",
+		worktreeExists: true,
+		projectName: null,
 		archivedAt: null,
 		archiveReason: null,
-		hostReachable,
+		hostReachable: false,
 		cloud: { status: cloud.status },
 	};
 }
@@ -98,37 +72,19 @@ export interface CloudWorkspaceItemsValue {
 }
 
 /**
- * Cloud workspaces as home-list rows: the cloud list for identity and status,
- * plus each ready sandbox's own `workspace.list` for live branch and worktree
- * state. Query keys match `useHostWorkspaces`, so opening a row resolves
- * straight from cache.
+ * Cloud workspaces as home-list rows, from the cloud list alone. Addresses
+ * are still brokered for every ready sandbox (that talks to the API, not the
+ * sandbox) so opening a row resolves its host at once.
  */
 export function useCloudWorkspaceItems(): CloudWorkspaceItemsValue {
 	const queryClient = useQueryClient();
 	const { workspaces: cloudRows, isReady: listReady } = useCloudWorkspaces();
 	const { targets, isReady: accessReady } = useSandboxAccess(cloudRows);
 
-	const served = useQueries({
-		queries: targets.map((target) => sandboxWorkspacesQuery(target)),
-	});
-
-	const items = useMemo<CloudWorkspaceItem[]>(() => {
-		const servedById = new Map<
-			string,
-			{ row: HostWorkspaceRow | undefined; reachable: boolean }
-		>();
-		targets.forEach((target, index) => {
-			const query = served[index];
-			servedById.set(target.workspaceId, {
-				row: query?.data?.find((row) => row.id === target.workspaceId),
-				reachable: Boolean(query?.data) && !query?.isError,
-			});
-		});
-		return cloudRows.map((cloud) => {
-			const entry = servedById.get(cloud.id);
-			return itemFromCloudRow(cloud, entry?.row, entry?.reachable ?? false);
-		});
-	}, [cloudRows, targets, served]);
+	const items = useMemo<CloudWorkspaceItem[]>(
+		() => cloudRows.map((cloud) => itemFromCloudRow(cloud)),
+		[cloudRows],
+	);
 
 	const cache = useMemo<HostWorkspacesCacheOps>(() => {
 		const keyFor = (hostId: string) => {

--- a/apps/mobile/hooks/useCloudWorkspaceItems/useCloudWorkspaceItems.ts
+++ b/apps/mobile/hooks/useCloudWorkspaceItems/useCloudWorkspaceItems.ts
@@ -20,21 +20,15 @@ export interface CloudWorkspaceItem extends HostWorkspaceItem {
 }
 
 /**
- * A cloud row rendered as a list item. The cloud row is the workspace's
- * identity (it is what created, named and lists it) and carries the branch it
- * was created on; the sandbox's own row is only consulted once the workspace
- * is opened (useWorkspaceHost), never from the list — the provider counts
- * every request as activity, so a list that asked each sandbox for its row
- * kept all of them awake for as long as Home was on screen.
+ * A cloud row as a list item, without asking its sandbox (a request per
+ * sandbox kept every one of them awake while Home was on screen); the served
+ * row is read only by the workspace screen (useWorkspaceHost).
  *
- * Two fields are invented, and both are load bearing only in what they
- * prevent: `worktreeExists: true` keeps the list from filtering the row as a
- * stale shell, and `worktreePath: ""` satisfies the shape — nothing reads a
- * path off a list row (the workspace screen's attachment target uses the
- * served row, which has the real one). `type` is not invented: the sandbox
- * self-seeds its workspace as `main`. `hostReachable` is false because the
- * list never asks; row decoration that needs the host (diff stats) waits for
- * the workspace to be opened.
+ * Two fields are invented: `worktreeExists: true` keeps the list from
+ * filtering the row as a stale shell, and `worktreePath: ""` satisfies the
+ * shape — nothing reads a path off a list row. `type` is not invented: the
+ * sandbox self-seeds its workspace as `main`. `hostReachable` is false so
+ * decoration that needs the host (diff stats) waits for the workspace to open.
  */
 function itemFromCloudRow(cloud: CloudWorkspaceRow): CloudWorkspaceItem {
 	return {
@@ -71,11 +65,7 @@ export interface CloudWorkspaceItemsValue {
 	isReady: boolean;
 }
 
-/**
- * Cloud workspaces as home-list rows, from the cloud list alone. Addresses
- * are still brokered for every ready sandbox (that talks to the API, not the
- * sandbox) so opening a row resolves its host at once.
- */
+/** Cloud workspaces as home-list rows. Addresses are brokered via the API, never the sandbox. */
 export function useCloudWorkspaceItems(): CloudWorkspaceItemsValue {
 	const queryClient = useQueryClient();
 	const { workspaces: cloudRows, isReady: listReady } = useCloudWorkspaces();

--- a/apps/mobile/hooks/useWorkspaceHost/useWorkspaceHost.ts
+++ b/apps/mobile/hooks/useWorkspaceHost/useWorkspaceHost.ts
@@ -21,9 +21,7 @@ const SANDBOX_REFETCH_INTERVAL_MS = 30_000;
 /**
  * The row a sandbox serves for its own workspace, restated under the cloud
  * workspace's id: the sandbox reports the machine id of the container it
- * happens to run in, which addresses nothing from here. Only the open
- * workspace asks — the provider counts every request as activity, so a list
- * that polled each sandbox kept all of them awake.
+ * happens to run in, which addresses nothing from here.
  */
 function sandboxWorkspacesQuery(target: SandboxTarget) {
 	return {

--- a/apps/mobile/hooks/useWorkspaceHost/useWorkspaceHost.ts
+++ b/apps/mobile/hooks/useWorkspaceHost/useWorkspaceHost.ts
@@ -1,6 +1,5 @@
 import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { sandboxWorkspacesQuery } from "@/hooks/useCloudWorkspaceItems";
 import {
 	type CloudWorkspaceRow,
 	useCloudWorkspaces,
@@ -11,11 +10,35 @@ import {
 	type HostWorkspaceRow,
 } from "@/hooks/useHostWorkspaces";
 import { NO_HOSTS, type OrgHost, useOrgHostsQuery } from "@/hooks/useOrgHosts";
-import { useSandboxAccess } from "@/hooks/useSandboxAccess";
+import { type SandboxTarget, useSandboxAccess } from "@/hooks/useSandboxAccess";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
 } from "@/lib/host-service/client";
+
+const SANDBOX_REFETCH_INTERVAL_MS = 30_000;
+
+/**
+ * The row a sandbox serves for its own workspace, restated under the cloud
+ * workspace's id: the sandbox reports the machine id of the container it
+ * happens to run in, which addresses nothing from here. Only the open
+ * workspace asks — the provider counts every request as activity, so a list
+ * that polled each sandbox kept all of them awake.
+ */
+function sandboxWorkspacesQuery(target: SandboxTarget) {
+	return {
+		queryKey: getHostWorkspacesQueryKey(target.workspaceId, target.url),
+		refetchInterval: SANDBOX_REFETCH_INTERVAL_MS,
+		retry: 1,
+		networkMode: "always" as const,
+		queryFn: async (): Promise<HostWorkspaceRow[]> => {
+			const rows = await getHostServiceClientByUrl(
+				target.url,
+			).workspace.list.query();
+			return rows.map((row) => ({ ...row, hostId: target.workspaceId }));
+		},
+	};
+}
 
 export interface WorkspaceHostResult {
 	workspace: HostWorkspaceRow | null;

--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -136,33 +136,17 @@ export function HomeScreen() {
 	const { workspaces, isReady, cache } = useHostWorkspaces(selectedHost);
 	const {
 		items: cloudItems,
-		targets: sandboxes,
 		cache: cloudCache,
 		isReady: cloudReady,
 	} = useCloudWorkspaceItems();
 	const cloudScope = useWorkspaceScope() === "cloud";
-	// Every addressed sandbox is a host of its own for the terminal fan-out,
-	// so cloud rows get session marks and attention like any other row. Lazier
-	// than the machine host on purpose: each sandbox is its own request, and a
-	// phone paying N requests every 5s for list decoration is the mistake
-	// desktop just walked back (#6570). Opening a workspace speeds up its own
-	// host via the shared query key.
-	// Only the scope on screen is polled: a sandbox costs its own request, and
-	// paying for every one of them to decorate rows the list isn't showing is
-	// the mistake desktop just walked back (#6570).
+	// Cloud rows get no session marks from the list: the terminal fan-out is
+	// one request per sandbox, and the provider counts every request as
+	// activity, so decorating the list would keep every sandbox awake for as
+	// long as Home is on screen. A sandbox's terminals show once it is opened.
 	const terminalHosts = useMemo<TerminalsHost[]>(
-		() =>
-			cloudScope
-				? sandboxes.map((sandbox) => ({
-						organizationId: sandbox.organizationId,
-						machineId: sandbox.workspaceId,
-						isOnline: true,
-						refetchIntervalMs: 30_000,
-					}))
-				: selectedHost
-					? [selectedHost]
-					: [],
-		[selectedHost, sandboxes, cloudScope],
+		() => (cloudScope || !selectedHost ? [] : [selectedHost]),
+		[selectedHost, cloudScope],
 	);
 	const { terminalsByWorkspace, attentionByWorkspace } =
 		useHostsTerminals(terminalHosts);

--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -140,10 +140,8 @@ export function HomeScreen() {
 		isReady: cloudReady,
 	} = useCloudWorkspaceItems();
 	const cloudScope = useWorkspaceScope() === "cloud";
-	// Cloud rows get no session marks from the list: the terminal fan-out is
-	// one request per sandbox, and the provider counts every request as
-	// activity, so decorating the list would keep every sandbox awake for as
-	// long as Home is on screen. A sandbox's terminals show once it is opened.
+	// No session marks for cloud rows: a request per sandbox keeps each one
+	// awake for as long as Home is on screen.
 	const terminalHosts = useMemo<TerminalsHost[]>(
 		() => (cloudScope || !selectedHost ? [] : [selectedHost]),
 		[selectedHost, cloudScope],

--- a/apps/mobile/screens/(authenticated)/(home)/search/SearchScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/search/SearchScreen.tsx
@@ -56,8 +56,7 @@ export function SearchScreen() {
 	const pinnedAt = usePinnedWorkspacesStore((state) => state.pinnedAt);
 
 	// Same hosts the home list polls, so the query keys are shared and the
-	// sheet decorates from cache instead of paying its own fan-out. Sandboxes
-	// are never among them: a request per sandbox keeps each one awake.
+	// sheet decorates from cache instead of paying its own fan-out.
 	const terminalHosts = useMemo<TerminalsHost[]>(
 		() => (cloudScope || !selectedHost ? [] : [selectedHost]),
 		[selectedHost, cloudScope],

--- a/apps/mobile/screens/(authenticated)/(home)/search/SearchScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/search/SearchScreen.tsx
@@ -51,25 +51,16 @@ export function SearchScreen() {
 	const selectedHost = useSelectedHost();
 	const cloudScope = useWorkspaceScope() === "cloud";
 	const { workspaces } = useHostWorkspaces(selectedHost);
-	const { items: cloudItems, targets: sandboxes } = useCloudWorkspaceItems();
+	const { items: cloudItems } = useCloudWorkspaceItems();
 	const { projects } = useHostProjects(selectedHost);
 	const pinnedAt = usePinnedWorkspacesStore((state) => state.pinnedAt);
 
 	// Same hosts the home list polls, so the query keys are shared and the
-	// sheet decorates from cache instead of paying its own fan-out.
+	// sheet decorates from cache instead of paying its own fan-out. Sandboxes
+	// are never among them: a request per sandbox keeps each one awake.
 	const terminalHosts = useMemo<TerminalsHost[]>(
-		() =>
-			cloudScope
-				? sandboxes.map((sandbox) => ({
-						organizationId: sandbox.organizationId,
-						machineId: sandbox.workspaceId,
-						isOnline: true,
-						refetchIntervalMs: 30_000,
-					}))
-				: selectedHost
-					? [selectedHost]
-					: [],
-		[selectedHost, sandboxes, cloudScope],
+		() => (cloudScope || !selectedHost ? [] : [selectedHost]),
+		[selectedHost, cloudScope],
 	);
 	const { terminalsByWorkspace } = useHostsTerminals(terminalHosts);
 

--- a/packages/trpc/src/router/integration/github/github.ts
+++ b/packages/trpc/src/router/integration/github/github.ts
@@ -6,7 +6,7 @@ import {
 } from "@superset/db/schema";
 import type { TRPCRouterRecord } from "@trpc/server";
 import { Client } from "@upstash/qstash";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../../env";
 import { protectedProcedure, userError } from "../../../trpc";
@@ -225,20 +225,19 @@ export const githubRouter = {
 				repos.map((repo) => [repo.id, repo.fullName]),
 			);
 
-			const wanted = new Set<string>();
-			const repoIds = new Set<string>();
-			const branches = new Set<string>();
+			const pairs = new Map<string, { repoId: string; headBranch: string }>();
 			for (const ref of input.refs) {
 				const repo = repoByFullName.get(ref.repoFullName.toLowerCase());
 				if (!repo) continue;
 				// The table has no head-repository owner, so a fork's `main` would
 				// match a checkout of this repository's default branch.
 				if (ref.headBranch === repo.defaultBranch) continue;
-				wanted.add(`${repo.id}\n${ref.headBranch}`);
-				repoIds.add(repo.id);
-				branches.add(ref.headBranch);
+				pairs.set(`${repo.id}\n${ref.headBranch}`, {
+					repoId: repo.id,
+					headBranch: ref.headBranch,
+				});
 			}
-			if (wanted.size === 0) {
+			if (pairs.size === 0) {
 				return { hasInstallation: true, pullRequests: [] };
 			}
 
@@ -261,8 +260,14 @@ export const githubRouter = {
 				.where(
 					and(
 						eq(githubPullRequests.organizationId, input.organizationId),
-						inArray(githubPullRequests.repositoryId, [...repoIds]),
-						inArray(githubPullRequests.headBranch, [...branches]),
+						// Exact pairs, so no requested ref can be crowded out of the
+						// limit by another ref's rows.
+						sql`(${githubPullRequests.repositoryId}, ${githubPullRequests.headBranch}) IN (${sql.join(
+							[...pairs.values()].map(
+								(pair) => sql`(${pair.repoId}::uuid, ${pair.headBranch})`,
+							),
+							sql`, `,
+						)})`,
 					),
 				)
 				.orderBy(desc(githubPullRequests.updatedAt))
@@ -273,7 +278,6 @@ export const githubRouter = {
 			const bestByRef = new Map<string, (typeof rows)[number]>();
 			for (const row of rows) {
 				const key = `${row.repositoryId}\n${row.headBranch}`;
-				if (!wanted.has(key)) continue;
 				const existing = bestByRef.get(key);
 				if (!existing || (existing.state !== "open" && row.state === "open")) {
 					bestByRef.set(key, row);

--- a/packages/trpc/src/router/integration/github/github.ts
+++ b/packages/trpc/src/router/integration/github/github.ts
@@ -180,6 +180,131 @@ export const githubRouter = {
 			});
 		}),
 
+	/**
+	 * The pull request to show for each (repository, head branch) pair — what
+	 * a sidebar row needs and nothing more. One PR per ref: an open one wins,
+	 * otherwise the most recently updated. Repositories are matched by full
+	 * name within the organization's installation, so a ref for a repository
+	 * the App is not installed on simply has no entry.
+	 *
+	 * `hasInstallation` lets a client that has its own PR source (a host it
+	 * can reach) decide whether to fall back to it.
+	 */
+	getByBranches: protectedProcedure
+		.input(
+			z.object({
+				organizationId: z.string().uuid(),
+				refs: z
+					.array(
+						z.object({
+							repoFullName: z.string().min(1),
+							headBranch: z.string().min(1),
+						}),
+					)
+					.max(500),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			await verifyOrgMembership(ctx.session.user.id, input.organizationId);
+
+			const installation = await db.query.githubInstallations.findFirst({
+				where: eq(githubInstallations.organizationId, input.organizationId),
+				columns: { id: true },
+			});
+			if (!installation) {
+				return { hasInstallation: false, pullRequests: [] };
+			}
+			if (input.refs.length === 0) {
+				return { hasInstallation: true, pullRequests: [] };
+			}
+
+			const repos = await db.query.githubRepositories.findMany({
+				where: eq(githubRepositories.installationId, installation.id),
+				columns: { id: true, fullName: true, defaultBranch: true },
+			});
+			const repoByFullName = new Map(
+				repos.map((repo) => [repo.fullName.toLowerCase(), repo]),
+			);
+			const fullNameByRepoId = new Map(
+				repos.map((repo) => [repo.id, repo.fullName]),
+			);
+
+			const wanted = new Set<string>();
+			const repoIds = new Set<string>();
+			const branches = new Set<string>();
+			for (const ref of input.refs) {
+				const repo = repoByFullName.get(ref.repoFullName.toLowerCase());
+				if (!repo) continue;
+				// The table records a PR's head branch but not the repository it
+				// lives in, so a fork's `main` is indistinguishable from this one's.
+				// A checkout of the default branch has no PR of its own, and would
+				// otherwise pick up whichever fork last opened one from theirs.
+				if (ref.headBranch === repo.defaultBranch) continue;
+				wanted.add(`${repo.id}\n${ref.headBranch}`);
+				repoIds.add(repo.id);
+				branches.add(ref.headBranch);
+			}
+			if (wanted.size === 0) {
+				return { hasInstallation: true, pullRequests: [] };
+			}
+
+			const rows = await db
+				.select({
+					repositoryId: githubPullRequests.repositoryId,
+					headBranch: githubPullRequests.headBranch,
+					number: githubPullRequests.prNumber,
+					url: githubPullRequests.url,
+					title: githubPullRequests.title,
+					state: githubPullRequests.state,
+					isDraft: githubPullRequests.isDraft,
+					reviewDecision: githubPullRequests.reviewDecision,
+					checksStatus: githubPullRequests.checksStatus,
+					checks: githubPullRequests.checks,
+					mergedAt: githubPullRequests.mergedAt,
+					updatedAt: githubPullRequests.updatedAt,
+				})
+				.from(githubPullRequests)
+				.where(
+					and(
+						eq(githubPullRequests.organizationId, input.organizationId),
+						inArray(githubPullRequests.repositoryId, [...repoIds]),
+						inArray(githubPullRequests.headBranch, [...branches]),
+					),
+				)
+				.orderBy(desc(githubPullRequests.updatedAt))
+				.limit(2_000);
+
+			// Rows arrive newest first, so the first open PR per ref is the newest
+			// open one, and the first row of any state is the newest overall.
+			const bestByRef = new Map<string, (typeof rows)[number]>();
+			for (const row of rows) {
+				const key = `${row.repositoryId}\n${row.headBranch}`;
+				if (!wanted.has(key)) continue;
+				const existing = bestByRef.get(key);
+				if (!existing || (existing.state !== "open" && row.state === "open")) {
+					bestByRef.set(key, row);
+				}
+			}
+
+			return {
+				hasInstallation: true,
+				pullRequests: [...bestByRef.values()].map((row) => ({
+					repoFullName: fullNameByRepoId.get(row.repositoryId) ?? "",
+					headBranch: row.headBranch,
+					number: row.number,
+					url: row.url,
+					title: row.title,
+					state: row.state,
+					isDraft: row.isDraft,
+					reviewDecision: row.reviewDecision,
+					checksStatus: row.checksStatus,
+					checks: row.checks ?? [],
+					mergedAt: row.mergedAt,
+					updatedAt: row.updatedAt,
+				})),
+			};
+		}),
+
 	getStats: protectedProcedure
 		.input(z.object({ organizationId: z.string().uuid() }))
 		.query(async ({ ctx, input }) => {

--- a/packages/trpc/src/router/integration/github/github.ts
+++ b/packages/trpc/src/router/integration/github/github.ts
@@ -181,14 +181,10 @@ export const githubRouter = {
 		}),
 
 	/**
-	 * The pull request to show for each (repository, head branch) pair — what
-	 * a sidebar row needs and nothing more. One PR per ref: an open one wins,
-	 * otherwise the most recently updated. Repositories are matched by full
-	 * name within the organization's installation, so a ref for a repository
-	 * the App is not installed on simply has no entry.
-	 *
-	 * `hasInstallation` lets a client that has its own PR source (a host it
-	 * can reach) decide whether to fall back to it.
+	 * One pull request per (repository, head branch) ref for sidebar chips:
+	 * an open one wins, else the most recently updated. A repository the App
+	 * is not installed on has no entry; `hasInstallation` lets a client fall
+	 * back to a host it can reach.
 	 */
 	getByBranches: protectedProcedure
 		.input(
@@ -235,10 +231,8 @@ export const githubRouter = {
 			for (const ref of input.refs) {
 				const repo = repoByFullName.get(ref.repoFullName.toLowerCase());
 				if (!repo) continue;
-				// The table records a PR's head branch but not the repository it
-				// lives in, so a fork's `main` is indistinguishable from this one's.
-				// A checkout of the default branch has no PR of its own, and would
-				// otherwise pick up whichever fork last opened one from theirs.
+				// The table has no head-repository owner, so a fork's `main` would
+				// match a checkout of this repository's default branch.
 				if (ref.headBranch === repo.defaultBranch) continue;
 				wanted.add(`${repo.id}\n${ref.headBranch}`);
 				repoIds.add(repo.id);


### PR DESCRIPTION
## Why

Every ready cloud workspace was awake around the clock (~$32/day for a 32 GB sandbox). The provider suspends a sandbox after ~15 s without an inbound request, and the desktop sidebar asked each sandbox's host-service for pull requests every 10 s and for its workspace list every 30 s; mobile Home asked for the workspace list every 30 s and, in the Cloud scope, for terminals every 30 s. That polling alone kept all of them running whether or not anyone was inside them.

## What

**Stop addressing sandboxes from lists**
- Desktop: `deriveHostWorkspacesQueryTargets` takes a single `openSandbox` instead of every brokered sandbox; `useHostWorkspacesSource` reads the open workspace id from the route and passes only that one. The served row, `resolveHostUrl` and `isSandboxHost` keep working for the open workspace and nothing addresses any other sandbox. `derivePullRequestQueryTargets` never adds sandbox targets.
- Mobile: `useCloudWorkspaceItems` builds Home rows from the cloud list alone; the per-sandbox `workspace.list` query moved into `useWorkspaceHost`, which runs only for the workspace being opened. Home cloud rows report `hostReachable: false`, so the viewport diff-stat fetch skips them. Home and Search no longer poll each sandbox for terminals in the Cloud scope, so cloud rows there have no session marks until opened.
- `SandboxAccessProvider` still mints an address for every ready workspace; that talks to the Superset API only.

**Pull-request chips for cloud rows, from the cloud table**
- New `integration.github.getByBranches({ organizationId, refs: [{ repoFullName, headBranch }] })`: one PR per ref from `github_pull_requests` (open wins, else most recently updated), matched as exact (repository, head branch) pairs within the organization's installation, plus `hasInstallation`.
- The Cloud section polls it every 30 s for its rows, matched against the cloud repository (`cloudWorkspace.repo`). Cloud rows get a chip for the first time; asking their sandbox instead would wake it.
- Local and relay hosts are unchanged: project rows keep the 10 s host-service poll, which links a PR by checkout and upstream owner and knows merge-queue state and the status rollup.
- "Remove PR link" on a cloud row is kept in local sidebar state (`sidebarState.suppressedPullRequestUrl`); the sandbox's own unlink is still called when it is open. Host rows keep the host's own suppression.
- Cloud workspaces render only in the Cloud section, whatever their local placement row says.
- Mobile already sourced its Home badges from the cloud table (`listPullRequests`); unchanged here.

**Known gaps, on purpose**
- The cloud table stores a PR's head branch but not the repository it lives in, so a fork's `main` is indistinguishable from this repository's. The default branch is therefore never matched (a checkout of it has no PR of its own). Other fork branch-name collisions remain possible until `github_pull_requests` carries the head repository owner; served workspace rows also lack the upstream triple, so this cannot be fixed client-side.
- Cloud `checks` come from `check_run` webhooks only, while host-service reads GitHub's status rollup (commit statuses included). A PR whose CI reports through commit statuses shows fewer checks from the cloud source. Not solved here.
- The host knows a fifth chip state, `queued` (merge queue); the webhooks do not carry it, so a queued PR shows as open.

## Verification

Dev desktop on this worktree, driven over CDP, signed in with two ready cloud workspaces:
- No workspace open, 45 s of `Network.requestWillBeSent`: 0 requests to `*.preview.bl.run`.
- Clicked "Cloud workspace" in the sidebar: the workspace opened with its panes and git state; 54 requests over 45 s, all to that one workspace's preview host.
- Clicked "New Workspace" to leave it: 0 requests to `*.preview.bl.run` in the next 45 s, and still 0 after the chip change.
- `getByBranches` called from the renderer: case-insensitive repo match, unknown repos ignored, `main` excluded, checks payload maps (lowercase `status`/`conclusion`). Cloud rows rendered chips end to end (before the default-branch exclusion they showed fork PRs from `main`, which is what prompted it). Project rows were not touched by the chip change and still render from the host poll.

**Who is still polling the test sandbox.** A packet capture inside `ws-d800b29088214aecb2815bf5` (tcpdump on `:4879`, User-Agent + X-Forwarded-For) attributed the remaining inbound requests to old clients only: Superset Canary 1.25.1-canary.20260902195321 and the iOS Simulator app on one Mac, and a 1.25.1-canary.20260901121104 plus a 1.25.1 stable on another network. Nothing server-side touches a sandbox after provisioning. So the sandboxes sleep once clients run this build: ship a canary and stable, and update the other desktops. Ground truth afterwards: the `ss -tn state established '( sport = :4879 )'` sample inside the sandbox goes silent, then `GET /v0/sandboxes/<name>` grows `state` and `lastUsedAt` (absent until the first suspend), and the tick log at `/tmp/sleep-ticks.log` there shows its first gap > 3 s.

Follow-up worth a look: the Sep 1 canary issued three `workspace.list` calls within 5 s, which looks like a retry loop next to #7105's GET fallback.

`lint:fix`, `typecheck`, desktop and mobile tests, `sherif`, and the Lingui check pass.
