### PR TITLE
feat(analytics): tag events with the app locale and track language changes

### DIFF
--- a/apps/desktop/src/renderer/components/PostHogLocaleTagger/PostHogLocaleTagger.tsx
+++ b/apps/desktop/src/renderer/components/PostHogLocaleTagger/PostHogLocaleTagger.tsx
@@ -1,0 +1,37 @@
+import { useLingui } from "@lingui/react";
+import { inferLocale } from "@superset/i18n";
+import { useEffect } from "react";
+import { authClient } from "renderer/lib/auth-client";
+import { electronTrpc } from "renderer/lib/electron-trpc";
+import { posthog } from "renderer/lib/posthog";
+import { resolveLocaleTag } from "./localeTag";
+
+/**
+ * Tags every event with the language actually on screen and whether it came
+ * from a pinned setting or the system language, so locale adoption and
+ * opt-outs are visible in PostHog without a dedicated event per surface.
+ * Must render inside I18nProvider: it reads the active Lingui locale.
+ */
+export function PostHogLocaleTagger() {
+	const { i18n } = useLingui();
+	const activeLocale = i18n.locale;
+	const { data: language } = electronTrpc.settings.getLanguage.useQuery();
+	const { data: session } = authClient.useSession();
+	const userId = session?.user?.id;
+
+	useEffect(() => {
+		const tag = resolveLocaleTag({
+			activeLocale,
+			language,
+			inferredLocale: inferLocale(),
+		});
+		if (!tag) return;
+
+		posthog.register(tag);
+
+		if (!userId) return;
+		posthog.people.set(tag);
+	}, [activeLocale, language, userId]);
+
+	return null;
+}

--- a/apps/desktop/src/renderer/components/PostHogLocaleTagger/index.ts
+++ b/apps/desktop/src/renderer/components/PostHogLocaleTagger/index.ts
@@ -1,0 +1,1 @@
+export { PostHogLocaleTagger } from "./PostHogLocaleTagger";

--- a/apps/desktop/src/renderer/components/PostHogLocaleTagger/localeTag.test.ts
+++ b/apps/desktop/src/renderer/components/PostHogLocaleTagger/localeTag.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { resolveLocaleTag } from "./localeTag";
+
+describe("resolveLocaleTag", () => {
+	test("waits for the setting to load", () => {
+		expect(
+			resolveLocaleTag({
+				activeLocale: "en",
+				language: undefined,
+				inferredLocale: "en",
+			}),
+		).toBeNull();
+	});
+
+	test("Auto tags the inferred system language as system", () => {
+		expect(
+			resolveLocaleTag({
+				activeLocale: "ja",
+				language: null,
+				inferredLocale: "ja",
+			}),
+		).toEqual({ app_locale: "ja", app_locale_source: "system" });
+	});
+
+	test("a pinned language is tagged as setting", () => {
+		expect(
+			resolveLocaleTag({
+				activeLocale: "fr",
+				language: "fr",
+				inferredLocale: "en",
+			}),
+		).toEqual({ app_locale: "fr", app_locale_source: "setting" });
+	});
+
+	test("skips the transitional English while a catalog loads", () => {
+		expect(
+			resolveLocaleTag({
+				activeLocale: "en",
+				language: null,
+				inferredLocale: "ja",
+			}),
+		).toBeNull();
+		expect(
+			resolveLocaleTag({
+				activeLocale: "en",
+				language: "zh-CN",
+				inferredLocale: "en",
+			}),
+		).toBeNull();
+	});
+
+	test("pinning English on a non-English system is a setting", () => {
+		expect(
+			resolveLocaleTag({
+				activeLocale: "en",
+				language: "en",
+				inferredLocale: "de",
+			}),
+		).toEqual({ app_locale: "en", app_locale_source: "setting" });
+	});
+});

