### PR TITLE
feat(sdk,cli): SDK usage telemetry and client identity headers for the SDK and CLI

### DIFF
--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -24,6 +24,10 @@ const client = new Superset({
 });
 ```
 
+### Telemetry
+
+The SDK reports one `sdk_method_called` event per resource call: the method name (for example `tasks.list`), SDK version, runtime, whether the call succeeded, and how long it took. Request and response data are never included. The report is sent after your call settles and is best-effort, so it cannot slow down or fail a call. Set `SUPERSET_TELEMETRY=0` to turn it off.
+
 ---
 
 ## tasks

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -4,6 +4,7 @@ import type { TRPCClient } from "@trpc/client";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import SuperJSON from "superjson";
 import { getApiUrl } from "./config";
+import { env } from "./env";
 
 export type ApiClient = TRPCClient<AppRouter>;
 
@@ -29,6 +30,7 @@ export function createApiClient(opts: {
 					if (opts.organizationId) {
 						headers[ORGANIZATION_HEADER] = opts.organizationId;
 					}
+					headers["x-superset-client"] = `cli/${env.VERSION}`;
 					return headers;
 				},
 			}),

--- a/packages/sdk/api.md
+++ b/packages/sdk/api.md
@@ -156,3 +156,7 @@ Types:
 Methods:
 
 - <code title="get /api/trpc/organization.members.list">client.organization.members.<a href="./src/resources/organization.ts">list</a>({ search?, limit? }) -> MemberListResponse</code>
+
+# Telemetry
+
+Every resource method reports one `sdk_method_called` event (method name, SDK version, runtime, success, duration) to `analytics.captureEvent` after the call settles. It is best-effort and never affects the call itself. Set `SUPERSET_TELEMETRY=0` to opt out.

--- a/packages/sdk/scripts/build.ts
+++ b/packages/sdk/scripts/build.ts
@@ -26,6 +26,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const DIST = join(ROOT, "dist");
 
+const pkg = JSON.parse(
+	readFileSync(join(ROOT, "package.json"), "utf-8"),
+) as Record<string, unknown>;
+
+console.log(`> stamping src/version.ts with ${pkg.version}`);
+writeFileSync(
+	join(ROOT, "src", "version.ts"),
+	`// Stamped from package.json by scripts/build.ts. Do not edit.\nexport const VERSION = "${pkg.version}";\n`,
+);
+
 console.log(`> cleaning ${DIST}`);
 rmSync(DIST, { recursive: true, force: true });
 mkdirSync(DIST, { recursive: true });
@@ -55,9 +65,6 @@ for (const f of ["LICENSE", "README.md", "api.md"]) {
 }
 
 console.log("> writing dist/package.json");
-const pkg = JSON.parse(
-	readFileSync(join(ROOT, "package.json"), "utf-8"),
-) as Record<string, unknown>;
 const publishName =
 	(pkg.publishConfig as { name?: string } | undefined)?.name ??
 	(pkg.name as string);

--- a/packages/sdk/scripts/build.ts
+++ b/packages/sdk/scripts/build.ts
@@ -8,6 +8,10 @@
  *
  * Strategy: bun bundles src/index.ts → dist/index.{js,cjs}; tsc emits the
  * .d.ts hierarchy into dist/. dist/package.json points at the bundled output.
+ *
+ * Releasing: bump "version" in package.json, run this script, publish from
+ * dist/. src/version.ts is stamped from package.json here and is never
+ * hand-edited; commit the regenerated file with the release.
  */
 
 import { execSync } from "node:child_process";

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -121,6 +121,12 @@ import {
 	WorkspaceListResponse,
 	Workspaces,
 } from "./resources/workspaces";
