### PR TITLE
fix(host-service): restart idle agents on account switch, launching fresh when there is nothing to resume

### DIFF
--- a/packages/host-service/src/terminal-agents/persistence.test.ts
+++ b/packages/host-service/src/terminal-agents/persistence.test.ts
@@ -263,7 +263,7 @@ describe("binding end marking and resume candidates", () => {
 		expect(findResumeCandidateBinding(db, "ws-1", "t1")).toBeUndefined();
 	});
 
-	it("does not offer never-prompted sessions (nothing persisted to resume)", () => {
+	it("offers never-prompted sessions too (the relaunch decides resume vs fresh)", () => {
 		const db = createTestDb();
 		db.insert(terminalSessions)
 			.values({
@@ -281,13 +281,16 @@ describe("binding end marking and resume candidates", () => {
 				agentSessionId: "sess-empty",
 				startedAt: 1,
 				lastEventAt: 2,
-				// SessionStart only — the agent never received a prompt, so the
-				// CLI has no conversation on disk to restore.
+				// SessionStart only — the agent never received a prompt. Still a
+				// candidate: resumeTerminalAgentSession checks the harness store
+				// and launches fresh when there is no conversation to restore.
 				lastEventType: "Attached",
 			})
 			.run();
 		markTerminalAgentBindingEnded(db, "t1", "terminal-exited");
-		expect(findResumeCandidateBinding(db, "ws-1", "t1")).toBeUndefined();
+		expect(findResumeCandidateBinding(db, "ws-1", "t1")?.lastEventType).toBe(
+			"Attached",
+		);
 	});
 
 	it("getEnded reports end state only for ended rows", () => {

--- a/packages/host-service/src/terminal-agents/persistence.ts
+++ b/packages/host-service/src/terminal-agents/persistence.ts
@@ -123,11 +123,12 @@ export function getTerminalAgentBindingSessionId(
 }
 
 /**
- * A dead terminal's binding is resumable when: agent session id captured, the
- * terminal died under the agent ("terminal-exited") rather than the agent
- * detaching cleanly, and the session progressed past its start — agents only
- * persist a conversation once it has a message, so resuming a never-prompted
- * session fails with "no conversation found".
+ * A dead terminal's binding is resumable when: agent session id captured and
+ * the terminal died under the agent ("terminal-exited") rather than the agent
+ * detaching cleanly. A session still at "Attached" (started, never prompted)
+ * qualifies too: the relaunch checks the harness's store and starts the agent
+ * fresh when there is no conversation to resume — see
+ * resumeTerminalAgentSession.
  */
 function resumeCandidatePredicate(workspaceId: string, terminalId: string) {
 	return and(
@@ -136,7 +137,6 @@ function resumeCandidatePredicate(workspaceId: string, terminalId: string) {
 		isNotNull(terminalAgentBindings.endedAt),
 		eq(terminalAgentBindings.endReason, "terminal-exited"),
 		isNotNull(terminalAgentBindings.agentSessionId),
-		ne(terminalAgentBindings.lastEventType, "Attached"),
 	);
 }
 

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.test.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.test.ts
@@ -148,8 +148,8 @@ describe("resumeTerminalAgentSession", () => {
 	it("launches a never-prompted session fresh instead of resuming into nothing", async () => {
 		const db = createTestDb();
 		seedResumableBinding(db, { lastEventType: "Attached" });
-		// Idle since SessionStart, no transcript on disk (or unknowable): a
-		// `--resume` would exit with "no conversation found".
+		// Idle since SessionStart with no transcript on disk: a `--resume`
+		// would exit with "no conversation found".
 		const { deps, runCalls, disposedTerminals } = createDeps(
 			db,
 			undefined,
@@ -180,6 +180,21 @@ describe("resumeTerminalAgentSession", () => {
 		const { deps, runCalls } = createDeps(db, undefined, (binding) =>
 			binding.agentSessionId === "sess-t1" ? true : null,
 		);
+
+		await resumeTerminalAgentSession(deps, {
+			workspaceId: "ws-1",
+			terminalId: "t1",
+		});
+
+		expect(runCalls.map((call) => call.resumeSessionId)).toEqual(["sess-t1"]);
+	});
+
+	it("resumes an idle session when the harness store cannot be read", async () => {
+		const db = createTestDb();
+		// Unreadable or unsurveyed store: not evidence the conversation is
+		// gone, so the saved session id is kept rather than discarded.
+		seedResumableBinding(db, { lastEventType: "Attached" });
+		const { deps, runCalls } = createDeps(db, undefined, () => null);
 
 		await resumeTerminalAgentSession(deps, {
 			workspaceId: "ws-1",

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.test.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.test.ts
@@ -40,7 +40,11 @@ function createTestDb(): HostDb {
 
 function seedResumableBinding(
 	db: HostDb,
-	{ terminalId = "t1", resumeArgs = ["--resume"] } = {},
+	{
+		terminalId = "t1",
+		resumeArgs = ["--resume"],
+		lastEventType = "Stop" as "Stop" | "Attached",
+	} = {},
 ) {
 	db.insert(hostAgentConfigs)
 		.values({
@@ -69,7 +73,7 @@ function seedResumableBinding(
 			agentSessionId: `sess-${terminalId}`,
 			startedAt: 1,
 			lastEventAt: 2,
-			lastEventType: "Stop",
+			lastEventType,
 			endedAt: 3,
 			endReason: "terminal-exited",
 		})
@@ -85,6 +89,7 @@ interface DepsHarness {
 function createDeps(
 	db: HostDb,
 	runAgent?: ResumeSessionDeps["runAgent"],
+	hasSession: ResumeSessionDeps["hasSession"] = () => null,
 ): DepsHarness {
 	const runCalls: DepsHarness["runCalls"] = [];
 	const disposedTerminals: string[] = [];
@@ -106,6 +111,7 @@ function createDeps(
 			disposedTerminals.push(terminalId);
 			return Promise.resolve();
 		},
+		hasSession,
 	};
 	return { deps, runCalls, disposedTerminals };
 }
@@ -137,6 +143,63 @@ describe("resumeTerminalAgentSession", () => {
 		expect(disposedTerminals).toEqual(["t1"]);
 		// The candidate is consumed for good.
 		expect(findResumeCandidateBinding(db, "ws-1", "t1")).toBeUndefined();
+	});
+
+	it("launches a never-prompted session fresh instead of resuming into nothing", async () => {
+		const db = createTestDb();
+		seedResumableBinding(db, { lastEventType: "Attached" });
+		// Idle since SessionStart, no transcript on disk (or unknowable): a
+		// `--resume` would exit with "no conversation found".
+		const { deps, runCalls, disposedTerminals } = createDeps(
+			db,
+			undefined,
+			() => false,
+		);
+
+		const result = await resumeTerminalAgentSession(deps, {
+			workspaceId: "ws-1",
+			terminalId: "t1",
+		});
+
+		expect(result).toEqual({
+			resumed: true,
+			terminalId: "t-new",
+			label: "Claude",
+		});
+		expect(runCalls).toEqual([
+			{ workspaceId: "ws-1", agent: CLAUDE_CONFIG_ID, prompt: "" },
+		]);
+		expect(disposedTerminals).toEqual(["t1"]);
+	});
+
+	it("resumes an idle session when the harness still holds its conversation", async () => {
+		const db = createTestDb();
+		// A session restored earlier and left idle is "Attached" too, but its
+		// transcript exists — relaunching fresh would drop that conversation.
+		seedResumableBinding(db, { lastEventType: "Attached" });
+		const { deps, runCalls } = createDeps(db, undefined, (binding) =>
+			binding.agentSessionId === "sess-t1" ? true : null,
+		);
+
+		await resumeTerminalAgentSession(deps, {
+			workspaceId: "ws-1",
+			terminalId: "t1",
+		});
+
+		expect(runCalls.map((call) => call.resumeSessionId)).toEqual(["sess-t1"]);
+	});
+
+	it("never consults the harness store for a session past its first prompt", async () => {
+		const db = createTestDb();
+		seedResumableBinding(db);
+		const { deps, runCalls } = createDeps(db, undefined, () => false);
+
+		await resumeTerminalAgentSession(deps, {
+			workspaceId: "ws-1",
+			terminalId: "t1",
+		});
+
+		expect(runCalls.map((call) => call.resumeSessionId)).toEqual(["sess-t1"]);
 	});
 
 	it("is idempotent: a repeat call after success launches nothing", async () => {
@@ -317,8 +380,9 @@ describe("listAccountRestartCandidates", () => {
 		seedLiveBinding(db, { terminalId: "t-claude" });
 		// Other provider — a claude switch must not touch it.
 		seedLiveBinding(db, { terminalId: "t-codex", agentId: "codex" });
-		// No conversation captured yet: nothing to resume into.
+		// No session id captured: no way to name what to relaunch.
 		seedLiveBinding(db, { terminalId: "t-no-session", agentSessionId: null });
+		// Idle since launch — still on the old account, still restarted.
 		seedLiveBinding(db, {
 			terminalId: "t-attached",
 			lastEventType: "Attached",
@@ -331,11 +395,16 @@ describe("listAccountRestartCandidates", () => {
 		);
 
 		expect(
-			candidates.map(({ binding, agentLabel }) => ({
-				terminalId: binding.terminalId,
-				agentLabel,
-			})),
-		).toEqual([{ terminalId: "t-claude", agentLabel: "Claude" }]);
+			candidates
+				.map(({ binding, agentLabel }) => ({
+					terminalId: binding.terminalId,
+					agentLabel,
+				}))
+				.sort((a, b) => a.terminalId.localeCompare(b.terminalId)),
+		).toEqual([
+			{ terminalId: "t-attached", agentLabel: "Claude" },
+			{ terminalId: "t-claude", agentLabel: "Claude" },
+		]);
 	});
 
 	it("skips sessions whose config cannot resume", () => {

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
@@ -3,8 +3,11 @@ import {
 	BUILTIN_AGENT_IDS,
 } from "@superset/shared/agent-catalog";
 import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import type { HostDb } from "../../../db";
+import { workspaces } from "../../../db/schema";
+import { hasHarnessSession } from "../../../terminal/harness-transcript";
 import {
 	createTerminalSessionInternal,
 	disposeSessionAndWait,
@@ -27,6 +30,7 @@ import {
 	runAgentInWorkspace,
 } from "../agents/agents";
 import { toTerminalSessionError } from "../terminal/errors";
+import { resolveDefaultAccountEnv } from "../usage/default-account";
 
 type GetOrCreateResult = {
 	binding: TerminalAgentBinding;
@@ -51,12 +55,47 @@ export interface ResumeSessionDeps {
 		workspaceId: string;
 		agent: string;
 		prompt: string;
-		resumeSessionId: string;
+		resumeSessionId?: string;
 	}) => Promise<AgentRunResult>;
 	disposeSession: (terminalId: string) => Promise<unknown>;
+	/**
+	 * Whether the harness still holds a conversation for the binding's session
+	 * id (`null` = cannot tell). Consulted only for a session that never
+	 * progressed past "Attached".
+	 */
+	hasSession: (binding: TerminalAgentBinding) => boolean | null;
 }
 
 const resumeInflight = new Map<string, Promise<ResumeResult>>();
+
+/**
+ * Whether the harness behind `binding` still holds its conversation, read
+ * from the directory the relaunch will run under: the default account can
+ * have changed since the session started (that is what the account-switch
+ * restart is for), and session sharing makes the transcript reachable from
+ * the new profile too.
+ */
+function bindingHasHarnessSession(
+	db: HostDb,
+	binding: TerminalAgentBinding,
+): boolean | null {
+	const config = resolveHostAgentConfig(
+		db,
+		binding.definitionId ?? binding.agentId,
+	);
+	if (!config) return null;
+	const worktreePath = db
+		.select({ path: workspaces.worktreePath })
+		.from(workspaces)
+		.where(eq(workspaces.id, binding.workspaceId))
+		.get()?.path;
+	return hasHarnessSession({
+		agentId: config.presetId,
+		sessionId: binding.agentSessionId,
+		worktreePath,
+		env: { ...resolveDefaultAccountEnv(db, config.presetId), ...config.env },
+	});
+}
 
 /**
  * Idempotently resume the agent session behind a dead terminal into a fresh
@@ -66,6 +105,13 @@ const resumeInflight = new Map<string, Promise<ResumeResult>>();
  * one resumed session — later callers either share its result or get
  * `{ resumed: false }`. The dead terminal is disposed after a successful
  * launch; a failed launch un-claims the candidate so it can be retried.
+ *
+ * A session still at "Attached" started but was never prompted, and agents
+ * only persist a conversation once it has a message — unless the harness
+ * store proves one exists (a resumed session idle since its restore), the
+ * agent is launched fresh instead of `--resume`-ing into "no conversation
+ * found". Nothing is lost either way: the pane comes back as the same agent
+ * on the current default account.
  */
 export async function resumeTerminalAgentSession(
 	deps: ResumeSessionDeps,
@@ -95,13 +141,16 @@ export async function resumeTerminalAgentSession(
 			return { resumed: false };
 		}
 
+		const resumable =
+			claimed.lastEventType !== "Attached" || deps.hasSession(claimed) === true;
+
 		let result: AgentRunResult;
 		try {
 			result = await deps.runAgent({
 				workspaceId,
 				agent: config.id,
 				prompt: "",
-				resumeSessionId: claimed.agentSessionId,
+				...(resumable ? { resumeSessionId: claimed.agentSessionId } : {}),
 			});
 		} catch (error) {
 			unclaimResumeCandidateBinding(deps.db, terminalId);
@@ -136,10 +185,12 @@ export async function resumeTerminalAgentSession(
 /**
  * Live agent sessions a default-account switch cannot reach: their PTY env
  * was frozen at spawn, so they keep the old login until relaunched. A
- * session qualifies when its binding captured a resumable conversation
- * (session id present, progressed past attach) and its config both belongs
- * to `provider` — the presetId keying resolveDefaultAccountEnv — and knows
- * how to resume. Sessions that fail the bar are left running rather than
+ * session qualifies when its binding captured a session id and its config
+ * both belongs to `provider` — the presetId keying resolveDefaultAccountEnv —
+ * and knows how to resume. A session idle since it started ("Attached")
+ * counts: it is exactly the agent the user would otherwise have to close and
+ * relaunch by hand, and the resume path starts it fresh when it has no
+ * conversation yet. Sessions that fail the bar are left running rather than
  * killed without a way back.
  */
 export function listAccountRestartCandidates(
@@ -149,9 +200,7 @@ export function listAccountRestartCandidates(
 ): Array<{ binding: TerminalAgentBinding; agentLabel: string }> {
 	const out: Array<{ binding: TerminalAgentBinding; agentLabel: string }> = [];
 	for (const binding of store.list()) {
-		if (!binding.agentSessionId || binding.lastEventType === "Attached") {
-			continue;
-		}
+		if (!binding.agentSessionId) continue;
 		const config = resolveHostAgentConfig(
 			db,
 			binding.definitionId ?? binding.agentId,
@@ -173,12 +222,13 @@ export interface RestartAccountSessionsDeps {
  * Relaunch every live `provider` agent onto the current default account.
  * Each candidate terminal is killed the way a crash would kill it — the
  * binding is marked "terminal-exited", never "disposed" — so the standard
- * auto-resume path relaunches the agent with its saved session id, and the
- * agent wrapper re-resolves the account pointer at launch: same
- * conversation, new account. Marking ended precedes the dispose because the
- * renderer re-checks for a resume candidate on the socket close the dispose
- * causes; the store's own "change" event never reaches it. Panes that are
- * not open resume when their workspace is next viewed, like any other
+ * auto-resume path relaunches the agent with its saved session id (or fresh,
+ * for one that never got a prompt), and the agent wrapper re-resolves the
+ * account pointer at launch: same conversation, new account. Marking ended
+ * precedes the dispose because the renderer re-checks for a resume candidate
+ * on the socket close the dispose causes; the store's own "change" event
+ * never reaches it. Panes that are not open resume when their workspace is
+ * next viewed, like any other
  * dead-terminal candidate.
  */
 export async function restartAccountSessions(
@@ -308,6 +358,7 @@ export const terminalAgentsRouter = router({
 					runAgent: (runInput) => runAgentInWorkspace(ctx, runInput),
 					disposeSession: (terminalId) =>
 						disposeSessionAndWait(terminalId, ctx.db),
+					hasSession: (binding) => bindingHasHarnessSession(ctx.db, binding),
 				},
 				input,
 			),

--- a/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
+++ b/packages/host-service/src/trpc/router/terminal-agents/terminal-agents.ts
@@ -107,11 +107,12 @@ function bindingHasHarnessSession(
  * launch; a failed launch un-claims the candidate so it can be retried.
  *
  * A session still at "Attached" started but was never prompted, and agents
- * only persist a conversation once it has a message — unless the harness
- * store proves one exists (a resumed session idle since its restore), the
- * agent is launched fresh instead of `--resume`-ing into "no conversation
- * found". Nothing is lost either way: the pane comes back as the same agent
- * on the current default account.
+ * only persist a conversation once it has a message — when the harness store
+ * shows none, the agent is launched fresh instead of `--resume`-ing into "no
+ * conversation found". A store that does hold one (a resumed session idle
+ * since its restore) or cannot be read resumes as usual. Nothing is lost
+ * either way: the pane comes back as the same agent on the current default
+ * account.
  */
 export async function resumeTerminalAgentSession(
 	deps: ResumeSessionDeps,
@@ -141,8 +142,11 @@ export async function resumeTerminalAgentSession(
 			return { resumed: false };
 		}
 
+		// Only a definite "no transcript" launches fresh: an unreadable or
+		// unsurveyed store must not cost a restored conversation its history.
 		const resumable =
-			claimed.lastEventType !== "Attached" || deps.hasSession(claimed) === true;
+			claimed.lastEventType !== "Attached" ||
+			deps.hasSession(claimed) !== false;
 
 		let result: AgentRunResult;
 		try {


### PR DESCRIPTION
## Summary
- The Usage-tab account switch now restarts idle Claude/Codex agents too. Sessions whose last event was "Attached" (launched but never prompted, or just resumed) were skipped, so they kept the old account and, when every running agent was idle, the switch offered no restart dialog at all.
- The auto-resume path launches an "Attached" candidate fresh unless the harness store proves a transcript exists, instead of `--resume`-ing into "no conversation found".

## Why / Context
Claude's SessionStart hook maps to the "Attached" lifecycle state, and a session stays there until its first prompt. `listAccountRestartCandidates` and `resumeCandidatePredicate` both excluded that state because Claude only writes a transcript after the first message, so resuming an idle session would fail. The side effect was that idle agents were exactly the ones an account switch never reached, and every session a restart resumed landed back in "Attached", immune to the next switch.

## How It Works
- `resumeCandidatePredicate` no longer excludes "Attached".
- `resumeTerminalAgentSession` takes a `hasSession` dependency. For an "Attached" candidate it launches the agent without `resumeSessionId` only when the store definitely holds no transcript; a confirmed or unreadable store keeps the saved session id. Non-idle candidates resume as before without consulting the store.
- The router wires `hasSession` to `hasHarnessSession` using the launch env (default-account overlay plus per-agent env), so the check looks in the directory the relaunch will actually run under.
- `listAccountRestartCandidates` includes idle sessions that have a session id.

## Manual QA Checklist
Verified over CDP in the dev desktop app, real two-account switch between `~/.claude` and `~/.claude-work`:
- [x] Idle Claude pane on account A, switch default to B: restart dialog appears (count 1), confirm relaunches the same pane fresh as B (`/status` shows B).
- [x] After a prompt, switch back to A: pane resumes the same session id as A.
- [x] Switch to B again while the just-resumed session is idle ("Attached" with a transcript): pane resumes the same session id as B rather than restarting fresh.
- [x] Before the change, the first scenario showed only the "Relaunch running agents" toast with no dialog.

## Testing
- `bun test src/trpc/router/terminal-agents/terminal-agents.test.ts src/terminal-agents/persistence.test.ts src/terminal-agents/store.test.ts` in `packages/host-service` (new cases for fresh-launch, resume-with-transcript, resume-when-store-unreadable, and non-idle-never-consults-store)
- `bun run typecheck` in `packages/host-service`
- `bunx biome check` on the changed files

## Known Limitations
- Crash restore now brings a dead idle agent pane back as a fresh agent instead of a bare shell. Deliberate, but a behavior change outside the account switch.
- A session that is mid-turn but never delivered a hook event looks idle and gets restarted; its conversation resumes but the in-flight turn is lost. Sessions need working hooks to have a session id at all, so the window is narrow.
- The dialog copy still says every session "picks its conversation back up", which is not literally true for the idle ones. Left as is to avoid a 16-locale string change.

https://claude.ai/code/session_0147KrvF4qppuqKtKWsDYQx5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the account-switch restart so idle Claude/Codex agents are relaunched onto the new account. Idle sessions previously stayed on the old account and, when every running agent was idle, the switch offered no restart dialog; they now resume or start fresh depending on whether the harness still has their transcript.

- Crash restore now brings a dead idle agent pane back as a fresh agent instead of a bare shell.
- For harnesses whose session store can't be read (like `grok`), an idle session keeps its saved session id and resumes; only a definite missing transcript launches fresh.
- A session mid-turn that never delivered a hook event gets restarted, losing the in-flight turn.
- The restart dialog copy still says every session "picks its conversation back up", which isn't literally true for idle ones.

<sup>Written for commit 012a7240c4e4a48b0a15bb0ced56515767c8544d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal agent sessions that started but never received a prompt can now be selected for restart.
  - Sessions resume existing conversations when available, or launch fresh when no conversation can be restored.
  - Restart candidate lists now include attached sessions that have not yet been prompted.

- **Bug Fixes**
  - Improved terminal agent recovery to avoid failed resume attempts when sessions have no restorable conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
