### PR TITLE
fix(relay): drop peer-gone disconnects before they reach Sentry

### DIFF
--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -288,6 +288,23 @@ app.get("/hosts/:hostId/*", async (c) => {
 	);
 });
 
+// A WebSocket ending is not a defect, but the runtime reports it as one: when a
+// peer goes away — a host restarting, a laptop sleeping, a deploy — the
+// invocation that opened the socket throws. Every control channel ends this
+// way, about 5,600 times an hour, which is 100% of the exceptions this Worker
+// currently raises. Sending them would spend the key's whole rate limit on
+// noise within the first minute of each hour and bury the real errors behind
+// it, so they are dropped before they leave the isolate.
+function isPeerGone(message: string): boolean {
+	return (
+		message === "Network connection lost." ||
+		// Hibernation or eviction closed the object under an in-flight handler.
+		message.startsWith(
+			"Connection closed: this Durable Object instance is no longer active",
+		)
+	);
+}
+
 // Exceptions only — console/breadcrumb capture stays off: retaining every log
 // line is a memory leak at relay volume. No-op until SENTRY_DSN is set.
 const sentryOptions = (env: RelayEnv): Sentry.CloudflareOptions => ({
@@ -296,6 +313,10 @@ const sentryOptions = (env: RelayEnv): Sentry.CloudflareOptions => ({
 	sendDefaultPii: false,
 	integrations: (defaults) =>
 		defaults.filter((integration) => integration.name !== "Console"),
+	beforeSend: (event) => {
+		const message = event.exception?.values?.[0]?.value;
+		return message && isPeerGone(message) ? null : event;
+	},
 });
 
 const InstrumentedHostTunnel = Sentry.instrumentDurableObjectWithSentry(


### PR DESCRIPTION
## Why
The relay's Sentry DSN has never been set, so relay exceptions have gone uncaptured since the Durable Objects relay took over the fleet. Turning capture on as-is would have blown the quota: a 75-second sample of live traffic caught 117 exceptions, and **every one** was `Error: Network connection lost.` on `/v2/control` — roughly 5,600 an hour, or 135k a day.

That is not a defect. Cloudflare reports a WebSocket peer going away as an exception on the invocation that opened the socket, and every control channel ends that way eventually: a host restarting, a laptop sleeping, a deploy.

## What
- `beforeSend` drops `Network connection lost.` and the Durable Object's `Connection closed: this Durable Object instance is no longer active…`, which is hibernation or eviction closing the object under an in-flight handler.
- Everything else is sent unchanged. No sampling: after the filter the expected steady-state is near zero, so any volume at all is a real bug and worth seeing in full.

## Paired infra change (already applied)
The relay project's client key was uncapped (`rateLimit: None`), the same trap that let the August desktop and host-service firehoses through. It is now **100 events/hour**, matching the shape of the 200/hour cap on host-service.

The two halves are complementary and both are needed. The cap bounds the worst case for an error class nobody has seen yet. The filter is what keeps the cap from being spent entirely on noise — a cap on its own would have made things worse, filling the budget with disconnects and rejecting the real errors behind them.

Per the August post-mortem, resolving or ignoring issues in Sentry does not reduce ingestion; only inbound filters, key rate limits, and client-side `beforeSend`/sampling do.

## Verification
- Exception shapes taken from `wrangler tail` on the live Worker, not guessed: 117/117 matched the filtered message.
- Relay typecheck and repo lint clean.
- The DSN stays unset until this deploys, so the filter is live before the first event is ever sent.

https://claude.ai/code/session_01Lo142KEzAfRh4vfPmmmsEX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out WebSocket peer-gone disconnects before they reach Sentry so the relay's error capture doesn't spend its entire budget on noise. Every exception this Worker raises today is `Network connection lost.` from a control channel ending — a host restarting, a laptop sleeping, a deploy — about 5,600 an hour, which would exhaust the 100-event/hour key cap in the first minute.

- Adds a `beforeSend` filter that drops `Network connection lost.` and the Durable Object's `Connection closed: this Durable Object instance is no longer active…` messages.
- Everything else is sent unchanged; no sampling, since the expected steady-state is near zero and any volume is a real bug.
- The relay project's client key is now capped at 100 events/hour to bound the worst case for an error class nobody has seen yet.
- The DSN stays unset until this deploys, so the filter is live before the first event is ever sent.

<sup>Written for commit 56b6d309597bc6e3c8790351340ca6e7bea836e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expected WebSocket peer disconnections.
  * Reduced unnecessary error reporting for known, non-actionable connection closures while preserving reporting for other exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->