### PR TITLE
feat(desktop): show each agent's latest tool call in the sidebar agents card

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
@@ -1,13 +1,20 @@
 import { useLingui } from "@lingui/react/macro";
+import { formatCompactRelativeTime } from "@superset/i18n/format";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
+import { useNow } from "renderer/hooks/useNow";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { getStatusTooltip } from "renderer/screens/main/components/StatusIndicator";
 import type {
 	DashboardSidebarRunningAgent,
+	RunningAgentActivity,
 	RunningAgentStatus,
 } from "../../../../hooks/useDashboardSidebarWorkspaceRunningAgents";
 import { DashboardSidebarAgentAvatar } from "../DashboardSidebarAgentAvatar";
+import {
+	type AgentActivityVerb,
+	describeAgentActivity,
+} from "./utils/describeAgentActivity";
 
 const STATUS_TEXT_CLASS: Record<RunningAgentStatus, string> = {
 	idle: "text-muted-foreground",
@@ -51,7 +58,12 @@ export function DashboardSidebarAgentHoverRow({
 				className="flex min-w-0 flex-1 items-center gap-1.5 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
 			>
 				<DashboardSidebarAgentAvatar agent={agent} />
-				<span className="min-w-0 truncate text-xs">{agent.label}</span>
+				<span className="flex min-w-0 flex-1 flex-col">
+					<span className="min-w-0 truncate text-xs">{agent.label}</span>
+					{agent.activity ? (
+						<DashboardSidebarAgentActivityLine activity={agent.activity} />
+					) : null}
+				</span>
 			</button>
 			<span
 				className={cn("shrink-0 text-[10px]", STATUS_TEXT_CLASS[agent.status])}
@@ -59,5 +71,62 @@ export function DashboardSidebarAgentHoverRow({
 				{statusLabel}
 			</span>
 		</div>
+	);
+}
+
+/**
+ * One line for the agent's latest tool call: "Edit · src/a.ts · 3s ago".
+ * The elapsed time ticks while the card is open so a stale line reads as
+ * stale instead of live.
+ */
+function DashboardSidebarAgentActivityLine({
+	activity,
+}: {
+	activity: RunningAgentActivity;
+}) {
+	const { t } = useLingui();
+	const now = useNow();
+	const { verb, tool, detail } = describeAgentActivity(activity);
+
+	const verbLabels: Record<AgentActivityVerb, string> = {
+		edit: t({
+			id: "dashboard.sidebar.agentHoverRow.activity.edit",
+			message: "Edit",
+		}),
+		read: t({
+			id: "dashboard.sidebar.agentHoverRow.activity.read",
+			message: "Read",
+		}),
+		run: t({
+			id: "dashboard.sidebar.agentHoverRow.activity.run",
+			message: "Run",
+		}),
+		search: t({
+			id: "dashboard.sidebar.agentHoverRow.activity.search",
+			message: "Search",
+		}),
+		fetch: t({
+			id: "dashboard.sidebar.agentHoverRow.activity.fetch",
+			message: "Fetch",
+		}),
+		delegate: t({
+			id: "dashboard.sidebar.agentHoverRow.activity.delegate",
+			message: "Subagent",
+		}),
+	};
+	const label = verb ? verbLabels[verb] : tool;
+	const text = detail ? `${label} · ${detail}` : label;
+
+	return (
+		<span
+			className="min-w-0 truncate text-[10px] text-muted-foreground"
+			title={text}
+		>
+			{text}
+			<span className="text-muted-foreground/70">
+				{" · "}
+				{formatCompactRelativeTime(activity.at, now)}
+			</span>
+		</span>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
@@ -119,13 +119,12 @@ function DashboardSidebarAgentActivityLine({
 
 	return (
 		<span
-			className="min-w-0 truncate text-[10px] text-muted-foreground"
+			className="flex min-w-0 items-baseline text-[10px] text-muted-foreground"
 			title={text}
 		>
-			{text}
-			<span className="text-muted-foreground/70">
-				{" · "}
-				{formatCompactRelativeTime(activity.at, now)}
+			<span className="min-w-0 truncate">{text}</span>
+			<span className="ml-1 shrink-0 text-muted-foreground/70">
+				· {formatCompactRelativeTime(activity.at, now)}
 			</span>
 		</span>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/utils/describeAgentActivity/describeAgentActivity.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/utils/describeAgentActivity/describeAgentActivity.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { describeAgentActivity } from "./describeAgentActivity";
+
+describe("describeAgentActivity", () => {
+	it("maps known tools to a verb regardless of case", () => {
+		expect(describeAgentActivity({ tool: "Edit", detail: "a.ts" })).toEqual({
+			verb: "edit",
+			tool: "Edit",
+			detail: "a.ts",
+		});
+		expect(describeAgentActivity({ tool: "bash" }).verb).toBe("run");
+		expect(describeAgentActivity({ tool: "WebFetch" }).verb).toBe("fetch");
+	});
+
+	it("falls through to the raw tool name for unknown tools", () => {
+		expect(describeAgentActivity({ tool: "mcp__linear__get_issue" })).toEqual({
+			verb: null,
+			tool: "mcp__linear__get_issue",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/utils/describeAgentActivity/describeAgentActivity.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/utils/describeAgentActivity/describeAgentActivity.ts
@@ -1,0 +1,49 @@
+/**
+ * Coarse verb for an agent tool name. Tool names are the agent's own
+ * (Claude's `Edit`, Grok's `bash`, …); matching is case-insensitive and
+ * anything unrecognized falls through as the raw tool name.
+ */
+export type AgentActivityVerb =
+	| "edit"
+	| "read"
+	| "run"
+	| "search"
+	| "fetch"
+	| "delegate";
+
+const VERB_BY_TOOL: Record<string, AgentActivityVerb> = {
+	edit: "edit",
+	multiedit: "edit",
+	write: "edit",
+	notebookedit: "edit",
+	apply_patch: "edit",
+	read: "read",
+	bash: "run",
+	shell: "run",
+	grep: "search",
+	glob: "search",
+	ls: "search",
+	webfetch: "fetch",
+	websearch: "fetch",
+	task: "delegate",
+	agent: "delegate",
+};
+
+export interface AgentActivityDescription {
+	/** Recognized verb, or null when the tool name should show as-is. */
+	verb: AgentActivityVerb | null;
+	tool: string;
+	detail?: string;
+}
+
+export function describeAgentActivity(activity: {
+	tool: string;
+	detail?: string;
+}): AgentActivityDescription {
+	const verb = VERB_BY_TOOL[activity.tool.toLowerCase()] ?? null;
+	return {
+		verb,
+		tool: activity.tool,
+		...(activity.detail ? { detail: activity.detail } : {}),
+	};
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/utils/describeAgentActivity/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/utils/describeAgentActivity/index.ts
@@ -1,0 +1,1 @@
+export * from "./describeAgentActivity";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/index.ts
@@ -1,5 +1,6 @@
 export {
 	type DashboardSidebarRunningAgent,
+	type RunningAgentActivity,
 	type RunningAgentStatus,
 	useDashboardSidebarWorkspaceRunningAgents,
 } from "./useDashboardSidebarWorkspaceRunningAgents";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/hooks/useDashboardSidebarWorkspaceRunningAgents/useDashboardSidebarWorkspaceRunningAgents.ts
@@ -3,6 +3,7 @@ import {
 	type AgentIdentityId,
 } from "@superset/shared/agent-catalog";
 import { useMemo } from "react";
+import type { TerminalAgentBinding } from "renderer/hooks/host-service/useTerminalAgentBindings";
 import { useSidebarWorkspaceStatus } from "renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarWorkspaceStatusProvider";
 import type { V2NotificationSource } from "renderer/stores/v2-notifications";
 import type { PaneStatus } from "shared/tabs-types";
@@ -12,6 +13,11 @@ import type { PaneStatus } from "shared/tabs-types";
  * currently `working` / awaiting `permission` / ready for `review`.
  */
 export type RunningAgentStatus = PaneStatus;
+
+/** The agent's latest tool call, as reported by its hooks. */
+export type RunningAgentActivity = NonNullable<
+	TerminalAgentBinding["activity"]
+>;
 
 export interface DashboardSidebarRunningAgent {
 	/** Stable key for React lists, derived from the notification source. */
@@ -27,6 +33,8 @@ export interface DashboardSidebarRunningAgent {
 	startedAt: number;
 	/** Agent display name (e.g. "Claude"). */
 	label: string;
+	/** Latest tool call; absent for agents without tool hooks. */
+	activity?: RunningAgentActivity;
 }
 
 /**
@@ -53,6 +61,7 @@ export function useDashboardSidebarWorkspaceRunningAgents(
 				status: statuses.get(binding.terminalId) ?? "idle",
 				startedAt: binding.startedAt,
 				label: AGENT_IDENTITY_LABELS[binding.agentId] ?? binding.agentId,
+				...(binding.activity ? { activity: binding.activity } : {}),
 			});
 		}
 		agents.sort((a, b) => a.startedAt - b.startedAt);

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -70,7 +70,13 @@ async function runNotifyHookAsync(
 
 /** Fake host-service answering notifications.hook like the real router. */
 function fakeHostService(ignored: boolean) {
-	const requests: Array<{ json: { terminalId?: string } }> = [];
+	const requests: Array<{
+		json: {
+			terminalId?: string;
+			eventType?: string;
+			activity?: { tool: string; detail: string };
+		};
+	}> = [];
 	const server = Bun.serve({
 		port: 0,
 		fetch: async (req) => {
@@ -104,7 +110,7 @@ function writeHookManifest(home: string, orgId: string, endpoint: string) {
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v9");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v10");
 	});
 
 	it("ignores hooks fired inside a subagent (agent_id present)", () => {
@@ -144,7 +150,7 @@ describe("getNotifyScriptContent", () => {
 
 		expect(script).toContain('HOOK_SESSION_ID=$(echo "$INPUT"');
 		expect(script).toContain(
-			'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$SESSION_ID")\\"}}}"',
+			'PAYLOAD="{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$SESSION_ID")\\"}$ACTIVITY_JSON}}"',
 		);
 		expect(script).toContain(
 			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
@@ -246,6 +252,83 @@ describe("getNotifyScriptContent", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.stderr.toString()).toBe("");
+	});
+});
+
+describe("tool activity", () => {
+	it("forwards the tool name and its main argument to the host", async () => {
+		const live = fakeHostService(false);
+		const home = mkdtempSync(path.join(tmpdir(), "notify-hook-home-"));
+		writeHookManifest(home, "org-a", live.url);
+		try {
+			const result = await runNotifyHookAsync(
+				{
+					hook_event_name: "PostToolUse",
+					session_id: "main-session",
+					tool_name: "Bash",
+					tool_input: {
+						command: 'echo "hi"\nbun test',
+						description: "Say hi",
+					},
+					tool_response: { stdout: "hi" },
+				},
+				{ SUPERSET_HOME_DIR: home },
+			);
+
+			expect(result.exitCode).toBe(0);
+			expect(live.requests).toHaveLength(1);
+			expect(live.requests[0]?.json.eventType).toBe("PostToolUse");
+			expect(live.requests[0]?.json.activity).toEqual({
+				tool: "Bash",
+				detail: 'echo "hi" bun test',
+			});
+		} finally {
+			live.stop();
+		}
+	});
+
+	it("prefers the file path over other arguments", async () => {
+		const live = fakeHostService(false);
+		const home = mkdtempSync(path.join(tmpdir(), "notify-hook-home-"));
+		writeHookManifest(home, "org-a", live.url);
+		try {
+			await runNotifyHookAsync(
+				{
+					hook_event_name: "PermissionRequest",
+					session_id: "main-session",
+					tool_name: "Write",
+					tool_input: {
+						content: '{"file_path":"decoy"}',
+						file_path: "/repo/src/a.ts",
+					},
+				},
+				{ SUPERSET_HOME_DIR: home },
+			);
+
+			expect(live.requests[0]?.json.activity).toEqual({
+				tool: "Write",
+				detail: "/repo/src/a.ts",
+			});
+		} finally {
+			live.stop();
+		}
+	});
+
+	it("sends no activity for events without a tool", async () => {
+		const live = fakeHostService(false);
+		const home = mkdtempSync(path.join(tmpdir(), "notify-hook-home-"));
+		writeHookManifest(home, "org-a", live.url);
+		try {
+			await runNotifyHookAsync(
+				{ hook_event_name: "Stop", session_id: "main-session" },
+				{ SUPERSET_HOME_DIR: home },
+			);
+
+			expect(live.requests).toHaveLength(1);
+			expect(live.requests[0]?.json).not.toHaveProperty("activity");
+		} finally {
+			live.stop();
+		}
 	});
 });
 

--- a/packages/agent-setup/src/notify-hook.ts
+++ b/packages/agent-setup/src/notify-hook.ts
@@ -5,7 +5,7 @@ import { getHooksDir } from "./paths";
 import { writeFileIfChanged } from "./write-file-if-changed";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v9";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v10";
 
 export function getNotifyScriptPath(): string {
 	return path.join(getHooksDir(), NOTIFY_SCRIPT_NAME);

--- a/packages/agent-setup/templates/notify-hook.template.sh
+++ b/packages/agent-setup/templates/notify-hook.template.sh
@@ -78,6 +78,25 @@ fi
 # a false completion notification.
 [ -z "$EVENT_TYPE" ] && exit 0
 
+# Tool activity for the sidebar's "what is it doing" line. Claude-schema
+# agents put tool_name at the top level and the tool's arguments under
+# tool_input; the first of these keys is the one worth showing. Values are
+# JSON string literals: unescape, drop control characters, and cap the
+# length so a heredoc command can't bloat the payload. Absent for agents
+# without tool hooks — the host keeps the line blank for them.
+json_string_field() {
+  printf '%s' "$INPUT" | grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"([^\"\\\\]|\\\\.)*\"" | head -1 | sed -e 's/^"[^"]*"[[:space:]]*:[[:space:]]*"//' -e 's/"$//'
+}
+TOOL_NAME=$(json_string_field tool_name)
+TOOL_DETAIL=""
+if [ -n "$TOOL_NAME" ]; then
+  for DETAIL_KEY in file_path command pattern url description; do
+    TOOL_DETAIL=$(json_string_field "$DETAIL_KEY")
+    [ -n "$TOOL_DETAIL" ] && break
+  done
+  TOOL_DETAIL=$(printf '%s' "$TOOL_DETAIL" | sed -e 's/\\[nrt]/ /g' -e 's/\\"/"/g' -e 's/\\\\/\\/g' | tr -d '\000-\037' | cut -c1-400)
+fi
+
 DEBUG_HOOKS_ENABLED="0"
 if [ -n "$SUPERSET_DEBUG_HOOKS" ]; then
   case "$SUPERSET_DEBUG_HOOKS" in
@@ -121,7 +140,11 @@ json_escape() {
 # then every org manifest's endpoint. Only the host that owns this terminal
 # answers "ignored":false; probing the other orgs' hosts is a harmless no-op.
 if [ -n "$SUPERSET_TERMINAL_ID" ]; then
-  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$SESSION_ID")\"}}}"
+  ACTIVITY_JSON=""
+  if [ -n "$TOOL_NAME" ]; then
+    ACTIVITY_JSON=",\"activity\":{\"tool\":\"$(json_escape "$TOOL_NAME")\",\"detail\":\"$(json_escape "$TOOL_DETAIL")\"}"
+  fi
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$SESSION_ID")\"}$ACTIVITY_JSON}}"
 
   HOOK_CANDIDATE_URLS="$SUPERSET_HOST_AGENT_HOOK_URL"
   for MANIFEST_FILE in "${SUPERSET_HOME_DIR:-$HOME/.superset}"/host/*/manifest.json; do

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -597,3 +597,138 @@ describe("TerminalAgentStore", () => {
 		expect(lateArrival.persisted.has("t1")).toBe(true);
 	});
 });
+
+describe("TerminalAgentStore activity", () => {
+	let store: TerminalAgentStore;
+
+	beforeEach(() => {
+		store = new TerminalAgentStore();
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			agentSessionId: "s1",
+			occurredAt: 100,
+		});
+	});
+
+	it("records the latest tool call and exposes it on every read path", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			activity: { tool: "Edit", detail: "src/a.ts" },
+			occurredAt: 200,
+		});
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			activity: { tool: "Bash", detail: "bun test" },
+			occurredAt: 300,
+		});
+
+		const expected = { tool: "Bash", detail: "bun test", at: 300 };
+		expect(store.get("t1")?.activity).toEqual(expected);
+		expect(store.listByWorkspace(WORKSPACE)[0]?.activity).toEqual(expected);
+		expect(store.list()[0]?.activity).toEqual(expected);
+		expect(store.findActive(WORKSPACE, "claude")?.activity).toEqual(expected);
+	});
+
+	it("keeps the last tool through Stop, Failed, and PermissionRequest", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			activity: { tool: "Bash", detail: "bun test" },
+			occurredAt: 200,
+		});
+		for (const eventType of ["PermissionRequest", "Failed", "Stop"]) {
+			store.recordEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType,
+				occurredAt: 300,
+			});
+			expect(store.get("t1")?.activity?.tool).toBe("Bash");
+		}
+	});
+
+	it("clears the line on a new prompt and on a new session", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			activity: { tool: "Bash", detail: "bun test" },
+			occurredAt: 200,
+		});
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			occurredAt: 300,
+		});
+		expect(store.get("t1")?.activity).toBeUndefined();
+
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			activity: { tool: "Read", detail: "README.md" },
+			occurredAt: 400,
+		});
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			agentSessionId: "s2",
+			occurredAt: 500,
+		});
+		expect(store.get("t1")?.activity).toBeUndefined();
+	});
+
+	it("drops the line when the binding ends", () => {
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			activity: { tool: "Bash", detail: "bun test" },
+			occurredAt: 200,
+		});
+		store.markTerminalExited("t1");
+		store.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Attached",
+			agentId: "claude",
+			agentSessionId: "s3",
+			occurredAt: 400_000,
+		});
+		expect(store.get("t1")?.activity).toBeUndefined();
+	});
+
+	it("never hands activity to persistence", () => {
+		const upserts: TerminalAgentBinding[] = [];
+		const persistence: TerminalAgentBindingPersistence = {
+			load: () => [],
+			upsert: (binding) => {
+				upserts.push(binding);
+			},
+			delete: () => {},
+		};
+		const persisted = new TerminalAgentStore(persistence);
+		persisted.recordEvent({
+			terminalId: "t1",
+			workspaceId: WORKSPACE,
+			eventType: "Start",
+			agentId: "claude",
+			activity: { tool: "Bash", detail: "bun test" },
+			occurredAt: 200,
+		});
+		expect(upserts).toHaveLength(1);
+		expect(upserts[0]).not.toHaveProperty("activity");
+		expect(persisted.get("t1")?.activity?.tool).toBe("Bash");
+	});
+});

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { AgentDefinitionId } from "@superset/shared/agent-catalog";
 import type {
+	TerminalAgentActivity,
 	TerminalAgentBinding,
 	TerminalAgentEndReason,
 	TerminalAgentId,
@@ -14,6 +15,8 @@ interface RecordEventInput {
 	agentSessionId?: string;
 	definitionId?: AgentDefinitionId;
 	occurredAt: number;
+	/** The tool call behind this event, when the hook carried one. */
+	activity?: Omit<TerminalAgentActivity, "at">;
 }
 
 export interface TerminalAgentBindingListFilter {
@@ -82,6 +85,15 @@ export interface TerminalAgentBindingPersistence {
  */
 export class TerminalAgentStore extends EventEmitter {
 	private readonly byTerminal = new Map<string, TerminalAgentBinding>();
+	/**
+	 * Latest tool call per terminal. Kept beside the bindings rather than on
+	 * them because reads are served from persistence when present, and this
+	 * is deliberately never written to disk.
+	 */
+	private readonly activityByTerminal = new Map<
+		string,
+		TerminalAgentActivity
+	>();
 	private readonly persistence: TerminalAgentBindingPersistence | undefined;
 
 	constructor(persistence?: TerminalAgentBindingPersistence) {
@@ -102,6 +114,7 @@ export class TerminalAgentStore extends EventEmitter {
 			agentSessionId,
 			definitionId,
 			occurredAt,
+			activity,
 		} = input;
 
 		const endReason = END_EVENT_REASONS.get(eventType);
@@ -170,7 +183,43 @@ export class TerminalAgentStore extends EventEmitter {
 
 		this.byTerminal.set(terminalId, next);
 		this.persistence?.upsert(next);
+		this.recordActivity(terminalId, eventType, occurredAt, {
+			activity,
+			sessionChanged: prior === undefined || sessionChanged,
+		});
 		this.emit("change", workspaceId);
+	}
+
+	/**
+	 * A tool event replaces the line. A bare `Start` (a new prompt, no tool)
+	 * clears it — the previous turn's last tool is not what the agent is
+	 * doing now. Stop/Failed/PermissionRequest without a tool keep it, so an
+	 * idle row still says what the agent last did.
+	 */
+	private recordActivity(
+		terminalId: string,
+		eventType: string,
+		occurredAt: number,
+		input: {
+			activity: Omit<TerminalAgentActivity, "at"> | undefined;
+			sessionChanged: boolean;
+		},
+	): void {
+		if (input.activity) {
+			this.activityByTerminal.set(terminalId, {
+				...input.activity,
+				at: occurredAt,
+			});
+			return;
+		}
+		if (input.sessionChanged || eventType === "Start") {
+			this.activityByTerminal.delete(terminalId);
+		}
+	}
+
+	private withActivity(binding: TerminalAgentBinding): TerminalAgentBinding {
+		const activity = this.activityByTerminal.get(binding.terminalId);
+		return activity ? { ...binding, activity } : binding;
 	}
 
 	markTerminalExited(terminalId: string): void {
@@ -210,7 +259,8 @@ export class TerminalAgentStore extends EventEmitter {
 	}
 
 	get(terminalId: string): TerminalAgentBinding | undefined {
-		return this.byTerminal.get(terminalId);
+		const binding = this.byTerminal.get(terminalId);
+		return binding ? this.withActivity(binding) : undefined;
 	}
 
 	listByWorkspace(
@@ -218,7 +268,9 @@ export class TerminalAgentStore extends EventEmitter {
 		filter?: TerminalAgentBindingListFilter,
 	): TerminalAgentBinding[] {
 		if (this.persistence?.listLiveByWorkspace) {
-			return this.persistence.listLiveByWorkspace(workspaceId, filter);
+			return this.persistence
+				.listLiveByWorkspace(workspaceId, filter)
+				.map((binding) => this.withActivity(binding));
 		}
 		const out: TerminalAgentBinding[] = [];
 		for (const binding of this.byTerminal.values()) {
@@ -226,16 +278,20 @@ export class TerminalAgentStore extends EventEmitter {
 			if (filter?.agentId && binding.agentId !== filter.agentId) continue;
 			if (filter?.definitionId && binding.definitionId !== filter.definitionId)
 				continue;
-			out.push(binding);
+			out.push(this.withActivity(binding));
 		}
 		return out;
 	}
 
 	list(): TerminalAgentBinding[] {
 		if (this.persistence?.listLive) {
-			return this.persistence.listLive();
+			return this.persistence
+				.listLive()
+				.map((binding) => this.withActivity(binding));
 		}
-		return [...this.byTerminal.values()];
+		return [...this.byTerminal.values()].map((binding) =>
+			this.withActivity(binding),
+		);
 	}
 
 	findActive(
@@ -244,11 +300,12 @@ export class TerminalAgentStore extends EventEmitter {
 		definitionId?: AgentDefinitionId,
 	): TerminalAgentBinding | undefined {
 		if (this.persistence?.findLiveActive) {
-			return this.persistence.findLiveActive(
+			const found = this.persistence.findLiveActive(
 				workspaceId,
 				agentId,
 				definitionId,
 			);
+			return found ? this.withActivity(found) : undefined;
 		}
 		let best: TerminalAgentBinding | undefined;
 		for (const binding of this.byTerminal.values()) {
@@ -260,7 +317,7 @@ export class TerminalAgentStore extends EventEmitter {
 				best = binding;
 			}
 		}
-		return best;
+		return best ? this.withActivity(best) : undefined;
 	}
 
 	/**
@@ -275,6 +332,7 @@ export class TerminalAgentStore extends EventEmitter {
 	): void {
 		const existing = this.byTerminal.get(terminalId);
 		this.byTerminal.delete(terminalId);
+		this.activityByTerminal.delete(terminalId);
 
 		let marked: { workspaceId: string } | undefined;
 		if (this.persistence?.markEnded) {

--- a/packages/host-service/src/terminal-agents/types.ts
+++ b/packages/host-service/src/terminal-agents/types.ts
@@ -23,6 +23,17 @@ export type TerminalAgentEndReason =
 	| "disposed";
 
 /**
+ * The agent's most recent tool call, as reported by its tool hooks: the tool
+ * name plus the argument worth showing (a path, a command, a pattern). One
+ * line, latest wins — the sidebar's "what is it doing" hint, not a log.
+ */
+export interface TerminalAgentActivity {
+	tool: string;
+	detail?: string;
+	at: number;
+}
+
+/**
  * One agent process bound to a terminal. Created on the first hook event we
  * receive for the terminal. When the agent or terminal ends the row is kept
  * with `endedAt`/`endReason` set (so `agentSessionId` survives for resume)
@@ -40,4 +51,9 @@ export interface TerminalAgentBinding {
 	lastEventType: string;
 	endedAt?: number;
 	endReason?: TerminalAgentEndReason;
+	/**
+	 * Held in memory only (not persisted): it is worthless after a restart
+	 * and changes on every tool call.
+	 */
+	activity?: TerminalAgentActivity;
 }

--- a/packages/host-service/src/trpc/router/notifications/notifications.test.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.test.ts
@@ -3,7 +3,7 @@ import type { AgentIdentity } from "@superset/shared/agent-identity";
 import type { AgentLifecycleEventType } from "../../../events";
 import { TerminalAgentStore } from "../../../terminal-agents";
 import type { HostServiceContext } from "../../../types";
-import { notificationsRouter } from "./notifications";
+import { normalizeAgentActivity, notificationsRouter } from "./notifications";
 
 interface BroadcastedAgentLifecycleEvent {
 	workspaceId: string;
@@ -15,7 +15,7 @@ interface BroadcastedAgentLifecycleEvent {
 
 function createContext(
 	originWorkspaceId: string | null,
-	options?: { taskId?: string | null },
+	options?: { taskId?: string | null; worktreePath?: string },
 ): {
 	ctx: HostServiceContext;
 	broadcastAgentLifecycle: ReturnType<
@@ -39,7 +39,10 @@ function createContext(
 					},
 	}));
 	const workspaceFindFirst = mock(() => ({
-		sync: () => ({ taskId: options?.taskId ?? null }),
+		sync: () => ({
+			taskId: options?.taskId ?? null,
+			worktreePath: options?.worktreePath ?? "/tmp/worktree",
+		}),
 	}));
 	const taskStart = mock((_input: { id: string }) => Promise.resolve({}));
 	const terminalAgentStore = new TerminalAgentStore();
@@ -276,5 +279,65 @@ describe("notificationsRouter.hook", () => {
 
 		const broadcast = broadcastAgentLifecycle.mock.calls[0]?.[0];
 		expect(broadcast?.agent).toBeUndefined();
+	});
+});
+
+describe("normalizeAgentActivity", () => {
+	it("drops activity without a tool name", () => {
+		expect(normalizeAgentActivity(undefined, {})).toBeUndefined();
+		expect(
+			normalizeAgentActivity({ tool: "  ", detail: "x" }, {}),
+		).toBeUndefined();
+	});
+
+	it("shortens worktree and home paths, in that order", () => {
+		expect(
+			normalizeAgentActivity(
+				{
+					tool: "Bash",
+					detail:
+						"cp /home/me/repo/src/a.ts /home/me/backup/a.ts && ls /home/me/other",
+				},
+				{ worktreePath: "/home/me/repo/", homeDir: "/home/me" },
+			),
+		).toEqual({
+			tool: "Bash",
+			detail: "cp src/a.ts ~/backup/a.ts && ls ~/other",
+		});
+	});
+
+	it("caps the display length and omits an empty detail", () => {
+		const result = normalizeAgentActivity(
+			{ tool: "T".repeat(80), detail: "d".repeat(500) },
+			{},
+		);
+		expect(result?.tool).toHaveLength(40);
+		expect(result?.detail).toHaveLength(160);
+		expect(normalizeAgentActivity({ tool: "Read", detail: " " }, {})).toEqual({
+			tool: "Read",
+		});
+	});
+});
+
+describe("notificationsRouter.hook activity", () => {
+	it("records the tool call on the binding with worktree-relative paths", async () => {
+		const { ctx, terminalAgentStore } = createContext("workspace-1", {
+			worktreePath: "/srv/wt",
+		});
+		const caller = notificationsRouter.createCaller(ctx);
+
+		await caller.hook({
+			terminalId: "terminal-1",
+			eventType: "PostToolUse",
+			agent: { agentId: "claude", sessionId: "session-abc" },
+			activity: { tool: "Edit", detail: "/srv/wt/src/a.ts" },
+		});
+
+		const binding = terminalAgentStore.get("terminal-1");
+		expect(binding?.lastEventType).toBe("Start");
+		expect(binding?.activity).toMatchObject({
+			tool: "Edit",
+			detail: "src/a.ts",
+		});
 	});
 });

--- a/packages/host-service/src/trpc/router/notifications/notifications.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -16,10 +17,23 @@ const agentIdentityInput = z
 	})
 	.optional();
 
+// The hook script caps `detail` before sending; the caps here are the
+// display budget, applied after paths are shortened.
+const ACTIVITY_TOOL_MAX_LENGTH = 40;
+const ACTIVITY_DETAIL_MAX_LENGTH = 160;
+
+const activityInput = z
+	.object({
+		tool: z.string().optional(),
+		detail: z.string().optional(),
+	})
+	.optional();
+
 const hookInput = z.object({
 	terminalId: z.string().optional(),
 	eventType: z.string().optional(),
 	agent: agentIdentityInput,
+	activity: activityInput,
 });
 
 function trimOrUndefined(value: string | undefined): string | undefined {
@@ -43,6 +57,36 @@ function normalizeAgentIdentity(
 	};
 }
 
+/**
+ * Shorten paths so the sidebar line reads "src/a.ts", not the worktree's
+ * absolute path: strip the workspace root first, then the home directory.
+ * Applies to commands too, which routinely embed absolute paths.
+ */
+export function normalizeAgentActivity(
+	activity: z.infer<typeof activityInput>,
+	options: { worktreePath?: string; homeDir?: string },
+): { tool: string; detail?: string } | undefined {
+	const tool = trimOrUndefined(activity?.tool)?.slice(
+		0,
+		ACTIVITY_TOOL_MAX_LENGTH,
+	);
+	if (!tool) return undefined;
+
+	let detail = trimOrUndefined(activity?.detail);
+	if (detail) {
+		const worktreePath = options.worktreePath?.replace(/\/+$/, "");
+		if (worktreePath) {
+			detail = detail.replaceAll(`${worktreePath}/`, "");
+		}
+		const homeDir = options.homeDir?.replace(/\/+$/, "");
+		if (homeDir) {
+			detail = detail.replaceAll(`${homeDir}/`, "~/");
+		}
+		detail = detail.slice(0, ACTIVITY_DETAIL_MAX_LENGTH);
+	}
+	return { tool, ...(detail ? { detail } : {}) };
+}
+
 // Tasks already nudged to "started" this process. `Start` fires on every
 // agent turn and tool use, so gate the cloud call to once per task per
 // process — `task.start` is idempotent and forward-only server-side, so a
@@ -51,15 +95,8 @@ const startedTaskIds = new Set<string>();
 
 function markLinkedTaskStarted(
 	ctx: HostServiceContext,
-	workspaceId: string,
+	taskId: string | null | undefined,
 ): void {
-	const workspace = ctx.db.query.workspaces
-		.findFirst({
-			where: eq(workspaces.id, workspaceId),
-			columns: { taskId: true },
-		})
-		.sync();
-	const taskId = workspace?.taskId;
 	if (!taskId || startedTaskIds.has(taskId)) return;
 	startedTaskIds.add(taskId);
 	void ctx.api.task.start.mutate({ id: taskId }).catch((err) => {
@@ -103,7 +140,18 @@ export const notificationsRouter = router({
 			return { success: true, ignored: true as const };
 		}
 
+		const workspace = ctx.db.query.workspaces
+			.findFirst({
+				where: eq(workspaces.id, terminalSession.originWorkspaceId),
+				columns: { taskId: true, worktreePath: true },
+			})
+			.sync();
+
 		const agent = normalizeAgentIdentity(input.agent);
+		const activity = normalizeAgentActivity(input.activity, {
+			worktreePath: workspace?.worktreePath,
+			homeDir: os.homedir(),
+		});
 		const occurredAt = Date.now();
 
 		ctx.eventBus.broadcastAgentLifecycle({
@@ -121,13 +169,14 @@ export const notificationsRouter = router({
 			...(agent?.agentId ? { agentId: agent.agentId } : {}),
 			...(agent?.sessionId ? { agentSessionId: agent.sessionId } : {}),
 			...(agent?.definitionId ? { definitionId: agent.definitionId } : {}),
+			...(activity ? { activity } : {}),
 			occurredAt,
 		});
 
 		// An agent began working in this workspace — nudge the linked task
 		// to In Progress.
 		if (eventType === "Start") {
-			markLinkedTaskStarted(ctx, terminalSession.originWorkspaceId);
+			markLinkedTaskStarted(ctx, workspace?.taskId);
 		}
 
 		return { success: true, ignored: false as const };

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Otevřené"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Nečinný"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Offen"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Inaktiv"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Open"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr "Subagent"
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr "Edit"
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr "Fetch"
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr "Read"
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr "Run"
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr "Search"
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Idle"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Abierta"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Inactivo"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Ouvrir"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Inactif"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Buka"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Idle"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Aperte"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Inattivo"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -7267,6 +7267,36 @@ msgstr "オープン"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "アイドル"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -7267,6 +7267,36 @@ msgstr "열림"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "대기 중"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Open"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Inactief"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Otwarte"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Bezczynny"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Abertos"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Ocioso"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Открытые"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Простаивает"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Açık"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Boşta"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -7267,6 +7267,36 @@ msgstr "Đang mở"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "Rảnh"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -7267,6 +7267,36 @@ msgstr "打开"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "空闲"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -7267,6 +7267,36 @@ msgstr "開啟"
 
 #. js-lingui-explicit-id
 #: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.delegate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.edit"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.fetch"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.read"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.run"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
+msgid "dashboard.sidebar.agentHoverRow.activity.search"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarExpandedWorkspaceRow/components/DashboardSidebarWorkspaceChips/components/DashboardSidebarAgentsChip/components/DashboardSidebarAgentHoverRow/DashboardSidebarAgentHoverRow.tsx
 msgid "dashboard.sidebar.agentHoverRow.idle"
 msgstr "空閒"
 


### PR DESCRIPTION
## What

The sidebar agents hover card gains one line per agent: the agent's latest tool call, e.g. `Edit · src/a.ts · 3s ago`, `Run · bun test · 40s ago`. Before, the card only showed the coarse status word.

## How

- **Hook script** (`notify-hook.template.sh`, marker bumped to v10): for Claude-schema agents, extracts `tool_name` and the first of `file_path` / `command` / `pattern` / `url` / `description` from `tool_input`, unescapes, strips control chars, caps at 400 chars, and sends it as `activity: { tool, detail }`. Events without a tool send no activity.
- **Host** (`notifications.hook` → `TerminalAgentStore`): normalizes the activity (worktree root and home dir shortened, display caps), and keeps it in an in-memory map beside the bindings, overlaid on every read path. A bare `Start` clears it; `Stop` / `Failed` / `PermissionRequest` keep it; session change or binding end drops it. Never persisted.
- **Desktop**: `DashboardSidebarAgentHoverRow` renders the line with a coarse verb (Edit / Read / Run / Search / Fetch / Subagent, raw tool name otherwise) and a ticking compact relative time that stays visible when the detail truncates.

## Scope

First of three PRs from the activity-line spec. Not in this PR: automation run outcomes, mobile rows, and PreToolUse (which would make the line "doing" rather than "last did" at the cost of an extra blocking hook per tool call).

Note: the agents chip only renders when a workspace has two or more live agents (existing behavior in `DashboardSidebarWorkspaceChips`), so a single-agent workspace never shows this line today. Worth revisiting in the next PR.

## Verification

- `bun test` in host-service (store + router) and agent-setup (hook script against a fake host), plus the new desktop unit test.
- Typecheck passes for host-service, agent-setup, and desktop.
- End-to-end over CDP against the dev app from this branch (renderer :4845, dev host-service): launched three Claude sessions in this worktree's workspace through `agents.run`, each prompted to use one tool. The real v10 hook posted `activity` to the dev host, the binding carried it (`Run · ls packages`, `Read · packages/i18n/README.md`, `Run · bun --version` mid-turn with status Working), and hovering the agents chip with real mouse input showed the lines with elapsed time. Screenshots captured; zero renderer exceptions.

https://claude.ai/code/session_01M2Z9wLHVRNWM31CjWbAK9H


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard sidebar agent hover rows now display the agent’s latest activity, including localized action labels, relevant details, and elapsed time.
  * Activity details update automatically while the hover row remains open.
  * Tool activity is captured and shown for supported agent actions, with readable file paths, commands, searches, and URLs.

* **Bug Fixes**
  * Improved formatting and truncation keep activity details readable without disrupting the sidebar layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->