### PR TITLE
feat(desktop): reply to PR review threads from the Changes pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/ReviewThreadReplyComposer/ReviewThreadReplyComposer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/ReviewThreadReplyComposer/ReviewThreadReplyComposer.tsx
@@ -1,0 +1,93 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
+import { Textarea } from "@superset/ui/textarea";
+import { cn } from "@superset/ui/utils";
+import type { ReactNode } from "react";
+import { LuLoaderCircle } from "react-icons/lu";
+
+interface ReviewThreadReplyComposerProps {
+	/** Controlled draft: the owner keeps it so it can hand the text back
+	 *  after a failed post. */
+	value: string;
+	onChange: (value: string) => void;
+	/** Dispatches the trimmed body. Returns false when there is nothing to
+	 *  reply onto (a thread without a comment id), which keeps the draft
+	 *  and tells the reviewer; true clears it. */
+	onReply: (body: string) => boolean;
+	isPending?: boolean;
+	/** Rendered before the Reply button, e.g. the resolve toggle. */
+	actions?: ReactNode;
+	/** Border, background, and horizontal padding of the footer, so each
+	 *  diff surface keeps its own tint. */
+	className?: string;
+}
+
+/**
+ * Reply box under a review thread: a textarea that sends on Cmd/Ctrl+Enter
+ * and a Reply button that stays disabled while the draft is blank or a post
+ * is in flight. Shared by the workspace Changes pane and the PR view's Code
+ * tab; the mutation itself belongs to the caller.
+ */
+export function ReviewThreadReplyComposer({
+	value,
+	onChange,
+	onReply,
+	isPending = false,
+	actions,
+	className,
+}: ReviewThreadReplyComposerProps) {
+	const { t } = useLingui();
+	const body = value.trim();
+	const submit = () => {
+		if (!body || isPending) return;
+		if (!onReply(body)) {
+			toast.error(
+				t({
+					message: "Couldn't send reply",
+				}),
+				{
+					description: t({
+						message: "This thread has no comment to reply to.",
+					}),
+				},
+			);
+			return;
+		}
+		// Cleared as soon as the post is dispatched; a failure surfaces as a
+		// toast from the caller's mutation, which may hand the draft back.
+		onChange("");
+	};
+
+	return (
+		<div className={cn("flex flex-col gap-2 border-t py-2", className)}>
+			<Textarea
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				onKeyDown={(e) => {
+					if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+						e.preventDefault();
+						submit();
+					}
+				}}
+				placeholder={t({
+					message: "Write a reply…",
+				})}
+				rows={2}
+				className="resize-none bg-background text-xs"
+			/>
+			<div className="flex items-center justify-end gap-2">
+				{actions}
+				<Button
+					type="button"
+					size="xs"
+					disabled={!body || isPending}
+					onClick={submit}
+				>
+					{isPending && <LuLoaderCircle className="size-3 animate-spin" />}
+					<Trans>Reply</Trans>
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/ReviewThreadReplyComposer/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/ReviewThreadReplyComposer/index.ts
@@ -1,0 +1,1 @@
+export { ReviewThreadReplyComposer } from "./ReviewThreadReplyComposer";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCommentThread/PullRequestCommentThread.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCommentThread/PullRequestCommentThread.tsx
@@ -7,7 +7,6 @@ import {
 	CollapsibleTrigger,
 } from "@superset/ui/collapsible";
 import { toast } from "@superset/ui/sonner";
-import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { useEffect, useState } from "react";
 import {
@@ -18,6 +17,7 @@ import {
 	LuLoaderCircle,
 } from "react-icons/lu";
 import { CommentMarkdown } from "renderer/components/CommentMarkdown";
+import { ReviewThreadReplyComposer } from "renderer/routes/_authenticated/_dashboard/components/ReviewThreadReplyComposer";
 import "./comment-thread.css";
 
 interface Comment {
@@ -49,7 +49,8 @@ interface PullRequestCommentThreadProps {
 // visuals, but the resolve mutation is injected via a prop instead of
 // wired to that component's workspaceId-scoped git.setReviewThreadResolution
 // call, since this one's callers (the PR list/detail Code tab) browse a PR
-// directly and don't necessarily have a workspace linked to it.
+// directly and don't necessarily have a workspace linked to it. The reply
+// box is the shared ReviewThreadReplyComposer; only the dispatch differs.
 export function PullRequestCommentThread({
 	isResolved,
 	isOutdated,
@@ -99,31 +100,6 @@ export function PullRequestCommentThread({
 	}, [focusTick]);
 
 	const firstComment = comments[0];
-	const handleReplySubmit = () => {
-		const trimmed = replyText.trim();
-		if (!trimmed) return;
-		const dispatched = onReply(trimmed);
-		if (!dispatched) {
-			toast.error(
-				t({
-					message: "Couldn't send reply",
-				}),
-				{
-					description: t({
-						message: "This thread has no comment to reply to.",
-					}),
-				},
-			);
-			return;
-		}
-		// Optimistic clear: the mutation itself is fire-and-forget from here,
-		// and a failure past this point already surfaces as a toast (see
-		// PullRequestCodeTab's replyToThread onError) — restoring the draft
-		// on failure would need a promise-returning prop for marginal
-		// benefit. `dispatched` only guards against onReply no-op'ing before
-		// ever calling the mutation.
-		setReplyText("");
-	};
 
 	return (
 		<Collapsible
@@ -238,23 +214,13 @@ export function PullRequestCommentThread({
 						<CommentRow key={comment.id} comment={comment} />
 					))}
 				</ul>
-				<div className="flex flex-col gap-2 border-t border-border/50 bg-muted/20 px-3 py-2">
-					<Textarea
-						value={replyText}
-						onChange={(e) => setReplyText(e.target.value)}
-						onKeyDown={(e) => {
-							if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-								e.preventDefault();
-								handleReplySubmit();
-							}
-						}}
-						placeholder={t({
-							message: "Write a reply…",
-						})}
-						rows={2}
-						className="resize-none bg-background text-xs"
-					/>
-					<div className="flex items-center justify-end gap-2">
+				<ReviewThreadReplyComposer
+					value={replyText}
+					onChange={setReplyText}
+					onReply={onReply}
+					isPending={isReplyPending}
+					className="border-border/50 bg-muted/20 px-3"
+					actions={
 						<Button
 							type="button"
 							size="xs"
@@ -271,19 +237,8 @@ export function PullRequestCommentThread({
 								<Trans>Resolve conversation</Trans>
 							)}
 						</Button>
-						<Button
-							type="button"
-							size="xs"
-							disabled={!replyText.trim() || isReplyPending}
-							onClick={handleReplySubmit}
-						>
-							{isReplyPending && (
-								<LuLoaderCircle className="size-3 animate-spin" />
-							)}
-							<Trans>Reply</Trans>
-						</Button>
-					</div>
-				</div>
+					}
+				/>
 			</CollapsibleContent>
 		</Collapsible>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -722,6 +722,7 @@ export function DiffPane({
 					isOutdated={m.isOutdated}
 					url={m.url}
 					comments={m.comments}
+					replyToCommentId={m.replyToCommentId}
 					focusTick={
 						focused
 							? data.focusTick

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.test.tsx
@@ -1,0 +1,180 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom is process-wide; unregister in afterAll so the shared mock
+// document is restored for the other renderer suites.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface ReplyVariables {
+	workspaceId: string;
+	commentId: number;
+	body: string;
+}
+interface ReplyMutationOptions {
+	onSuccess?: () => void;
+	onError?: (error: Error, variables: ReplyVariables) => void;
+}
+
+const replyMutate = mock((_variables: ReplyVariables) => {});
+const invalidateThreads = mock((_input: { workspaceId: string }) => {});
+// The component wires its reply mutation once per render; capturing the
+// options lets a test settle the request the way tRPC would.
+let replyOptions: ReplyMutationOptions = {};
+let replyPending = false;
+
+mock.module("@superset/workspace-client", () => ({
+	workspaceTrpc: {
+		useUtils: () => ({
+			git: { getPullRequestThreads: { invalidate: invalidateThreads } },
+		}),
+		git: {
+			setReviewThreadResolution: {
+				useMutation: () => ({ mutate: () => {}, isPending: false }),
+			},
+			replyToReviewThread: {
+				useMutation: (options: ReplyMutationOptions) => {
+					replyOptions = options;
+					return { mutate: replyMutate, isPending: replyPending };
+				},
+			},
+		},
+	},
+}));
+
+const { act, cleanup, fireEvent, render, within } = await import(
+	"@testing-library/react"
+);
+const { CommentThread } = await import("./CommentThread");
+
+beforeEach(() => {
+	replyMutate.mockClear();
+	invalidateThreads.mockClear();
+	replyOptions = {};
+	replyPending = false;
+});
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+const COMMENTS = [
+	{ id: "c1", authorLogin: "octocat", body: "Rename this?", createdAt: 0 },
+];
+
+// `orphaned` renders a thread whose comments carry no databaseId — passing
+// an explicit undefined would just trigger a default parameter.
+async function setup({ orphaned = false } = {}) {
+	let view!: ReturnType<typeof render>;
+	await act(async () => {
+		view = render(
+			<CommentThread
+				workspaceId="ws-1"
+				threadId="thread-1"
+				isResolved={false}
+				comments={COMMENTS}
+				replyToCommentId={orphaned ? undefined : 555}
+			/>,
+		);
+	});
+	const ui = within(view.baseElement as HTMLElement);
+	const textarea = ui.getByPlaceholderText("Write a reply…");
+	const replyButton = ui.getByRole("button", { name: "Reply" });
+	const type = async (text: string) => {
+		await act(async () => {
+			fireEvent.change(textarea, { target: { value: text } });
+		});
+	};
+	return { textarea, replyButton, type };
+}
+
+describe("CommentThread reply", () => {
+	test("posts the trimmed draft onto the thread's comment and clears it", async () => {
+		const { textarea, replyButton, type } = await setup();
+		await type("  Looks good  ");
+		await act(async () => {
+			fireEvent.click(replyButton);
+		});
+
+		expect(replyMutate.mock.calls).toEqual([
+			[{ workspaceId: "ws-1", commentId: 555, body: "Looks good" }],
+		]);
+		expect((textarea as HTMLTextAreaElement).value).toBe("");
+
+		await act(async () => {
+			replyOptions.onSuccess?.();
+		});
+		expect(invalidateThreads.mock.calls).toEqual([[{ workspaceId: "ws-1" }]]);
+	});
+
+	test("Cmd+Enter submits from the textarea", async () => {
+		const { textarea, type } = await setup();
+		await type("Ship it");
+		await act(async () => {
+			fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+		});
+
+		expect(replyMutate).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps Reply disabled until there is a non-blank draft", async () => {
+		const { replyButton, type } = await setup();
+		expect((replyButton as HTMLButtonElement).disabled).toBe(true);
+		await type("   ");
+		expect((replyButton as HTMLButtonElement).disabled).toBe(true);
+		await type("hi");
+		expect((replyButton as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	test("does not post while a reply is already in flight", async () => {
+		replyPending = true;
+		const { replyButton, textarea, type } = await setup();
+		await type("again");
+		await act(async () => {
+			fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+		});
+
+		expect((replyButton as HTMLButtonElement).disabled).toBe(true);
+		expect(replyMutate).not.toHaveBeenCalled();
+	});
+
+	test("keeps the draft when the thread has no comment to reply onto", async () => {
+		const { textarea, replyButton, type } = await setup({ orphaned: true });
+		await type("Orphaned");
+		await act(async () => {
+			fireEvent.click(replyButton);
+		});
+
+		expect(replyMutate).not.toHaveBeenCalled();
+		expect((textarea as HTMLTextAreaElement).value).toBe("Orphaned");
+	});
+
+	test("hands the draft back when GitHub rejects the reply", async () => {
+		const { textarea, replyButton, type } = await setup();
+		await type("Looks good");
+		await act(async () => {
+			fireEvent.click(replyButton);
+		});
+		expect((textarea as HTMLTextAreaElement).value).toBe("");
+
+		await act(async () => {
+			replyOptions.onError?.(new Error("boom"), {
+				workspaceId: "ws-1",
+				commentId: 555,
+				body: "Looks good",
+			});
+		});
+		expect((textarea as HTMLTextAreaElement).value).toBe("Looks good");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.test.tsx
@@ -53,6 +53,14 @@ mock.module("@superset/workspace-client", () => ({
 	},
 }));
 
+// Comment bodies are irrelevant here, and the real renderer pulls in
+// react-syntax-highlighter, whose CommonJS build extends React.PureComponent
+// at load time. Two earlier suites replace `react` with a hooks-only stub
+// for the rest of the process, so loading it from here crashes on CI.
+mock.module("renderer/components/CommentMarkdown", () => ({
+	CommentMarkdown: ({ body }: { body: string }) => body,
+}));
+
 const { act, cleanup, fireEvent, render, within } = await import(
 	"@testing-library/react"
 );

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
@@ -9,6 +9,7 @@ import {
 	CollapsibleTrigger,
 } from "@superset/ui/collapsible";
 import { toast } from "@superset/ui/sonner";
+import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useEffect, useState } from "react";
@@ -38,6 +39,10 @@ interface CommentThreadProps {
 	isOutdated?: boolean;
 	url?: string;
 	comments: Comment[];
+	/** REST databaseId of a comment already in the thread — replies thread
+	 *  onto it regardless of which comment they target. Undefined only if
+	 *  GitHub ever returns a thread with zero comments (shouldn't happen). */
+	replyToCommentId?: number;
 	/** Force-expand the bubble whenever this changes — lets jump-to-line
 	 *  reveal a collapsed (resolved/outdated) thread. */
 	focusTick?: number;
@@ -50,6 +55,7 @@ export function CommentThread({
 	isOutdated,
 	url,
 	comments,
+	replyToCommentId,
 	focusTick,
 }: CommentThreadProps) {
 	const { t } = useLingui();
@@ -105,6 +111,45 @@ export function CommentThread({
 			},
 		},
 	);
+	const [replyText, setReplyText] = useState("");
+	const replyToThread = workspaceTrpc.git.replyToReviewThread.useMutation({
+		onSuccess: () => {
+			void utils.git.getPullRequestThreads.invalidate({ workspaceId });
+		},
+		onError: (error, variables) => {
+			// The draft is cleared as soon as it's sent; hand it back so a
+			// rejected reply isn't retyped — unless a new one is already
+			// underway.
+			setReplyText((current) => (current.trim() ? current : variables.body));
+			toast.error(
+				t({
+					message: "Couldn't post reply",
+				}),
+				{
+					description: errorMessage(error),
+				},
+			);
+		},
+	});
+	const handleReplySubmit = () => {
+		const body = replyText.trim();
+		if (!body || replyToThread.isPending) return;
+		if (replyToCommentId == null) {
+			toast.error(
+				t({
+					message: "Couldn't send reply",
+				}),
+				{
+					description: t({
+						message: "This thread has no comment to reply to.",
+					}),
+				},
+			);
+			return;
+		}
+		replyToThread.mutate({ workspaceId, commentId: replyToCommentId, body });
+		setReplyText("");
+	};
 
 	return (
 		<Collapsible
@@ -195,29 +240,57 @@ export function CommentThread({
 						<CommentRow key={comment.id} comment={comment} />
 					))}
 				</ul>
-				<div className="flex items-center justify-end border-t border-border bg-muted/30 px-2.5 py-1.5">
-					<Button
-						type="button"
-						size="xs"
-						variant="outline"
-						disabled={setResolution.isPending}
-						onClick={() =>
-							setResolution.mutate({
-								workspaceId,
-								threadId,
-								resolved: !isResolved,
-							})
-						}
-					>
-						{setResolution.isPending && (
-							<LuLoaderCircle className="size-3 animate-spin" />
-						)}
-						{isResolved ? (
-							<Trans>Unresolve</Trans>
-						) : (
-							<Trans>Resolve conversation</Trans>
-						)}
-					</Button>
+				<div className="flex flex-col gap-2 border-t border-border bg-muted/30 px-2.5 py-2">
+					<Textarea
+						value={replyText}
+						onChange={(e) => setReplyText(e.target.value)}
+						onKeyDown={(e) => {
+							if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+								e.preventDefault();
+								handleReplySubmit();
+							}
+						}}
+						placeholder={t({
+							message: "Write a reply…",
+						})}
+						rows={2}
+						className="resize-none bg-background text-xs"
+					/>
+					<div className="flex items-center justify-end gap-2">
+						<Button
+							type="button"
+							size="xs"
+							variant="outline"
+							disabled={setResolution.isPending}
+							onClick={() =>
+								setResolution.mutate({
+									workspaceId,
+									threadId,
+									resolved: !isResolved,
+								})
+							}
+						>
+							{setResolution.isPending && (
+								<LuLoaderCircle className="size-3 animate-spin" />
+							)}
+							{isResolved ? (
+								<Trans>Unresolve</Trans>
+							) : (
+								<Trans>Resolve conversation</Trans>
+							)}
+						</Button>
+						<Button
+							type="button"
+							size="xs"
+							disabled={!replyText.trim() || replyToThread.isPending}
+							onClick={handleReplySubmit}
+						>
+							{replyToThread.isPending && (
+								<LuLoaderCircle className="size-3 animate-spin" />
+							)}
+							<Trans>Reply</Trans>
+						</Button>
+					</div>
 				</div>
 			</CollapsibleContent>
 		</Collapsible>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/CommentThread/CommentThread.tsx
@@ -9,7 +9,6 @@ import {
 	CollapsibleTrigger,
 } from "@superset/ui/collapsible";
 import { toast } from "@superset/ui/sonner";
-import { Textarea } from "@superset/ui/textarea";
 import { cn } from "@superset/ui/utils";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useEffect, useState } from "react";
@@ -21,6 +20,7 @@ import {
 	LuLoaderCircle,
 } from "react-icons/lu";
 import { CommentMarkdown } from "renderer/components/CommentMarkdown";
+import { ReviewThreadReplyComposer } from "renderer/routes/_authenticated/_dashboard/components/ReviewThreadReplyComposer";
 import "./comment-thread.css";
 import { msg } from "@lingui/core/macro";
 
@@ -131,25 +131,6 @@ export function CommentThread({
 			);
 		},
 	});
-	const handleReplySubmit = () => {
-		const body = replyText.trim();
-		if (!body || replyToThread.isPending) return;
-		if (replyToCommentId == null) {
-			toast.error(
-				t({
-					message: "Couldn't send reply",
-				}),
-				{
-					description: t({
-						message: "This thread has no comment to reply to.",
-					}),
-				},
-			);
-			return;
-		}
-		replyToThread.mutate({ workspaceId, commentId: replyToCommentId, body });
-		setReplyText("");
-	};
 
 	return (
 		<Collapsible
@@ -240,23 +221,21 @@ export function CommentThread({
 						<CommentRow key={comment.id} comment={comment} />
 					))}
 				</ul>
-				<div className="flex flex-col gap-2 border-t border-border bg-muted/30 px-2.5 py-2">
-					<Textarea
-						value={replyText}
-						onChange={(e) => setReplyText(e.target.value)}
-						onKeyDown={(e) => {
-							if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-								e.preventDefault();
-								handleReplySubmit();
-							}
-						}}
-						placeholder={t({
-							message: "Write a reply…",
-						})}
-						rows={2}
-						className="resize-none bg-background text-xs"
-					/>
-					<div className="flex items-center justify-end gap-2">
+				<ReviewThreadReplyComposer
+					value={replyText}
+					onChange={setReplyText}
+					onReply={(body) => {
+						if (replyToCommentId == null) return false;
+						replyToThread.mutate({
+							workspaceId,
+							commentId: replyToCommentId,
+							body,
+						});
+						return true;
+					}}
+					isPending={replyToThread.isPending}
+					className="border-border bg-muted/30 px-2.5"
+					actions={
 						<Button
 							type="button"
 							size="xs"
@@ -279,19 +258,8 @@ export function CommentThread({
 								<Trans>Resolve conversation</Trans>
 							)}
 						</Button>
-						<Button
-							type="button"
-							size="xs"
-							disabled={!replyText.trim() || replyToThread.isPending}
-							onClick={handleReplySubmit}
-						>
-							{replyToThread.isPending && (
-								<LuLoaderCircle className="size-3 animate-spin" />
-							)}
-							<Trans>Reply</Trans>
-						</Button>
-					</div>
-				</div>
+					}
+				/>
 			</CollapsibleContent>
 		</Collapsible>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffAnnotations/useDiffAnnotations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffAnnotations/useDiffAnnotations.ts
@@ -21,6 +21,9 @@ export interface DiffCommentThread {
 	isOutdated: boolean;
 	url?: string;
 	sourceLine?: number;
+	/** REST databaseId of the thread's first comment — replies thread onto
+	 *  it. Unset only if GitHub ever returns a thread with zero comments. */
+	replyToCommentId?: number;
 }
 
 /** Local-only metadata for a draft composer pinned to the end of a selection. */
@@ -118,6 +121,7 @@ export function useDiffAnnotationsByPath({
 					isResolved: thread.isResolved,
 					isOutdated: thread.isOutdated,
 					...(url ? { url } : {}),
+					...(firstDbId != null ? { replyToCommentId: firstDbId } : {}),
 					comments: thread.comments.map((c) => {
 						const createdAt = parseTimestamp(c.createdAt);
 						return {

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -47,6 +47,7 @@ import {
 	parseGraphQLThreads,
 	REVIEW_THREADS_QUERY,
 } from "./utils/graphql";
+import { replyToReviewComment } from "./utils/reply-to-review-comment";
 import { resolveWorktreePath } from "./utils/resolve-worktree";
 import { attachSpawnFailureDiagnostics } from "./utils/spawn-failure-diagnostics";
 
@@ -1052,5 +1053,52 @@ export const gitRouter = router({
 			}
 
 			return { threadId: input.threadId, isResolved: input.resolved };
+		}),
+
+	/**
+	 * Replies into a review thread on the workspace's linked PR. Threads onto
+	 * `commentId` — a REST databaseId from getPullRequestThreads — which
+	 * GitHub accepts for any comment already in the thread.
+	 */
+	replyToReviewThread: protectedProcedure
+		.input(
+			z.object({
+				workspaceId: z.string(),
+				commentId: z.number().int().positive(),
+				body: z.string().trim().min(1),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const workspace = ctx.db.query.workspaces
+				.findFirst({ where: eq(workspaces.id, input.workspaceId) })
+				.sync();
+			if (!workspace?.pullRequestId) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace has no associated pull request",
+				});
+			}
+
+			const pr = ctx.db.query.pullRequests
+				.findFirst({ where: eq(pullRequests.id, workspace.pullRequestId) })
+				.sync();
+			if (!pr) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: `Pull request ${workspace.pullRequestId} not found in database`,
+				});
+			}
+
+			// The PR row already names the repo the PR lives in, so there's no
+			// remote to parse (resolveGithubRepo). A comment id from some other
+			// PR 404s rather than landing somewhere unexpected.
+			const octokit = await ctx.github();
+			return replyToReviewComment(octokit, {
+				owner: pr.repoOwner,
+				repo: pr.repoName,
+				prNumber: pr.prNumber,
+				commentId: input.commentId,
+				body: input.body,
+			});
 		}),
 });

--- a/packages/host-service/src/trpc/router/git/reply-to-review-thread.test.ts
+++ b/packages/host-service/src/trpc/router/git/reply-to-review-thread.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { TRPCError } from "@trpc/server";
+import type { HostServiceContext } from "../../../types";
+import { gitRouter } from "./git";
+
+interface ReplyCall {
+	owner: string;
+	repo: string;
+	pull_number: number;
+	comment_id: number;
+	body: string;
+}
+
+function createCaller(opts: {
+	workspace?: { pullRequestId: string | null };
+	pr?: { repoOwner: string; repoName: string; prNumber: number };
+	/** Thrown by the GitHub call instead of returning the new comment. */
+	rejection?: unknown;
+}) {
+	const replyCalls: ReplyCall[] = [];
+	const ctx = {
+		isAuthenticated: true,
+		db: {
+			query: {
+				workspaces: {
+					findFirst: () => ({ sync: () => opts.workspace }),
+				},
+				pullRequests: {
+					findFirst: () => ({ sync: () => opts.pr }),
+				},
+			},
+		},
+		github: async () => ({
+			pulls: {
+				createReplyForReviewComment: async (args: ReplyCall) => {
+					replyCalls.push(args);
+					if (opts.rejection !== undefined) throw opts.rejection;
+					return { data: { id: 9001 } };
+				},
+			},
+		}),
+	} as unknown as HostServiceContext;
+	return { caller: gitRouter.createCaller(ctx), replyCalls };
+}
+
+const LINKED = {
+	workspace: { pullRequestId: "pr-1" },
+	pr: { repoOwner: "acme", repoName: "widgets", prNumber: 17 },
+};
+
+async function expectTrpcError(
+	promise: Promise<unknown>,
+	code: TRPCError["code"],
+) {
+	try {
+		await promise;
+		throw new Error("expected the call to reject");
+	} catch (error) {
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe(code);
+	}
+}
+
+describe("gitRouter.replyToReviewThread", () => {
+	it("threads the reply onto the comment in the workspace's PR", async () => {
+		const { caller, replyCalls } = createCaller(LINKED);
+
+		const result = await caller.replyToReviewThread({
+			workspaceId: "ws-1",
+			commentId: 555,
+			body: "  Looks good  ",
+		});
+
+		expect(result).toEqual({ id: 9001 });
+		expect(replyCalls).toEqual([
+			{
+				owner: "acme",
+				repo: "widgets",
+				pull_number: 17,
+				comment_id: 555,
+				body: "Looks good",
+			},
+		]);
+	});
+
+	it("rejects a blank body before reaching GitHub", async () => {
+		const { caller, replyCalls } = createCaller(LINKED);
+
+		await expectTrpcError(
+			caller.replyToReviewThread({
+				workspaceId: "ws-1",
+				commentId: 555,
+				body: "   ",
+			}),
+			"BAD_REQUEST",
+		);
+		expect(replyCalls).toHaveLength(0);
+	});
+
+	it("returns NOT_FOUND when the workspace has no pull request", async () => {
+		const { caller, replyCalls } = createCaller({
+			workspace: { pullRequestId: null },
+		});
+
+		await expectTrpcError(
+			caller.replyToReviewThread({
+				workspaceId: "ws-1",
+				commentId: 555,
+				body: "Looks good",
+			}),
+			"NOT_FOUND",
+		);
+		expect(replyCalls).toHaveLength(0);
+	});
+
+	it("maps GitHub's rejection onto the matching tRPC code", async () => {
+		const { caller } = createCaller({
+			...LINKED,
+			rejection: Object.assign(new Error("Not Found"), { status: 404 }),
+		});
+
+		await expectTrpcError(
+			caller.replyToReviewThread({
+				workspaceId: "ws-1",
+				commentId: 555,
+				body: "Looks good",
+			}),
+			"NOT_FOUND",
+		);
+	});
+});

--- a/packages/host-service/src/trpc/router/git/reply-to-review-thread.test.ts
+++ b/packages/host-service/src/trpc/router/git/reply-to-review-thread.test.ts
@@ -113,6 +113,22 @@ describe("gitRouter.replyToReviewThread", () => {
 		expect(replyCalls).toHaveLength(0);
 	});
 
+	it("reports a linked pull request missing from the database as a server error", async () => {
+		const { caller, replyCalls } = createCaller({
+			workspace: { pullRequestId: "pr-1" },
+		});
+
+		await expectTrpcError(
+			caller.replyToReviewThread({
+				workspaceId: "ws-1",
+				commentId: 555,
+				body: "Looks good",
+			}),
+			"INTERNAL_SERVER_ERROR",
+		);
+		expect(replyCalls).toHaveLength(0);
+	});
+
 	it("maps GitHub's rejection onto the matching tRPC code", async () => {
 		const { caller } = createCaller({
 			...LINKED,

--- a/packages/host-service/src/trpc/router/git/utils/reply-to-review-comment.ts
+++ b/packages/host-service/src/trpc/router/git/utils/reply-to-review-comment.ts
@@ -1,0 +1,38 @@
+import type { Octokit } from "@octokit/rest";
+import { actionRejectionError } from "../../github/github";
+
+export interface ReplyToReviewCommentInput {
+	owner: string;
+	repo: string;
+	prNumber: number;
+	/** REST databaseId of any comment already in the thread — GitHub's
+	 *  reply endpoint threads the new comment onto it regardless of which
+	 *  comment in the thread you target. */
+	commentId: number;
+	body: string;
+}
+
+/**
+ * Posts a reply into an existing review thread on GitHub.
+ *
+ * Shared by pullRequests.replyToThread (project + PR number scoped) and
+ * git.replyToReviewThread (workspace scoped): the two differ only in how
+ * they find the repo and PR, not in what they send.
+ */
+export async function replyToReviewComment(
+	octokit: Pick<Octokit, "pulls">,
+	input: ReplyToReviewCommentInput,
+): Promise<{ id: number }> {
+	try {
+		const { data } = await octokit.pulls.createReplyForReviewComment({
+			owner: input.owner,
+			repo: input.repo,
+			pull_number: input.prNumber,
+			comment_id: input.commentId,
+			body: input.body,
+		});
+		return { id: data.id };
+	} catch (error) {
+		throw actionRejectionError(error, "GitHub refused the reply.");
+	}
+}

--- a/packages/host-service/src/trpc/router/pull-requests/procedures/reply-to-thread.ts
+++ b/packages/host-service/src/trpc/router/pull-requests/procedures/reply-to-thread.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { protectedProcedure } from "../../../index";
-import { actionRejectionError } from "../../github/github";
+import { replyToReviewComment } from "../../git/utils/reply-to-review-comment";
 import { resolveGithubRepo } from "../../workspace-creation/shared/project-helpers";
 
 const replyToThreadInputSchema = z.object({
@@ -13,21 +13,19 @@ const replyToThreadInputSchema = z.object({
 	body: z.string().trim().min(1),
 });
 
+// Project+PR scoped, unlike git.replyToReviewThread (workspaceId scoped —
+// it resolves the PR via a workspace's DB row). The Code tab browses a PR
+// directly, with no workspace necessarily linked to it.
 export const replyToThread = protectedProcedure
 	.input(replyToThreadInputSchema)
 	.mutation(async ({ ctx, input }) => {
 		const repo = await resolveGithubRepo(ctx, input.projectId);
 		const octokit = await ctx.github();
-		try {
-			const { data } = await octokit.pulls.createReplyForReviewComment({
-				owner: repo.owner,
-				repo: repo.name,
-				pull_number: input.prNumber,
-				comment_id: input.commentId,
-				body: input.body,
-			});
-			return { id: data.id };
-		} catch (error) {
-			throw actionRejectionError(error, "GitHub refused the reply.");
-		}
+		return replyToReviewComment(octokit, {
+			owner: repo.owner,
+			repo: repo.name,
+			prNumber: input.prNumber,
+			commentId: input.commentId,
+			body: input.body,
+		});
 	});


### PR DESCRIPTION
## Summary
- The workspace Changes pane can now reply to PR review threads and post them to GitHub, matching the PR view's Code tab. Each thread bubble gets a reply box (Cmd/Ctrl+Enter submits) and a Reply button beside Resolve.
- New workspace-scoped `git.replyToReviewThread` mutation. The GitHub call it shares with `pullRequests.replyToThread` moves into one helper so the two surfaces can't drift.

## Why / Context
Review threads already rendered inline in the Changes pane with resolve/unresolve, but answering one meant leaving for the PR view or GitHub. The PR view had the full reply flow, so this ports that implementation over rather than inventing a second one.

## How It Works
- `git.getPullRequestThreads` already returns each comment's REST `databaseId`; `useDiffAnnotationsByPath` now puts the first comment's id on the thread metadata as `replyToCommentId`.
- DiffPane's `CommentThread` owns a `git.replyToReviewThread` mutation. On send it clears the draft; on success it invalidates the workspace threads query, and the annotation version hash already includes comment count, so the new comment renders on the next refetch. On failure it toasts and hands the draft back (unless a new one was started).
- `git.replyToReviewThread` looks up workspace → linked PR row and posts via `pulls.createReplyForReviewComment` using the PR row's repo owner/name/number. A comment id from another PR 404s rather than landing somewhere unexpected.
- `replyToReviewComment` (new, `git/utils`) wraps the octokit call plus `actionRejectionError` mapping; `pullRequests.replyToThread` is refactored onto it.

## Manual QA Checklist
Not run against the live app: no dev app was running from this worktree, and posting a real reply to GitHub is outward-facing. Worth a pass before merge:
- [ ] In a workspace linked to a PR with review comments, open the Changes pane: each thread shows the reply box under the comments
- [ ] Type a reply and click Reply (or Cmd+Enter): it appears on GitHub and shows in the thread within the 30s poll or on window focus
- [ ] Reply stays disabled while the draft is blank or a post is in flight
- [ ] With network off or a revoked token: "Couldn't post reply" toast and the draft comes back
- [ ] Resolve / Unresolve still work beside the new button
- [ ] Resolved and outdated threads still start collapsed; expanding shows the reply box

## Testing
- `bun run typecheck` (host-service and desktop)
- `bun test src/trpc/router/git src/trpc/router/pull-requests` in host-service (145 pass). New `reply-to-review-thread.test.ts`: happy path, blank body rejected before GitHub, no linked PR → NOT_FOUND, GitHub 404 → NOT_FOUND
- `bun test` on the DiffPane tree in desktop (30 pass). New `CommentThread.test.tsx`: submit + clear + invalidate, Cmd+Enter, disabled states, in-flight guard, orphaned thread keeps its draft, failure restores the draft
- `bun run check:i18n` clean. Every string the reply box uses already exists in all 17 locales from the PR view, so no catalog changes
- `bun test` in packages/i18n (enforced-dirs, display-only) and `biome check` on the changed files

## Design Decisions
- **PR row over `resolveGithubRepo` for the reply target**: `getCheckJobLogs` already uses the PR row; it needs no remote parsing and names exactly the repo the comment ids came from.
- **Draft restore on failure**: the PR view clears optimistically and can't restore because its reply is a prop callback. Here the component owns the mutation, so restoring is two lines. A small, deliberate divergence.

## Follow-ups
- The resolve/unresolve GraphQL mutation is still duplicated between `git.setReviewThreadResolution` and `pullRequests.setThreadResolution`. The same shared-helper treatment would fit; left out to keep this focused.

https://claude.ai/code/session_01DQF36hf8kmYHRggDxFwXuk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reply support for PR review threads in the workspace Changes pane, matching the PR view's Code tab. You can now type a reply in each thread and submit it to GitHub; previously the pane only allowed resolving/unresolving threads.

**New Features**
- Adds a reply box and Reply button to each thread bubble; Cmd/Ctrl+Enter also submits.
- New workspace-scoped `git.replyToReviewThread` mutation posts the reply to the linked PR.
- Failed replies toast an error and restore your draft.

**Refactors**
- The reply box is now a shared `ReviewThreadReplyComposer`, used by the Changes pane and the PR view's Code tab.
- The GitHub reply call and error mapping now live in a shared helper used by `pullRequests.replyToThread` and the new mutation.
- Thread metadata now carries the first comment's database id so replies thread onto the correct comment.

<sup>Written for commit 36ff9a65a4efa511e9d95392493f4a0584197f8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to reply directly to review comment threads in the diff view.
  * Replies support trimmed text, Reply button, and Ctrl/Cmd+Enter submission.
  * Drafts are preserved when posting fails, with controls disabled for blank drafts or while submitting.
  * Reply controls are now consistent across diff and pull request review threads.

* **Bug Fixes**
  * Review replies are correctly associated with the selected comment thread.

* **Tests**
  * Added coverage for reply submission, validation, pending states, draft handling, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->