+import {
+	buildMethodCalledEvent,
+	isTelemetryEnabled,
+	type TelemetryTarget,
+	type TRPCCall,
+} from "./lib/telemetry";
 import { VERSION } from "./version";
 
 export interface ClientOptions {
@@ -253,6 +259,7 @@ export class Superset {
 	private _relayUrlExplicit = false;
 	private _relayUrlCache: { url: string; expiresAt: number } | null = null;
 	private _relayUrlInflight: Promise<string> | null = null;
+	private _telemetryEnabled = isTelemetryEnabled();
 
 	/**
 	 * API Client for interfacing with the Superset API.
@@ -489,11 +496,13 @@ export class Superset {
 	 * `{ result: { data: { json: ... } } }`.
 	 */
 	mutation<Rsp>(
-		procedurePath: string,
+		call: TRPCCall,
 		input?: unknown,
 		options?: RequestOptions,
 	): APIPromise<Rsp> {
-		return this.post<TRPCEnvelope<Rsp>>(`/api/trpc/${procedurePath}`, {
+		return this._trackedRequest<TRPCEnvelope<Rsp>>(call, "cloud", {
+			method: "post",
+			path: `/api/trpc/${call.procedure}`,
 			body: { json: input ?? null },
 			...options,
 		})._thenUnwrap((r) => r.result.data.json);
@@ -504,7 +513,7 @@ export class Superset {
 	 * `?input=<json>` query param when provided, and unwraps the response.
 	 */
 	query<Rsp>(
-		procedurePath: string,
+		call: TRPCCall,
 		input?: unknown,
 		options?: RequestOptions,
 	): APIPromise<Rsp> {
@@ -512,7 +521,9 @@ export class Superset {
 		if (input !== undefined) {
 			queryParams.input = JSON.stringify({ json: input });
 		}
-		return this.get<TRPCEnvelope<Rsp>>(`/api/trpc/${procedurePath}`, {
+		return this._trackedRequest<TRPCEnvelope<Rsp>>(call, "cloud", {
+			method: "get",
+			path: `/api/trpc/${call.procedure}`,
 			query: queryParams,
 			...options,
 		})._thenUnwrap((r) => r.result.data.json);
@@ -528,7 +539,7 @@ export class Superset {
 	 */
 	hostMutation<Rsp>(
 		hostId: string,
-		procedurePath: string,
+		call: TRPCCall,
 		input?: unknown,
 		options?: RequestOptions,
 	): APIPromise<Rsp> {
@@ -545,7 +556,7 @@ export class Superset {
 				// JWT or replace the tRPC envelope.
 				...options,
 				method: "post" as const,
-				path: `${relayUrl}/hosts/${routingKey}/trpc/${procedurePath}`,
+				path: `${relayUrl}/hosts/${routingKey}/trpc/${call.procedure}`,
 				body: { json: input ?? null },
 				headers: buildHeaders([
 					options?.headers,
@@ -554,9 +565,11 @@ export class Superset {
 				]),
 			}),
 		);
-		return this.request<TRPCEnvelope<Rsp>>(optsPromise)._thenUnwrap(
-			(r) => r.result.data.json,
-		);
+		return this._trackedRequest<TRPCEnvelope<Rsp>>(
+			call,
+			"host",
+			optsPromise,
+		)._thenUnwrap((r) => r.result.data.json);
 	}
 
 	/**
@@ -564,7 +577,7 @@ export class Superset {
 	 */
 	hostQuery<Rsp>(
 		hostId: string,
-		procedurePath: string,
+		call: TRPCCall,
 		input?: unknown,
 		options?: RequestOptions,
 	): APIPromise<Rsp> {
@@ -582,7 +595,7 @@ export class Superset {
 			([jwt, relayUrl]) => ({
 				...options,
 				method: "get" as const,
-				path: `${relayUrl}/hosts/${routingKey}/trpc/${procedurePath}`,
+				path: `${relayUrl}/hosts/${routingKey}/trpc/${call.procedure}`,
 				query: queryParams,
 				headers: buildHeaders([
 					options?.headers,
@@ -590,9 +603,60 @@ export class Superset {
 				]),
 			}),
 		);
-		return this.request<TRPCEnvelope<Rsp>>(optsPromise)._thenUnwrap(
-			(r) => r.result.data.json,
-		);
+		return this._trackedRequest<TRPCEnvelope<Rsp>>(
+			call,
+			"host",
+			optsPromise,
+		)._thenUnwrap((r) => r.result.data.json);
+	}
+
+	/**
+	 * Issue the request behind a public resource method and, once it settles,
+	 * report the call to `analytics.captureEvent`. The report hangs off a
+	 * branch of the response promise, never the promise handed back to the
+	 * caller: it cannot delay, fail, or retry the user's call. The capture
+	 * request goes through `post`, not `mutation`, so it is not itself
+	 * reported.
+	 */
+	private _trackedRequest<Rsp>(
+		call: TRPCCall,
+		target: TelemetryTarget,
+		options: PromiseOrValue<FinalRequestOptions>,
+	): APIPromise<Rsp> {
+		const startedAt = Date.now();
+		const responsePromise = this.makeRequest(options, null, undefined);
+		if (this._telemetryEnabled) {
+			responsePromise.then(
+				() => this._captureMethodCalled(call, target, true, startedAt),
+				() => this._captureMethodCalled(call, target, false, startedAt),
+			);
+		}
+		return new APIPromise(this, responsePromise);
+	}
+
+	private _captureMethodCalled(
+		call: TRPCCall,
+		target: TelemetryTarget,
+		success: boolean,
+		startedAt: number,
+	): void {
+		try {
+			const event = buildMethodCalledEvent({
+				method: call.method,
+				target,
+				success,
+				durationMs: Date.now() - startedAt,
+			});
+			this.post("/api/trpc/analytics.captureEvent", {
+				body: { json: event },
+				maxRetries: 0,
+				timeout: 10_000,
+			}).catch(() => {
+				// Telemetry is best-effort; never surface failures to the caller.
+			});
+		} catch {
+			// Same: a bug in telemetry must not reach the caller.
+		}
 	}
 
 	/**
@@ -1087,6 +1151,7 @@ export class Superset {
 			{
 				Accept: "application/json",
 				"User-Agent": this.getUserAgent(),
+				"x-superset-client": `sdk/${VERSION}`,
 				"X-Stainless-Retry-Count": String(retryCount),
 				...(options.timeout
 					? {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -32,7 +32,7 @@ import {
 	type HeadersLike,
 	type NullableHeaders,
 } from "./internal/headers";
-import type { APIResponseProps } from "./internal/parse";
+import { type APIResponseProps, defaultParseResponse } from "./internal/parse";
 import type {
 	FinalRequestOptions,
 	RequestOptions,
@@ -500,12 +500,12 @@ export class Superset {
 		input?: unknown,
 		options?: RequestOptions,
 	): APIPromise<Rsp> {
-		return this._trackedRequest<TRPCEnvelope<Rsp>>(call, "cloud", {
+		return this._trackedRequest<Rsp>(call, "cloud", {
 			method: "post",
 			path: `/api/trpc/${call.procedure}`,
 			body: { json: input ?? null },
 			...options,
-		})._thenUnwrap((r) => r.result.data.json);
+		});
 	}
 
 	/**
@@ -521,12 +521,12 @@ export class Superset {
 		if (input !== undefined) {
 			queryParams.input = JSON.stringify({ json: input });
 		}
-		return this._trackedRequest<TRPCEnvelope<Rsp>>(call, "cloud", {
+		return this._trackedRequest<Rsp>(call, "cloud", {
 			method: "get",
 			path: `/api/trpc/${call.procedure}`,
 			query: queryParams,
 			...options,
-		})._thenUnwrap((r) => r.result.data.json);
+		});
 	}
 
 	/**
@@ -565,11 +565,7 @@ export class Superset {
 				]),
 			}),
 		);
-		return this._trackedRequest<TRPCEnvelope<Rsp>>(
-			call,
-			"host",
-			optsPromise,
-		)._thenUnwrap((r) => r.result.data.json);
+		return this._trackedRequest<Rsp>(call, "host", optsPromise);
 	}
 
 	/**
@@ -603,20 +599,18 @@ export class Superset {
 				]),
 			}),
 		);
-		return this._trackedRequest<TRPCEnvelope<Rsp>>(
-			call,
-			"host",
-			optsPromise,
-		)._thenUnwrap((r) => r.result.data.json);
+		return this._trackedRequest<Rsp>(call, "host", optsPromise);
 	}
 
 	/**
-	 * Issue the request behind a public resource method and, once it settles,
-	 * report the call to `analytics.captureEvent`. The report hangs off a
-	 * branch of the response promise, never the promise handed back to the
-	 * caller: it cannot delay, fail, or retry the user's call. The capture
-	 * request goes through `post`, not `mutation`, so it is not itself
-	 * reported.
+	 * Issue the request behind a public resource method, unwrap the tRPC
+	 * envelope, and report the call to `analytics.captureEvent` once the
+	 * caller's promise settles: success only after the body parsed and the
+	 * envelope unwrapped, failure on transport, HTTP, or parse errors. The
+	 * report never sits in the caller's chain, so it cannot delay, fail, or
+	 * retry the user's call, and it does not force a parse on callers that
+	 * only want `asResponse()`. The capture request goes through `post`, not
+	 * `mutation`, so it is not itself reported.
 	 */
 	private _trackedRequest<Rsp>(
 		call: TRPCCall,
@@ -625,13 +619,27 @@ export class Superset {
 	): APIPromise<Rsp> {
 		const startedAt = Date.now();
 		const responsePromise = this.makeRequest(options, null, undefined);
-		if (this._telemetryEnabled) {
-			responsePromise.then(
-				() => this._captureMethodCalled(call, target, true, startedAt),
-				() => this._captureMethodCalled(call, target, false, startedAt),
-			);
-		}
-		return new APIPromise(this, responsePromise);
+		let reported = false;
+		const report = (success: boolean) => {
+			if (reported || !this._telemetryEnabled) return;
+			reported = true;
+			this._captureMethodCalled(call, target, success, startedAt);
+		};
+		responsePromise.then(undefined, () => report(false));
+		return new APIPromise(this, responsePromise, async (client, props) => {
+			try {
+				const envelope = await defaultParseResponse<TRPCEnvelope<Rsp>>(
+					client,
+					props,
+				);
+				const data = envelope.result.data.json;
+				report(true);
+				return data;
+			} catch (error) {
+				report(false);
+				throw error;
+			}
+		});
 	}
 
 	private _captureMethodCalled(

--- a/packages/sdk/src/lib/telemetry.ts
+++ b/packages/sdk/src/lib/telemetry.ts
@@ -1,0 +1,92 @@
+import { getPlatformHeaders } from "../internal/detect-platform";
+import { readEnv } from "../internal/utils/env";
+import { VERSION } from "../version";
+
+/**
+ * Usage telemetry, mirroring the CLI's `cli_command_invoked`: one
+ * `sdk_method_called` event per public resource call, sent best-effort to
+ * `analytics.captureEvent` after the call settles. The event and property
+ * names are read by dashboard tiles — treat them as a contract.
+ *
+ * Opt out with `SUPERSET_TELEMETRY=0`.
+ */
+export const TELEMETRY_EVENT = "sdk_method_called";
+export const TELEMETRY_OPT_OUT_ENV = "SUPERSET_TELEMETRY";
+
+/** Which side of the API a public method talks to. */
+export type TelemetryTarget = "cloud" | "host";
+
+export type TelemetryRuntime =
+	| "node"
+	| "bun"
+	| "deno"
+	| "edge"
+	| "browser"
+	| "unknown";
+
+/**
+ * Names a public SDK method and the tRPC procedure that backs it. `method`
+ * is what the caller typed (`tasks.list`, `workspaces.create`) and is the
+ * only name telemetry reports; `procedure` is the wire path and differs
+ * between cloud and host routers.
+ */
+export interface TRPCCall {
+	method: string;
+	procedure: string;
+}
+
+export interface MethodCalledEvent {
+	source: "sdk";
+	event: typeof TELEMETRY_EVENT;
+	properties: {
+		method: string;
+		sdk_version: string;
+		sdk_lang: "js";
+		runtime: TelemetryRuntime;
+		target: TelemetryTarget;
+		success: boolean;
+		duration_ms: number;
+	};
+}
+
+export function isTelemetryEnabled(): boolean {
+	const value = readEnv(TELEMETRY_OPT_OUT_ENV)?.toLowerCase();
+	return value !== "0" && value !== "false";
+}
+
+let _runtime: TelemetryRuntime | undefined;
+
+export function detectRuntime(): TelemetryRuntime {
+	if (_runtime) return _runtime;
+	const versions = (globalThis as any).process?.versions;
+	if (versions?.bun) {
+		_runtime = "bun";
+		return _runtime;
+	}
+	const stainlessRuntime = getPlatformHeaders()["X-Stainless-Runtime"];
+	_runtime = stainlessRuntime.startsWith("browser:")
+		? "browser"
+		: (stainlessRuntime as Exclude<TelemetryRuntime, "bun" | "browser">);
+	return _runtime;
+}
+
+export function buildMethodCalledEvent(input: {
+	method: string;
+	target: TelemetryTarget;
+	success: boolean;
+	durationMs: number;
+}): MethodCalledEvent {
+	return {
+		source: "sdk",
+		event: TELEMETRY_EVENT,
+		properties: {
+			method: input.method,
+			sdk_version: VERSION,
+			sdk_lang: "js",
+			runtime: detectRuntime(),
+			target: input.target,
+			success: input.success,
+			duration_ms: Math.max(0, Math.round(input.durationMs)),
+		},
+	};
+}

--- a/packages/sdk/src/resources/agents.ts
+++ b/packages/sdk/src/resources/agents.ts
@@ -23,7 +23,7 @@ export class Agents extends APIResource {
 		this._requireOrgId();
 		return this._client.hostQuery<AgentListResponse>(
 			params.hostId,
-			"settings.agentConfigs.list",
+			{ method: "agents.list", procedure: "settings.agentConfigs.list" },
 			undefined,
 			options,
 		);
@@ -40,7 +40,7 @@ export class Agents extends APIResource {
 		this._requireOrgId();
 		return this._client.hostMutation<AgentCreateResult>(
 			params.hostId,
-			"agents.run",
+			{ method: "agents.create", procedure: "agents.run" },
 			{
 				workspaceId: params.workspaceId,
 				agent: params.agent,

--- a/packages/sdk/src/resources/automations.ts
+++ b/packages/sdk/src/resources/automations.ts
@@ -14,7 +14,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<AutomationListResponse> {
 		return this._client.query<AutomationListResponse>(
-			"automation.list",
+			{ method: "automations.list", procedure: "automation.list" },
 			params,
 			options,
 		);
@@ -31,7 +31,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<AutomationSummary> {
 		return this._client.query<AutomationSummary>(
-			"automation.get",
+			{ method: "automations.retrieve", procedure: "automation.get" },
 			{ id },
 			options,
 		);
@@ -47,7 +47,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<Automation> {
 		return this._client.mutation<Automation>(
-			"automation.create",
+			{ method: "automations.create", procedure: "automation.create" },
 			body,
 			options,
 		);
@@ -63,7 +63,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<Automation> {
 		return this._client.mutation<Automation>(
-			"automation.update",
+			{ method: "automations.update", procedure: "automation.update" },
 			body,
 			options,
 		);
@@ -76,7 +76,7 @@ export class Automations extends APIResource {
 	 */
 	delete(id: string, options?: RequestOptions): APIPromise<void> {
 		return this._client
-			.mutation<unknown>("automation.delete", { id }, options)
+			.mutation<unknown>({ method: "automations.delete", procedure: "automation.delete" }, { id }, options)
 			._thenUnwrap(() => undefined);
 	}
 
@@ -87,7 +87,7 @@ export class Automations extends APIResource {
 	 */
 	run(id: string, options?: RequestOptions): APIPromise<AutomationRunDispatched> {
 		return this._client.mutation<AutomationRunDispatched>(
-			"automation.runNow",
+			{ method: "automations.run", procedure: "automation.runNow" },
 			{ id },
 			options,
 		);
@@ -100,7 +100,7 @@ export class Automations extends APIResource {
 	 */
 	pause(id: string, options?: RequestOptions): APIPromise<Automation> {
 		return this._client.mutation<Automation>(
-			"automation.setEnabled",
+			{ method: "automations.pause", procedure: "automation.setEnabled" },
 			{ id, enabled: false },
 			options,
 		);
@@ -113,7 +113,7 @@ export class Automations extends APIResource {
 	 */
 	resume(id: string, options?: RequestOptions): APIPromise<Automation> {
 		return this._client.mutation<Automation>(
-			"automation.setEnabled",
+			{ method: "automations.resume", procedure: "automation.setEnabled" },
 			{ id, enabled: true },
 			options,
 		);
@@ -130,7 +130,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<AutomationLogsResponse> {
 		return this._client.query<AutomationLogsResponse>(
-			"automation.listRuns",
+			{ method: "automations.logs", procedure: "automation.listRuns" },
 			{ automationId, limit: params?.limit ?? 20 },
 			options,
 		);
@@ -147,7 +147,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<{ prompt: string }> {
 		return this._client.query<{ prompt: string }>(
-			"automation.getPrompt",
+			{ method: "automations.getPrompt", procedure: "automation.getPrompt" },
 			{ id },
 			options,
 		);
@@ -165,7 +165,7 @@ export class Automations extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<Automation> {
 		return this._client.mutation<Automation>(
-			"automation.setPrompt",
+			{ method: "automations.setPrompt", procedure: "automation.setPrompt" },
 			{ id, prompt },
 			options,
 		);

--- a/packages/sdk/src/resources/hosts.ts
+++ b/packages/sdk/src/resources/hosts.ts
@@ -12,7 +12,7 @@ export class Hosts extends APIResource {
 	 */
 	list(options?: RequestOptions): APIPromise<HostListResponse> {
 		return this._client.query<HostListResponse>(
-			"host.list",
+			{ method: "hosts.list", procedure: "host.list" },
 			{ organizationId: this._requireOrgId() },
 			options,
 		);

--- a/packages/sdk/src/resources/organization.ts
+++ b/packages/sdk/src/resources/organization.ts
@@ -13,7 +13,7 @@ export class Members extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<MemberListResponse> {
 		return this._client.query<MemberListResponse>(
-			"organization.members.list",
+			{ method: "organization.members.list", procedure: "organization.members.list" },
 			query ?? undefined,
 			options,
 		);

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -20,7 +20,7 @@ export class Projects extends APIResource {
 		this._requireOrgId();
 		return this._client.hostQuery<ProjectListResponse>(
 			params.hostId,
-			"project.list",
+			{ method: "projects.list", procedure: "project.list" },
 			undefined,
 			options,
 		);

--- a/packages/sdk/src/resources/tasks.ts
+++ b/packages/sdk/src/resources/tasks.ts
@@ -24,7 +24,7 @@ export class TaskStatuses extends APIResource {
 	 */
 	list(options?: RequestOptions): APIPromise<TaskStatusListResponse> {
 		return this._client.query<TaskStatusListResponse>(
-			"task.statuses.list",
+			{ method: "tasks.statuses.list", procedure: "task.statuses.list" },
 			undefined,
 			options,
 		);
@@ -47,7 +47,7 @@ export class Tasks extends APIResource {
 	 */
 	create(body: TaskCreateParams, options?: RequestOptions): APIPromise<Task> {
 		return this._client
-			.mutation<CreateOrUpdateWire>("task.create", body, options)
+			.mutation<CreateOrUpdateWire>({ method: "tasks.create", procedure: "task.create" }, body, options)
 			._thenUnwrap((r) => r.task);
 	}
 
@@ -67,7 +67,7 @@ export class Tasks extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<Task | null> {
 		return this._client.query<Task | null>(
-			"task.byIdOrSlug",
+			{ method: "tasks.retrieve", procedure: "task.byIdOrSlug" },
 			idOrSlug,
 			options,
 		);
@@ -88,7 +88,7 @@ export class Tasks extends APIResource {
 		options?: RequestOptions,
 	): APIPromise<TaskListResponse> {
 		return this._client
-			.query<Array<ListRowWire>>("task.list", query ?? undefined, options)
+			.query<Array<ListRowWire>>({ method: "tasks.list", procedure: "task.list" }, query ?? undefined, options)
 			._thenUnwrap((rows) =>
 				rows.map((row) => ({
 					...row.task,
@@ -106,7 +106,7 @@ export class Tasks extends APIResource {
 	 */
 	update(body: TaskUpdateParams, options?: RequestOptions): APIPromise<Task> {
 		return this._client
-			.mutation<CreateOrUpdateWire>("task.update", body, options)
+			.mutation<CreateOrUpdateWire>({ method: "tasks.update", procedure: "task.update" }, body, options)
 			._thenUnwrap((r) => r.task);
 	}
 
@@ -115,7 +115,7 @@ export class Tasks extends APIResource {
 	 */
 	delete(id: string, options?: RequestOptions): APIPromise<void> {
 		return this._client
-			.mutation<DeleteWire>("task.delete", id, options)
+			.mutation<DeleteWire>({ method: "tasks.delete", procedure: "task.delete" }, id, options)
 			._thenUnwrap(() => undefined);
 	}
 }

--- a/packages/sdk/src/resources/terminals.ts
+++ b/packages/sdk/src/resources/terminals.ts
@@ -15,7 +15,7 @@ export class Terminals extends APIResource {
 		this._requireOrgId();
 		return this._client.hostMutation<TerminalCreateResult>(
 			params.hostId,
-			"terminal.createSession",
+			{ method: "terminals.create", procedure: "terminal.createSession" },
 			{
 				workspaceId: params.workspaceId,
 				initialCommand: params.command,
@@ -29,7 +29,7 @@ export class Terminals extends APIResource {
 		this._requireOrgId();
 		return this._client.hostQuery<TerminalListResult>(
 			params.hostId,
-			"terminal.list",
+			{ method: "terminals.list", procedure: "terminal.list" },
 			{ workspaceId: params.workspaceId },
 		);
 	}
@@ -43,7 +43,7 @@ export class Terminals extends APIResource {
 		this._requireOrgId();
 		return this._client.hostMutation<TerminalSendResult>(
 			params.hostId,
-			"terminal.send",
+			{ method: "terminals.send", procedure: "terminal.send" },
 			{
 				terminalId: params.terminalId,
 				workspaceId: params.workspaceId,
@@ -61,7 +61,7 @@ export class Terminals extends APIResource {
 		this._requireOrgId();
 		return this._client.hostQuery<TerminalReadResult>(
 			params.hostId,
-			"terminal.snapshot",
+			{ method: "terminals.read", procedure: "terminal.snapshot" },
 			{
 				terminalId: params.terminalId,
 				workspaceId: params.workspaceId,
@@ -75,7 +75,7 @@ export class Terminals extends APIResource {
 		this._requireOrgId();
 		return this._client.hostMutation<TerminalCloseResult>(
 			params.hostId,
-			"terminal.killSession",
+			{ method: "terminals.close", procedure: "terminal.killSession" },
 			{ terminalId: params.terminalId, workspaceId: params.workspaceId },
 		);
 	}

--- a/packages/sdk/src/resources/workspaces.ts
+++ b/packages/sdk/src/resources/workspaces.ts
@@ -41,7 +41,7 @@ export class Workspaces extends APIResource {
 		this._requireOrgId();
 		const workspaces = await this._client.hostQuery<HostWorkspaceRow[]>(
 			params.hostId,
-			"workspace.list",
+			{ method: "workspaces.list", procedure: "workspace.list" },
 		);
 		const search = params.search?.toLowerCase();
 		return workspaces
@@ -72,7 +72,7 @@ export class Workspaces extends APIResource {
 	): APIPromise<WorkspaceCreateResult> {
 		return this._client.hostMutation<WorkspaceCreateResult>(
 			params.hostId,
-			"workspaces.create",
+			{ method: "workspaces.create", procedure: "workspaces.create" },
 			{
 				projectId: params.projectId,
 				name: params.name,
@@ -99,7 +99,7 @@ export class Workspaces extends APIResource {
 	): APIPromise<WorkspaceCreateSessionResult> {
 		return this._client.hostMutation<WorkspaceCreateSessionResult>(
 			params.hostId,
-			"workspaces.createSession",
+			{ method: "workspaces.createSession", procedure: "workspaces.createSession" },
 			{
 				name: params.name,
 				agents: params.agents,
@@ -125,7 +125,7 @@ export class Workspaces extends APIResource {
 		this._requireOrgId();
 		return this._client.hostMutation<WorkspaceUpdateResult>(
 			options.hostId,
-			"workspace.update",
+			{ method: "workspaces.update", procedure: "workspace.update" },
 			{ id, ...params },
 		);
 	}
@@ -142,7 +142,7 @@ export class Workspaces extends APIResource {
 		this._requireOrgId();
 		return this._client.hostMutation<WorkspaceDeleteResult>(
 			options.hostId,
-			"workspace.delete",
+			{ method: "workspaces.delete", procedure: "workspace.delete" },
 			{ id },
 		);
 	}

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.0.1-alpha.7";
+export const VERSION = "0.0.1-alpha.12";

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,1 +1,2 @@
+// Stamped from package.json by scripts/build.ts. Do not edit.
 export const VERSION = "0.0.1-alpha.12";

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -12,14 +12,14 @@ export type { I18nErrorCause } from "./i18n-error";
 export { isI18nErrorCause, userError } from "./i18n-error";
 
 export interface ApiClientInfo {
-	product: "desktop" | "mobile" | "cli";
+	product: "desktop" | "mobile" | "cli" | "sdk";
 	version: string;
 }
 
 export const CLIENT_VERSION_HEADER = "x-superset-client";
 
 const CLIENT_HEADER_PATTERN =
-	/^(desktop|mobile|cli)\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/;
+	/^(desktop|mobile|cli|sdk)\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)$/;
 
 // Absent or unparseable header = web or a pre-header build, both treated as
 // always-current.


### PR DESCRIPTION
## Summary

Instruments `@superset_sh/sdk` the way the CLI is instrumented so the "MCP & CLI Usage" dashboard can show SDK usage. The four SDK tiles on dashboard 1566665 read `sdk_method_called`, broken down by `method` and `sdk_version`; those names are unchanged.

- Every public resource method reports one `sdk_method_called` event to `analytics.captureEvent` with `source: "sdk"` and `properties: { method, sdk_version, sdk_lang, runtime, target, success, duration_ms }`. `method` is the public name the caller typed (`tasks.list`, `workspaces.create`), never the tRPC path.
- The report is issued from the `APIPromise` parse step inside the hand-written tRPC helpers, which now also owns the envelope unwrap: `success: true` only once the caller's data has resolved, `false` on transport, HTTP, or parse errors, and `duration_ms` runs to final settlement. It never sits in the caller's chain (no await, no throw, no retry, one 10 s timeout) and does not force a parse on callers that only want `asResponse()`, so those calls go unreported rather than double-reading the body. The capture goes through `post`, so it is not itself reported. A sync bug in telemetry is caught too.
- `SUPERSET_TELEMETRY=0` (or `false`) opts out. The CLI has no opt-out today, so there was no existing name to reuse.
- Cloud requests send `x-superset-client: sdk/<version>`. `ApiClientInfo.product` and `CLIENT_HEADER_PATTERN` accept `sdk`. The only consumers of `product` are the Sentry tag in `apps/api` and the `client_product` property; neither switches on it exhaustively. No test fixtures reference the header.
- Docs: a Telemetry note in `apps/docs/.../sdk/reference.mdx` and `packages/sdk/api.md`. The CLI reference says nothing about its telemetry, so there was nothing to mirror; the note is short.

## Design notes

- Stainless's CONTRIBUTING says the generator never touches `src/lib/`, so the telemetry module lives at `packages/sdk/src/lib/telemetry.ts`. Neither `stainless-sdks/superset-typescript` nor `cadra-typescript` wires analytics, and the generated client only exposes pre-request hooks (`prepareOptions`, `prepareRequest`), so observing the response promise in our own helpers is the smallest way to get `success` and `duration_ms`.
- `client.ts` carries a "generated" header but has eight hand-edit commits (the tRPC and host helpers are ours, no Stainless config exists in the repo). The edits are confined to those helpers plus one header line in `buildHeaders`, next to `User-Agent` and the `X-Stainless-*` identity headers.
- The helpers now take `{ method, procedure }` instead of a bare procedure string, which touches all 32 resource call sites but keeps the label explicit rather than a mapping table that would drift.
- `VERSION` in `version.ts` was still `0.0.1-alpha.7` while `package.json` and npm are at `alpha.12`, so every published SDK since alpha.8 has identified itself as alpha.7. `scripts/build.ts` now rewrites `src/version.ts` from `package.json` before bundling, so the published `User-Agent`, `x-superset-client`, and `sdk_version` always match. Publishing is manual (`bun run build`, then `npm publish` from `dist/`) with no CI path around it, so the stamp cannot be skipped; the build script header now documents the release steps and that `version.ts` is never hand-edited.
- `runtime` reuses `detect-platform.ts` (`X-Stainless-Runtime`) and adds a `process.versions.bun` check, since Stainless reports Bun as `node`.
- The CLI did not send `x-superset-client` at all (only desktop and mobile did), so CLI-caused API errors and CLI procedure usage were invisible to the same two consumers. It now sends `cli/<version>` from the `headers()` callback in `packages/cli/src/lib/api-client.ts`; the server already accepted `cli`. Dev builds send `cli/0.0.0-dev`, which matches the pattern.

## Verification

- `bun run lint:fix`, `bun run typecheck`, `bunx sherif --fix`: clean. `bun test` per package: `packages/trpc` 125 pass, `packages/cli` 143 pass. (A root-level `bun test` shows 258 unrelated failures in host-service, desktop, workspace-client, and pty-daemon that pass when run per package.)
- No unit test: `packages/sdk` has no test setup and its tsconfig deliberately sets `types: []`, so a `bun:test` file fails its typecheck. Per the brief, no new test setup was introduced.
- End to end against the local dev stack (API on the workspace's Neon branch, dev API key minted for satya@superset.sh, revoked afterwards): one `client.tasks.list()` produced `GET /api/trpc/task.list 200` followed by `POST /api/trpc/analytics.captureEvent 200`, and the event arrived in PostHog project 264828 ("Local Development", confirmed as the owner of the `NEXT_PUBLIC_POSTHOG_KEY` in `.env`):

```json
{
  "uuid": "01a06902-9f1a-71fb-be5b-fb5147b49811",
  "event": "sdk_method_called",
  "timestamp": "2026-09-03T20:42:54.859000Z",
  "distinct_id": "0da9ed59-9eb3-4f73-ac71-6f1df5a44816",
  "properties": {
    "source": "sdk",
    "method": "tasks.list",
    "sdk_version": "0.0.1-alpha.7",
    "sdk_lang": "js",
    "runtime": "bun",
    "target": "cloud",
    "success": true,
    "duration_ms": 2212,
    "active_organization_id": "b2c3d4e5-f6a7-4890-9bcd-ef1234567891",
    "plan": null
  }
}
```

(`sdk_version` reads `alpha.7` because the run predates the `VERSION` bump in this PR.)

https://claude.ai/code/session_01Ckhb622VMbkDVoaKsjVTqg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SDK usage telemetry for resource method calls, including method, runtime, success status, and duration.
  - Telemetry excludes request and response data, runs best-effort after calls complete, and can be disabled with `SUPERSET_TELEMETRY=0` or `false`.
  - SDK requests now identify the SDK client and version.

- **Breaking Changes**
  - Updated low-level SDK request methods to accept structured call descriptors.

- **Documentation**
  - Added telemetry details to the SDK reference documentation.

- **Chores**
  - Updated the SDK version to `0.0.1-alpha.12`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->