### PR TITLE
fix(sentry): stop reporting the same error thousands of times

### DIFF
--- a/apps/desktop/src/main/lib/sentry.ts
+++ b/apps/desktop/src/main/lib/sentry.ts
@@ -1,9 +1,14 @@
 import * as Sentry from "@sentry/electron/main";
 import { IPCMode } from "@sentry/electron/main";
+import { createSentryEventThrottle } from "@superset/shared/sentry-throttle";
 import { session } from "electron";
 import { env } from "../env.main";
 
 let sentryInitialized = false;
+
+// Shared across the process: the point is to notice a repeat, which needs one
+// instance rather than one per call.
+const throttleRepeats = createSentryEventThrottle();
 
 export function initSentry(): void {
 	if (sentryInitialized) return;
@@ -18,6 +23,9 @@ export function initSentry(): void {
 			environment: env.NODE_ENV,
 			tracesSampleRate: 0,
 			sendDefaultPii: false,
+			// One machine repeating one failure should not crowd out everyone
+			// else's rare ones, nor spend the org's quota getting there.
+			beforeSend: throttleRepeats,
 			ipcMode: IPCMode.Classic,
 			getSessions: () => [
 				session.defaultSession,

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -1,7 +1,12 @@
 import { SENTRY_IGNORE_ERRORS } from "@superset/shared/sentry";
+import { createSentryEventThrottle } from "@superset/shared/sentry-throttle";
 import { env } from "../env.renderer";
 
 let sentryInitialized = false;
+
+// Shared across the process: the point is to notice a repeat, which needs one
+// instance rather than one per call.
+const throttleRepeats = createSentryEventThrottle();
 
 export async function initSentry(): Promise<void> {
 	if (sentryInitialized) return;
@@ -27,7 +32,7 @@ export async function initSentry(): Promise<void> {
 				if (original instanceof Error && original.name === "TRPCClientError") {
 					return null;
 				}
-				return event;
+				return throttleRepeats(event);
 			},
 		});
 

--- a/packages/host-service/src/sentry.ts
+++ b/packages/host-service/src/sentry.ts
@@ -1,6 +1,11 @@
 import * as Sentry from "@sentry/node";
+import { createSentryEventThrottle } from "@superset/shared/sentry-throttle";
 
 let initialized = false;
+
+// Shared across the process: the point is to notice a repeat, which needs one
+// instance rather than one per call.
+const throttleRepeats = createSentryEventThrottle();
 
 export function initSentry(options: { organizationId?: string }): void {
 	if (initialized) return;
@@ -11,6 +16,9 @@ export function initSentry(options: { organizationId?: string }): void {
 		release: process.env.HOST_SERVICE_SENTRY_RELEASE,
 		environment: process.env.HOST_SERVICE_SENTRY_ENVIRONMENT,
 		tracesSampleRate: 0,
+		// A host that fails once usually fails in a loop: git.getStatus alone
+		// sent 135k copies of one `spawn EBADF` from seven machines last month.
+		beforeSend: throttleRepeats,
 		// safety.ts keeps the process alive through uncaught exceptions; Sentry
 		// must capture them without re-introducing the exit.
 		integrations: [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -56,6 +56,10 @@
 			"types": "./src/sentry.ts",
 			"default": "./src/sentry.ts"
 		},
+		"./sentry-throttle": {
+			"types": "./src/sentry-throttle.ts",
+			"default": "./src/sentry-throttle.ts"
+		},
 		"./slash-commands": {
 			"types": "./src/slash-commands.ts",
 			"default": "./src/slash-commands.ts"

--- a/packages/shared/src/sentry-throttle.ts
+++ b/packages/shared/src/sentry-throttle.ts
@@ -1,0 +1,128 @@
+/**
+ * Client-side throttle for an error that repeats.
+ *
+ * Sentry's own Dedupe integration keeps a single previous event and drops only
+ * an immediate repeat, so an interleaved retry loop walks straight past it: one
+ * machine leaking file descriptors sent 97,800 copies of the same `spawn EBADF`
+ * in a month with Dedupe enabled. A failure that repeats is worth knowing about
+ * a few times an hour, not ten thousand; the events it crowds out are the rare
+ * ones actually worth reading, and the quota it burns is what took the whole
+ * organization's error reporting offline for four days.
+ *
+ * Keeps the first few events per fingerprint per window, drops the rest, and
+ * reports how many were dropped on the next one through — a suppressed
+ * firehose still has to read as a firehose, or throttling just hides the bug.
+ */
+
+/** The shape this needs from a Sentry event; structural so no SDK import. */
+export interface ThrottleableEvent {
+	/** Set on transactions and other non-error envelopes. */
+	type?: string;
+	message?: string;
+	exception?: {
+		values?: Array<{
+			type?: string;
+			value?: string;
+			stacktrace?: {
+				frames?: Array<{
+					filename?: string;
+					function?: string;
+					lineno?: number;
+				}>;
+			};
+		}>;
+	};
+	extra?: Record<string, unknown>;
+}
+
+export interface SentryThrottleOptions {
+	/** Events allowed per fingerprint per window. */
+	limit?: number;
+	windowMs?: number;
+	/** Ceiling on tracked fingerprints, so a unique-per-event message (a path,
+	 * a pid) cannot grow this without bound. */
+	maxFingerprints?: number;
+	now?: () => number;
+}
+
+interface WindowState {
+	start: number;
+	sent: number;
+	suppressed: number;
+}
+
+const DEFAULT_LIMIT = 3;
+const DEFAULT_WINDOW_MS = 60 * 60_000;
+const DEFAULT_MAX_FINGERPRINTS = 500;
+
+/**
+ * Returns a `beforeSend` that drops repeats of an error it has already
+ * reported this window. Returns the event to send, or null to drop it.
+ */
+export function createSentryEventThrottle(
+	options: SentryThrottleOptions = {},
+): <T extends ThrottleableEvent>(event: T) => T | null {
+	const limit = options.limit ?? DEFAULT_LIMIT;
+	const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+	const maxFingerprints = options.maxFingerprints ?? DEFAULT_MAX_FINGERPRINTS;
+	const now = options.now ?? Date.now;
+	// Insertion order is recency order: every touched key is re-inserted, so
+	// the first entry is always the least recently seen.
+	const windows = new Map<string, WindowState>();
+
+	return <T extends ThrottleableEvent>(event: T): T | null => {
+		// Transactions are not what floods, and they have their own sampling.
+		if (event.type) return event;
+
+		const key = fingerprintOf(event);
+		const at = now();
+		const state = windows.get(key);
+		windows.delete(key);
+
+		if (!state || at - state.start >= windowMs) {
+			windows.set(key, { start: at, sent: 1, suppressed: 0 });
+			evictBeyond(windows, maxFingerprints);
+			const suppressed = state?.suppressed ?? 0;
+			if (suppressed > 0) {
+				event.extra = { ...event.extra, suppressed_since_last: suppressed };
+			}
+			return event;
+		}
+
+		if (state.sent < limit) {
+			state.sent += 1;
+			windows.set(key, state);
+			return event;
+		}
+
+		state.suppressed += 1;
+		windows.set(key, state);
+		return null;
+	};
+}
+
+function fingerprintOf(event: ThrottleableEvent): string {
+	const exception = event.exception?.values?.[0];
+	if (!exception) return `message:${event.message ?? ""}`;
+	// Sentry orders frames oldest first, so the throwing frame is the last one.
+	const frames = exception.stacktrace?.frames;
+	const frame = frames?.[frames.length - 1];
+	return [
+		exception.type ?? "",
+		exception.value ?? "",
+		frame?.filename ?? "",
+		frame?.function ?? "",
+		frame?.lineno ?? "",
+	].join("|");
+}
+
+function evictBeyond(
+	windows: Map<string, WindowState>,
+	maxFingerprints: number,
+): void {
+	while (windows.size > maxFingerprints) {
+		const oldest = windows.keys().next();
+		if (oldest.done) return;
+		windows.delete(oldest.value);
+	}
+}


### PR DESCRIPTION
## Why
The single biggest consumer of our Sentry quota is one bug on a handful of machines. Grouping `Error: spawn EBADF` by `server_name` over 30 days:

| Machine | Events |
|---|---|
| Mac.elecom | 97,800 |
| WdeMac-mini.local | 15,555 |
| maskndaf-mn4927.linkedin.biz | 10,863 |
| four others | 10,724 |

**134,942 events from seven machines, 72% from one.** A sample event carries the cause in its extra data: `open_file_descriptors: 10269` on an app started three days earlier. `spawn` then fails EBADF, the error is handled, and the caller retries `git.getStatus` forever — each retry reported.

Sentry's `dedupeIntegration` was enabled the whole time. It keeps exactly one `previousEvent` and drops only an event identical to the one immediately before it, so an interleaved retry loop walks straight past it. There is no built-in per-fingerprint throttle in the SDK; the only library that does this has 8 weekly downloads and peers solely on `@sentry/node`, which would not cover the renderer.

## What
A `beforeSend` in `@superset/shared/sentry-throttle`, wired into host-service and both desktop processes. It keeps the first 3 events per fingerprint per hour and drops the rest.

- **Dropped events are still counted.** The number suppressed since the last one through is attached to the next event as `suppressed_since_last`, so a throttled firehose still reads as a firehose. Throttling that silently hid the leak would be worse than the leak.
- **Fingerprint** is exception type + message + throwing frame. The same bug on different machines fingerprints separately, which is fine — Sentry's own grouping still collapses them server-side, and the case that matters is one machine repeating one error.
- **Bounded**: the tracked set is capped and evicts least-recently-seen, so a message embedding a path or pid cannot grow it without end.
- Transactions pass through untouched; they have their own sampling.

## Effect
100,000 identical events spread over ~28 hours collapse to 84 sent, with no distinct signal lost.

## Rollout caveat
This only takes effect in builds that ship it. The machines leaking file descriptors on 1.25.1 keep sending at full rate until they update, which is why the project key rate limits set today (desktop 1000/hr, host-service 200/hr, relay 100/hr) remain the tourniquet in the meantime.

## Verification
Behaviour checked against a throwaway harness covering: the first N pass and the rest drop; distinct fingerprints are independent; the throwing frame participates in the fingerprint; a window rollover restores capacity and reports the suppressed count; nothing is attached when nothing was dropped; transactions are untouched; and the 100k-event flood above. Root typecheck 38/38, lint clean, sherif clean. `packages/shared` 931 pass, `packages/host-service` 1511 pass, `apps/desktop` 3455 pass with one unrelated pre-existing failure (`LeaderboardRank`, from #7118, passes in isolation and references nothing in this change).

https://claude.ai/code/session_01Lo142KEzAfRh4vfPmmmsEX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Sentry from reporting the same error thousands of times: Sentry's dedupe only drops immediate repeats, so an interleaved retry loop sent 134,942 copies of one `spawn EBADF` from seven machines in a month. Adds a `beforeSend` throttle in `@superset/shared/sentry-throttle`, wired into host-service and both desktop processes, that keeps the first 3 events per fingerprint per hour and drops the rest.

**Rollout caveats**
- Dropped events are still counted: the next event through carries `suppressed_since_last`.
- Only affects builds that ship it; older clients keep sending at full rate, so the existing project key rate limits stay in place.
- Transactions pass through untouched.

<sup>Written for commit 6d2f1929b1861f94a76f82a1f2ec67dee8436479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate error reports across desktop and host services by throttling repeated Sentry events.
  * Preserved transaction events while suppressing excessive identical error notifications.
  * Included the number of suppressed events with the next reported occurrence for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->