### PR TITLE
fix(desktop): open local chat artifact links

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/ChatV3Pane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/ChatV3Pane.tsx
@@ -5,14 +5,17 @@ import { NewSessionView } from "./components/NewSessionView";
 import { SessionPicker } from "./components/SessionPicker";
 import { SessionView } from "./components/SessionView";
 import { useSessionClient } from "./hooks/useSessionClient";
+import { MarkdownFileLinkProvider } from "./providers/MarkdownFileLinkProvider";
 
 export function ChatV3Pane({
+	onOpenFile,
 	onSessionIdChange,
 	sessionId,
 	workspaceId,
 }: {
 	workspaceId: string;
 	sessionId: string | null;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
 	onSessionIdChange: (sessionId: string | null) => void;
 }) {
 	const { client, wiring } = useSessionClient(sessionId);
@@ -57,13 +60,15 @@ export function ChatV3Pane({
 	}
 
 	return (
-		<SessionView
-			client={client}
-			headerLeft={picker}
-			key={sessionId}
-			onFirstPromptSent={() => setPendingFirstPrompt(null)}
-			pendingFirstPrompt={pendingFirstPrompt}
-			sessionId={sessionId}
-		/>
+		<MarkdownFileLinkProvider onOpenFile={onOpenFile} workspaceId={workspaceId}>
+			<SessionView
+				client={client}
+				headerLeft={picker}
+				key={sessionId}
+				onFirstPromptSent={() => setPendingFirstPrompt(null)}
+				pendingFirstPrompt={pendingFirstPrompt}
+				sessionId={sessionId}
+			/>
+		</MarkdownFileLinkProvider>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/MarkdownView.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/MarkdownView.test.tsx
@@ -1,0 +1,56 @@
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { ReactNode } from "react";
+
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const openFile = mock(
+	async (
+		_path: string,
+		_event: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean },
+	) => {},
+);
+
+mock.module("renderer/lib/clickPolicy", () => ({
+	ClickHint: ({ children }: { children: ReactNode }) => children,
+}));
+mock.module("../../providers/MarkdownFileLinkProvider", () => ({
+	useMarkdownFileLink: () => ({ hint: "Command click: open", open: openFile }),
+}));
+
+const { cleanup, fireEvent, render } = await import("@testing-library/react");
+const { MarkdownView } = await import("./MarkdownView");
+
+beforeEach(() => openFile.mockClear());
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+test("routes a local Markdown link through the workspace file handler", () => {
+	const view = render(
+		<MarkdownView text="[Open preview](/tmp/my%20preview.png)" />,
+	);
+	const link = view.getByRole("link", { name: "Open preview" });
+
+	fireEvent.click(link, { metaKey: true });
+
+	expect(openFile).toHaveBeenCalledTimes(1);
+	expect(openFile.mock.calls[0]?.[0]).toBe("/tmp/my preview.png");
+	expect(openFile.mock.calls[0]?.[1].metaKey).toBe(true);
+});
+
+test("keeps web URLs on the regular external-link path", () => {
+	const view = render(
+		<MarkdownView text="[Superset](https://superset.sh/docs)" />,
+	);
+	const link = view.getByRole("link", { name: "Superset" });
+
+	expect(link.getAttribute("href")).toBe("https://superset.sh/docs");
+	expect(link.getAttribute("target")).toBe("_blank");
+	expect(openFile).not.toHaveBeenCalled();
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/MarkdownView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/MarkdownView.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@superset/ui/utils";
 import { memo, useMemo } from "react";
+import type { Components } from "streamdown";
 import { Streamdown } from "streamdown";
+import { MarkdownLink } from "./components/MarkdownLink";
 import { planMarkdown } from "./utils/planMarkdown";
+
+const MARKDOWN_COMPONENTS: Components = { a: MarkdownLink };
 
 const MarkdownBlock = memo(function MarkdownBlock({
 	block,
@@ -11,6 +15,7 @@ const MarkdownBlock = memo(function MarkdownBlock({
 	return (
 		<Streamdown
 			className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+			components={MARKDOWN_COMPONENTS}
 			linkSafety={{ enabled: false }}
 			mode="streaming"
 		>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/components/MarkdownLink/MarkdownLink.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/components/MarkdownLink/MarkdownLink.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@superset/ui/utils";
+import type { ComponentProps } from "react";
+import { ClickHint } from "renderer/lib/clickPolicy";
+import { useMarkdownFileLink } from "../../../../providers/MarkdownFileLinkProvider";
+import { filePathFromMarkdownHref } from "../../utils/filePathFromMarkdownHref";
+
+type MarkdownLinkProps = ComponentProps<"a"> & {
+	node?: unknown;
+};
+
+export function MarkdownLink({
+	children,
+	className,
+	href,
+	node: _node,
+	onClick,
+	...props
+}: MarkdownLinkProps) {
+	const fileLink = useMarkdownFileLink();
+	const filePath = filePathFromMarkdownHref(href);
+	const linkClassName = cn(
+		"wrap-anywhere font-medium text-primary underline",
+		className,
+	);
+
+	if (!fileLink || !filePath) {
+		return (
+			<a
+				className={linkClassName}
+				href={href}
+				onClick={onClick}
+				rel="noreferrer"
+				target="_blank"
+				{...props}
+			>
+				{children}
+			</a>
+		);
+	}
+
+	const anchor = (
+		<a
+			className={cn(linkClassName, "cursor-pointer")}
+			href={href}
+			onClick={(event) => {
+				onClick?.(event);
+				if (event.defaultPrevented) return;
+				event.preventDefault();
+				void fileLink.open(filePath, event);
+			}}
+			{...props}
+		>
+			{children}
+		</a>
+	);
+
+	return <ClickHint hint={fileLink.hint}>{anchor}</ClickHint>;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/components/MarkdownLink/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/components/MarkdownLink/index.ts
@@ -1,0 +1,1 @@
+export { MarkdownLink } from "./MarkdownLink";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/utils/filePathFromMarkdownHref/filePathFromMarkdownHref.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/utils/filePathFromMarkdownHref/filePathFromMarkdownHref.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { filePathFromMarkdownHref } from "./filePathFromMarkdownHref";
+
+describe("filePathFromMarkdownHref", () => {
+	test.each([
+		[
+			"/Users/dev/project/artifacts/preview.png",
+			"/Users/dev/project/artifacts/preview.png",
+		],
+		["artifacts/preview.png", "artifacts/preview.png"],
+		["./artifacts/preview.png", "./artifacts/preview.png"],
+		["../shared/preview.png", "../shared/preview.png"],
+		["~/Downloads/preview.png", "~/Downloads/preview.png"],
+		["C:\\project\\preview.png", "C:\\project\\preview.png"],
+		["file:///Users/dev/preview.png", "file:///Users/dev/preview.png"],
+		["artifacts/my%20preview.png", "artifacts/my preview.png"],
+		["artifacts/name%23one.png#preview", "artifacts/name#one.png"],
+	])("recognizes local file href %s", (href, expected) => {
+		expect(filePathFromMarkdownHref(href)).toBe(expected);
+	});
+
+	test.each([
+		undefined,
+		"",
+		"#section",
+		"//example.com/image.png",
+		"https://example.com/image.png",
+		"mailto:hello@example.com",
+		"data:image/png;base64,abc",
+		"streamdown:incomplete-link",
+	])("keeps non-file href %s on the regular link path", (href) => {
+		expect(filePathFromMarkdownHref(href)).toBeNull();
+	});
+
+	test("preserves a malformed percent escape for host-side resolution", () => {
+		expect(filePathFromMarkdownHref("artifacts/100%.png")).toBe(
+			"artifacts/100%.png",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/utils/filePathFromMarkdownHref/filePathFromMarkdownHref.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/utils/filePathFromMarkdownHref/filePathFromMarkdownHref.ts
@@ -1,0 +1,39 @@
+const URI_SCHEME = /^[a-z][a-z\d+.-]*:/i;
+const WINDOWS_ABSOLUTE_PATH = /^[a-z]:[\\/]/i;
+
+/**
+ * Returns a local path for Markdown links that can be resolved by the workspace
+ * host. Web URLs, page fragments, and protocol-relative URLs stay regular links.
+ */
+export function filePathFromMarkdownHref(
+	href: string | undefined,
+): string | null {
+	if (!href) return null;
+
+	const trimmed = href.trim();
+	if (
+		!trimmed ||
+		trimmed.startsWith("#") ||
+		trimmed.startsWith("//") ||
+		trimmed === "streamdown:incomplete-link"
+	) {
+		return null;
+	}
+
+	const isWindowsPath = WINDOWS_ABSOLUTE_PATH.test(trimmed);
+	const isFileUri = /^file:\/\//i.test(trimmed);
+	if (!isWindowsPath && !isFileUri && URI_SCHEME.test(trimmed)) {
+		return null;
+	}
+
+	// A literal fragment belongs to the Markdown destination rather than the
+	// filename. Real `#` characters in paths arrive percent-encoded and survive.
+	const withoutFragment = trimmed.split("#", 1)[0];
+	if (!withoutFragment) return null;
+
+	try {
+		return decodeURIComponent(withoutFragment);
+	} catch {
+		return withoutFragment;
+	}
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/utils/filePathFromMarkdownHref/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/components/MarkdownView/utils/filePathFromMarkdownHref/index.ts
@@ -1,0 +1,1 @@
+export { filePathFromMarkdownHref } from "./filePathFromMarkdownHref";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/providers/MarkdownFileLinkProvider/MarkdownFileLinkProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/providers/MarkdownFileLinkProvider/MarkdownFileLinkProvider.tsx
@@ -1,0 +1,79 @@
+import { workspaceTrpc } from "@superset/workspace-client";
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useMemo,
+} from "react";
+import {
+	type ModifierEvent,
+	useInlineFilePolicy,
+} from "renderer/lib/clickPolicy";
+import { TerminalLinkResolver } from "renderer/lib/terminal/links/link-resolver";
+import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
+
+interface MarkdownFileLinkContextValue {
+	hint: string;
+	open: (path: string, event: ModifierEvent) => Promise<void>;
+}
+
+const MarkdownFileLinkContext =
+	createContext<MarkdownFileLinkContextValue | null>(null);
+
+export function MarkdownFileLinkProvider({
+	children,
+	onOpenFile,
+	workspaceId,
+}: {
+	children: ReactNode;
+	onOpenFile: (path: string, openInNewTab?: boolean) => void;
+	workspaceId: string;
+}) {
+	const filePolicy = useInlineFilePolicy();
+	const openInExternalEditor = useOpenInExternalEditor(workspaceId);
+	const statPath = workspaceTrpc.filesystem.statPath.useMutation();
+	const resolver = useMemo(
+		() =>
+			new TerminalLinkResolver(async (path) => {
+				try {
+					return await statPath.mutateAsync({ workspaceId, path });
+				} catch {
+					return null;
+				}
+			}),
+		[statPath.mutateAsync, workspaceId],
+	);
+
+	const open = useCallback(
+		async (path: string, event: ModifierEvent) => {
+			const action = filePolicy.getAction(event);
+			if (action === null) return;
+
+			const resolved = await resolver.resolveLink(path);
+			if (!resolved || resolved.isDirectory) return;
+
+			if (action === "external") {
+				openInExternalEditor(resolved.path);
+			} else {
+				onOpenFile(resolved.path, action === "newTab");
+			}
+		},
+		[filePolicy, onOpenFile, openInExternalEditor, resolver],
+	);
+
+	const value = useMemo(
+		() => ({ hint: filePolicy.hint, open }),
+		[filePolicy.hint, open],
+	);
+
+	return (
+		<MarkdownFileLinkContext.Provider value={value}>
+			{children}
+		</MarkdownFileLinkContext.Provider>
+	);
+}
+
+export function useMarkdownFileLink(): MarkdownFileLinkContextValue | null {
+	return useContext(MarkdownFileLinkContext);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/providers/MarkdownFileLinkProvider/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/ChatV3Pane/providers/MarkdownFileLinkProvider/index.ts
@@ -1,0 +1,4 @@
+export {
+	MarkdownFileLinkProvider,
+	useMarkdownFileLink,
+} from "./MarkdownFileLinkProvider";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -676,6 +676,7 @@ export function usePaneRegistry({
 								const data = ctx.pane.data as ChatV3PaneData;
 								return (
 									<ChatV3Pane
+										onOpenFile={onOpenFile}
 										workspaceId={workspaceId}
 										sessionId={data.sessionId}
 										onSessionIdChange={(id) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -174,6 +174,7 @@ function V2WorkspaceContent() {
 	});
 
 	const {
+		openFilePane,
 		openFilePaneFromTreeClick,
 		revealPath,
 		selectedFilePath,
@@ -206,7 +207,7 @@ function V2WorkspaceContent() {
 		[openDiffPane],
 	);
 	const paneRegistry = usePaneRegistry({
-		onOpenFile: openFilePaneFromTreeClick,
+		onOpenFile: openFilePane,
 		onOpenDiffInNewTab: openDiffInNewTab,
 		onRevealPath: revealPath,
 		launcher,


### PR DESCRIPTION
## Summary

- turn local filesystem destinations in Chat V3 Markdown into workspace-aware file links
- resolve and validate paths through the host service before opening a file pane or external editor
- reuse the existing Settings → Links click policy and generic pane opener so chat links do not accidentally pin the active file

## Verification

- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- targeted Markdown link tests: 20 passed
- Electron renderer verification through CDP: hover displayed the configured Command-click hint; a real Command-click opened the linked PNG as a blob-backed image pane

`bun run test` was also run. Two unrelated existing/environment-sensitive failures remained:

- the desktop git utility test expects an exact shell PATH, while this machine adds `/usr/local/sbin` (isolated result: 38 passed, 1 failed)
- the host-service PR materialization integration test exceeded its 5-second timeout under the full suite (isolated rerun with a 30-second timeout: 3 passed)

## Visual verification

- local link hover rect: `x=298, y=268, width=86.94, height=17`
- click hint: `Command click: open`
- opened image pane: `513.48 × 314.52`, blob-backed source

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes local file links in Chat V3 Markdown open the file in a pane or external editor instead of doing nothing.

- Local paths are resolved and validated through the workspace host service before opening.
- Link clicks follow the existing Settings → Links click policy, including the hover hint.
- Opening uses the generic pane opener, so chat links no longer pin the active file the way tree clicks do.
- Web URLs, fragments, and other non-file links keep their regular external-link behavior.

<sup>Written for commit e0a46b75434ffe3f5fc2b4e20b0fdb61e33229e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown links to workspace files in Chat can now open the referenced file directly.
  * Supports opening files in the current view, a new tab, or an external editor based on the selected interaction.
  * External web links continue opening separately and securely.

* **Bug Fixes**
  * Local file paths in Markdown links are now correctly resolved, including encoded, relative, Windows, and `file://` paths.

* **Tests**
  * Added coverage for local file link handling, external URLs, path decoding, fragments, and modifier-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->