### PR TITLE
chore(desktop): bump version to 1.26.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.25.1",
+	"version": "1.26.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -865,7 +865,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/cli-framework": "workspace:*",
@@ -962,7 +962,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",
@@ -1141,7 +1141,7 @@
     },
     "packages/pty-daemon": {
       "name": "@superset/pty-daemon",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "bin": {
         "pty-daemon": "./src/main.ts",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.25.1",
+	"version": "1.26.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.25.1",
+	"version": "1.26.0",
 	"private": true,
 	"type": "module",
 	"exports": {

--- a/packages/pty-daemon/package.json
+++ b/packages/pty-daemon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/pty-daemon",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

Desktop 1.25.1 -> 1.26.0 (host-service + cli move in lockstep; pty-daemon 0.3.2 -> 0.3.3 because its source changed since the last daemon bump).

Release build: https://github.com/superset-sh/superset/actions/runs/33826917506
Draft release: https://github.com/superset-sh/superset/releases/tag/desktop-v1.26.0

https://claude.ai/code/session_01RcWzUv3a5rUeNs3nxCWZRt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop app and supporting packages to their latest release versions.
  * Incremented the terminal daemon package patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->