### PR TITLE
feat(desktop): reasoning effort picker for cursor-agent

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -234,9 +234,11 @@ export function PromptGroup({
 		EFFORT_STORAGE_KEY,
 		effortSupport ? selectedPresetId : null,
 	);
-	// Codex's top two efforts only exist on its GPT-5.6 models, so the offered
-	// list follows the model picker. A remembered effort the current model
-	// rejects stays stored but shows (and launches) as the agent default.
+	// Codex's top two efforts only exist on its GPT-5.6 models and cursor-agent
+	// has a ladder for only some models, so the offered list follows the model
+	// picker and the control disappears when there is nothing to offer. A
+	// remembered effort the current model rejects stays stored but shows (and
+	// launches) as the agent default.
 	const effortOptions = useMemo(
 		() =>
 			selectedPresetId
@@ -669,7 +671,7 @@ export function PromptGroup({
 								triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 							/>
 						)}
-						{effortSupport && (
+						{effortSupport && effortOptions.length > 0 && (
 							<AgentModelSelect
 								models={effortOptions}
 								value={selectedEffort}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -504,9 +504,11 @@ export function NewWorkspaceScreen({
 		EFFORT_STORAGE_KEY,
 		effortSupport ? selectedPresetId : null,
 	);
-	// Codex's top two efforts only exist on its GPT-5.6 models, so the offered
-	// list follows the model picker. A remembered effort the current model
-	// rejects stays stored but shows (and launches) as the agent default.
+	// Codex's top two efforts only exist on its GPT-5.6 models and cursor-agent
+	// has a ladder for only some models, so the offered list follows the model
+	// picker and the control disappears when there is nothing to offer. A
+	// remembered effort the current model rejects stays stored but shows (and
+	// launches) as the agent default.
 	const effortOptions = useMemo(
 		() =>
 			selectedPresetId
@@ -903,7 +905,7 @@ export function NewWorkspaceScreen({
 										triggerClassName={`${PILL_BUTTON_CLASS} px-1.5 gap-1 text-foreground w-auto max-w-[160px]`}
 									/>
 								)}
-								{effortSupport && (
+								{effortSupport && effortOptions.length > 0 && (
 									<AgentModelSelect
 										models={effortOptions}
 										value={selectedEffort}

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -747,6 +747,16 @@ describe("validateAgentEffortSelection", () => {
 		}
 	});
 
+	it("accepts a cursor-agent effort sibling passed as the model itself", () => {
+		expect(() =>
+			validateAgentModelSelection(
+				"cursor-agent",
+				"Cursor Agent",
+				"claude-fable-5-thinking-xhigh",
+			),
+		).not.toThrow();
+	});
+
 	it("accepts cursor-agent efforts only on models with a ladder", () => {
 		expect(() =>
 			validateAgentEffortSelection(

--- a/packages/host-service/src/trpc/router/agents/agents.test.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.test.ts
@@ -746,6 +746,38 @@ describe("validateAgentEffortSelection", () => {
 			);
 		}
 	});
+
+	it("accepts cursor-agent efforts only on models with a ladder", () => {
+		expect(() =>
+			validateAgentEffortSelection(
+				"cursor-agent",
+				"Cursor Agent",
+				"low",
+				"claude-opus-4-8-high",
+			),
+		).not.toThrow();
+		try {
+			validateAgentEffortSelection(
+				"cursor-agent",
+				"Cursor Agent",
+				"low",
+				"auto",
+			);
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect((error as Error).message).toBe(
+				"Cursor Agent does not support a reasoning effort override with model auto. Omit effort to use the agent default.",
+			);
+		}
+		try {
+			validateAgentEffortSelection("cursor-agent", "Cursor Agent", "low");
+			throw new Error("Expected validation to fail");
+		} catch (error) {
+			expect((error as Error).message).toBe(
+				"Cursor Agent does not support a reasoning effort override without a model. Omit effort to use the agent default.",
+			);
+		}
+	});
 });
 
 describe("validateAgentModeSelection", () => {

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -9,6 +9,7 @@ import {
 	getAgentEfforts,
 	getAgentModelSupport,
 	getAgentModeSupport,
+	isCuratedAgentModel,
 	resolveAgentLaunchPresetId,
 } from "@superset/shared/agent-models";
 import {
@@ -248,7 +249,7 @@ export function validateAgentModelSelection(
 		});
 	}
 
-	if (!support.models.some((option) => option.id === model)) {
+	if (!isCuratedAgentModel(presetId, model)) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: `Unsupported model "${model}" for ${label}. Choose one of: ${support.models.map((option) => option.id).join(", ")}.`,

--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -277,8 +277,15 @@ export function validateAgentEffortSelection(
 	}
 
 	// Some efforts only exist on some of the agent's models (Codex's max and
-	// ultra need GPT-5.6), so the accepted set follows the selected model.
+	// ultra need GPT-5.6; cursor-agent only has a ladder for some models),
+	// so the accepted set follows the selected model.
 	const efforts = getAgentEfforts(presetId, model);
+	if (efforts.length === 0) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `${label} does not support a reasoning effort override${model ? ` with model ${model}` : " without a model"}. Omit effort to use the agent default.`,
+		});
+	}
 	if (!efforts.some((option) => option.id === effort)) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
@@ -493,7 +500,11 @@ export function buildTerminalAgentLaunch(
 	}
 
 	const prompt = buildAttachmentBlock(input.prompt, resolvedAttachments);
-	const modelArgs = buildAgentModelArgs(launchPresetId, input.model);
+	const modelArgs = buildAgentModelArgs(
+		launchPresetId,
+		input.model,
+		input.effort,
+	);
 	const effortArgs = buildAgentEffortArgs(
 		launchPresetId,
 		input.effort,

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -443,6 +443,9 @@ describe("getAgentEfforts", () => {
 		expect(
 			getAgentEfforts("cursor-agent", "gpt-5.6-sol-medium").map((e) => e.id),
 		).toEqual(["none", "low", "medium", "high", "xhigh", "max"]);
+		expect(
+			getAgentEfforts("cursor-agent", "kimi-k3-max").map((e) => e.id),
+		).toEqual(["low", "high", "max"]);
 		expect(getAgentEfforts("cursor-agent", "auto")).toEqual([]);
 		expect(getAgentEfforts("cursor-agent", "composer-2.5")).toEqual([]);
 		expect(getAgentEfforts("cursor-agent")).toEqual([]);
@@ -464,6 +467,12 @@ describe("buildAgentModelArgs with effort", () => {
 		expect(
 			buildAgentModelArgs("cursor-agent", "gpt-5.6-luna-medium", "none"),
 		).toEqual(["--model", "gpt-5.6-luna-none"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "gpt-5.5-medium", "xhigh"),
+		).toEqual(["--model", "gpt-5.5-extra-high"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-opus-4-7-xhigh", "low"),
+		).toEqual(["--model", "claude-opus-4-7-low"]);
 	});
 
 	it("keeps the default level when the model has no such effort", () => {

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -11,6 +11,7 @@ import {
 	getAgentEfforts,
 	getAgentModelSupport,
 	getAgentModeSupport,
+	isCuratedAgentModel,
 	resolveAgentLaunchPresetId,
 	SUPERSET_CHAT_MODELS,
 } from "./agent-models";
@@ -487,6 +488,24 @@ describe("buildAgentModelArgs with effort", () => {
 			"--model",
 			"auto",
 		]);
+	});
+
+	it("still launches a sibling id saved before it was folded into its family", () => {
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-xhigh"),
+		).toEqual(["--model", "claude-fable-5-thinking-xhigh"]);
+		expect(buildAgentModelArgs("cursor-agent", "claude-opus-4-8-low")).toEqual([
+			"--model",
+			"claude-opus-4-8-low",
+		]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-opus-4-8-bogus"),
+		).toEqual([]);
+		expect(isCuratedAgentModel("cursor-agent", "gpt-5.5-extra-high")).toBe(
+			true,
+		);
+		expect(isCuratedAgentModel("claude", "claude-opus-5")).toBe(true);
+		expect(isCuratedAgentModel("claude", "opus-9")).toBe(false);
 	});
 
 	it("ignores effort for flag-based presets", () => {

--- a/packages/shared/src/agent-models.test.ts
+++ b/packages/shared/src/agent-models.test.ts
@@ -164,8 +164,15 @@ describe("buildAgentModelArgs", () => {
 			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-high"),
 		).toEqual(["--model", "claude-fable-5-thinking-high"]);
 		expect(
-			buildAgentModelArgs("cursor-agent", "claude-fable-5-thinking-xhigh"),
+			buildAgentModelArgs(
+				"cursor-agent",
+				"claude-fable-5-thinking-high",
+				"xhigh",
+			),
 		).toEqual(["--model", "claude-fable-5-thinking-xhigh"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-fable-5-1-thinking-high"),
+		).toEqual(["--model", "claude-fable-5-1-thinking-high"]);
 		expect(buildAgentModelArgs("opencode", "anthropic/claude-fable-5")).toEqual(
 			["--model", "anthropic/claude-fable-5"],
 		);
@@ -261,6 +268,22 @@ describe("AGENT_EFFORT_SUPPORT", () => {
 			expect(entry.efforts.length).toBeGreaterThan(0);
 		}
 	});
+
+	it("keys model variants by curated models and efforts", () => {
+		for (const entry of AGENT_EFFORT_SUPPORT) {
+			if (!entry.modelVariants) continue;
+			const modelIds = new Set(
+				getAgentModelSupport(entry.presetId)?.models.map((m) => m.id),
+			);
+			const effortIds = new Set(entry.efforts.map((e) => e.id));
+			for (const [model, variants] of Object.entries(entry.modelVariants)) {
+				expect(modelIds.has(model)).toBe(true);
+				for (const effort of Object.keys(variants)) {
+					expect(effortIds.has(effort)).toBe(true);
+				}
+			}
+		}
+	});
 });
 
 describe("AGENT_MODE_SUPPORT", () => {
@@ -351,6 +374,12 @@ describe("buildAgentEffortArgs", () => {
 		expect(buildAgentEffortArgs("copilot", "max")).toEqual([]);
 	});
 
+	it("returns [] for cursor-agent, whose effort rides the model id", () => {
+		expect(
+			buildAgentEffortArgs("cursor-agent", "low", "claude-opus-5-high"),
+		).toEqual([]);
+	});
+
 	it("drops an effort the selected model does not accept", () => {
 		expect(buildAgentEffortArgs("codex", "ultra", "gpt-5.6-sol")).toEqual([
 			"-c",
@@ -402,6 +431,60 @@ describe("getAgentEfforts", () => {
 
 	it("returns [] for presets without effort support", () => {
 		expect(getAgentEfforts("gemini")).toEqual([]);
+	});
+
+	it("offers cursor-agent efforts only for models with a ladder", () => {
+		expect(
+			getAgentEfforts("cursor-agent", "claude-opus-4-8-high").map((e) => e.id),
+		).toEqual(["low", "medium", "high", "xhigh", "max"]);
+		expect(
+			getAgentEfforts("cursor-agent", "claude-opus-5-high").map((e) => e.id),
+		).toEqual(["low", "medium", "high"]);
+		expect(
+			getAgentEfforts("cursor-agent", "gpt-5.6-sol-medium").map((e) => e.id),
+		).toEqual(["none", "low", "medium", "high", "xhigh", "max"]);
+		expect(getAgentEfforts("cursor-agent", "auto")).toEqual([]);
+		expect(getAgentEfforts("cursor-agent", "composer-2.5")).toEqual([]);
+		expect(getAgentEfforts("cursor-agent")).toEqual([]);
+		expect(getAgentEfforts("cursor-agent", "gpt-9")).toEqual([]);
+	});
+});
+
+describe("buildAgentModelArgs with effort", () => {
+	it("swaps in the cursor-agent sibling id for the effort", () => {
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-opus-4-8-high", "low"),
+		).toEqual(["--model", "claude-opus-4-8-low"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "gpt-5.3-codex", "medium"),
+		).toEqual(["--model", "gpt-5.3-codex"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "gpt-5.3-codex", "xhigh"),
+		).toEqual(["--model", "gpt-5.3-codex-xhigh"]);
+		expect(
+			buildAgentModelArgs("cursor-agent", "gpt-5.6-luna-medium", "none"),
+		).toEqual(["--model", "gpt-5.6-luna-none"]);
+	});
+
+	it("keeps the default level when the model has no such effort", () => {
+		expect(
+			buildAgentModelArgs("cursor-agent", "claude-opus-5-high", "max"),
+		).toEqual(["--model", "claude-opus-5-high"]);
+		expect(buildAgentModelArgs("cursor-agent", "auto", "high")).toEqual([
+			"--model",
+			"auto",
+		]);
+		expect(buildAgentModelArgs("cursor-agent", "auto")).toEqual([
+			"--model",
+			"auto",
+		]);
+	});
+
+	it("ignores effort for flag-based presets", () => {
+		expect(buildAgentModelArgs("claude", "opus", "high")).toEqual([
+			"--model",
+			"opus",
+		]);
 	});
 });
 

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -151,16 +151,18 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 		presetId: "cursor-agent",
 		modelFlag: "--model",
 		models: [
-			// cursor-agent has no effort flag, so effort/thinking levels are
-			// baked into the model ids. Ids verified against a live account's
-			// `--list-models` (2026-08-05); the list is account-dependent and
-			// unknown ids are rejected by the CLI, not silently ignored.
-			// "auto" is the only id free-plan accounts can use (besides
-			// composer) — named models fail there with "Named models
-			// unavailable", so keep an explicit working choice in the picker.
+			// cursor-agent has no effort flag: every effort level is its own
+			// model id, and these are each family's default level. The effort
+			// picker swaps in the sibling id (`CURSOR_EFFORT_VARIANTS`). Ids
+			// verified against a live account's `--list-models` (2026-09-04);
+			// the list is account-dependent and unknown ids are rejected by
+			// the CLI, not silently ignored. "auto" is the only id free-plan
+			// accounts can use (besides composer) — named models fail there
+			// with "Named models unavailable", so keep an explicit working
+			// choice in the picker.
 			{ id: "auto", label: "Auto" },
+			{ id: "claude-fable-5-1-thinking-high", label: "Fable 5.1" },
 			{ id: "claude-fable-5-thinking-high", label: "Fable 5" },
-			{ id: "claude-fable-5-thinking-xhigh", label: "Fable 5 xHigh" },
 			{ id: "claude-opus-5-high", label: "Opus 5" },
 			{ id: "claude-opus-4-8-high", label: "Opus 4.8" },
 			{ id: "claude-4.6-sonnet-medium", label: "Sonnet 4.6" },
@@ -249,7 +251,11 @@ export interface AgentEffortOption extends AgentModelOption {
 
 export interface AgentEffortSupport {
 	presetId: string;
-	effortFlag: string;
+	/**
+	 * Flag that carries the effort. `null` when the CLI has none and effort
+	 * instead selects a sibling model id via `modelVariants`.
+	 */
+	effortFlag: string | null;
 	/**
 	 * Prepended to the selected effort id to form the flag's value token.
 	 * Codex has no dedicated effort flag, so effort rides a config override:
@@ -257,6 +263,13 @@ export interface AgentEffortSupport {
 	 */
 	effortValuePrefix?: string;
 	efforts: AgentEffortOption[];
+	/**
+	 * Curated model id → effort id → model id to launch instead. cursor-agent
+	 * publishes one model id per effort level (`claude-opus-4-8-low`), so the
+	 * effort rewrites the `--model` token and only models with a ladder here
+	 * offer an effort at all.
+	 */
+	modelVariants?: Readonly<Record<string, Readonly<Record<string, string>>>>;
 }
 
 export interface AgentModeOption extends AgentModelOption {
@@ -268,6 +281,72 @@ export interface AgentModeSupport {
 	presetId: string;
 	modes: AgentModeOption[];
 }
+
+/**
+ * cursor-agent model ids for each effort level of one family. Every level is
+ * `<family>-<level>` except where `overrides` says otherwise (Codex 5.3's
+ * medium is the bare `gpt-5.3-codex`). Verified against `--list-models`
+ * (cursor-agent 2026.08.11); the CLI's bracket override syntax
+ * (`model[effort=high]`) is rejected by its model validator, so sibling ids
+ * are the only route.
+ */
+function cursorEffortVariants(
+	family: string,
+	levels: readonly string[],
+	overrides: Readonly<Record<string, string>> = {},
+): Readonly<Record<string, string>> {
+	return Object.fromEntries(
+		levels.map((level) => [level, overrides[level] ?? `${family}-${level}`]),
+	);
+}
+
+const CURSOR_CLAUDE_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+const CURSOR_GPT_LEVELS = [
+	"none",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+
+const CURSOR_EFFORT_VARIANTS: Readonly<
+	Record<string, Readonly<Record<string, string>>>
+> = {
+	"claude-fable-5-1-thinking-high": cursorEffortVariants(
+		"claude-fable-5-1-thinking",
+		CURSOR_CLAUDE_LEVELS,
+	),
+	"claude-fable-5-thinking-high": cursorEffortVariants(
+		"claude-fable-5-thinking",
+		CURSOR_CLAUDE_LEVELS,
+	),
+	// Opus 5 without thinking only goes up to high; xhigh and max exist on
+	// its thinking sibling, which is a different model in Cursor's catalog.
+	"claude-opus-5-high": cursorEffortVariants("claude-opus-5", [
+		"low",
+		"medium",
+		"high",
+	]),
+	"claude-opus-4-8-high": cursorEffortVariants(
+		"claude-opus-4-8",
+		CURSOR_CLAUDE_LEVELS,
+	),
+	"gpt-5.6-sol-medium": cursorEffortVariants("gpt-5.6-sol", CURSOR_GPT_LEVELS),
+	"gpt-5.6-terra-medium": cursorEffortVariants(
+		"gpt-5.6-terra",
+		CURSOR_GPT_LEVELS,
+	),
+	"gpt-5.6-luna-medium": cursorEffortVariants(
+		"gpt-5.6-luna",
+		CURSOR_GPT_LEVELS,
+	),
+	"gpt-5.3-codex": cursorEffortVariants(
+		"gpt-5.3-codex",
+		["low", "medium", "high", "xhigh"],
+		{ medium: "gpt-5.3-codex" },
+	),
+};
 
 const PI_THINKING_LEVELS: AgentModelOption[] = [
 	{ id: "off", label: "Off" },
@@ -282,8 +361,8 @@ const PI_THINKING_LEVELS: AgentModelOption[] = [
  * Curated per-agent reasoning-effort catalogs, mirroring
  * `AGENT_MODEL_SUPPORT`. Flags and accepted values were verified against each
  * CLI's `--help` (or its own validator) — agents absent from this list
- * (gemini, opencode, cursor-agent, droid, superset chat) expose no effort
- * control on their interactive launch command.
+ * (gemini, opencode, droid, superset chat) expose no effort control on their
+ * interactive launch command.
  */
 export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 	{
@@ -364,6 +443,19 @@ export const AGENT_EFFORT_SUPPORT: readonly AgentEffortSupport[] = [
 			{ id: "xhigh", label: "xHigh" },
 		],
 	},
+	{
+		presetId: "cursor-agent",
+		effortFlag: null,
+		efforts: [
+			{ id: "none", label: "None" },
+			{ id: "low", label: "Low" },
+			{ id: "medium", label: "Medium" },
+			{ id: "high", label: "High" },
+			{ id: "xhigh", label: "xHigh" },
+			{ id: "max", label: "Max" },
+		],
+		modelVariants: CURSOR_EFFORT_VARIANTS,
+	},
 ];
 
 /**
@@ -416,7 +508,9 @@ export function getAgentModeSupport(
  * Efforts the given preset offers for `model` — the full curated list minus
  * any option the selected model rejects. An unset model (or an id outside the
  * curated catalog, which `buildAgentModelArgs` drops so the launch runs the
- * agent's own default) keeps the full list.
+ * agent's own default) keeps the full list. Presets whose effort is a sibling
+ * model id (`modelVariants`) offer only that model's ladder, and nothing when
+ * the model is unset or has no ladder.
  */
 export function getAgentEfforts(
 	presetId: string,
@@ -429,6 +523,11 @@ export function getAgentEfforts(
 	)
 		? model
 		: undefined;
+	if (support.modelVariants) {
+		const variants = selected ? support.modelVariants[selected] : undefined;
+		if (!variants) return [];
+		return support.efforts.filter((effort) => effort.id in variants);
+	}
 	return support.efforts.filter(
 		(effort) => !effort.models || !selected || effort.models.includes(selected),
 	);
@@ -439,7 +538,8 @@ export function getAgentEfforts(
  * `["--effort", "high"]` (codex: `["-c", "model_reasoning_effort=high"]`).
  * Same degrade-to-default contract as `buildAgentModelArgs`: unknown presets,
  * effort ids outside the curated list, and efforts the selected model rejects
- * return `[]`.
+ * return `[]`. Presets without an effort flag (cursor-agent) also return `[]`:
+ * their effort already rode the `--model` token from `buildAgentModelArgs`.
  */
 export function buildAgentEffortArgs(
 	presetId: string,
@@ -448,7 +548,7 @@ export function buildAgentEffortArgs(
 ): string[] {
 	if (!effort) return [];
 	const support = getAgentEffortSupport(presetId);
-	if (!support) return [];
+	if (!support?.effortFlag) return [];
 	const efforts = getAgentEfforts(presetId, model);
 	if (!efforts.some((option) => option.id === effort)) return [];
 	return [support.effortFlag, `${support.effortValuePrefix ?? ""}${effort}`];
@@ -474,17 +574,23 @@ export function buildAgentModeArgs(
  * a CLI flag (superset chat), an unset model, or a model id that isn't in
  * the preset's curated list — callers can spread the result unconditionally
  * and a stale or arbitrary model id degrades to the CLI default instead of
- * a broken launch.
+ * a broken launch. When the preset's effort is a sibling model id
+ * (cursor-agent), a curated `effort` swaps that id in; an effort the model
+ * has no ladder for launches the model's default level.
  */
 export function buildAgentModelArgs(
 	presetId: string,
 	model: string | undefined,
+	effort?: string,
 ): string[] {
 	if (!model) return [];
 	const support = getAgentModelSupport(presetId);
 	if (!support?.modelFlag) return [];
 	if (!support.models.some((option) => option.id === model)) return [];
-	return [support.modelFlag, model];
+	const variant = effort
+		? getAgentEffortSupport(presetId)?.modelVariants?.[model]?.[effort]
+		: undefined;
+	return [support.modelFlag, variant ?? model];
 }
 
 /**

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -79,6 +79,9 @@ export const SUPERSET_CHAT_MODELS: readonly SupersetChatModel[] = [
 
 const LATEST_GROUP = "Latest";
 const PINNED_GROUP = "Pinned releases";
+const CURSOR_ANTHROPIC_GROUP = "Anthropic";
+const CURSOR_OPENAI_GROUP = "OpenAI";
+const CURSOR_OTHER_GROUP = "Other";
 const CURRENT_GROUP = "Current";
 const CODEX_RETIRING_GROUP = "Retiring 2026-08-31";
 
@@ -161,16 +164,72 @@ export const AGENT_MODEL_SUPPORT: readonly AgentModelSupport[] = [
 			// with "Named models unavailable", so keep an explicit working
 			// choice in the picker.
 			{ id: "auto", label: "Auto" },
-			{ id: "claude-fable-5-1-thinking-high", label: "Fable 5.1" },
-			{ id: "claude-fable-5-thinking-high", label: "Fable 5" },
-			{ id: "claude-opus-5-high", label: "Opus 5" },
-			{ id: "claude-opus-4-8-high", label: "Opus 4.8" },
-			{ id: "claude-4.6-sonnet-medium", label: "Sonnet 4.6" },
-			{ id: "gpt-5.6-sol-medium", label: "GPT-5.6 Sol" },
-			{ id: "gpt-5.6-terra-medium", label: "GPT-5.6 Terra" },
-			{ id: "gpt-5.6-luna-medium", label: "GPT-5.6 Luna" },
-			{ id: "gpt-5.3-codex", label: "Codex 5.3" },
 			{ id: "composer-2.5", label: "Composer 2.5" },
+			{
+				id: "claude-fable-5-1-thinking-high",
+				label: "Fable 5.1",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "claude-fable-5-thinking-high",
+				label: "Fable 5",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "claude-opus-5-high",
+				label: "Opus 5",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "claude-sonnet-5-thinking-high",
+				label: "Sonnet 5",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "claude-opus-4-8-high",
+				label: "Opus 4.8",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "claude-opus-4-7-xhigh",
+				label: "Opus 4.7",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "claude-4.6-sonnet-medium",
+				label: "Sonnet 4.6",
+				group: CURSOR_ANTHROPIC_GROUP,
+			},
+			{
+				id: "gpt-5.6-sol-medium",
+				label: "GPT-5.6 Sol",
+				group: CURSOR_OPENAI_GROUP,
+			},
+			{
+				id: "gpt-5.6-terra-medium",
+				label: "GPT-5.6 Terra",
+				group: CURSOR_OPENAI_GROUP,
+			},
+			{
+				id: "gpt-5.6-luna-medium",
+				label: "GPT-5.6 Luna",
+				group: CURSOR_OPENAI_GROUP,
+			},
+			{ id: "gpt-5.5-medium", label: "GPT-5.5", group: CURSOR_OPENAI_GROUP },
+			{ id: "gpt-5.4-medium", label: "GPT-5.4", group: CURSOR_OPENAI_GROUP },
+			{ id: "gpt-5.3-codex", label: "Codex 5.3", group: CURSOR_OPENAI_GROUP },
+			{
+				id: "gemini-3.8-flash-high",
+				label: "Gemini 3.8 Flash",
+				group: CURSOR_OTHER_GROUP,
+			},
+			{
+				id: "cursor-grok-4.6-high",
+				label: "Grok 4.6",
+				group: CURSOR_OTHER_GROUP,
+			},
+			{ id: "kimi-k3-max", label: "Kimi K3", group: CURSOR_OTHER_GROUP },
+			{ id: "glm-5.2-high", label: "GLM 5.2", group: CURSOR_OTHER_GROUP },
 		],
 	},
 	{
@@ -328,8 +387,16 @@ const CURSOR_EFFORT_VARIANTS: Readonly<
 		"medium",
 		"high",
 	]),
+	"claude-sonnet-5-thinking-high": cursorEffortVariants(
+		"claude-sonnet-5-thinking",
+		CURSOR_CLAUDE_LEVELS,
+	),
 	"claude-opus-4-8-high": cursorEffortVariants(
 		"claude-opus-4-8",
+		CURSOR_CLAUDE_LEVELS,
+	),
+	"claude-opus-4-7-xhigh": cursorEffortVariants(
+		"claude-opus-4-7",
 		CURSOR_CLAUDE_LEVELS,
 	),
 	"gpt-5.6-sol-medium": cursorEffortVariants("gpt-5.6-sol", CURSOR_GPT_LEVELS),
@@ -341,11 +408,37 @@ const CURSOR_EFFORT_VARIANTS: Readonly<
 		"gpt-5.6-luna",
 		CURSOR_GPT_LEVELS,
 	),
+	// GPT-5.5 spells its top level out ("extra-high") where every other
+	// family uses "xhigh".
+	"gpt-5.5-medium": cursorEffortVariants(
+		"gpt-5.5",
+		["none", "low", "medium", "high", "xhigh"],
+		{ xhigh: "gpt-5.5-extra-high" },
+	),
+	"gpt-5.4-medium": cursorEffortVariants("gpt-5.4", [
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+	]),
 	"gpt-5.3-codex": cursorEffortVariants(
 		"gpt-5.3-codex",
 		["low", "medium", "high", "xhigh"],
 		{ medium: "gpt-5.3-codex" },
 	),
+	"gemini-3.8-flash-high": cursorEffortVariants("gemini-3.8-flash", [
+		"low",
+		"medium",
+		"high",
+	]),
+	"cursor-grok-4.6-high": cursorEffortVariants("cursor-grok-4.6", [
+		"low",
+		"medium",
+		"high",
+		"xhigh",
+	]),
+	"kimi-k3-max": cursorEffortVariants("kimi-k3", ["low", "high", "max"]),
+	"glm-5.2-high": cursorEffortVariants("glm-5.2", ["high", "max"]),
 };
 
 const PI_THINKING_LEVELS: AgentModelOption[] = [

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -662,6 +662,24 @@ export function buildAgentModeArgs(
 }
 
 /**
+ * Whether `model` is an id the preset's launch accepts: a curated picker entry
+ * or, for presets whose effort is a sibling model id, any of those siblings.
+ * That keeps a preference saved before a sibling was folded into its family
+ * (cursor-agent's old "Fable 5 xHigh" entry) launching, and lets CLI callers
+ * pass any level id directly.
+ */
+export function isCuratedAgentModel(presetId: string, model: string): boolean {
+	const support = getAgentModelSupport(presetId);
+	if (!support) return false;
+	if (support.models.some((option) => option.id === model)) return true;
+	const variants = getAgentEffortSupport(presetId)?.modelVariants;
+	if (!variants) return false;
+	return Object.values(variants).some((ladder) =>
+		Object.values(ladder).includes(model),
+	);
+}
+
+/**
  * Argv tokens that select `model` for the given preset, e.g.
  * `["--model", "sonnet"]`. Returns `[]` for unknown presets, presets without
  * a CLI flag (superset chat), an unset model, or a model id that isn't in
@@ -679,7 +697,7 @@ export function buildAgentModelArgs(
 	if (!model) return [];
 	const support = getAgentModelSupport(presetId);
 	if (!support?.modelFlag) return [];
-	if (!support.models.some((option) => option.id === model)) return [];
+	if (!isCuratedAgentModel(presetId, model)) return [];
 	const variant = effort
 		? getAgentEffortSupport(presetId)?.modelVariants?.[model]?.[effort]
 		: undefined;


### PR DESCRIPTION
## Summary

Cursor Agent had no effort dropdown because `cursor-agent` has no effort flag. Its catalog publishes one model id per level instead (`claude-opus-4-8-low`, `gpt-5.6-sol-xhigh`, ...), and the bracket override syntax its `--help` advertises (`model[effort=high]`) is rejected by the CLI's model validator (verified on cursor-agent 2026.08.11). So:

- `AGENT_EFFORT_SUPPORT` gains a `cursor-agent` entry with `effortFlag: null` and a `modelVariants` map: curated model id → effort id → sibling model id, generated from families and checked against `--list-models`.
- `buildAgentModelArgs` takes an optional effort and swaps in the sibling id; `buildAgentEffortArgs` emits nothing for flag-less presets. Host launch passes the effort through.
- `getAgentEfforts` offers only the selected model's ladder, and nothing for Auto / Composer / Sonnet 4.6 or an unset model. Both new-workspace surfaces hide the effort control when the list is empty, so it appears and disappears with the model.
- Host validation rejects an effort for a model without a ladder with a clear message.
- Catalog refresh: adds Fable 5.1, Sonnet 5, Opus 4.7, GPT-5.5, GPT-5.4, Gemini 3.8 Flash, Grok 4.6, Kimi K3 and GLM 5.2 with their ladders, grouped by vendor (all 74 ids checked against a live `--list-models`); folds "Fable 5 xHigh" into Fable 5 + xHigh effort. Every effort sibling id stays an accepted model id, so a saved "Fable 5 xHigh" preference still launches and CLI callers can pass any level id directly.

Opus 5 (non-thinking) only has low/medium/high in Cursor's catalog; xhigh/max live on its thinking sibling, which is a different model there, so the picker shows three levels for it.

## Test plan

- [x] `packages/shared` agent-models tests (58 pass), incl. variant map integrity and arg rewriting
- [x] `packages/host-service` agents router tests (50 pass), incl. cursor validation messages
- [x] tsc for shared, host-service, desktop
- [x] Dev app via CDP: Cursor Agent → Opus 4.8 shows effort pill with Low/Medium/High/xHigh/Max; picking xHigh persists; Opus 5 shows Low/Medium/High; Auto hides the pill

https://claude.ai/code/session_01Xx9zDw4dL7h8yWTck7FQru

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Cursor Agent model choices across Anthropic, OpenAI, and other providers.
  * Added model-specific effort levels and automatic selection of supported model variants.
  * The effort selector now appears only when the selected model offers effort options.

* **Bug Fixes**
  * Unsupported remembered effort settings now fall back to the agent default.
  * Added validation with clear errors for unsupported model and effort selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cursor Agent previously had no reasoning-effort picker because its CLI exposes each level as a separate model ID, not an effort flag. This adds model-aware effort selection by swapping in the matching sibling model, while models without an effort ladder keep the control hidden.

**New Features**
- Adds curated Cursor models and effort ladders for Fable 5.1, Sonnet 5, Opus 4.7, GPT-5.5, GPT-5.4, Gemini 3.8 Flash, Grok 4.6, Kimi K3, and GLM 5.2.
- Validates effort overrides against the selected model and emits no separate effort flag for Cursor Agent.
- Folds Fable 5 xHigh into Fable 5’s effort options while continuing to accept saved or directly supplied sibling model IDs.

<sup>Written for commit b324078bbb377313904ebe99b5ea0319fca10174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

