### PR TITLE
fix(desktop,pty-daemon): reap wedged host-service children and bound pty pause

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -33,8 +33,8 @@ import {
 } from "main/lib/host-service-manifest";
 import { pollHealthCheck } from "main/lib/host-service-utils";
 import { env } from "./env";
+import { createShutdown } from "./shutdown";
 
-const SHUTDOWN_GRACE_MS = 3_000;
 const WATCHDOG_INTERVAL_MS = 2_000;
 const MANIFEST_RECLAIM_INTERVAL_MS = 15_000;
 
@@ -44,34 +44,24 @@ async function main(): Promise<void> {
 	initSentry({ organizationId: env.ORGANIZATION_ID });
 
 	// Install the parent watchdog before any awaits so a crash during
-	// startup can still reap this child. `serverRef` is filled in once
-	// serve() returns; shutdown handles both pre- and post-bind states.
+	// startup can still reap this child. `serverRef` / `disposeRef` are filled
+	// in once serve() / createApp() return; shutdown handles both pre- and
+	// post-bind states. Sequencing lives in ./shutdown.ts — see there for why
+	// a plain process.exit() could leave this child orphaned forever.
 	const serverRef: { current: Server | null } = { current: null };
-	let shuttingDown = false;
-	let manifestReclaimTimer: NodeJS.Timeout | null = null;
-	const shutdown = (reason: string) => {
-		if (shuttingDown) return;
-		shuttingDown = true;
-		// A reclaim tick during the drain window would resurrect the manifest
-		// the coordinator just removed, leaving it naming a dead pid.
-		if (manifestReclaimTimer) clearInterval(manifestReclaimTimer);
-		console.log(`[host-service] shutdown (${reason}), draining connections`);
-		const server = serverRef.current;
-		if (!server) {
-			process.exit(0);
-		}
-		server.close();
-		// SSE/WS streams (chat, watchers) ignore server.close() — give in-flight
-		// HTTP a brief window, then forcibly tear sockets down.
-		const forceExit = setTimeout(() => {
-			const httpServer = server as unknown as {
-				closeAllConnections?: () => void;
-			};
-			httpServer.closeAllConnections?.();
-			process.exit(0);
-		}, SHUTDOWN_GRACE_MS);
-		forceExit.unref();
+	const disposeRef: { current: (() => Promise<void>) | null } = {
+		current: null,
 	};
+	let manifestReclaimTimer: NodeJS.Timeout | null = null;
+	const shutdown = createShutdown({
+		getServer: () => serverRef.current,
+		getDispose: () => disposeRef.current,
+		clearReclaimTimer: () => {
+			if (manifestReclaimTimer) clearInterval(manifestReclaimTimer);
+		},
+		exit: (code) => process.exit(code),
+		hardExit: () => process.kill(process.pid, "SIGKILL"),
+	});
 
 	process.on("SIGTERM", () => shutdown("SIGTERM"));
 	process.on("SIGINT", () => shutdown("SIGINT"));
@@ -105,7 +95,7 @@ async function main(): Promise<void> {
 		apiUrl: env.SUPERSET_API_URL,
 	});
 
-	const { app, injectWebSocket, api, db } = createApp({
+	const { app, injectWebSocket, api, db, dispose } = createApp({
 		config: {
 			organizationId: env.ORGANIZATION_ID,
 			dbPath: env.HOST_DB_PATH,
@@ -123,6 +113,7 @@ async function main(): Promise<void> {
 			credentials: new LocalGitCredentialProvider(),
 		},
 	});
+	disposeRef.current = dispose;
 
 	const startedAt = Date.now();
 	const server = serve(

--- a/apps/desktop/src/main/host-service/shutdown.test.ts
+++ b/apps/desktop/src/main/host-service/shutdown.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	createShutdown,
+	DISPOSE_TIMEOUT_MS,
+	SHUTDOWN_GRACE_MS,
+	type ShutdownDeps,
+	type ShutdownServer,
+} from "./shutdown";
+
+interface Timer {
+	callback: () => void;
+	delayMs: number;
+	cancelled: boolean;
+}
+
+interface Harness {
+	shutdown: (reason: string) => void;
+	server: ShutdownServer & {
+		close: ReturnType<typeof mock>;
+		closeAllConnections: ReturnType<typeof mock>;
+	};
+	exit: ReturnType<typeof mock>;
+	hardExit: ReturnType<typeof mock>;
+	clearReclaimTimer: ReturnType<typeof mock>;
+	timers: Timer[];
+	logs: string[];
+	/** Run the next pending timer (the grace window, then the dispose deadline). */
+	fireNextTimer(): Timer;
+	/** Let the dispose promise's continuations run. */
+	settle(): Promise<void>;
+}
+
+function createHarness(
+	overrides: Partial<ShutdownDeps> & {
+		dispose?: (() => Promise<void>) | null;
+		hasServer?: boolean;
+	} = {},
+): Harness {
+	const {
+		dispose = async () => {},
+		hasServer = true,
+		...depOverrides
+	} = overrides;
+	const server = {
+		close: mock(() => {}),
+		closeAllConnections: mock(() => {}),
+	};
+	const exit = mock((_code: number) => {});
+	const hardExit = mock(() => {});
+	const clearReclaimTimer = mock(() => {});
+	const timers: Timer[] = [];
+	const logs: string[] = [];
+
+	const shutdown = createShutdown({
+		getServer: () => (hasServer ? server : null),
+		getDispose: () => dispose,
+		clearReclaimTimer,
+		exit,
+		hardExit,
+		scheduleTimer: (callback, delayMs) => {
+			const timer: Timer = { callback, delayMs, cancelled: false };
+			timers.push(timer);
+			return () => {
+				timer.cancelled = true;
+			};
+		},
+		log: (message) => logs.push(message),
+		...depOverrides,
+	});
+
+	return {
+		shutdown,
+		server,
+		exit,
+		hardExit,
+		clearReclaimTimer,
+		timers,
+		logs,
+		fireNextTimer() {
+			const next = timers.find((t) => !t.cancelled && !("fired" in t));
+			if (!next) throw new Error("no pending timer");
+			Object.assign(next, { fired: true });
+			next.callback();
+			return next;
+		},
+		async settle() {
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+		},
+	};
+}
+
+describe("createShutdown", () => {
+	test("exits immediately when the server never bound", () => {
+		const h = createHarness({ hasServer: false });
+
+		h.shutdown("SIGTERM");
+
+		expect(h.clearReclaimTimer).toHaveBeenCalledTimes(1);
+		expect(h.exit).toHaveBeenCalledWith(0);
+		expect(h.hardExit).not.toHaveBeenCalled();
+		expect(h.timers).toHaveLength(0);
+	});
+
+	test("closes the server, then after the grace tears sockets down, disposes and exits 0", async () => {
+		const dispose = mock(async () => {});
+		const h = createHarness({ dispose });
+
+		h.shutdown("SIGTERM");
+
+		expect(h.clearReclaimTimer).toHaveBeenCalledTimes(1);
+		expect(h.server.close).toHaveBeenCalledTimes(1);
+		expect(h.server.closeAllConnections).not.toHaveBeenCalled();
+		expect(h.exit).not.toHaveBeenCalled();
+
+		const grace = h.fireNextTimer();
+		expect(grace.delayMs).toBe(SHUTDOWN_GRACE_MS);
+		expect(h.server.closeAllConnections).toHaveBeenCalledTimes(1);
+		expect(dispose).toHaveBeenCalledTimes(1);
+
+		await h.settle();
+		expect(h.exit).toHaveBeenCalledWith(0);
+		expect(h.hardExit).not.toHaveBeenCalled();
+		// The dispose deadline was armed and then cancelled by the resolve.
+		const deadline = h.timers[1];
+		expect(deadline?.delayMs).toBe(DISPOSE_TIMEOUT_MS);
+		expect(deadline?.cancelled).toBe(true);
+		expect(h.logs.at(-1)).toContain("shutdown complete");
+	});
+
+	test("hard-exits when dispose never resolves (wedged worker)", async () => {
+		const h = createHarness({ dispose: () => new Promise<void>(() => {}) });
+
+		h.shutdown("parent-exit");
+		h.fireNextTimer();
+		await h.settle();
+		expect(h.exit).not.toHaveBeenCalled();
+
+		const deadline = h.fireNextTimer();
+		expect(deadline.delayMs).toBe(DISPOSE_TIMEOUT_MS);
+		expect(h.hardExit).toHaveBeenCalledTimes(1);
+		expect(h.exit).not.toHaveBeenCalled();
+		expect(h.logs.at(-1)).toContain("hard-exiting");
+	});
+
+	test("a dispose that resolves after the deadline does not exit twice", async () => {
+		let resolveDispose: () => void = () => {};
+		const h = createHarness({
+			dispose: () =>
+				new Promise<void>((resolve) => {
+					resolveDispose = resolve;
+				}),
+		});
+
+		h.shutdown("SIGTERM");
+		h.fireNextTimer();
+		h.fireNextTimer();
+		expect(h.hardExit).toHaveBeenCalledTimes(1);
+
+		resolveDispose();
+		await h.settle();
+		expect(h.exit).not.toHaveBeenCalled();
+	});
+
+	test("a rejected dispose still exits 0 instead of hanging", async () => {
+		const h = createHarness({
+			dispose: async () => {
+				throw new Error("db already closed");
+			},
+		});
+
+		h.shutdown("SIGINT");
+		h.fireNextTimer();
+		await h.settle();
+
+		expect(h.exit).toHaveBeenCalledWith(0);
+		expect(h.hardExit).not.toHaveBeenCalled();
+		expect(h.logs.some((l) => l.includes("dispose failed"))).toBe(true);
+	});
+
+	test("exits 0 after the grace when createApp has not run yet", () => {
+		const h = createHarness({ dispose: null });
+
+		h.shutdown("SIGTERM");
+		h.fireNextTimer();
+
+		expect(h.server.closeAllConnections).toHaveBeenCalledTimes(1);
+		expect(h.exit).toHaveBeenCalledWith(0);
+		expect(h.timers).toHaveLength(1);
+	});
+
+	test("a second signal while shutting down hard-exits immediately", () => {
+		const h = createHarness({ dispose: () => new Promise<void>(() => {}) });
+
+		h.shutdown("SIGTERM");
+		h.shutdown("SIGTERM");
+
+		expect(h.hardExit).toHaveBeenCalledTimes(1);
+		expect(h.server.close).toHaveBeenCalledTimes(1);
+		expect(h.clearReclaimTimer).toHaveBeenCalledTimes(1);
+		expect(h.exit).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/main/host-service/shutdown.test.ts
+++ b/apps/desktop/src/main/host-service/shutdown.test.ts
@@ -92,8 +92,8 @@ function createHarness(
 }
 
 describe("createShutdown", () => {
-	test("exits immediately when the server never bound", () => {
-		const h = createHarness({ hasServer: false });
+	test("exits 0 without a drain window when the server never bound and there is nothing to dispose", () => {
+		const h = createHarness({ hasServer: false, dispose: null });
 
 		h.shutdown("SIGTERM");
 
@@ -101,6 +101,35 @@ describe("createShutdown", () => {
 		expect(h.exit).toHaveBeenCalledWith(0);
 		expect(h.hardExit).not.toHaveBeenCalled();
 		expect(h.timers).toHaveLength(0);
+	});
+
+	test("server never bound but createApp ran: disposes under the deadline, no drain window", async () => {
+		const dispose = mock(async () => {});
+		const h = createHarness({ hasServer: false, dispose });
+
+		h.shutdown("SIGTERM");
+		expect(dispose).toHaveBeenCalledTimes(1);
+		expect(h.server.close).not.toHaveBeenCalled();
+		expect(h.timers).toHaveLength(1);
+		expect(h.timers[0]?.delayMs).toBe(DISPOSE_TIMEOUT_MS);
+
+		await h.settle();
+		expect(h.exit).toHaveBeenCalledWith(0);
+		expect(h.hardExit).not.toHaveBeenCalled();
+	});
+
+	test("server never bound and dispose wedged: hard-exits at the deadline", async () => {
+		const h = createHarness({
+			hasServer: false,
+			dispose: () => new Promise<void>(() => {}),
+		});
+
+		h.shutdown("SIGTERM");
+		await h.settle();
+		expect(h.exit).not.toHaveBeenCalled();
+
+		h.fireNextTimer();
+		expect(h.hardExit).toHaveBeenCalledTimes(1);
 	});
 
 	test("closes the server, then after the grace tears sockets down, disposes and exits 0", async () => {

--- a/apps/desktop/src/main/host-service/shutdown.ts
+++ b/apps/desktop/src/main/host-service/shutdown.ts
@@ -115,7 +115,10 @@ export function createShutdown(deps: ShutdownDeps): (reason: string) => void {
 		log(`[host-service] shutdown (${reason}), draining connections`);
 		const server = getServer();
 		if (!server) {
-			exit(0);
+			// Nothing listening yet, so there is nothing to drain. Workers may
+			// already exist though (createApp() runs before serve()), so exit
+			// through the same bounded dispose rather than a bare process.exit().
+			disposeThenExit();
 			return;
 		}
 		server.close();

--- a/apps/desktop/src/main/host-service/shutdown.ts
+++ b/apps/desktop/src/main/host-service/shutdown.ts
@@ -1,0 +1,127 @@
+/**
+ * Shutdown sequencing for the host-service child.
+ *
+ * Extracted from `index.ts` (which boots Sentry, the DB and the HTTP server at
+ * import time) so the wedged-worker path can be exercised in a unit test.
+ *
+ * Why this exists: on a Squirrel.Mac auto-update the Electron parent quits
+ * seconds after `before-quit`, so the child is left to terminate itself. The
+ * old sequence ended in `process.exit(0)`, which joins every `worker_threads`
+ * Worker before the process can die. A host-worker wedged in native code (a
+ * hung `spawnSync` git, a long SQLite call) blocks that join forever, and the
+ * child becomes a PPID-1 orphan pinned at ~100% CPU that ignores every further
+ * SIGTERM. Its open pty-daemon socket then freezes terminals for the live
+ * host-service too. The fix: dispose the app under a deadline, and past it
+ * hard-exit with a kernel-delivered SIGKILL that needs no cooperation from V8.
+ */
+
+/** In-flight HTTP gets this long to finish before sockets are torn down. */
+export const SHUTDOWN_GRACE_MS = 3_000;
+
+/** How long `dispose()` (workers, SQLite, watchers) may take before SIGKILL. */
+export const DISPOSE_TIMEOUT_MS = 2_000;
+
+export interface ShutdownServer {
+	close: () => unknown;
+	/** SSE/WS streams ignore `close()`; this tears them down. */
+	closeAllConnections?: () => void;
+}
+
+export interface ShutdownDeps {
+	/** Null before `serve()` has returned; shutdown then just exits. */
+	getServer: () => ShutdownServer | null;
+	/** Null before `createApp()` has run; nothing to dispose yet. */
+	getDispose: () => (() => Promise<void>) | null;
+	/**
+	 * A reclaim tick during the drain window would resurrect the manifest the
+	 * coordinator just removed, leaving it naming a dead pid.
+	 */
+	clearReclaimTimer: () => void;
+	exit: (code: number) => void;
+	/** Kernel-level self-kill for when Node's own exit path would hang. */
+	hardExit: () => void;
+	/** Returns a cancel function. Production wraps an unref'd `setTimeout`. */
+	scheduleTimer?: (callback: () => void, delayMs: number) => () => void;
+	log?: (message: string) => void;
+	graceMs?: number;
+	disposeTimeoutMs?: number;
+}
+
+export function createShutdown(deps: ShutdownDeps): (reason: string) => void {
+	const {
+		getServer,
+		getDispose,
+		clearReclaimTimer,
+		exit,
+		hardExit,
+		scheduleTimer = (callback, delayMs) => {
+			const timer = setTimeout(callback, delayMs);
+			timer.unref();
+			return () => clearTimeout(timer);
+		},
+		log = (message) => console.log(message),
+		graceMs = SHUTDOWN_GRACE_MS,
+		disposeTimeoutMs = DISPOSE_TIMEOUT_MS,
+	} = deps;
+
+	let shuttingDown = false;
+
+	const disposeThenExit = () => {
+		const dispose = getDispose();
+		if (!dispose) {
+			exit(0);
+			return;
+		}
+		let settled = false;
+		const cancelDeadline = scheduleTimer(() => {
+			if (settled) return;
+			settled = true;
+			log(
+				`[host-service] dispose did not finish within ${disposeTimeoutMs}ms (worker wedged?); hard-exiting`,
+			);
+			hardExit();
+		}, disposeTimeoutMs);
+		dispose().then(
+			() => {
+				if (settled) return;
+				settled = true;
+				cancelDeadline();
+				log("[host-service] shutdown complete");
+				exit(0);
+			},
+			(error: unknown) => {
+				if (settled) return;
+				settled = true;
+				cancelDeadline();
+				log(`[host-service] dispose failed: ${String(error)}`);
+				exit(0);
+			},
+		);
+	};
+
+	return (reason: string) => {
+		if (shuttingDown) {
+			// A repeat signal means whoever is waiting on us has run out of
+			// patience (the coordinator's SIGKILL escalation, or a human with
+			// `kill`). Ignoring it is how the orphan stayed alive for hours.
+			log(
+				`[host-service] shutdown (${reason}) while already shutting down; hard-exiting`,
+			);
+			hardExit();
+			return;
+		}
+		shuttingDown = true;
+		clearReclaimTimer();
+		log(`[host-service] shutdown (${reason}), draining connections`);
+		const server = getServer();
+		if (!server) {
+			exit(0);
+			return;
+		}
+		server.close();
+		scheduleTimer(() => {
+			server.closeAllConnections?.();
+			disposeThenExit();
+		}, graceMs);
+	};
+}

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -581,9 +581,9 @@ describe("HostServiceCoordinator single-flight / adoption", () => {
 	): void {
 		(
 			coordinator as unknown as {
-				inspectProcess: (pid: number) => typeof identity;
+				inspectProcess: (pid: number) => Promise<typeof identity>;
 			}
-		).inspectProcess = () => identity;
+		).inspectProcess = async () => identity;
 	}
 
 	test("reaps an alive-but-unhealthy manifest holder started this boot before spawning", async () => {

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -571,6 +571,64 @@ describe("HostServiceCoordinator single-flight / adoption", () => {
 		expect(conn.port).toBe(60000);
 	});
 
+	test("reaps an alive-but-unhealthy manifest holder started this boot before spawning", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now(),
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => true);
+
+		const conn = await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toEqual([{ pid: 4321, signal: "SIGKILL" }]);
+		expect(removeManifestMock).toHaveBeenCalled();
+		expect(manifestStore.current).toBeNull();
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+		expect(conn.port).toBe(60000);
+	});
+
+	test("does not reap a manifest holder whose pid is dead", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now(),
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => false);
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toHaveLength(0);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not reap a manifest holder whose startedAt predates this boot (recycled pid)", async () => {
+		// baseManifest's startedAt is 0: older than any boot.
+		manifestStore.current = baseManifest(4321, "http://127.0.0.1:55555");
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => true);
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toHaveLength(0);
+		expect(removeManifestMock).not.toHaveBeenCalled();
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not reap a healthy manifest holder (adopts it instead)", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now(),
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(true));
+
+		const conn = await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toHaveLength(0);
+		expect(spawnMock).not.toHaveBeenCalled();
+		expect(conn.port).toBe(55555);
+	});
+
 	test("under-lock double-check adopts a manifest that appears after the first miss", async () => {
 		manifestStore.current = baseManifest(4321, "http://127.0.0.1:55555");
 		// Outer adopt attempt sees nothing; the re-check under the lock does.
@@ -1035,6 +1093,112 @@ describe("HostServiceCoordinator.stop manifest ownership", () => {
 
 		expect(removeManifestMock).toHaveBeenCalled();
 		expect(manifestStore.current).toBeNull();
+	});
+});
+
+describe("HostServiceCoordinator.stop SIGKILL escalation", () => {
+	let coordinator: InstanceType<typeof HostServiceCoordinator>;
+	let internals: {
+		instances: Map<string, unknown>;
+		handleChildExit(
+			organizationId: string,
+			childPid: number,
+			code: number | null,
+			signal: NodeJS.Signals | null,
+		): void;
+	};
+	let pendingTimers: Array<{ run: () => void; delayMs: number }>;
+
+	function trackOwned(pid: number): void {
+		internals.instances.set("org-1", {
+			pid,
+			port: 55555,
+			secret: "secret",
+			status: "running",
+			spawnedAt: Date.now(),
+			outputTail: "",
+			redactions: ["secret"],
+			owned: true,
+		});
+	}
+
+	beforeEach(() => {
+		resetMocks();
+		testManifestRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hsc-test-"));
+		coordinator = new HostServiceCoordinator();
+		internals = coordinator as unknown as typeof internals;
+		pendingTimers = [];
+		(
+			coordinator as unknown as {
+				scheduleRespawnTimer: (
+					run: () => void,
+					delayMs: number,
+				) => ReturnType<typeof setTimeout>;
+			}
+		).scheduleRespawnTimer = (run, delayMs) => {
+			pendingTimers.push({ run, delayMs });
+			return { unref() {} } as unknown as ReturnType<typeof setTimeout>;
+		};
+	});
+
+	afterEach(() => {
+		coordinator.stopAll();
+		if (testManifestRoot) {
+			fs.rmSync(testManifestRoot, { recursive: true, force: true });
+			testManifestRoot = "";
+		}
+	});
+
+	test("escalates to SIGKILL when the child is still alive after the grace", () => {
+		trackOwned(4242);
+
+		coordinator.stop("org-1");
+
+		expect(killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+		expect(pendingTimers).toHaveLength(1);
+		expect(pendingTimers[0]?.delayMs).toBeGreaterThan(0);
+
+		pendingTimers[0]?.run();
+
+		expect(killedPids).toEqual([
+			{ pid: 4242, signal: "SIGTERM" },
+			{ pid: 4242, signal: "SIGKILL" },
+		]);
+	});
+
+	test("does not SIGKILL when the child exited before the grace elapsed", () => {
+		trackOwned(4242);
+
+		coordinator.stop("org-1");
+		internals.handleChildExit("org-1", 4242, 0, null);
+		pendingTimers[0]?.run();
+
+		expect(killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+	});
+
+	test("does not SIGKILL a pid that is already gone when the grace elapses", () => {
+		trackOwned(4242);
+
+		coordinator.stop("org-1");
+		isProcessAliveMock.mockImplementation(() => false);
+		pendingTimers[0]?.run();
+
+		expect(killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+	});
+
+	test("never schedules an escalation for an adopted (foreign) child", () => {
+		internals.instances.set("org-1", {
+			pid: 4321,
+			port: 55555,
+			secret: "manifest-secret",
+			status: "running",
+			owned: false,
+		});
+
+		coordinator.stop("org-1");
+
+		expect(killedPids).toHaveLength(0);
+		expect(pendingTimers).toHaveLength(0);
 	});
 });
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -571,13 +571,30 @@ describe("HostServiceCoordinator single-flight / adoption", () => {
 		expect(conn.port).toBe(60000);
 	});
 
+	/** A live process that looks like the host-service that wrote the manifest. */
+	function stubHolderIdentity(
+		identity: { elapsedMs: number; command: string } | null = {
+			elapsedMs: 30_000,
+			command:
+				"/Applications/Superset.app/Contents/MacOS/Superset /app/host-service.js",
+		},
+	): void {
+		(
+			coordinator as unknown as {
+				inspectProcess: (pid: number) => typeof identity;
+			}
+		).inspectProcess = () => identity;
+	}
+
 	test("reaps an alive-but-unhealthy manifest holder started this boot before spawning", async () => {
 		manifestStore.current = {
 			...baseManifest(4321, "http://127.0.0.1:55555"),
-			startedAt: Date.now(),
+			startedAt: Date.now() - 20_000,
 		};
 		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
-		isProcessAliveMock.mockImplementation(() => true);
+		// Alive until SIGKILLed, so the post-kill wait returns promptly.
+		isProcessAliveMock.mockImplementation(() => killedPids.length === 0);
+		stubHolderIdentity();
 
 		const conn = await coordinator.start("org-1", spawnConfig);
 
@@ -586,6 +603,90 @@ describe("HostServiceCoordinator single-flight / adoption", () => {
 		expect(manifestStore.current).toBeNull();
 		expect(spawnMock).toHaveBeenCalledTimes(1);
 		expect(conn.port).toBe(60000);
+	});
+
+	test("reap leaves a manifest another instance claimed after the kill", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now() - 20_000,
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => killedPids.length === 0);
+		stubHolderIdentity();
+		killProcessMock.mockImplementationOnce((pid, signal) => {
+			killedPids.push({ pid, signal });
+			// A peer claims the manifest between our kill and our removal.
+			manifestStore.current = baseManifest(9999, "http://127.0.0.1:55556");
+		});
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(removeManifestMock).not.toHaveBeenCalled();
+		expect(manifestStore.current?.pid).toBe(9999);
+	});
+
+	test("does not reap when the live pid is not a host-service (same-boot pid recycling)", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now() - 20_000,
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => true);
+		stubHolderIdentity({ elapsedMs: 5_000, command: "/usr/bin/vim notes.md" });
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toHaveLength(0);
+		expect(removeManifestMock).not.toHaveBeenCalled();
+		expect(spawnMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("does not reap a host-service that started after the manifest was written (recycled onto another host-service)", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now() - 30 * 60_000,
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => true);
+		// Started 10 s ago; the manifest is 30 min old.
+		stubHolderIdentity({
+			elapsedMs: 10_000,
+			command:
+				"/Applications/Superset.app/Contents/MacOS/Superset /app/host-service.js",
+		});
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toHaveLength(0);
+	});
+
+	test("does not reap when the pid cannot be inspected", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "http://127.0.0.1:55555"),
+			startedAt: Date.now() - 20_000,
+		};
+		pollHealthCheckMock.mockImplementation(() => Promise.resolve(false));
+		isProcessAliveMock.mockImplementation(() => true);
+		stubHolderIdentity(null);
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(killedPids).toHaveLength(0);
+	});
+
+	test("does not reap a manifest whose endpoint was never probed (unparsable)", async () => {
+		manifestStore.current = {
+			...baseManifest(4321, "not a url"),
+			startedAt: Date.now() - 20_000,
+		};
+		isProcessAliveMock.mockImplementation(() => true);
+		stubHolderIdentity();
+
+		await coordinator.start("org-1", spawnConfig);
+
+		expect(pollHealthCheckMock).not.toHaveBeenCalled();
+		expect(killedPids).toHaveLength(0);
+		expect(spawnMock).toHaveBeenCalledTimes(1);
 	});
 
 	test("does not reap a manifest holder whose pid is dead", async () => {
@@ -1199,6 +1300,17 @@ describe("HostServiceCoordinator.stop SIGKILL escalation", () => {
 
 		expect(killedPids).toHaveLength(0);
 		expect(pendingTimers).toHaveLength(0);
+	});
+});
+
+describe("parseEtime", () => {
+	test("parses ps's [[dd-]hh:]mm:ss elapsed column", async () => {
+		const { parseEtime } = await import("./host-service-coordinator");
+		expect(parseEtime("00:05")).toBe(5_000);
+		expect(parseEtime("01:02:03")).toBe((3600 + 120 + 3) * 1000);
+		expect(parseEtime("2-01:02:03")).toBe((2 * 86400 + 3600 + 120 + 3) * 1000);
+		expect(parseEtime("garbage")).toBeNull();
+		expect(parseEtime("")).toBeNull();
 	});
 });
 

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -186,15 +186,22 @@ function getStablePortForOrganization(organizationId: string): number {
  * for a pid that is gone, or for output we cannot parse; callers treat null
  * as "unknown", never as "safe to kill".
  */
-function inspectProcessWithPs(pid: number): ProcessIdentity | null {
+async function inspectProcessWithPs(
+	pid: number,
+): Promise<ProcessIdentity | null> {
 	if (process.platform === "win32") return null;
-	const result = childProcess.spawnSync(
-		"ps",
-		["-o", "etime=,command=", "-p", String(pid)],
-		{ encoding: "utf8", timeout: 2_000 },
-	);
-	if (result.status !== 0) return null;
-	const line = result.stdout.trim().split("\n")[0]?.trim();
+	// Async on purpose: a synchronous subprocess here would stall the whole
+	// main process (every IPC reply queues behind it) for as long as `ps` takes.
+	const stdout = await new Promise<string | null>((resolve) => {
+		childProcess.execFile(
+			"ps",
+			["-o", "etime=,command=", "-p", String(pid)],
+			{ encoding: "utf8", timeout: 2_000 },
+			(error, out) => resolve(error ? null : out),
+		);
+	});
+	if (stdout == null) return null;
+	const line = stdout.trim().split("\n")[0]?.trim();
 	const match = line ? /^(\S+)\s+(.*)$/.exec(line) : null;
 	if (!match) return null;
 	const elapsedMs = parseEtime(match[1] ?? "");
@@ -261,7 +268,7 @@ export class HostServiceCoordinator extends EventEmitter {
 	 * Seam for the startup reap's identity check. Production shells out to
 	 * `ps`; tests hand back a canned identity for their fake pids.
 	 */
-	private inspectProcess: (pid: number) => ProcessIdentity | null =
+	private inspectProcess: (pid: number) => Promise<ProcessIdentity | null> =
 		inspectProcessWithPs;
 
 	/**
@@ -1314,7 +1321,7 @@ export class HostServiceCoordinator extends EventEmitter {
 		const bootedAt = Date.now() - os.uptime() * 1000;
 		if (manifest.startedAt < bootedAt) return;
 
-		const identity = this.inspectProcess(manifest.pid);
+		const identity = await this.inspectProcess(manifest.pid);
 		const processStartedAt =
 			identity == null ? null : Date.now() - identity.elapsedMs;
 		const looksLikeHolder =

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -2,6 +2,7 @@ import * as childProcess from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import path from "node:path";
 import { i18n } from "@superset/i18n";
 import { organizations, settings } from "@superset/local-db";
@@ -116,6 +117,14 @@ const START_OR_ADOPT_DEADLINE_MS = SPAWN_LOCK_STALE_MS + HEALTH_POLL_TIMEOUT_MS;
 const ADOPT_WAIT_INTERVAL_MS = 250;
 
 /**
+ * How long a SIGTERMed child gets to exit on its own before SIGKILL. The
+ * child's own shutdown budget (grace + dispose deadline in
+ * `host-service/shutdown.ts`) is ~5s, so this only fires for a child whose
+ * signal handler never ran at all.
+ */
+const STOP_KILL_ESCALATION_MS = 5_000;
+
+/**
  * A Node abort dumps ~5KB of native + JS backtrace on the way down, so a
  * smaller window would evict the assertion line and every app log before it.
  */
@@ -178,6 +187,12 @@ export class HostServiceCoordinator extends EventEmitter {
 	private devReloadWatcher: fs.FSWatcher | null = null;
 	private respawns = new Map<string, RespawnState>();
 	private desiredOrganizationIds = new Set<string>();
+	/**
+	 * SIGKILL escalations pending for SIGTERMed children, by pid. Cancelled by
+	 * `handleChildExit` so a pid the kernel has since recycled is never
+	 * signalled.
+	 */
+	private killEscalations = new Map<number, ReturnType<typeof setTimeout>>();
 	private startGeneration = 0;
 	private configProvider: (() => Promise<SpawnConfig | null>) | null = null;
 	/**
@@ -333,7 +348,10 @@ export class HostServiceCoordinator extends EventEmitter {
 		// drop our local reference below; never SIGTERM it or remove its manifest.
 		if (instance.owned) {
 			try {
-				if (instance.pid > 0) killProcess(instance.pid, "SIGTERM");
+				if (instance.pid > 0) {
+					killProcess(instance.pid, "SIGTERM");
+					this.scheduleKillEscalation(organizationId, instance.pid);
+				}
 			} catch {}
 			this.removeManifestIfHeldBy(organizationId, instance.pid);
 		}
@@ -628,6 +646,7 @@ export class HostServiceCoordinator extends EventEmitter {
 					// attempt and taking the lock — re-check before spawning.
 					const raced = await this.tryAdopt(organizationId, isStartAllowed);
 					if (raced) return raced;
+					this.reapWedgedManifestHolder(organizationId);
 					return await this.spawn(
 						organizationId,
 						config,
@@ -971,8 +990,9 @@ export class HostServiceCoordinator extends EventEmitter {
 		signal: NodeJS.Signals | null,
 	): void {
 		log.info(
-			`[host-service:${organizationId}] exited with code ${code} signal ${signal}`,
+			`[host-service:${organizationId}] pid=${childPid} exited with code ${code} signal ${signal}`,
 		);
+		this.cancelKillEscalation(childPid);
 		const current = this.instances.get(organizationId);
 		if (!current || current.pid !== childPid || current.status === "stopped")
 			return;
@@ -1163,6 +1183,75 @@ export class HostServiceCoordinator extends EventEmitter {
 		if (state.timer) clearTimeout(state.timer);
 		if (state.stableTimer) clearTimeout(state.stableTimer);
 		this.respawns.delete(organizationId);
+	}
+
+	/**
+	 * SIGTERM is a request the child can fail to honour: a host-worker wedged
+	 * in native code leaves `process.exit()` blocked joining it, and the child
+	 * then ignores every later SIGTERM. Follow up with SIGKILL after a grace.
+	 * Unref'd on purpose: on quit the parent must not wait around for this,
+	 * and the startup reap in `reapWedgedManifestHolder` covers a child that
+	 * outlives us.
+	 */
+	private scheduleKillEscalation(organizationId: string, pid: number): void {
+		this.cancelKillEscalation(pid);
+		const timer = this.scheduleRespawnTimer(() => {
+			// A cancelled escalation (the child exited, `handleChildExit` ran) is
+			// no longer the registered one; never signal a pid we know is gone.
+			if (this.killEscalations.get(pid) !== timer) return;
+			this.killEscalations.delete(pid);
+			if (!isProcessAlive(pid)) return;
+			log.warn(
+				`[host-service:${organizationId}] pid=${pid} still alive ${STOP_KILL_ESCALATION_MS}ms after SIGTERM; escalating to SIGKILL`,
+			);
+			try {
+				killProcess(pid, "SIGKILL");
+			} catch (error) {
+				log.warn(
+					`[host-service:${organizationId}] SIGKILL of pid=${pid} failed`,
+					error,
+				);
+			}
+		}, STOP_KILL_ESCALATION_MS);
+		timer.unref?.();
+		this.killEscalations.set(pid, timer);
+	}
+
+	private cancelKillEscalation(pid: number): void {
+		const timer = this.killEscalations.get(pid);
+		if (!timer) return;
+		clearTimeout(timer);
+		this.killEscalations.delete(pid);
+	}
+
+	/**
+	 * Kill a manifest holder that is alive but failed the adopt health probe
+	 * before spawning beside it. That holder is a wedged host-service: in
+	 * practice an orphan of a Squirrel auto-update relaunch whose exit hung
+	 * joining a stuck worker. Left alone it keeps the port (the replacement
+	 * ends up on a fallback port) and its pty-daemon subscriptions, which
+	 * freezes those terminals for the replacement too. Runs under the spawn
+	 * lock, right after the under-lock adopt miss, so the probe verdict is
+	 * fresh. A pid started before this boot is skipped: pids recycle across
+	 * reboots, and a pre-boot `startedAt` can name any process at all.
+	 */
+	private reapWedgedManifestHolder(organizationId: string): void {
+		const manifest = readManifest(organizationId);
+		if (!manifest || !isProcessAlive(manifest.pid)) return;
+		const bootedAt = Date.now() - os.uptime() * 1000;
+		if (manifest.startedAt < bootedAt) return;
+		log.warn(
+			`[host-service:${organizationId}] manifest pid=${manifest.pid} at ${manifest.endpoint} is alive but unhealthy; SIGKILLing it before spawning`,
+		);
+		try {
+			killProcess(manifest.pid, "SIGKILL");
+		} catch (error) {
+			log.warn(
+				`[host-service:${organizationId}] reap: SIGKILL of pid=${manifest.pid} failed`,
+				error,
+			);
+		}
+		removeManifest(organizationId);
 	}
 
 	/**

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -125,6 +125,25 @@ const ADOPT_WAIT_INTERVAL_MS = 250;
 const STOP_KILL_ESCALATION_MS = 5_000;
 
 /**
+ * Startup reap identity window. `ps` reports process age at 1 s granularity
+ * and the manifest's `startedAt` is written after createApp() (migrations
+ * included), so the process is somewhat older than the manifest, never
+ * younger. A process that started after the manifest cannot have written it.
+ */
+const REAP_IDENTITY_MAX_OLDER_MS = 10 * 60_000;
+const REAP_IDENTITY_MAX_YOUNGER_MS = 60_000;
+
+/** After SIGKILLing a wedged holder, wait this long for its port to free. */
+const REAP_EXIT_WAIT_MS = 1_000;
+const REAP_EXIT_POLL_MS = 25;
+
+/** What `ps` reports for a live pid; null when the pid cannot be inspected. */
+interface ProcessIdentity {
+	elapsedMs: number;
+	command: string;
+}
+
+/**
  * A Node abort dumps ~5KB of native + JS backtrace on the way down, so a
  * smaller window would evict the assertion line and every app log before it.
  */
@@ -160,6 +179,39 @@ function getStablePortForOrganization(organizationId: string): number {
 		hash = Math.imul(hash, 16_777_619);
 	}
 	return STABLE_PORT_BASE + ((hash >>> 0) % STABLE_PORT_COUNT);
+}
+
+/**
+ * `ps -o etime=,command=` for one pid. Returns null on Windows (no `ps`),
+ * for a pid that is gone, or for output we cannot parse; callers treat null
+ * as "unknown", never as "safe to kill".
+ */
+function inspectProcessWithPs(pid: number): ProcessIdentity | null {
+	if (process.platform === "win32") return null;
+	const result = childProcess.spawnSync(
+		"ps",
+		["-o", "etime=,command=", "-p", String(pid)],
+		{ encoding: "utf8", timeout: 2_000 },
+	);
+	if (result.status !== 0) return null;
+	const line = result.stdout.trim().split("\n")[0]?.trim();
+	const match = line ? /^(\S+)\s+(.*)$/.exec(line) : null;
+	if (!match) return null;
+	const elapsedMs = parseEtime(match[1] ?? "");
+	if (elapsedMs == null) return null;
+	return { elapsedMs, command: match[2] ?? "" };
+}
+
+/** Parse ps's `[[dd-]hh:]mm:ss` elapsed-time column into milliseconds. */
+export function parseEtime(etime: string): number | null {
+	const match = /^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/.exec(etime.trim());
+	if (!match) return null;
+	const [, days = "0", hours = "0", minutes, seconds] = match;
+	return (
+		(((Number(days) * 24 + Number(hours)) * 60 + Number(minutes)) * 60 +
+			Number(seconds)) *
+		1000
+	);
 }
 
 function isValidPort(port: number | null | undefined): port is number {
@@ -205,6 +257,12 @@ export class HostServiceCoordinator extends EventEmitter {
 		delayMs: number,
 	) => ReturnType<typeof setTimeout> = (run, delayMs) =>
 		setTimeout(run, delayMs);
+	/**
+	 * Seam for the startup reap's identity check. Production shells out to
+	 * `ps`; tests hand back a canned identity for their fake pids.
+	 */
+	private inspectProcess: (pid: number) => ProcessIdentity | null =
+		inspectProcessWithPs;
 
 	/**
 	 * Supplies fresh spawn config for automatic respawns. A respawn must not
@@ -646,7 +704,7 @@ export class HostServiceCoordinator extends EventEmitter {
 					// attempt and taking the lock — re-check before spawning.
 					const raced = await this.tryAdopt(organizationId, isStartAllowed);
 					if (raced) return raced;
-					this.reapWedgedManifestHolder(organizationId);
+					await this.reapWedgedManifestHolder(organizationId);
 					return await this.spawn(
 						organizationId,
 						config,
@@ -1234,12 +1292,44 @@ export class HostServiceCoordinator extends EventEmitter {
 	 * lock, right after the under-lock adopt miss, so the probe verdict is
 	 * fresh. A pid started before this boot is skipped: pids recycle across
 	 * reboots, and a pre-boot `startedAt` can name any process at all.
+	 *
+	 * Pids recycle within a boot too, and `kill(pid, 0)` only proves *a*
+	 * process exists. So before SIGKILL the live process must look like the
+	 * host-service that wrote the manifest: our script on its command line and
+	 * an age consistent with `startedAt`. Anything else, including a pid `ps`
+	 * cannot inspect, is left alone.
 	 */
-	private reapWedgedManifestHolder(organizationId: string): void {
+	private async reapWedgedManifestHolder(
+		organizationId: string,
+	): Promise<void> {
 		const manifest = readManifest(organizationId);
 		if (!manifest || !isProcessAlive(manifest.pid)) return;
+		// tryAdopt() returns null without probing when the endpoint is
+		// unparsable; only a probed miss is evidence of a wedge.
+		let port: number | null = null;
+		try {
+			port = Number(new URL(manifest.endpoint).port);
+		} catch {}
+		if (!isValidPort(port)) return;
 		const bootedAt = Date.now() - os.uptime() * 1000;
 		if (manifest.startedAt < bootedAt) return;
+
+		const identity = this.inspectProcess(manifest.pid);
+		const processStartedAt =
+			identity == null ? null : Date.now() - identity.elapsedMs;
+		const looksLikeHolder =
+			identity != null &&
+			processStartedAt != null &&
+			identity.command.includes(path.basename(this.scriptPath)) &&
+			processStartedAt >= manifest.startedAt - REAP_IDENTITY_MAX_OLDER_MS &&
+			processStartedAt <= manifest.startedAt + REAP_IDENTITY_MAX_YOUNGER_MS;
+		if (!looksLikeHolder) {
+			log.warn(
+				`[host-service:${organizationId}] manifest pid=${manifest.pid} is alive but unhealthy and does not look like the host-service that wrote the manifest (${identity ? `"${identity.command}", age ${Math.round(identity.elapsedMs / 1000)}s` : "not inspectable"}); leaving it alone`,
+			);
+			return;
+		}
+
 		log.warn(
 			`[host-service:${organizationId}] manifest pid=${manifest.pid} at ${manifest.endpoint} is alive but unhealthy; SIGKILLing it before spawning`,
 		);
@@ -1251,7 +1341,25 @@ export class HostServiceCoordinator extends EventEmitter {
 				error,
 			);
 		}
-		removeManifest(organizationId);
+		// SIGKILL is asynchronous: give the kernel a moment to tear the process
+		// down so spawn()'s findFreePort sees its preferred port free instead
+		// of falling back to a random one.
+		const exited = await this.waitForExit(manifest.pid, REAP_EXIT_WAIT_MS);
+		if (!exited) {
+			log.warn(
+				`[host-service:${organizationId}] reap: pid=${manifest.pid} still alive ${REAP_EXIT_WAIT_MS}ms after SIGKILL`,
+			);
+		}
+		this.removeManifestIfHeldBy(organizationId, manifest.pid);
+	}
+
+	private async waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+		const deadline = Date.now() + timeoutMs;
+		while (isProcessAlive(pid)) {
+			if (Date.now() >= deadline) return false;
+			await new Promise((r) => setTimeout(r, REAP_EXIT_POLL_MS));
+		}
+		return true;
 	}
 
 	/**

--- a/packages/host-service/src/app.ts
+++ b/packages/host-service/src/app.ts
@@ -392,6 +392,16 @@ export function createApp(options: CreateAppOptions): CreateAppResult {
 		} catch (err) {
 			console.warn("[host-service] chatV3.dispose failed:", err);
 		}
+		// Retire the host-worker threads (and reap their in-flight git
+		// children) here rather than leaving them to process.exit(): exit joins
+		// every Worker, and a worker wedged in native code hangs that join
+		// forever. The desktop entry point bounds this dispose with a deadline
+		// and hard-exits past it.
+		try {
+			await getHostWorkerPool().dispose();
+		} catch (err) {
+			console.warn("[host-service] hostWorkerPool.dispose failed:", err);
+		}
 		try {
 			eventBus.close();
 		} catch (err) {

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -594,6 +594,9 @@ export class Server {
 					c.subscriptions.delete(session.id);
 				}
 				c.pausedSessions.delete(session.id);
+				// This conn holds nothing paused now; a later congestion episode
+				// must get a fresh deadline, not the remainder of this one.
+				if (c.pausedSessions.size === 0) this.clearPauseTimer(c);
 			}
 			// Delete the session immediately. Without this, every closed
 			// terminal pane left a row in the store forever — list-reply

--- a/packages/pty-daemon/src/Server/Server.ts
+++ b/packages/pty-daemon/src/Server/Server.ts
@@ -40,6 +40,12 @@ export interface ServerOptions {
 	/** Pause producing PTYs when a subscriber buffers past this (flow control). */
 	outboundPauseThreshold?: number;
 	/**
+	 * Disconnect a subscriber that stays congested (never drains) this long.
+	 * A pause holds the PTY for every subscriber, so one dead reader would
+	 * otherwise freeze the terminal for everyone.
+	 */
+	pausedConnTimeoutMs?: number;
+	/**
 	 * Override for the PTY-spawn factory. Production leaves this unset;
 	 * `defaultSpawn` (real node-pty) is used. Tests inject a fake here so
 	 * they can drive sessions deterministically without a real shell.
@@ -57,12 +63,23 @@ const DEFAULT_OUTBOUND_BUFFER_CAP_BYTES = 8 * 1024 * 1024;
 // instead of renderer ACKs). Resume on socket 'drain'.
 const DEFAULT_OUTBOUND_PAUSE_THRESHOLD_BYTES = 1 * 1024 * 1024;
 
+// A pause is only bounded by the subscriber draining or closing. A host-service
+// that is alive but wedged (its exit hung on a stuck worker after an app
+// update) keeps its socket open and never reads, so its pause held every
+// terminal frozen for the live host-service too, and the destroy cap above was
+// never reached because a paused PTY produces nothing. Bound the pause: a
+// subscriber still congested after this long is dropped, which resumes the
+// PTYs for everyone else.
+const DEFAULT_PAUSED_CONN_TIMEOUT_MS = 30_000;
+
 interface ConnState extends Conn {
 	socket: net.Socket;
 	decoder: FrameDecoder;
 	negotiated: number | null;
 	/** Session ids whose PTYs we paused because this conn was congested. */
 	pausedSessions: Set<string>;
+	/** Armed while this conn holds PTYs paused; fires to disconnect it. */
+	pauseTimer: NodeJS.Timeout | null;
 }
 
 export class Server {
@@ -382,6 +399,7 @@ export class Server {
 			negotiated: null,
 			subscriptions: new Set(),
 			pausedSessions: new Set(),
+			pauseTimer: null,
 			send: (msg, payload) =>
 				writeMessage(socket, msg, payload, outboundBufferCap),
 		};
@@ -543,6 +561,7 @@ export class Server {
 				c.send(out, chunk);
 				if (!c.socket.destroyed && c.socket.writableLength > pauseThreshold) {
 					c.pausedSessions.add(session.id);
+					this.armPauseTimer(c);
 					congested = true;
 				}
 			}
@@ -597,10 +616,39 @@ export class Server {
 	}
 
 	/**
+	 * Start the clock on a congestion episode. One timer per conn: it is
+	 * cleared when the conn drains or drops, and a later episode re-arms it.
+	 */
+	private armPauseTimer(conn: ConnState): void {
+		if (conn.pauseTimer) return;
+		const timeoutMs =
+			this.opts.pausedConnTimeoutMs ?? DEFAULT_PAUSED_CONN_TIMEOUT_MS;
+		conn.pauseTimer = setTimeout(() => {
+			conn.pauseTimer = null;
+			// Nothing paused any more (the sessions exited) — the conn is not
+			// blocking anyone, so leave it be.
+			if (conn.socket.destroyed || conn.pausedSessions.size === 0) return;
+			process.stderr.write(
+				`[pty-daemon] subscriber stopped reading for ${timeoutMs}ms while holding ${conn.pausedSessions.size} session(s) paused; disconnecting it\n`,
+			);
+			// 'close' -> dropConn resumes the PTYs for the remaining subscribers.
+			conn.socket.destroy();
+		}, timeoutMs);
+		conn.pauseTimer.unref();
+	}
+
+	private clearPauseTimer(conn: ConnState): void {
+		if (!conn.pauseTimer) return;
+		clearTimeout(conn.pauseTimer);
+		conn.pauseTimer = null;
+	}
+
+	/**
 	 * Resume every PTY paused on behalf of `conn`, unless another congested
 	 * conn still holds it paused. Called on socket 'drain' and on conn drop.
 	 */
 	private resumePausedSessions(conn: ConnState): void {
+		this.clearPauseTimer(conn);
 		for (const id of conn.pausedSessions) {
 			conn.pausedSessions.delete(id);
 			let heldElsewhere = false;

--- a/packages/pty-daemon/test/flow-control.test.ts
+++ b/packages/pty-daemon/test/flow-control.test.ts
@@ -105,3 +105,71 @@ test("consumer disconnect while paused resumes the PTY for the next subscriber",
 	await c2.waitFor((m) => m.type === "closed" && m.id === "flow-1", 3000);
 	await c2.close();
 });
+
+test("a subscriber that never drains is dropped after pausedConnTimeoutMs; other subscribers keep receiving", async () => {
+	// A pause holds the PTY for every subscriber. Without a bound, a wedged
+	// host-service that keeps its socket open but never reads froze those
+	// terminals for the live host-service too.
+	const PAUSED_CONN_TIMEOUT_MS = 500;
+	const timeoutSock = path.join(
+		os.tmpdir(),
+		`pty-daemon-flow-timeout-${process.pid}.sock`,
+	);
+	const timeoutServer = new Server({
+		socketPath: timeoutSock,
+		daemonVersion: "0.0.0-test",
+		outboundPauseThreshold: PAUSE_THRESHOLD,
+		outboundBufferCap: DESTROY_CAP,
+		pausedConnTimeoutMs: PAUSED_CONN_TIMEOUT_MS,
+	});
+	await timeoutServer.listen();
+	try {
+		const stuck = await connectAndHello(timeoutSock);
+		stuck.send({ type: "open", id: "flow-2", meta: FLOOD_META });
+		await stuck.waitFor((m) => m.type === "open-ok" && m.id === "flow-2");
+		stuck.send({ type: "subscribe", id: "flow-2", replay: false });
+		await stuck.waitFor((m) => m.type === "output" && m.id === "flow-2", 3000);
+
+		const live = await connectAndHello(timeoutSock);
+		live.send({ type: "subscribe", id: "flow-2", replay: false });
+		await live.waitFor((m) => m.type === "output" && m.id === "flow-2", 3000);
+
+		// Congest `stuck` and never read again. The daemon must drop it once
+		// the timeout elapses, not wait for a drain that will never come.
+		stuck.socket.pause();
+		// Well past the timeout. Without the bound the PTY is still paused here
+		// and nothing is in flight for `live` any more, so the wait below times
+		// out; with it the drop resumed the PTY and output is flowing again.
+		await new Promise((r) => setTimeout(r, PAUSED_CONN_TIMEOUT_MS * 3));
+		await live.waitForNext(
+			(m) =>
+				m.type === "output" &&
+				m.id === "flow-2" &&
+				payloadAsString(m).includes("flood-line"),
+			3000,
+		);
+		assert.equal(live.closed(), false);
+
+		// A paused client socket never reads, so it cannot observe the daemon's
+		// destroy until it resumes. Resume now and confirm the FIN was there:
+		// an un-dropped connection would just drain and stay open.
+		const stuckClosed = new Promise<void>((resolve) => stuck.onClose(resolve));
+		stuck.socket.resume();
+		await Promise.race([
+			stuckClosed,
+			new Promise((_, reject) =>
+				setTimeout(
+					() => reject(new Error("stuck subscriber was not disconnected")),
+					3000,
+				),
+			),
+		]);
+		assert.equal(stuck.closed(), true);
+
+		live.send({ type: "close", id: "flow-2", signal: "SIGKILL" });
+		await live.waitFor((m) => m.type === "closed" && m.id === "flow-2", 3000);
+		await live.close();
+	} finally {
+		await timeoutServer.close();
+	}
+});


### PR DESCRIPTION
## Summary
- A host-service child orphaned by a Squirrel auto-update relaunch (PPID 1, ~98% CPU, ignores SIGTERM) froze terminal sessions 1-2x/week. Three defects combined; this fixes all three.
- The child now exits under a deadline and hard-kills itself if `dispose()` wedges; the coordinator escalates SIGTERM to SIGKILL and reaps a wedged manifest holder before spawning beside it; pty-daemon bounds how long one non-reading subscriber can hold a PTY paused for everyone.

## Why / Context
On the update path the Electron parent quits seconds after `before-quit` and leaves the child to self-terminate. Every orphan in `main.log` + DiagnosticReports lines up with an update relaunch. `[host-service] shutdown (SIGTERM), draining connections` is logged, sometimes 2-3 times for the same pid, and a completion line never follows.

1. **Child shutdown could hang forever.** `shutdown()` did `server.close()` then `process.exit(0)`. It never called the `dispose()` from `createApp()`, and `process.exit()` joins every `worker_threads` Worker. A host-worker wedged in native code (hung `spawnSync` git, long SQLite call) blocks that join, and `if (shuttingDown) return` made every later SIGTERM a no-op.
2. **Coordinator never escalated or reaped.** `stop()` sent one SIGTERM. `startOrAdopt()` health-probed the manifest pid, and on a miss just spawned a new child next to the wedged one (on a fallback port when the old one still held the socket, e.g. `listening on port 63847` instead of 48046). Only the explicit `reset()` path ever SIGKILLed.
3. **pty-daemon pause was unbounded.** When any subscriber's socket buffered past 1 MB the PTY was paused for every subscriber, and only that socket's `drain` or `close` resumed it. The 8 MB destroy cap was never reached because a paused PTY produces nothing. A wedged-but-alive orphan kept its socket open, never read, and froze those terminals for the live host-service too.

## How It Works
- **`apps/desktop/src/main/host-service/shutdown.ts`** (new): shutdown sequencing with injected deps, same style as `quit-sequence.ts`. Log reason, clear the reclaim timer, `server.close()`, after the 3 s grace `closeAllConnections()` then `await dispose()` bounded by 2 s. Resolves → `process.exit(0)`. Times out → `process.kill(process.pid, "SIGKILL")`, a kernel-delivered kill that needs no cooperation from V8. A second signal while shutting down hard-exits immediately. A signal before `serve()` returned goes through the same bounded dispose (no drain window).
- **`host-service-coordinator.ts`**: `stop()` schedules an unref'd SIGKILL 5 s after SIGTERM through the existing `scheduleRespawnTimer` seam; `handleChildExit()` cancels it so a recycled pid is never signalled. Under the spawn lock, after the adopt re-check misses, a manifest pid that is alive, failed the probe, and has `startedAt` after this boot (`Date.now() - os.uptime()*1000`, guards recycled pids from before a reboot) is SIGKILLed and its manifest removed before `spawn()`. Exit log line now includes the pid.
- **`packages/pty-daemon/src/Server/Server.ts`**: `ServerOptions.pausedConnTimeoutMs` (default 30 s). Armed once per conn when it first causes a pause, cleared on `drain` and in `dropConn`. On fire, `socket.destroy()` that conn; its `close` → `dropConn` resumes the PTYs for everyone else. If the host-service is the one dropped, its existing daemon-disconnect path closes every terminal WS with 1011, the renderer reconnects, and the next `getDaemonClient()` rebuilds the client and re-subscribes with ring replay. Shells survive in the daemon.

## Manual QA (before / after reproductions)

**1. Child shutdown hang.** Real Node child with an HTTP server plus a Worker blocked in native `spawnSync`. Driver sends SIGTERM like the coordinator.

Before (pre-fix shutdown code):
```
+  239ms driver: sending SIGTERM #1
+  239ms child: [host-service] shutdown (SIGTERM), draining connections
+ 3240ms driver: still alive after 3s, sending SIGTERM #2
  PID STAT  %CPU COMMAND
43086 S      0.0 node .../wedged-child.mjs old
+ 6244ms driver: RESULT=old: ORPHAN — child ignored two SIGTERMs; SIGKILLing it by hand
```
After (`createShutdown`):
```
+  235ms child: [host-service] shutdown (SIGTERM), draining connections
+ 1537ms child: [host-service] dispose did not finish within 1000ms (worker wedged?); hard-exiting
+ 1539ms driver: child exited code=null signal=SIGKILL
```
After, second SIGTERM while dispose is still pending:
```
+ 3244ms child: [host-service] shutdown (SIGTERM) while already shutting down; hard-exiting
+ 3246ms driver: child exited code=null signal=SIGKILL
```

**2. Coordinator.** New coordinator tests run against the pre-fix coordinator: 48 pass, 2 fail (`reaps an alive-but-unhealthy manifest holder`, `escalates to SIGKILL after the grace`). Against the fixed coordinator: 50 pass.

**3. Terminal freeze.** Real pty-daemon, PTY running `yes`, two subscribers. "stuck" stops reading at t=2s. Live subscriber's throughput per second:

Before:
```
t= 3s live subscriber received 132 KB this second
t= 4s ... 0 KB   t= 5s ... 0 KB   t= 6s ... 0 KB   t= 7s ... 0 KB   t= 8s ... 0 KB   t= 9s ... 0 KB
t=10s RESULT: live subscriber is FROZEN
```
After (timeout 3 s for the demo; shipped default 30 s):
```
t= 4s live subscriber received 0 KB this second
[pty-daemon] subscriber stopped reading for 3000ms while holding 1 session(s) paused; disconnecting it
t= 6s live subscriber received 69195 KB this second
t=10s RESULT: live subscriber is receiving output again
```

**Edge cases driven:**
- Slow-but-draining subscriber (pause 600 ms, resume, drain, repeat, with a 1 s timeout): 11 cycles over 8 s, never dropped. A busy-but-healthy host-service on a loaded machine is not disconnected.
- Second SIGTERM while dispose is pending: hard-exits immediately (above).
- Signal before `serve()` bound: disposes under the deadline, no drain window.
- pty-daemon `signal-recovery` (daemon SIGKILL, clients receive close events) still passes.

## Testing
- `bun test src/main/host-service/shutdown.test.ts src/main/lib/host-service-coordinator.test.ts` (apps/desktop): 59 pass
- `bun test src/main/lib src/main/host-service` (apps/desktop): 637 pass
- `bun run test` + `bun run test:integration` (packages/pty-daemon): 81 + 57 pass (`signal-recovery` needs `bun run build:daemon` first)
- New pty test proven to fail without the fix (live subscriber's wait times out)
- host-service node tests (after the better-sqlite3 ABI flip): `terminal.daemon-stall-retry`, `terminal.adoption`, `DaemonClient`, `test:integration:terminal` all pass. `DaemonSupervisor` has one failure, `auto-update defers when live sessions exist`, which fails identically against the pre-fix daemon bundle, so it is pre-existing on main and not from this change.
- `bun run typecheck` in apps/desktop and packages/pty-daemon
- `bunx biome check` on all touched files

## Design Decisions
- **Self-SIGKILL instead of `process.exit` past the deadline**: `process.exit()` is the thing that hangs (worker join). `process.kill(process.pid, "SIGKILL")` is delivered by the kernel and works regardless of V8 state. SQLite is journaled, so a hard exit past a 5 s budget is safe.
- **Reap under the spawn lock, after two probe misses**: the outer `tryAdopt` and the under-lock re-check each probe for 2.5 s, so a holder must be unresponsive for ~5 s before it is killed. Same probe the child's own `shouldYieldManifest` already trusts.
- **Boot-time guard on `startedAt`**: pids recycle across reboots, and a manifest left from before a reboot could name anything. `os.uptime()` comes from `kern.boottime`, so sleep does not move it.
- **30 s pause timeout**: a subscriber that cannot drain a ≤1 MB buffer in 30 s is not serving anyone. The cost of a false positive is one terminal WS reconnect through the existing daemon-disconnect path, not lost shells.

## Known Limitations
- The coordinator's SIGKILL escalation is unref'd, so on app quit or update it never fires; the child-side hard exit and the startup reap are what cover that path. `quit-sequence.ts` is deliberately untouched: the app cannot wait for children on the update path.
- A CLI-spawned host-service that is stalled for >5 s at app start will be reaped and replaced by an app-owned one (the CLI then reads the new manifest).
- The field orphans sat at ~98% CPU; the synthetic wedge (worker blocked in `spawnSync`) hangs at 0%. The exit path exercised is the same, but the CPU burn itself was not reproduced. Next time one appears, `sample <pid>` would show which thread is spinning.

## Rollback
- Revert the PR. No data or schema changes. The pty-daemon option is server-side only; no protocol change, so mixed daemon/host-service versions are fine.

https://claude.ai/code/session_01Nrm3XYbYud255QumC9vJeb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal sessions freezing 1–2x/week after Squirrel auto-updates, caused by a host-service child orphaned at ~98% CPU that ignored SIGTERM. The child now hard-exits under a deadline, the coordinator escalates to SIGKILL and reaps wedged children, and `pty-daemon` drops a subscriber that holds a PTY paused too long. A CLI-spawned host-service stalled more than 5s at app start is now reaped and replaced.

**Bug Fixes**

- Child shutdown now awaits `dispose()` (including retiring the host-worker pool) under a 2s deadline and SIGKILLs itself on timeout; a second signal while shutting down hard-exits immediately.
- Coordinator `stop()` escalates SIGTERM to SIGKILL after 5s (cancelled on child exit) and, before spawning beside a holder, reaps it only if it is alive, unhealthy, started this boot, and its process identity matches the manifest (command line and age).
- `pty-daemon` disconnects a subscriber still congested after 30s (`pausedConnTimeoutMs`), resuming paused PTYs for the remaining subscribers; a pause timer is cleared when the congested subscriber's sessions exit.

<sup>Written for commit 75f43e35414356fbeaaa25b8b3eff666333eaa89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop service shutdown reliability by ensuring active connections close gracefully and resources are released within a defined time.
  - Added force-termination safeguards for services or child processes that become unresponsive during shutdown or recovery.
  - Improved recovery of unhealthy service instances while preserving healthy running instances.
  - Prevented stalled PTY subscribers from blocking output delivery indefinitely; congested connections are now disconnected automatically so other sessions can resume.
  - Improved cleanup of background worker processes during application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->