### PR TITLE
feat(mobile): move the workspace PR link beside the quick keys

### DIFF
--- a/apps/mobile/modules/composer/ios/ComposerModel.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModel.swift
@@ -60,9 +60,9 @@ final class ComposerModel {
   /// has no catalog. See `ComposerSessionTabLabels`.
   var sessionTabLabels = ComposerSessionTabLabels()
 
-  /// The strip's leading control. Nil on every surface with nothing to link
-  /// to, which is all of them but the workspace terminal.
-  var sessionAction: ComposerSessionAction?
+  /// The control beside the quick keys. Nil on every surface with nothing to
+  /// link to, which is all of them but the workspace terminal.
+  var quickKeysAction: ComposerQuickKeysAction?
 
   /// What the active agent can run behind `/` (or `$`). Empty hides the
   /// suggestion panel entirely — a plain shell, an agent without discovery,
@@ -123,8 +123,9 @@ final class ComposerModel {
   @ObservationIgnored var onSessionTabCopyId: ((String) -> Void)?
   @ObservationIgnored var onNewSessionPress: (() -> Void)?
   @ObservationIgnored var onAllSessionsPress: (() -> Void)?
-  /// The leading control was pressed. Where it goes is React Native's to know.
-  @ObservationIgnored var onSessionActionPress: (() -> Void)?
+  /// The control beside the quick keys was pressed. Where it goes is React
+  /// Native's to know.
+  @ObservationIgnored var onQuickKeysActionPress: (() -> Void)?
   /// Files and images pasted into the field, already written to disk. The tray
   /// lives in React Native, so the composer hands over URIs and lets it add
   /// them the same way the pickers do.

--- a/apps/mobile/modules/composer/ios/ComposerModule.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModule.swift
@@ -17,7 +17,7 @@ public final class ComposerModule: Module {
         "onSessionTabPress",
         "onSessionTabClose",
         "onSessionTabCopyId",
-        "onSessionActionPress",
+        "onQuickKeysActionPress",
         "onNewSessionPress",
         "onAllSessionsPress",
         "onPaste",
@@ -90,14 +90,16 @@ public final class ComposerModule: Module {
         }
       }
 
-      /// The strip's leading control, or nothing. Guarded for the reason
+      /// The control beside the quick keys, or nothing. Guarded for the reason
       /// `sessionTabs` is: the caller rebuilds this object every render, and an
       /// unguarded assignment would open a layout transaction on a chip that
-      /// has not changed.
-      Prop("sessionAction") { (view: ComposerAnchorView, action: ComposerSessionAction?) in
-        guard view.overlay.model.sessionAction != action else { return }
+      /// has not changed. Arriving pushes the keys over and narrows the bar
+      /// behind them; the transaction is what makes that a slide rather than
+      /// a jump. See `ComposerQuickKeys`.
+      Prop("quickKeysAction") { (view: ComposerAnchorView, action: ComposerQuickKeysAction?) in
+        guard view.overlay.model.quickKeysAction != action else { return }
         withAnimation(ComposerMetrics.growth) {
-          view.overlay.model.sessionAction = action
+          view.overlay.model.quickKeysAction = action
         }
       }
 
@@ -180,7 +182,7 @@ final class ComposerAnchorView: ExpoView {
   private let onSessionTabPress = EventDispatcher()
   private let onSessionTabClose = EventDispatcher()
   private let onSessionTabCopyId = EventDispatcher()
-  private let onSessionActionPress = EventDispatcher()
+  private let onQuickKeysActionPress = EventDispatcher()
   private let onNewSessionPress = EventDispatcher()
   private let onAllSessionsPress = EventDispatcher()
   private let onPaste = EventDispatcher()
@@ -211,8 +213,8 @@ final class ComposerAnchorView: ExpoView {
     overlay.model.onSessionTabCopyId = { [weak self] id in
       self?.onSessionTabCopyId(["id": id])
     }
-    overlay.model.onSessionActionPress = { [weak self] in
-      self?.onSessionActionPress([:])
+    overlay.model.onQuickKeysActionPress = { [weak self] in
+      self?.onQuickKeysActionPress([:])
     }
     overlay.model.onNewSessionPress = { [weak self] in self?.onNewSessionPress([:]) }
     overlay.model.onAllSessionsPress = { [weak self] in self?.onAllSessionsPress([:]) }

--- a/apps/mobile/modules/composer/ios/ComposerQuickKeys.swift
+++ b/apps/mobile/modules/composer/ios/ComposerQuickKeys.swift
@@ -19,36 +19,112 @@ import SwiftUI
 /// wearing a background would slide the panel out of the frame along with the
 /// keys.
 ///
+/// The bar is always exactly as wide as its row. Nine keys are narrower than
+/// a Pro Max and wider than an iPhone 17 once the pull request control has
+/// taken its share, so neither "hug the keys" nor "fill the row" is right on
+/// its own: hugging leaves a stub of empty row after the bar on the wide
+/// phones, filling leaves a stretch of empty panel after the last key. The
+/// keys therefore share out whatever room the row has beyond their natural
+/// width — see `QuickKeyRow` — and start scrolling the moment there is none.
+///
 /// Only the *shape* of a key crosses the bridge. What each one writes into the
 /// PTY is React Native's business — the composer reports an id and forgets.
+///
+/// The control ahead of the surface — the workspace's pull request, in the
+/// only caller today — is a peer of the bar, not a key in it: the keys scroll,
+/// it does not, and it has to be reachable however long the strip is. It takes
+/// its room only once it exists: the bar has the whole row until then, and the
+/// keys slide over when it arrives. Reserving the slot was tried and read as a
+/// dead control at the head of the row on every workspace without a pull
+/// request, which is most of them for most of their life.
 struct ComposerQuickKeys: View {
   let keys: [ComposerQuickKey]
+  /// The control beside the keys, or nothing.
+  let action: ComposerQuickKeysAction?
   let onPress: (String) -> Void
+  let onAction: () -> Void
 
-  /// How wide the keys actually are, and which edges have more behind them.
-  /// The width sizes the surface; the edges drive the mask, so a clipped key
-  /// reads as "keep going" rather than as a rendering bug.
-  @State private var layout = Layout(contentWidth: 0, leading: false, trailing: false)
+  /// How wide the bar's viewport is, and which edges have more behind them.
+  /// The width is what the keys spread out to fill; the edges drive the mask,
+  /// so a clipped key reads as "keep going" rather than as a rendering bug.
+  @State private var layout = Layout(viewportWidth: 0, leading: false, trailing: false)
 
   private struct Layout: Equatable {
-    var contentWidth: CGFloat
+    var viewportWidth: CGFloat
     var leading: Bool
     var trailing: Bool
   }
 
   var body: some View {
-    // Leading-aligned with a spacer rather than centred: a surface narrower
-    // than the row would otherwise float in the middle of it.
-    HStack(spacing: 0) {
-      surface
-      Spacer(minLength: 0)
+    HStack(spacing: ComposerMetrics.quickKeyActionGap) {
+      // Inserted, not reserved, so it is only ever on screen when it means
+      // something. The keys move once per workspace as a result — the moment
+      // a pull request exists — and the module opens a transaction around
+      // that, so they slide over together with the bar narrowing behind them
+      // rather than jumping.
+      if let action {
+        Button(action: onAction) {
+          glyph(for: action)
+            // On the label, not on the button: the style below paints
+            // `.primary` on whatever it is handed, and the inner style wins.
+            .foregroundStyle(
+              ComposerQuickKeysActionTint(rawValue: action.tint ?? "")
+                .map { AnyShapeStyle($0.color) } ?? AnyShapeStyle(.primary)
+            )
+        }
+        .buttonStyle(QuickKeysActionStyle())
+        .accessibilityLabel(action.label)
+        .transition(.opacity)
+      }
+      // Greedy, so it takes whatever the control leaves — there is no spacer
+      // because the bar itself is what fills the row.
+      if !keys.isEmpty {
+        surface
+      }
     }
     .padding(.horizontal, ComposerMetrics.horizontalMargin)
   }
 
+  /// The bundled mark when one has resolved, the SF Symbol until then.
+  ///
+  /// Templated rather than drawn as-is, so a one-colour mark takes the tint the
+  /// symbol would have — the art carries the shape, this side carries the
+  /// palette, the same split as everywhere else in the composer.
+  @ViewBuilder
+  private func glyph(for action: ComposerQuickKeysAction) -> some View {
+    if let uri = action.iconUri, !uri.isEmpty, let url = URL(string: uri) {
+      AsyncImage(url: url) { image in
+        image
+          .renderingMode(.template)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+      } placeholder: {
+        // The symbol rather than blank, so the chip does not flash empty on
+        // the frame before the file lands.
+        symbolGlyph(action.symbol)
+      }
+      .frame(
+        width: ComposerMetrics.quickKeyActionMark,
+        height: ComposerMetrics.quickKeyActionMark
+      )
+    } else {
+      symbolGlyph(action.symbol)
+    }
+  }
+
+  private func symbolGlyph(_ symbol: String) -> some View {
+    Image(systemName: symbol)
+      .font(.system(size: ComposerMetrics.quickKeyGlyphSize, weight: .semibold))
+  }
+
   private var surface: some View {
     ScrollView(.horizontal) {
-      HStack(spacing: ComposerMetrics.quickKeySpacing) {
+      QuickKeyRow(
+        // The viewport less the inset on either side, since the inset is
+        // applied outside the row and the row cannot see it.
+        fillWidth: max(0, layout.viewportWidth - ComposerMetrics.quickKeyBarInset * 2),
+        spacing: ComposerMetrics.quickKeySpacing
+      ) {
         ForEach(keys) { key in
           if key.divider {
             Rectangle()
@@ -56,9 +132,15 @@ struct ComposerQuickKeys: View {
               .frame(width: 1, height: ComposerMetrics.quickKeyDividerHeight)
               .padding(.horizontal, ComposerMetrics.quickKeyDividerGap)
               .accessibilityHidden(true)
+              // A hairline stays a hairline: the room goes to the keys.
+              .layoutValue(key: QuickKeyStretches.self, value: false)
           } else {
             Button { onPress(key.id) } label: {
-              label(for: key).frame(minWidth: ComposerMetrics.quickKeyMinWidth)
+              // `maxWidth` so the label — and with it the press highlight and
+              // the hit area — grows to whatever share of the row the layout
+              // hands the key, rather than sitting small inside it.
+              label(for: key)
+                .frame(minWidth: ComposerMetrics.quickKeyMinWidth, maxWidth: .infinity)
             }
             .buttonStyle(QuickKeyStyle())
             .accessibilityLabel(key.label ?? key.id)
@@ -71,11 +153,6 @@ struct ComposerQuickKeys: View {
       .padding(ComposerMetrics.quickKeyBarInset)
     }
     .scrollIndicators(.hidden)
-    // The surface is exactly as wide as the keys, until the keys are wider than
-    // the row — `maxWidth` is a cap, so past that it takes what is available and
-    // starts scrolling. A greedy scroll view left a stretch of empty panel after
-    // the last key, which read as a bar that had lost its contents.
-    .frame(maxWidth: layout.contentWidth > 0 ? layout.contentWidth : .infinity)
     // Masks the keys only. Applied before the background so the surface itself
     // never fades — the panel has hard edges, the content inside it does not.
     .mask(mask)
@@ -86,7 +163,7 @@ struct ComposerQuickKeys: View {
     .onScrollGeometryChange(for: Layout.self) { geometry in
       let maxOffset = geometry.contentSize.width - geometry.containerSize.width
       return Layout(
-        contentWidth: geometry.contentSize.width,
+        viewportWidth: geometry.containerSize.width,
         leading: geometry.contentOffset.x > ComposerMetrics.quickKeyScrollThreshold,
         trailing: geometry.contentOffset.x
           < maxOffset - ComposerMetrics.quickKeyScrollThreshold
@@ -143,5 +220,104 @@ private struct QuickKeyStyle: ButtonStyle {
       )
       .animation(.snappy(duration: 0.16), value: configuration.isPressed)
       .contentShape(.rect)
+  }
+}
+
+/// Whether a subview of `QuickKeyRow` takes a share of the row's spare width.
+/// Keys do; the hairlines between groups do not.
+private struct QuickKeyStretches: LayoutValueKey {
+  static let defaultValue = true
+}
+
+/// The keys in a row that is never narrower than they are, and never narrower
+/// than the bar's viewport either.
+///
+/// Room beyond the keys' natural width is split evenly between them, so the
+/// bar fills its row with no empty panel after the last key; with no room to
+/// spare they sit at their natural width and the scroll view around them takes
+/// over. A layout rather than flexible frames because inside a horizontal
+/// scroll view the width proposal is unbounded — `maxWidth: .infinity` there
+/// means infinite, not "the viewport" — so the viewport has to be handed in.
+private struct QuickKeyRow: Layout {
+  var fillWidth: CGFloat
+  var spacing: CGFloat
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+    return CGSize(
+      width: max(naturalWidth(of: sizes), fillWidth),
+      height: sizes.map(\.height).max() ?? 0
+    )
+  }
+
+  func placeSubviews(
+    in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+  ) {
+    let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+    let stretching = subviews.filter { $0[QuickKeyStretches.self] }.count
+    let share = stretching > 0
+      ? max(0, bounds.width - naturalWidth(of: sizes)) / CGFloat(stretching)
+      : 0
+    var x = bounds.minX
+    for (subview, size) in zip(subviews, sizes) {
+      let width = size.width + (subview[QuickKeyStretches.self] ? share : 0)
+      subview.place(
+        at: CGPoint(x: x, y: bounds.midY),
+        anchor: .leading,
+        proposal: ProposedViewSize(width: width, height: size.height)
+      )
+      x += width + spacing
+    }
+  }
+
+  private func naturalWidth(of sizes: [CGSize]) -> CGFloat {
+    sizes.reduce(0) { $0 + $1.width } + spacing * CGFloat(max(0, sizes.count - 1))
+  }
+}
+
+/// Press feedback for the control beside the bar.
+///
+/// The bar's own surface, cut loose: same fill, same corner, same height, so
+/// the row reads as one strip with a break in it rather than a chip parked
+/// next to a panel.
+private struct QuickKeysActionStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .frame(
+        width: ComposerMetrics.quickKeyBarHeight,
+        height: ComposerMetrics.quickKeyBarHeight
+      )
+      .foregroundStyle(.primary)
+      .background(
+        .white.opacity(configuration.isPressed ? 0.20 : 0.12),
+        in: .rect(cornerRadius: ComposerMetrics.quickKeyBarRadius, style: .continuous)
+      )
+      .animation(.snappy(duration: 0.16), value: configuration.isPressed)
+      .contentShape(.rect)
+  }
+}
+
+/// What a linked pull request's state colours the control, as it reaches this
+/// side of the bridge.
+///
+/// Same split as `ComposerSessionAttention`: the state name crosses, the
+/// palette is the composer's. Kept in step by hand with `PULL_REQUEST_STATUS`
+/// in `screens/(authenticated)/workspace/[id]/utils/pullRequest/status.ts`,
+/// which is where the rest of the app reads the same five colours from.
+enum ComposerQuickKeysActionTint: String {
+  case open
+  case draft
+  case queued
+  case merged
+  case closed
+
+  var color: Color {
+    switch self {
+    case .open: Color(red: 0.00, green: 0.74, blue: 0.49)  // emerald-500
+    case .draft: Color(white: 0.64)  // muted-foreground, dark
+    case .queued: Color(red: 0.99, green: 0.60, blue: 0.00)  // amber-500
+    case .merged: Color(red: 0.68, green: 0.27, blue: 1.00)  // purple-500
+    case .closed: Color(red: 0.88, green: 0.31, blue: 0.31)  // destructive, dark
+    }
   }
 }

--- a/apps/mobile/modules/composer/ios/ComposerQuickKeysAction.swift
+++ b/apps/mobile/modules/composer/ios/ComposerQuickKeysAction.swift
@@ -1,0 +1,37 @@
+import ExpoModulesCore
+
+/// The one static control beside the quick keys.
+///
+/// Same contract as `ComposerQuickKey`: the composer draws a chip and reports
+/// that it was pressed. What it opens — the workspace's pull requests, in the
+/// only caller today — stays in React Native, which is why nothing here names
+/// one.
+///
+/// Absent on every surface that has no such link, which is also how the home
+/// composer never grows one.
+struct ComposerQuickKeysAction: Record, Equatable {
+  /// SF Symbol name, e.g. `arrow.triangle.pull`. Chosen in React Native, the
+  /// way `ComposerQuickKey.symbol` is. Drawn while `iconUri` is still
+  /// resolving, and instead of it when there is none.
+  @Field var symbol: String = ""
+
+  /// A mark to draw in place of the symbol. Same rule as
+  /// `ComposerSessionTab.iconUri`: a *local file* URI, resolved in React
+  /// Native with `expo-asset`, never a Metro asset reference. Rendered as a
+  /// template so `tint` reaches it.
+  @Field var iconUri: String? = nil
+
+  /// Which accent the glyph takes, as a state name — or absent for the same
+  /// foreground the keys use. The meaning crosses the bridge, the palette is
+  /// the composer's: see `ComposerQuickKeysActionTint`.
+  @Field var tint: String? = nil
+
+  /// Accessibility label, translated in React Native like every other string
+  /// the composer draws.
+  @Field var label: String = ""
+
+  static func == (lhs: ComposerQuickKeysAction, rhs: ComposerQuickKeysAction) -> Bool {
+    lhs.symbol == rhs.symbol && lhs.iconUri == rhs.iconUri && lhs.tint == rhs.tint
+      && lhs.label == rhs.label
+  }
+}

--- a/apps/mobile/modules/composer/ios/ComposerRootView.swift
+++ b/apps/mobile/modules/composer/ios/ComposerRootView.swift
@@ -87,6 +87,16 @@ enum ComposerMetrics {
   /// Slack before a scroll offset counts as "there is more that way", so a
   /// rubber-band overshoot does not flicker the fades.
   static let quickKeyScrollThreshold: CGFloat = 4
+  /// The bar's outer height — a key plus the inset either side of it — which
+  /// is also the side of the square control ahead of it.
+  static let quickKeyBarHeight: CGFloat = quickKeyHeight + quickKeyBarInset * 2
+  /// Air between that control and the bar. Wider than the keys' own spacing:
+  /// the break is what says the control is not one of them.
+  static let quickKeyActionGap: CGFloat = 8
+  /// A drawn mark needs more box than an SF Symbol at the same nominal size —
+  /// the symbol's own bounds already carry optical padding, a 24-unit lucide
+  /// path does not.
+  static let quickKeyActionMark: CGFloat = 16
 
   /// The session tab strip, above the quick keys.
   ///
@@ -114,10 +124,6 @@ enum ComposerMetrics {
   static let sessionTabCloseFade: CGFloat = 12
   static let sessionTabControlSize: CGFloat = 28
   static let sessionTabControlGlyph: CGFloat = 13
-  /// A drawn mark needs more box than an SF Symbol at the same nominal size —
-  /// the symbol's own bounds already carry optical padding, a 24-unit lucide
-  /// path does not.
-  static let sessionTabControlMark: CGFloat = 16
   static let sessionTabControlGap: CGFloat = sessionTabGap
   /// How far the strip scrolls before the scroll-home chevron is fully in.
   /// The reveal is a ratio of this, not a threshold crossing, so the control
@@ -290,24 +296,27 @@ struct ComposerRootView: View {
             // is also what keeps the terminal's inset honest: the height
             // reported below is measured off this stack, so a tab strip
             // appearing is already in the number the caller insets by.
-            // Or a leading action with no sessions yet: the strip is still
-            // the row that control belongs to, and drawing it is cheaper than
-            // a second place for the caller to put one.
-            if !model.sessionTabs.isEmpty || model.sessionAction != nil {
+            if !model.sessionTabs.isEmpty {
               ComposerSessionTabs(
                 tabs: model.sessionTabs,
                 labels: model.sessionTabLabels,
-                action: model.sessionAction,
                 onSelect: { model.onSessionTabPress?($0) },
                 onClose: { model.onSessionTabClose?($0) },
                 onCopyId: { model.onSessionTabCopyId?($0) },
-                onAction: { model.onSessionActionPress?() },
                 onNewSession: { model.onNewSessionPress?() },
                 onAllSessions: { model.onAllSessionsPress?() }
               )
             }
-            if !model.quickKeys.isEmpty {
-              ComposerQuickKeys(keys: model.quickKeys) { model.onQuickKeyPress?($0) }
+            // The keys, or the control beside them: select mode empties the
+            // keys, and a workspace with a pull request keeps its row through
+            // that, so the cluster's height holds and the link stays put.
+            if !model.quickKeys.isEmpty || model.quickKeysAction != nil {
+              ComposerQuickKeys(
+                keys: model.quickKeys,
+                action: model.quickKeysAction,
+                onPress: { model.onQuickKeyPress?($0) },
+                onAction: { model.onQuickKeysActionPress?() }
+              )
             }
             surface
               .padding(.horizontal, ComposerMetrics.horizontalMargin)

--- a/apps/mobile/modules/composer/ios/ComposerSessionTab.swift
+++ b/apps/mobile/modules/composer/ios/ComposerSessionTab.swift
@@ -35,42 +35,6 @@ struct ComposerSessionTab: Record, Identifiable, Equatable {
   }
 }
 
-/// A single static control at the head of the session strip.
-///
-/// Same contract as `ComposerQuickKey`: the composer draws a chip and reports
-/// that it was pressed. What it opens — the workspace's pull requests, in the
-/// only caller today — stays in React Native, which is why nothing here names
-/// one.
-///
-/// Absent on every surface that has no such link, which is also how the home
-/// composer never grows one.
-struct ComposerSessionAction: Record, Equatable {
-  /// SF Symbol name, e.g. `arrow.triangle.pull`. Chosen in React Native, the
-  /// way `ComposerQuickKey.symbol` is. Drawn while `iconUri` is still
-  /// resolving, and instead of it when there is none.
-  @Field var symbol: String = ""
-
-  /// A mark to draw in place of the symbol. Same rule as
-  /// `ComposerSessionTab.iconUri`: a *local file* URI, resolved in React
-  /// Native with `expo-asset`, never a Metro asset reference. Rendered as a
-  /// template so `tint` reaches it.
-  @Field var iconUri: String? = nil
-
-  /// Which accent the glyph takes, as a state name — or absent for the same
-  /// foreground the strip's other controls use. The meaning crosses the
-  /// bridge, the palette is the composer's: see `ComposerSessionActionTint`.
-  @Field var tint: String? = nil
-
-  /// Accessibility label, translated in React Native like every other string
-  /// the strip draws.
-  @Field var label: String = ""
-
-  static func == (lhs: ComposerSessionAction, rhs: ComposerSessionAction) -> Bool {
-    lhs.symbol == rhs.symbol && lhs.iconUri == rhs.iconUri && lhs.tint == rhs.tint
-      && lhs.label == rhs.label
-  }
-}
-
 /// Every user-facing string the tab strip draws.
 ///
 /// They arrive as data because the composer cannot translate: Lingui's macros

--- a/apps/mobile/modules/composer/ios/ComposerSessionTabs.swift
+++ b/apps/mobile/modules/composer/ios/ComposerSessionTabs.swift
@@ -15,13 +15,9 @@ import SwiftUI
 struct ComposerSessionTabs: View {
   let tabs: [ComposerSessionTab]
   let labels: ComposerSessionTabLabels
-  /// The strip's one leading control, or nothing. Absent on every surface that
-  /// has no link to offer.
-  let action: ComposerSessionAction?
   let onSelect: (String) -> Void
   let onClose: (String) -> Void
   let onCopyId: (String) -> Void
-  let onAction: () -> Void
   let onNewSession: () -> Void
   let onAllSessions: () -> Void
 
@@ -37,19 +33,6 @@ struct ComposerSessionTabs: View {
 
   var body: some View {
     HStack(spacing: ComposerMetrics.sessionTabControlGap) {
-      // Ahead of the scroll view, so it holds still while the tabs move under
-      // the thumb — the whole point of putting it here rather than in the bar.
-      // The scroll-home chevron overlays the strip's own leading edge, so once
-      // the row has scrolled the two sit side by side.
-      if let action {
-        control(
-          symbol: action.symbol,
-          label: action.label,
-          tint: ComposerSessionActionTint(rawValue: action.tint ?? "")?.color,
-          iconUri: action.iconUri,
-          action: onAction
-        )
-      }
       ScrollViewReader { proxy in
         ScrollView(.horizontal) {
           HStack(spacing: ComposerMetrics.sessionTabGap) {
@@ -129,50 +112,14 @@ struct ComposerSessionTabs: View {
     symbol: String,
     label: String,
     opaque: Bool = false,
-    tint: Color? = nil,
-    iconUri: String? = nil,
     action: @escaping () -> Void
   ) -> some View {
     Button(action: action) {
-      glyph(symbol: symbol, iconUri: iconUri)
-        // On the label, not on the button: the style below paints
-        // `.primary` on whatever it is handed, and the inner style wins.
-        .foregroundStyle(tint.map { AnyShapeStyle($0) } ?? AnyShapeStyle(.primary))
+      Image(systemName: symbol)
+        .font(.system(size: ComposerMetrics.sessionTabControlGlyph, weight: .semibold))
     }
     .buttonStyle(ComposerSessionTabControlStyle(opaque: opaque))
     .accessibilityLabel(label)
-  }
-
-  /// The bundled mark when one has resolved, the SF Symbol until then.
-  ///
-  /// Templated rather than drawn as-is, so a one-colour mark takes the tint the
-  /// symbol would have — the art carries the shape, this side carries the
-  /// palette, the same split as everywhere else in the strip.
-  @ViewBuilder
-  private func glyph(symbol: String, iconUri: String?) -> some View {
-    if let uri = iconUri, !uri.isEmpty, let url = URL(string: uri) {
-      AsyncImage(url: url) { image in
-        image
-          .renderingMode(.template)
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-      } placeholder: {
-        // The symbol rather than blank, so the chip does not flash empty on
-        // the frame before the file lands.
-        symbolGlyph(symbol)
-      }
-      .frame(
-        width: ComposerMetrics.sessionTabControlMark,
-        height: ComposerMetrics.sessionTabControlMark
-      )
-    } else {
-      symbolGlyph(symbol)
-    }
-  }
-
-  private func symbolGlyph(_ symbol: String) -> some View {
-    Image(systemName: symbol)
-      .font(.system(size: ComposerMetrics.sessionTabControlGlyph, weight: .semibold))
   }
 }
 
@@ -346,31 +293,6 @@ private struct ComposerSessionMark: View {
     Text(tab.initial)
       .font(.system(size: size * 0.62, weight: .bold))
       .foregroundStyle(.secondary)
-  }
-}
-
-/// What a linked pull request's state colours the leading control, as it
-/// reaches this side of the bridge.
-///
-/// Same split as `ComposerSessionAttention` below: the state name crosses, the
-/// palette is the composer's. Kept in step by hand with `PULL_REQUEST_STATUS`
-/// in `screens/(authenticated)/workspace/[id]/utils/pullRequest/status.ts`,
-/// which is where the rest of the app reads the same five colours from.
-enum ComposerSessionActionTint: String {
-  case open
-  case draft
-  case queued
-  case merged
-  case closed
-
-  var color: Color {
-    switch self {
-    case .open: Color(red: 0.00, green: 0.74, blue: 0.49)  // emerald-500
-    case .draft: Color(white: 0.64)  // muted-foreground, dark
-    case .queued: Color(red: 0.99, green: 0.60, blue: 0.00)  // amber-500
-    case .merged: Color(red: 0.68, green: 0.27, blue: 1.00)  // purple-500
-    case .closed: Color(red: 0.88, green: 0.31, blue: 0.31)  // destructive, dark
-    }
   }
 }
 

--- a/apps/mobile/modules/composer/src/index.tsx
+++ b/apps/mobile/modules/composer/src/index.tsx
@@ -21,7 +21,7 @@ interface NativeComposerViewProps {
 	sessionTabs?: ComposerSessionTab[];
 	sessionTabLabels?: ComposerSessionTabLabels;
 	/** Null, never undefined — see the pass-through below. */
-	sessionAction?: ComposerSessionAction | null;
+	quickKeysAction?: ComposerQuickKeysAction | null;
 	slashCommands?: ComposerSlashCommand[];
 	showAttachments?: boolean;
 	autocapitalization?: "sentences" | "never";
@@ -37,7 +37,7 @@ interface NativeComposerViewProps {
 	onSessionTabCopyId?: (event: { nativeEvent: { id: string } }) => void;
 	onNewSessionPress?: () => void;
 	onAllSessionsPress?: () => void;
-	onSessionActionPress?: () => void;
+	onQuickKeysActionPress?: () => void;
 	onHeightChange?: (event: { nativeEvent: { height: number } }) => void;
 	onPaste?: (event: { nativeEvent: { items: ComposerPastedItem[] } }) => void;
 	onDraftChange?: (event: { nativeEvent: { text: string } }) => void;
@@ -141,17 +141,17 @@ export interface ComposerSessionTab {
 }
 
 /**
- * The one static control at the head of the session strip.
+ * The one static control beside the quick keys.
  *
- * Data only, like everything else in this row: the composer draws a chip and
- * says it was pressed. What it opens is the caller's to know — the workspace
- * terminal points it at that workspace's pull requests, and nothing here names
- * one.
+ * Data only, like the keys: the composer draws a chip and says it was pressed.
+ * What it opens is the caller's to know — the workspace terminal points it at
+ * that workspace's pull requests, and nothing here names one.
  *
- * It holds still while the tabs scroll under it, so a strip long enough to
- * scroll never carries it out of reach.
+ * It sits ahead of the bar rather than inside it, so it holds still while the
+ * keys scroll. It takes its room only once it exists: the keys slide over the
+ * moment it arrives, animated by the composer.
  */
-export interface ComposerSessionAction {
+export interface ComposerQuickKeysAction {
 	/** SF Symbol name, e.g. `arrow.triangle.pull`. */
 	symbol: string;
 	/**
@@ -162,9 +162,9 @@ export interface ComposerSessionAction {
 	 */
 	iconUri?: string;
 	/**
-	 * Which accent the glyph takes. Omit for the same foreground the strip's
-	 * other controls use. The name crosses the bridge and the composer owns the
-	 * colour, the way `ComposerSessionTab.attention` does.
+	 * Which accent the glyph takes. Omit for the same foreground the keys use.
+	 * The name crosses the bridge and the composer owns the colour, the way
+	 * `ComposerSessionTab.attention` does.
 	 */
 	tint?: "open" | "draft" | "queued" | "merged" | "closed";
 	/** Accessibility label. Translated here; the composer has no catalog. */
@@ -280,12 +280,12 @@ interface ComposerBaseProps {
 	 */
 	quickKeys?: ComposerQuickKey[];
 	/**
-	 * The one static control at the head of the session strip. Omitted on every
-	 * surface with nothing to link to — which is all of them but the workspace
-	 * terminal. Independent of `sessionTabs`: an action with no sessions yet
-	 * still draws the row it belongs to.
+	 * The one static control beside the quick keys. Omitted on every surface
+	 * with nothing to link to — which is all of them but the workspace
+	 * terminal. Independent of `quickKeys`: an action with the keys away still
+	 * draws the row it belongs to.
 	 */
-	sessionAction?: ComposerSessionAction;
+	quickKeysAction?: ComposerQuickKeysAction;
 	/**
 	 * What the active agent can run behind `/` (or `$`). Empty or omitted
 	 * hides the suggestion panel — a plain shell, an agent without command
@@ -336,10 +336,11 @@ interface ComposerBaseProps {
 	onNewSessionPress?: () => void;
 	onAllSessionsPress?: () => void;
 	/**
-	 * The leading control was pressed. Only ever fires when `sessionAction` is
-	 * set, so the caller that provided the chip is the one that hears about it.
+	 * The control beside the quick keys was pressed. Only ever fires when
+	 * `quickKeysAction` is set, so the caller that provided the chip is the one
+	 * that hears about it.
 	 */
-	onSessionActionPress?: () => void;
+	onQuickKeysActionPress?: () => void;
 	/**
 	 * How much room the composer occupies above the bottom safe area — the
 	 * session tabs, the card, the quick keys and the gaps between them.
@@ -401,7 +402,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 			quickKeys,
 			sessionTabs,
 			sessionTabLabels,
-			sessionAction,
+			quickKeysAction,
 			slashCommands,
 			showAttachments = true,
 			autocapitalization = "sentences",
@@ -417,7 +418,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 			onSessionTabCopyId,
 			onNewSessionPress,
 			onAllSessionsPress,
-			onSessionActionPress,
+			onQuickKeysActionPress,
 			onHeightChange,
 			onPaste,
 			onDraftChange,
@@ -451,7 +452,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 				// Null rather than undefined: React Native drops undefined props
 				// before they reach the view, so the native setter is never called
 				// and a chip that has gone away stays on screen.
-				sessionAction={sessionAction ?? null}
+				quickKeysAction={quickKeysAction ?? null}
 				slashCommands={slashCommands}
 				showAttachments={showAttachments}
 				autocapitalization={autocapitalization}
@@ -471,7 +472,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 				}
 				onNewSessionPress={onNewSessionPress}
 				onAllSessionsPress={onAllSessionsPress}
-				onSessionActionPress={onSessionActionPress}
+				onQuickKeysActionPress={onQuickKeysActionPress}
 				onHeightChange={(event) => onHeightChange?.(event.nativeEvent.height)}
 				onPaste={(event) => onPaste?.(event.nativeEvent.items)}
 				onDraftChange={(event) => onDraftChange?.(event.nativeEvent.text)}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -3,7 +3,7 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
 	ComposerHandle,
-	ComposerSessionAction,
+	ComposerQuickKeysAction,
 	ComposerSessionTab,
 } from "@superset/composer";
 import { i18n } from "@superset/i18n";
@@ -107,8 +107,8 @@ const STATE_BANNERS: Partial<
  * The workspace IS the terminal: sessions render as tabs (agent mark + name),
  * the active tab is the one live attached stream, and the + menu launches a
  * new session from the host's agent presets (or a plain shell). Chrome: the
- * compact header (name → action sheet) and the terminal composer, whose tab
- * strip also carries this workspace's pull requests.
+ * compact header (name → action sheet) and the terminal composer, whose
+ * quick-key row also carries this workspace's pull requests.
  *
  * The tab strip is drawn by the composer rather than here. It sits directly
  * above the quick keys, inside the composer's own view tree, because its
@@ -567,13 +567,13 @@ export function WorkspaceScreen() {
 		[id, hostUrl, workspace],
 	);
 
-	// The strip's leading chip, or nothing. Mark and colour both come off the
-	// newest pull request, the way the pill this replaced did.
+	// The chip beside the quick keys, or nothing. Mark and colour both come off
+	// the newest pull request, the way the pill this replaced did.
 	const pullRequestStatusNow = pullRequests[0]
 		? pullRequestStatus(pullRequests[0])
 		: null;
 	const pullRequestIconUri = usePullRequestIconUri(pullRequestStatusNow);
-	const pullRequestAction = useMemo((): ComposerSessionAction | undefined => {
+	const pullRequestAction = useMemo((): ComposerQuickKeysAction | undefined => {
 		const latest = pullRequests[0];
 		if (!latest) return undefined;
 		const status = pullRequestStatus(latest);
@@ -861,8 +861,8 @@ export function WorkspaceScreen() {
 					onSessionTabCopyId={copyTerminalId}
 					onNewSessionPress={openAddMenu}
 					onAllSessionsPress={openSessions}
-					sessionAction={pullRequestAction}
-					onSessionActionPress={openPullRequests}
+					quickKeysAction={pullRequestAction}
+					onQuickKeysActionPress={openPullRequests}
 					attachmentTarget={attachmentTarget}
 					onActiveChange={setComposerActive}
 					onHeightChange={setComposerHeight}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
@@ -3,7 +3,7 @@ import {
 	Composer,
 	type ComposerHandle,
 	type ComposerQuickKey,
-	type ComposerSessionAction,
+	type ComposerQuickKeysAction,
 	type ComposerSessionTab,
 	type ComposerSlashCommand,
 } from "@superset/composer";
@@ -65,12 +65,12 @@ interface TerminalComposerProps {
 	onNewSessionPress: () => void;
 	onAllSessionsPress: () => void;
 	/**
-	 * The static chip leading the tab strip — this workspace's pull requests.
+	 * The static chip beside the quick keys — this workspace's pull requests.
 	 * Omitted when it has none, which is also how a workspace that never
 	 * produced one never grows the control.
 	 */
-	sessionAction?: ComposerSessionAction;
-	onSessionActionPress: () => void;
+	quickKeysAction?: ComposerQuickKeysAction;
+	onQuickKeysActionPress: () => void;
 	/** Focused, or the keyboard is up — the screen covers the terminal with a
 	 *  tap-to-dismiss target while this is true. */
 	onActiveChange?: (active: boolean) => void;
@@ -110,8 +110,8 @@ export const TerminalComposer = forwardRef<
 		onSessionTabCopyId,
 		onNewSessionPress,
 		onAllSessionsPress,
-		sessionAction,
-		onSessionActionPress,
+		quickKeysAction,
+		onQuickKeysActionPress,
 		onActiveChange,
 		onHeightChange,
 		selectActive,
@@ -263,8 +263,8 @@ export const TerminalComposer = forwardRef<
 				onSessionTabCopyId={onSessionTabCopyId}
 				onNewSessionPress={onNewSessionPress}
 				onAllSessionsPress={onAllSessionsPress}
-				sessionAction={sessionAction}
-				onSessionActionPress={onSessionActionPress}
+				quickKeysAction={quickKeysAction}
+				onQuickKeysActionPress={onQuickKeysActionPress}
 				slashCommands={slashCommands.map(
 					(command): ComposerSlashCommand => ({
 						id: `${command.trigger}${command.name}`,


### PR DESCRIPTION
## What & why

The pull request chip sat at the head of the session tab strip. It moves to its own square ahead of the quick-key bar: a peer of the bar rather than a key in it, sharing its fill, corner and height so the row reads as one strip with a break in it.

Three decisions in the diff:

- **Inserted, not reserved.** A reserved slot was built first and read as a dead control at the head of the row on every workspace without a pull request. So the bar has the whole row until a pull request exists, and the keys slide over once when it arrives, inside the same growth transaction everything else in the cluster uses.
- **The bar fills its row on every phone.** Nine keys are narrower than a Pro Max and wider than an iPhone 17 once the chip has taken its share, so hugging the keys left a stub of empty row after the bar and filling the row left empty panel after the last key. A small custom `Layout` (`QuickKeyRow`) splits spare width evenly between the keys, hairlines excluded, and falls back to natural width plus scrolling when there is none. Flexible frames do not work here: inside a horizontal scroll view `maxWidth: .infinity` means infinite, not the viewport.
- **Renamed end to end** since it no longer belongs to the strip: `ComposerSessionAction` → `ComposerQuickKeysAction` (own file), prop `quickKeysAction`, event `onQuickKeysActionPress`. The strip is back to tabs plus its trailing controls.

Routing, tints, accessibility labels and the bundled marks are unchanged. Desktop is untouched.

## How I tested it

Screenshots from an iPhone 17 Pro Max simulator (iOS 26) against prod, with and without a pull request, are on the Superset page: https://app.superset.sh/page/pr-button-left-of-the-key-bar-7f8jo2

- [x] Open PR: emerald mark in a 36pt square ahead of the bar, bar narrows and scrolls beside it with the edge fade
- [x] No PR: no chip, bar spans the row edge to edge with the keys spread evenly and `^C` fully visible
- [x] Copy Selection (select mode) becomes one full-width key as a side effect of the fill
- [x] `xcodebuild -scheme Composer` and a full `-scheme Superset` Debug build, no errors
- [x] `biome check`, mobile `tsc --noEmit`, `bun test` (66 pass)

Not exercised live: the slide when a pull request first appears. It is the same mechanism a new session tab uses (view inserted into the row under the module's `growth` transaction), read off the code rather than recorded.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the workspace pull request link from the front of the session tabs to its own square beside the quick-key bar. The link appears only when a pull request exists; when it appears, the keys animate over and narrow, while the bar fills the available phone width and scrolls when needed.

**Changes**

- Distributes spare width evenly across key buttons while keeping dividers at their natural size.
- Renames the native and React Native APIs to `quickKeysAction` and `onQuickKeysActionPress`.
- Keeps the control fixed while the quick keys scroll and preserves its icon, tint, accessibility label, and routing.
- Leaves desktop behavior unchanged.

<sup>Written for commit 0205ae3f0057ff912791fd713f5fe6e05fa2e59c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional action control beside the composer’s quick keys.
  - Supports custom icons, accessibility labels, and pull-request status colors.
  - Quick-key buttons now expand to use available horizontal space.

- **Changes**
  - Moved the pull-request action from the session-tab strip to the quick-key row.
  - The quick-key row remains visible when an action is available, even without quick-key items.
  - Updated related naming and interaction labels to reflect the new placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->