### PR TITLE
fix(desktop): keep the sidebar project order manual under every sort

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/DashboardSidebar.tsx
@@ -62,6 +62,7 @@ interface DashboardSidebarProps {
 interface SortableProjectWrapperProps {
 	project: DashboardSidebarProject;
 	isCollapsed: boolean;
+	isDragDisabled: boolean;
 	workspaceShortcutLabels: Map<string, string>;
 	onWorkspaceHover: (workspaceId: string) => void | Promise<void>;
 	onToggleCollapse: (projectId: string) => void;
@@ -70,10 +71,12 @@ interface SortableProjectWrapperProps {
 const SortableProjectWrapper = memo(function SortableProjectWrapper({
 	project,
 	isCollapsed,
+	isDragDisabled,
 	workspaceShortcutLabels,
 	onWorkspaceHover,
 	onToggleCollapse,
 }: SortableProjectWrapperProps) {
+	const { activeType } = useDashboardSidebarDnd();
 	const {
 		attributes,
 		listeners,
@@ -81,8 +84,7 @@ const SortableProjectWrapper = memo(function SortableProjectWrapper({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: project.id });
-	const { activeType } = useDashboardSidebarDnd();
+	} = useSortable({ id: project.id, disabled: isDragDisabled });
 	const isDraggingProject = activeType === "project";
 
 	// useSortable re-renders this wrapper on every pointer move of any drag in
@@ -207,7 +209,11 @@ export function DashboardSidebar({
 	);
 	const trimmedFilterQuery = projectFilterQuery.trim();
 	const isFilterActive = trimmedFilterQuery !== "";
-	const isDragDisabled = sortMode !== "manual" || isFilterActive;
+	// The sort modes only reorder rows inside a project, so the project list
+	// is still the manual order and stays draggable; only a filter, which
+	// hides projects outright, makes a project drop unsafe to commit.
+	const isProjectDragDisabled = isFilterActive;
+	const isChildDragDisabled = sortMode !== "manual" || isFilterActive;
 
 	// Sorted but unfiltered, so ⌘1–⌘9 targets stay put while typing a query.
 	// The filtered view expands matches through derived objects, so a jump
@@ -337,7 +343,8 @@ export function DashboardSidebar({
 								isSidebarCollapsed={isCollapsed}
 								workspaceShortcutLabels={workspaceShortcutLabels}
 								onReorderProjects={handleReorderProjects}
-								isDragDisabled={isDragDisabled}
+								isProjectDragDisabled={isProjectDragDisabled}
+								isChildDragDisabled={isChildDragDisabled}
 							>
 								<div className="flex h-full flex-col border-r border-border bg-sidebar dark:bg-muted/35">
 									<DashboardSidebarHeader isCollapsed={isCollapsed} />
@@ -388,6 +395,7 @@ export function DashboardSidebar({
 														key={project.id}
 														project={project}
 														isCollapsed={isCollapsed}
+														isDragDisabled={isProjectDragDisabled}
 														workspaceShortcutLabels={workspaceShortcutLabels}
 														onWorkspaceHover={refreshWorkspacePullRequest}
 														onToggleCollapse={toggleProjectCollapsed}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/components/SortableCollapsedWorkspaceItem/SortableCollapsedWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarProjectSection/components/DashboardSidebarCollapsedProjectContent/components/SortableCollapsedWorkspaceItem/SortableCollapsedWorkspaceItem.tsx
@@ -1,6 +1,7 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useMemo } from "react";
+import { useDashboardSidebarDnd } from "../../../../../../hooks/useSidebarDnd";
 import type { DashboardSidebarWorkspace } from "../../../../../../types";
 import { DashboardSidebarWorkspaceItem } from "../../../../../DashboardSidebarWorkspaceItem";
 
@@ -19,6 +20,7 @@ export function SortableCollapsedWorkspaceItem({
 	shortcutLabel,
 	disabled,
 }: SortableCollapsedWorkspaceItemProps) {
+	const { isChildDragDisabled } = useDashboardSidebarDnd();
 	const {
 		setNodeRef,
 		attributes,
@@ -26,7 +28,10 @@ export function SortableCollapsedWorkspaceItem({
 		isDragging,
 		transform,
 		transition,
-	} = useSortable({ id: sortableId, disabled });
+	} = useSortable({
+		id: sortableId,
+		disabled: disabled || isChildDragDisabled,
+	});
 
 	// useSortable re-renders this wrapper on every pointer move of any drag in
 	// the sidebar's DndContext; keep the row body referentially stable so only

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspacesHeader/components/DashboardSidebarProjectsSortMenu/DashboardSidebarProjectsSortMenu.tsx
@@ -20,9 +20,10 @@ interface DashboardSidebarProjectsSortMenuProps {
 }
 
 /**
- * Sort-mode picker in the Projects header. Lives inside the header strip,
- * which toggles the section on click, so the trigger and the (portaled, but
- * React-bubbling) menu content both stop propagation.
+ * Sort-mode picker in the Projects header. Sorts the workspaces inside each
+ * project — the project list itself is always the manual drag order. Lives
+ * inside the header strip, which toggles the section on click, so the trigger
+ * and the (portaled, but React-bubbling) menu content both stop propagation.
  */
 export function DashboardSidebarProjectsSortMenu({
 	sortMode,
@@ -50,7 +51,7 @@ export function DashboardSidebarProjectsSortMenu({
 						<button
 							type="button"
 							aria-label={t({
-								message: "Sort projects",
+								message: "Sort workspaces",
 							})}
 							onClick={(event) => event.stopPropagation()}
 							onKeyDown={(event) => event.stopPropagation()}
@@ -68,7 +69,7 @@ export function DashboardSidebarProjectsSortMenu({
 				</TooltipTrigger>
 				<TooltipContent side="bottom">
 					{t({
-						message: `Sort projects (${currentLabel})`,
+						message: `Sort workspaces (${currentLabel})`,
 					})}
 				</TooltipContent>
 			</Tooltip>
@@ -98,7 +99,7 @@ export function DashboardSidebarProjectsSortMenu({
 				{sortMode !== "manual" && (
 					<div className="px-2 pb-1 pt-1.5 text-[11px] text-muted-foreground/70">
 						{t({
-							message: "Drag to reorder in Manual order",
+							message: "Drag workspaces to reorder in Manual order",
 						})}
 					</div>
 				)}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -8,6 +8,7 @@ import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/u
 import { parseSidebarFolderKey } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import { RenameInput } from "renderer/screens/main/components/WorkspaceSidebar/RenameInput";
 import { PROJECT_COLOR_DEFAULT } from "shared/constants/project-colors";
+import { useDashboardSidebarDnd } from "../../hooks/useSidebarDnd";
 import type {
 	DashboardSidebarSection,
 	DashboardSidebarWorkspaceIndentation,
@@ -36,6 +37,7 @@ export function SortableSectionHeader({
 	onRename,
 	onToggleCollapse,
 }: SortableSectionHeaderProps) {
+	const { isChildDragDisabled } = useDashboardSidebarDnd();
 	const { setSectionColor } = useDashboardSidebarState();
 	const { clearPendingSectionRename, pendingRenameSectionId } =
 		useDashboardSidebarSectionRename();
@@ -57,7 +59,7 @@ export function SortableSectionHeader({
 		transform,
 		transition,
 		isDragging,
-	} = useSortable({ id: sortableId });
+	} = useSortable({ id: sortableId, disabled: isChildDragDisabled });
 
 	const hasColor =
 		section.color != null && section.color !== PROJECT_COLOR_DEFAULT;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -123,7 +123,7 @@ export function SortableSectionHeader({
 					}
 					isCollapsed={section.isCollapsed}
 					isEditing={isRenaming}
-					isDraggable
+					isDraggable={!isChildDragDisabled}
 					indentation={indentation}
 					onToggleCollapse={() => onToggleCollapse(section.id)}
 					actions={

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@superset/ui/utils";
 import { useMemo } from "react";
+import { useDashboardSidebarDnd } from "../../hooks/useSidebarDnd";
 import type { WorkspaceSelectionEvent } from "../../providers/DashboardSidebarSelectionProvider";
 import type {
 	DashboardSidebarWorkspace,
@@ -51,6 +52,7 @@ export function SortableWorkspaceItem({
 	onSelectionClick,
 	pinnedContext,
 }: SortableWorkspaceItemProps) {
+	const { isChildDragDisabled } = useDashboardSidebarDnd();
 	const {
 		setNodeRef,
 		attributes,
@@ -58,7 +60,10 @@ export function SortableWorkspaceItem({
 		isDragging,
 		transform,
 		transition,
-	} = useSortable({ id: sortableId, disabled });
+	} = useSortable({
+		id: sortableId,
+		disabled: disabled || isChildDragDisabled,
+	});
 
 	// useSortable re-renders this wrapper on every pointer move of any drag in
 	// the sidebar's DndContext; the row body (query hooks, menus) is expensive,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -334,6 +334,8 @@ export interface DashboardSidebarDndValue {
 	projectsById: Map<string, DashboardSidebarProject>;
 	groupInfo: Map<string, { sectionId: string; color: string | null }>;
 	collapsedSectionIds: Set<string>;
+	/** Rows and folders are a sorted view: their sortables are inert. */
+	isChildDragDisabled: boolean;
 }
 
 const DashboardSidebarDndContext =
@@ -391,13 +393,21 @@ interface UseSidebarDndOptions {
 	sessionChildren: DashboardSidebarProjectChild[];
 	onReorderProjects: (projectIds: string[]) => void;
 	/**
-	 * True while a non-manual sort or an active filter means the rendered
-	 * lists are a transformed view of the manual order. Committing a drop in
-	 * that state would rewrite tabOrder against the view and corrupt the real
-	 * order of hidden/reordered siblings, so every drag (projects, workspaces,
-	 * folders, pinned, sessions) is inert.
+	 * True while a filter hides projects: the rendered project list is a
+	 * subset of the manual order, so committing a drop would rewrite tabOrder
+	 * against the view. The sort modes never reorder projects, so they do not
+	 * set this — a project stays draggable while its workspaces are sorted.
 	 */
-	disabled?: boolean;
+	projectDragDisabled?: boolean;
+	/**
+	 * True while a non-manual sort or an active filter means every project's
+	 * child list is a transformed view of the manual order. Committing a drop
+	 * there would corrupt the real order of reordered/hidden siblings, so
+	 * every row drag (workspaces, folders, pinned, sessions) is inert —
+	 * including in the unsorted Pinned and Sessions lanes, whose drags can
+	 * land in a project.
+	 */
+	childDragDisabled?: boolean;
 }
 
 export function useSidebarDnd({
@@ -405,7 +415,8 @@ export function useSidebarDnd({
 	pinnedWorkspaces,
 	sessionChildren,
 	onReorderProjects,
-	disabled = false,
+	projectDragDisabled = false,
+	childDragDisabled = false,
 }: UseSidebarDndOptions) {
 	const {
 		reorderPinnedWorkspaces,
@@ -414,6 +425,7 @@ export function useSidebarDnd({
 		setWorkspacePinned,
 	} = useDashboardSidebarState();
 
+	const noDragsPossible = projectDragDisabled && childDragDisabled;
 	// useSensor memoizes on the options object's identity, and this hook
 	// re-renders on every hovered-row change mid-drag. Inline option literals
 	// therefore rebuilt the sensor list each time, which recomputed every
@@ -427,11 +439,20 @@ export function useSidebarDnd({
 			// already swallowed by dnd-kit (capture-phase document click
 			// listener installed at activation, detached one event loop after
 			// the drag ends).
-			mouse: { activationConstraint: { distance: 5 }, disabled },
-			touch: { activationConstraint: { delay: 200, tolerance: 5 }, disabled },
-			keyboard: { coordinateGetter: sortableKeyboardCoordinates, disabled },
+			mouse: {
+				activationConstraint: { distance: 5 },
+				disabled: noDragsPossible,
+			},
+			touch: {
+				activationConstraint: { delay: 200, tolerance: 5 },
+				disabled: noDragsPossible,
+			},
+			keyboard: {
+				coordinateGetter: sortableKeyboardCoordinates,
+				disabled: noDragsPossible,
+			},
 		}),
-		[disabled],
+		[noDragsPossible],
 	);
 	const sensors = useSensors(
 		useSensor(GatedMouseSensor, sensorOptions.mouse),
@@ -1179,6 +1200,7 @@ export function useSidebarDnd({
 			projectsById,
 			groupInfo,
 			collapsedSectionIds,
+			isChildDragDisabled: childDragDisabled,
 		}),
 		[
 			items,
@@ -1193,6 +1215,7 @@ export function useSidebarDnd({
 			projectsById,
 			groupInfo,
 			collapsedSectionIds,
+			childDragDisabled,
 		],
 	);
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarDndProvider/DashboardSidebarDndProvider.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/providers/DashboardSidebarDndProvider/DashboardSidebarDndProvider.tsx
@@ -28,10 +28,15 @@ interface DashboardSidebarDndProviderProps {
 	workspaceShortcutLabels: Map<string, string>;
 	onReorderProjects: (projectIds: string[]) => void;
 	/**
-	 * True while `projects` is a sorted/filtered view rather than the manual
-	 * order — see useSidebarDnd's `disabled` option.
+	 * True while `projects` is a filtered view rather than the manual order —
+	 * see useSidebarDnd's `projectDragDisabled` option.
 	 */
-	isDragDisabled?: boolean;
+	isProjectDragDisabled?: boolean;
+	/**
+	 * True while the rows inside `projects` are a sorted/filtered view — see
+	 * useSidebarDnd's `childDragDisabled` option.
+	 */
+	isChildDragDisabled?: boolean;
 	children: ReactNode;
 }
 
@@ -48,7 +53,8 @@ export function DashboardSidebarDndProvider({
 	isSidebarCollapsed,
 	workspaceShortcutLabels,
 	onReorderProjects,
-	isDragDisabled = false,
+	isProjectDragDisabled = false,
+	isChildDragDisabled = false,
 	children,
 }: DashboardSidebarDndProviderProps) {
 	const {
@@ -64,7 +70,8 @@ export function DashboardSidebarDndProvider({
 		pinnedWorkspaces,
 		sessionChildren,
 		onReorderProjects,
-		disabled: isDragDisabled,
+		projectDragDisabled: isProjectDragDisabled,
+		childDragDisabled: isChildDragDisabled,
 	});
 
 	// Dragging sweeps the pointer across rows, which would otherwise drive the

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/index.ts
@@ -1,5 +1,4 @@
 export {
-	getProjectActivityTimestamp,
 	getWorkspaceActivityTime,
 	sortDashboardSidebarProjectChildren,
 	sortDashboardSidebarProjects,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.test.ts
@@ -6,7 +6,6 @@ import {
 	makeWorkspace,
 } from "../testProjectFixtures";
 import {
-	getProjectActivityTimestamp,
 	getWorkspaceActivityTime,
 	sortDashboardSidebarProjectChildren,
 	sortDashboardSidebarProjects,
@@ -51,86 +50,6 @@ describe("getWorkspaceActivityTime", () => {
 	});
 });
 
-describe("getProjectActivityTimestamp", () => {
-	it("uses the most recently active workspace, including inside sections", () => {
-		const project = makeProject({
-			id: "p1",
-			name: "Alpha",
-			updatedAt: new Date("2026-06-01"),
-			children: [
-				{
-					type: "workspace",
-					workspace: makeWorkspace({
-						id: "w1",
-						name: "one",
-						lastActivityAt: at("2026-02-01"),
-					}),
-				},
-				{
-					type: "section",
-					section: makeSection({
-						id: "s1",
-						name: "Section",
-						workspaces: [
-							makeWorkspace({
-								id: "w2",
-								name: "two",
-								lastActivityAt: at("2026-03-01"),
-							}),
-						],
-					}),
-				},
-			],
-		});
-		expect(getProjectActivityTimestamp(project)).toBe(at("2026-03-01"));
-	});
-
-	it("falls back to the project's own updatedAt when there are no workspaces", () => {
-		const project = makeProject({
-			id: "p1",
-			name: "Alpha",
-			updatedAt: new Date("2026-05-01"),
-		});
-		expect(getProjectActivityTimestamp(project)).toBe(at("2026-05-01"));
-	});
-
-	it("falls back to createdAt when updatedAt is garbage", () => {
-		const project = makeProject({
-			id: "p1",
-			name: "Alpha",
-			createdAt: new Date("2026-04-01"),
-			updatedAt: "nope" as unknown as Date,
-		});
-		expect(getProjectActivityTimestamp(project)).toBe(at("2026-04-01"));
-	});
-
-	it("skips NaN workspace timestamps instead of poisoning the max", () => {
-		const project = makeProject({
-			id: "p1",
-			name: "Alpha",
-			children: [
-				{
-					type: "workspace",
-					workspace: makeWorkspace({
-						id: "w-bad",
-						name: "bad",
-						updatedAt: "garbage" as unknown as Date,
-					}),
-				},
-				{
-					type: "workspace",
-					workspace: makeWorkspace({
-						id: "w-good",
-						name: "good",
-						lastActivityAt: at("2026-03-01"),
-					}),
-				},
-			],
-		});
-		expect(getProjectActivityTimestamp(project)).toBe(at("2026-03-01"));
-	});
-});
-
 describe("sortDashboardSidebarProjects", () => {
 	const older = makeProject({
 		id: "p-older",
@@ -168,31 +87,22 @@ describe("sortDashboardSidebarProjects", () => {
 		expect(sortDashboardSidebarProjects(projects, "manual")).toBe(projects);
 	});
 
-	it("sorts newest created first in created mode", () => {
+	it("keeps the manual project order in created mode", () => {
 		expect(
 			sortDashboardSidebarProjects([older, newer], "created").map((p) => p.id),
-		).toEqual(["p-newer", "p-older"]);
+		).toEqual(["p-older", "p-newer"]);
 	});
 
-	it("sorts by workspace activity in active mode", () => {
+	it("keeps the manual project order in active mode", () => {
 		expect(
 			sortDashboardSidebarProjects([newer, older], "active").map((p) => p.id),
-		).toEqual(["p-older", "p-newer"]);
+		).toEqual(["p-newer", "p-older"]);
 	});
 
 	it("does not mutate the input array", () => {
 		const projects = [newer, older];
 		sortDashboardSidebarProjects(projects, "active");
 		expect(projects.map((p) => p.id)).toEqual(["p-newer", "p-older"]);
-	});
-
-	it("breaks timestamp ties by name, then id", () => {
-		const a = makeProject({ id: "p-a", name: "Apple" });
-		const b = makeProject({ id: "p-b", name: "Banana" });
-		const b2 = makeProject({ id: "p-b2", name: "Banana" });
-		expect(
-			sortDashboardSidebarProjects([b2, b, a], "created").map((p) => p.id),
-		).toEqual(["p-a", "p-b", "p-b2"]);
 	});
 
 	it("keeps a project's identity when its children are already in order", () => {
@@ -202,11 +112,19 @@ describe("sortDashboardSidebarProjects", () => {
 
 	// Persisted caches can revive Date columns as ISO strings; sorting must
 	// coerce them, never throw mid-render.
-	it("sorts workspaces whose timestamps are ISO strings at runtime", () => {
-		const stringDated = makeProject({
-			id: "p-string",
-			name: "StringDates",
+	it("sorts children whose timestamps are ISO strings at runtime", () => {
+		const project = makeProject({
+			id: "p1",
+			name: "Alpha",
 			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w-date",
+						name: "host-served",
+						updatedAt: new Date("2026-05-01"),
+					}),
+				},
 				{
 					type: "workspace",
 					workspace: makeWorkspace({
@@ -217,49 +135,8 @@ describe("sortDashboardSidebarProjects", () => {
 				},
 			],
 		});
-		const dateDated = makeProject({
-			id: "p-date",
-			name: "DateDates",
-			children: [
-				{
-					type: "workspace",
-					workspace: makeWorkspace({
-						id: "w-date",
-						name: "host-served",
-						updatedAt: new Date("2026-05-01"),
-					}),
-				},
-			],
-		});
-		expect(
-			sortDashboardSidebarProjects([dateDated, stringDated], "active").map(
-				(p) => p.id,
-			),
-		).toEqual(["p-string", "p-date"]);
-	});
-
-	it("sinks garbage timestamps below dated projects and orders them by name", () => {
-		const dated = makeProject({
-			id: "p-dated",
-			name: "Zed",
-			createdAt: new Date("2020-01-01"),
-		});
-		const garbage = makeProject({
-			id: "p-garbage",
-			name: "Apple",
-			createdAt: "not-a-date" as unknown as Date,
-		});
-		const alsoGarbage = makeProject({
-			id: "p-garbage-2",
-			name: "Banana",
-			createdAt: "also-not-a-date" as unknown as Date,
-		});
-		expect(
-			sortDashboardSidebarProjects(
-				[alsoGarbage, dated, garbage],
-				"created",
-			).map((p) => p.id),
-		).toEqual(["p-dated", "p-garbage", "p-garbage-2"]);
+		const [sorted] = sortDashboardSidebarProjects([project], "active");
+		expect(childIds(sorted?.children ?? [])).toEqual(["w-string", "w-date"]);
 	});
 
 	it("does not throw for null or undefined timestamps", () => {
@@ -437,6 +314,68 @@ describe("sortDashboardSidebarProjectChildren", () => {
 		expect(childIds(sorted)).toEqual(["w-created-late", "w-created-early"]);
 	});
 
+	it("breaks timestamp ties by name, then id", () => {
+		const tie = at("2026-05-01");
+		const apple = makeWorkspace({
+			id: "w-a",
+			name: "Apple",
+			lastActivityAt: tie,
+		});
+		const banana = makeWorkspace({
+			id: "w-b",
+			name: "Banana",
+			lastActivityAt: tie,
+		});
+		const banana2 = makeWorkspace({
+			id: "w-b2",
+			name: "Banana",
+			lastActivityAt: tie,
+		});
+		const sorted = sortDashboardSidebarProjectChildren(
+			[banana2, banana, apple].map((workspace) => ({
+				type: "workspace" as const,
+				workspace,
+			})),
+			"active",
+		);
+		expect(childIds(sorted)).toEqual(["w-a", "w-b", "w-b2"]);
+	});
+
+	it("sinks garbage timestamps below dated rows and orders them by name", () => {
+		const dated: DashboardSidebarProjectChild = {
+			type: "workspace",
+			workspace: makeWorkspace({
+				id: "w-dated",
+				name: "Zed",
+				createdAt: new Date("2020-01-01"),
+			}),
+		};
+		const garbage: DashboardSidebarProjectChild = {
+			type: "workspace",
+			workspace: makeWorkspace({
+				id: "w-garbage",
+				name: "Apple",
+				createdAt: "not-a-date" as unknown as Date,
+			}),
+		};
+		const alsoGarbage: DashboardSidebarProjectChild = {
+			type: "workspace",
+			workspace: makeWorkspace({
+				id: "w-garbage-2",
+				name: "Banana",
+				createdAt: "also-not-a-date" as unknown as Date,
+			}),
+		};
+		expect(
+			childIds(
+				sortDashboardSidebarProjectChildren(
+					[alsoGarbage, dated, garbage],
+					"created",
+				),
+			),
+		).toEqual(["w-dated", "w-garbage", "w-garbage-2"]);
+	});
+
 	it("does not mutate the input children or sections", () => {
 		const children = [section, oldWorktree, newWorktree];
 		const sectionWorkspaceIds = section.section.workspaces.map((w) => w.id);
@@ -541,45 +480,40 @@ describe("lastActivityAt in active mode", () => {
 		]);
 	});
 
-	it("bubbles activity up to project ordering", () => {
-		const staleMetadata = makeProject({
-			id: "p-busy",
-			name: "Busy",
-			updatedAt: new Date("2026-01-01"),
-			children: [
-				{
-					type: "workspace",
-					workspace: makeWorkspace({
-						id: "w1",
-						name: "one",
-						updatedAt: new Date("2026-01-01"),
-						lastActivityAt: at("2026-07-01"),
-					}),
-				},
-			],
-		});
-		const freshMetadata = makeProject({
+	// Activity ranks rows inside a project and stops there — a busy workspace
+	// must not drag its project up past the one above it.
+	it("does not bubble activity up to project ordering", () => {
+		const idle = makeProject({
 			id: "p-idle",
 			name: "Idle",
-			updatedAt: new Date("2026-08-01"),
 			children: [
 				{
 					type: "workspace",
 					workspace: makeWorkspace({
 						id: "w2",
 						name: "two",
-						updatedAt: new Date("2026-08-01"),
 						lastActivityAt: at("2026-05-01"),
 					}),
 				},
 			],
 		});
+		const busy = makeProject({
+			id: "p-busy",
+			name: "Busy",
+			children: [
+				{
+					type: "workspace",
+					workspace: makeWorkspace({
+						id: "w1",
+						name: "one",
+						lastActivityAt: at("2026-07-01"),
+					}),
+				},
+			],
+		});
 		expect(
-			sortDashboardSidebarProjects(
-				[freshMetadata, staleMetadata],
-				"active",
-			).map((p) => p.id),
-		).toEqual(["p-busy", "p-idle"]);
+			sortDashboardSidebarProjects([idle, busy], "active").map((p) => p.id),
+		).toEqual(["p-idle", "p-busy"]);
 	});
 
 	it("bubbles activity inside a section up to the section's rank", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/utils/sortDashboardSidebarProjects/sortDashboardSidebarProjects.ts
@@ -4,7 +4,6 @@ import type {
 	DashboardSidebarProjectChild,
 	DashboardSidebarWorkspace,
 } from "../../types";
-import { getProjectChildrenWorkspaces } from "../projectChildren";
 
 // Timestamps are typed as Date but can arrive as ISO strings at runtime
 // (IndexedDB snapshots, persisted query caches). Sorting is cosmetic, so
@@ -43,21 +42,6 @@ export function getWorkspaceActivityTime(
 	const activity = workspace.lastActivityAt;
 	if (typeof activity === "number" && !Number.isNaN(activity)) return activity;
 	return toTime(workspace.updatedAt);
-}
-
-// A project's own updatedAt only moves on metadata patches (rename), so its
-// activity is that of its most recently active workspace.
-export function getProjectActivityTimestamp(
-	project: DashboardSidebarProject,
-): number {
-	const activity = newest(
-		getProjectChildrenWorkspaces(project.children).map(
-			getWorkspaceActivityTime,
-		),
-	);
-	if (!Number.isNaN(activity)) return activity;
-	const updatedAt = toTime(project.updatedAt);
-	return Number.isNaN(updatedAt) ? toTime(project.createdAt) : updatedAt;
 }
 
 function makeStableComparator<Item>(
@@ -157,9 +141,12 @@ export function sortDashboardSidebarProjectChildren(
 }
 
 /**
- * Orders projects (and their children) for a sort mode. `manual` returns the
- * input untouched; the other modes never mutate it. A project whose children
- * are already in order keeps its identity.
+ * Sorts each project's children for a sort mode. The project list itself is
+ * always the manual (drag) order: projects are the stable landmarks people
+ * navigate by, and reshuffling them under the user because an agent touched
+ * a workspace loses the map. `manual` returns the input untouched; the other
+ * modes never mutate it, and a project whose children are already in order
+ * keeps its identity.
  */
 export function sortDashboardSidebarProjects(
 	projects: DashboardSidebarProject[],
@@ -167,21 +154,11 @@ export function sortDashboardSidebarProjects(
 ): DashboardSidebarProject[] {
 	if (mode === "manual") return projects;
 
-	const compareProjects = makeStableComparator<DashboardSidebarProject>(
-		mode === "created"
-			? (project) => toTime(project.createdAt)
-			: getProjectActivityTimestamp,
-		(project) => project.name,
-		(project) => project.id,
-	);
-
-	return projects
-		.map((project) => {
-			const children = sortDashboardSidebarProjectChildren(
-				project.children,
-				mode,
-			);
-			return children === project.children ? project : { ...project, children };
-		})
-		.sort(compareProjects);
+	return projects.map((project) => {
+		const children = sortDashboardSidebarProjectChildren(
+			project.children,
+			mode,
+		);
+		return children === project.children ? project : { ...project, children };
+	});
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/LeaderboardCard/components/LeaderboardRank/LeaderboardRank.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/LeaderboardCard/components/LeaderboardRank/LeaderboardRank.test.tsx
@@ -1,5 +1,8 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+// The marketing origin is env-derived: a developer's local .env repoints it at
+// a dev server, so assert the links the component builds, not a literal host.
+import { COMPANY } from "@superset/shared/constants";
 
 // happy-dom is process-wide; unregister in afterAll so the shared mock
 // document is restored for the other renderer suites.
@@ -51,8 +54,8 @@ describe("LeaderboardRank", () => {
 		const links = [...container.querySelectorAll("a")].map((a) =>
 			a.getAttribute("href"),
 		);
-		expect(links).toContain("https://superset.sh/user/kiet");
-		expect(links).toContain("https://superset.sh/leaderboard");
+		expect(links).toContain(`${COMPANY.MARKETING_URL}/user/kiet`);
+		expect(links).toContain(`${COMPANY.MARKETING_URL}/leaderboard`);
 		expect(getByText("kiet")).toBeTruthy();
 	});
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Přetažením přesunete"
 msgid "Drag to reorder"
 msgstr "Přetažením změníte pořadí"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Přetažením změníte pořadí v ručním řazení"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Přetažením pracovních prostorů změníte pořadí v ručním řazení"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Řadit podle"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Seřadit podle {label}, aktuálně {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Seřadit projekty"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Seřadit projekty ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Seřadit pracovní prostory"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Seřadit pracovní prostory ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Zvuky a vyzvánění pro dokončené úkoly"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Ziehen zum Verschieben"
 msgid "Drag to reorder"
 msgstr "Zum Umsortieren ziehen"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Ziehen zum Neuordnen in manueller Reihenfolge"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Arbeitsbereiche ziehen zum Neuordnen in manueller Reihenfolge"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Sortieren nach"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Nach {label} sortieren, aktuell {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Projekte sortieren"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Projekte sortieren ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Arbeitsbereiche sortieren"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Arbeitsbereiche sortieren ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Töne und Klingelton für abgeschlossene Aufgaben"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Drag to move"
 msgid "Drag to reorder"
 msgstr "Drag to reorder"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Drag to reorder in Manual order"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Drag workspaces to reorder in Manual order"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Sort by"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Sort by {label}, currently {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Sort projects"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Sort projects ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Sort workspaces"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Sort workspaces ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Sounds and ringtone for completed tasks"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Arrastrar para mover"
 msgid "Drag to reorder"
 msgstr "Arrastra para reordenar"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Arrastra para reordenar en Orden manual"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Arrastra los espacios de trabajo para reordenarlos en Orden manual"
 
 msgid "Drawer"
 msgstr "Panel deslizante"
@@ -12743,14 +12743,11 @@ msgstr "Ordenar por"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Ordenar por {label}, actualmente {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Ordenar proyectos"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Ordenar proyectos ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Ordenar espacios de trabajo"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Ordenar espacios de trabajo ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Sonidos y tono para las tareas completadas"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Glisser pour déplacer"
 msgid "Drag to reorder"
 msgstr "Faites glisser pour réorganiser"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Glisser pour réordonner en ordre manuel"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Glisser les espaces de travail pour les réordonner en ordre manuel"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Trier par"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Trier par {label}, actuellement {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Trier les projets"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Trier les projets ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Trier les espaces de travail"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Trier les espaces de travail ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Sons et sonnerie pour les tâches terminées"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Seret untuk memindahkan"
 msgid "Drag to reorder"
 msgstr "Seret untuk mengurutkan ulang"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Seret untuk mengatur ulang dalam Urutan manual"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Seret workspace untuk mengatur ulang dalam Urutan manual"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Urutkan menurut"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Urutkan menurut {label}, saat ini {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Urutkan proyek"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Urutkan proyek ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Urutkan workspace"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Urutkan workspace ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Suara dan nada dering untuk tugas yang selesai"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Trascina per spostare"
 msgid "Drag to reorder"
 msgstr "Trascina per riordinare"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Trascina per riordinare in Ordine manuale"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Trascina i workspace per riordinarli in Ordine manuale"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Ordina per"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Ordina per {label}, attualmente {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Ordina progetti"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Ordina progetti ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Ordina i workspace"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Ordina i workspace ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Suoni e suoneria per i task completati"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -4985,8 +4985,8 @@ msgstr "ドラッグして移動"
 msgid "Drag to reorder"
 msgstr "ドラッグして並べ替え"
 
-msgid "Drag to reorder in Manual order"
-msgstr "手動順ではドラッグして並べ替え"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "手動順ではワークスペースをドラッグして並べ替え"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "並び替え"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "{label}で並べ替え、現在{sortLabel}"
 
-msgid "Sort projects"
-msgstr "プロジェクトを並び替え"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "プロジェクトを並び替え({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "ワークスペースを並べ替え"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "ワークスペースを並べ替え（{currentLabel}）"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "タスク完了時のサウンドと着信音"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -4985,8 +4985,8 @@ msgstr "드래그하여 이동"
 msgid "Drag to reorder"
 msgstr "끌어서 순서 변경"
 
-msgid "Drag to reorder in Manual order"
-msgstr "수동 정렬에서 드래그하여 순서 변경"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "수동 정렬에서 워크스페이스를 드래그하여 순서 변경"
 
 msgid "Drawer"
 msgstr "드로어"
@@ -12743,14 +12743,11 @@ msgstr "정렬 기준"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "{label} 기준 정렬, 현재 {sortLabel}"
 
-msgid "Sort projects"
-msgstr "프로젝트 정렬"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "프로젝트 정렬 ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "워크스페이스 정렬"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "워크스페이스 정렬 ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "완료된 작업에 사용할 소리와 벨소리"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Sleep om te verplaatsen"
 msgid "Drag to reorder"
 msgstr "Sleep om te herordenen"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Sleep om te herordenen in Handmatige volgorde"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Sleep werkruimtes om ze te herordenen in Handmatige volgorde"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Sorteren op"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Sorteren op {label}, nu {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Projecten sorteren"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Projecten sorteren ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Werkruimtes sorteren"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Werkruimtes sorteren ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Geluiden en beltoon voor afgeronde taken"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Przeciągnij, aby przenieść"
 msgid "Drag to reorder"
 msgstr "Przeciągnij, aby zmienić kolejność"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Przeciągnij, aby zmienić kolejność w trybie ręcznym"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Przeciągaj obszary robocze, aby zmienić kolejność w trybie ręcznym"
 
 msgid "Drawer"
 msgstr "Szuflada"
@@ -12743,14 +12743,11 @@ msgstr "Sortuj według"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Sortuj wg {label}, obecnie {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Sortuj projekty"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Sortuj projekty ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Sortuj obszary robocze"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Sortuj obszary robocze ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Dźwięki i dzwonek dla zakończonych zadań"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Arraste para mover"
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Arraste para reordenar na ordem manual"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Arraste as áreas de trabalho para reordenar na ordem manual"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Ordenar por"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Ordenar por {label}, atualmente {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Ordenar projetos"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Ordenar projetos ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Ordenar áreas de trabalho"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Ordenar áreas de trabalho ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Sons e toque para tarefas concluídas"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Перетащите, чтобы переместить"
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Перетащите для изменения порядка в ручной сортировке"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Перетаскивайте рабочие области для изменения порядка в ручной сортировке"
 
 msgid "Drawer"
 msgstr "Шторка"
@@ -12743,14 +12743,11 @@ msgstr "Сортировать по"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Сортировать по {label}, сейчас {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Сортировать проекты"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Сортировать проекты ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Сортировать рабочие области"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Сортировать рабочие области ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Звуки и мелодия для завершённых задач"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Taşımak için sürükle"
 msgid "Drag to reorder"
 msgstr "Sıralamak için sürükleyin"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Manuel sıralamada yeniden düzenlemek için sürükleyin"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Manuel sıralamada yeniden düzenlemek için çalışma alanlarını sürükleyin"
 
 msgid "Drawer"
 msgstr "Çekmece"
@@ -12743,14 +12743,11 @@ msgstr "Sıralama ölçütü"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "{label} ölçütüne göre sırala, şu anda {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Projeleri sırala"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Projeleri sırala ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Çalışma alanlarını sırala"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Çalışma alanlarını sırala ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Tamamlanan görevler için sesler ve zil sesi"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -4985,8 +4985,8 @@ msgstr "Kéo để di chuyển"
 msgid "Drag to reorder"
 msgstr "Kéo để sắp xếp lại"
 
-msgid "Drag to reorder in Manual order"
-msgstr "Kéo để sắp xếp lại trong Thứ tự thủ công"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "Kéo workspace để sắp xếp lại trong Thứ tự thủ công"
 
 msgid "Drawer"
 msgstr "Drawer"
@@ -12743,14 +12743,11 @@ msgstr "Sắp xếp theo"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "Sắp xếp theo {label}, hiện tại {sortLabel}"
 
-msgid "Sort projects"
-msgstr "Sắp xếp dự án"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "Sắp xếp dự án ({currentLabel})"
-
 msgid "Sort workspaces"
 msgstr "Sắp xếp workspace"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "Sắp xếp workspace ({currentLabel})"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "Âm thanh và nhạc chuông cho tác vụ đã hoàn tất"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -4985,8 +4985,8 @@ msgstr "拖动以移动"
 msgid "Drag to reorder"
 msgstr "拖动以重新排序"
 
-msgid "Drag to reorder in Manual order"
-msgstr "在手动排序下可拖拽重新排列"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "在手动排序下可拖拽工作区重新排列"
 
 msgid "Drawer"
 msgstr "抽屉"
@@ -12743,14 +12743,11 @@ msgstr "排序方式"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "按{label}排序，当前为{sortLabel}"
 
-msgid "Sort projects"
-msgstr "项目排序"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "项目排序（{currentLabel}）"
-
 msgid "Sort workspaces"
 msgstr "排序工作区"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "排序工作区（{currentLabel}）"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "任务完成时的声音和铃声"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -4985,8 +4985,8 @@ msgstr "拖曳以移動"
 msgid "Drag to reorder"
 msgstr "拖曳以重新排序"
 
-msgid "Drag to reorder in Manual order"
-msgstr "在手動排序中拖曳以重新排列"
+msgid "Drag workspaces to reorder in Manual order"
+msgstr "在手動排序中拖曳工作區以重新排列"
 
 msgid "Drawer"
 msgstr "抽屜"
@@ -12743,14 +12743,11 @@ msgstr "排序方式"
 msgid "Sort by {label}, currently {sortLabel}"
 msgstr "按{label}排序，目前為{sortLabel}"
 
-msgid "Sort projects"
-msgstr "排序專案"
-
-msgid "Sort projects ({currentLabel})"
-msgstr "排序專案（{currentLabel}）"
-
 msgid "Sort workspaces"
 msgstr "排序工作區"
+
+msgid "Sort workspaces ({currentLabel})"
+msgstr "排序工作區（{currentLabel}）"
 
 msgid "Sounds and ringtone for completed tasks"
 msgstr "任務完成時的聲音和鈴聲"


### PR DESCRIPTION
## What

The Projects sort menu sorted the project list as well as the rows inside it. Picking **Last active** therefore reshuffled the projects themselves every time an agent touched a workspace — the landmarks people navigate the sidebar by moved under them.

Sorting now stops at a project's boundary:

- **Projects** are always the manual drag order, in every mode.
- **Workspaces and folders inside a project** sort by the selected mode (Manual / Last active / Date created), unchanged.

I took "always manual" to cover **Date created** too, not just Last active — a project list that reorders itself is the thing that's wrong, and the mode you picked shouldn't decide whether your drag order survives.

## Drag follows

Because the project list is no longer a transformed view of the manual order, **projects stay draggable while a sort is active** — otherwise you'd have to switch to Manual, drag, and switch back to reorder the list the app claims is manual. The single sensor-level drag gate splits in two:

| | blocked by |
|---|---|
| project drags | filter only (it hides projects, so a drop would rewrite `tabOrder` against the view) |
| row drags (workspaces, folders, pinned, sessions) | any non-manual sort, or the filter |

Row drags stay blocked in the unsorted Pinned and Sessions lanes too, since a row dragged out of them can land in a sorted project list. The sensors can no longer be the single gate, so each sortable reads the row gate off the dnd context.

Menu copy follows the behaviour: "Sort projects" → "Sort workspaces", and the hint reads "Drag workspaces to reorder in Manual order". 16 locales translated.

## Testing

- `bun test` in `apps/desktop`: 3489 pass, 1 pre-existing env-dependent failure (`LeaderboardRank`, passes under `env -i`; unrelated to this change).
- Sort unit tests rewritten: project order preserved in both sort modes, with the tie-break and garbage-timestamp coverage moved down to the row level where the comparator still runs. Dead `getProjectActivityTimestamp` removed.
- `typecheck`, `lint`, `check:i18n` clean.
- **Not driven in the app** — the drag split deserves a minute of hands-on: with Last active selected, drag a project (should move and stick) and drag a workspace (should be inert).

https://claude.ai/code/session_01GvK1ZzjBWK3iCMjzY48oRR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Projects sort menu reordering the project list itself, so picking **Last active** no longer reshuffles projects under you. Sorting now stops at a project's boundary: projects always keep the manual drag order, while workspaces and folders inside sort by the selected mode.

- Projects stay draggable while a sort is active; only the filter blocks project drags.
- Row drags (workspaces, folders, pinned, sessions) remain inert under any non-manual sort or the filter, enforced per sortable instead of at the sensor level.
- Folder headers no longer show a grab cursor when row drags are inert, since their sortable is disabled too.
- Sort menu copy now reads "Sort workspaces" across 16 locales, and the manual-order hint says "Drag workspaces to reorder in Manual order".
- Removed the dead `getProjectActivityTimestamp` helper and moved its test coverage down to the row comparator.
- Hardened the `LeaderboardRank` test to build expected hrefs from `COMPANY.MARKETING_URL` instead of a literal host, so it passes on machines with `NEXT_PUBLIC_MARKETING_URL` set locally.

<sup>Written for commit bbe123b35b4d3cecada0bea4e89cd77eb0ccea88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Projects now remain in manual drag order while workspace sorting options reorder workspaces within each project.
  - Project and workspace dragging is managed independently, including filtered views and non-manual sorting modes.

- **User Interface**
  - Updated sort labels, tooltips, and guidance to clearly refer to workspaces and show the active sort mode.

- **Localization**
  - Updated workspace sorting and reordering translations across supported languages.

- **Tests**
  - Expanded coverage for project ordering, workspace sorting, and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->