### PR TITLE
fix(host-service): delete orphaned pull_request rows instead of keeping them forever

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/index.ts
@@ -1,4 +1,8 @@
 export {
+	deletePullRequestIfOrphaned,
+	pruneOrphanedPullRequests,
+} from "./prune-orphaned";
+export {
 	type CheckoutPullRequestMetadata,
 	PullRequestRuntimeManager,
 	type PullRequestRuntimeManagerOptions,

--- a/packages/host-service/src/runtime/pull-requests/prune-orphaned.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/prune-orphaned.test.ts
@@ -1,0 +1,130 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../../db";
+import * as schema from "../../db/schema";
+import { pullRequests } from "../../db/schema";
+import {
+	deletePullRequestIfOrphaned,
+	ORPHANED_PULL_REQUEST_GRACE_MS,
+	pruneOrphanedPullRequests,
+} from "./prune-orphaned";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../../drizzle");
+const PROJECT_ID = "project-1";
+const NOW = 1_750_000_000_000;
+const STALE = NOW - ORPHANED_PULL_REQUEST_GRACE_MS - 1;
+
+function createRealDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db as unknown as HostDb;
+}
+
+function seedProject(db: HostDb) {
+	db.insert(schema.projects)
+		.values({ id: PROJECT_ID, repoPath: "/repo", createdAt: NOW })
+		.run();
+}
+
+function seedPullRequest(
+	db: HostDb,
+	pr: { id: string; prNumber: number; updatedAt: number },
+) {
+	db.insert(schema.pullRequests)
+		.values({
+			id: pr.id,
+			projectId: PROJECT_ID,
+			repoProvider: "github",
+			repoOwner: "owner",
+			repoName: "repo",
+			prNumber: pr.prNumber,
+			url: `https://github.com/owner/repo/pull/${pr.prNumber}`,
+			title: `PR ${pr.prNumber}`,
+			state: "open",
+			headBranch: `branch-${pr.prNumber}`,
+			headSha: "a".repeat(40),
+			createdAt: pr.updatedAt,
+			updatedAt: pr.updatedAt,
+		})
+		.run();
+}
+
+function seedWorkspace(
+	db: HostDb,
+	w: { id: string; pullRequestId?: string | null },
+) {
+	db.insert(schema.workspaces)
+		.values({
+			id: w.id,
+			projectId: PROJECT_ID,
+			worktreePath: `/repo/.worktrees/${w.id}`,
+			branch: w.id,
+			createdAt: NOW,
+			pullRequestId: w.pullRequestId ?? null,
+		})
+		.run();
+}
+
+function prIds(db: HostDb): string[] {
+	return db
+		.select({ id: pullRequests.id })
+		.from(pullRequests)
+		.all()
+		.map((row) => row.id)
+		.sort();
+}
+
+describe("pruneOrphanedPullRequests", () => {
+	test("deletes stale unreferenced rows, keeps linked and fresh rows", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, { id: "pr-orphan", prNumber: 1, updatedAt: STALE });
+		seedPullRequest(db, { id: "pr-linked", prNumber: 2, updatedAt: STALE });
+		// Fresh row simulates an upsert whose link assignment hasn't landed yet.
+		seedPullRequest(db, { id: "pr-fresh", prNumber: 3, updatedAt: NOW });
+		seedWorkspace(db, { id: "ws", pullRequestId: "pr-linked" });
+
+		expect(pruneOrphanedPullRequests(db, NOW)).toBe(1);
+		expect(prIds(db)).toEqual(["pr-fresh", "pr-linked"]);
+	});
+
+	test("returns 0 and deletes nothing when every row is referenced", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, { id: "pr-1", prNumber: 1, updatedAt: STALE });
+		seedWorkspace(db, { id: "ws-a", pullRequestId: "pr-1" });
+		seedWorkspace(db, { id: "ws-b", pullRequestId: "pr-1" });
+
+		expect(pruneOrphanedPullRequests(db, NOW)).toBe(0);
+		expect(prIds(db)).toEqual(["pr-1"]);
+	});
+});
+
+describe("deletePullRequestIfOrphaned", () => {
+	test("deletes an unreferenced row regardless of freshness", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, { id: "pr-1", prNumber: 1, updatedAt: NOW });
+
+		expect(deletePullRequestIfOrphaned(db, "pr-1")).toBe(true);
+		expect(prIds(db)).toEqual([]);
+	});
+
+	test("keeps a row another workspace still links to", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, { id: "pr-1", prNumber: 1, updatedAt: STALE });
+		seedWorkspace(db, { id: "ws-other", pullRequestId: "pr-1" });
+
+		expect(deletePullRequestIfOrphaned(db, "pr-1")).toBe(false);
+		expect(
+			db.select().from(pullRequests).where(eq(pullRequests.id, "pr-1")).get(),
+		).toBeDefined();
+	});
+});

