### PR TITLE
fix(desktop): land a dropped sidebar workspace where the drag preview showed it

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -364,7 +364,7 @@ export function useSidebarDnd({
 	const {
 		reorderPinnedWorkspaces,
 		reorderProjectChildren,
-		moveWorkspaceToSectionAtIndex,
+		setSectionWorkspaceOrder,
 		setWorkspacePinned,
 	} = useDashboardSidebarState();
 
@@ -751,12 +751,10 @@ export function useSidebarDnd({
 
 			// Each section's workspace order
 			for (const [sectionId, wsIds] of Object.entries(parsed.sections)) {
-				for (let i = 0; i < wsIds.length; i++) {
-					moveWorkspaceToSectionAtIndex(wsIds[i], projectId, sectionId, i);
-				}
+				setSectionWorkspaceOrder(projectId, sectionId, wsIds);
 			}
 		},
-		[reorderProjectChildren, moveWorkspaceToSectionAtIndex],
+		[reorderProjectChildren, setSectionWorkspaceOrder],
 	);
 
 	const persistWorkspaceDrop = useCallback(

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -529,55 +529,42 @@ export function useDashboardSidebarState() {
 		],
 	);
 
-	const moveWorkspaceToSectionAtIndex = useCallback(
-		(
-			workspaceId: string,
-			projectId: string | null,
-			sectionId: string,
-			index: number,
-		) => {
-			const existing = collections.v2WorkspaceLocalState.get(workspaceId);
-			if (!existing) return;
-			// Same rule as moveWorkspaceToSection: the tag comes from the key;
-			// members are found through the shared resolver, not the pointer.
+	/**
+	 * Writes one folder's full member order. The caller hands over exactly the
+	 * rows the folder holds, so nothing is re-derived from the collection:
+	 * membership lives in host tags, and a row that just left this folder in the
+	 * same commit still carries its tag until the optimistic write lands. Deriving
+	 * siblings from those tags pulled the departed row back in and renumbered it,
+	 * so a drop landed somewhere other than the preview.
+	 */
+	const setSectionWorkspaceOrder = useCallback(
+		(projectId: string | null, sectionId: string, workspaceIds: string[]) => {
+			// Same rule as moveWorkspaceToSection: the tag comes from the key.
 			const targetTag = parseSidebarFolderKey(sectionId)?.tag ?? null;
-			if (targetTag !== null) {
-				const folderIndex = getProjectFolderIndex(
-					collections,
-					hostWorkspaces,
-					tagFolderContext,
-					projectId,
-				);
-				writeWorkspaceTags(
-					workspaceId,
-					applyFolderTagChange(
-						getHostWorkspaceTags(hostWorkspaces, workspaceId),
-						folderIndex.keys(),
-						targetTag,
-					),
-				);
-			}
-			const siblings = Array.from(
-				collections.v2WorkspaceLocalState.state.values(),
-			)
-				.filter(
-					(item) =>
-						item.sidebarState.projectId === projectId &&
-						isSidebarWorkspaceVisible(item) &&
-						item.workspaceId !== workspaceId &&
-						getEffectiveSectionId(
+			const folderIndex =
+				targetTag !== null
+					? getProjectFolderIndex(
 							collections,
 							hostWorkspaces,
 							tagFolderContext,
-							item,
-						) === sectionId,
-				)
-				.sort((a, b) => a.sidebarState.tabOrder - b.sidebarState.tabOrder);
-			const reordered = [...siblings];
-			reordered.splice(index, 0, existing);
-			reordered.forEach((item, i) => {
-				collections.v2WorkspaceLocalState.update(item.workspaceId, (draft) => {
-					draft.sidebarState.tabOrder = i + 1;
+							projectId,
+						)
+					: null;
+			workspaceIds.forEach((workspaceId, index) => {
+				if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
+				if (targetTag !== null && folderIndex) {
+					const currentTags = getHostWorkspaceTags(hostWorkspaces, workspaceId);
+					const nextTags = applyFolderTagChange(
+						currentTags,
+						folderIndex.keys(),
+						targetTag,
+					);
+					if (nextTags.join("\n") !== currentTags.join("\n")) {
+						writeWorkspaceTags(workspaceId, nextTags);
+					}
+				}
+				collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+					draft.sidebarState.tabOrder = index + 1;
 					draft.sidebarState.sectionId = targetTag !== null ? null : sectionId;
 					draft.sidebarState.projectId = projectId;
 					draft.sidebarState.isHidden = false;
@@ -1057,7 +1044,7 @@ export function useDashboardSidebarState() {
 		ensureWorkspaceInSidebar,
 		hideWorkspaceInSidebar,
 		moveWorkspaceToSection,
-		moveWorkspaceToSectionAtIndex,
+		setSectionWorkspaceOrder,
 		setProjectHidden,
 		reorderPinnedWorkspaces,
 		reorderProjectChildren,


### PR DESCRIPTION
## Problem

Dragging a workspace out of a sidebar folder showed the drop slot at one position and then landed the row somewhere else (typically ungrouped at the bottom of the lane), with a visible jump after the drop animation. Repro: https://www.loom.com/share/5037d389c0bc468a8b998016526e69fc

## Root cause

`commitContainerToDb` wrote the top-level order, then re-filed each folder's remaining members one at a time through `moveWorkspaceToSectionAtIndex`, which re-derived the folder's siblings from host tags. Folder membership *is* a host tag, and the dragged row's tag strip is an optimistic host write that has not reached the hook's closure within the same tick. The departed row therefore still counted as a sibling of its old folder and was renumbered inside it (ending with a tab order around the folder's size). Once the tag write landed, the row surfaced ungrouped with a tab order larger than every folder's, i.e. at the bottom. The "flicker" is dnd-kit holding the preview layout through the drop animation and then the list re-rendering in that wrong order. The into-folder direction was corrupt the same way (tied tab orders).

## Fix

`setSectionWorkspaceOrder(projectId, sectionId, workspaceIds)` writes exactly the member list the drop handler already holds: tab order by index, tag write only when it changes, `sectionId` cleared for tag folders. `moveWorkspaceToSectionAtIndex` is removed; the drop handler calls the new function once per folder.

## Verification

CDP-driven drags in the dev app (Sessions lane: 2 ungrouped rows + a 4-member folder, dragging the 2nd member onto the folder header), with an in-page 15 ms poller recording row tops and transforms:

- Unfixed: preview between the 2nd ungrouped row and the folder header, landed at the bottom (reproduced twice).
- Fixed: lands in the preview slot with a single transition after the drop animation; position survives reload. Verified out-of-folder and into-folder.
- `bun test` on the sidebar, sidebar-state, and tag-folder suites: 210 pass. Typecheck and biome clean.

https://claude.ai/code/session_017uzF29WjvuFMQJWQqEpJD8


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar drag-and-drop so a workspace dropped out of a folder lands exactly where the drag preview showed it, instead of jumping to the bottom after the drop animation.

**Bug Fixes**
- Replaced per-item reordering with `setSectionWorkspaceOrder`, which writes the whole folder's member list in one pass from the list the drop handler already holds.
- Ordering is applied directly instead of re-deriving siblings from host tags, which still counted the departing row as a member because its tag write is optimistic and hadn't reached the closure.
- Tag writes are skipped when the tag is unchanged, and the same corruption in the into-folder direction is fixed.

<sup>Written for commit d0d4817c58a0a9b9e316f0ea73304f4b299021fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace ordering in sidebar sections and folders.
  * Workspace reordering now preserves the complete intended order more reliably, including during rapid changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->