### PR TITLE
feat(desktop): add search and filter to v2 file explorer

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
 	DEFAULT_V2_USER_PREFERENCES,
+	type FileExplorerFilter,
 	type LinkTierMap,
 	V2_USER_PREFERENCES_ID,
 	type V2UserPreferencesRow,
@@ -21,6 +22,11 @@ export interface V2UserPreferencesApi {
 	setRightSidebarWidth: (next: number) => void;
 	setDeleteLocalBranch: (next: boolean) => void;
 	setShowPresetsBar: (next: boolean) => void;
+	setFileExplorerFilter: (
+		next:
+			| FileExplorerFilter
+			| ((prev: FileExplorerFilter) => FileExplorerFilter),
+	) => void;
 }
 
 export function useV2UserPreferences(): V2UserPreferencesApi {
@@ -169,6 +175,33 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		[collections],
 	);
 
+	const setFileExplorerFilter = useCallback(
+		(
+			next:
+				| FileExplorerFilter
+				| ((prev: FileExplorerFilter) => FileExplorerFilter),
+		) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			const prev =
+				existing?.fileExplorerFilter ??
+				DEFAULT_V2_USER_PREFERENCES.fileExplorerFilter;
+			const value = typeof next === "function" ? next(prev) : next;
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					fileExplorerFilter: value,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.fileExplorerFilter = value;
+			});
+		},
+		[collections],
+	);
+
 	return {
 		preferences,
 		setFileLinks,
@@ -179,5 +212,6 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setRightSidebarWidth,
 		setDeleteLocalBranch,
 		setShowPresetsBar,
+		setFileExplorerFilter,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/FilesTab.tsx
@@ -23,9 +23,10 @@ import {
 	Loader2,
 	RefreshCw,
 } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { FileStatus } from "renderer/hooks/host-service/useGitStatusMap";
 import { useGitStatusMap } from "renderer/hooks/host-service/useGitStatusMap";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import {
 	folderIntentFor,
 	ShadowClickHint,
@@ -38,6 +39,7 @@ import {
 	TREE_INDENT,
 } from "renderer/screens/main/components/WorkspaceView/RightSidebar/FilesView/constants";
 import { FileMenuItems } from "./components/FileMenuItems";
+import { FilesTabFilterBar } from "./components/FilesTabFilterBar";
 import { FolderMenuItems } from "./components/FolderMenuItems";
 import { RowContextMenu } from "./components/RowContextMenu";
 import { useFilesTabBridge } from "./hooks/useFilesTabBridge";
@@ -160,6 +162,11 @@ export function FilesTab({
 	const { fileStatusByPath, folderStatusByPath, ignoredPaths } =
 		useGitStatusMap(gitStatus);
 
+	const { preferences } = useV2UserPreferences();
+	const { excludeNames, hideGitignored } = preferences.fileExplorerFilter;
+	const excludeSet = useMemo(() => new Set(excludeNames), [excludeNames]);
+	const [query, setQuery] = useState("");
+
 	// Pierre's `gitStatus` is consumed only at construction; live updates
 	// flow via model.setGitStatus in an effect below.
 	const initialGitStatusEntriesRef = useRef(
@@ -188,7 +195,10 @@ export function FilesTab({
 	const { model } = usePierreFileTree({
 		paths: [],
 		initialExpansion: "closed",
+		// Pierre's own search input stays off — FilesTabFilterBar drives the
+		// same search session headlessly via model.setSearch below.
 		search: false,
+		fileTreeSearchMode: "hide-non-matches",
 		renaming: {
 			onRename: (event) => handlersRef.current.onRename(event),
 			onError: (message) => toast.error(message),
@@ -209,7 +219,45 @@ export function FilesTab({
 		renderRowDecoration: (ctx) => handlersRef.current.renderRowDecoration(ctx),
 	});
 
-	const bridge = useFilesTabBridge({ model, workspaceId, rootPath });
+	// Keeps a stable identity across renders (see the option doc in
+	// useFilesTabBridge) — excludeSet/hideGitignored/ignoredPaths changes are
+	// read live via the ref the bridge maintains internally.
+	const shouldIncludeEntry = useCallback(
+		(relPath: string, _isDirectory: boolean): boolean => {
+			if (excludeSet.has(basename(relPath))) return false;
+			if (hideGitignored && ignoredPaths.has(relPath)) return false;
+			return true;
+		},
+		[excludeSet, hideGitignored, ignoredPaths],
+	);
+
+	const bridge = useFilesTabBridge({
+		model,
+		workspaceId,
+		rootPath,
+		shouldIncludeEntry,
+	});
+
+	// Re-apply the exclude/gitignore filter to already-loaded directories
+	// whenever the user changes it — skip the mount run since there's nothing
+	// loaded yet. Paths a relaxed filter newly allows are picked up here too.
+	const skipFilterRefreshRef = useRef(true);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: excludeSet/hideGitignored aren't read in the body — they're the trigger for re-running doRefresh, which reads the current filter via the bridge's internal ref.
+	useEffect(() => {
+		if (skipFilterRefreshRef.current) {
+			skipFilterRefreshRef.current = false;
+			return;
+		}
+		void bridge.doRefresh();
+	}, [excludeSet, hideGitignored, bridge.doRefresh]);
+
+	// Drive Pierre's native search session from our own search input instead
+	// of its built-in one (kept off via `search: false` above). Only matches
+	// against paths already loaded into the tree — same lazy-load limitation
+	// the rest of the tree has; a full-repo search lives elsewhere.
+	useEffect(() => {
+		model.setSearch(query.trim() ? query : null);
+	}, [model, query]);
 
 	// Push live git status updates into Pierre.
 	useEffect(() => {
@@ -632,6 +680,7 @@ export function FilesTab({
 			className="flex h-full min-h-0 flex-col overflow-hidden"
 			onClickCapture={handleClickCapture}
 		>
+			<FilesTabFilterBar query={query} onQueryChange={setQuery} />
 			<ShadowClickHint hint={filePolicy.hint} findRow={findFileRow}>
 				<PierreFileTree
 					model={model}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabFilterBar/FilesTabFilterBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabFilterBar/FilesTabFilterBar.tsx
@@ -1,0 +1,215 @@
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Input } from "@superset/ui/input";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { ListFilter, Plus, Search, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
+import {
+	DEFAULT_FILE_EXPLORER_EXCLUDES,
+	type FileExplorerFilter,
+} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+
+interface FilesTabFilterBarProps {
+	query: string;
+	onQueryChange: (next: string) => void;
+}
+
+function isFilterActive(filter: FileExplorerFilter): boolean {
+	const presetSet = new Set<string>(DEFAULT_FILE_EXPLORER_EXCLUDES);
+	const currentSet = new Set(filter.excludeNames);
+	if (filter.hideGitignored) return true;
+	if (currentSet.size !== presetSet.size) return true;
+	for (const name of presetSet) if (!currentSet.has(name)) return true;
+	return false;
+}
+
+export function FilesTabFilterBar({
+	query,
+	onQueryChange,
+}: FilesTabFilterBarProps) {
+	const { preferences, setFileExplorerFilter } = useV2UserPreferences();
+	const filter = preferences.fileExplorerFilter;
+	const [customDraft, setCustomDraft] = useState("");
+
+	const presetExcludes = useMemo(
+		() => [...DEFAULT_FILE_EXPLORER_EXCLUDES] as string[],
+		[],
+	);
+	const customExcludes = useMemo(
+		() => filter.excludeNames.filter((n) => !presetExcludes.includes(n)),
+		[filter.excludeNames, presetExcludes],
+	);
+
+	const filterActive = isFilterActive(filter);
+
+	function togglePreset(name: string, checked: boolean) {
+		setFileExplorerFilter((prev) => {
+			const set = new Set(prev.excludeNames);
+			if (checked) set.add(name);
+			else set.delete(name);
+			return { ...prev, excludeNames: [...set] };
+		});
+	}
+
+	function removeCustom(name: string) {
+		setFileExplorerFilter((prev) => ({
+			...prev,
+			excludeNames: prev.excludeNames.filter((n) => n !== name),
+		}));
+	}
+
+	function addCustom() {
+		const trimmed = customDraft.trim();
+		if (!trimmed) return;
+		setFileExplorerFilter((prev) => {
+			if (prev.excludeNames.includes(trimmed)) return prev;
+			return { ...prev, excludeNames: [...prev.excludeNames, trimmed] };
+		});
+		setCustomDraft("");
+	}
+
+	function resetToDefaults() {
+		setFileExplorerFilter({
+			excludeNames: [...DEFAULT_FILE_EXPLORER_EXCLUDES],
+			hideGitignored: false,
+		});
+	}
+
+	return (
+		<div className="flex shrink-0 items-center gap-1 border-b border-border bg-background px-2 py-1.5">
+			<div className="relative flex-1">
+				<Search className="pointer-events-none absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground" />
+				<Input
+					value={query}
+					onChange={(e) => onQueryChange(e.target.value)}
+					placeholder="Search files"
+					className="h-7 pl-6 pr-6 text-xs"
+					spellCheck={false}
+				/>
+				{query && (
+					<button
+						type="button"
+						onClick={() => onQueryChange("")}
+						className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded text-muted-foreground hover:text-foreground"
+						aria-label="Clear search"
+					>
+						<X className="size-3" />
+					</button>
+				)}
+			</div>
+			<DropdownMenu>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenuTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="relative size-7 shrink-0"
+								aria-label="Filter files"
+							>
+								<ListFilter className="size-3.5" />
+								{filterActive && (
+									<span className="absolute right-1 top-1 size-1.5 rounded-full bg-primary" />
+								)}
+							</Button>
+						</DropdownMenuTrigger>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">Filter</TooltipContent>
+				</Tooltip>
+				<DropdownMenuContent align="end" className="w-64">
+					<DropdownMenuLabel>Hide</DropdownMenuLabel>
+					{presetExcludes.map((name) => (
+						<DropdownMenuCheckboxItem
+							key={name}
+							checked={filter.excludeNames.includes(name)}
+							onCheckedChange={(checked) =>
+								togglePreset(name, Boolean(checked))
+							}
+							onSelect={(e) => e.preventDefault()}
+						>
+							<span className="font-mono text-xs">{name}</span>
+						</DropdownMenuCheckboxItem>
+					))}
+					{customExcludes.length > 0 && (
+						<>
+							<DropdownMenuSeparator />
+							<DropdownMenuLabel className="text-xs text-muted-foreground">
+								Custom
+							</DropdownMenuLabel>
+							{customExcludes.map((name) => (
+								<div
+									key={name}
+									className="flex items-center justify-between gap-2 px-2 py-1 text-sm"
+								>
+									<span className="truncate font-mono text-xs">{name}</span>
+									<button
+										type="button"
+										onClick={() => removeCustom(name)}
+										className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+										aria-label={`Remove ${name}`}
+									>
+										<X className="size-3" />
+									</button>
+								</div>
+							))}
+						</>
+					)}
+					<div className="flex items-center gap-1 px-2 py-1.5">
+						<Input
+							value={customDraft}
+							onChange={(e) => setCustomDraft(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault();
+									addCustom();
+								}
+							}}
+							placeholder="Add folder/file name"
+							className="h-7 text-xs"
+							spellCheck={false}
+						/>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="size-7 shrink-0"
+							onClick={addCustom}
+							disabled={!customDraft.trim()}
+							aria-label="Add exclude"
+						>
+							<Plus className="size-3.5" />
+						</Button>
+					</div>
+					<DropdownMenuSeparator />
+					<DropdownMenuCheckboxItem
+						checked={filter.hideGitignored}
+						onCheckedChange={(checked) =>
+							setFileExplorerFilter((prev) => ({
+								...prev,
+								hideGitignored: Boolean(checked),
+							}))
+						}
+						onSelect={(e) => e.preventDefault()}
+					>
+						Hide gitignored files
+					</DropdownMenuCheckboxItem>
+					<DropdownMenuSeparator />
+					<button
+						type="button"
+						onClick={resetToDefaults}
+						className="w-full rounded-sm px-2 py-1.5 text-left text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+					>
+						Reset to defaults
+					</button>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabFilterBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/components/FilesTabFilterBar/index.ts
@@ -1,0 +1,1 @@
+export { FilesTabFilterBar } from "./FilesTabFilterBar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/components/FilesTab/hooks/useFilesTabBridge/useFilesTabBridge.ts
@@ -14,6 +14,14 @@ interface UseFilesTabBridgeOptions {
 	model: FileTree;
 	workspaceId: string;
 	rootPath: string;
+	/**
+	 * Called for every listed entry before it's added to Pierre; return false
+	 * to keep an excluded/gitignored entry out of the tree entirely. Read via
+	 * ref internally so toggling the underlying filter doesn't change
+	 * fetchDir/doRefresh identity — callers must invoke `doRefresh()` after
+	 * changing the filter to re-apply it to already-loaded directories.
+	 */
+	shouldIncludeEntry: (relPath: string, isDirectory: boolean) => boolean;
 }
 
 export interface FilesTabBridge {
@@ -71,6 +79,7 @@ export function useFilesTabBridge({
 	model,
 	workspaceId,
 	rootPath,
+	shouldIncludeEntry,
 }: UseFilesTabBridgeOptions): FilesTabBridge {
 	const utils = workspaceTrpc.useUtils();
 	const [isRefreshing, setIsRefreshing] = useState(false);
@@ -82,6 +91,11 @@ export function useFilesTabBridge({
 	const loadedDirsRef = useRef(new Set<string>());
 	const loadingDirsRef = useRef(new Set<string>());
 	const pendingCreatesRef = useRef(new Map<string, "file" | "folder">());
+
+	// Latest-closure indirection so fetchDir/doRefresh keep a stable identity
+	// across renders even as the filter changes (see option doc above).
+	const shouldIncludeEntryRef = useRef(shouldIncludeEntry);
+	shouldIncludeEntryRef.current = shouldIncludeEntry;
 
 	// Bumped on workspace/root change so async listings started against an
 	// old workspace can detect they're stale and bail out before mutating.
@@ -103,7 +117,9 @@ export function useFilesTabBridge({
 				const ops: { type: "add"; path: string }[] = [];
 				for (const entry of result.entries) {
 					const rel = toRel(rootPath, entry.absolutePath);
-					const treePath = entry.kind === "directory" ? `${rel}/` : rel;
+					const isDirectory = entry.kind === "directory";
+					if (!shouldIncludeEntryRef.current(rel, isDirectory)) continue;
+					const treePath = isDirectory ? `${rel}/` : rel;
 					if (knownPathsRef.current.has(treePath)) continue;
 					knownPathsRef.current.add(treePath);
 					ops.push({ type: "add", path: treePath });
@@ -142,7 +158,9 @@ export function useFilesTabBridge({
 					if (versionRef.current !== startVersion) return;
 					for (const entry of result.entries) {
 						const rel = toRel(rootPath, entry.absolutePath);
-						freshPaths.add(entry.kind === "directory" ? `${rel}/` : rel);
+						const isDirectory = entry.kind === "directory";
+						if (!shouldIncludeEntryRef.current(rel, isDirectory)) continue;
+						freshPaths.add(isDirectory ? `${rel}/` : rel);
 					}
 					loadedDirsRef.current.add(dir);
 				} catch (error) {
@@ -254,7 +272,7 @@ export function useFilesTabBridge({
 						}
 						addKnownPath(model, knownPathsRef.current, newKey);
 					}
-				} else {
+				} else if (shouldIncludeEntryRef.current(rel, isFolder)) {
 					addKnownPath(model, knownPathsRef.current, newKey);
 				}
 				return;
@@ -277,6 +295,7 @@ export function useFilesTabBridge({
 
 			if (event.kind === "create") {
 				const isFolder = event.isDirectory ?? false;
+				if (!shouldIncludeEntryRef.current(rel, isFolder)) return;
 				const key = isFolder ? `${rel}/` : rel;
 				addKnownPath(model, knownPathsRef.current, key);
 				return;

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -198,6 +198,33 @@ const DEFAULT_SIDEBAR_FILE_LINKS: LinkTierMap = {
 	metaShift: "external",
 };
 
+// Folder/file basenames hidden by default in the v2 explorer. Mirrors the VS
+// Code convention: hide build artefacts and SCM internals, but leave dotfiles
+// like .env, .gitignore, .eslintrc visible so they remain searchable.
+export const DEFAULT_FILE_EXPLORER_EXCLUDES = [
+	"node_modules",
+	".git",
+	".turbo",
+	".next",
+	"dist",
+	"build",
+	".DS_Store",
+] as const;
+
+const fileExplorerFilterSchema = z.object({
+	excludeNames: z
+		.array(z.string())
+		.default([...DEFAULT_FILE_EXPLORER_EXCLUDES]),
+	hideGitignored: z.boolean().default(false),
+});
+
+export type FileExplorerFilter = z.infer<typeof fileExplorerFilterSchema>;
+
+const DEFAULT_FILE_EXPLORER_FILTER: FileExplorerFilter = {
+	excludeNames: [...DEFAULT_FILE_EXPLORER_EXCLUDES],
+	hideGitignored: false,
+};
+
 export const v2UserPreferencesSchema = z.object({
 	id: z.literal("preferences"),
 	fileLinks: linkTierMapSchema.default(DEFAULT_LINK_TIER_MAP),
@@ -208,6 +235,9 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
+	fileExplorerFilter: fileExplorerFilterSchema.default(
+		DEFAULT_FILE_EXPLORER_FILTER,
+	),
 });
 
 export type V2UserPreferencesRow = z.infer<typeof v2UserPreferencesSchema>;
@@ -224,6 +254,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 	showPresetsBar: true,
+	fileExplorerFilter: DEFAULT_FILE_EXPLORER_FILTER,
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds a search input bar to the files tab in the v2 workspace sidebar
- Provides filter dropdown to exclude specific folder/file names (preset: node_modules, .git, .turbo, .next, dist, build, .DS_Store)
- Supports hiding gitignored files via checkbox
- Allows custom exclude patterns

## How it works
- `FilesTabFilterBar` component manages search input and filter UI with dropdown menu
- Filter state stored in `FileExplorerFilter` preferences (excludeNames array + hideGitignored flag)
- `shouldIncludeEntry` callback passed to `useFilesTabBridge` filters entries before they reach Pierre file tree
- Search driven via Pierre's native `model.setSearch()` — matches against already-loaded paths
- Filter refreshes already-loaded directories when preset/custom excludes change

## Testing
Manual testing of search and filter UI in v2 workspace file explorer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds search and filtering to the v2 file explorer so large workspaces are easier to navigate. The files tab now has a search input and a filter menu with preset excludes, custom excludes, and a hide-gitignored option.

**Notes**
- Search matches only paths already loaded in the tree, not the full repo.
- Filtering removes excluded entries from the tree and refreshes already-loaded directories when the filter changes.
- Filter choices persist per user and default to hiding `node_modules`, `.git`, `.turbo`, `.next`, `dist`, `build`, and `.DS_Store`.

<sup>Written for commit 5704dca9b422a54df200145b59ef8de60d88093a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search to the workspace file explorer, including instant filtering and a clear option.
  * Added file explorer filters for hiding common folders and files, custom exclusions, and Git-ignored paths.
  * Added filter settings that persist across sessions, with an option to reset them to defaults.
  * Filtered files remain excluded during refreshes and live file-system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->