### PR TITLE
chore(api,trpc): use the http client for single-statement queries

### DIFF
--- a/apps/api/src/app/api/automations/dispatch/[id]/route.ts
+++ b/apps/api/src/app/api/automations/dispatch/[id]/route.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { automations } from "@superset/db/schema";
 import { dispatchAutomation } from "@superset/trpc/automation-dispatch";
 import { eq } from "drizzle-orm";
@@ -28,7 +28,7 @@ export async function POST(
 		return Response.json({ error: "Invalid payload" }, { status: 400 });
 	}
 
-	const [automation] = await dbWs
+	const [automation] = await db
 		.select()
 		.from(automations)
 		.where(eq(automations.id, parsed.data.automationId))

--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import {
 	automations,
 	automationTriggers,
@@ -62,7 +62,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	const now = new Date();
 
-	const rows = await dbWs
+	const rows = await db
 		.select({
 			automationId: automations.id,
 			triggerId: automationTriggers.id,
@@ -154,7 +154,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	const advanceResults = await Promise.allSettled(
 		planned.map(async ({ triggerId, next }) => {
-			await dbWs
+			await db
 				.update(automationTriggers)
 				// Always a date for rules the product accepts (finite recurrences
 				// are refused at save); legacy finite data writes null and simply

--- a/apps/api/src/app/api/automations/run-failed/route.ts
+++ b/apps/api/src/app/api/automations/run-failed/route.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { automationRuns, automations } from "@superset/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -56,7 +56,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	const { automationId } = source.data;
 
-	const [automation] = await dbWs
+	const [automation] = await db
 		.select({
 			organizationId: automations.organizationId,
 			name: automations.name,
@@ -73,7 +73,7 @@ export async function POST(request: Request): Promise<Response> {
 	const failed = { status: "dispatch_failed", error: errorText } as const;
 
 	if ("scheduledFor" in source.data) {
-		await dbWs
+		await db
 			.insert(automationRuns)
 			.values({
 				automationId,
@@ -89,7 +89,7 @@ export async function POST(request: Request): Promise<Response> {
 				set: failed,
 			});
 	} else {
-		await dbWs
+		await db
 			.insert(automationRuns)
 			.values({
 				automationId,

--- a/apps/api/src/app/api/ingest/jobs/maintain-partitions/route.ts
+++ b/apps/api/src/app/api/ingest/jobs/maintain-partitions/route.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { sql } from "drizzle-orm";
 
 import { verifyQstashRequest } from "@/lib/verifyQstash";
@@ -39,7 +39,7 @@ export async function POST(request: Request): Promise<Response> {
 	let defaultRows: number | null = null;
 	try {
 		const [row] = (
-			await dbWs.execute(sql`
+			await db.execute(sql`
 				SELECT count(*)::int AS n FROM ingest.webhook_payloads_default
 			`)
 		).rows as Array<{ n: number }>;
@@ -58,7 +58,7 @@ export async function POST(request: Request): Promise<Response> {
 
 	let changes: Array<{ action: string; partition_name: string }>;
 	try {
-		const result = await dbWs.execute(sql`
+		const result = await db.execute(sql`
 			SELECT action, partition_name
 			FROM ingest.maintain_webhook_payload_partitions(${DAYS_AHEAD}, ${RETAIN_DAYS})
 		`);

--- a/apps/api/src/app/api/integrations/google/jobs/sweep-schedules/route.ts
+++ b/apps/api/src/app/api/integrations/google/jobs/sweep-schedules/route.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { automations, automationTriggers } from "@superset/db/schema";
 import {
 	findGoogleConnection,
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
 	);
 	if (rejected) return rejected;
 
-	const owners = await dbWs
+	const owners = await db
 		.selectDistinct({
 			organizationId: automationTriggers.organizationId,
 			ownerUserId: automations.ownerUserId,

--- a/apps/api/src/app/api/integrations/google/lib/scheduleCalendarFires.ts
+++ b/apps/api/src/app/api/integrations/google/lib/scheduleCalendarFires.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { automations, automationTriggers } from "@superset/db/schema";
 import { scopeAllows } from "@superset/shared/automation-matching";
 import type { TriggerScope } from "@superset/shared/automation-triggers";
@@ -43,7 +43,7 @@ export async function loadFirePlan(
 	ended: boolean;
 	allows: (calendarId: string) => boolean;
 } | null> {
-	const rows = await dbWs
+	const rows = await db
 		.select({ config: automationTriggers.config })
 		.from(automationTriggers)
 		.innerJoin(automations, eq(automations.id, automationTriggers.automationId))

--- a/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
+++ b/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import {
 	automationEvents,
 	automations,
@@ -76,7 +76,7 @@ export async function dispatchMatchingTriggers(params: {
 		}
 	}
 
-	const candidates = await dbWs
+	const candidates = await db
 		.select({
 			triggerId: automationTriggers.id,
 			config: automationTriggers.config,
@@ -173,7 +173,7 @@ export async function dispatchMatchingTriggers(params: {
  * gate must fail closed on a plan string this build doesn't know.
  */
 async function organizationPlan(organizationId: string): Promise<PlanTier> {
-	const [subscription] = await dbWs
+	const [subscription] = await db
 		.select({ plan: subscriptions.plan })
 		.from(subscriptions)
 		.where(
@@ -194,7 +194,7 @@ async function organizationPlan(organizationId: string): Promise<PlanTier> {
  * unmarked are picked up by the re-dispatch sweep.
  */
 async function markDispatched(eventId: string) {
-	await dbWs
+	await db
 		.update(automationEvents)
 		.set({ dispatchedAt: new Date() })
 		.where(eq(automationEvents.id, eventId));

--- a/apps/api/src/lib/automations/redispatchUndispatched.ts
+++ b/apps/api/src/lib/automations/redispatchUndispatched.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { automationEvents } from "@superset/db/schema";
 import { and, asc, gt, isNotNull, isNull, lt } from "drizzle-orm";
 import { dispatchMatchingTriggers } from "./dispatchMatchingTriggers";
@@ -33,7 +33,7 @@ export async function redispatchUndispatched(): Promise<{
 	failed: number;
 }> {
 	const now = Date.now();
-	const stuck = await dbWs
+	const stuck = await db
 		.select({
 			id: automationEvents.id,
 			organizationId: automationEvents.organizationId,

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -699,7 +699,7 @@ export const automationRouter = {
 			const organizationId = await requireActiveOrgMembership(ctx);
 			await getAutomationForUser(ctx.session.user.id, organizationId, input.id);
 
-			await dbWs.delete(automations).where(eq(automations.id, input.id));
+			await db.delete(automations).where(eq(automations.id, input.id));
 
 			return { ok: true };
 		}),

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -1,5 +1,5 @@
 import { mintUserJwt } from "@superset/auth/server";
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import {
 	automationEvents,
 	automationRuns,
@@ -117,7 +117,7 @@ export async function dispatchAutomation(
 		return { status: "skipped_offline", runId: inserted?.id ?? null, error };
 	}
 
-	const [run] = await dbWs
+	const [run] = await db
 		.insert(automationRuns)
 		.values({
 			automationId: automation.id,
@@ -134,7 +134,7 @@ export async function dispatchAutomation(
 
 	let workspaceId: string | null = null;
 	try {
-		const [owner] = await dbWs
+		const [owner] = await db
 			.select({ email: users.email })
 			.from(users)
 			.where(eq(users.id, automation.ownerUserId))
@@ -167,7 +167,7 @@ export async function dispatchAutomation(
 		};
 
 		const event = cause.eventId
-			? ((await dbWs.query.automationEvents.findFirst({
+			? ((await db.query.automationEvents.findFirst({
 					where: eq(automationEvents.id, cause.eventId),
 					columns: {
 						provider: true,
@@ -221,7 +221,7 @@ export async function dispatchAutomation(
 			if (!pinGone) throw err;
 			// Clear the pin (CAS so a concurrent repin is never erased) and use
 			// a fresh workspace from here on.
-			await dbWs
+			await db
 				.update(automations)
 				.set({ v2WorkspaceId: null })
 				.where(
@@ -236,7 +236,7 @@ export async function dispatchAutomation(
 			result = await runAgent(workspaceId);
 		}
 
-		await dbWs
+		await db
 			.update(automationRuns)
 			.set({
 				status: "dispatched",
@@ -249,7 +249,7 @@ export async function dispatchAutomation(
 			.where(eq(automationRuns.id, run.id));
 	} catch (err) {
 		const error = describeError(err, "dispatch");
-		await dbWs
+		await db
 			.update(automationRuns)
 			.set({
 				status: "dispatch_failed",
@@ -267,7 +267,7 @@ async function resolveCandidateHosts(
 	automation: DispatchableAutomation,
 ): Promise<Array<typeof v2Hosts.$inferSelect>> {
 	if (automation.targetHostId) {
-		const [host] = await dbWs
+		const [host] = await db
 			.select()
 			.from(v2Hosts)
 			.where(
@@ -281,7 +281,7 @@ async function resolveCandidateHosts(
 		return host ? [host] : [];
 	}
 
-	return dbWs
+	return db
 		.select({
 			organizationId: v2Hosts.organizationId,
 			machineId: v2Hosts.machineId,
@@ -390,7 +390,7 @@ async function recordUndispatched(
 	status: "skipped_offline" | "dispatch_failed",
 	error: string,
 ): Promise<{ id: string } | undefined> {
-	const [row] = await dbWs
+	const [row] = await db
 		.insert(automationRuns)
 		.values({
 			automationId: automation.id,

--- a/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
+++ b/packages/trpc/src/router/cloud-workspace/cloud-workspace.ts
@@ -1,4 +1,4 @@
-import { db, dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { cloudWorkspaces, environments } from "@superset/db/schema";
 import { isCloudAgentId } from "@superset/shared/cloud-agent-launch";
 import { SHARED_ENVIRONMENT_ORGANIZATION_ID } from "@superset/shared/constants";
@@ -154,7 +154,7 @@ export const cloudWorkspaceRouter = {
 			// rejects whenever two creates overlap.
 			const id = crypto.randomUUID();
 			const providerSandboxId = sandboxNameFor(id);
-			const [row] = await dbWs
+			const [row] = await db
 				.insert(cloudWorkspaces)
 				.values({
 					id,
@@ -217,7 +217,7 @@ export const cloudWorkspaceRouter = {
 			} catch (error) {
 				// Nothing was provisioned, so there is no sandbox to tear down —
 				// but the row must not sit in `provisioning` with no job coming.
-				await dbWs
+				await db
 					.update(cloudWorkspaces)
 					.set({ status: "failed" })
 					.where(eq(cloudWorkspaces.id, row.id));
@@ -258,7 +258,7 @@ export const cloudWorkspaceRouter = {
 			}
 			assertInternal(ctx.email);
 			assertMember(ctx.organizationIds, row.organizationId);
-			const [renamed] = await dbWs
+			const [renamed] = await db
 				.update(cloudWorkspaces)
 				.set({ name: input.name })
 				.where(eq(cloudWorkspaces.id, input.id))
@@ -319,7 +319,7 @@ export const cloudWorkspaceRouter = {
 			if (row.providerSandboxId) {
 				await deleteSandbox(row.providerSandboxId);
 			}
-			await dbWs
+			await db
 				.update(cloudWorkspaces)
 				.set({ status: "deleted", sandboxUrl: null })
 				.where(eq(cloudWorkspaces.id, row.id));

--- a/packages/trpc/src/router/cloud-workspace/provision.ts
+++ b/packages/trpc/src/router/cloud-workspace/provision.ts
@@ -1,4 +1,4 @@
-import { db, dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { cloudWorkspaces } from "@superset/db/schema";
 import {
 	type CloudAgentLaunch,
@@ -93,7 +93,7 @@ export async function provisionCloudWorkspace(
 		const nameWrite =
 			resolvedName === row.name
 				? Promise.resolve()
-				: dbWs
+				: db
 						.update(cloudWorkspaces)
 						.set({ name: resolvedName })
 						.where(eq(cloudWorkspaces.id, row.id));
@@ -136,7 +136,7 @@ export async function provisionCloudWorkspace(
 			nameWrite,
 		]);
 
-		await dbWs
+		await db
 			.update(cloudWorkspaces)
 			.set({
 				providerSandboxId: sandbox.providerSandboxId,
@@ -158,7 +158,7 @@ export async function provisionCloudWorkspace(
 				teardownError,
 			);
 		});
-		await dbWs
+		await db
 			.update(cloudWorkspaces)
 			.set({ status: "failed" })
 			.where(eq(cloudWorkspaces.id, row.id));

--- a/packages/trpc/src/router/environment/environment.ts
+++ b/packages/trpc/src/router/environment/environment.ts
@@ -1,4 +1,4 @@
-import { db, dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { cloudWorkspaces, environments } from "@superset/db/schema";
 import {
 	SANDBOX_IMAGE_NAME,
@@ -98,7 +98,7 @@ export const environmentRouter = {
 		.mutation(async ({ ctx, input }) => {
 			assertInternal(ctx.email);
 			assertMember(ctx.organizationIds, input.organizationId);
-			const [row] = await dbWs
+			const [row] = await db
 				.insert(environments)
 				.values({
 					organizationId: input.organizationId,
@@ -146,7 +146,7 @@ export const environmentRouter = {
 				goldenName,
 			});
 
-			const [row] = await dbWs
+			const [row] = await db
 				.insert(environments)
 				.values({
 					id: environmentId,
@@ -171,7 +171,7 @@ export const environmentRouter = {
 		.mutation(async ({ ctx, input }) => {
 			assertInternal(ctx.email);
 			assertOwned(await loadEnvironment(input.id, ctx.organizationIds));
-			const [row] = await dbWs
+			const [row] = await db
 				.update(environments)
 				.set({
 					...(input.name ? { name: input.name } : {}),
@@ -187,7 +187,7 @@ export const environmentRouter = {
 		.mutation(async ({ ctx, input }) => {
 			assertInternal(ctx.email);
 			assertOwned(await loadEnvironment(input.id, ctx.organizationIds));
-			await dbWs
+			await db
 				.update(environments)
 				.set({ archivedAt: new Date() })
 				.where(eq(environments.id, input.id));

--- a/packages/trpc/src/router/environment/secrets/secrets.ts
+++ b/packages/trpc/src/router/environment/secrets/secrets.ts
@@ -1,4 +1,4 @@
-import { db, dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { environmentSecrets, users } from "@superset/db/schema";
 import {
 	MAX_TOTAL_SIZE,
@@ -159,7 +159,7 @@ export const secretsRouter = {
 				});
 			}
 
-			await dbWs
+			await db
 				.insert(environmentSecrets)
 				.values({
 					organizationId,
@@ -205,7 +205,7 @@ export const secretsRouter = {
 				environment,
 				ctx.activeOrganizationId,
 			);
-			await dbWs
+			await db
 				.delete(environmentSecrets)
 				.where(
 					and(

--- a/packages/trpc/src/router/host/host.ts
+++ b/packages/trpc/src/router/host/host.ts
@@ -1,4 +1,4 @@
-import { db, dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import {
 	subscriptions,
 	users,
@@ -133,7 +133,7 @@ export const hostRouter = {
 				});
 			}
 
-			const [inserted] = await dbWs
+			const [inserted] = await db
 				.insert(v2Hosts)
 				.values({
 					organizationId: input.organizationId,
@@ -164,7 +164,7 @@ export const hostRouter = {
 			}
 
 			if (host.createdByUserId === ctx.userId) {
-				await dbWs
+				await db
 					.insert(v2UsersHosts)
 					.values({
 						organizationId: input.organizationId,
@@ -311,7 +311,7 @@ export const hostRouter = {
 				});
 			}
 
-			await dbWs
+			await db
 				.update(v2Hosts)
 				.set({ wakeCommand: input.wakeCommand })
 				.where(

--- a/packages/trpc/src/router/page/publish.ts
+++ b/packages/trpc/src/router/page/publish.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { dbWs } from "@superset/db/client";
+import { db, dbWs } from "@superset/db/client";
 import {
 	attachments,
 	files,
@@ -97,7 +97,7 @@ async function runPublish({
 	// name it. A concurrent publish of the same page collides on the unique
 	// (page, version) index and retries under the next number.
 	const target = await resolveTargetPage({
-		executor: dbWs,
+		executor: db,
 		input,
 		organizationId,
 		userId,
@@ -108,7 +108,7 @@ async function runPublish({
 	// version number.
 	const staged = target ? await verifyStagedAssets(target.id) : [];
 	const pageId = target?.id ?? randomUUID();
-	const version = (target ? await latestVersionNumber(dbWs, target.id) : 0) + 1;
+	const version = (target ? await latestVersionNumber(db, target.id) : 0) + 1;
 	const key = pageVersionKey(pageId, version);
 
 	const published: PublishedVersion = await dbWs.transaction(async (tx) => {
@@ -255,7 +255,7 @@ async function runPublish({
 async function verifyStagedAssets(
 	pageId: string,
 ): Promise<{ id: string; fileId: string; path: string }[]> {
-	const rows = await dbWs
+	const rows = await db
 		.select({ file: files, path: attachments.path, id: attachments.id })
 		.from(attachments)
 		.innerJoin(files, eq(files.id, attachments.fileId))
@@ -295,7 +295,7 @@ async function verifyStagedAssets(
 
 			// Guarded on `pending`: if the sweep claimed this row mid-publish, the
 			// update matches nothing and the asset has to be uploaded again.
-			const [updated] = await dbWs
+			const [updated] = await db
 				.update(files)
 				.set({
 					contentType: sniffContentType(bytes, file.contentType),

--- a/packages/trpc/src/router/task/task.ts
+++ b/packages/trpc/src/router/task/task.ts
@@ -37,7 +37,7 @@ const TASK_SLUG_CONSTRAINT = "tasks_org_slug_unique";
 const TASK_SLUG_RETRY_LIMIT = 5;
 
 type DbWsTransaction = Parameters<Parameters<typeof dbWs.transaction>[0]>[0];
-type Executor = typeof dbWs | DbWsTransaction;
+type Executor = typeof db | DbWsTransaction;
 
 function isConstraintError(error: unknown, constraint: string): boolean {
 	if (!error || typeof error !== "object") {

--- a/packages/trpc/src/router/v2-project/v2-project.ts
+++ b/packages/trpc/src/router/v2-project/v2-project.ts
@@ -1,4 +1,4 @@
-import { dbWs } from "@superset/db/client";
+import { db } from "@superset/db/client";
 import { organizations, v2Projects } from "@superset/db/schema";
 import { parseGitHubRemote } from "@superset/shared/github-remote";
 import type { TRPCRouterRecord } from "@trpc/server";
@@ -28,7 +28,7 @@ export const v2ProjectRouter = {
 			// canonical https URL. Compare lower-cased on both sides.
 			const canonicalUrl = parsed.url.toLowerCase();
 
-			const rows = await dbWs
+			const rows = await db
 				.select({
 					id: v2Projects.id,
 					name: v2Projects.name,


### PR DESCRIPTION
`db` is the neon-http client and `dbWs` the websocket pool; the rule is that `dbWs` is only for `.transaction(...)`. An audit found 44 call sites using `dbWs` for single statements across 18 files. This switches every one of them to `db` and leaves every `.transaction(...)` and every transaction-typed helper exactly as it was.

Mechanical: the only edits are `dbWs` → `db` at those sites and the matching import lines. Files that keep both clients (`task`, `page/publish`, `leaderboard`, `automation`) now import both. `automation/helpers.ts` is deliberately untouched: its only non-transactional `dbWs` was the executor union that `triggerSet` flows a websocket transaction through, and mixing the HTTP database into that union breaks the `.returning()` overloads on the transaction side.

The one site with real volume is `dispatchMatchingTriggers`, about 1.5M statements a day on the ingest path; the rest are per-run or per-tick. No behavior change: each statement already ran on its own, and the two `execute` calls in the partition-maintenance route are single statements whose DDL lives inside a Postgres function.

Verified with `tsc --noEmit` in packages/trpc and apps/api, `bun test` in both, biome clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves single-statement queries off the websocket pool (`dbWs`) onto the HTTP client (`db`), keeping `dbWs` for transactions only. An audit found 44 call sites across 18 files using `dbWs` for statements that run on their own; all now use `db`, and every `.transaction(...)` and transaction-typed helper is left untouched.

**Details**
- The only edits are `dbWs` → `db` at those sites plus matching import lines.
- `automation/helpers.ts` is deliberately unchanged: its executor union flows through a websocket transaction, and mixing in the HTTP client breaks the `.returning()` overloads on that transaction.
- `dispatchMatchingTriggers` (~1.5M statements/day on the ingest path) is the highest-volume site; everything else is per-run or per-tick.
- No behavior change: each statement already ran on its own, and the two `execute` calls in the partition-maintenance route are single statements whose DDL lives inside a Postgres function.

<sup>Written for commit dca82cbbdae332d73801a8498c55d5188f1f72f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency across automation scheduling, dispatching, retries, and deletion.
  * Improved database operation stability for cloud workspaces, environments, secrets, hosts, publishing, and project lookups.
  * Strengthened background maintenance and Google Calendar scheduling workflows.
  * Preserved existing validation, error handling, and user-facing behavior while improving the consistency of these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->