--- a/packages/host-service/src/runtime/pull-requests/prune-orphaned.ts
+++ b/packages/host-service/src/runtime/pull-requests/prune-orphaned.ts
@@ -1,0 +1,69 @@
+import { and, eq, inArray, isNull, lt } from "drizzle-orm";
+import type { HostDb } from "../../db";
+import { pullRequests, workspaces } from "../../db/schema";
+
+/**
+ * `pull_requests` rows are only reachable through `workspaces.pullRequestId`
+ * links — once nothing references a row it can never surface again, but until
+ * these helpers existed nothing deleted it either, so every PR ever opened
+ * from a local workspace accumulated in host.db forever.
+ */
+
+// Refresh upserts a PR row before link assignment, and the two can sit on
+// opposite sides of an await boundary — a sweep firing in that gap would see
+// the fresh row as unreferenced. Every upsert bumps `updatedAt`, so skipping
+// recently-touched rows closes the race.
+export const ORPHANED_PULL_REQUEST_GRACE_MS = 60_000;
+
+/**
+ * Delete every pull-request row no workspace references anymore, except rows
+ * touched within the grace window. Returns the number of rows deleted.
+ */
+export function pruneOrphanedPullRequests(
+	db: HostDb,
+	now = Date.now(),
+): number {
+	const orphaned = db
+		.select({ id: pullRequests.id })
+		.from(pullRequests)
+		.leftJoin(workspaces, eq(workspaces.pullRequestId, pullRequests.id))
+		.where(
+			and(
+				isNull(workspaces.id),
+				lt(pullRequests.updatedAt, now - ORPHANED_PULL_REQUEST_GRACE_MS),
+			),
+		)
+		.all();
+	if (orphaned.length === 0) return 0;
+
+	db.delete(pullRequests)
+		.where(
+			inArray(
+				pullRequests.id,
+				orphaned.map((row) => row.id),
+			),
+		)
+		.run();
+	return orphaned.length;
+}
+
+/**
+ * Targeted variant for workspace deletion: drop one PR row immediately —
+ * no grace window, the caller just severed the only suspect link — unless
+ * another workspace still references it (same branch checked out twice).
+ * Returns whether the row was deleted.
+ */
+export function deletePullRequestIfOrphaned(
+	db: HostDb,
+	pullRequestId: string,
+): boolean {
+	const stillLinked = db
+		.select({ id: workspaces.id })
+		.from(workspaces)
+		.where(eq(workspaces.pullRequestId, pullRequestId))
+		.get();
+	if (stillLinked) return false;
+
+	db.delete(pullRequests).where(eq(pullRequests.id, pullRequestId)).run();
+	return true;
+}

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -736,3 +736,35 @@ describe("default-branch guard", () => {
 		);
 	});
 });
