### PR TITLE
fix(desktop): dismiss the browser pane's overflow menu on a click into the page

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
@@ -122,3 +122,41 @@ describe("browserRuntimeRegistry detached persistence", () => {
 		}
 	});
 });
+
+describe("browserRuntimeRegistry host popover passthrough", () => {
+	test("keeps webviews passed through until the last open popover closes", () => {
+		const makeEntry = () => ({
+			webview: { style: { pointerEvents: "auto" } },
+			visible: true,
+		});
+		const a = makeEntry();
+		const b = makeEntry();
+		const registryInternals = browserRuntimeRegistry as unknown as {
+			entries: Map<string, ReturnType<typeof makeEntry>>;
+		};
+		registryInternals.entries.set("popover-pane-a", a);
+		registryInternals.entries.set("popover-pane-b", b);
+
+		try {
+			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-a", true);
+			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-b", true);
+			expect(a.webview.style.pointerEvents).toBe("none");
+			expect(b.webview.style.pointerEvents).toBe("none");
+
+			// One pane closing (or unmounting) must not restore pointer events
+			// while another pane's popover is still open.
+			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-b", false);
+			expect(a.webview.style.pointerEvents).toBe("none");
+			expect(b.webview.style.pointerEvents).toBe("none");
+
+			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-a", false);
+			expect(a.webview.style.pointerEvents).toBe("auto");
+			expect(b.webview.style.pointerEvents).toBe("auto");
+		} finally {
+			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-a", false);
+			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-b", false);
+			registryInternals.entries.delete("popover-pane-a");
+			registryInternals.entries.delete("popover-pane-b");
+		}
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -78,11 +78,12 @@ class BrowserRuntimeRegistryImpl {
 	private globalListenersInstalled = false;
 	private windowDragPassthrough = false;
 	private shellInteractionPassthrough = false;
-	// A host popover (the toolbar's overflow menu) is open. The webview
-	// swallows pointer events, so a click on the page would never reach the
-	// document listener Radix dismisses on; passing the click through to the
-	// host lets it dismiss the popover instead, as in a real browser.
-	private hostPopoverPassthrough = false;
+	// Panes whose host popover (the toolbar's overflow menu) is open. The
+	// webview swallows pointer events, so a click on the page would never
+	// reach the document listener Radix dismisses on; passing the click
+	// through to the host lets it dismiss the popover instead, as in a real
+	// browser. Keyed by pane so one pane closing can't drop another's.
+	private hostPopoverOpenPaneIds = new Set<string>();
 	// Panes an agent is driving (live CDP session or in-flight capture, fed
 	// by the main process). Parked presentable instead of hidden — a
 	// visibility-hidden webview gets no compositor frames, so CDP
@@ -198,9 +199,10 @@ class BrowserRuntimeRegistryImpl {
 		this.applyPointerPassthroughIfChanged(wasActive);
 	}
 
-	setHostPopoverPassthrough(passthrough: boolean): void {
+	setHostPopoverOpen(paneId: string, open: boolean): void {
 		const wasActive = this.isPointerPassthroughActive();
-		this.hostPopoverPassthrough = passthrough;
+		if (open) this.hostPopoverOpenPaneIds.add(paneId);
+		else this.hostPopoverOpenPaneIds.delete(paneId);
 		this.applyPointerPassthroughIfChanged(wasActive);
 	}
 
@@ -208,7 +210,7 @@ class BrowserRuntimeRegistryImpl {
 		return (
 			this.windowDragPassthrough ||
 			this.shellInteractionPassthrough ||
-			this.hostPopoverPassthrough
+			this.hostPopoverOpenPaneIds.size > 0
 		);
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -78,6 +78,11 @@ class BrowserRuntimeRegistryImpl {
 	private globalListenersInstalled = false;
 	private windowDragPassthrough = false;
 	private shellInteractionPassthrough = false;
+	// A host popover (the toolbar's overflow menu) is open. The webview
+	// swallows pointer events, so a click on the page would never reach the
+	// document listener Radix dismisses on; passing the click through to the
+	// host lets it dismiss the popover instead, as in a real browser.
+	private hostPopoverPassthrough = false;
 	// Panes an agent is driving (live CDP session or in-flight capture, fed
 	// by the main process). Parked presentable instead of hidden — a
 	// visibility-hidden webview gets no compositor frames, so CDP
@@ -193,8 +198,18 @@ class BrowserRuntimeRegistryImpl {
 		this.applyPointerPassthroughIfChanged(wasActive);
 	}
 
+	setHostPopoverPassthrough(passthrough: boolean): void {
+		const wasActive = this.isPointerPassthroughActive();
+		this.hostPopoverPassthrough = passthrough;
+		this.applyPointerPassthroughIfChanged(wasActive);
+	}
+
 	private isPointerPassthroughActive() {
-		return this.windowDragPassthrough || this.shellInteractionPassthrough;
+		return (
+			this.windowDragPassthrough ||
+			this.shellInteractionPassthrough ||
+			this.hostPopoverPassthrough
+		);
 	}
 
 	private applyPointerPassthroughIfChanged(wasActive: boolean) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -73,9 +73,9 @@ export function BrowserOverflowMenu({
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 
 	useEffect(() => {
-		browserRuntimeRegistry.setHostPopoverPassthrough(isMenuOpen);
-		return () => browserRuntimeRegistry.setHostPopoverPassthrough(false);
-	}, [isMenuOpen]);
+		browserRuntimeRegistry.setHostPopoverOpen(paneId, isMenuOpen);
+		return () => browserRuntimeRegistry.setHostPopoverOpen(paneId, false);
+	}, [paneId, isMenuOpen]);
 
 	const handlePrint = () => browserRuntimeRegistry.print(paneId);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { CheckIcon, MinusIcon, PlusIcon, RotateCcwIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { TbDots } from "react-icons/tb";
 import { ImportHistoryDialog } from "renderer/components/ImportHistoryDialog";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
@@ -70,6 +70,12 @@ export function BrowserOverflowMenu({
 	const [isDownloadsOpen, setIsDownloadsOpen] = useState(false);
 	const [isScreenshotsOpen, setIsScreenshotsOpen] = useState(false);
 	const [isClearDataOpen, setIsClearDataOpen] = useState(false);
+	const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+	useEffect(() => {
+		browserRuntimeRegistry.setHostPopoverPassthrough(isMenuOpen);
+		return () => browserRuntimeRegistry.setHostPopoverPassthrough(false);
+	}, [isMenuOpen]);
 
 	const handlePrint = () => browserRuntimeRegistry.print(paneId);
 
@@ -142,7 +148,7 @@ export function BrowserOverflowMenu({
 
 	return (
 		<>
-			<DropdownMenu>
+			<DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
 				<DropdownMenuTrigger asChild>
 					<button
 						type="button"


### PR DESCRIPTION
## Problem

Clicking into the page while the browser pane's three-dot menu is open leaves the menu open. The page is a native `<webview>` hoisted over the pane by `browserRuntimeRegistry` with its own inline `pointer-events: auto`, so a click on it goes straight to the guest renderer and never reaches the document listener Radix dismisses on.

Passing `modal` to the `DropdownMenu` does not help: Radix puts `pointer-events: none` on `<body>`, but the webview's inline `auto` wins. Verified live: with `modal`, body was `pointer-events: none`, the guest still received `pointerdown`/`mousedown`/`click`, the host saw nothing, and the menu stayed open.

## Fix

Reuse the registry's existing pointer passthrough (already used for window drags and sidebar/pane resizes). `BrowserOverflowMenu` is now controlled and flips a new `setHostPopoverPassthrough` reason on open, cleared on close and on unmount. While the menu is open the webview passes pointer events through to the host element beneath it, so the click dismisses the menu and does not reach the page, the same as Chrome.

The Design mode popover and the find bar have the same underlying issue and can call the same method; left out to keep this to the reported menu.

## Verification (CDP on the dev app, trusted `Input.dispatchMouseEvent`)

| Build | Click into page | Menu after |
|---|---|---|
| main | lands in guest page | still open, also after a second click |
| this PR | lands on host | closed |

`bun run typecheck` and `browserRuntimeRegistry.test.ts` pass.

https://claude.ai/code/session_01EeQVpWNJ5iMPB7P9xukRPE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser pane's overflow menu staying open when clicking into the page. Now the menu closes on such clicks by routing pointer events through to the host while the menu is open, matching real browser behavior.

<sup>Written for commit f0a478e721e369aa531fe13962663e3fad9d653a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction handling when multiple browser overflow menus are open.
  * Prevented underlying webviews from capturing pointer events while any menu is displayed.
  * Restored normal pointer interaction after all open menus are closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->