### PR TITLE
perf(usercontent): let a page document cache, and serve it from the colo cache

### DIFF
--- a/apps/usercontent/src/index.ts
+++ b/apps/usercontent/src/index.ts
@@ -47,26 +47,32 @@ function ticketSeconds(claims: PageTicketClaims): number {
 
 /**
  * The colo cache holding a version's rendered document. The storage key names
- * one page at one version, and neither its bytes nor the script tag added to
- * them ever change — a publish writes a new version under a new key — so a
- * hit needs no revalidation. Internal: nothing routes to this host.
+ * one page at one version and a publish writes a new version under a new key,
+ * so the stored bytes never change — but what this Worker injects into them
+ * does, on any deploy that moves the runtime or retunes the theme. The render
+ * revision is what keeps a hit needing no revalidation while still expiring
+ * the day-old copies a theme change would otherwise strand.
+ * Internal: nothing routes to this host.
  */
 function documentCacheKey(storageKey: string): Request {
-	return new Request(`https://document.usercontent.internal/${storageKey}`);
+	return new Request(
+		`https://document.usercontent.internal/${RENDER_REVISION}/${storageKey}`,
+	);
 }
 
 const CACHED_DOCUMENT_TTL_SECONDS = 24 * 60 * 60;
 
 /**
- * A short, stable name for the rendering policy a response carries. The ETag
- * has to change when the policy does: a `304` sends no body and no fresh
- * headers, so naming the version alone would leave readers on the old
- * `Content-Security-Policy` until the page happened to publish again.
+ * A short, stable name for a string that a cached answer was built with, so
+ * changing it expires what it produced. Two callers: the ETag, because a `304`
+ * sends no body and no fresh headers and would otherwise leave readers on the
+ * old `Content-Security-Policy`; and the document cache key, because the theme
+ * and runtime tag are injected into the bytes it holds.
  */
-function policyRevision(policy: string): string {
+function revisionOf(input: string): string {
 	let hash = 0x811c9dc5;
-	for (let index = 0; index < policy.length; index++) {
-		hash ^= policy.charCodeAt(index);
+	for (let index = 0; index < input.length; index++) {
+		hash ^= input.charCodeAt(index);
 		hash = Math.imul(hash, 0x01000193);
 	}
 	return (hash >>> 0).toString(36);
@@ -93,6 +99,14 @@ function ifNoneMatchSatisfied(
 		.split(",")
 		.some((candidate) => weakTag(candidate.trim()) === target);
 }
+
+/**
+ * What this Worker injects into a stored document. A deploy that changes either
+ * has to miss the cache rather than serve last week's theme for a day.
+ */
+const RENDER_REVISION = revisionOf(
+	`${RUNTIME_SCRIPT_PATH}\u0000${PAGE_THEME_CSS}`,
+);
 
 function baseHost(c: Context<AppContext>): string {
 	return new URL(c.env.USERCONTENT_URL).host;
@@ -200,7 +214,7 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 	);
 	// What a page serves at a version never changes, so the version names it —
 	// together with the policy, which a `304` has no other way to refresh.
-	const etag = `W/"${version}.${policyRevision(policy)}"`;
+	const etag = `W/"${version}.${revisionOf(policy)}"`;
 	if (ifNoneMatchSatisfied(c.req.header("if-none-match"), etag)) {
 		return new Response(null, {
 			status: 304,

--- a/apps/usercontent/src/index.ts
+++ b/apps/usercontent/src/index.ts
@@ -46,13 +46,9 @@ function ticketSeconds(claims: PageTicketClaims): number {
 }
 
 /**
- * The colo cache holding a version's rendered document. The storage key names
- * one page at one version and a publish writes a new version under a new key,
- * so the stored bytes never change — but what this Worker injects into them
- * does, on any deploy that moves the runtime or retunes the theme. The render
- * revision is what keeps a hit needing no revalidation while still expiring
- * the day-old copies a theme change would otherwise strand.
- * Internal: nothing routes to this host.
+ * The colo cache holding a version's rendered document. Keyed by storage key
+ * and render revision: the stored bytes never change, but what gets injected
+ * into them does. Internal: nothing routes to this host.
  */
 function documentCacheKey(storageKey: string): Request {
 	return new Request(
@@ -62,13 +58,7 @@ function documentCacheKey(storageKey: string): Request {
 
 const CACHED_DOCUMENT_TTL_SECONDS = 24 * 60 * 60;
 
-/**
- * A short, stable name for a string that a cached answer was built with, so
- * changing it expires what it produced. Two callers: the ETag, because a `304`
- * sends no body and no fresh headers and would otherwise leave readers on the
- * old `Content-Security-Policy`; and the document cache key, because the theme
- * and runtime tag are injected into the bytes it holds.
- */
+/** Expires anything built from `input` when `input` changes. */
 function revisionOf(input: string): string {
 	let hash = 0x811c9dc5;
 	for (let index = 0; index < input.length; index++) {
@@ -82,11 +72,7 @@ function weakTag(value: string): string {
 	return value.startsWith("W/") ? value.slice(2) : value;
 }
 
-/**
- * RFC 9110: `If-None-Match` is a comma-separated list, `*` matches any current
- * representation, and the comparison is weak. Browsers echo back the exact tag
- * they were given, so this mostly serves hand-written clients and proxies.
- */
+/** RFC 9110: `*`, comma-separated lists, weak comparison. */
 function ifNoneMatchSatisfied(
 	header: string | undefined,
 	etag: string,
@@ -100,10 +86,7 @@ function ifNoneMatchSatisfied(
 		.some((candidate) => weakTag(candidate.trim()) === target);
 }
 
-/**
- * What this Worker injects into a stored document. A deploy that changes either
- * has to miss the cache rather than serve last week's theme for a day.
- */
+/** A deploy that moves either has to miss the cache, not serve stale styling. */
 const RENDER_REVISION = revisionOf(
 	`${RUNTIME_SCRIPT_PATH}\u0000${PAGE_THEME_CSS}`,
 );
@@ -212,8 +195,7 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 	const policy = pageContentSecurityPolicy(
 		c.env.FRAME_ANCESTORS.split(/\s+/).filter(Boolean),
 	);
-	// What a page serves at a version never changes, so the version names it —
-	// together with the policy, which a `304` has no other way to refresh.
+	// The policy is in the tag because a 304 has no other way to refresh it.
 	const etag = `W/"${version}.${revisionOf(policy)}"`;
 	if (ifNoneMatchSatisfied(c.req.header("if-none-match"), etag)) {
 		return new Response(null, {
@@ -240,15 +222,11 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 			"Cache-Control": cacheControl,
 		});
 
-	// Only the rendered HTML is ever written here, so anything else would miss
-	// on every request; the manifest already names the type, so skip the lookup
-	// rather than pay it. The read happens after authorization, against a
-	// manifest loaded this request, so it widens nothing: a page that lost its
-	// manifest 404s before reaching here.
+	// Read after authorization against a manifest loaded this request, so it
+	// widens nothing: a page that lost its manifest 404s before reaching here.
 	const cacheKey = documentCacheKey(entry.key);
 	const cached = entry.contentType.startsWith("text/html")
-		? // The cache is an optimization, never a dependency: if the colo cannot
-			// answer, fall through to R2 rather than failing the page.
+		? // An optimization, never a dependency: fall through to R2 on failure.
 			await caches.default.match(cacheKey).catch((error: unknown) => {
 				Sentry.captureException(error);
 				return undefined;

--- a/apps/usercontent/src/index.ts
+++ b/apps/usercontent/src/index.ts
@@ -57,6 +57,43 @@ function documentCacheKey(storageKey: string): Request {
 
 const CACHED_DOCUMENT_TTL_SECONDS = 24 * 60 * 60;
 
+/**
+ * A short, stable name for the rendering policy a response carries. The ETag
+ * has to change when the policy does: a `304` sends no body and no fresh
+ * headers, so naming the version alone would leave readers on the old
+ * `Content-Security-Policy` until the page happened to publish again.
+ */
+function policyRevision(policy: string): string {
+	let hash = 0x811c9dc5;
+	for (let index = 0; index < policy.length; index++) {
+		hash ^= policy.charCodeAt(index);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	return (hash >>> 0).toString(36);
+}
+
+function weakTag(value: string): string {
+	return value.startsWith("W/") ? value.slice(2) : value;
+}
+
+/**
+ * RFC 9110: `If-None-Match` is a comma-separated list, `*` matches any current
+ * representation, and the comparison is weak. Browsers echo back the exact tag
+ * they were given, so this mostly serves hand-written clients and proxies.
+ */
+function ifNoneMatchSatisfied(
+	header: string | undefined,
+	etag: string,
+): boolean {
+	if (!header) return false;
+	const value = header.trim();
+	if (value === "*") return true;
+	const target = weakTag(etag);
+	return value
+		.split(",")
+		.some((candidate) => weakTag(candidate.trim()) === target);
+}
+
 function baseHost(c: Context<AppContext>): string {
 	return new URL(c.env.USERCONTENT_URL).host;
 }
@@ -158,9 +195,13 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 			: pinned
 				? `private, max-age=${ticketSeconds(auth)}, immutable`
 				: "private, no-cache";
-	// What a page serves at a version never changes, so the version names it.
-	const etag = `W/"${version}"`;
-	if (c.req.header("if-none-match") === etag) {
+	const policy = pageContentSecurityPolicy(
+		c.env.FRAME_ANCESTORS.split(/\s+/).filter(Boolean),
+	);
+	// What a page serves at a version never changes, so the version names it —
+	// together with the policy, which a `304` has no other way to refresh.
+	const etag = `W/"${version}.${policyRevision(policy)}"`;
+	if (ifNoneMatchSatisfied(c.req.header("if-none-match"), etag)) {
 		return new Response(null, {
 			status: 304,
 			headers: { ETag: etag, "Cache-Control": cacheControl },
@@ -177,9 +218,7 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 			// propagates.
 			"Origin-Agent-Cluster": "?1",
 			"Superset-Storage-Key": entry.key,
-			"Content-Security-Policy": pageContentSecurityPolicy(
-				c.env.FRAME_ANCESTORS.split(/\s+/).filter(Boolean),
-			),
+			"Content-Security-Policy": policy,
 			"X-Content-Type-Options": "nosniff",
 			"Referrer-Policy": "no-referrer",
 			"X-Robots-Tag": "noindex, nofollow",
@@ -187,11 +226,20 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 			"Cache-Control": cacheControl,
 		});
 
-	// Only ever holds the rendered HTML, so a hit is one by construction. It is
-	// read after authorization, against a manifest loaded this request, so it
-	// widens nothing: a page that lost its manifest 404s before reaching here.
+	// Only the rendered HTML is ever written here, so anything else would miss
+	// on every request; the manifest already names the type, so skip the lookup
+	// rather than pay it. The read happens after authorization, against a
+	// manifest loaded this request, so it widens nothing: a page that lost its
+	// manifest 404s before reaching here.
 	const cacheKey = documentCacheKey(entry.key);
-	const cached = await caches.default.match(cacheKey);
+	const cached = entry.contentType.startsWith("text/html")
+		? // The cache is an optimization, never a dependency: if the colo cannot
+			// answer, fall through to R2 rather than failing the page.
+			await caches.default.match(cacheKey).catch((error: unknown) => {
+				Sentry.captureException(error);
+				return undefined;
+			})
+		: undefined;
 	if (cached) {
 		return new Response(cached.body, { headers: headersFor("text/html") });
 	}
@@ -209,15 +257,19 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 		PAGE_THEME_CSS,
 	);
 	c.executionCtx.waitUntil(
-		caches.default.put(
-			cacheKey,
-			new Response(html, {
-				headers: {
-					"Content-Type": "text/html; charset=utf-8",
-					"Cache-Control": `public, max-age=${CACHED_DOCUMENT_TTL_SECONDS}`,
-				},
+		caches.default
+			.put(
+				cacheKey,
+				new Response(html, {
+					headers: {
+						"Content-Type": "text/html; charset=utf-8",
+						"Cache-Control": `public, max-age=${CACHED_DOCUMENT_TTL_SECONDS}`,
+					},
+				}),
+			)
+			.catch((error: unknown) => {
+				Sentry.captureException(error);
 			}),
-		),
 	);
 	return new Response(html, { headers: headersFor(contentType) });
 }

--- a/apps/usercontent/src/index.ts
+++ b/apps/usercontent/src/index.ts
@@ -32,6 +32,31 @@ const app = new Hono<AppContext>();
 
 const IMMUTABLE = "public, max-age=31536000, immutable";
 
+/**
+ * How long a reader may keep what a ticket fetched: never past the ticket
+ * itself, and never more than a day. The document, its thumbnail and its
+ * assets all answer this the same way, so revoking access is bounded by
+ * ticket life rather than by which of the three was asked for.
+ */
+function ticketSeconds(claims: PageTicketClaims): number {
+	return Math.max(
+		0,
+		Math.min(claims.exp - Math.floor(Date.now() / 1000), 86400),
+	);
+}
+
+/**
+ * The colo cache holding a version's rendered document. The storage key names
+ * one page at one version, and neither its bytes nor the script tag added to
+ * them ever change — a publish writes a new version under a new key — so a
+ * hit needs no revalidation. Internal: nothing routes to this host.
+ */
+function documentCacheKey(storageKey: string): Request {
+	return new Request(`https://document.usercontent.internal/${storageKey}`);
+}
+
+const CACHED_DOCUMENT_TTL_SECONDS = 24 * 60 * 60;
+
 function baseHost(c: Context<AppContext>): string {
 	return new URL(c.env.USERCONTENT_URL).host;
 }
@@ -117,42 +142,84 @@ async function servePage(c: Context<AppContext>): Promise<Response> {
 	const entry = manifest.versions[String(version)];
 	if (!entry) return notFound();
 
-	if (!(await authorized(c, manifest, version))) {
-		return signInRedirect(c, manifest.slug);
+	const auth = await authorized(c, manifest, version);
+	if (!auth) return signInRedirect(c, manifest.slug);
+
+	// A pinned version is an immutable snapshot, so it caches like the assets
+	// beside it. The served alias moves when a new version is published, so it
+	// has to revalidate — the ETag is what makes that cost a set of headers
+	// rather than the whole document again.
+	const pinned = requested !== null;
+	const cacheControl =
+		auth === "public"
+			? pinned
+				? IMMUTABLE
+				: "no-cache"
+			: pinned
+				? `private, max-age=${ticketSeconds(auth)}, immutable`
+				: "private, no-cache";
+	// What a page serves at a version never changes, so the version names it.
+	const etag = `W/"${version}"`;
+	if (c.req.header("if-none-match") === etag) {
+		return new Response(null, {
+			status: 304,
+			headers: { ETag: etag, "Cache-Control": cacheControl },
+		});
+	}
+
+	const headersFor = (contentType: string): Headers =>
+		new Headers({
+			"Content-Type": contentType.startsWith("text/html")
+				? "text/html; charset=utf-8"
+				: contentType,
+			// Each page is its own origin; ask for an origin-keyed agent cluster
+			// so sibling pages never share a renderer process while the PSL entry
+			// propagates.
+			"Origin-Agent-Cluster": "?1",
+			"Superset-Storage-Key": entry.key,
+			"Content-Security-Policy": pageContentSecurityPolicy(
+				c.env.FRAME_ANCESTORS.split(/\s+/).filter(Boolean),
+			),
+			"X-Content-Type-Options": "nosniff",
+			"Referrer-Policy": "no-referrer",
+			"X-Robots-Tag": "noindex, nofollow",
+			ETag: etag,
+			"Cache-Control": cacheControl,
+		});
+
+	// Only ever holds the rendered HTML, so a hit is one by construction. It is
+	// read after authorization, against a manifest loaded this request, so it
+	// widens nothing: a page that lost its manifest 404s before reaching here.
+	const cacheKey = documentCacheKey(entry.key);
+	const cached = await caches.default.match(cacheKey);
+	if (cached) {
+		return new Response(cached.body, { headers: headersFor("text/html") });
 	}
 
 	const object = await c.env.PRIVATE.get(entry.key);
 	if (!object) return notFound();
 
 	const contentType = object.httpMetadata?.contentType ?? entry.contentType;
-	const isHtml = contentType.startsWith("text/html");
-	const ticketed = manifest.visibility !== "everyone";
-	const headers = new Headers({
-		"Content-Type": isHtml ? "text/html; charset=utf-8" : contentType,
-		// Each page is its own origin; ask for an origin-keyed agent cluster
-		// so sibling pages never share a renderer process while the PSL entry
-		// propagates.
-		"Origin-Agent-Cluster": "?1",
-		"Superset-Storage-Key": entry.key,
-		"Content-Security-Policy": pageContentSecurityPolicy(
-			c.env.FRAME_ANCESTORS.split(/\s+/).filter(Boolean),
-		),
-		"X-Content-Type-Options": "nosniff",
-		"Referrer-Policy": "no-referrer",
-		"X-Robots-Tag": "noindex, nofollow",
-		"Cache-Control": ticketed
-			? "private, no-store"
-			: requested === null
-				? "no-cache"
-				: IMMUTABLE,
-	});
+	if (!contentType.startsWith("text/html")) {
+		return new Response(object.body, { headers: headersFor(contentType) });
+	}
 
-	if (!isHtml) return new Response(object.body, { headers });
-	const document = injectStyleTag(
+	const html = injectStyleTag(
 		injectScriptTag(await object.text(), RUNTIME_SCRIPT_PATH),
 		PAGE_THEME_CSS,
 	);
-	return new Response(document, { headers });
+	c.executionCtx.waitUntil(
+		caches.default.put(
+			cacheKey,
+			new Response(html, {
+				headers: {
+					"Content-Type": "text/html; charset=utf-8",
+					"Cache-Control": `public, max-age=${CACHED_DOCUMENT_TTL_SECONDS}`,
+				},
+			}),
+		),
+	);
+	return new Response(html, { headers: headersFor(contentType) });
 }
 
 async function serveThumbnail(c: Context<AppContext>): Promise<Response> {
@@ -169,10 +236,7 @@ async function serveThumbnail(c: Context<AppContext>): Promise<Response> {
 	// A restricted thumbnail may live in the browser cache only as long as
 	// the ticket that fetched it: after a visibility flip, stale copies age
 	// out with the ticket instead of surviving another day.
-	const remaining =
-		auth === "public"
-			? null
-			: Math.max(0, Math.min(auth.exp - Math.floor(Date.now() / 1000), 86400));
+	const remaining = auth === "public" ? null : ticketSeconds(auth);
 	return new Response(object.body, {
 		headers: {
 			"Content-Type": "image/jpeg",
@@ -329,10 +393,7 @@ async function serveAsset(c: Context<AppContext>): Promise<Response> {
 	const cacheControl =
 		auth === "public"
 			? IMMUTABLE
-			: `private, max-age=${Math.max(
-					0,
-					Math.min(auth.exp - Math.floor(Date.now() / 1000), 86400),
-				)}, immutable`;
+			: `private, max-age=${ticketSeconds(auth)}, immutable`;
 	const isHtml = asset.contentType.startsWith("text/html");
 	// Everything that is not the page's own document gets a policy of its own:
 	// without one an SVG navigated to directly ran as a top-level document with


### PR DESCRIPTION
## Why

Pages feel slow to open, so I measured the serving path in production rather than guessing. Median of eight requests each, against a real page:

| request | bytes | time to first byte |
|---|---|---|
| `runtime.js`, no storage read | 5 KB | 73 ms |
| page document | 13 KB | 249 ms |
| page thumbnail | 78 KB | 239 ms |
| page document | 1023 KB | 277 ms |

Two things fall out. Time to first byte is the two sequential R2 reads, manifest then object, not the bytes: eighty times the payload costs 28 ms. And none of it is ever cached, because the document goes out as `private, no-store`.

That header is not a considered choice for private pages, it is every page. `ticketed` is `manifest.visibility !== "everyone"`, and `everyone` is unreachable: it exists in the database enum and the manifest type, but the only values any API accepts are `just_me` and `org`. So every page ever published is `no-store`, and every view including a plain reload repeats the full 249 ms. The thumbnail on the same page, behind the same ticket check, already goes out `private, max-age=86400`.

## What changes

**The document caches like everything else on the page.** A pinned version URL is an immutable snapshot, so it gets the same ticket-bounded `max-age` the assets and thumbnail beside it already get. The served alias moves when a new version is published, so it cannot cache outright; it gets `no-cache` plus an `ETag` naming the version. A reload revalidates and comes back `304` with no body and no document read.

**The rendered document is kept in the colo cache**, keyed by its storage key. The key names one page at one version and a publish writes a new version under a new key, so both the key and its bytes are immutable and a hit needs no revalidation. That removes the second of the two R2 reads.

**The ticket-lifetime arithmetic** was written out three times; it is one helper now.

## Safety

Authorization is unchanged and still runs first, against a manifest read on every request. The cache is consulted only after it passes, so a hit widens nothing. Verified against a locally running Worker:

- Document deleted from storage, cache warm: still serves. That is what proves the colo cache is being used.
- Manifest deleted, cache warm: `404`. Page deletion removes the manifest first, so it still fails closed.
- No ticket, cache warm: `302` to sign-in, not the document.

## Verification

Run locally with `wrangler dev` against a seeded R2 bucket and a signed ticket:

```
alias URL          200  Cache-Control: private, no-cache          ETag: W/"7"
alias + ETag       304  Cache-Control: private, no-cache          ETag: W/"7"
pinned version     200  Cache-Control: private, max-age=3560, immutable
```

The body is byte-identical, script tag included. `bun run lint:fix`, `typecheck` for `apps/usercontent`, and `bun test` in `shared` (924) pass.

I have not deployed this, so the production numbers above are the before. The after is worth measuring on the same page once it ships.

## Deliberately not in here

Streaming the script injection with `HTMLRewriter` instead of buffering the document. I had it third on my own list until I measured: at 1 MB the whole buffer-and-inject step costs about 28 ms, and `HTMLRewriter` re-parses and re-serializes user HTML, which is a correctness risk I would not take for that. It becomes worth doing if pages get much larger, which #7159 permits by raising the cap to 16 MB.

Caching the manifest is also left alone on purpose. It is the one read that must stay fresh, because it is what makes a republish visible.

https://claude.ai/code/session_01KkipnuPDEC3u32Y6sbzW9d

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pages served their document with `private, no-store`, so every view — including a reload — repeated two sequential R2 reads for nothing. The document now caches like the thumbnail and assets on the same page, and a warm colo cache skips the second read.

- Pinned versions get the same ticket-bounded `max-age` as the assets beside them; the served alias gets `no-cache` plus an `ETag` naming the version and rendering policy, so a reload revalidates as a 304 without a document read and a `FRAME_ANCESTORS` change can't strand an old `Content-Security-Policy`.
- Rendered documents are stored in the colo cache keyed by their storage key plus a render revision over the runtime and theme, so a deploy that changes what's injected misses instead of serving stale bytes. The cache is an optimization: lookups and writes fall back to R2, failures are reported and swallowed, and non-HTML documents skip it entirely.
- `If-None-Match` is parsed per RFC 9110 (`*`, comma-separated lists, weak comparison), and ticket-lifetime arithmetic is now one helper instead of three copies.
- Authorization is unchanged and still runs first against a manifest read, so a cache hit cannot widen access.

<sup>Written for commit aeb4510cffaeb689bb1ed02721ffbc52c7ed30a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved page, document, thumbnail, and asset caching for faster repeat visits.
  * Cached authorized HTML pages after access checks.
  * Avoided retransmitting unchanged content when possible.
* **Reliability**
  * Improved handling of HTML and non-HTML page content.
  * Applied consistent expiration behavior across tickets and cached content.
  * Added appropriate caching controls for public and private content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->