+
+describe("PullRequestRuntimeManager orphan pruning", () => {
+	test("safety-net sweep deletes PR rows no workspace references", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, {
+			id: "pr-linked",
+			prNumber: 1,
+			headBranch: "kept",
+			headSha: "sha-linked",
+		});
+		// Debris from a deleted workspace; seeded updatedAt is far outside the
+		// prune grace window.
+		seedPullRequest(db, {
+			id: "pr-orphan",
+			prNumber: 2,
+			headBranch: "gone",
+			headSha: "sha-orphan",
+		});
+		seedWorkspace(db, { id: "ws", branch: "kept", pullRequestId: "pr-linked" });
+		// Default git factory throws, so each per-workspace sync warns and
+		// no-ops — the sweep's prune must still run afterwards.
+		const manager = createManager(db);
+
+		// biome-ignore lint/complexity/useLiteralKeys: element access is the escape hatch into the private sweep; dot access is a TS visibility error
+		await withSilencedWarnings(() => manager["syncWorkspaceBranches"]());
+
+		expect(getPrById(db, "pr-orphan")).toBeUndefined();
+		expect(getPrById(db, "pr-linked")).toBeDefined();
+		expect(getWorkspace(db, "ws")?.pullRequestId).toBe("pr-linked");
+	});
+});

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -7,6 +7,7 @@ import { projects, pullRequests, workspaces } from "../../db/schema";
 import type { GitWatcher } from "../../events/git-watcher";
 import type { ExecGh } from "../../trpc/router/workspace-creation/utils/exec-gh";
 import { type GitFactory, resolveDefaultBranchName } from "../git";
+import { pruneOrphanedPullRequests } from "./prune-orphaned";
 import {
 	fetchOpenPullRequests,
 	fetchOpenPullRequestsFromGh,
@@ -475,6 +476,18 @@ export class PullRequestRuntimeManager {
 		// dedupes across workspaces in the same project via inFlightProjects.
 		for (const row of ids) {
 			await this.enqueueWorkspaceSync(row.id);
+		}
+
+		// Every link is settled now, so anything unreferenced is debris from
+		// deleted workspaces or retargeted branches — without this, every PR
+		// ever opened from a local workspace lives in host.db forever. The
+		// grace window inside spares rows upserted mid-refresh that haven't
+		// been link-assigned yet.
+		const pruned = pruneOrphanedPullRequests(this.db);
+		if (pruned > 0) {
+			console.log(
+				`[host-service:pull-request-runtime] Pruned ${pruned} orphaned pull request row(s)`,
+			);
 		}
 	}
 

--- a/packages/host-service/src/workspaces/local-workspace-store.test.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.test.ts
@@ -1,0 +1,121 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { HostDb } from "../db";
+import * as schema from "../db/schema";
+import { pullRequests, workspaces } from "../db/schema";
+import type { EventBus } from "../events";
+import {
+	deleteLocalWorkspace,
+	type WorkspaceStoreContext,
+} from "./local-workspace-store";
+
+const MIGRATIONS_FOLDER = resolve(import.meta.dir, "../../drizzle");
+const PROJECT_ID = "project-1";
+
+function createRealDb(): HostDb {
+	const sqlite = new Database(":memory:");
+	sqlite.exec("PRAGMA foreign_keys = ON;");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+	return db as unknown as HostDb;
+}
+
+function makeCtx(db: HostDb): WorkspaceStoreContext {
+	return {
+		db,
+		eventBus: { broadcastWorkspaceChanged: () => {} } as unknown as EventBus,
+	};
+}
+
+function seedProject(db: HostDb) {
+	db.insert(schema.projects)
+		.values({ id: PROJECT_ID, repoPath: "/repo", createdAt: Date.now() })
+		.run();
+}
+
+function seedPullRequest(db: HostDb, id: string, prNumber: number) {
+	db.insert(schema.pullRequests)
+		.values({
+			id,
+			projectId: PROJECT_ID,
+			repoProvider: "github",
+			repoOwner: "owner",
+			repoName: "repo",
+			prNumber,
+			url: `https://github.com/owner/repo/pull/${prNumber}`,
+			title: `PR ${prNumber}`,
+			state: "open",
+			headBranch: `branch-${prNumber}`,
+			headSha: "a".repeat(40),
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		})
+		.run();
+}
+
+function seedWorkspace(
+	db: HostDb,
+	w: { id: string; pullRequestId?: string | null },
+) {
+	db.insert(schema.workspaces)
+		.values({
+			id: w.id,
+			projectId: PROJECT_ID,
+			worktreePath: `/repo/.worktrees/${w.id}`,
+			branch: w.id,
+			createdAt: Date.now(),
+			pullRequestId: w.pullRequestId ?? null,
+		})
+		.run();
+}
+
+function getPr(db: HostDb, id: string) {
+	return db.select().from(pullRequests).where(eq(pullRequests.id, id)).get();
+}
+
+describe("deleteLocalWorkspace pull-request cleanup", () => {
+	test("deletes the linked PR row along with its last workspace", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, "pr-1", 1);
+		seedWorkspace(db, { id: "ws", pullRequestId: "pr-1" });
+
+		deleteLocalWorkspace(makeCtx(db), "ws");
+
+		expect(
+			db.select().from(workspaces).where(eq(workspaces.id, "ws")).get(),
+		).toBeUndefined();
+		expect(getPr(db, "pr-1")).toBeUndefined();
+	});
+
+	test("keeps the PR row while another workspace still links to it", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, "pr-1", 1);
+		seedWorkspace(db, { id: "ws-a", pullRequestId: "pr-1" });
+		seedWorkspace(db, { id: "ws-b", pullRequestId: "pr-1" });
+
+		deleteLocalWorkspace(makeCtx(db), "ws-a");
+
+		expect(getPr(db, "pr-1")).toBeDefined();
+
+		deleteLocalWorkspace(makeCtx(db), "ws-b");
+
+		expect(getPr(db, "pr-1")).toBeUndefined();
+	});
+
+	test("is a no-op for workspaces without a PR link", () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedPullRequest(db, "pr-unrelated", 1);
+		seedWorkspace(db, { id: "ws" });
+
+		deleteLocalWorkspace(makeCtx(db), "ws");
+
+		expect(getPr(db, "pr-unrelated")).toBeDefined();
+	});
+});

