### PR TITLE
style(marketing): unbold job description headings, retune join-us type

### DIFF
--- a/apps/marketing/src/app/[lang]/join-us/page.tsx
+++ b/apps/marketing/src/app/[lang]/join-us/page.tsx
@@ -64,7 +64,7 @@ export default async function JoinUsPage() {
 		<main className="relative min-h-screen bg-background">
 			<div className="max-w-[90rem] mx-auto px-6 pt-24 md:pt-32">
 				<section className="grid gap-10 md:grid-cols-[2fr_3fr] md:gap-24 lg:gap-32">
-					<h1 className="text-4xl md:text-5xl font-normal leading-tight text-foreground m-0">
+					<h1 className="text-4xl md:text-6xl font-normal leading-tight tracking-[-0.02em] text-foreground m-0">
 						<Trans>Building the last piece of software</Trans>
 					</h1>
 
@@ -109,7 +109,7 @@ export default async function JoinUsPage() {
 
 			<div className="max-w-[90rem] mx-auto px-6 pb-24 md:pb-32">
 				<section id="open-roles" className="mt-24 md:mt-32 scroll-mt-24">
-					<h2 className="text-2xl md:text-3xl font-normal text-foreground mb-6">
+					<h2 className="text-2xl md:text-3xl font-normal tracking-[-0.02em] text-foreground mb-6">
 						<Trans>Open roles</Trans>
 					</h2>
 
@@ -171,6 +171,13 @@ export default async function JoinUsPage() {
 								".back-link{" + mono + ";font-size:12px !important}",
 								".sidebar-label{" + mono + ";font-size:11px !important}",
 								".sidebar-item{border-bottom:1px solid var(--_border) !important}", // default rgba(0,0,0,.06) vanishes on dark bg
+								// regular-weight title and section headings (WaaS wraps section titles in <h3><strong>), 16px body
+								".job-title{font-size:36px !important;font-weight:400 !important;letter-spacing:-0.02em !important;line-height:1.2 !important}",
+								".description{font-size:16px !important;line-height:1.5 !important;color:var(--_text) !important}",
+								".description :is(h1,h2,h3){font-size:var(--_font-size-md) !important;font-weight:400 !important;margin:40px 0 12px !important}",
+								".description :is(h1,h2,h3) strong{font-weight:400 !important}",
+								".description :is(p,ul,ol){margin:16px 0 !important}",
+								".description li{margin-bottom:8px !important}",
 							].join("");
 							const formCss = [
 								".primary-button{" + mono + ";font-size:13px !important;font-weight:400 !important;background:var(--foreground) !important;color:var(--background) !important;transition:background-color .15s ease,color .15s ease !important}",

--- a/apps/marketing/src/app/globals.css
+++ b/apps/marketing/src/app/globals.css
@@ -19,6 +19,11 @@
 	--brand-dark: #9e400a;
 }
 
+/* The site is always dark; the shared muted grey reads too dim for body copy here */
+.dark {
+	--muted-foreground: oklch(0.8 0 0);
+}
+
 @layer base {
 	/* Linear-style Inter: optical sizing (Display cut at large sizes) +
 	   alternate glyphs. Feature settings are ignored by the mono/pixel fonts. */


### PR DESCRIPTION
## What

Job detail on `/join-us` (the YC Work at a Startup embed) and the page around it:

- Section headings ("What you'll do" etc.) are regular weight. WaaS ships them as `<h3><strong>`, so both the heading and the nested strong get reset in the shadow-root override we already inject.
- Job title 36px regular with -0.02em tracking (was 22px semibold). Body 16px/24px in full foreground.
- Page headline 60px with -0.02em tracking; "Open roles" tracked to match.
- Marketing muted grey lifted from oklch 0.708 to 0.80. Scoped to `apps/marketing/globals.css`, desktop untouched.

## Why

Headings were the only bold text on the page. Body grey was dimmer than Linear's intro copy and Cursor's job pages; both measured in headless Chrome for reference.

## Verified

Rendered locally at 1440px from the dev server, plus computed font-weight 400 on every description heading via CDP.

https://claude.ai/code/session_01LYu5icxF1ZGMv7WicnS5Q2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retunes `/join-us` typography so the embedded job listing and the page around it share the same type treatment.

- Resets the job listing's section headings from bold to regular weight, with the job title at 36px and body copy at 16px/24px in full foreground.
- Scales the page headline to 60px and applies matching -0.02em tracking to "Open roles".
- Lightens marketing muted grey in dark mode only, so desktop styling stays unchanged.

<sup>Written for commit 49bf2fdaa5f3820926a6765dd98a731607006345. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved typography on the Join Us page, including heading sizing and letter spacing.
  * Enhanced readability and spacing for embedded job details and lists.
  * Increased muted text contrast across the dark-themed marketing site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->