### PR TITLE
fix(desktop): align sidebar folder headers with the lane's workspace rows

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarGroupHeader/DashboardSidebarGroupHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarGroupHeader/DashboardSidebarGroupHeader.tsx
@@ -5,6 +5,7 @@ import {
 	type ReactNode,
 } from "react";
 import { HiChevronRight } from "react-icons/hi2";
+import type { DashboardSidebarWorkspaceIndentation } from "../../types";
 
 interface DashboardSidebarGroupHeaderProps
 	extends ComponentPropsWithoutRef<"div"> {
@@ -14,6 +15,11 @@ interface DashboardSidebarGroupHeaderProps
 	actions?: ReactNode;
 	isEditing?: boolean;
 	isDraggable?: boolean;
+	/**
+	 * Column the header's chevron sits in: the same one the lane's ungrouped
+	 * rows use, so a folder reads as a sibling of the rows around it.
+	 */
+	indentation?: Exclude<DashboardSidebarWorkspaceIndentation, "grouped">;
 }
 
 /** Shared visual and interaction shell for every nested sidebar group. */
@@ -29,6 +35,7 @@ export const DashboardSidebarGroupHeader = forwardRef<
 			actions,
 			isEditing = false,
 			isDraggable = false,
+			indentation = "workspace",
 			className,
 			...props
 		},
@@ -53,7 +60,9 @@ export const DashboardSidebarGroupHeader = forwardRef<
 			className={cn(
 				// Group containers have a 2px left accent border. Use a 6px left
 				// margin so their content aligns with borderless top-level rows.
-				"group ml-1.5 mr-2 flex min-h-7 items-center rounded-md py-1 pl-2 pr-2 text-[13px] font-medium text-muted-foreground transition-colors hover:bg-fill-hover",
+				"group ml-1.5 mr-2 flex min-h-7 items-center rounded-md py-1 pr-2 text-[13px] font-medium text-muted-foreground transition-colors hover:bg-fill-hover",
+				// Mirrors DashboardSidebarExpandedWorkspaceRow's per-lane padding.
+				indentation === "top-level" ? "pl-2" : "pl-6",
 				className,
 			)}
 			{...props}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarExpandedProjectContent/DashboardSidebarExpandedProjectContent.tsx
