### PR TITLE
fix(workspaces): base a PR workspace on the branch the PR merges into

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -366,9 +366,11 @@ async function handleNewWorktree({
 
 	const knownBranches = await getKnownBranchesSafe(project.mainRepoPath);
 	const compareBaseBranch = resolveWorkspaceBaseBranch({
-		// A PR is reviewed against the branch it merges into, not the project
-		// default — a stacked PR would otherwise open showing its parent's
-		// commits as its own changes.
+		// A PR is reviewed against the branch it merges into, not the project's
+		// configured base — a stacked PR would otherwise open showing its
+		// parent's commits as its own changes. A base we cannot compare
+		// against leaves the project's own precedence (configured base, then
+		// repo default) untouched.
 		explicitBaseBranch: resolvePrBaseBranch({
 			baseRefName: prInfo.baseRefName,
 			remoteBranches: knownBranches?.remote,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -7,7 +7,10 @@ import { workspaceInitManager } from "main/lib/workspace-init-manager";
 import { z } from "zod";
 import { publicProcedure, router } from "../../..";
 import { attemptWorkspaceAutoRenameFromPrompt } from "../utils/ai-name";
-import { resolveWorkspaceBaseBranch } from "../utils/base-branch";
+import {
+	resolvePrBaseBranch,
+	resolveWorkspaceBaseBranch,
+} from "../utils/base-branch";
 import { setBranchBaseConfig } from "../utils/base-branch-config";
 import { resolveBranchPrefix } from "../utils/branch-prefix";
 import {
@@ -359,6 +362,13 @@ async function handleNewWorktree({
 
 	const knownBranches = await getKnownBranchesSafe(project.mainRepoPath);
 	const compareBaseBranch = resolveWorkspaceBaseBranch({
+		// A PR is reviewed against the branch it merges into, not the project
+		// default — a stacked PR would otherwise open showing its parent's
+		// commits as its own changes.
+		explicitBaseBranch: resolvePrBaseBranch({
+			baseRefName: prInfo.baseRefName,
+			knownBranches,
+		}),
 		workspaceBaseBranch: project.workspaceBaseBranch,
 		defaultBranch: project.defaultBranch,
 		knownBranches,

--- a/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/procedures/create.ts
@@ -320,12 +320,16 @@ interface HandleNewWorktreeParams {
 	workspaceName: string;
 }
 
+/**
+ * `remote` holds remote-tracking branches with the "origin/" prefix stripped,
+ * matching `all`'s shape. Undefined when git could not be read at all.
+ */
 async function getKnownBranchesSafe(
 	repoPath: string,
-): Promise<string[] | undefined> {
+): Promise<{ all: string[]; remote: string[] } | undefined> {
 	try {
 		const { local, remote } = await listBranches(repoPath);
-		return [...local, ...remote];
+		return { all: [...local, ...remote], remote };
 	} catch (error) {
 		console.warn(
 			`[workspaces/create] Failed to list branches for ${repoPath}:`,
@@ -367,11 +371,11 @@ async function handleNewWorktree({
 		// commits as its own changes.
 		explicitBaseBranch: resolvePrBaseBranch({
 			baseRefName: prInfo.baseRefName,
-			knownBranches,
+			remoteBranches: knownBranches?.remote,
 		}),
 		workspaceBaseBranch: project.workspaceBaseBranch,
 		defaultBranch: project.defaultBranch,
-		knownBranches,
+		knownBranches: knownBranches?.all,
 	});
 
 	const worktree = localDb
@@ -1070,7 +1074,7 @@ export const createCreateProcedures = () => {
 				const compareBaseBranch = resolveWorkspaceBaseBranch({
 					workspaceBaseBranch: project.workspaceBaseBranch,
 					defaultBranch: project.defaultBranch,
-					knownBranches,
+					knownBranches: knownBranches?.all,
 				});
 
 				let imported = 0;
@@ -1150,7 +1154,7 @@ export const createCreateProcedures = () => {
 				const compareBaseBranch = resolveWorkspaceBaseBranch({
 					workspaceBaseBranch: project.workspaceBaseBranch,
 					defaultBranch: project.defaultBranch,
-					knownBranches,
+					knownBranches: knownBranches?.all,
 				});
 
 				const allExternalWorktrees = await listExternalWorktrees(

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts
@@ -60,21 +60,32 @@ describe("resolvePrBaseBranch", () => {
 		expect(
 			resolvePrBaseBranch({
 				baseRefName: "release/2026-q1",
-				knownBranches: ["main", "release/2026-q1"],
+				remoteBranches: ["main", "release/2026-q1"],
 			}),
 		).toBe("release/2026-q1");
 	});
 
-	test("ignores a base branch the repo does not have", () => {
+	test("ignores a base branch with no remote-tracking ref", () => {
 		expect(
 			resolvePrBaseBranch({
 				baseRefName: "release/2026-q1",
-				knownBranches: ["main"],
+				remoteBranches: ["main"],
 			}),
 		).toBeUndefined();
 	});
 
-	test("keeps the base branch when knownBranches is unavailable (offline)", () => {
+	test("ignores a base branch that exists only locally", () => {
+		// The changes view diffs against origin/<base>, so a local-only branch
+		// would silently produce an empty diff.
+		expect(
+			resolvePrBaseBranch({
+				baseRefName: "release/2026-q1",
+				remoteBranches: [],
+			}),
+		).toBeUndefined();
+	});
+
+	test("keeps the base branch when branches cannot be listed (offline)", () => {
 		expect(resolvePrBaseBranch({ baseRefName: "release/2026-q1" })).toBe(
 			"release/2026-q1",
 		);
@@ -83,7 +94,7 @@ describe("resolvePrBaseBranch", () => {
 	test("ignores a missing or blank base branch", () => {
 		expect(resolvePrBaseBranch({})).toBeUndefined();
 		expect(
-			resolvePrBaseBranch({ baseRefName: "   ", knownBranches: ["main"] }),
+			resolvePrBaseBranch({ baseRefName: "   ", remoteBranches: ["main"] }),
 		).toBeUndefined();
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveWorkspaceBaseBranch } from "./base-branch";
+import { resolvePrBaseBranch, resolveWorkspaceBaseBranch } from "./base-branch";
 
 describe("resolveWorkspaceBaseBranch", () => {
 	test("uses explicit base branch when provided", () => {
@@ -52,5 +52,38 @@ describe("resolveWorkspaceBaseBranch", () => {
 	test('falls back to "main" when no defaultBranch or workspaceBaseBranch is provided', () => {
 		const resolved = resolveWorkspaceBaseBranch({});
 		expect(resolved).toBe("main");
+	});
+});
+
+describe("resolvePrBaseBranch", () => {
+	test("uses the branch the PR merges into", () => {
+		expect(
+			resolvePrBaseBranch({
+				baseRefName: "release/2026-q1",
+				knownBranches: ["main", "release/2026-q1"],
+			}),
+		).toBe("release/2026-q1");
+	});
+
+	test("ignores a base branch the repo does not have", () => {
+		expect(
+			resolvePrBaseBranch({
+				baseRefName: "release/2026-q1",
+				knownBranches: ["main"],
+			}),
+		).toBeUndefined();
+	});
+
+	test("keeps the base branch when knownBranches is unavailable (offline)", () => {
+		expect(resolvePrBaseBranch({ baseRefName: "release/2026-q1" })).toBe(
+			"release/2026-q1",
+		);
+	});
+
+	test("ignores a missing or blank base branch", () => {
+		expect(resolvePrBaseBranch({})).toBeUndefined();
+		expect(
+			resolvePrBaseBranch({ baseRefName: "   ", knownBranches: ["main"] }),
+		).toBeUndefined();
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
@@ -36,3 +36,25 @@ export function resolveWorkspaceBaseBranch({
 
 	return preferred;
 }
+
+/**
+ * The PR's own base branch, when the repo actually has it. A base that never
+ * landed locally (nor as a remote-tracking branch) would make every diff in
+ * the workspace fail, so those fall back to the project's default.
+ */
+export function resolvePrBaseBranch({
+	baseRefName,
+	knownBranches,
+}: {
+	baseRefName?: string;
+	knownBranches?: string[];
+}): string | undefined {
+	const base = normalizeBranch(baseRefName);
+	if (!base) {
+		return undefined;
+	}
+	if (knownBranches?.length && !knownBranches.includes(base)) {
+		return undefined;
+	}
+	return base;
+}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
@@ -41,8 +41,9 @@ export function resolveWorkspaceBaseBranch({
  * The PR's own base branch, when the repo can actually compare against it.
  * The changes view diffs against `origin/<base>` and reports a failed diff as
  * an empty one, so a base with no remote-tracking ref — including one that
- * exists only as a local branch — falls back to the project's default rather
- * than showing the workspace as having no changes.
+ * exists only as a local branch — is dropped rather than showing the
+ * workspace as having no changes. Dropping it hands the choice back to
+ * `resolveWorkspaceBaseBranch`, which is what non-PR workspaces already use.
  *
  * `remoteBranches` carries remote-tracking names with "origin/" stripped;
  * undefined means git could not be read, where the PR's own base is still the

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.ts
@@ -38,22 +38,28 @@ export function resolveWorkspaceBaseBranch({
 }
 
 /**
- * The PR's own base branch, when the repo actually has it. A base that never
- * landed locally (nor as a remote-tracking branch) would make every diff in
- * the workspace fail, so those fall back to the project's default.
+ * The PR's own base branch, when the repo can actually compare against it.
+ * The changes view diffs against `origin/<base>` and reports a failed diff as
+ * an empty one, so a base with no remote-tracking ref — including one that
+ * exists only as a local branch — falls back to the project's default rather
+ * than showing the workspace as having no changes.
+ *
+ * `remoteBranches` carries remote-tracking names with "origin/" stripped;
+ * undefined means git could not be read, where the PR's own base is still the
+ * better guess.
  */
 export function resolvePrBaseBranch({
 	baseRefName,
-	knownBranches,
+	remoteBranches,
 }: {
 	baseRefName?: string;
-	knownBranches?: string[];
+	remoteBranches?: string[];
 }): string | undefined {
 	const base = normalizeBranch(baseRefName);
 	if (!base) {
 		return undefined;
 	}
-	if (knownBranches?.length && !knownBranches.includes(base)) {
+	if (remoteBranches && !remoteBranches.includes(base)) {
 		return undefined;
 	}
 	return base;

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1742,6 +1742,8 @@ export interface PullRequestInfo {
 	number: number;
 	title: string;
 	headRefName: string;
+	/** Branch the PR merges into — the workspace's compare base. */
+	baseRefName: string;
 	/** Head commit SHA — ground truth for whether a PR checkout completed. */
 	headRefOid?: string;
 	headRepository: {
@@ -1832,7 +1834,7 @@ export async function getPrInfo({
 				"--repo",
 				`${owner}/${repo}`,
 				"--json",
-				"number,title,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository",
+				"number,title,headRefName,baseRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository",
 			],
 			{ timeout: 30_000 },
 		);


### PR DESCRIPTION
A workspace opened from a linked PR now compares against the branch that PR merges into, not the project's default branch. Before this, a stacked PR opened showing its parent's commits as its own changes.

Only the v1 desktop path needed the change. The v2 host-service path already records `branch.<name>.base` from `prMetadata.baseRefName`.

## What changed

- `utils/git.ts`: `getPrInfo` asks `gh` for `baseRefName`, and `PullRequestInfo` carries it.
- `procedures/create.ts` (`handleNewWorktree`): passes the PR's base as `explicitBaseBranch`, so it lands in the worktree row's `baseBranch` and in `branch.<name>.base` via `setBranchBaseConfig`.
- `utils/base-branch.ts`: new `resolvePrBaseBranch` drops a base the repo does not have, so a missing branch falls back to the project default instead of breaking every diff in the workspace. When branch listing fails (offline), the PR base is kept.
- `base-branch.test.ts`: four cases covering the above.

## Testing

- `bun run --cwd apps/desktop typecheck` passes.
- `bun test apps/desktop/src/lib/trpc/routers/workspaces/utils/base-branch.test.ts` — 10 pass.

Reopening a workspace whose worktree already exists keeps its stored base. Overwriting it would clobber a base someone set by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PR workspaces so they compare against the branch the PR merges into instead of the project's default branch. A stacked PR previously showed its parent's commits as its own changes.

**Bug Fixes**
- `getPrInfo` now reads `baseRefName` from `gh`, and `handleNewWorktree` passes it as the workspace's explicit base.
- `resolvePrBaseBranch` keeps the PR base only when the repo has a matching remote-tracking ref; a base that exists only locally is dropped so the workspace falls back to the project's configured base branch (then the repo default) instead of showing an empty diff.
- When branch listing fails (offline), the PR base is kept.
- Reopening an existing workspace keeps its stored base rather than overwriting it.
- Only the v1 desktop path needed the change; the v2 host-service path already records `branch.<name>.base` from `prMetadata.baseRefName`.

<sup>Written for commit 7d88ea623602cb65530d353064ac612a5451dd80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace comparisons created from pull requests now use the pull request’s target branch as the comparison base when available.
  - Improved handling of local, remote-tracking, missing, blank, and unavailable branch information to prevent incorrect base-branch selection.
  - Workspace imports now consistently use known branches when determining comparison bases.

- **Tests**
  - Added coverage for pull request base-branch resolution across matching, local-only, missing, blank, and unavailable branch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->