### PR TITLE
fix(desktop): disable mermaid HTML labels so Download as PNG works

### DIFF
--- a/apps/desktop/src/renderer/components/CommentMarkdown/components/CommentCodeBlock/CommentCodeBlock.tsx
+++ b/apps/desktop/src/renderer/components/CommentMarkdown/components/CommentCodeBlock/CommentCodeBlock.tsx
@@ -1,4 +1,4 @@
-import { mermaid } from "@streamdown/mermaid";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import type { ReactNode } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import {
@@ -7,8 +7,6 @@ import {
 } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { useTheme } from "renderer/stores";
 import { Streamdown } from "streamdown";
-
-const mermaidPlugins = { mermaid };
 
 const MERMAID_DARK_VARS = {
 	background: "#1e1e2e",
@@ -65,12 +63,10 @@ export function CommentCodeBlock({
 			<Streamdown
 				mode="static"
 				plugins={mermaidPlugins}
-				mermaid={{
-					config: {
-						theme: "base",
-						themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
-					},
-				}}
+				mermaid={mermaidConfig({
+					theme: "base",
+					themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
+				})}
 			>
 				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
 			</Streamdown>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/CodeBlock/CodeBlock.tsx
@@ -1,10 +1,8 @@
-import { mermaid } from "@streamdown/mermaid";
 import { ShowCode } from "@superset/ui/ai-elements/show-code";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import type { ReactNode } from "react";
 import { useTheme } from "renderer/stores";
 import { Streamdown } from "streamdown";
-
-const mermaidPlugins = { mermaid };
 
 interface CodeNode {
 	position?: {
@@ -43,7 +41,7 @@ export function CodeBlock({ children, className, node }: CodeBlockProps) {
 			<Streamdown
 				mode="static"
 				plugins={mermaidPlugins}
-				mermaid={{ config: { theme: isDark ? "dark" : "default" } }}
+				mermaid={mermaidConfig({ theme: isDark ? "dark" : "default" })}
 			>
 				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
 			</Streamdown>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/components/EditableCodeBlockView/EditableCodeBlockView.tsx
@@ -1,10 +1,10 @@
-import { mermaid } from "@streamdown/mermaid";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
+import { mermaidConfig, mermaidPlugins } from "@superset/ui/lib/mermaid";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import { useState } from "react";
@@ -22,8 +22,6 @@ import {
 } from "renderer/lib/tiptap/code-block-languages";
 import { useTheme } from "renderer/stores";
 import { Streamdown } from "streamdown";
-
-const mermaidPlugins = { mermaid };
 
 export function EditableCodeBlockView({
 	node,
@@ -145,7 +143,7 @@ export function EditableCodeBlockView({
 					<Streamdown
 						mode="static"
 						plugins={mermaidPlugins}
-						mermaid={{ config: { theme: isDark ? "dark" : "default" } }}
+						mermaid={mermaidConfig({ theme: isDark ? "dark" : "default" })}
 					>
 						{`\`\`\`\`mermaid\n${mermaidSource}\n\`\`\`\``}
 					</Streamdown>

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/CommentPane/CommentPane.tsx
@@ -1,4 +1,3 @@
-import { mermaid } from "@streamdown/mermaid";
 import { Avatar, AvatarFallback, AvatarImage } from "@superset/ui/avatar";
 import {
 	type ReactNode,
@@ -14,20 +13,10 @@ import {
 	LuCopy,
 	LuMessageSquare,
 } from "react-icons/lu";
-import ReactMarkdown from "react-markdown";
 import type { MosaicBranch } from "react-mosaic-component";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import {
-	oneDark,
-	oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
-import rehypeRaw from "rehype-raw";
-import rehypeSanitize from "rehype-sanitize";
-import remarkGfm from "remark-gfm";
+import { CommentMarkdown } from "renderer/components/CommentMarkdown";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
-import { useTheme } from "renderer/stores/theme";
-import { Streamdown } from "streamdown";
 import { BasePaneWindow, PaneTitle, PaneToolbarActions } from "../components";
 import "./comment-pane.css";
 
@@ -179,13 +168,10 @@ export function CommentPane({
 					</div>
 					<div className="comment-pane-markdown min-h-0 flex-1 overflow-y-auto select-text">
 						<article className="w-full px-6 py-5">
-							<ReactMarkdown
-								remarkPlugins={[remarkGfm]}
-								rehypePlugins={[rehypeRaw, rehypeSanitize]}
+							<CommentMarkdown
+								body={comment.body}
 								components={commentComponents}
-							>
-								{comment.body}
-							</ReactMarkdown>
+							/>
 						</article>
 					</div>
 				</div>
@@ -194,93 +180,7 @@ export function CommentPane({
 	);
 }
 
-const mermaidPlugins = { mermaid };
-
-const MERMAID_DARK_VARS = {
-	background: "#1e1e2e",
-	primaryColor: "#313244",
-	primaryTextColor: "#cdd6f4",
-	primaryBorderColor: "#45475a",
-	secondaryColor: "#313244",
-	secondaryTextColor: "#cdd6f4",
-	secondaryBorderColor: "#45475a",
-	tertiaryColor: "#313244",
-	tertiaryTextColor: "#cdd6f4",
-	tertiaryBorderColor: "#45475a",
-	nodeBorder: "#45475a",
-	nodeTextColor: "#cdd6f4",
-	mainBkg: "#313244",
-	clusterBkg: "#1e1e2e",
-	titleColor: "#cdd6f4",
-	edgeLabelBackground: "transparent",
-	lineColor: "#6c7086",
-	textColor: "#cdd6f4",
-};
-
-const MERMAID_LIGHT_VARS = {
-	background: "#ffffff",
-	primaryColor: "#f0f0f4",
-	primaryTextColor: "#1e1e2e",
-	primaryBorderColor: "#d0d0d8",
-	lineColor: "#888",
-	textColor: "#1e1e2e",
-};
-
-function CommentCodeBlock({
-	className,
-	children,
-}: {
-	className?: string;
-	children?: ReactNode;
-}) {
-	const theme = useTheme();
-	const isDark = theme?.type !== "light";
-
-	const match = /language-(\w+)/.exec(className || "");
-	const language = match ? match[1] : undefined;
-	const codeString = String(children).replace(/\n$/, "");
-
-	if (language === "mermaid") {
-		return (
-			<Streamdown
-				mode="static"
-				plugins={mermaidPlugins}
-				mermaid={{
-					config: {
-						theme: "base",
-						themeVariables: isDark ? MERMAID_DARK_VARS : MERMAID_LIGHT_VARS,
-					},
-				}}
-			>
-				{`\`\`\`mermaid\n${codeString}\n\`\`\``}
-			</Streamdown>
-		);
-	}
-
-	if (!language) {
-		return (
-			<code className="px-1.5 py-0.5 rounded bg-muted font-mono text-sm">
-				{children}
-			</code>
-		);
-	}
-
-	return (
-		<SyntaxHighlighter
-			style={
-				(isDark ? oneDark : oneLight) as Record<string, React.CSSProperties>
-			}
-			language={language}
-			PreTag="div"
-			className="rounded-md text-sm"
-		>
-			{codeString}
-		</SyntaxHighlighter>
-	);
-}
-
 const commentComponents = {
-	code: CommentCodeBlock,
 	table: ({ children }: { children?: ReactNode }) => (
 		<CopyableTable>{children}</CopyableTable>
 	),

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Trans, useLingui } from "@lingui/react/macro";
-import { mermaid } from "@streamdown/mermaid";
 import type { FileUIPart, UIMessage } from "ai";
 import {
 	ChevronLeftIcon,
@@ -11,8 +10,8 @@ import {
 } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
-import type { PluginConfig } from "streamdown";
 import { Streamdown } from "streamdown";
+import { mermaidConfig, mermaidPlugins } from "../../lib/mermaid";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { ButtonGroup, ButtonGroupText } from "../ui/button-group";
@@ -23,9 +22,6 @@ import {
 	TooltipTrigger,
 } from "../ui/tooltip";
 
-const streamdownPlugins: PluginConfig = {
-	mermaid: mermaid as unknown as PluginConfig["mermaid"],
-};
 const defaultMessageAnimation = {
 	animation: "blurIn",
 	sep: "char",
@@ -342,7 +338,13 @@ export const TOOL_CALL_MD_CLASSNAME =
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 export const MessageResponse = memo(
-	({ className, animated, isAnimating, ...props }: MessageResponseProps) => (
+	({
+		className,
+		animated,
+		isAnimating,
+		mermaid,
+		...props
+	}: MessageResponseProps) => (
 		<Streamdown
 			animated={animated ?? defaultMessageAnimation}
 			className={cn(
@@ -352,8 +354,9 @@ export const MessageResponse = memo(
 			controls={{ table: false }}
 			isAnimating={isAnimating}
 			linkSafety={{ enabled: false }}
+			mermaid={{ ...mermaid, ...mermaidConfig(mermaid?.config) }}
 			mode="streaming"
-			plugins={isAnimating ? undefined : streamdownPlugins}
+			plugins={isAnimating ? undefined : mermaidPlugins}
 			{...props}
 		/>
 	),

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -9,7 +9,14 @@ import {
 	XIcon,
 } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
-import { createContext, memo, useContext, useEffect, useState } from "react";
+import {
+	createContext,
+	memo,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import { Streamdown } from "streamdown";
 import { mermaidConfig, mermaidPlugins } from "../../lib/mermaid";
 import { cn } from "../../lib/utils";
@@ -344,22 +351,28 @@ export const MessageResponse = memo(
 		isAnimating,
 		mermaid,
 		...props
-	}: MessageResponseProps) => (
-		<Streamdown
-			animated={animated ?? defaultMessageAnimation}
-			className={cn(
-				"text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:list-outside [&_ol]:pl-6 [&_ul]:list-outside [&_ul]:pl-6 [&_li]:break-words [&_li]:whitespace-pre-wrap [&_p]:break-words [&_p]:whitespace-pre-wrap [&_:not(pre)>code]:break-all [&_[data-streamdown=table-wrapper]]:overflow-hidden [&_[data-streamdown=table-wrapper]]:bg-transparent [&_[data-streamdown=table-wrapper]]:p-0 [&_[data-streamdown=table-wrapper]]:gap-0 [&_[data-streamdown=table-wrapper]>div]:border-0 [&_[data-streamdown=table-wrapper]>div]:bg-transparent [&_[data-streamdown=table-wrapper]>div]:rounded-none [&_thead]:bg-muted/50",
-				className,
-			)}
-			controls={{ table: false }}
-			isAnimating={isAnimating}
-			linkSafety={{ enabled: false }}
-			mermaid={{ ...mermaid, ...mermaidConfig(mermaid?.config) }}
-			mode="streaming"
-			plugins={isAnimating ? undefined : mermaidPlugins}
-			{...props}
-		/>
-	),
+	}: MessageResponseProps) => {
+		const mermaidOptions = useMemo(
+			() => ({ ...mermaid, ...mermaidConfig(mermaid?.config) }),
+			[mermaid],
+		);
+		return (
+			<Streamdown
+				animated={animated ?? defaultMessageAnimation}
+				className={cn(
+					"text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_ol]:list-outside [&_ol]:pl-6 [&_ul]:list-outside [&_ul]:pl-6 [&_li]:break-words [&_li]:whitespace-pre-wrap [&_p]:break-words [&_p]:whitespace-pre-wrap [&_:not(pre)>code]:break-all [&_[data-streamdown=table-wrapper]]:overflow-hidden [&_[data-streamdown=table-wrapper]]:bg-transparent [&_[data-streamdown=table-wrapper]]:p-0 [&_[data-streamdown=table-wrapper]]:gap-0 [&_[data-streamdown=table-wrapper]>div]:border-0 [&_[data-streamdown=table-wrapper]>div]:bg-transparent [&_[data-streamdown=table-wrapper]>div]:rounded-none [&_thead]:bg-muted/50",
+					className,
+				)}
+				controls={{ table: false }}
+				isAnimating={isAnimating}
+				linkSafety={{ enabled: false }}
+				mermaid={mermaidOptions}
+				mode="streaming"
+				plugins={isAnimating ? undefined : mermaidPlugins}
+				{...props}
+			/>
+		);
+	},
 	(prevProps, nextProps) =>
 		prevProps.children === nextProps.children &&
 		prevProps.isAnimating === nextProps.isAnimating &&

--- a/packages/ui/src/lib/mermaid.test.ts
+++ b/packages/ui/src/lib/mermaid.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("@streamdown/mermaid", () => ({ mermaid: {} }));
+
+const { mermaidConfig } = await import("./mermaid");
+
+describe("mermaidConfig", () => {
+	it("disables HTML labels so the PNG export canvas is not tainted", () => {
+		expect(mermaidConfig().config?.htmlLabels).toBe(false);
+	});
+
+	it("keeps the caller's config", () => {
+		const { config } = mermaidConfig({
+			theme: "dark",
+			themeVariables: { lineColor: "#888" },
+		});
+		expect(config?.theme).toBe("dark");
+		expect(config?.themeVariables).toEqual({ lineColor: "#888" });
+	});
+
+	it("wins over a caller re-enabling HTML labels", () => {
+		expect(mermaidConfig({ htmlLabels: true }).config?.htmlLabels).toBe(false);
+	});
+
+	it("leaves the deprecated flowchart.htmlLabels unset", () => {
+		expect(
+			mermaidConfig({ flowchart: { curve: "basis" } }).config?.flowchart,
+		).toEqual({
+			curve: "basis",
+		});
+	});
+});

--- a/packages/ui/src/lib/mermaid.ts
+++ b/packages/ui/src/lib/mermaid.ts
@@ -1,0 +1,24 @@
+import { type MermaidConfig, mermaid } from "@streamdown/mermaid";
+import type { MermaidOptions, PluginConfig } from "streamdown";
+
+/** Shared `plugins` prop for every `<Streamdown>` that renders mermaid. */
+export const mermaidPlugins: PluginConfig = { mermaid };
+
+/**
+ * Build the `mermaid` prop for `<Streamdown>` with HTML labels disabled.
+ *
+ * Mermaid defaults to `htmlLabels: true`, which renders node/edge labels inside
+ * `<foreignObject>`. Streamdown's "Download as PNG" control rasterizes the
+ * diagram by loading the SVG into an `<img>` and drawing it onto a `<canvas>`;
+ * Chromium taints any canvas drawn from an `<img>` containing `<foreignObject>`,
+ * so `canvas.toBlob()` returns null and the download silently fails (Streamdown
+ * swallows the error). Forcing native SVG `<text>` labels keeps the canvas clean
+ * so PNG export works, while SVG/MMD downloads are unaffected.
+ *
+ * `htmlLabels` is spread last so a caller cannot re-enable it. Only the root
+ * key is set: mermaid 11.16 resolves `htmlLabels ?? flowchart.htmlLabels` and
+ * logs a deprecation warning whenever `flowchart.htmlLabels` is present.
+ */
+export function mermaidConfig(config: MermaidConfig = {}): MermaidOptions {
+	return { config: { ...config, htmlLabels: false } };
+}


### PR DESCRIPTION
**Links**
- Linear: [SUPER-2131](https://linear.app/superset-sh/issue/SUPER-2131/fix-mermaid-diagram-download-as-png-silently-failing)
- Supersedes #5433 (same approach, ported onto current `main`)

## Summary
- "Download as PNG" on a rendered mermaid diagram silently did nothing in chat messages, markdown file previews, and the comment pane. It now downloads a correct PNG.
- Adds a shared `mermaidConfig` helper in `@superset/ui` that forces `htmlLabels: false`, and applies it at every `<Streamdown>` mermaid call site.
- Replaces the v1 CommentPane's inline copy of `CommentCodeBlock` with the shared `CommentMarkdown` renderer, so the comment pane gets the fix and 100 duplicated lines go away.

## Why / Context
Mermaid renders node and edge labels inside `<foreignObject>` by default. Streamdown's PNG export loads the SVG into an `<img>` and draws it onto a `<canvas>`; Chromium taints any canvas drawn from an image containing `<foreignObject>`, so `canvas.toBlob()` returns `null` and Streamdown swallows the error. SVG and `.mmd` downloads never touched a canvas, which is why only PNG was broken.

## How It Works
- `packages/ui/src/lib/mermaid.ts` exports `mermaidPlugins` (the shared `plugins` prop) and `mermaidConfig(config)`, which spreads the caller's config and then sets the root-level `htmlLabels: false` last so a caller cannot re-enable it. Mermaid then emits native SVG `<text>` labels and the canvas stays clean.
- Only the root key is set. mermaid 11.16.1 resolves labels as `htmlLabels ?? flowchart.htmlLabels ?? true` and logs `FLOWCHART_HTML_LABELS_DEPRECATED` whenever `flowchart.htmlLabels` is present, so the `flowchart` override from #5433 was dropped.
- `MessageResponse` destructures the `mermaid` prop and passes it through the helper, which covers every chat rendering path. The three desktop call sites (`CodeBlock`, `EditableCodeBlockView`, `CommentCodeBlock`) use it directly.
- `MessageResponse` now uses the shared `mermaidPlugins` object; the old `as unknown as PluginConfig["mermaid"]` cast turned out to be unnecessary and is gone.

## Manual QA Checklist
Verified in the dev app over CDP on this branch:
- [x] Markdown file preview with a flowchart and a sequence diagram: both SVGs contain 0 `<foreignObject>` elements and only `<text>` labels
- [x] Download diagram → PNG produces a 45 KB `image/png` blob, Electron saves it to `~/Downloads`, and the file opens with every node and edge label intact
- [x] No renderer console errors during render or download

Not verified in this PR:
- [ ] PNG download from a chat message (`MessageResponse`) and from the comment pane. Same helper, same code path, but not clicked through
- [ ] SVG and MMD downloads after the change (they never used the canvas, so they should be unaffected)
- [ ] A before-fix failure was not re-captured in this session; the mechanism is documented in the task and in the helper's doc comment

## Testing
- `bun run lint:fix`, `bun run lint`
- `bun run typecheck` (39/39 tasks)
- `bun test` in `packages/ui` (64 pass, including 4 new `mermaidConfig` cases: default, caller config preserved, caller `htmlLabels: true` overridden, `flowchart.htmlLabels` left unset)

## Design Decisions
- **Force `htmlLabels` after the spread, not before:** a bot review on #5433 caught that spreading last would let a caller re-enable HTML labels and reintroduce the bug.
- **Root `htmlLabels` only:** setting `flowchart.htmlLabels` too would log a deprecation warning on every render under mermaid 11.16.

## Known Limitations
- SVG text labels drop FontAwesome icons and HTML tags other than `<br/>` inside node labels. Markdown bold/italic and word wrap still work. Accepted trade-off for a working PNG export.

## Follow-ups
- Close #5433 once this merges.

https://claude.ai/code/session_012611fp2VgPNMwtf5CgQ9gT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mermaid "Download as PNG" silently doing nothing in chat messages, markdown file previews, and the comment pane. Mermaid rendered labels inside `<foreignObject>`, which taints the canvas Streamdown uses for PNG export; forcing `htmlLabels: false` makes mermaid emit native SVG text labels so the export now works. The comment pane also now reuses the shared markdown renderer, removing ~100 duplicated lines.

**Details**
- Adds a `mermaidConfig` helper in `@superset/ui` that forces `htmlLabels: false` and applies it at every mermaid call site.
- Memoizes the forced config in `MessageResponse` so re-renders don't re-render every diagram in a message.
- SVG and `.mmd` downloads are unaffected since they never touched the canvas.
- SVG labels drop FontAwesome icons and non-`<br/>` HTML tags; bold/italic and word wrap still work.

<sup>Written for commit ff490fed8e021099f66347da12e2deb39b503d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mermaid diagram image downloads that could fail when diagrams used certain text labels.
  * Improved consistency of Mermaid diagram rendering across comments, markdown, editable code blocks, and AI-generated messages.
  * Preserved light and dark theme support for Mermaid diagrams.

* **Improvements**
  * Standardized Mermaid configuration for more reliable diagram display and export behavior.
  * Comment content now uses the same markdown rendering experience as the rest of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->