### PR TITLE
fix(host-service): keep a swept terminal's agent session resumable

### DIFF
--- a/packages/host-service/src/terminal-agents/persistence.test.ts
+++ b/packages/host-service/src/terminal-agents/persistence.test.ts
@@ -13,7 +13,6 @@ import {
 	markTerminalAgentBindingEnded,
 	SqliteTerminalAgentBindingPersistence,
 	seedEndedTerminalAgentBinding,
-	snapshotTerminalAgentBindingSessionIds,
 	unclaimResumeCandidateBinding,
 } from "./persistence";
 import { TerminalAgentStore } from "./store";
@@ -381,6 +380,34 @@ describe("binding end marking and resume candidates", () => {
 		).toEqual({ endedAt: 42, agentSessionId: "sess-t1" });
 	});
 
+	it("a dispose leaves a resumed claim and a clean detach as they are", () => {
+		// Resume cleanup disposes the dead terminal after the claim, and a pane
+		// close after a real quit disposes a detached one; neither is a resume
+		// candidate, so the override has nothing to protect and the row keeps
+		// the reason that tells its history.
+		const db = createTestDb();
+		const endReasonOf = (id: string) =>
+			db
+				.select({ endReason: terminalAgentBindings.endReason })
+				.from(terminalAgentBindings)
+				.where(eq(terminalAgentBindings.terminalId, id))
+				.get()?.endReason;
+		seedWithSessionId(db, "t-resumed");
+		markTerminalAgentBindingEnded(db, "t-resumed", "terminal-exited", 42);
+		expect(claimResumeCandidateBinding(db, "ws-1", "t-resumed")).toBeDefined();
+		expect(
+			markTerminalAgentBindingEnded(db, "t-resumed", "disposed", 90),
+		).toBeUndefined();
+		expect(endReasonOf("t-resumed")).toBe("resumed");
+
+		seedWithSessionId(db, "t-detached");
+		markTerminalAgentBindingEnded(db, "t-detached", "detached", 42);
+		expect(
+			markTerminalAgentBindingEnded(db, "t-detached", "disposed", 90_000),
+		).toBeUndefined();
+		expect(endReasonOf("t-detached")).toBe("detached");
+	});
+
 	it("a claimed row survives late terminal-death marking untouched", () => {
 		// Disposing the dead terminal after a successful resume routes through
 		// markTerminalExited — that must not resurrect the candidate.
@@ -504,34 +531,5 @@ describe("seedEndedTerminalAgentBinding (v1 pane migration)", () => {
 				agentSessionId: "sess-v1",
 			}),
 		).toBe("terminal-not-found");
-	});
-});
-
-describe("snapshotTerminalAgentBindingSessionIds", () => {
-	it("tells a bound session, a binding without one, and no binding apart", () => {
-		const db = createTestDb();
-		// seedSession's binding carries no agentSessionId.
-		seedSession(db, { id: "t-idless", status: "active", workspaceId: "ws-1" });
-		seedSession(db, { id: "t-bound", status: "active", workspaceId: "ws-1" });
-		db.update(terminalAgentBindings)
-			.set({ agentSessionId: "sess-1" })
-			.where(eq(terminalAgentBindings.terminalId, "t-bound"))
-			.run();
-		db.insert(terminalSessions)
-			.values({
-				id: "t-unbound",
-				status: "active",
-				originWorkspaceId: "ws-1",
-				createdAt: 1,
-			})
-			.run();
-
-		const snapshot = snapshotTerminalAgentBindingSessionIds(db);
-
-		// A caller ending bindings after an async probe needs all three apart:
-		// only `undefined` means "nothing to strand here".
-		expect(snapshot.get("t-bound")).toBe("sess-1");
-		expect(snapshot.get("t-idless")).toBeNull();
-		expect(snapshot.has("t-unbound")).toBe(false);
 	});
 });

--- a/packages/host-service/src/terminal-agents/persistence.test.ts
+++ b/packages/host-service/src/terminal-agents/persistence.test.ts
@@ -357,6 +357,28 @@ describe("binding end marking and resume candidates", () => {
 		expect(claimResumeCandidateBinding(db, "ws-1", "t1")).toBeUndefined();
 	});
 
