### PR TITLE
fix(relay2,host-service): fail fast on failed dial-backs and place tunnel objects at the host

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.ts
@@ -1,3 +1,4 @@
+import { DIAL_TIMEOUT_MS } from "@superset/shared/tunnel-v2-protocol";
 import type { RelayAffinityProbe } from "@superset/workspace-client";
 import {
 	createRelaySocket,
@@ -655,6 +656,10 @@ export function connect(
 		},
 		minReconnectionDelay: BASE_RECONNECT_DELAY,
 		maxReconnectionDelay: MAX_RECONNECT_DELAY,
+		// The relay holds the upgrade until the host dials back, up to
+		// DIAL_TIMEOUT_MS. partysocket's 4s default cancelled attempts the host
+		// was still answering, and every retry cost the host another dial.
+		connectionTimeout: DIAL_TIMEOUT_MS + 2_000,
 		// send() is a no-op unless open; we gate writes on connectionState anyway.
 		maxEnqueuedMessages: 0,
 	});

--- a/apps/relay2/src/host-tunnel.ts
+++ b/apps/relay2/src/host-tunnel.ts
@@ -1,6 +1,6 @@
 import {
-	type ControlPing,
 	DIAL_TIMEOUT_MS,
+	type HostControlMessage,
 	RELAY_CLOSE,
 	type StreamDial,
 } from "@superset/shared/tunnel-v2-protocol";
@@ -31,7 +31,11 @@ type ConnState =
 	| { kind: "client"; ticket: string; peer?: string }
 	| { kind: "dial"; ticket: string; peer?: string };
 
-export type PrepareStreamResult = "ready" | "no-host" | "timeout";
+export type PrepareStreamResult =
+	| "ready"
+	| "no-host"
+	| "timeout"
+	| "dial-failed";
 
 // One Durable Object per hostId: the host's control channel plus every
 // spliced stream terminate here. Stream traffic is never parsed. The Worker
