### PR TITLE
fix(desktop): keep the workspace delete dialog from confirming on the keystroke that opened it

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.test.tsx
@@ -1,0 +1,97 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom over the preloaded plain-object document: Radix needs a real DOM.
+// Globals are process-wide, so unregister in afterAll (see Redirect.test.tsx).
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Queries go through `within(document.body)` rather than `screen`: in a full
+// suite run an earlier file may have loaded testing-library against a previous
+// happy-dom window, and `screen` stays bound to that stale body.
+const { act, cleanup, fireEvent, render, within } = await import(
+	"@testing-library/react"
+);
+const React = await import("react");
+const { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } =
+	await import("@superset/ui/context-menu");
+const { DestroyConfirmPane } = await import("./DestroyConfirmPane");
+
+afterEach(() => {
+	cleanup();
+	document.body.style.pointerEvents = "";
+});
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+/**
+ * The sidebar's delete flow: a ContextMenu "Delete" item opens the confirm
+ * pane. Selecting the item with Enter must not also confirm the pane — the
+ * keystroke that picked the item is still bubbling when the pane mounts.
+ */
+function MenuOpensConfirmPane({ onConfirm }: { onConfirm: () => void }) {
+	const [open, setOpen] = React.useState(false);
+	return (
+		<>
+			<ContextMenu>
+				<ContextMenuTrigger asChild>
+					<button type="button">row</button>
+				</ContextMenuTrigger>
+				<ContextMenuContent>
+					<ContextMenuItem onSelect={() => setOpen(true)}>
+						Delete
+					</ContextMenuItem>
+				</ContextMenuContent>
+			</ContextMenu>
+			<DestroyConfirmPane
+				open={open}
+				onOpenChange={setOpen}
+				workspaceName="ws"
+				deleteBranch={false}
+				onDeleteBranchChange={() => {}}
+				hasChanges={false}
+				hasUnpushedCommits={false}
+				canConfirm
+				blockingReason={null}
+				onConfirm={onConfirm}
+				confirmLabel="Delete"
+			/>
+		</>
+	);
+}
+
+describe("DestroyConfirmPane Enter-to-confirm", () => {
+	test("the Enter that selects the menu item does not confirm the pane", async () => {
+		const onConfirm = mock(() => {});
+		render(<MenuOpensConfirmPane onConfirm={onConfirm} />);
+		const page = () => within(document.body);
+
+		await act(async () => {
+			fireEvent.contextMenu(page().getByText("row"), {
+				clientX: 10,
+				clientY: 10,
+			});
+		});
+		const item = await page().findByRole("menuitem");
+		await act(async () => {
+			fireEvent.keyDown(item, { key: "Enter", code: "Enter" });
+		});
+
+		expect(page().getByRole("alertdialog")).toBeTruthy();
+		expect(onConfirm).not.toHaveBeenCalled();
+
+		// Once the opening keystroke has finished dispatching, Enter confirms
+		// from anywhere: the closing menu hands focus back outside the dialog.
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		await act(async () => {
+			fireEvent.keyDown(document.body, { key: "Enter", code: "Enter" });
+		});
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from "@superset/ui/button";
 import { Checkbox } from "@superset/ui/checkbox";
 import { Label } from "@superset/ui/label";
-import { useEffect, useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import { shouldConfirmDeleteDialogKey } from "../../utils/shouldConfirmDeleteDialogKey";
 
 interface DestroyConfirmPaneProps {
@@ -46,13 +46,20 @@ export function DestroyConfirmPane({
 	const checkboxId = useId();
 	const hasWarnings = hasChanges || hasUnpushedCommits;
 
+	// Read through a ref so a re-render while the dialog is open (checkbox
+	// toggle, warning banner) doesn't tear down and re-arm the listener.
+	const onConfirmRef = useRef(onConfirm);
+	useEffect(() => {
+		onConfirmRef.current = onConfirm;
+	}, [onConfirm]);
+
 	useEffect(() => {
 		if (!open || !canConfirm) return;
 
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (!shouldConfirmDeleteDialogKey(event)) return;
 			event.preventDefault();
-			onConfirm();
+			onConfirmRef.current();
 		};
 
 		// Arm after the current task: the Enter that selected "Delete" in a
@@ -66,7 +73,7 @@ export function DestroyConfirmPane({
 			clearTimeout(timer);
 			window.removeEventListener("keydown", handleKeyDown);
 		};
-	}, [canConfirm, onConfirm, open]);
+	}, [canConfirm, open]);
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -55,8 +55,17 @@ export function DestroyConfirmPane({
 			onConfirm();
 		};
 
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
+		// Arm after the current task: the Enter that selected "Delete" in a
+		// context menu is still bubbling when this pane mounts, and a listener
+		// added now would confirm the delete on that same keystroke.
+		const timer = setTimeout(
+			() => window.addEventListener("keydown", handleKeyDown),
+			0,
+		);
+		return () => {
+			clearTimeout(timer);
+			window.removeEventListener("keydown", handleKeyDown);
+		};
 	}, [canConfirm, onConfirm, open]);
 
 	return (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.test.ts
@@ -14,6 +14,12 @@ describe("shouldConfirmDeleteDialogKey", () => {
 		expect(shouldConfirmDeleteDialogKey(plainEnter)).toBe(true);
 	});
 
+	test("rejects a held (auto-repeating) Enter", () => {
+		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, repeat: true })).toBe(
+			false,
+		);
+	});
+
 	test("rejects modified Enter", () => {
 		expect(shouldConfirmDeleteDialogKey({ ...plainEnter, metaKey: true })).toBe(
 			false,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/utils/shouldConfirmDeleteDialogKey.ts
@@ -5,13 +5,15 @@ interface ConfirmDeleteDialogKeyEvent {
 	ctrlKey: boolean;
 	altKey: boolean;
 	isComposing?: boolean;
+	/** A held key must not confirm a destructive dialog. */
+	repeat?: boolean;
 	keyCode?: number;
 }
 
 export function shouldConfirmDeleteDialogKey(
 	event: ConfirmDeleteDialogKeyEvent,
 ): boolean {
-	if (event.isComposing || event.keyCode === 229) return false;
+	if (event.isComposing || event.keyCode === 229 || event.repeat) return false;
 	return (
 		event.key === "Enter" &&
 		!event.shiftKey &&


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/7125 (regression report in the comments)

## Summary
- Selecting **Delete** in a sidebar workspace context menu with Enter deleted the workspace with no confirmation dialog. It now shows the dialog like a mouse click does.
- A held (auto-repeating) Enter can no longer confirm the delete dialog.

## Why / Context
A user on #7125 reported that right-click → Delete now skips the confirmation. Reproduced over CDP in the dev app: the mouse path is fine, but picking the menu item with Enter destroys the workspace immediately. Not new in 1.26.0; the listener has been there since #4673, so the reporter most likely hit it via keyboard or key repeat. There is no "skip confirmation" setting for workspace deletes.

## How It Works
`DestroyConfirmPane` adds a window-level `keydown` listener (Enter → confirm) in an effect. React flushes that effect synchronously inside the discrete keydown, so the same Enter that selected the Radix menu item kept bubbling to `window` and confirmed the destroy before the dialog was ever painted.

- Arm the listener in a `setTimeout(0)`: a keydown dispatch is synchronous, so the opening keystroke can never reach it. Enter-to-confirm afterwards is unchanged.
- `shouldConfirmDeleteDialogKey` rejects `event.repeat`.

Scoping the listener to the dialog content (`onKeyDown` on `AlertDialogContent`) was tried first and rejected: after the context menu closes, Radix returns focus outside the dialog, so Enter stopped confirming at all in the real app. `TeardownFailedPane` is untouched; it only reopens asynchronously after a failed destroy, so no keystroke can be shared.

## Manual QA Checklist
All run in the dev desktop app over CDP against a throwaway workspace, screenshots captured:

- [x] Before fix: right-click row → ArrowUp → Enter on "Delete" → workspace deleted, no dialog (reproduced)
- [x] After fix: same keystrokes → dialog appears, workspace still present
- [x] After fix: second Enter → "Deleting…" toast, workspace removed
- [x] Mouse: right-click → click Delete → dialog → click Delete button → deleted
- [x] ⌘⇧⌫ on the active workspace → dialog → Enter → deleted

## Testing
- `bun run typecheck` (desktop)
- `bunx biome check` on the dialog directory
- `bun test .../DashboardSidebarDeleteDialog` — new `DestroyConfirmPane.test.tsx` drives the real ContextMenu → Enter → dialog journey in happy-dom and fails on main; `shouldConfirmDeleteDialogKey.test.ts` covers the repeat guard

https://claude.ai/code/session_01BUrNtfFgDWeaeBDpjYp4AL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop workspace delete flow so selecting "Delete" in the sidebar context menu with Enter opens the confirmation dialog instead of deleting immediately. A held (auto-repeating) Enter can no longer confirm the destructive dialog.

**Bug Fixes**
- The Enter-to-confirm listener is armed after the opening keystroke finishes dispatching, so the same Enter that selected the menu item can't confirm the dialog.
- The listener stays armed while the dialog is open, so re-renders (checkbox toggle, warning banner) don't briefly drop Enter-to-confirm.
- `shouldConfirmDeleteDialogKey` now rejects repeated keydown events.
- Added a happy-dom test covering the menu → Enter → dialog journey and a unit test for the repeat guard.

<sup>Written for commit 89a10fc358f9ca9847290d1855005cba0ab4cc48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the Enter key used to open the delete confirmation dialog from immediately confirming the deletion.
  * Repeated or held Enter key events no longer trigger unintended deletion confirmations.
  * Delete confirmation remains reliable after dialog content changes, such as toggling options or displaying warnings.
  * Existing confirmation behavior remains available when Enter is pressed intentionally afterward.

* **Tests**
  * Added coverage for keyboard-triggered delete dialogs, repeated Enter key events, and confirmation behavior after dialog updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->