--- a/packages/host-service/src/workspaces/local-workspace-store.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.ts
@@ -8,6 +8,7 @@ import type { HostDb } from "../db";
 import { workspaces } from "../db/schema";
 import type { EventBus } from "../events";
 import type { WorkspaceSnapshot } from "../events/types";
+import { deletePullRequestIfOrphaned } from "../runtime/pull-requests/prune-orphaned";
 import type { ApiClient } from "../types";
 
 export type HostWorkspaceRow = typeof workspaces.$inferSelect;
@@ -202,6 +203,20 @@ export function deleteLocalWorkspace(
 ): void {
 	const existing = getLocalWorkspace(ctx.db, id);
 	ctx.db.delete(workspaces).where(eq(workspaces.id, id)).run();
+	if (existing?.pullRequestId) {
+		// This is the choke point for workspace deletion, so the linked PR row
+		// goes away with its last workspace instead of rotting in host.db
+		// until the runtime manager's next orphan sweep. Best-effort — a
+		// failure here must never fail the workspace delete.
+		try {
+			deletePullRequestIfOrphaned(ctx.db, existing.pullRequestId);
+		} catch (error) {
+			console.warn(
+				"[host-service:workspace-store] Failed to prune pull request row after workspace delete",
+				{ workspaceId: id, pullRequestId: existing.pullRequestId, error },
+			);
+		}
+	}
 	if (existing) {
 		ctx.eventBus.broadcastWorkspaceChanged({
 			workspaceId: id,

--- a/packages/host-service/test/pull-requests-scaling.test.ts
+++ b/packages/host-service/test/pull-requests-scaling.test.ts
@@ -89,6 +89,11 @@ async function runSync(workspaceCount: number) {
 		select: mock(() => ({
 			from: mock(() => ({
 				all: mock(() => workspaces),
+				// The sweep's trailing orphan prune joins pull_requests against
+				// workspaces; report no orphans so it costs nothing here.
+				leftJoin: mock(() => ({
+					where: mock(() => ({ all: mock(() => []) })),
+				})),
 			})),
 		})),
 		// syncWorkspaceBranches only writes when state changed; nothing should change here.

--- a/packages/host-service/test/pull-requests.test.ts
+++ b/packages/host-service/test/pull-requests.test.ts
@@ -22,6 +22,11 @@ describe("PullRequestRuntimeManager branch sync", () => {
 			select: mock(() => ({
 				from: mock(() => ({
 					all: allMock,
+					// The sweep's trailing orphan prune joins pull_requests
+					// against workspaces; report no orphans here.
+					leftJoin: mock(() => ({
+						where: mock(() => ({ all: mock(() => []) })),
+					})),
 				})),
 			})),
 			update: updateMock,
@@ -113,6 +118,11 @@ describe("PullRequestRuntimeManager branch sync", () => {
 			select: mock(() => ({
 				from: mock(() => ({
 					all: allMock,
+					// The sweep's trailing orphan prune joins pull_requests
+					// against workspaces; report no orphans here.
+					leftJoin: mock(() => ({
+						where: mock(() => ({ all: mock(() => []) })),
+					})),
 				})),
 			})),
 			update: updateMock,


### PR DESCRIPTION
## Summary
- Every PR opened from a local workspace inserted a row into host.db's `pull_requests` table, and nothing ever deleted it. Deleting the workspace or retargeting its branch dropped the link but left the row behind permanently.
- Adds two cleanup paths that share one orphan check: `deleteLocalWorkspace` now removes the linked PR row with its last workspace, and the runtime manager's safety-net sweep prunes any remaining unreferenced rows.

## Why
`pull_requests` rows are only reachable through `workspaces.pullRequestId` links, so once nothing references a row it can never surface again. Without a deleter, rows accumulate forever; one long-lived install had 97 of 108 rows orphaned.

## How it works
- New `prune-orphaned.ts` exports two helpers:
  - `pruneOrphanedPullRequests(db, now)` left-joins `pull_requests` against `workspaces` and deletes rows with no link whose `updatedAt` is older than a 60s grace window. The grace window matters because refresh upserts a PR row before assigning the workspace link, and the two can sit on opposite sides of an await boundary. Every upsert bumps `updatedAt`, so skipping recently-touched rows closes that race.
  - `deletePullRequestIfOrphaned(db, id)` is the targeted variant for workspace deletion: no grace window, since the caller just severed the only suspect link, but it still keeps the row if another workspace references it (same branch checked out twice).
- `deleteLocalWorkspace` calls the targeted helper after removing the workspace row. It's wrapped in try/catch so a prune failure can never fail the workspace delete.
- `PullRequestRuntimeManager.syncWorkspaceBranches` calls the sweep after every per-workspace sync has settled, logging the count when anything was pruned.
- The two existing mock-DB tests in `test/` gain a `leftJoin` stub returning no orphans so the trailing prune is a no-op there.

## Testing
Ran the five touched test files in `packages/host-service`:

```
bun test src/runtime/pull-requests/prune-orphaned.test.ts src/runtime/pull-requests/pull-requests.test.ts src/workspaces/local-workspace-store.test.ts test/pull-requests.test.ts test/pull-requests-scaling.test.ts
```

24 pass, 0 fail. New coverage includes: stale orphans deleted while linked and fresh rows survive; targeted delete keeps a row another workspace still links to; `deleteLocalWorkspace` drops the PR with its last workspace, keeps it while a second workspace links to it, and no-ops for unlinked workspaces; the runtime manager's sweep prunes debris end-to-end on a real in-memory SQLite DB.

Lint and typecheck: not run.

https://claude.ai/code/session_01UvUnQCR4KRQPRz5pooWEf5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes orphaned `pull_requests` rows from host.db instead of keeping them forever. Previously every PR opened from a local workspace left a row behind when its workspace was deleted or branch retargeted.

- `deleteLocalWorkspace` now removes the linked PR row with its last workspace, and never fails the workspace delete.
- A runtime-manager sweep prunes remaining unreferenced rows after each sync, with a 60s grace window for rows upserted mid-refresh.
- Both paths keep the row if another workspace still references it.
- Mock-DB tests in `test/` gain a `leftJoin` stub so the trailing sweep is a no-op.

<sup>Written for commit 68fca0fbf4942899541a0304eb32283071256424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes stale pull-request records that are no longer linked to a workspace.
  * Cleans up pull-request records when their final linked workspace is deleted.
  * Preserves pull requests that are still referenced or were updated recently.
  * Workspace deletion continues successfully even if related pull-request cleanup encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->