--- a/apps/desktop/src/renderer/components/PostHogLocaleTagger/localeTag.ts
+++ b/apps/desktop/src/renderer/components/PostHogLocaleTagger/localeTag.ts
@@ -1,0 +1,26 @@
+export interface LocaleTag {
+	app_locale: string;
+	app_locale_source: "setting" | "system";
+}
+
+/**
+ * What to tag events with, or null while the answer is not known yet:
+ * the setting has not loaded (`language === undefined`), or a non-English
+ * catalog is still loading and English is on screen in the meantime.
+ */
+export function resolveLocaleTag({
+	activeLocale,
+	language,
+	inferredLocale,
+}: {
+	activeLocale: string;
+	language: string | null | undefined;
+	inferredLocale: string;
+}): LocaleTag | null {
+	if (language === undefined) return null;
+	if (activeLocale !== (language ?? inferredLocale)) return null;
+	return {
+		app_locale: activeLocale,
+		app_locale_source: language ? "setting" : "system",
+	};
+}

--- a/apps/desktop/src/renderer/routes/-layout.tsx
+++ b/apps/desktop/src/renderer/routes/-layout.tsx
@@ -2,6 +2,7 @@ import { I18nProvider } from "@superset/i18n/react";
 import { Alerter } from "@superset/ui/atoms/Alert";
 import type { ReactNode } from "react";
 import { DesktopNoticesGate } from "renderer/components/DesktopNotices";
+import { PostHogLocaleTagger } from "renderer/components/PostHogLocaleTagger";
 import { PostHogSurfaceTagger } from "renderer/components/PostHogSurfaceTagger";
 import { PostHogUserIdentifier } from "renderer/components/PostHogUserIdentifier";
 import { TelemetrySync } from "renderer/components/TelemetrySync";
@@ -14,7 +15,12 @@ import { PostHogProvider } from "renderer/providers/PostHogProvider";
 function LanguageAwareI18nProvider({ children }: { children: ReactNode }) {
 	// Persisted setting wins; undefined falls back to first-load inference.
 	const { data: language } = electronTrpc.settings.getLanguage.useQuery();
-	return <I18nProvider locale={language ?? undefined}>{children}</I18nProvider>;
+	return (
+		<I18nProvider locale={language ?? undefined}>
+			<PostHogLocaleTagger />
+			{children}
+		</I18nProvider>
+	);
 }
 
 export function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/OnboardingLanguageRow/OnboardingLanguageRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/onboarding/components/OnboardingLanguageRow/OnboardingLanguageRow.tsx
