### PR TITLE
feat(shared,host-service): add GPT-6 Astra to the Codex model picker and pricing table

### DIFF
--- a/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.test.ts
@@ -20,6 +20,19 @@ describe("matchModelRate", () => {
 		expect(rate.inputPerM).toBe(2);
 	});
 
+	test("prices GPT-6 Astra for codex and vendor-qualified harness ids", () => {
+		expect(matchModelRate("codex", "gpt-6-astra")).toMatchObject({
+			inputPerM: 10,
+			outputPerM: 50,
+			approximate: false,
+		});
+		expect(matchModelRate("omp", "openai-codex/gpt-6-astra")).toMatchObject({
+			inputPerM: 10,
+			outputPerM: 50,
+			approximate: false,
+		});
+	});
+
 	test("prices Fable 5.1 and Mythos 5.1 cache reads at their own rate, not the usual 0.1x", () => {
 		const fable51 = matchModelRate("claude", "claude-fable-5-1");
 		const fable5 = matchModelRate("claude", "claude-fable-5");

--- a/packages/host-service/src/trpc/router/usage/history/pricing.ts
+++ b/packages/host-service/src/trpc/router/usage/history/pricing.ts
@@ -8,7 +8,7 @@ import type { UsageAgent } from "../types";
  * Longest-prefix match on the lowercased model id; unknown models fall back
  * to the agent's cheapest rate and mark the result approximate.
  */
-export const PRICING_TABLE_UPDATED = "2026-09-01";
+export const PRICING_TABLE_UPDATED = "2026-09-03";
 
 export interface ModelRate {
 	inputPerM: number;
@@ -49,6 +49,8 @@ const CLAUDE_RATES: Record<string, ModelRate> = {
 };
 
 const CODEX_RATES: Record<string, ModelRate> = {
+	// GPT-6 Astra (2026-09-03): cached input is $1/M, the usual 0.1x.
+	"gpt-6-astra": { inputPerM: 10, outputPerM: 50 },
 	// Sol's promotional price, published as lasting at least through
 	// 2026-11-21; the bare `gpt-5.6` id follows Sol.
 	"gpt-5.6-sol": { inputPerM: 4, outputPerM: 20 },

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -52,10 +52,11 @@ describe("AGENT_MODEL_SUPPORT", () => {
 });
 
 describe("SUPERSET_CHAT_MODELS", () => {
-	it("includes opus 5, fable 5.1 and the GPT-5.6 Codex models", () => {
+	it("includes opus 5, fable 5.1, GPT-6 Astra and the GPT-5.6 Codex models", () => {
 		const ids = SUPERSET_CHAT_MODELS.map((model) => model.id);
 		expect(ids).toContain("anthropic/claude-opus-5");
 		expect(ids).toContain("anthropic/claude-fable-5-1");
+		expect(ids).toContain("openai/gpt-6-astra");
 		expect(ids).toContain("openai/gpt-5.6-sol");
 		expect(ids).toContain("openai/gpt-5.6-terra");
 		expect(ids).toContain("openai/gpt-5.6-luna");
@@ -186,6 +187,17 @@ describe("buildAgentModelArgs", () => {
 		for (const model of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
 			expect(buildAgentModelArgs("codex", model)).toEqual(["--model", model]);
 		}
+	});
+
+	it("offers GPT-6 Astra in codex's current section", () => {
+		expect(buildAgentModelArgs("codex", "gpt-6-astra")).toEqual([
+			"--model",
+			"gpt-6-astra",
+		]);
+		const models = getAgentModelSupport("codex")?.models ?? [];
+		expect(models.find((model) => model.id === "gpt-6-astra")?.group).toBe(
+			"Current",
+		);
 	});
 
 	it("includes opus 5 and the GPT-5.6 models for the other CLIs", () => {
@@ -357,6 +369,13 @@ describe("getAgentEfforts", () => {
 			"xhigh",
 			"max",
 			"ultra",
+		]);
+		expect(getAgentEfforts("codex", "gpt-6-astra").map((e) => e.id)).toEqual([
+			"low",
+			"medium",
+			"high",
+			"xhigh",
+			"max",
 		]);
 		expect(getAgentEfforts("codex", "gpt-5.6-luna").map((e) => e.id)).toEqual([
 			"low",

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -63,6 +63,7 @@ export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
 		label: "Haiku 4.5",
 		provider: "Anthropic",
 	},
+	{ id: "openai/gpt-6-astra", label: "GPT-6 Astra", provider: "OpenAI" },
 	{ id: "openai/gpt-5.6-sol", label: "GPT-5.6 Sol", provider: "OpenAI" },
 	{
 		id: "openai/gpt-5.6-terra",
@@ -110,6 +111,11 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "codex",
 		modelFlag: "--model",
 		models: [
+			// GPT-6 Astra is the slug Codex's model docs publish (2026-09-03) and
+			// the API's only GPT-6 id. OpenAI is enabling it account by account,
+			// so it shows up in a login's live catalog (`codex app-server` →
+			// `model/list`) only once that account has access.
+			{ id: "gpt-6-astra", label: "GPT-6 Astra", group: CURRENT_GROUP },
 			{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol", group: CURRENT_GROUP },
 			{ id: "gpt-5.6-terra", label: "GPT-5.6 Terra", group: CURRENT_GROUP },
 			{ id: "gpt-5.6-luna", label: "GPT-5.6 Luna", group: CURRENT_GROUP },
@@ -316,11 +322,13 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 			// Per-model support taken from Codex's own model catalog
 			// (`supported_reasoning_levels`, codex-cli 0.149.1): every GPT-5.6
 			// model takes `max`, and `ultra` — max reasoning plus automatic
-			// task delegation — is Sol and Terra only.
+			// task delegation — is Sol and Terra only. GPT-6 Astra documents
+			// `max` (API `reasoning.effort`); `ultra` stays off until its live
+			// catalog entry confirms it.
 			{
 				id: "max",
 				label: "Max",
-				models: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+				models: ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
 			},
 			{ id: "ultra", label: "Ultra", models: ["gpt-5.6-sol", "gpt-5.6-terra"] },
 		],


### PR DESCRIPTION
## Summary
- Add GPT-6 Astra (`gpt-6-astra`, launched 2026-09-03) to the Codex model picker and the Superset chat catalog, and let it take Codex's `max` reasoning effort.
- Price it in the usage history table at $10 / $50 per MTok (cached input $1, which is the default 0.1x), and bump the "pricing table updated" date shown on Settings → Usage.

## Why / Context
GPT-6 Astra is OpenAI's new flagship and the pickers only offer curated ids. Without the pricing row, Codex sessions run on Astra would be costed at the cheapest Codex rate and flagged approximate.

## How It Works
- `gpt-6-astra` is the only GPT-6 id in OpenAI's API docs and the slug Codex's model docs publish. It sits first in the picker's Current group.
- Effort: OpenAI documents `low` through `max` for `reasoning.effort`, so Astra joins the `max` allowlist. Codex's `ultra` (max plus subagent delegation) stays off until a live catalog entry confirms it, because a wrong allowlist entry breaks the launch instead of hiding an option.
- Pricing uses longest-prefix match, so `openai-codex/gpt-6-astra` from OMP or opencode logs also resolves through the slash segment (covered by a test).

## How the id was verified
- [OpenAI API model page](https://developers.openai.com/api/docs/models/gpt-6-astra) and the [Codex models doc](https://learn.chatgpt.com/docs/models).
- Live per-account catalog: `codex app-server` → `model/list` with this login on Codex 0.152.1 and 0.153.0 still lists only the GPT-5.6 family, GPT-5.5, and the retiring GPT-5.4 pair. OpenAI's rollout is phased (Trusted Access Program today, Plus/Pro/Business/Enterprise "in the coming days").
- models.dev and the bundled OMP catalog have no gpt-6 entry; cursor-agent's `--list-models` needs a login.

## Manual QA
- Not launched end to end: this account's Codex catalog does not include Astra yet, so a launch fails on OpenAI's side today. Picker rendering, grouping, and the effort filter are covered by the unit tests. Once the rollout lands, choosing Astra + Max should start `codex --model gpt-6-astra -c model_reasoning_effort=max`.

## Testing
- `bun test packages/shared/src/agent-models.test.ts` (52 pass)
- `bun test packages/host-service/src/trpc/router/usage/history/pricing.test.ts` (6 pass)
- `bunx biome check` on the four changed files
- `bun run typecheck` in `packages/shared` and `packages/host-service`

## Known Limitations
- Astra shows in the picker before every account can use it; until OpenAI enables the account, the launch errors server-side.
- Not added to the opencode, OMP, cursor-agent, or Copilot pickers: their catalogs do not carry the id yet and they reject unknown ids at launch.

## Follow-ups
- Add `ultra` for Astra once `model/list` shows it.
- The Codex picker's "Retiring 2026-08-31" group is past its date and `gpt-5.3-codex` no longer appears in the live catalog; drop them in a separate PR.

https://claude.ai/code/session_011FkRSxPP9wCUU1psiLfvn5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GPT-6 Astra (`gpt-6-astra`) to the Codex model picker and Superset chat catalog, priced at $10/$50 per MTok in the usage history table. Without the pricing row, Astra sessions on Codex were costed at the cheapest rate and flagged approximate.

- Supports Codex's `max` reasoning effort; `ultra` stays off until the live catalog confirms it.
- The picker shows Astra before every account has access, so launching errors server-side until OpenAI enables the account.
- Bumps the usage history pricing table's updated date to 2026-09-03.

<sup>Written for commit 2dffa0f47b74867233d9c45404882abd81d168e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-6 Astra to the available Superset Chat and Codex model catalogs.
  * GPT-6 Astra supports low through maximum reasoning effort levels in Codex.

* **Billing**
  * Added GPT-6 Astra usage pricing at $10 per million input tokens and $50 per million output tokens.
  * Updated the pricing information date to September 3, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->