@@ -41,7 +45,10 @@ export type PrepareStreamResult = "ready" | "no-host" | "timeout";
 export class HostTunnel extends Server<RelayEnv> {
 	static options = { hibernate: true };
 
-	private readonly pendingDials = new Map<string, (ok: boolean) => void>();
+	private readonly pendingDials = new Map<
+		string,
+		(result: PrepareStreamResult) => void
+	>();
 	private readonly earlyFrames = new Map<
 		string,
 		(string | ArrayBuffer | ArrayBufferView)[]
@@ -81,11 +88,10 @@ export class HostTunnel extends Server<RelayEnv> {
 	): Promise<PrepareStreamResult> {
 		const host = this.hostConn();
 		if (!host) return "no-host";
-		const arrived = new Promise<boolean>((resolve) => {
+		const arrived = new Promise<PrepareStreamResult>((resolve) => {
 			this.pendingDials.set(ticket, resolve);
 			setTimeout(() => {
-				this.pendingDials.delete(ticket);
-				resolve(false);
+				if (this.pendingDials.delete(ticket)) resolve("timeout");
 			}, DIAL_TIMEOUT_MS);
 		});
 		this.sendDial(host, {
@@ -95,7 +101,7 @@ export class HostTunnel extends Server<RelayEnv> {
 			path,
 			query,
 		});
-		return (await arrived) ? "ready" : "timeout";
+		return arrived;
 	}
 
 	async proxyHttp(request: HttpExchangeRequest): Promise<HttpExchangeResult> {
@@ -171,7 +177,7 @@ export class HostTunnel extends Server<RelayEnv> {
 					);
 				}, UNPAIRED_DIAL_TIMEOUT_MS),
 			);
-			waiting(true);
+			waiting("ready");
 			return;
 		}
 
@@ -220,13 +226,17 @@ export class HostTunnel extends Server<RelayEnv> {
 		// tunneled bytes that happen to equal it.
 		if (state.kind === "host") {
 			if (typeof message !== "string") return;
-			let ping: ControlPing;
+			let control: HostControlMessage;
 			try {
-				ping = JSON.parse(message) as ControlPing;
+				control = JSON.parse(message) as HostControlMessage;
 			} catch {
 				return;
 			}
-			if (ping.type !== "ping") return;
+			if (control.type === "stream:dial-failed") {
+				this.failDial(control.ticket);
+				return;
+			}
+			if (control.type !== "ping") return;
 			// Only the live host refreshes liveness: a ping in flight from a
 			// just-replaced socket must not extend the stale window.
 			if (this.hostConn()?.id === conn.id) {
@@ -329,6 +339,18 @@ export class HostTunnel extends Server<RelayEnv> {
 	}
 
 	// ── Internals ─────────────────────────────────────────────────────
+
+	// The host gave up dialing this ticket: answer the waiting client now
+	// instead of at the deadline.
+	private failDial(ticket: string): void {
+		const waiting = this.pendingDials.get(ticket);
+		if (waiting) {
+			this.pendingDials.delete(ticket);
+			waiting("dial-failed");
+			return;
+		}
+		this.httpExchanges.fail(ticket);
+	}
 
 	private hostConn(): Connection | null {
 		for (const conn of this.getConnections(HOST_TAG)) {

--- a/apps/relay2/src/http-exchange.ts
+++ b/apps/relay2/src/http-exchange.ts
@@ -21,7 +21,7 @@ export type HttpExchangeResult =
 			headers: Record<string, string>;
 			body: Uint8Array<ArrayBuffer>;
 	  }
-	| { ok: false; reason: "timeout" };
+	| { ok: false; reason: "timeout" | "dial-failed" };
 
 interface Exchange {
 	request: HttpExchangeRequest;
@@ -129,6 +129,15 @@ export class HttpExchanges {
 			});
 			dial.close(1000, "Exchange complete");
 		}
+	}
+
+	/** The host reported it could not dial back: fail now, not at the deadline. */
+	fail(ticket: string): void {
+		const exchange = this.exchanges.get(ticket);
+		if (!exchange) return;
+		clearTimeout(exchange.timer);
+		this.exchanges.delete(ticket);
+		exchange.resolve({ ok: false, reason: "dial-failed" });
 	}
 
 	abortAll(): void {

--- a/apps/relay2/src/index.ts
+++ b/apps/relay2/src/index.ts
@@ -8,6 +8,7 @@ import { getServerByName } from "partyserver";
 import { accessDenialMessage, checkHostAccess } from "./access";
 import { type AuthContext, verifyJWT } from "./auth";
 import { HostTunnel } from "./host-tunnel";
+import { placeHost, readPlacement } from "./placement";
 import { isTrpcPath, trpcErrorResponse } from "./trpc-error";
 import type { RelayEnv } from "./types";
 
@@ -32,8 +33,12 @@ function extractToken(c: Context<AppContext>): string | null {
 	return c.req.query("token") ?? null;
 }
 
-function tunnelStub(c: Context<AppContext>, hostId: string) {
-	return getServerByName(c.env.HostTunnel, hostId);
+// Null when the host has never connected: nothing may create its object but
+// the host itself, so callers answer "offline" instead of instantiating one
+// wherever they happen to be.
+async function tunnelStub(c: Context<AppContext>, hostId: string) {
+	const placement = await readPlacement(c.env, hostId);
+	return placement ? getServerByName(c.env.HostTunnel, placement.name) : null;
 }
 
 function isWsUpgrade(c: Context<AppContext>): boolean {
@@ -98,7 +103,12 @@ app.get("/v2/control", async (c) => {
 		);
 	}
 
-	const stub = await tunnelStub(c, hostId);
+	const placement = await placeHost(
+		c.env,
+		hostId,
+		c.req.raw.cf as IncomingRequestCfProperties | undefined,
+	);
+	const stub = await getServerByName(c.env.HostTunnel, placement.name);
 	return stub.fetch(
 		`https://relay2/register?hostId=${encodeURIComponent(hostId)}`,
 		{ headers: { Upgrade: "websocket", "x-relay-token": result.token } },
@@ -119,6 +129,8 @@ app.get("/v2/dial", async (c) => {
 	if (!hostId || !ticket)
 		return acceptAndClose(RELAY_CLOSE.badRequest, "Missing hostId or ticket");
 	const stub = await tunnelStub(c, hostId);
+	if (!stub)
+		return acceptAndClose(RELAY_CLOSE.unknownTicket, "Host not placed");
 	return stub.fetch(
 		`https://relay2/dial?ticket=${encodeURIComponent(ticket)}`,
 		{
@@ -156,6 +168,7 @@ app.get("/presence", async (c) => {
 			);
 			if (!access.ok) return null;
 			const stub = await tunnelStub(c, hostId);
+			if (!stub) return [hostId, { online: false, lastSeenAt: null }] as const;
 			return [hostId, await stub.presenceInfo()] as const;
 		}),
 	);
@@ -181,7 +194,7 @@ app.get("/hosts/:hostId/_whoowns", async (c) => {
 		return c.json({ error: result.message }, result.status);
 	}
 	const stub = await tunnelStub(c, hostId);
-	if (!(await stub.isConnected())) {
+	if (!stub || !(await stub.isConnected())) {
 		return c.json({ error: "Host not connected" }, 503);
 	}
 	return c.json({ ok: true, region: "cf" });
@@ -218,6 +231,9 @@ app.all("/hosts/:hostId/trpc/*", async (c) => {
 	const headers = buildUpstreamHeaders(c.req.raw.headers, c.get("auth").sub);
 
 	const stub = await tunnelStub(c, hostId);
+	if (!stub) {
+		return trpcErrorResponse(c, "SERVICE_UNAVAILABLE", "Host is not online");
+	}
 	const result = await stub.proxyHttp({
 		method: c.req.method,
 		pathWithQuery: query ? `${path}?${query}` : path,
@@ -225,6 +241,13 @@ app.all("/hosts/:hostId/trpc/*", async (c) => {
 		body: new Uint8Array(await c.req.raw.arrayBuffer()),
 	});
 	if (!result.ok) {
+		if (result.reason === "dial-failed") {
+			return trpcErrorResponse(
+				c,
+				"BAD_GATEWAY",
+				"Host could not reach the relay",
+			);
+		}
 		return (await stub.isConnected())
 			? trpcErrorResponse(c, "BAD_GATEWAY", "Request timed out")
 			: trpcErrorResponse(c, "SERVICE_UNAVAILABLE", "Host is not online");
@@ -249,12 +272,16 @@ app.get("/hosts/:hostId/*", async (c) => {
 	// The 101 is deferred until the host has dialed, so offline hosts fail
 	// before the handshake instead of open-then-close.
 	const stub = await tunnelStub(c, hostId);
+	if (!stub) return c.json({ error: "Host not connected" }, 503);
 	const prepared = await stub.prepareStream(ticket, path, query || undefined);
 	if (prepared === "no-host") {
 		return c.json({ error: "Host not connected" }, 503);
 	}
 	if (prepared === "timeout") {
 		return c.json({ error: "Host did not answer" }, 504);
+	}
+	if (prepared === "dial-failed") {
+		return c.json({ error: "Host could not reach the relay" }, 502);
 	}
 	return stub.fetch(
 		`https://relay2/client?ticket=${encodeURIComponent(ticket)}`,

--- a/apps/relay2/src/placement.ts
+++ b/apps/relay2/src/placement.ts
@@ -1,0 +1,76 @@
+import type { RelayEnv } from "./types";
+
+// A Durable Object lives wherever the request that first creates it came
+// from, and never moves. Before this directory that was often the API's
+// presence lookup from the US, which pinned European and Asian hosts to a US
+// object for good. Now only the host's own control connect creates an object,
+// so it lands at the host's ingress; every other route resolves through this
+// record and treats a host without one as offline.
+
+export interface Placement {
+	/** Durable Object name: `<hostId>#<generation>`. */
+	name: string;
+	generation: number;
+	/** Host's continent at creation; a move to another continent re-places. */
+	continent: string;
+	colo: string;
+}
+
+const KEY_PREFIX = "placement:";
+// Per-isolate memo on top of KV's own edge cache; a change made at another
+// edge is visible within KV's propagation window plus this.
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<
+	string,
+	{ placement: Placement | null; expiresAt: number }
+>();
+
+function key(hostId: string): string {
+	return `${KEY_PREFIX}${hostId}`;
+}
+
+export async function readPlacement(
+	env: RelayEnv,
+	hostId: string,
+): Promise<Placement | null> {
+	const cached = cache.get(hostId);
+	if (cached && cached.expiresAt > Date.now()) return cached.placement;
+	const placement = await env.PLACEMENT.get<Placement>(key(hostId), "json");
+	cache.set(hostId, { placement, expiresAt: Date.now() + CACHE_TTL_MS });
+	return placement;
+}
+
+/**
+ * Host connect: keep the record while the host is still on the same
+ * continent, otherwise mint the next generation so the object is re-created
+ * where this request came in. Reads KV directly: the memo may lag a write.
+ */
+export async function placeHost(
+	env: RelayEnv,
+	hostId: string,
+	cf: Pick<IncomingRequestCfProperties, "continent" | "colo"> | undefined,
+): Promise<Placement> {
+	const continent = cf?.continent ?? "unknown";
+	const colo = cf?.colo ?? "unknown";
+	const current = await env.PLACEMENT.get<Placement>(key(hostId), "json");
+	if (current && current.continent === continent) {
+		cache.set(hostId, {
+			placement: current,
+			expiresAt: Date.now() + CACHE_TTL_MS,
+		});
+		return current;
+	}
+	const generation = (current?.generation ?? 0) + 1;
+	const placement: Placement = {
+		name: `${hostId}#${generation}`,
+		generation,
+		continent,
+		colo,
+	};
+	await env.PLACEMENT.put(key(hostId), JSON.stringify(placement));
+	cache.set(hostId, { placement, expiresAt: Date.now() + CACHE_TTL_MS });
+	console.log(
+		`[relay2] placed host ${hostId} generation ${generation} at ${colo} (${continent})${current ? ` replacing ${current.colo}` : ""}`,
+	);
+	return placement;
+}

--- a/apps/relay2/src/types.ts
+++ b/apps/relay2/src/types.ts
@@ -5,4 +5,6 @@ export interface RelayEnv {
 	/** Optional; Sentry capture is a no-op until the secret is set. */
 	SENTRY_DSN?: string;
 	HostTunnel: DurableObjectNamespace<HostTunnel>;
+	/** Host → tunnel object placement records; see placement.ts. */
+	PLACEMENT: KVNamespace;
 }

--- a/apps/relay2/wrangler.jsonc
+++ b/apps/relay2/wrangler.jsonc
@@ -23,6 +23,11 @@
 	"durable_objects": {
 		"bindings": [{ "name": "HostTunnel", "class_name": "HostTunnel" }]
 	},
+	// Which Durable Object serves each host, written only by the host's own
+	// control connect so the object is created at the host's ingress.
+	"kv_namespaces": [
+		{ "binding": "PLACEMENT", "id": "7ebff5dc36db4edcb31172e37e40eb31" }
+	],
 	"migrations": [{ "tag": "v1", "new_sqlite_classes": ["HostTunnel"] }],
 	"observability": { "enabled": true }
 }

--- a/packages/host-service/src/tunnel/tunnel-client-v2.ts
+++ b/packages/host-service/src/tunnel/tunnel-client-v2.ts
@@ -2,6 +2,7 @@ import {
 	describeRelayClose,
 	type HttpDialFrame,
 	type StreamDial,
+	type StreamDialFailed,
 } from "@superset/shared/tunnel-v2-protocol";
 import ReconnectingWebSocket from "partysocket/ws";
 
@@ -32,6 +33,12 @@ function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
 		}),
 	]);
 }
+// Each dial-back gets its own connect budget, kept inside the relay's
+// DIAL_TIMEOUT_MS: two 3s attempts leave the relay time to hear the failure
+// report and answer the client at once instead of after the 10s stream or 30s
+// exchange window. A lost SYN or a slow resolver used to cost the whole window.
+const DIAL_CONNECT_TIMEOUT_MS = 3_000;
+const DIAL_ATTEMPTS = 2;
 const MAX_BUFFERED_FRAMES = 256;
 // Bodies are chunked below the Durable Object's per-message ceiling; large
 // tRPC payloads (file contents, diffs) would otherwise fail outright.
@@ -201,12 +208,9 @@ export class TunnelClientV2 {
 
 	private handleDial(dial: StreamDial): void {
 		if (dial.kind === "http") {
-			this.handleHttpDial(dial);
+			this.dialRelay(dial.ticket, (relayWs) => this.serveHttpDial(relayWs));
 			return;
 		}
-
-		const relayWs = new WebSocket(this.dialUrl(dial.ticket));
-		relayWs.binaryType = "arraybuffer";
 
 		const localUrl = new URL(`ws://127.0.0.1:${this.options.localPort}`);
 		localUrl.pathname = dial.path;
@@ -216,17 +220,73 @@ export class TunnelClientV2 {
 				if (key !== "token") localUrl.searchParams.set(key, value);
 			}
 		}
-		const localWs = new WebSocket(localUrl.toString());
-		localWs.binaryType = "arraybuffer";
-
-		pipe(relayWs, localWs);
-		pipe(localWs, relayWs);
+		this.dialRelay(dial.ticket, (relayWs) => {
+			const localWs = new WebSocket(localUrl.toString());
+			localWs.binaryType = "arraybuffer";
+			pipe(relayWs, localWs);
+			pipe(localWs, relayWs);
+		});
 	}
 
-	private handleHttpDial(dial: StreamDial): void {
-		const relayWs = new WebSocket(this.dialUrl(dial.ticket));
-		relayWs.binaryType = "arraybuffer";
+	// Opens the dial-back socket, retrying a connect that fails or stalls, and
+	// hands the open socket over synchronously inside its open event so no
+	// frame can land before the caller's handlers are attached. When every
+	// attempt fails the relay is told, so the waiting client gets a fast 502
+	// rather than the dial window.
+	private dialRelay(
+		ticket: string,
+		attach: (relayWs: WebSocket) => void,
+	): void {
+		const attempt = (n: number) => {
+			const ws = new WebSocket(this.dialUrl(ticket));
+			ws.binaryType = "arraybuffer";
+			const listeners = new AbortController();
+			const retry = () => {
+				if (n < DIAL_ATTEMPTS) attempt(n + 1);
+				else this.reportDialFailed(ticket);
+			};
+			const timer = setTimeout(() => {
+				listeners.abort();
+				closeQuietly(ws, 1000, "Dial connect timed out");
+				retry();
+			}, DIAL_CONNECT_TIMEOUT_MS);
+			ws.addEventListener(
+				"open",
+				() => {
+					clearTimeout(timer);
+					listeners.abort();
+					attach(ws);
+				},
+				{ signal: listeners.signal },
+			);
+			// close always follows error
+			ws.addEventListener(
+				"close",
+				() => {
+					clearTimeout(timer);
+					listeners.abort();
+					retry();
+				},
+				{ signal: listeners.signal },
+			);
+		};
+		attempt(1);
+	}
 
+	private reportDialFailed(ticket: string): void {
+		console.warn(
+			`[host-service:tunnel-v2] dial-back failed after ${DIAL_ATTEMPTS} attempts; reporting to relay`,
+		);
+		if (this.control?.readyState !== WebSocket.OPEN) return;
+		this.control.send(
+			JSON.stringify({
+				type: "stream:dial-failed",
+				ticket,
+			} satisfies StreamDialFailed),
+		);
+	}
+
+	private serveHttpDial(relayWs: WebSocket): void {
 		let header: {
 			method: string;
 			path: string;

--- a/packages/shared/src/tunnel-v2-protocol.ts
+++ b/packages/shared/src/tunnel-v2-protocol.ts
@@ -19,6 +19,16 @@ export interface ControlPing {
 	type: "ping";
 }
 
+/** Host → relay: the dial-back for `ticket` could not be opened (connect
+ * failed or timed out after the host's own retries). The relay fails the
+ * waiting client at once instead of letting the dial window run out. */
+export interface StreamDialFailed {
+	type: "stream:dial-failed";
+	ticket: string;
+}
+
+export type HostControlMessage = ControlPing | StreamDialFailed;
+
 // ── Close codes ─────────────────────────────────────────────────────
 // Application close codes (4400-4499) with fixed recovery semantics, so
 // every leg logs the same name and no client infers behavior from reason
@@ -85,5 +95,7 @@ export interface HttpEnd {
 
 export type HttpDialFrame = HttpRequestHeader | HttpResponseHeader | HttpEnd;
 
-/** How long the host has to dial back before the relay abandons the stream. */
+/** How long the host has to dial back before the relay abandons the stream.
+ * The host's own connect budget (attempts × per-attempt timeout) stays inside
+ * this so a `stream:dial-failed` report still finds the relay waiting. */
 export const DIAL_TIMEOUT_MS = 10_000;

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -4,6 +4,7 @@ import type {
 	ServerMessage,
 } from "@superset/host-service/events";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
+import { DIAL_TIMEOUT_MS } from "@superset/shared/tunnel-v2-protocol";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import type { RelayAffinityProbe } from "./primeRelayAffinity";
 import { createRelaySocket, type RelaySocket } from "./relaySocket";
@@ -390,6 +391,9 @@ function getOrCreateConnection(
 		accessDeniedRetryMs: ACCESS_DENIED_RETRY_MS,
 		minReconnectionDelay: RECONNECT_BASE_MS,
 		maxReconnectionDelay: RECONNECT_MAX_MS,
+		// Relay upgrades wait for the host's dial-back (DIAL_TIMEOUT_MS);
+		// partysocket's 4s default gave up on attempts the host was answering.
+		connectionTimeout: DIAL_TIMEOUT_MS + 2_000,
 		maxEnqueuedMessages: 0,
 		onProbe: (probe) => {
 			setConnectionStatus(state, { probe });


### PR DESCRIPTION
## Summary
- A host that cannot open its dial-back socket now retries once (3 s connect timeout) and then tells the relay, which answers the waiting client with 502 immediately instead of after the 10 s stream or 30 s exchange window. Desktop terminal and event-bus sockets stop cancelling upgrades at partysocket's 4 s default while the host is still dialing.
- Each host's Durable Object is now created only by the host's own control connect and recorded in a `PLACEMENT` KV namespace (`<hostId>#<generation>`). Presence, `_whoowns`, streams and tRPC resolve through that record and answer offline for a host that has never connected. A host reconnecting from another continent gets a new generation.

## Why
In a 395 s production sample, 0.86% of tRPC exchanges hit the 30 s timeout and 22% of terminal attaches were cancelled by the client at ~4 s while the relay was still waiting on the host. Measured from host-originated RPC latency, 38% of active hosts had their object 60 ms or more away from the host (21% at 120–250 ms) because the API's US presence lookups created objects before hosts connected.

## Verification
- Root typecheck 39/39, desktop terminal tests 341 pass, workspace-client 24 pass, Biome clean.
- Local end-to-end under `wrangler dev` with a mock JWKS/access API and the real `TunnelClientV2`, 14/14: unplaced host → 503/offline with no object created; normal stream and HTTP proxy; host-reported dial failure → 502 in ~10 ms; refused dial → two attempts → 502 in 6 ms; black-holed dial → 502 at 6.0 s.

## Rollout
- KV namespace `PLACEMENT` (id in `wrangler.jsonc`) already exists on the account.
- Deploying relay2 drops every control socket; hosts reconnect and self-place within seconds. Clients at other edges may see a host as offline for up to a minute while the record propagates. One-time.
- The host-side retry ships with the next desktop and CLI release; the relay change is compatible with current hosts and clients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails terminal and tRPC requests quickly when a host cannot dial back, and pins each host's tunnel object to the host's own ingress. Previously a failed dial-back cost clients the whole relay window, and presence lookups created tunnel objects before hosts connected.

**Changes**
- Host retries a dial-back once (3 s connect timeout) and reports the failed ticket over the control channel.
- The relay answers the waiting client with 502 immediately instead of after the 10 s stream or 30 s exchange window.
- Desktop terminal and event-bus sockets use a connect timeout above the dial window, so `partysocket` no longer cancels upgrades the host is still answering.
- Only the host's own control connect creates its tunnel object and records it in `PLACEMENT` KV as `<hostId>#<generation>`; presence, `_whoowns`, streams, tRPC, and dial answer offline for a host without a record.
- A host reconnecting from another continent gets a new generation, so its object is re-created near it.

**Rollout**
- `PLACEMENT` KV already exists on the account.
- Deploying relay2 drops every control socket; hosts reconnect and self-place within seconds.
- Clients at other edges may see a host as offline for up to a minute while the record propagates; this is one-time.
- Host-side retry ships with the next desktop and CLI release; the relay change is compatible with current hosts and clients.

<sup>Written for commit 5d51ac69ec425dc70de9e4ca3e4238bfea379e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel connection reliability by retrying dial-back connections before reporting failure.
  * Failed connection attempts now resolve promptly instead of stalling until a timeout.
  * Relay requests now provide clearer failure responses when a host is offline or unreachable.
  * Improved routing when hosts reconnect from a different network location.
  * Extended connection wait periods to accommodate slower relay and host negotiations.
  * Improved status reporting for unavailable hosts and failed connection requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->