@@ -12,6 +12,7 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { HiOutlineLanguage } from "react-icons/hi2";
+import { track } from "renderer/lib/analytics";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
@@ -57,12 +58,17 @@ export function OnboardingLanguageRow() {
 			</div>
 			<Select
 				value={language ?? AUTO}
-				onValueChange={(value) =>
+				onValueChange={(value) => {
+					track("language_changed", {
+						from: language ?? AUTO,
+						to: value,
+						surface: "onboarding",
+					});
 					setLanguage.mutate({
 						language:
 							value === AUTO || !isSupportedLocale(value) ? null : value,
-					})
-				}
+					});
+				}}
 			>
 				<SelectTrigger
 					size="sm"

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/LanguageSection/LanguageSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/appearance/components/AppearanceSettings/components/LanguageSection/LanguageSection.tsx
@@ -8,6 +8,7 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { toast } from "@superset/ui/sonner";
+import { track } from "renderer/lib/analytics";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 import { HighlightText } from "renderer/routes/_authenticated/settings/components/HighlightText";
@@ -78,9 +79,14 @@ export function LanguageSection() {
 			</div>
 			<Select
 				value={language ?? AUTO}
-				onValueChange={(value) =>
-					setLanguage.mutate({ language: value === AUTO ? null : value })
-				}
+				onValueChange={(value) => {
+					track("language_changed", {
+						from: language ?? AUTO,
+						to: value,
+						surface: "settings",
+					});
+					setLanguage.mutate({ language: value === AUTO ? null : value });
+				}}
 			>
 				<SelectTrigger size="sm" className="w-auto min-w-44 px-2">
 					<SelectValue />

--- a/apps/docs/src/app/components/NavigationBar/NavigationBar.tsx
+++ b/apps/docs/src/app/components/NavigationBar/NavigationBar.tsx
@@ -5,6 +5,7 @@ import { LanguageSwitcher } from "@superset/i18n/react";
 import { COMPANY } from "@superset/shared/constants";
 import { Languages, Menu } from "lucide-react";
 import Link from "next/link";
+import posthog from "posthog-js";
 import { MobileSearchIcon } from "@/app/(docs)/[[...slug]]/components/DocsPageLayout/components/PageClient/components/MobileSearchIcon";
 import {
 	NavigationMobile,
@@ -103,6 +104,13 @@ export default function NavigationBar() {
 							<LanguageSwitcher
 								label={t({ id: "docs.nav.languageLabel", message: "Language" })}
 								className="absolute inset-0 cursor-pointer opacity-0"
+								onChange={(next, current) =>
+									posthog.capture("language_switched", {
+										from: current,
+										to: next,
+										surface: "docs-nav",
+									})
+								}
 							/>
 						</li>
 						<a

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { inferLocaleWithSource } from "@superset/i18n";
 import { POSTHOG_COOKIE_NAME } from "@superset/shared/constants";
 import {
 	SENTRY_DENY_URLS,
@@ -21,9 +22,12 @@ if (env.NEXT_PUBLIC_POSTHOG_KEY) {
 		persistence: "cookie",
 		persistence_name: POSTHOG_COOKIE_NAME,
 		loaded: (posthog) => {
+			const { locale, source } = inferLocaleWithSource();
 			posthog.register({
 				app_name: "docs",
 				domain: window.location.hostname,
+				app_locale: locale,
+				app_locale_source: source,
 			});
 		},
 	});

--- a/apps/marketing/src/app/[lang]/components/Footer/Footer.tsx
+++ b/apps/marketing/src/app/[lang]/components/Footer/Footer.tsx
@@ -21,6 +21,7 @@ import { ArrowUpRight, Check, ChevronDown, Languages } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
+import { track } from "@/lib/analytics";
 import { Soc2Badge } from "../Soc2Badge";
 import { SocialLinks } from "../SocialLinks";
 
@@ -271,11 +272,16 @@ function FooterLinkItem({ link }: { link: FooterLink }) {
 function FooterLanguageSwitcher({ locale }: { locale?: SupportedLocale }) {
 	const { t } = useLingui();
 	const pathname = usePathname() ?? "/";
+	// The server passes the URL's locale; every switch is a full navigation,
+	// so the value never changes within a page's lifetime and needs no
+	// subscription. The i18n fallback covers renders outside the [lang] tree.
+	const current = locale ?? (i18n.locale as SupportedLocale);
 	// The URL carries the locale, so applying a choice is a navigation: strip
 	// any current locale prefix, then go to the same page under the new one
 	// (bare for English). The cookie still records the choice for the
 	// client-resolved apps (docs, web).
 	const selectLocale = (next: SupportedLocale) => {
+		track("language_switched", { from: current, to: next, surface: "footer" });
 		const segments = pathname.split("/");
 		const barePath = isSupportedLocale(segments[1] ?? "")
 			? `/${segments.slice(2).join("/")}`
@@ -288,10 +294,6 @@ function FooterLanguageSwitcher({ locale }: { locale?: SupportedLocale }) {
 				: `/${next}${barePath === "/" ? "" : barePath}`,
 		);
 	};
-	// The server passes the URL's locale; every switch is a full navigation,
-	// so the value never changes within a page's lifetime and needs no
-	// subscription. The i18n fallback covers renders outside the [lang] tree.
-	const current = locale ?? (i18n.locale as SupportedLocale);
 	return (
 		<DropdownMenu modal={false}>
 			<DropdownMenuTrigger

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -42,6 +42,11 @@ async function initPosthog() {
 	posthog.register({
 		app_name: "marketing",
 		domain: window.location.hostname,
+		// The URL decides the language (bare paths are English); the server
+		// writes the resolved locale into <html lang>, and every language
+		// switch is a full navigation that re-runs this init.
+		app_locale: document.documentElement.lang,
+		app_locale_source: "url",
 	});
 
 	setPosthogInstance(posthog);

--- a/apps/web/src/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
+++ b/apps/web/src/components/PostHogUserIdentifier/PostHogUserIdentifier.tsx
@@ -3,6 +3,7 @@
 import { authClient } from "@superset/auth/client";
 import posthog from "posthog-js";
 import { useEffect } from "react";
+import { registerBaseProperties } from "@/lib/posthog-client";
 
 export function PostHogUserIdentifier() {
 	const { data: session } = authClient.useSession();
@@ -14,7 +15,10 @@ export function PostHogUserIdentifier() {
 				name: session.user.name,
 			});
 		} else if (session === null) {
+			// reset() drops the super properties with the person; put back the
+			// ones every event needs.
 			posthog.reset();
+			registerBaseProperties();
 		}
 	}, [session]);
 

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -7,6 +7,7 @@ import {
 import posthog from "posthog-js";
 
 import { env } from "@/env";
+import { registerBaseProperties } from "@/lib/posthog-client";
 
 posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	api_host: "/ingest",
@@ -22,10 +23,7 @@ posthog.init(env.NEXT_PUBLIC_POSTHOG_KEY, {
 	persistence_name: POSTHOG_COOKIE_NAME,
 });
 
-posthog.register({
-	app_name: "web",
-	domain: window.location.hostname,
-});
+registerBaseProperties();
 
 Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,

--- a/apps/web/src/lib/posthog-client.ts
+++ b/apps/web/src/lib/posthog-client.ts
@@ -1,0 +1,16 @@
+import { inferLocaleWithSource } from "@superset/i18n";
+import posthog from "posthog-js";
+
+/**
+ * Super properties every web event carries. Registered at init, and again
+ * after posthog.reset() on sign-out, which clears them along with the person.
+ */
+export function registerBaseProperties(): void {
+	const { locale, source } = inferLocaleWithSource();
+	posthog.register({
+		app_name: "web",
+		domain: window.location.hostname,
+		app_locale: locale,
+		app_locale_source: source,
+	});
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -51,6 +51,21 @@ function ensureEnglish(): void {
 // navigator.languages (React Native, Node) pass their own preference list to
 // resolveLocale/initI18n instead. A persisted user setting takes precedence.
 export function inferLocale(): SupportedLocale {
+	return inferLocaleWithSource().locale;
+}
+
+export type InferredLocaleSource = "cookie" | "system";
+
+/**
+ * inferLocale plus where the answer came from: an explicit switcher choice
+ * pinned in LOCALE_COOKIE, or the browser's language preferences. Analytics
+ * use the source to separate users who chose a language from users who were
+ * handed one.
+ */
+export function inferLocaleWithSource(): {
+	locale: SupportedLocale;
+	source: InferredLocaleSource;
+} {
 	// An explicit choice from a language switcher outranks browser preferences.
 	// Accessed through globalThis so this file typechecks under Node-only lib
 	// settings, where the document global does not exist.
@@ -60,12 +75,14 @@ export function inferLocale(): SupportedLocale {
 			new RegExp(`(?:^|; )${LOCALE_COOKIE}=([^;]*)`),
 		);
 		const chosen = match?.[1];
-		if (chosen && isSupportedLocale(chosen)) return chosen;
+		if (chosen && isSupportedLocale(chosen)) {
+			return { locale: chosen, source: "cookie" };
+		}
 	}
 	if (typeof navigator !== "undefined" && Array.isArray(navigator.languages)) {
-		return resolveLocale(navigator.languages);
+		return { locale: resolveLocale(navigator.languages), source: "system" };
 	}
-	return DEFAULT_LOCALE;
+	return { locale: DEFAULT_LOCALE, source: "system" };
 }
 
 /** Loads a catalog without activating it. Resolves immediately if cached. */

--- a/packages/i18n/src/infer-locale.test.ts
+++ b/packages/i18n/src/infer-locale.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { inferLocaleWithSource } from "./index";
+
+const g = globalThis as { document?: { cookie: string }; navigator?: unknown };
+const originalDocument = g.document;
+const originalNavigator = Object.getOwnPropertyDescriptor(
+	globalThis,
+	"navigator",
+);
+
+function setNavigator(value: unknown) {
+	Object.defineProperty(globalThis, "navigator", {
+		value,
+		configurable: true,
+		writable: true,
+	});
+}
+
+afterEach(() => {
+	g.document = originalDocument;
+	if (originalNavigator) {
+		Object.defineProperty(globalThis, "navigator", originalNavigator);
+	}
+});
+
+describe("inferLocaleWithSource", () => {
+	test("a switcher cookie wins and reports as cookie", () => {
+		g.document = { cookie: "other=1; superset_locale=ja" };
+		setNavigator({ languages: ["fr-FR", "fr"] });
+		expect(inferLocaleWithSource()).toEqual({ locale: "ja", source: "cookie" });
+	});
+
+	test("browser languages report as system", () => {
+		g.document = { cookie: "" };
+		setNavigator({ languages: ["fr-FR", "fr"] });
+		expect(inferLocaleWithSource()).toEqual({ locale: "fr", source: "system" });
+	});
+
+	test("an unsupported cookie value falls through to the browser", () => {
+		g.document = { cookie: "superset_locale=xx" };
+		setNavigator({ languages: ["de-DE"] });
+		expect(inferLocaleWithSource()).toEqual({ locale: "de", source: "system" });
+	});
+
+	test("no preferences at all is the default locale, from the system", () => {
+		g.document = { cookie: "" };
+		setNavigator({});
+		expect(inferLocaleWithSource()).toEqual({ locale: "en", source: "system" });
+	});
+});

--- a/packages/i18n/src/react.tsx
+++ b/packages/i18n/src/react.tsx
@@ -70,6 +70,12 @@ interface LanguageSwitcherProps {
 	 */
 	onSelect?: (locale: SupportedLocale) => void;
 	/**
+	 * Called with the chosen and the outgoing locale before the choice is
+	 * applied, so apps can record the switch ahead of the reload or
+	 * navigation that follows.
+	 */
+	onChange?: (next: SupportedLocale, current: SupportedLocale) => void;
+	/**
 	 * Server-resolved effective locale, when the caller knows it. Client
 	 * components server-render through the non-RSC module instance, whose
 	 * i18n singleton has not been activated for the request — without this
@@ -98,6 +104,7 @@ export function LanguageSwitcher({
 	label,
 	locale,
 	onSelect,
+	onChange,
 	className,
 }: LanguageSwitcherProps) {
 	// The effective locale: starts at the module's current value (the server
@@ -118,6 +125,7 @@ export function LanguageSwitcher({
 			value={value}
 			onChange={(event) => {
 				const next = event.target.value as SupportedLocale;
+				onChange?.(next, value);
 				if (onSelect) {
 					onSelect(next);
 					return;


### PR DESCRIPTION
## Summary
- Every desktop event now carries `app_locale` (language on screen) and `app_locale_source` (`setting` when pinned in the picker, `system` when Auto), and both are mirrored to the PostHog person.
- Marketing, docs, and web events carry the same two properties: marketing from the URL (`url`), docs and web from the switcher cookie or the browser (`cookie` | `system`).
- `language_changed { from, to, surface }` fires from the desktop Settings and onboarding pickers; `language_switched { from, to, surface }` fires from the marketing footer (`footer`) and the docs navbar (`docs-nav`).
- Fixes a pre-existing web bug: `posthog.reset()` on a signed-out session wiped `app_name` and `domain` from every later event.

## Why / Context
The 17-locale release went out in desktop 1.25.1 with no locale telemetry. The only signals were `$browser_language` (OS language, a proxy for what Auto would pick) and the `users.locale` column (explicit choices). Neither answers "how many users see a translated UI" or "who switched back to English", which is the first thing we need to judge translation quality per language. The web surfaces had the same gap.

## How It Works
- **Desktop:** `PostHogLocaleTagger` renders inside `I18nProvider` and reads the active Lingui locale plus the persisted setting. `resolveLocaleTag` decides what to tag: nothing until the setting has loaded, and nothing while a non-English catalog is still loading and English is transiently active, so a Japanese boot never records an English session first. It then calls `posthog.register` and, when signed in, `posthog.people.set`, mirroring `PostHogSurfaceTagger`. The pickers call `track("language_changed", …)` before the mutation, with `auto` as the value for the Auto option.
- **Web surfaces:** `inferLocaleWithSource()` in `@superset/i18n` is `inferLocale()` plus where the answer came from. Marketing registers `document.documentElement.lang` (server-resolved per request; every switch is a full navigation that re-runs init). Docs registers inside `loaded`, web at module scope, both before posthog-js captures the first pageview.
- **Switch events:** `LanguageSwitcher` gains an `onChange(next, current)` hook called before the cookie write and reload. Docs uses it; marketing's own footer picker tracks directly.

## Manual QA
All driven over CDP with real clicks against the Local Development PostHog project, then confirmed with HogQL.

**Desktop (dev app)**
- [x] Boot with Auto on an English system: `app_locale=en`, `app_locale_source=system` registered, no `language_changed`.
- [x] Settings → Appearance → Language → 日本語: `language_changed {from: auto, to: ja, surface: settings}`; exactly one `register` with `ja / setting` (no transitional `en`); one `people.set`.
- [x] Restart with Japanese pinned: UI renders in Japanese, `desktop_opened` and `$pageview` arrive with `app_locale=ja`, `app_locale_source=setting`.
- [x] 言語 → 自動(システム): `language_changed {from: ja, to: auto}`, tags return to `en / system`, person properties in PostHog show the same.

**Marketing and docs (headless Chrome, normal user agent)**
- [x] Marketing `/`: pageview with `app_locale=en, source=url`. Footer picker → 日本語: `language_switched {from: en, to: ja, surface: footer}` arrives before the navigation, then a `/ja` pageview with `app_locale=ja`.
- [x] Docs, landing with the shared `superset_locale=ja` cookie: pageview with `app_locale=ja, source=cookie`. Navbar select → English: `language_switched {from: ja, to: en, surface: docs-nav}`, then a pageview with `en / cookie`.
- [x] Web sign-in page (signed out, so `reset()` fires): cookie shows `app_name=web`, `app_locale=en`, `source=system` after the reset. Before the fix it held neither `app_name` nor `app_locale`.

Not exercised end to end: the desktop onboarding picker (same call shape, this account is already onboarded).

Note for anyone repeating this: posthog-js drops every capture when `navigator.webdriver` is true or the UA brands say HeadlessChrome, so a plain headless session never reaches PostHog. Override the user agent and `webdriver` in one persistent CDP session.

## Testing
- `bun run typecheck` (desktop, marketing, docs, web, i18n)
- `bunx biome check` on the changed files
- `bun test src/renderer/components/PostHogLocaleTagger` (5 tests; the transitional-locale case was proven to fail against the naive implementation)
- `bun test` in `packages/i18n` (123 tests incl. 4 new for `inferLocaleWithSource`)
- `bun run --cwd packages/i18n check` (no new strings)

## Known Limitations
- Desktop events emitted before the setting query resolves (`desktop_opened` on a cold first boot) carry the previous boot's persisted tag, or none on a fresh install.
- Marketing, docs, and web share one PostHog cookie per domain, so each app re-registers the locale on every load. That is already how `app_name` works.

https://claude.ai/code/session_01GGjG5PLSdViCcBWxFNkNsQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more accurate locale detection across the desktop app, web app, documentation, and marketing site.
  - Language preferences now distinguish between system, browser, URL, and manually selected settings.
  - Added analytics tracking for language changes made during onboarding, in settings, and through language switchers.

- **Bug Fixes**
  - Preserved standard analytics details when a web session is reset or a user signs out.

- **Tests**
  - Added coverage for locale detection and language-source handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->