### PR TITLE
fix(ci): own the macOS signing keychain instead of letting electron-builder do it

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -109,16 +109,67 @@ jobs:
           TARGET_ARCH: ${{ matrix.arch }}
         run: bun run compile:app
 
+      # electron-builder manages its own signing keychain when CSC_LINK is set,
+      # and that path is broken: createKeychain makes the keychain with a random
+      # password, then importCerts calls
+      #   security set-key-partition-list ... -k <cscKeyPassword>
+      # passing the .p12 password where the *keychain* password belongs
+      # (app-builder-lib/out/codeSign/macCodeSign.js, still wrong in 26.15.3).
+      # It only works while the keychain happens to still be unlocked, so it
+      # fails intermittently with "SecKeychainUnlock: The user name or
+      # passphrase you entered is not correct" — roughly a third of macOS jobs.
+      # Owning the keychain ourselves keeps the two passwords straight, and
+      # electron-builder uses CSC_KEYCHAIN as-is when CSC_LINK is absent
+      # (app-builder-lib/out/macPackager.js).
+      - name: Set up signing keychain
+        env:
+          MAC_CERTIFICATE: ${{ secrets.MAC_CERTIFICATE }}
+          MAC_CERTIFICATE_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/superset-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+
+          printf '%s' "$MAC_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          test -s "$CERT_PATH" || {
+            echo "::error::MAC_CERTIFICATE did not decode to a .p12 — expected base64"
+            exit 1
+          }
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # No -l and no -u: never lock on sleep or on a timeout. The default
+          # 300s timeout is what makes the keychain lock mid-build.
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$CERT_PATH" -k "$KEYCHAIN" -P "$MAC_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          # -k here is the keychain password, not the .p12 password.
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          # Keep the login keychain in the search list so everything else still resolves.
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          rm -f "$CERT_PATH"
+
+          security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "Developer ID Application" || {
+            echo "::error::No Developer ID Application identity in the signing keychain"
+            exit 1
+          }
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
       - name: Build Electron app
         working-directory: apps/desktop
         env:
-          CSC_LINK: ${{ secrets.MAC_CERTIFICATE }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
+          # No CSC_LINK on purpose — see the keychain step above.
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TARGET_ARCH: ${{ matrix.arch }}
         run: bun run package -- --publish never --config ${{ inputs.electron_builder_config }} --${{ matrix.arch }}
+
+      - name: Delete signing keychain
+        if: always()
+        run: security delete-keychain "$RUNNER_TEMP/superset-signing.keychain-db" || true
 
       - name: Verify app-update.yml exists
         working-directory: apps/desktop


### PR DESCRIPTION
About a third of macOS canary jobs die in signing. Twelve macOS jobs ran on 2026-09-04 and four failed, independently rather than in pairs, including one run where both failed and two where both passed. The published error is truncated to `/usr/bin/security process failed 1`; the real line is:

```
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

## Cause

It is electron-builder, not our certificate or our secrets. In `app-builder-lib/out/codeSign/macCodeSign.js`, `createKeychain` builds the temporary keychain with a freshly generated random password:

```js
const keychainPassword = randomBytes(32).toString("base64")
["create-keychain",  "-p", keychainPassword, keychainFile],
["unlock-keychain",  "-p", keychainPassword, keychainFile],
```

and then `importCerts` passes a different password to the command that needs that one:

```js
const password = keyPasswords[i] ?? ""             // CSC_KEY_PASSWORD, the .p12 password
security import ... -P password                     // correct, -P wants the .p12 password
security set-key-partition-list ... -k password     // wrong, -k wants the keychain password
```

The random keychain password is never handed to `importCerts` at all.

**Why it is intermittent rather than constant:** `set-key-partition-list` only needs to unlock the keychain if it is locked. Normally it is still unlocked from `unlock-keychain` moments earlier, so the wrong `-k` is never exercised and the build passes. When the keychain has locked in between, the wrong password is used and the job dies.

**Upgrading does not fix it.** The same code is present in 26.15.3, the current latest; we are on 26.8.1.

## Verification

Reproduced locally against a throwaway keychain and a self-signed `.p12`, with the keychain password and the certificate password deliberately different:

| case | result |
|---|---|
| `-k` keychain password, unlocked | succeeds |
| `-k` .p12 password, locked | `SecKeychainUnlock: The user name or passphrase you entered is not correct.` |
| `-k` keychain password, locked | succeeds |

The middle row is the CI failure, exactly.

## The change

Create the keychain, import the certificate and run `set-key-partition-list` in the workflow, keeping the two passwords straight and disabling auto-lock so it cannot lock mid-build, then hand electron-builder `CSC_KEYCHAIN`. It uses that as-is when `CSC_LINK` is absent (`app-builder-lib/out/macPackager.js`), so `CSC_LINK` is deliberately no longer set on the build step. This is the manually-managed-keychain pattern from the electron-builder docs.

The step fails loudly if no Developer ID Application identity ends up in the keychain, which turns a late and confusing signing failure into an early and obvious one. The keychain is deleted afterwards with `if: always()`.

## Testing this

`build-desktop.yml` is `workflow_call` only and never runs on a pull request, so PR CI does not exercise this. It needs a canary dispatch on this branch to prove out. Worth noting that a failed build job skips `Update Canary Release`, so a failed attempt leaves the published canary untouched.

https://claude.ai/code/session_01TzD4tqeanYqTMxpWRJGpwZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent macOS signing failures in canary jobs by managing the signing keychain directly in CI, bypassing electron-builder's bug that passes the .p12 password where the keychain password belongs.

- Creates a dedicated keychain with auto-lock disabled, imports the certificate, and sets the partition list with the correct keychain password.
- Passes `CSC_KEYCHAIN` to electron-builder and removes `CSC_LINK` since electron-builder uses the keychain as-is when `CSC_LINK` is absent.
- Adds an early failure check for missing Developer ID Application identity and deletes the keychain in an `always()` step.
- Reproduced the failure locally: the wrong password against a locked keychain produces the exact CI error.

<sup>Written for commit a2e9cd396096f88f7255bfa4812ecab76cc6e45b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS desktop build signing to use a temporary, dedicated keychain.
  * Added automatic cleanup of the temporary signing keychain after builds complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->