@@ -28,8 +28,15 @@ interface DashboardSidebarExpandedProjectContentProps {
 	/** Lane the rows are filed under: the project id, or null for sessions. */
 	projectId: string | null;
 	isCollapsed: boolean;
-	/** Row indentation overrides; the Sessions lane sits flush with its header. */
-	topLevelIndentation?: DashboardSidebarWorkspaceIndentation;
+	/**
+	 * Row indentation overrides; the Sessions lane sits flush with its header.
+	 * Folder headers share the top-level column so they read as siblings of
+	 * the ungrouped rows.
+	 */
+	topLevelIndentation?: Exclude<
+		DashboardSidebarWorkspaceIndentation,
+		"grouped"
+	>;
 	groupedIndentation?: DashboardSidebarWorkspaceIndentation;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
@@ -128,6 +135,7 @@ export function DashboardSidebarExpandedProjectContent({
 												key={String(id)}
 												sortableId={String(id)}
 												section={section}
+												indentation={topLevelIndentation}
 												onDelete={onDeleteSection}
 												onRename={onRenameSection}
 												onToggleCollapse={onToggleSectionCollapse}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -8,7 +8,10 @@ import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/u
 import { parseSidebarFolderKey } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
-import type { DashboardSidebarSection } from "../../types";
+import type {
+	DashboardSidebarSection,
+	DashboardSidebarWorkspaceIndentation,
+} from "../../types";
 import { DashboardSidebarGroupHeader } from "../DashboardSidebarGroupHeader";
 import {
 	DashboardSidebarSectionActionsDropdown,
@@ -18,6 +21,8 @@ import {
 interface SortableSectionHeaderProps {
 	sortableId: string;
 	section: DashboardSidebarSection;
+	/** Column of the lane's ungrouped rows; the header lines up with them. */
+	indentation?: Exclude<DashboardSidebarWorkspaceIndentation, "grouped">;
 	onDelete: (sectionId: string) => void;
 	onRename: (sectionId: string, name: string) => void;
 	onToggleCollapse: (sectionId: string) => void;
@@ -26,6 +31,7 @@ interface SortableSectionHeaderProps {
 export function SortableSectionHeader({
 	sortableId,
 	section,
+	indentation,
 	onDelete,
 	onRename,
 	onToggleCollapse,
@@ -116,6 +122,7 @@ export function SortableSectionHeader({
 					isCollapsed={section.isCollapsed}
 					isEditing={isRenaming}
 					isDraggable
+					indentation={indentation}
 					onToggleCollapse={() => onToggleCollapse(section.id)}
 					actions={
 						<DashboardSidebarSectionActionsDropdown

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -108,6 +108,9 @@ export function SortableWorkspaceItem({
 			<div
 				className={cn(
 					"grid transition-[grid-template-rows,opacity] duration-150 ease-out",
+					// Pull the row back over the accent border so grouped rows keep
+					// the same left edge whether or not their folder has a color.
+					accentColor && "-ml-0.5",
 					collapsed
 						? "grid-rows-[0fr] opacity-0"
 						: "grid-rows-[1fr] opacity-100",


### PR DESCRIPTION
## Summary
- Folder group headers in the Projects lane now sit at the same column as regular workspace rows, instead of the project-icon column one step left.
- Rows under a colored folder no longer drift 2px right of rows under an uncolored one.
- Sessions lane is unchanged: its folders already matched the top-level session rows.

## Why / Context
The shared `DashboardSidebarGroupHeader` always used `pl-2`. Under a project that put the chevron at 16px while the workspace rows around it start at 32px, so a folder read as a sibling of the project instead of a sibling of the workspaces. Sessions only looked right because its top-level rows also use `pl-2`.

## How It Works
- `DashboardSidebarGroupHeader` takes an `indentation` prop (`top-level` | `workspace`) and picks `pl-2` or `pl-6`, mirroring `DashboardSidebarExpandedWorkspaceRow`.
- `SortableSectionHeader` threads it through; `DashboardSidebarExpandedProjectContent` passes the lane's existing `topLevelIndentation`, so projects default to the deeper column and Sessions keeps passing `top-level`. No new call-site config.
- `SortableWorkspaceItem` adds `-ml-0.5` when it draws the 2px accent border, matching the `ml-1.5` compensation the header already had.

## Manual QA
Measured over CDP against this worktree's dev app (same probe before and after; icon/chevron left edge relative to the sidebar):

| Lane | Element | Before | After |
|---|---|---|---|
| Projects | workspace row icon | 32px | 32px |
| Projects | folder chevron | 16px | 32px |
| Projects | grouped row icon | 48 / 50px | 48px |
| Sessions | session row icon | 16px | 16px |
| Sessions | folder chevron | 16px | 16px |
| Sessions | grouped row icon | 32px | 32px |

- [x] Project with colored and uncolored folders (Superset) renders folders flush with workspace rows, children one level deeper
- [x] Sessions lane with the `automation` folder unchanged
- [x] Folder hover box still spans the same horizontal extent as row hover boxes

## Testing
- `bun run typecheck` (desktop)
- `biome check` on `DashboardSidebar/`
- `bun test src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar` (162 pass)

## Known Limitations
- An uncolored folder still draws its gray accent bar on the header only, while a colored folder's bar spans header plus rows. Pre-existing and left as is.

https://claude.ai/code/session_01NSANnBdHZAic1mehCD6FtS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar folder header alignment in the desktop app so project folders line up with the workspace rows around them instead of sitting one column left. Also stops grouped rows under colored folders from drifting 2px right of rows under uncolored folders; the Sessions lane is unchanged.

<sup>Written for commit 57e72684d46cd1a29f7abc65e1efce831d335226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard sidebar alignment for project, folder, and grouped workspace rows.
  * Corrected indentation for section headers and nested content.
  * Standardized row positioning when folders use accent colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->