### PR TITLE
@blaxel/core 0.3.19: forks take their env on the fork request

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@superset/repo",
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
-        "@blaxel/core": "0.3.11",
+        "@blaxel/core": "0.3.19",
         "@types/bun": "1.3.14",
         "@types/semver": "7.7.1",
         "dotenv-cli": "11.0.0",
@@ -1195,7 +1195,7 @@
         "@aws-sdk/client-s3": "3.899.0",
         "@aws-sdk/s3-request-presigner": "3.899.0",
         "@azure/msal-node": "5.5.0",
-        "@blaxel/core": "0.3.11",
+        "@blaxel/core": "0.3.19",
         "@googleapis/calendar": "16.0.0",
         "@googleapis/gmail": "18.0.0",
         "@linear/sdk": "68.1.1",
@@ -1782,7 +1782,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-9ma7C4g8Sq3cBlRJD2yrsHXB1mnnEBdpy7PhvFrylQWQb4PoyCmPucdX7frvsSBQuFtIiKCrolPl/8tCZrKvgQ=="],
 
-    "@blaxel/core": ["@blaxel/core@0.3.11", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-vkFMd3jVbC4zz8BQ5LuVw4BcK1KVVIgQTeHTG/1cGu9CAeaHined1WP68XRoxksXC+zGmCnMv619IuMGjQhkDw=="],
+    "@blaxel/core": ["@blaxel/core@0.3.19", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^17.4.2", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-xq0uFLx7BPkfqI1PiJVxlRWr0lBr7zPP6v9UtMtAFopJ/CkWrU9xkIFiMDS0DoPR6ra1Rtx134bOkSjHCgQhdw=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
@@ -7272,7 +7272,7 @@
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+    "@blaxel/core/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "@blaxel/core/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,7 +12,10 @@ minimumReleaseAge = 259200
 # every one of these. Excluding them keeps the repo installable from scratch.
 # Remove once the pins age past the window — they are exact, so this list only
 # ever covers versions we already chose.
+# @blaxel/core: the sandbox SDK ships fixes we depend on within hours, and the
+# pin is exact, so the guard would only ever delay a version we already chose.
 minimumReleaseAgeExcludes = [
+  "@blaxel/core",
   "@expo/ui",
   "@pierre/diffs",
   "expo",

--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -247,6 +247,17 @@ space are volumes (one per sandbox, attached at creation, not forkable) and
 Agent Drive; neither fits the golden-and-fork model, which is why memory is the
 lever.
 
+**A fork takes its env on the fork request, and again on the boot script.**
+`@blaxel/core` 0.3.19 accepts `envs` on `fork()`, which replaced the spec
+update (and the restart it caused) that used to hand a fork its identity. The
+values reach processes only when the sandbox runtime baked into the image is
+current: on a golden built 2026-09-02 they landed in the spec and no process
+saw them, PID 1 included; on one rebuilt 2026-09-03 every process did, and
+fork plus get took under half a second. The `/app/start.sh` exec carries the
+same env for goldens from before that rebuild, since everything the workspace
+runs descends from it. A fork can only set or add variables, never drop one,
+so promoting a workspace blanks its identity with empty values instead.
+
 **A fork can never have the egress proxy.** The proxy routing that injects
 the org's model keys (`network.proxy.routing`) exists only on sandboxes created
 with it: Blaxel's docs say enabling the proxy on a sandbox created without it

--- a/docs/cloud-sandbox-mismatches.md
+++ b/docs/cloud-sandbox-mismatches.md
@@ -256,7 +256,9 @@ saw them, PID 1 included; on one rebuilt 2026-09-03 every process did, and
 fork plus get took under half a second. The `/app/start.sh` exec carries the
 same env for goldens from before that rebuild, since everything the workspace
 runs descends from it. A fork can only set or add variables, never drop one,
-so promoting a workspace blanks its identity with empty values instead.
+so promoting a workspace blanks its identity with empty values instead; an
+empty value does override an inherited one (verified 2026-09-03: a golden's
+`NODE_ENV=production` came back empty on a fork that set it to `""`).
 
 **A fork can never have the egress proxy.** The proxy routing that injects
 the org's model keys (`network.proxy.routing`) exists only on sandboxes created
@@ -264,11 +266,11 @@ with it: Blaxel's docs say enabling the proxy on a sandbox created without it
 requires a new sandbox, and a fork is created without it (its `spec.network`
 is null, and a source that carries routing hands its forks unresolved
 `{{file(/var/run/secrets/…)}}` proxy templates, so every outbound request
-fails with "Unsupported proxy syntax"). Applying routing to a fork with
-`updateSandbox` is worse than useless: the platform builds a new instance from
-the image, and the fork comes back without `node_modules`, the tools, or
-anything else the environment carried (verified 2026-09-02 on a release
-probe). So a workspace forked from an environment gets its model keys the
+fails with "Unsupported proxy syntax"). Applying routing to a fork afterwards with a
+spec update (the SDK's `updateSandbox`, which nothing in this codebase calls
+any more) is worse than useless: the platform builds a new instance from the
+image, and the fork comes back without `node_modules`, the tools, or anything
+else the environment carried (verified 2026-09-02 on a release probe). So a workspace forked from an environment gets its model keys the
 plain way, as `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` in the environment's
 variables, and host-service approves that key for Claude Code before an
 unattended launch so it does not stop on the "use this custom API key?"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"release:cli": "bun scripts/release/cli.ts",
 		"release:canary": "./scripts/release-canary.sh",
 		"check:versions": "bun scripts/release/check-versions.ts",
+		"check:i18n": "bun run --cwd packages/i18n check",
 		"typecheck:release": "tsc -p scripts/release/tsconfig.json",
 		"test:release": "bun test scripts/release",
 		"db:push": "bun run --cwd packages/db push",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.2",
-		"@blaxel/core": "0.3.11",
+		"@blaxel/core": "0.3.19",
 		"@types/bun": "1.3.14",
 		"@types/semver": "7.7.1",
 		"dotenv-cli": "11.0.0",
@@ -47,7 +47,6 @@
 		"release:cli": "bun scripts/release/cli.ts",
 		"release:canary": "./scripts/release-canary.sh",
 		"check:versions": "bun scripts/release/check-versions.ts",
-		"check:i18n": "bun run --cwd packages/i18n check",
 		"typecheck:release": "tsc -p scripts/release/tsconfig.json",
 		"test:release": "bun test scripts/release",
 		"db:push": "bun run --cwd packages/db push",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -79,7 +79,7 @@
 		"@aws-sdk/client-s3": "3.899.0",
 		"@aws-sdk/s3-request-presigner": "3.899.0",
 		"@azure/msal-node": "5.5.0",
-		"@blaxel/core": "0.3.11",
+		"@blaxel/core": "0.3.19",
 		"@googleapis/calendar": "16.0.0",
 		"@googleapis/gmail": "18.0.0",
 		"@linear/sdk": "68.1.1",

--- a/packages/trpc/src/lib/blaxel/blaxel.ts
+++ b/packages/trpc/src/lib/blaxel/blaxel.ts
@@ -8,7 +8,7 @@
  * token — no relay hop, so websockets work and the sandbox can still sleep.
  */
 
-import { SandboxInstance, settings, updateSandbox } from "@blaxel/core";
+import { SandboxInstance, settings } from "@blaxel/core";
 import { CLOUD_AGENT_LAUNCH_ENV_NAMES } from "@superset/shared/cloud-agent-launch";
 import { SANDBOX_CREDENTIAL_PLACEHOLDER } from "@superset/shared/constants";
 import { env } from "../../env";
@@ -81,33 +81,16 @@ async function forkSandbox(
 	workspaceEnv: Record<string, string>,
 ): Promise<SandboxInstance> {
 	const source = await SandboxInstance.get(sourceSandbox);
-	await source.fork(name);
-	const forked = await SandboxInstance.get(name);
-
-	const spec = structuredClone(forked.spec) as {
-		runtime?: { envs?: Array<{ name: string; value: string }> };
-	};
-	const inherited = spec.runtime?.envs ?? [];
-	const replaced = new Set<string>();
-	const envs = inherited.map((entry) => {
-		const override = workspaceEnv[entry.name];
-		if (override === undefined) return entry;
-		replaced.add(entry.name);
-		return { name: entry.name, value: override };
-	});
-	for (const [key, value] of Object.entries(workspaceEnv)) {
-		if (!replaced.has(key)) envs.push({ name: key, value });
-	}
-	if (!spec.runtime) spec.runtime = {};
-	spec.runtime.envs = envs;
-
-	await updateSandbox({
-		path: { sandboxName: name },
-		body: {
-			...(forked as never as { sandbox: object }).sandbox,
-			spec,
-		} as never,
-		throwOnError: true,
+	// The fork request carries the workspace's env, so no spec update and no
+	// restart follow it. The values also ride on the boot script's own exec
+	// (see provisionSandbox): a golden whose sandbox runtime predates fork
+	// envs hands its children the source's env instead, and the script is
+	// what everything the workspace runs descends from.
+	await source.fork(name, {
+		envs: Object.entries(workspaceEnv).map(([envName, value]) => ({
+			name: envName,
+			value,
+		})),
 	});
 	return await SandboxInstance.get(name);
 }
@@ -188,10 +171,15 @@ export async function provisionSandbox(args: {
 	// Start host-service and return — the only thing provisioning runs inside a
 	// sandbox, and it is not awaited. The script needs a second or two; the
 	// client discovers the result by polling the health endpoint it already
-	// polls, so there is nothing to wait for here.
+	// polls, so there is nothing to wait for here. A fork gets its env on this
+	// exec as well as on the fork request, which covers goldens whose sandbox
+	// runtime predates fork envs (docs/cloud-sandbox-mismatches.md).
 	await sandbox.process.exec({
 		name: "host-service",
 		command: "/app/start.sh",
+		...(args.environment.sourceKind === "fork"
+			? { env: args.workspaceEnv }
+			: {}),
 		waitForCompletion: false,
 	} as never);
 
@@ -226,7 +214,13 @@ export async function promoteSandboxToEnvironment(args: {
 }): Promise<string> {
 	configureBlaxel();
 	const source = await SandboxInstance.get(args.sourceSandbox);
-	await source.fork(args.goldenName);
+	// A fork inherits the source's env and can only set or add variables, never
+	// drop one, so the promoting workspace's identity is blanked on the fork
+	// request: every later workspace forked from this environment would
+	// otherwise carry the promoter's git token and launch the promoter's agent.
+	await source.fork(args.goldenName, {
+		envs: [...INHERITED_IDENTITY_ENVS].map((name) => ({ name, value: "" })),
+	});
 
 	const golden = await SandboxInstance.get(args.goldenName);
 
@@ -247,29 +241,6 @@ export async function promoteSandboxToEnvironment(args: {
 		command: "pkill -f pty-daemon.js || true",
 		waitForCompletion: true,
 	} as never);
-
-	// Blaxel copies the source's env into the fork and env is immutable after
-	// creation, so the promoting workspace's credentials would otherwise ride
-	// into a shared environment every later workspace forks from. The git token
-	// is the dangerous one: provisioning only sets it when the clone needs it,
-	// so a public-repo workspace would inherit the promoter's instead.
-	const current = await SandboxInstance.get(args.goldenName);
-	const spec = structuredClone(current.spec) as {
-		runtime?: { envs?: Array<{ name: string; value: string }> };
-	};
-	if (spec.runtime?.envs) {
-		spec.runtime.envs = spec.runtime.envs.filter(
-			(entry) => !INHERITED_IDENTITY_ENVS.has(entry.name),
-		);
-		await updateSandbox({
-			path: { sandboxName: args.goldenName },
-			body: {
-				...(current as never as { sandbox: object }).sandbox,
-				spec,
-			} as never,
-			throwOnError: true,
-		});
-	}
 
 	return args.goldenName;
 }


### PR DESCRIPTION
## What

`@blaxel/core` 0.3.11 → 0.3.19, and forks take their env on the fork request.

Blaxel's fork doc added `envs` on `fork()`. That replaces the spec update, and the restart it caused, that used to hand a fork its identity: `forkSandbox` is one call, promoting a workspace blanks its identity on the fork request instead of stripping it afterwards, and `updateSandbox` is gone from the module.

`bunfig.toml` excludes `@blaxel/core` from the 3-day release-age guard. 0.3.17 through 0.3.19 all shipped within a day, the pin is exact, and this SDK ships sandbox fixes we depend on within hours.

## One caveat, verified twice

Fork envs reach processes only when the sandbox runtime baked into the image is current. On a golden built 2026-09-02 they landed in the spec and no process saw them, PID 1 included, because a fork resumes the source's runtime with the source's env. On a golden rebuilt 2026-09-03 every process saw them, and fork plus get took under half a second. So the boot script's exec carries the same env as a guard for goldens from before that rebuild, and `docs/cloud-sandbox-mismatches.md` records it. Both goldens were re-released on the rebuilt base with this code: dev `env-internal-mtm5u71e`, prod `env-internal-mtm5z9zc`, every probe check green.

## Evidence

- `bun run sandbox:release` (dev, full base rebuild on 0.3.19): golden checks and the fork probe all pass, host-service answering 18 s after the fork started, dependencies intact, both provider keys reachable, Electron up.
- Through the desktop: a workspace created from the Superset (fork) environment with Claude reached `ready` in 12 s instead of about 25 s; the marker was written, the `claude` process ran with its prompt, and it answered in the adopted pane.
- `fork(name, { envs })` on the rebuilt golden: `exec_sees_fork_env=yes`, every process has it, 475 ms for fork plus get.
- Empty values override inherited ones, which is what promote relies on: a golden's `NODE_ENV=production` came back as an empty, set variable on a fork that passed `NODE_ENV=""`.

## Not in this PR

- `fork` still takes no `network`, so the egress proxy remains creation-only; environment-level proxy credentials are parked in #7132 until that changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Forked sandboxes now receive workspace environment variables correctly during creation.
  - Empty environment variable values override inherited values as expected.
  - Environment promotion now removes inherited identity and credential variables.
  - Forked sandbox startup processes receive the appropriate workspace variables.

- **Documentation**
  - Clarified environment variable override behavior and how to apply egress routing changes to existing forks.

- **Chores**
  - Updated the Blaxel SDK version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->