+	it("a dispose overrides a terminal-death stamp that beat it", () => {
+		// The pane-close route marks the binding disposed before its kill, but
+		// the terminal can already be dead: a pty exit or the reaper's sweep
+		// stamps "terminal-exited" first. The user's decision still has to
+		// win, or auto-resume brings the killed session back.
+		const db = createTestDb();
+		seedWithSessionId(db, "t1");
+		markTerminalAgentBindingEnded(db, "t1", "terminal-exited", 42);
+		expect(findResumeCandidateBinding(db, "ws-1", "t1")).toBeDefined();
+
+		expect(markTerminalAgentBindingEnded(db, "t1", "disposed", 90)).toEqual({
+			workspaceId: "ws-1",
+		});
+
+		expect(findResumeCandidateBinding(db, "ws-1", "t1")).toBeUndefined();
+		expect(claimResumeCandidateBinding(db, "ws-1", "t1")).toBeUndefined();
+		// Only the reason changes — the first writer's timestamp stands.
+		expect(
+			new SqliteTerminalAgentBindingPersistence(db).getEnded("t1"),
+		).toEqual({ endedAt: 42, agentSessionId: "sess-t1" });
+	});
+
 	it("a claimed row survives late terminal-death marking untouched", () => {
 		// Disposing the dead terminal after a successful resume routes through
 		// markTerminalExited — that must not resurrect the candidate.

--- a/packages/host-service/src/terminal-agents/persistence.test.ts
+++ b/packages/host-service/src/terminal-agents/persistence.test.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../db";
@@ -12,6 +13,7 @@ import {
 	markTerminalAgentBindingEnded,
 	SqliteTerminalAgentBindingPersistence,
 	seedEndedTerminalAgentBinding,
+	snapshotTerminalAgentBindingSessionIds,
 	unclaimResumeCandidateBinding,
 } from "./persistence";
 import { TerminalAgentStore } from "./store";
@@ -502,5 +504,34 @@ describe("seedEndedTerminalAgentBinding (v1 pane migration)", () => {
 				agentSessionId: "sess-v1",
 			}),
 		).toBe("terminal-not-found");
+	});
+});
+
+describe("snapshotTerminalAgentBindingSessionIds", () => {
+	it("tells a bound session, a binding without one, and no binding apart", () => {
+		const db = createTestDb();
+		// seedSession's binding carries no agentSessionId.
+		seedSession(db, { id: "t-idless", status: "active", workspaceId: "ws-1" });
+		seedSession(db, { id: "t-bound", status: "active", workspaceId: "ws-1" });
+		db.update(terminalAgentBindings)
+			.set({ agentSessionId: "sess-1" })
+			.where(eq(terminalAgentBindings.terminalId, "t-bound"))
+			.run();
+		db.insert(terminalSessions)
+			.values({
+				id: "t-unbound",
+				status: "active",
+				originWorkspaceId: "ws-1",
+				createdAt: 1,
+			})
+			.run();
+
+		const snapshot = snapshotTerminalAgentBindingSessionIds(db);
+
+		// A caller ending bindings after an async probe needs all three apart:
+		// only `undefined` means "nothing to strand here".
+		expect(snapshot.get("t-bound")).toBe("sess-1");
+		expect(snapshot.get("t-idless")).toBeNull();
+		expect(snapshot.has("t-unbound")).toBe(false);
 	});
 });

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -64,13 +64,9 @@ function rowToBinding(row: BindingRow): TerminalAgentBinding {
  */
 const DEATH_GASP_DETACH_WINDOW_MS = 30_000;
 
-/**
- * The db surface these helpers need: the root handle or an open transaction,
- * so a caller that also writes the terminal row can read and stamp the
- * binding inside that same transaction.
- */
-export type BindingReader = Pick<HostDb, "select">;
-export type BindingWriter = BindingReader & Pick<HostDb, "update">;
+/** The root db handle or an open transaction, so a caller that also writes
+ * the terminal row can stamp the binding inside that same transaction. */
+export type BindingDb = Pick<HostDb, "select" | "update">;
 
 /**
  * Mark a binding's agent session as ended without deleting the row, so its
@@ -81,7 +77,7 @@ export type BindingWriter = BindingReader & Pick<HostDb, "update">;
  * the workspaceId when a row was updated.
  */
 export function markTerminalAgentBindingEnded(
-	db: BindingWriter,
+	db: BindingDb,
 	terminalId: string,
 	reason: TerminalAgentEndReason,
 	endedAt: number = Date.now(),
@@ -98,21 +94,18 @@ export function markTerminalAgentBindingEnded(
 	if (!row) return undefined;
 
 	if (row.endedAt !== null) {
+		// Two upgrades may rewrite an ended row's reason (never its `endedAt`):
+		// a detach inside the death-gasp window was the agent's goodbye as its
+		// pty died, and a dispose after "terminal-exited" is the user killing a
+		// session auto-resume would otherwise bring back. "resumed" and an
+		// older "detached" are final.
 		const isDeathGaspDetach =
 			reason === "terminal-exited" &&
 			row.endReason === "detached" &&
 			endedAt - row.endedAt <= DEATH_GASP_DETACH_WINDOW_MS;
-		// A dispose is the user ending the session, so it beats a
-		// "terminal-exited" stamp that got there first — a pty exit, or the
-		// reaper sweeping the row after daemon loss — which would otherwise
-		// leave the killed session a resume candidate for auto-resume to bring
-		// back at the next pane mount. Only that resumable stamp is overridden:
-		// a "resumed" claim or a clean "detached" is already final and keeps
-		// its own history. Only the reason changes: `endedAt` keeps the first
-		// writer's timestamp, the same way the death-gasp upgrade does.
 		const isDisposeOfResumable =
 			reason === "disposed" && row.endReason === "terminal-exited";
-		if (!isDisposeOfResumable && !isDeathGaspDetach) return undefined;
+		if (!isDeathGaspDetach && !isDisposeOfResumable) return undefined;
 		db.update(terminalAgentBindings)
 			.set({ endReason: reason })
 			.where(eq(terminalAgentBindings.terminalId, terminalId))
@@ -129,7 +122,7 @@ export function markTerminalAgentBindingEnded(
 
 /** The agent session id a terminal's binding currently points at, if any. */
 export function getTerminalAgentBindingSessionId(
-	db: BindingReader,
+	db: HostDb,
 	terminalId: string,
 ): string | undefined {
 	const row = db

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -65,11 +65,12 @@ function rowToBinding(row: BindingRow): TerminalAgentBinding {
 const DEATH_GASP_DETACH_WINDOW_MS = 30_000;
 
 /**
- * The db surface this helper needs: the root handle or an open transaction,
- * so a caller that also writes the terminal row can stamp the binding inside
- * that same transaction.
+ * The db surface these helpers need: the root handle or an open transaction,
+ * so a caller that also writes the terminal row can read and stamp the
+ * binding inside that same transaction.
  */
-export type BindingWriter = Pick<HostDb, "select" | "update">;
+export type BindingReader = Pick<HostDb, "select">;
+export type BindingWriter = BindingReader & Pick<HostDb, "update">;
 
 /**
  * Mark a binding's agent session as ended without deleting the row, so its
@@ -123,17 +124,59 @@ export function markTerminalAgentBindingEnded(
 	return { workspaceId: row.workspaceId };
 }
 
-/** The agent session id a terminal's binding currently points at, if any. */
-export function getTerminalAgentBindingSessionId(
-	db: HostDb,
+/**
+ * Which agent session a terminal's binding points at, as three distinct
+ * answers: the session id, `null` when the binding has none, `undefined` when
+ * the terminal has no binding at all. Callers that must tell "this binding
+ * was replaced" from "this terminal never had one" need all three; the ones
+ * that only want a concrete id use
+ * {@link getTerminalAgentBindingSessionId}.
+ */
+export function readTerminalAgentBindingSessionId(
+	db: BindingReader,
 	terminalId: string,
-): string | undefined {
+): string | null | undefined {
 	const row = db
 		.select({ agentSessionId: terminalAgentBindings.agentSessionId })
 		.from(terminalAgentBindings)
 		.where(eq(terminalAgentBindings.terminalId, terminalId))
 		.get();
-	return row?.agentSessionId ?? undefined;
+	return row === undefined ? undefined : row.agentSessionId;
+}
+
+/** The agent session id a terminal's binding currently points at, if any. */
+export function getTerminalAgentBindingSessionId(
+	db: BindingReader,
+	terminalId: string,
+): string | undefined {
+	return readTerminalAgentBindingSessionId(db, terminalId) ?? undefined;
+}
+
+/**
+ * Every binding's agent session id, keyed by terminal, in the shape
+ * {@link readTerminalAgentBindingSessionId} returns per terminal: absent from
+ * the map means no binding row, `null` means a binding without a concrete
+ * session id.
+ *
+ * A caller that ends bindings after an async probe captures this before that
+ * probe starts. The probe's verdict is about the agent session bound to the
+ * terminal when it began, and the session id is that session's identity — so
+ * an entry that changed by write time means a different session now owns the
+ * terminal and the verdict no longer applies to it. Same ownership model as
+ * `sweepAgentBindingsAfterDaemonLoss`, which snapshots the same value per
+ * candidate before its own daemon probe.
+ */
+export function snapshotTerminalAgentBindingSessionIds(
+	db: BindingReader,
+): Map<string, string | null> {
+	const rows = db
+		.select({
+			terminalId: terminalAgentBindings.terminalId,
+			agentSessionId: terminalAgentBindings.agentSessionId,
+		})
+		.from(terminalAgentBindings)
+		.all();
+	return new Map(rows.map((row) => [row.terminalId, row.agentSessionId]));
 }
 
 /**

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -102,14 +102,17 @@ export function markTerminalAgentBindingEnded(
 			reason === "terminal-exited" &&
 			row.endReason === "detached" &&
 			endedAt - row.endedAt <= DEATH_GASP_DETACH_WINDOW_MS;
-		// A dispose is the user ending the session, so it overrides whatever
-		// end reason got there first. Otherwise a "terminal-exited" stamp that
-		// beat the dispose — a pty exit, or the reaper sweeping the row after
-		// daemon loss — would leave the killed session a resume candidate and
-		// auto-resume would bring it back at the next pane mount. Only the
-		// reason changes: `endedAt` keeps the first writer's timestamp, the
-		// same way the death-gasp upgrade does.
-		if (reason !== "disposed" && !isDeathGaspDetach) return undefined;
+		// A dispose is the user ending the session, so it beats a
+		// "terminal-exited" stamp that got there first — a pty exit, or the
+		// reaper sweeping the row after daemon loss — which would otherwise
+		// leave the killed session a resume candidate for auto-resume to bring
+		// back at the next pane mount. Only that resumable stamp is overridden:
+		// a "resumed" claim or a clean "detached" is already final and keeps
+		// its own history. Only the reason changes: `endedAt` keeps the first
+		// writer's timestamp, the same way the death-gasp upgrade does.
+		const isDisposeOfResumable =
+			reason === "disposed" && row.endReason === "terminal-exited";
+		if (!isDisposeOfResumable && !isDeathGaspDetach) return undefined;
 		db.update(terminalAgentBindings)
 			.set({ endReason: reason })
 			.where(eq(terminalAgentBindings.terminalId, terminalId))
@@ -124,59 +127,17 @@ export function markTerminalAgentBindingEnded(
 	return { workspaceId: row.workspaceId };
 }
 
-/**
- * Which agent session a terminal's binding points at, as three distinct
- * answers: the session id, `null` when the binding has none, `undefined` when
- * the terminal has no binding at all. Callers that must tell "this binding
- * was replaced" from "this terminal never had one" need all three; the ones
- * that only want a concrete id use
- * {@link getTerminalAgentBindingSessionId}.
- */
-export function readTerminalAgentBindingSessionId(
-	db: BindingReader,
-	terminalId: string,
-): string | null | undefined {
-	const row = db
-		.select({ agentSessionId: terminalAgentBindings.agentSessionId })
-		.from(terminalAgentBindings)
-		.where(eq(terminalAgentBindings.terminalId, terminalId))
-		.get();
-	return row === undefined ? undefined : row.agentSessionId;
-}
-
 /** The agent session id a terminal's binding currently points at, if any. */
 export function getTerminalAgentBindingSessionId(
 	db: BindingReader,
 	terminalId: string,
 ): string | undefined {
-	return readTerminalAgentBindingSessionId(db, terminalId) ?? undefined;
-}
-
-/**
- * Every binding's agent session id, keyed by terminal, in the shape
- * {@link readTerminalAgentBindingSessionId} returns per terminal: absent from
- * the map means no binding row, `null` means a binding without a concrete
- * session id.
- *
- * A caller that ends bindings after an async probe captures this before that
- * probe starts. The probe's verdict is about the agent session bound to the
- * terminal when it began, and the session id is that session's identity — so
- * an entry that changed by write time means a different session now owns the
- * terminal and the verdict no longer applies to it. Same ownership model as
- * `sweepAgentBindingsAfterDaemonLoss`, which snapshots the same value per
- * candidate before its own daemon probe.
- */
-export function snapshotTerminalAgentBindingSessionIds(
-	db: BindingReader,
-): Map<string, string | null> {
-	const rows = db
-		.select({
-			terminalId: terminalAgentBindings.terminalId,
-			agentSessionId: terminalAgentBindings.agentSessionId,
-		})
+	const row = db
+		.select({ agentSessionId: terminalAgentBindings.agentSessionId })
 		.from(terminalAgentBindings)
-		.all();
-	return new Map(rows.map((row) => [row.terminalId, row.agentSessionId]));
+		.where(eq(terminalAgentBindings.terminalId, terminalId))
+		.get();
+	return row?.agentSessionId ?? undefined;
 }
 
 /**

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -65,6 +65,13 @@ function rowToBinding(row: BindingRow): TerminalAgentBinding {
 const DEATH_GASP_DETACH_WINDOW_MS = 30_000;
 
 /**
+ * The db surface this helper needs: the root handle or an open transaction,
+ * so a caller that also writes the terminal row can stamp the binding inside
+ * that same transaction.
+ */
+export type BindingWriter = Pick<HostDb, "select" | "update">;
+
+/**
  * Mark a binding's agent session as ended without deleting the row, so its
  * `agentSessionId` survives for resume. "terminal-exited" is sticky: a
  * goodbye that trickles in after the terminal already died never downgrades
@@ -73,7 +80,7 @@ const DEATH_GASP_DETACH_WINDOW_MS = 30_000;
  * the workspaceId when a row was updated.
  */
 export function markTerminalAgentBindingEnded(
-	db: HostDb,
+	db: BindingWriter,
 	terminalId: string,
 	reason: TerminalAgentEndReason,
 	endedAt: number = Date.now(),
@@ -94,9 +101,16 @@ export function markTerminalAgentBindingEnded(
 			reason === "terminal-exited" &&
 			row.endReason === "detached" &&
 			endedAt - row.endedAt <= DEATH_GASP_DETACH_WINDOW_MS;
-		if (!isDeathGaspDetach) return undefined;
+		// A dispose is the user ending the session, so it overrides whatever
+		// end reason got there first. Otherwise a "terminal-exited" stamp that
+		// beat the dispose — a pty exit, or the reaper sweeping the row after
+		// daemon loss — would leave the killed session a resume candidate and
+		// auto-resume would bring it back at the next pane mount. Only the
+		// reason changes: `endedAt` keeps the first writer's timestamp, the
+		// same way the death-gasp upgrade does.
+		if (reason !== "disposed" && !isDeathGaspDetach) return undefined;
 		db.update(terminalAgentBindings)
-			.set({ endReason: "terminal-exited" })
+			.set({ endReason: reason })
 			.where(eq(terminalAgentBindings.terminalId, terminalId))
 			.run();
 		return { workspaceId: row.workspaceId };

--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -1,11 +1,23 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../../db/index.ts";
+import * as schema from "../../db/schema.ts";
+import { terminalAgentBindings, terminalSessions } from "../../db/schema.ts";
+import { findResumeCandidateBinding } from "../../terminal-agents/persistence.ts";
 import {
+	markStaleActiveRows,
 	PORT_SCAN_WARMUP_DELAYS_MS,
 	planPortScanSync,
 	planStaleActiveRows,
 	REAP_INTERVAL_MS,
 	shouldReapRow,
 } from "./reaper.ts";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../drizzle");
 
 const noneLive = () => false;
 
@@ -271,5 +283,131 @@ describe("planStaleActiveRows", () => {
 			now: NOW,
 		});
 		expect(stale).toEqual({ exited: ["t-crashed"], disposed: ["t-disposing"] });
+	});
+});
+
+describe("markStaleActiveRows agent bindings", () => {
+	const OLD = Date.now() - 10 * 60_000;
+
+	function createTestDb(): HostDb {
+		const sqlite = new Database(":memory:");
+		const db = drizzle(sqlite, { schema });
+		migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+		// bun:sqlite's drizzle type differs from the better-sqlite3-based
+		// HostDb; the query surface used here is identical (same cast as
+		// terminal-agents/persistence.test.ts).
+		return db as unknown as HostDb;
+	}
+
+	function seed(
+		db: HostDb,
+		row: {
+			id: string;
+			status?: string;
+			workspaceId?: string | null;
+			createdAt?: number;
+			disposeRequestedAt?: number | null;
+			binding?: {
+				agentSessionId?: string | null;
+				lastEventType?: string;
+				endedAt?: number | null;
+				endReason?: string | null;
+			} | null;
+		},
+	) {
+		db.insert(terminalSessions)
+			.values({
+				id: row.id,
+				status: row.status ?? "active",
+				originWorkspaceId: row.workspaceId ?? "ws-1",
+				createdAt: row.createdAt ?? OLD,
+				disposeRequestedAt: row.disposeRequestedAt ?? null,
+			})
+			.run();
+		if (row.binding === null) return;
+		db.insert(terminalAgentBindings)
+			.values({
+				terminalId: row.id,
+				workspaceId: row.workspaceId ?? "ws-1",
+				agentId: "claude",
+				agentSessionId: row.binding?.agentSessionId ?? "sess-1",
+				startedAt: OLD,
+				lastEventAt: OLD,
+				lastEventType: row.binding?.lastEventType ?? "Stop",
+				endedAt: row.binding?.endedAt ?? null,
+				endReason: row.binding?.endReason ?? null,
+			})
+			.run();
+	}
+
+	function statusOf(db: HostDb, id: string): string | undefined {
+		return db
+			.select({ status: terminalSessions.status })
+			.from(terminalSessions)
+			.where(eq(terminalSessions.id, id))
+			.get()?.status;
+	}
+
+	function bindingOf(db: HostDb, id: string) {
+		return db
+			.select({
+				endedAt: terminalAgentBindings.endedAt,
+				endReason: terminalAgentBindings.endReason,
+			})
+			.from(terminalAgentBindings)
+			.where(eq(terminalAgentBindings.terminalId, id))
+			.get();
+	}
+
+	it("leaves a daemon-lost agent session resumable", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-lost" });
+
+		markStaleActiveRows(db, [], new Map());
+
+		expect(statusOf(db, "t-lost")).toBe("exited");
+		expect(bindingOf(db, "t-lost")?.endReason).toBe("terminal-exited");
+		expect(
+			findResumeCandidateBinding(db, "ws-1", "t-lost")?.agentSessionId,
+		).toBe("sess-1");
+	});
+
+	it("keeps a dispose-stamped row's agent out of the resume candidates", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-killed", disposeRequestedAt: OLD });
+
+		markStaleActiveRows(db, [], new Map());
+
+		expect(statusOf(db, "t-killed")).toBe("disposed");
+		expect(findResumeCandidateBinding(db, "ws-1", "t-killed")).toBeUndefined();
+	});
+
+	it("leaves bindings of rows it does not sweep untouched", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-alive" });
+		seed(db, { id: "t-fresh", createdAt: Date.now() });
+
+		markStaleActiveRows(db, [{ id: "t-alive" }], new Map());
+
+		expect(statusOf(db, "t-alive")).toBe("active");
+		expect(bindingOf(db, "t-alive")?.endedAt).toBeNull();
+		expect(statusOf(db, "t-fresh")).toBe("active");
+		expect(bindingOf(db, "t-fresh")?.endedAt).toBeNull();
+	});
+
+	it("does not overwrite an older clean detach", () => {
+		const db = createTestDb();
+		seed(db, {
+			id: "t-detached",
+			binding: { endedAt: OLD, endReason: "detached" },
+		});
+
+		markStaleActiveRows(db, [], new Map());
+
+		expect(statusOf(db, "t-detached")).toBe("exited");
+		expect(bindingOf(db, "t-detached")?.endReason).toBe("detached");
+		expect(
+			findResumeCandidateBinding(db, "ws-1", "t-detached"),
+		).toBeUndefined();
 	});
 });

--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -11,6 +11,7 @@ import {
 	claimResumeCandidateBinding,
 	findResumeCandidateBinding,
 	markTerminalAgentBindingEnded,
+	snapshotTerminalAgentBindingSessionIds,
 } from "../../terminal-agents/persistence.ts";
 import {
 	markStaleActiveRows,
@@ -329,17 +330,23 @@ describe("markStaleActiveRows agent bindings", () => {
 			})
 			.run();
 		if (row.binding === null) return;
+		const binding = row.binding ?? {};
 		db.insert(terminalAgentBindings)
 			.values({
 				terminalId: row.id,
 				workspaceId: row.workspaceId ?? "ws-1",
 				agentId: "claude",
-				agentSessionId: row.binding?.agentSessionId ?? "sess-1",
+				// An explicit null asks for a binding that never captured a
+				// session id; omitting it takes the default.
+				agentSessionId:
+					binding.agentSessionId === undefined
+						? "sess-1"
+						: binding.agentSessionId,
 				startedAt: OLD,
 				lastEventAt: OLD,
-				lastEventType: row.binding?.lastEventType ?? "Stop",
-				endedAt: row.binding?.endedAt ?? null,
-				endReason: row.binding?.endReason ?? null,
+				lastEventType: binding.lastEventType ?? "Stop",
+				endedAt: binding.endedAt ?? null,
+				endReason: binding.endReason ?? null,
 			})
 			.run();
 	}
@@ -382,6 +389,7 @@ describe("markStaleActiveRows agent bindings", () => {
 	function bindingOf(db: HostDb, id: string) {
 		return db
 			.select({
+				agentSessionId: terminalAgentBindings.agentSessionId,
 				endedAt: terminalAgentBindings.endedAt,
 				endReason: terminalAgentBindings.endReason,
 			})
@@ -522,6 +530,134 @@ describe("markStaleActiveRows agent bindings", () => {
 		expect(
 			findResumeCandidateBinding(db, "ws-1", "t-pane-closed"),
 		).toBeUndefined();
+	});
+
+	it("leaves an agent session bound during the daemon probe alone", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-respawned" });
+
+		// What the reaper captures before it awaits the daemon — getting a
+		// client and its session list is a real wait (bootstrap, reconnect,
+		// RPC). A renderer attach lands inside that window: the respawn ends
+		// the lost pty's binding and the new shell's agent binds a fresh
+		// session to the same terminal.
+		const beforeProbe = snapshotTerminalAgentBindingSessionIds(db);
+		const respawnedAt = Date.now();
+		db.update(terminalAgentBindings)
+			.set({
+				agentSessionId: "sess-2",
+				startedAt: respawnedAt,
+				lastEventAt: respawnedAt,
+				lastEventType: "SessionStart",
+				endedAt: null,
+				endReason: null,
+			})
+			.where(eq(terminalAgentBindings.terminalId, "t-respawned"))
+			.run();
+
+		// The daemon's answer condemns the pty that died, not the one that
+		// replaced it, so this pass must write nothing.
+		expect(markStaleActiveRows(db, [], new Map(), beforeProbe)).toBe(0);
+
+		// The replacement is still live in every read...
+		expect(bindingOf(db, "t-respawned")?.agentSessionId).toBe("sess-2");
+		expect(bindingOf(db, "t-respawned")?.endedAt).toBeNull();
+		expect(bindingOf(db, "t-respawned")?.endReason).toBeNull();
+		// ...and its row is still attachable: `exited` would answer
+		// session-gone forever, with no later pass to undo it.
+		expect(statusOf(db, "t-respawned")).toBe("active");
+
+		// Retryable, not skipped forever — the next pass re-probes the daemon
+		// and re-captures ownership, and that is what decides the row then.
+		expect(
+			markStaleActiveRows(
+				db,
+				[],
+				new Map(),
+				snapshotTerminalAgentBindingSessionIds(db),
+			),
+		).toBe(1);
+	});
+
+	it("leaves a terminal that gained a binding during the probe alone", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-bare", binding: null });
+
+		const beforeProbe = snapshotTerminalAgentBindingSessionIds(db);
+		// First hook event from an agent launched in the respawned shell.
+		db.insert(terminalAgentBindings)
+			.values({
+				terminalId: "t-bare",
+				workspaceId: "ws-1",
+				agentId: "claude",
+				agentSessionId: "sess-new",
+				startedAt: Date.now(),
+				lastEventAt: Date.now(),
+				lastEventType: "SessionStart",
+			})
+			.run();
+
+		expect(markStaleActiveRows(db, [], new Map(), beforeProbe)).toBe(0);
+
+		expect(statusOf(db, "t-bare")).toBe("active");
+		expect(bindingOf(db, "t-bare")?.endedAt).toBeNull();
+	});
+
+	it("sweeps when the session it captured is still the one bound", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-lost" });
+
+		expect(
+			markStaleActiveRows(
+				db,
+				[],
+				new Map(),
+				snapshotTerminalAgentBindingSessionIds(db),
+			),
+		).toBe(1);
+
+		expect(statusOf(db, "t-lost")).toBe("exited");
+		expect(
+			findResumeCandidateBinding(db, "ws-1", "t-lost")?.agentSessionId,
+		).toBe("sess-1");
+	});
+
+	it("still sweeps a stale row that never had an agent binding", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-no-agent", binding: null });
+
+		expect(
+			markStaleActiveRows(
+				db,
+				[],
+				new Map(),
+				snapshotTerminalAgentBindingSessionIds(db),
+			),
+		).toBe(1);
+
+		expect(statusOf(db, "t-no-agent")).toBe("exited");
+		expect(bindingOf(db, "t-no-agent")).toBeUndefined();
+	});
+
+	it("leaves a binding with no agent session id, and its row, for later", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-idless", binding: { agentSessionId: null } });
+
+		expect(
+			markStaleActiveRows(
+				db,
+				[],
+				new Map(),
+				snapshotTerminalAgentBindingSessionIds(db),
+			),
+		).toBe(0);
+
+		// No concrete session id is no baseline to claim ownership by — the
+		// same reason `sweepAgentBindingsAfterDaemonLoss` leaves those
+		// bindings untouched — and an `exited` row would strand a replacement
+		// this pass cannot rule out.
+		expect(statusOf(db, "t-idless")).toBe("active");
+		expect(bindingOf(db, "t-idless")?.endedAt).toBeNull();
 	});
 
 	it("does not overwrite an older clean detach", () => {

--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -446,12 +446,15 @@ describe("markStaleActiveRows agent bindings", () => {
 		// A binding write that fails for any reason (locked db, constraint,
 		// corrupt row). Committing the status flip without the binding stamp
 		// is unrecoverable: the row leaves `active`, so no later sweep, attach
-		// or respawn ever ends the binding again.
+		// or respawn ever ends the binding again. The sweep fails as a whole
+		// instead (the reap pass logs it) and nothing is committed.
 		db.run(
 			sql`CREATE TRIGGER fail_binding_write BEFORE UPDATE ON terminal_agent_bindings BEGIN SELECT RAISE(ABORT, 'binding write failed'); END`,
 		);
 
-		markStaleActiveRows(db, [], new Map());
+		expect(() => markStaleActiveRows(db, [], new Map())).toThrow(
+			/binding write failed/,
+		);
 
 		// Nothing committed, so the row is still a candidate for the sweep.
 		expect(statusOf(db, "t-lost")).toBe("active");
@@ -464,28 +467,6 @@ describe("markStaleActiveRows agent bindings", () => {
 		expect(
 			findResumeCandidateBinding(db, "ws-1", "t-lost")?.agentSessionId,
 		).toBe("sess-1");
-	});
-
-	it("lets a dispose that lands after the snapshot beat the exit flip", () => {
-		const db = createTestDb();
-		seed(db, { id: "t-racing" });
-		// The plan is built from rows read before the daemon answered; the
-		// user's dispose stamps its durable intent during that window.
-		const snapshot = snapshotRows(db);
-		requestDispose(db, "t-racing");
-
-		markStaleActiveRows(db, [], snapshot);
-
-		// Not flipped to the resumable `exited` outcome: the row stays
-		// `active`, which is what the in-flight dispose (or the next pass)
-		// resolves.
-		expect(statusOf(db, "t-racing")).toBe("active");
-		expect(bindingOf(db, "t-racing")?.endedAt).toBeNull();
-		expect(findResumeCandidateBinding(db, "ws-1", "t-racing")).toBeUndefined();
-
-		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
-		expect(statusOf(db, "t-racing")).toBe("disposed");
-		expect(findResumeCandidateBinding(db, "ws-1", "t-racing")).toBeUndefined();
 	});
 
 	it("stops offering resume when a dispose lands after the exit flip", () => {

--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -11,7 +11,6 @@ import {
 	claimResumeCandidateBinding,
 	findResumeCandidateBinding,
 	markTerminalAgentBindingEnded,
-	snapshotTerminalAgentBindingSessionIds,
 } from "../../terminal-agents/persistence.ts";
 import {
 	markStaleActiveRows,
@@ -532,132 +531,28 @@ describe("markStaleActiveRows agent bindings", () => {
 		).toBeUndefined();
 	});
 
-	it("leaves an agent session bound during the daemon probe alone", () => {
-		const db = createTestDb();
-		seed(db, { id: "t-respawned" });
-
-		// What the reaper captures before it awaits the daemon — getting a
-		// client and its session list is a real wait (bootstrap, reconnect,
-		// RPC). A renderer attach lands inside that window: the respawn ends
-		// the lost pty's binding and the new shell's agent binds a fresh
-		// session to the same terminal.
-		const beforeProbe = snapshotTerminalAgentBindingSessionIds(db);
-		const respawnedAt = Date.now();
-		db.update(terminalAgentBindings)
-			.set({
-				agentSessionId: "sess-2",
-				startedAt: respawnedAt,
-				lastEventAt: respawnedAt,
-				lastEventType: "SessionStart",
-				endedAt: null,
-				endReason: null,
-			})
-			.where(eq(terminalAgentBindings.terminalId, "t-respawned"))
-			.run();
-
-		// The daemon's answer condemns the pty that died, not the one that
-		// replaced it, so this pass must write nothing.
-		expect(markStaleActiveRows(db, [], new Map(), beforeProbe)).toBe(0);
-
-		// The replacement is still live in every read...
-		expect(bindingOf(db, "t-respawned")?.agentSessionId).toBe("sess-2");
-		expect(bindingOf(db, "t-respawned")?.endedAt).toBeNull();
-		expect(bindingOf(db, "t-respawned")?.endReason).toBeNull();
-		// ...and its row is still attachable: `exited` would answer
-		// session-gone forever, with no later pass to undo it.
-		expect(statusOf(db, "t-respawned")).toBe("active");
-
-		// Retryable, not skipped forever — the next pass re-probes the daemon
-		// and re-captures ownership, and that is what decides the row then.
-		expect(
-			markStaleActiveRows(
-				db,
-				[],
-				new Map(),
-				snapshotTerminalAgentBindingSessionIds(db),
-			),
-		).toBe(1);
-	});
-
-	it("leaves a terminal that gained a binding during the probe alone", () => {
-		const db = createTestDb();
-		seed(db, { id: "t-bare", binding: null });
-
-		const beforeProbe = snapshotTerminalAgentBindingSessionIds(db);
-		// First hook event from an agent launched in the respawned shell.
-		db.insert(terminalAgentBindings)
-			.values({
-				terminalId: "t-bare",
-				workspaceId: "ws-1",
-				agentId: "claude",
-				agentSessionId: "sess-new",
-				startedAt: Date.now(),
-				lastEventAt: Date.now(),
-				lastEventType: "SessionStart",
-			})
-			.run();
-
-		expect(markStaleActiveRows(db, [], new Map(), beforeProbe)).toBe(0);
-
-		expect(statusOf(db, "t-bare")).toBe("active");
-		expect(bindingOf(db, "t-bare")?.endedAt).toBeNull();
-	});
-
-	it("sweeps when the session it captured is still the one bound", () => {
-		const db = createTestDb();
-		seed(db, { id: "t-lost" });
-
-		expect(
-			markStaleActiveRows(
-				db,
-				[],
-				new Map(),
-				snapshotTerminalAgentBindingSessionIds(db),
-			),
-		).toBe(1);
-
-		expect(statusOf(db, "t-lost")).toBe("exited");
-		expect(
-			findResumeCandidateBinding(db, "ws-1", "t-lost")?.agentSessionId,
-		).toBe("sess-1");
-	});
-
 	it("still sweeps a stale row that never had an agent binding", () => {
 		const db = createTestDb();
 		seed(db, { id: "t-no-agent", binding: null });
 
-		expect(
-			markStaleActiveRows(
-				db,
-				[],
-				new Map(),
-				snapshotTerminalAgentBindingSessionIds(db),
-			),
-		).toBe(1);
+		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
 
 		expect(statusOf(db, "t-no-agent")).toBe("exited");
 		expect(bindingOf(db, "t-no-agent")).toBeUndefined();
 	});
 
-	it("leaves a binding with no agent session id, and its row, for later", () => {
+	it("sweeps a stale row whose binding never captured a session id", () => {
+		// Such a binding can never be a resume candidate, but the row still has
+		// to leave `active` — that is what stops live-session reads from
+		// offering an agent whose pty is gone.
 		const db = createTestDb();
 		seed(db, { id: "t-idless", binding: { agentSessionId: null } });
 
-		expect(
-			markStaleActiveRows(
-				db,
-				[],
-				new Map(),
-				snapshotTerminalAgentBindingSessionIds(db),
-			),
-		).toBe(0);
+		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
 
-		// No concrete session id is no baseline to claim ownership by — the
-		// same reason `sweepAgentBindingsAfterDaemonLoss` leaves those
-		// bindings untouched — and an `exited` row would strand a replacement
-		// this pass cannot rule out.
-		expect(statusOf(db, "t-idless")).toBe("active");
-		expect(bindingOf(db, "t-idless")?.endedAt).toBeNull();
+		expect(statusOf(db, "t-idless")).toBe("exited");
+		expect(bindingOf(db, "t-idless")?.endReason).toBe("terminal-exited");
+		expect(findResumeCandidateBinding(db, "ws-1", "t-idless")).toBeUndefined();
 	});
 
 	it("does not overwrite an older clean detach", () => {

--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -1,13 +1,17 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import type { HostDb } from "../../db/index.ts";
 import * as schema from "../../db/schema.ts";
 import { terminalAgentBindings, terminalSessions } from "../../db/schema.ts";
-import { findResumeCandidateBinding } from "../../terminal-agents/persistence.ts";
+import {
+	claimResumeCandidateBinding,
+	findResumeCandidateBinding,
+	markTerminalAgentBindingEnded,
+} from "../../terminal-agents/persistence.ts";
 import {
 	markStaleActiveRows,
 	PORT_SCAN_WARMUP_DELAYS_MS,
@@ -340,6 +344,33 @@ describe("markStaleActiveRows agent bindings", () => {
 			.run();
 	}
 
+	/**
+	 * The row snapshot the reaper passes in, loaded the way its own
+	 * `loadTerminalRowsById` does. Tests that exercise the policy must supply
+	 * it: with a non-empty `liveSessions` the sweep trusts the caller's map
+	 * and never reloads, so an empty map means the policy sees no rows at all.
+	 */
+	function snapshotRows(db: HostDb) {
+		const rows = db
+			.select({
+				id: terminalSessions.id,
+				status: terminalSessions.status,
+				originWorkspaceId: terminalSessions.originWorkspaceId,
+				disposeRequestedAt: terminalSessions.disposeRequestedAt,
+				createdAt: terminalSessions.createdAt,
+			})
+			.from(terminalSessions)
+			.all();
+		return new Map(rows.map((row) => [row.id, row]));
+	}
+
+	function requestDispose(db: HostDb, id: string) {
+		db.update(terminalSessions)
+			.set({ disposeRequestedAt: Date.now() })
+			.where(eq(terminalSessions.id, id))
+			.run();
+	}
+
 	function statusOf(db: HostDb, id: string): string | undefined {
 		return db
 			.select({ status: terminalSessions.status })
@@ -386,13 +417,111 @@ describe("markStaleActiveRows agent bindings", () => {
 		const db = createTestDb();
 		seed(db, { id: "t-alive" });
 		seed(db, { id: "t-fresh", createdAt: Date.now() });
+		seed(db, { id: "t-stale" });
 
-		markStaleActiveRows(db, [{ id: "t-alive" }], new Map());
+		// t-alive is still in the daemon's list and t-fresh is inside the
+		// spawn grace window; only t-stale is condemned. Its sweep is what
+		// proves the policy actually evaluated these rows.
+		expect(markStaleActiveRows(db, [{ id: "t-alive" }], snapshotRows(db))).toBe(
+			1,
+		);
 
+		expect(statusOf(db, "t-stale")).toBe("exited");
 		expect(statusOf(db, "t-alive")).toBe("active");
 		expect(bindingOf(db, "t-alive")?.endedAt).toBeNull();
 		expect(statusOf(db, "t-fresh")).toBe("active");
 		expect(bindingOf(db, "t-fresh")?.endedAt).toBeNull();
+	});
+
+	it("rolls the row back when the binding write fails, and retries later", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-lost" });
+		// A binding write that fails for any reason (locked db, constraint,
+		// corrupt row). Committing the status flip without the binding stamp
+		// is unrecoverable: the row leaves `active`, so no later sweep, attach
+		// or respawn ever ends the binding again.
+		db.run(
+			sql`CREATE TRIGGER fail_binding_write BEFORE UPDATE ON terminal_agent_bindings BEGIN SELECT RAISE(ABORT, 'binding write failed'); END`,
+		);
+
+		markStaleActiveRows(db, [], new Map());
+
+		// Nothing committed, so the row is still a candidate for the sweep.
+		expect(statusOf(db, "t-lost")).toBe("active");
+		expect(bindingOf(db, "t-lost")?.endedAt).toBeNull();
+
+		db.run(sql`DROP TRIGGER fail_binding_write`);
+		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
+
+		expect(statusOf(db, "t-lost")).toBe("exited");
+		expect(
+			findResumeCandidateBinding(db, "ws-1", "t-lost")?.agentSessionId,
+		).toBe("sess-1");
+	});
+
+	it("lets a dispose that lands after the snapshot beat the exit flip", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-racing" });
+		// The plan is built from rows read before the daemon answered; the
+		// user's dispose stamps its durable intent during that window.
+		const snapshot = snapshotRows(db);
+		requestDispose(db, "t-racing");
+
+		markStaleActiveRows(db, [], snapshot);
+
+		// Not flipped to the resumable `exited` outcome: the row stays
+		// `active`, which is what the in-flight dispose (or the next pass)
+		// resolves.
+		expect(statusOf(db, "t-racing")).toBe("active");
+		expect(bindingOf(db, "t-racing")?.endedAt).toBeNull();
+		expect(findResumeCandidateBinding(db, "ws-1", "t-racing")).toBeUndefined();
+
+		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
+		expect(statusOf(db, "t-racing")).toBe("disposed");
+		expect(findResumeCandidateBinding(db, "ws-1", "t-racing")).toBeUndefined();
+	});
+
+	it("stops offering resume when a dispose lands after the exit flip", () => {
+		const db = createTestDb();
+		seed(db, { id: "t-swept" });
+
+		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
+		expect(findResumeCandidateBinding(db, "ws-1", "t-swept")).toBeDefined();
+
+		// The user closes the pane a moment later. The dispose route stamps
+		// the binding first, then `disposeSessionAndWait` stamps the durable
+		// intent and flips the row — and none of it may leave the pane
+		// auto-resuming the session they just ended.
+		markTerminalAgentBindingEnded(db, "t-swept", "disposed");
+		requestDispose(db, "t-swept");
+		db.update(terminalSessions)
+			.set({ status: "disposed", endedAt: Date.now() })
+			.where(eq(terminalSessions.id, "t-swept"))
+			.run();
+
+		expect(bindingOf(db, "t-swept")?.endReason).toBe("disposed");
+		expect(findResumeCandidateBinding(db, "ws-1", "t-swept")).toBeUndefined();
+		expect(claimResumeCandidateBinding(db, "ws-1", "t-swept")).toBeUndefined();
+	});
+
+	it("keeps a binding the dispose route already stamped out of resume", () => {
+		// The reverse interleaving: the dispose route stamped the binding
+		// disposed and its kill has not flipped the row yet, so the sweep
+		// still sees an `active` row with no intent stamp. "disposed" is
+		// sticky — the sweep's terminal-death stamp must not overwrite it.
+		const db = createTestDb();
+		seed(db, {
+			id: "t-pane-closed",
+			binding: { endedAt: OLD, endReason: "disposed" },
+		});
+
+		expect(markStaleActiveRows(db, [], new Map())).toBe(1);
+
+		expect(statusOf(db, "t-pane-closed")).toBe("exited");
+		expect(bindingOf(db, "t-pane-closed")?.endReason).toBe("disposed");
+		expect(
+			findResumeCandidateBinding(db, "ws-1", "t-pane-closed"),
+		).toBeUndefined();
 	});
 
 	it("does not overwrite an older clean detach", () => {

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { HostDb } from "../../db/index.ts";
 import { terminalSessions } from "../../db/schema.ts";
 import { portManager } from "../../ports/port-manager.ts";
@@ -171,10 +171,59 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
 }
 
 /**
+ * Flip one daemon-lost `active` row to `exited` and end its agent binding in
+ * a single transaction, so the two can never come apart. An `exited` row is
+ * the pty dying under whatever was running in it, so the binding gets the
+ * same "terminal-exited" stamp the pty exit callback and the lazy respawn
+ * write — that stamp is what makes the session a resume candidate.
+ *
+ * Both writes or neither. A committed status flip whose binding stamp was
+ * lost is unrecoverable in this process: the row is no longer `active`, so
+ * this sweep never reconsiders it, and an attach answers session-gone before
+ * it reaches the respawn that would have ended the binding. Rolling back
+ * leaves the row `active` for the next pass to retry instead.
+ *
+ * The flip also requires the dispose stamp to still be absent, re-read here
+ * inside the transaction: {@link planStaleActiveRows} classified this row
+ * from a snapshot taken before the daemon answered, and a dispose that
+ * landed since must not be overwritten with the resumable `exited` outcome.
+ * Such a row stays `active`, and the next pass condemns it as `disposed`.
+ *
+ * Returns whether the row was marked.
+ */
+function markStaleExitedRow(
+	db: HostDb,
+	terminalId: string,
+	endedAt: number,
+): boolean {
+	return db.transaction((tx) => {
+		const marked = tx
+			.update(terminalSessions)
+			.set({ status: "exited", endedAt })
+			.where(
+				and(
+					eq(terminalSessions.id, terminalId),
+					eq(terminalSessions.status, "active"),
+					isNull(terminalSessions.disposeRequestedAt),
+				),
+			)
+			.returning({ id: terminalSessions.id })
+			.get();
+		if (!marked) return false;
+		markTerminalAgentBindingEnded(tx, terminalId, "terminal-exited", endedAt);
+		return true;
+	});
+}
+
+/**
  * Flip daemon-lost `active` rows to `exited` (or `disposed`, honoring a
  * pending dispose) so live-session reads stop offering ptys that no longer
  * exist, and end the exited rows' agent bindings so their sessions stay
- * resumable. Returns how many rows the plan condemned.
+ * resumable. A `disposed` row's binding is left alone for the same reason
+ * the dispose route leaves it alone — a session the user killed must not
+ * come back as a resume candidate. Returns how many rows were marked;
+ * anything the plan condemned that this pass could not write stays `active`
+ * for the next pass.
  */
 export function markStaleActiveRows(
 	db: HostDb,
@@ -191,49 +240,44 @@ export function markStaleActiveRows(
 		isLive: isLiveTerminalSession,
 		now: Date.now(),
 	});
-	const total = stale.exited.length + stale.disposed.length;
-	if (total === 0) return 0;
+	if (stale.exited.length + stale.disposed.length === 0) return 0;
 	const endedAt = Date.now();
-	for (const [ids, status] of [
-		[stale.exited, "exited"],
-		[stale.disposed, "disposed"],
-	] as const) {
-		if (ids.length === 0) continue;
-		const marked = db
+
+	// Per row, so a failed binding write costs only its own row: that one
+	// rolls back for the next pass to retry, the rest are still swept.
+	let exited = 0;
+	for (const terminalId of stale.exited) {
+		try {
+			if (markStaleExitedRow(db, terminalId, endedAt)) exited += 1;
+		} catch (err) {
+			console.warn(
+				`[host-service] terminal reaper: left ${terminalId} active — ending its agent binding failed:`,
+				err,
+			);
+		}
+	}
+
+	let disposed = 0;
+	if (stale.disposed.length > 0) {
+		disposed = db
 			.update(terminalSessions)
-			.set({ status, endedAt })
+			.set({ status: "disposed", endedAt })
 			.where(
 				and(
-					inArray(terminalSessions.id, ids),
+					inArray(terminalSessions.id, stale.disposed),
 					eq(terminalSessions.status, "active"),
 				),
 			)
 			.returning({ id: terminalSessions.id })
-			.all();
-		// An `exited` row is the pty dying under whatever was running in it, so
-		// end its agent binding the way the pty exit callback and the lazy
-		// respawn do — that "terminal-exited" stamp is what makes the session a
-		// resume candidate. Without it the sweep drops the terminal out of every
-		// live read and leaves nothing to resume from: the row is no longer
-		// `active`, so an attach answers session-gone before it can reach the
-		// respawn that would have ended the binding. `disposed` rows are left
-		// alone for the same reason the dispose route leaves them alone — a
-		// session the user killed must not come back as a resume candidate.
-		if (status !== "exited") continue;
-		for (const row of marked) {
-			try {
-				markTerminalAgentBindingEnded(db, row.id, "terminal-exited", endedAt);
-			} catch (err) {
-				console.warn(
-					`[host-service] terminal reaper: failed to end agent binding for ${row.id}:`,
-					err,
-				);
-			}
-		}
+			.all().length;
 	}
-	console.log(
-		`[host-service] terminal reaper: marked ${total} daemon-lost session(s) ended (${stale.exited.length} exited, ${stale.disposed.length} disposed)`,
-	);
+
+	const total = exited + disposed;
+	if (total > 0) {
+		console.log(
+			`[host-service] terminal reaper: marked ${total} daemon-lost session(s) ended (${exited} exited, ${disposed} disposed)`,
+		);
+	}
 	return total;
 }
 

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../../db/index.ts";
 import { terminalSessions } from "../../db/schema.ts";
 import { portManager } from "../../ports/port-manager.ts";
+import { markTerminalAgentBindingEnded } from "../../terminal-agents/persistence.ts";
 import { getDaemonClient } from "../daemon-client-singleton.ts";
 import { disposeSessionAndWait, isLiveTerminalSession } from "../terminal.ts";
 
@@ -169,9 +170,13 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
 	return new Map(rows.map((row) => [row.id, row]));
 }
 
-/** Flip daemon-lost `active` rows to `exited` so live-session reads (agent
- * bindings, resume candidates) stop offering ptys that no longer exist. */
-function markStaleActiveRows(
+/**
+ * Flip daemon-lost `active` rows to `exited` (or `disposed`, honoring a
+ * pending dispose) so live-session reads stop offering ptys that no longer
+ * exist, and end the exited rows' agent bindings so their sessions stay
+ * resumable. Returns how many rows the plan condemned.
+ */
+export function markStaleActiveRows(
 	db: HostDb,
 	liveSessions: { id: string }[],
 	rowById: Map<string, TerminalRow>,
@@ -188,20 +193,43 @@ function markStaleActiveRows(
 	});
 	const total = stale.exited.length + stale.disposed.length;
 	if (total === 0) return 0;
+	const endedAt = Date.now();
 	for (const [ids, status] of [
 		[stale.exited, "exited"],
 		[stale.disposed, "disposed"],
 	] as const) {
 		if (ids.length === 0) continue;
-		db.update(terminalSessions)
-			.set({ status, endedAt: Date.now() })
+		const marked = db
+			.update(terminalSessions)
+			.set({ status, endedAt })
 			.where(
 				and(
 					inArray(terminalSessions.id, ids),
 					eq(terminalSessions.status, "active"),
 				),
 			)
-			.run();
+			.returning({ id: terminalSessions.id })
+			.all();
+		// An `exited` row is the pty dying under whatever was running in it, so
+		// end its agent binding the way the pty exit callback and the lazy
+		// respawn do — that "terminal-exited" stamp is what makes the session a
+		// resume candidate. Without it the sweep drops the terminal out of every
+		// live read and leaves nothing to resume from: the row is no longer
+		// `active`, so an attach answers session-gone before it can reach the
+		// respawn that would have ended the binding. `disposed` rows are left
+		// alone for the same reason the dispose route leaves them alone — a
+		// session the user killed must not come back as a resume candidate.
+		if (status !== "exited") continue;
+		for (const row of marked) {
+			try {
+				markTerminalAgentBindingEnded(db, row.id, "terminal-exited", endedAt);
+			} catch (err) {
+				console.warn(
+					`[host-service] terminal reaper: failed to end agent binding for ${row.id}:`,
+					err,
+				);
+			}
+		}
 	}
 	console.log(
 		`[host-service] terminal reaper: marked ${total} daemon-lost session(s) ended (${stale.exited.length} exited, ${stale.disposed.length} disposed)`,

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -2,7 +2,11 @@ import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { HostDb } from "../../db/index.ts";
 import { terminalSessions } from "../../db/schema.ts";
 import { portManager } from "../../ports/port-manager.ts";
-import { markTerminalAgentBindingEnded } from "../../terminal-agents/persistence.ts";
+import {
+	markTerminalAgentBindingEnded,
+	readTerminalAgentBindingSessionId,
+	snapshotTerminalAgentBindingSessionIds,
+} from "../../terminal-agents/persistence.ts";
 import { getDaemonClient } from "../daemon-client-singleton.ts";
 import { disposeSessionAndWait, isLiveTerminalSession } from "../terminal.ts";
 
@@ -189,14 +193,41 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
  * landed since must not be overwritten with the resumable `exited` outcome.
  * Such a row stays `active`, and the next pass condemns it as `disposed`.
  *
+ * `expectedSessionId` is which agent session owned this terminal when the
+ * daemon probe began (see {@link snapshotTerminalAgentBindingSessionIds}),
+ * re-checked here so both writes land on that same binding or on none. The
+ * probe is a real await: a respawn can bind a NEW agent session to the
+ * terminal while it runs, and that session's pty is not the one the daemon
+ * declared lost. Ending its binding would hide a live agent from every read,
+ * and committing `exited` alongside it would strand it for good — the row
+ * leaves `active`, so no later pass reconsiders it and an attach answers
+ * session-gone. So a terminal whose binding was replaced, or that gained one
+ * during the probe, is left entirely alone for the next pass to re-probe.
+ *
+ * A binding with no concrete session id (`null`) is no baseline at all — the
+ * same reason `sweepAgentBindingsAfterDaemonLoss` leaves those untouched —
+ * so it is skipped rather than swept on an ownership claim we cannot make.
+ * That row keeps haunting live reads until an attach respawns it or a dispose
+ * kills it, which is the cheaper mistake: those bindings are never resume
+ * candidates, so the sweep has little to win on them and a live agent to lose.
+ * A terminal with no binding at either point has nothing to strand and is
+ * swept as before.
+ *
  * Returns whether the row was marked.
  */
 function markStaleExitedRow(
 	db: HostDb,
 	terminalId: string,
 	endedAt: number,
+	expectedSessionId: string | null | undefined,
 ): boolean {
 	return db.transaction((tx) => {
+		// Before any write: a plain `return` commits the transaction, so an
+		// ownership refusal has to happen while there is nothing to roll back.
+		const ownerSessionId = readTerminalAgentBindingSessionId(tx, terminalId);
+		if (ownerSessionId === null || ownerSessionId !== expectedSessionId) {
+			return false;
+		}
 		const marked = tx
 			.update(terminalSessions)
 			.set({ status: "exited", endedAt })
@@ -224,11 +255,21 @@ function markStaleExitedRow(
  * come back as a resume candidate. Returns how many rows were marked;
  * anything the plan condemned that this pass could not write stays `active`
  * for the next pass.
+ *
+ * `bindingSessionIds` is the binding ownership the caller captured *before*
+ * the daemon probe whose answer produced `liveSessions`; see
+ * {@link markStaleExitedRow} for what it protects. It defaults to a snapshot
+ * taken right here, which is only correct for a caller that does not probe
+ * asynchronously first.
  */
 export function markStaleActiveRows(
 	db: HostDb,
 	liveSessions: { id: string }[],
 	rowById: Map<string, TerminalRow>,
+	bindingSessionIds: Map<
+		string,
+		string | null
+	> = snapshotTerminalAgentBindingSessionIds(db),
 ): number {
 	const rowsById =
 		rowById.size > 0 || liveSessions.length > 0
@@ -248,7 +289,13 @@ export function markStaleActiveRows(
 	let exited = 0;
 	for (const terminalId of stale.exited) {
 		try {
-			if (markStaleExitedRow(db, terminalId, endedAt)) exited += 1;
+			const swept = markStaleExitedRow(
+				db,
+				terminalId,
+				endedAt,
+				bindingSessionIds.get(terminalId),
+			);
+			if (swept) exited += 1;
 		} catch (err) {
 			console.warn(
 				`[host-service] terminal reaper: left ${terminalId} active — ending its agent binding failed:`,
@@ -311,6 +358,12 @@ function applyPortScanSync(
 }
 
 async function runPortScanSync(db: HostDb) {
+	// Captured before the first await, and carried out with the daemon's
+	// answer, so it is the ownership that held when *this* probe began — the
+	// probe a coalesced caller is about to act on. Getting a daemon client can
+	// itself take seconds (bootstrap, reconnect), which is exactly the window
+	// in which a respawn rebinds a terminal to a new agent session.
+	const bindingSessionIds = snapshotTerminalAgentBindingSessionIds(db);
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
 	const rowById =
@@ -318,7 +371,7 @@ async function runPortScanSync(db: HostDb) {
 			? loadTerminalRowsById(db)
 			: new Map<string, TerminalRow>();
 	applyPortScanSync(liveSessions, rowById);
-	return { liveSessions, rowById };
+	return { liveSessions, rowById, bindingSessionIds };
 }
 
 let inFlightPortScanSync: ReturnType<typeof runPortScanSync> | null = null;
@@ -334,6 +387,8 @@ let inFlightPortScanSync: ReturnType<typeof runPortScanSync> | null = null;
  * the reap pass both call this, and a slow `daemon.list()` right after adoption
  * (exactly when the warm-up fires) could otherwise let a second sync observe a
  * transiently-empty list and unregister sessions the first just registered.
+ * A coalesced caller therefore also gets the binding ownership captured before
+ * that shared probe started, not before its own call.
  */
 function syncPortScans(db: HostDb): ReturnType<typeof runPortScanSync> {
 	if (inFlightPortScanSync) return inFlightPortScanSync;
@@ -349,13 +404,13 @@ async function reapOrphanedSessions(
 ): Promise<ReapResult> {
 	// Sync the port scanner before the empty-list short-circuit below so an idle
 	// daemon still drops stale scans.
-	const { liveSessions, rowById } = await syncPortScans(db);
+	const { liveSessions, rowById, bindingSessionIds } = await syncPortScans(db);
 
 	// The daemon answered (syncPortScans would have thrown otherwise), so its
 	// list is authoritative: reconcile rows stuck `active` for sessions it no
 	// longer owns. Best-effort — a failure here must not block the orphan reap.
 	try {
-		markStaleActiveRows(db, liveSessions, rowById);
+		markStaleActiveRows(db, liveSessions, rowById, bindingSessionIds);
 	} catch (err) {
 		console.warn("[host-service] stale-session sweep failed:", err);
 	}

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../../db/index.ts";
 import { terminalSessions } from "../../db/schema.ts";
 import { portManager } from "../../ports/port-manager.ts";
@@ -171,63 +171,15 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
 }
 
 /**
- * Flip one daemon-lost `active` row to `exited` and end its agent binding in
- * a single transaction, so the two can never come apart. An `exited` row is
- * the pty dying under whatever was running in it, so the binding gets the
- * same "terminal-exited" stamp the pty exit callback and the lazy respawn
- * write — that stamp is what makes the session a resume candidate.
- *
- * Both writes or neither. A committed status flip whose binding stamp was
- * lost is unrecoverable in this process: the row is no longer `active`, so
- * this sweep never reconsiders it, and an attach answers session-gone before
- * it reaches the respawn that would have ended the binding. Rolling back
- * leaves the row `active` for the next pass to retry instead.
- *
- * The flip also requires the dispose stamp to still be absent, re-read here
- * inside the transaction: {@link planStaleActiveRows} classified this row
- * from a snapshot taken before the daemon answered, and a dispose that
- * landed since must not be overwritten with the resumable `exited` outcome.
- * Such a row stays `active`, and the next pass condemns it as `disposed`.
- *
- * Returns whether the row was marked.
- */
-function markStaleExitedRow(
-	db: HostDb,
-	terminalId: string,
-	endedAt: number,
-): boolean {
-	return db.transaction((tx) => {
-		const marked = tx
-			.update(terminalSessions)
-			.set({ status: "exited", endedAt })
-			.where(
-				and(
-					eq(terminalSessions.id, terminalId),
-					eq(terminalSessions.status, "active"),
-					isNull(terminalSessions.disposeRequestedAt),
-				),
-			)
-			.returning({ id: terminalSessions.id })
-			.get();
-		if (!marked) return false;
-		markTerminalAgentBindingEnded(tx, terminalId, "terminal-exited", endedAt);
-		return true;
-	});
-}
-
-/**
  * Flip daemon-lost `active` rows to `exited` (or `disposed`, honoring a
  * pending dispose) so live-session reads stop offering ptys that no longer
- * exist, and end the exited rows' agent bindings so their sessions stay
- * resumable. A `disposed` row's binding is left alone for the same reason
- * the dispose route leaves it alone — a session the user killed must not
- * come back as a resume candidate. Returns how many rows were marked;
- * anything the plan condemned that this pass could not write stays `active`
- * for the next pass.
- *
- * A terminal respawned while the daemon probe was in flight is live in this
- * process's session map by the time the plan runs, so {@link planStaleActiveRows}
- * already leaves it — and whatever new agent session bound to it — alone.
+ * exist, and stamp the exited rows' agent bindings "terminal-exited" — the
+ * pty died under the agent, same as the pty exit callback — so their sessions
+ * become resume candidates. One transaction: an `exited` row whose binding
+ * kept its open stamp is unreachable afterwards (the sweep only revisits
+ * `active` rows and an attach answers session-gone), so the session would
+ * stay unresumable until the next boot's sweepDefunct. A `disposed` row's
+ * binding was stamped by the dispose route and must not come back.
  */
 export function markStaleActiveRows(
 	db: HostDb,
@@ -247,34 +199,30 @@ export function markStaleActiveRows(
 	if (stale.exited.length + stale.disposed.length === 0) return 0;
 	const endedAt = Date.now();
 
-	// Per row, so a failed binding write costs only its own row: that one
-	// rolls back for the next pass to retry, the rest are still swept.
-	let exited = 0;
-	for (const terminalId of stale.exited) {
-		try {
-			if (markStaleExitedRow(db, terminalId, endedAt)) exited += 1;
-		} catch (err) {
-			console.warn(
-				`[host-service] terminal reaper: left ${terminalId} active — ending its agent binding failed:`,
-				err,
-			);
+	const { exited, disposed } = db.transaction((tx) => {
+		const flip = (ids: string[], status: "exited" | "disposed") =>
+			ids.length === 0
+				? []
+				: tx
+						.update(terminalSessions)
+						.set({ status, endedAt })
+						.where(
+							and(
+								inArray(terminalSessions.id, ids),
+								eq(terminalSessions.status, "active"),
+							),
+						)
+						.returning({ id: terminalSessions.id })
+						.all();
+		const exited = flip(stale.exited, "exited");
+		for (const { id } of exited) {
+			markTerminalAgentBindingEnded(tx, id, "terminal-exited", endedAt);
 		}
-	}
-
-	let disposed = 0;
-	if (stale.disposed.length > 0) {
-		disposed = db
-			.update(terminalSessions)
-			.set({ status: "disposed", endedAt })
-			.where(
-				and(
-					inArray(terminalSessions.id, stale.disposed),
-					eq(terminalSessions.status, "active"),
-				),
-			)
-			.returning({ id: terminalSessions.id })
-			.all().length;
-	}
+		return {
+			exited: exited.length,
+			disposed: flip(stale.disposed, "disposed").length,
+		};
+	});
 
 	const total = exited + disposed;
 	if (total > 0) {

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -2,11 +2,7 @@ import { and, eq, inArray, isNull } from "drizzle-orm";
 import type { HostDb } from "../../db/index.ts";
 import { terminalSessions } from "../../db/schema.ts";
 import { portManager } from "../../ports/port-manager.ts";
-import {
-	markTerminalAgentBindingEnded,
-	readTerminalAgentBindingSessionId,
-	snapshotTerminalAgentBindingSessionIds,
-} from "../../terminal-agents/persistence.ts";
+import { markTerminalAgentBindingEnded } from "../../terminal-agents/persistence.ts";
 import { getDaemonClient } from "../daemon-client-singleton.ts";
 import { disposeSessionAndWait, isLiveTerminalSession } from "../terminal.ts";
 
@@ -193,41 +189,14 @@ function loadTerminalRowsById(db: HostDb): Map<string, TerminalRow> {
  * landed since must not be overwritten with the resumable `exited` outcome.
  * Such a row stays `active`, and the next pass condemns it as `disposed`.
  *
- * `expectedSessionId` is which agent session owned this terminal when the
- * daemon probe began (see {@link snapshotTerminalAgentBindingSessionIds}),
- * re-checked here so both writes land on that same binding or on none. The
- * probe is a real await: a respawn can bind a NEW agent session to the
- * terminal while it runs, and that session's pty is not the one the daemon
- * declared lost. Ending its binding would hide a live agent from every read,
- * and committing `exited` alongside it would strand it for good — the row
- * leaves `active`, so no later pass reconsiders it and an attach answers
- * session-gone. So a terminal whose binding was replaced, or that gained one
- * during the probe, is left entirely alone for the next pass to re-probe.
- *
- * A binding with no concrete session id (`null`) is no baseline at all — the
- * same reason `sweepAgentBindingsAfterDaemonLoss` leaves those untouched —
- * so it is skipped rather than swept on an ownership claim we cannot make.
- * That row keeps haunting live reads until an attach respawns it or a dispose
- * kills it, which is the cheaper mistake: those bindings are never resume
- * candidates, so the sweep has little to win on them and a live agent to lose.
- * A terminal with no binding at either point has nothing to strand and is
- * swept as before.
- *
  * Returns whether the row was marked.
  */
 function markStaleExitedRow(
 	db: HostDb,
 	terminalId: string,
 	endedAt: number,
-	expectedSessionId: string | null | undefined,
 ): boolean {
 	return db.transaction((tx) => {
-		// Before any write: a plain `return` commits the transaction, so an
-		// ownership refusal has to happen while there is nothing to roll back.
-		const ownerSessionId = readTerminalAgentBindingSessionId(tx, terminalId);
-		if (ownerSessionId === null || ownerSessionId !== expectedSessionId) {
-			return false;
-		}
 		const marked = tx
 			.update(terminalSessions)
 			.set({ status: "exited", endedAt })
@@ -256,20 +225,14 @@ function markStaleExitedRow(
  * anything the plan condemned that this pass could not write stays `active`
  * for the next pass.
  *
- * `bindingSessionIds` is the binding ownership the caller captured *before*
- * the daemon probe whose answer produced `liveSessions`; see
- * {@link markStaleExitedRow} for what it protects. It defaults to a snapshot
- * taken right here, which is only correct for a caller that does not probe
- * asynchronously first.
+ * A terminal respawned while the daemon probe was in flight is live in this
+ * process's session map by the time the plan runs, so {@link planStaleActiveRows}
+ * already leaves it — and whatever new agent session bound to it — alone.
  */
 export function markStaleActiveRows(
 	db: HostDb,
 	liveSessions: { id: string }[],
 	rowById: Map<string, TerminalRow>,
-	bindingSessionIds: Map<
-		string,
-		string | null
-	> = snapshotTerminalAgentBindingSessionIds(db),
 ): number {
 	const rowsById =
 		rowById.size > 0 || liveSessions.length > 0
@@ -289,13 +252,7 @@ export function markStaleActiveRows(
 	let exited = 0;
 	for (const terminalId of stale.exited) {
 		try {
-			const swept = markStaleExitedRow(
-				db,
-				terminalId,
-				endedAt,
-				bindingSessionIds.get(terminalId),
-			);
-			if (swept) exited += 1;
+			if (markStaleExitedRow(db, terminalId, endedAt)) exited += 1;
 		} catch (err) {
 			console.warn(
 				`[host-service] terminal reaper: left ${terminalId} active — ending its agent binding failed:`,
@@ -358,12 +315,6 @@ function applyPortScanSync(
 }
 
 async function runPortScanSync(db: HostDb) {
-	// Captured before the first await, and carried out with the daemon's
-	// answer, so it is the ownership that held when *this* probe began — the
-	// probe a coalesced caller is about to act on. Getting a daemon client can
-	// itself take seconds (bootstrap, reconnect), which is exactly the window
-	// in which a respawn rebinds a terminal to a new agent session.
-	const bindingSessionIds = snapshotTerminalAgentBindingSessionIds(db);
 	const daemon = await getDaemonClient();
 	const liveSessions = (await daemon.list()).filter((session) => session.alive);
 	const rowById =
@@ -371,7 +322,7 @@ async function runPortScanSync(db: HostDb) {
 			? loadTerminalRowsById(db)
 			: new Map<string, TerminalRow>();
 	applyPortScanSync(liveSessions, rowById);
-	return { liveSessions, rowById, bindingSessionIds };
+	return { liveSessions, rowById };
 }
 
 let inFlightPortScanSync: ReturnType<typeof runPortScanSync> | null = null;
@@ -387,8 +338,6 @@ let inFlightPortScanSync: ReturnType<typeof runPortScanSync> | null = null;
  * the reap pass both call this, and a slow `daemon.list()` right after adoption
  * (exactly when the warm-up fires) could otherwise let a second sync observe a
  * transiently-empty list and unregister sessions the first just registered.
- * A coalesced caller therefore also gets the binding ownership captured before
- * that shared probe started, not before its own call.
  */
 function syncPortScans(db: HostDb): ReturnType<typeof runPortScanSync> {
 	if (inFlightPortScanSync) return inFlightPortScanSync;
@@ -404,13 +353,13 @@ async function reapOrphanedSessions(
 ): Promise<ReapResult> {
 	// Sync the port scanner before the empty-list short-circuit below so an idle
 	// daemon still drops stale scans.
-	const { liveSessions, rowById, bindingSessionIds } = await syncPortScans(db);
+	const { liveSessions, rowById } = await syncPortScans(db);
 
 	// The daemon answered (syncPortScans would have thrown otherwise), so its
 	// list is authoritative: reconcile rows stuck `active` for sessions it no
 	// longer owns. Best-effort — a failure here must not block the orphan reap.
 	try {
-		markStaleActiveRows(db, liveSessions, rowById, bindingSessionIds);
+		markStaleActiveRows(db, liveSessions, rowById);
 	} catch (err) {
 		console.warn("[host-service] stale-session sweep failed:", err);
 	}


### PR DESCRIPTION
## What & why

I hit this after the host service restarted while a Claude terminal's PTY daemon no longer had the session. When I reopened the terminal, Superset returned `session-gone` and did not offer the Claude session for resume. Restarting the host service again made it resumable.

#7102 correctly changes a daemon-lost terminal row from `active` to `exited`. It does not end the associated agent binding in the same pass. The terminal then disappears from live reads, while the binding cannot become a resume candidate until `sweepDefunct` stamps it during the next host-service startup.

This patch makes those lifecycle records transition together. `markStaleActiveRows` ends the binding for each row it actually changes to `exited`, using the same persistence operation as PTY exit and lazy respawn.

The guarded update returns only rows that won the `active` → `exited` transition. Previously ended bindings preserve their existing stamp. Dispose-stamped rows remain non-resumable.

Related: #5443 explored pruning defunct bindings under an older persistence model. Current Superset retains ended bindings as durable resume records. This narrower follow-up preserves that model and closes the runtime gap after #7102.

## How I tested it

On unchanged `3a35182`, the new regression test fails with the terminal row marked `exited`, the binding's `endReason` still `null`, and no resume candidate:

```text
21 pass
1 fail
Expected: "terminal-exited"
Received: null
```

With the patch:

- focused reaper tests: 22 passed, 0 failed
- complete host-service suite: 1,493 passed, 0 failed; 8 pre-existing `todo` tests were not run
- host-service typecheck: passed
- Biome: passed
- Sherif: passed
- `git diff --check`: passed
- fork CI run 33751389140: passed

## Checklist

- [x] PR title follows conventional commits
- [x] `bun run lint` and `bun run typecheck` pass
- [x] Allow edits from maintainers is enabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the host-service terminal reaper so a daemon-lost terminal's agent session stays resumable instead of waiting for a restart. `markStaleActiveRows` now ends the agent binding with `terminal-exited` in the same transaction that flips the `active` row to `exited`; previously the binding stayed open until the next boot's `sweepDefunct`.

- The whole sweep runs in one transaction; a failed binding write rolls everything back for the next pass to retry.
- The flip re-reads `disposeRequestedAt` inside the transaction, so a dispose that landed after the plan's snapshot is not overwritten.
- Rows whose binding has no agent session id are swept like any other; they are never resume candidates.
- `disposed` overrides an earlier `terminal-exited` stamp (keeping the first writer's `endedAt`), so a killed session is never offered for resume; `resumed` claims and clean `detached` stamps keep their own history.
- Adds regression tests covering resumability, dispose races, failed binding writes, untouched rows, and pre-ended bindings.

<sup>Written for commit d3f75c3e7320867f020131e51be4ed8243e290a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when the host daemon disconnects unexpectedly.
  - Disconnected sessions are marked as exited with consistent terminal and resume-binding status.
  - Intentionally disposed sessions remain closed and are excluded from resume options.
  - Disposal preserves original end times and does not override resumed or detached sessions.
  - Cleanup updates are applied atomically, allowing failed operations to be retried without partial state changes.
  - Existing detached sessions and bindings retain their expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->