### PR TITLE
fix(host-service): keep workspace tags to the user who applied them

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -3,6 +3,7 @@ import { useParams } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useKnownHosts } from "renderer/hooks/known-hosts/useKnownHosts";
 import { useRelayUrl } from "renderer/hooks/useRelayUrl";
+import { authClient } from "renderer/lib/auth-client";
 import { getHostEventBus } from "renderer/lib/host-event-bus";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
@@ -236,6 +237,8 @@ export function useHostWorkspacesSource(
 	});
 
 	const busEverOpenedRef = useRef<Set<string>>(new Set());
+	const { data: session } = authClient.useSession();
+	const currentUserId = session?.user?.id ?? null;
 
 	// Live updates: each reachable host's workspace:changed patches its own
 	// cached list without a refetch.
@@ -263,6 +266,7 @@ export function useHostWorkspacesSource(
 									machineId: target.machineId,
 								},
 								workspaceId,
+								currentUserId,
 							);
 							if (next && next !== rows) {
 								saveHostWorkspacesSnapshot(
@@ -324,7 +328,7 @@ export function useHostWorkspacesSource(
 		return () => {
 			for (const cleanup of cleanups) cleanup();
 		};
-	}, [targets, queryClient, includeArchived]);
+	}, [targets, queryClient, includeArchived, currentUserId]);
 
 	const workspaces = useMemo(() => {
 		const merged = mergeHostWorkspaces({

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -240,6 +240,20 @@ export function useHostWorkspacesSource(
 	const { data: session } = authClient.useSession();
 	const currentUserId = session?.user?.id ?? null;
 
+	// Served rows are scoped to whoever asked (tags are personal), so rows
+	// fetched before the session resolved, or by the previous account, are
+	// not this user's view: refetch every host once the user is known.
+	const targetsRef = useRef(targets);
+	targetsRef.current = targets;
+	useEffect(() => {
+		if (currentUserId === null) return;
+		for (const target of targetsRef.current) {
+			void queryClient.invalidateQueries({
+				queryKey: getHostWorkspacesQueryKey(target),
+			});
+		}
+	}, [currentUserId, queryClient]);
+
 	// Live updates: each reachable host's workspace:changed patches its own
 	// cached list without a refetch.
 	//

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
@@ -150,6 +150,40 @@ describe("applyWorkspaceChangedEvent tags", () => {
 		expect(rows?.[0]?.tags).toEqual(["legacy", "mine"]);
 	});
 
+	it("shows nobody's tags while the session is unresolved", () => {
+		const initial = applyWorkspaceChangedEvent(
+			undefined,
+			{
+				eventType: "created",
+				workspace: makeSnapshot({
+					id: "w1",
+					tags: ["theirs"],
+					tagAssignments: [{ tag: "theirs", createdByUserId: "user-b" }],
+				}),
+			},
+			HOST,
+			"w1",
+			null,
+		);
+		expect(initial?.[0]?.tags).toEqual([]);
+		const cached = initial?.map((row) => ({ ...row, tags: ["cached"] }));
+		const updated = applyWorkspaceChangedEvent(
+			cached,
+			{
+				eventType: "updated",
+				workspace: makeSnapshot({
+					id: "w1",
+					tags: ["theirs"],
+					tagAssignments: [{ tag: "theirs", createdByUserId: "user-b" }],
+				}),
+			},
+			HOST,
+			"w1",
+			null,
+		);
+		expect(updated?.[0]?.tags).toEqual(["cached"]);
+	});
+
 	it("falls back to the union from a host that predates tag creators", () => {
 		const rows = applyWorkspaceChangedEvent(
 			undefined,

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.test.ts
@@ -51,6 +51,7 @@ describe("applyWorkspaceChangedEvent lastActivityAt", () => {
 			{ eventType: "created", workspace: makeSnapshot({ id: "w1" }) },
 			HOST,
 			"w1",
+			null,
 		);
 		expect(rows?.[0]?.lastActivityAt).toBe(1_700_000_050_000);
 	});
@@ -61,6 +62,7 @@ describe("applyWorkspaceChangedEvent lastActivityAt", () => {
 			{ eventType: "created", workspace: makeSnapshot({ id: "w1" }) },
 			HOST,
 			"w1",
+			null,
 		);
 		const updated = applyWorkspaceChangedEvent(
 			initial,
@@ -73,6 +75,7 @@ describe("applyWorkspaceChangedEvent lastActivityAt", () => {
 			},
 			HOST,
 			"w1",
+			null,
 		);
 		expect(updated?.[0]?.lastActivityAt).toBe(1_700_000_999_000);
 	});
@@ -92,6 +95,7 @@ describe("applyWorkspaceChangedEvent lastActivityAt", () => {
 			},
 			HOST,
 			"w1",
+			null,
 		);
 		expect(rows?.[0]?.lastActivityAt).toBeNull();
 	});
@@ -102,6 +106,7 @@ describe("applyWorkspaceChangedEvent lastActivityAt", () => {
 			{ eventType: "created", workspace: makeSnapshot({ id: "w1" }) },
 			HOST,
 			"w1",
+			null,
 		);
 		const legacy = makeSnapshot({ id: "w1" }) as unknown as Record<
 			string,
@@ -116,8 +121,47 @@ describe("applyWorkspaceChangedEvent lastActivityAt", () => {
 			},
 			HOST,
 			"w1",
+			null,
 		);
 		expect(updated?.[0]?.lastActivityAt).toBe(1_700_000_050_000);
+	});
+});
+
+describe("applyWorkspaceChangedEvent tags", () => {
+	it("keeps only the viewer's own and creator-less tags", () => {
+		const rows = applyWorkspaceChangedEvent(
+			undefined,
+			{
+				eventType: "created",
+				workspace: makeSnapshot({
+					id: "w1",
+					tags: ["legacy", "mine", "theirs"],
+					tagAssignments: [
+						{ tag: "theirs", createdByUserId: "user-b" },
+						{ tag: "mine", createdByUserId: "user-a" },
+						{ tag: "legacy", createdByUserId: null },
+					],
+				}),
+			},
+			HOST,
+			"w1",
+			"user-a",
+		);
+		expect(rows?.[0]?.tags).toEqual(["legacy", "mine"]);
+	});
+
+	it("falls back to the union from a host that predates tag creators", () => {
+		const rows = applyWorkspaceChangedEvent(
+			undefined,
+			{
+				eventType: "created",
+				workspace: makeSnapshot({ id: "w1", tags: ["shared"] }),
+			},
+			HOST,
+			"w1",
+			"user-a",
+		);
+		expect(rows?.[0]?.tags).toEqual(["shared"]);
 	});
 });
 
@@ -128,6 +172,7 @@ describe("toHostWorkspaceItem", () => {
 			{ eventType: "created", workspace: makeSnapshot({ id: "w1" }) },
 			HOST,
 			"w1",
+			null,
 		) ?? [];
 	if (!row) throw new Error("expected a row");
 

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -1,5 +1,6 @@
 import type { SelectV2Workspace } from "@superset/db/schema";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
+import { visibleWorkspaceTags } from "@superset/shared/workspace-tags";
 import type {
 	HostConnectionState,
 	WorkspaceSnapshotPayload,
@@ -216,6 +217,10 @@ export function isEventBusReopen(
 /**
  * Apply a workspace:changed event to a host's cached list. Created/updated
  * upsert from the event's snapshot payload; deleted removes the row.
+ *
+ * The host broadcasts one snapshot to every client, so it carries every
+ * user's tags with their creators; `viewerUserId` keeps this client's own,
+ * matching what `workspace.list` already served it.
  */
 export function applyWorkspaceChangedEvent(
 	rows: HostWorkspaceRow[] | undefined,
@@ -225,6 +230,7 @@ export function applyWorkspaceChangedEvent(
 	},
 	host: { organizationId: string; machineId: string },
 	workspaceId: string,
+	viewerUserId: string | null,
 ): HostWorkspaceRow[] | undefined {
 	if (event.eventType === "deleted") {
 		if (!rows) return rows;
@@ -246,7 +252,11 @@ export function applyWorkspaceChangedEvent(
 		taskId: snapshot.taskId,
 		// Runtime-optional despite the payload type: an older host's events
 		// carry no tags — keep the row's last known set rather than wiping it.
-		tags: snapshot.tags ?? existing?.tags,
+		// A host that predates tag creators sends only the union and can't
+		// tell whose is whose; show it as before rather than nothing.
+		tags: snapshot.tagAssignments
+			? visibleWorkspaceTags(snapshot.tagAssignments, viewerUserId)
+			: (snapshot.tags ?? existing?.tags),
 		createdAt: new Date(snapshot.createdAt),
 		updatedAt: new Date(snapshot.updatedAt),
 		// Same runtime-optionality as tags: an older host's events omit it, so

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.utils.ts
@@ -230,6 +230,7 @@ export function applyWorkspaceChangedEvent(
 	},
 	host: { organizationId: string; machineId: string },
 	workspaceId: string,
+	/** Null while the session is unresolved — not "no identity". */
 	viewerUserId: string | null,
 ): HostWorkspaceRow[] | undefined {
 	if (event.eventType === "deleted") {
@@ -255,7 +256,11 @@ export function applyWorkspaceChangedEvent(
 		// A host that predates tag creators sends only the union and can't
 		// tell whose is whose; show it as before rather than nothing.
 		tags: snapshot.tagAssignments
-			? visibleWorkspaceTags(snapshot.tagAssignments, viewerUserId)
+			? viewerUserId === null
+				? // The session hasn't resolved yet: nobody's tags are ours to
+					// show (or persist), so keep what the row already had.
+					(existing?.tags ?? [])
+				: visibleWorkspaceTags(snapshot.tagAssignments, viewerUserId)
 			: (snapshot.tags ?? existing?.tags),
 		createdAt: new Date(snapshot.createdAt),
 		updatedAt: new Date(snapshot.updatedAt),

--- a/packages/host-service/drizzle/0031_workspace_tag_creator.sql
+++ b/packages/host-service/drizzle/0031_workspace_tag_creator.sql
@@ -1,0 +1,15 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_workspace_tags` (
+	`workspace_id` text NOT NULL,
+	`tag` text NOT NULL,
+	`created_by_user_id` text DEFAULT '' NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`workspace_id`, `tag`, `created_by_user_id`),
+	FOREIGN KEY (`workspace_id`) REFERENCES `workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_workspace_tags`("workspace_id", "tag", "created_by_user_id", "created_at") SELECT `workspace_tags`.`workspace_id`, `workspace_tags`.`tag`, COALESCE(`workspaces`.`created_by_user_id`, ''), `workspace_tags`.`created_at` FROM `workspace_tags` LEFT JOIN `workspaces` ON `workspaces`.`id` = `workspace_tags`.`workspace_id`;--> statement-breakpoint
+DROP TABLE `workspace_tags`;--> statement-breakpoint
+ALTER TABLE `__new_workspace_tags` RENAME TO `workspace_tags`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `workspace_tags_tag_idx` ON `workspace_tags` (`tag`);

--- a/packages/host-service/drizzle/0032_tag_folder_creator.sql
+++ b/packages/host-service/drizzle/0032_tag_folder_creator.sql
@@ -1,0 +1,16 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_tag_folder_settings` (
+	`scope` text NOT NULL,
+	`tag` text NOT NULL,
+	`created_by_user_id` text DEFAULT '' NOT NULL,
+	`display_name` text,
+	`color` text,
+	`tab_order` integer,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope`, `tag`, `created_by_user_id`)
+);
+--> statement-breakpoint
+INSERT INTO `__new_tag_folder_settings`("scope", "tag", "created_by_user_id", "display_name", "color", "tab_order", "updated_at") SELECT "scope", "tag", '', "display_name", "color", "tab_order", "updated_at" FROM `tag_folder_settings`;--> statement-breakpoint
+DROP TABLE `tag_folder_settings`;--> statement-breakpoint
+ALTER TABLE `__new_tag_folder_settings` RENAME TO `tag_folder_settings`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/host-service/drizzle/meta/0031_snapshot.json
+++ b/packages/host-service/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,1146 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ca40890b-48df-49e8-9796-5fe9c9b1ac41",
+  "prevId": "92bd0761-7bf4-4725-a1a6-59ca19dbc9e7",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fork_args_json": {
+          "name": "fork_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_claude_config_dir": {
+          "name": "default_claude_config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_codex_home": {
+          "name": "default_codex_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_folder_settings": {
+      "name": "tag_folder_settings",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tag_folder_settings_scope_tag_pk": {
+          "columns": [
+            "scope",
+            "tag"
+          ],
+          "name": "tag_folder_settings_scope_tag_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_pull_requests": {
+      "name": "workspace_pull_requests",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_pull_requests_workspace_idx": {
+          "name": "workspace_pull_requests_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_pull_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspace_pull_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_pull_requests_pull_request_id_pull_requests_id_fk": {
+          "name": "workspace_pull_requests_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_pull_requests_workspace_id_pull_request_id_pk": {
+          "columns": [
+            "workspace_id",
+            "pull_request_id"
+          ],
+          "name": "workspace_pull_requests_workspace_id_pull_request_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_tags": {
+      "name": "workspace_tags",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_tags_tag_idx": {
+          "name": "workspace_tags_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_tags_workspace_id_workspaces_id_fk": {
+          "name": "workspace_tags_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_tags",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_tags_workspace_id_tag_created_by_user_id_pk": {
+          "columns": [
+            "workspace_id",
+            "tag",
+            "created_by_user_id"
+          ],
+          "name": "workspace_tags_workspace_id_tag_created_by_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/0032_snapshot.json
+++ b/packages/host-service/drizzle/meta/0032_snapshot.json
@@ -1,0 +1,1155 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "778f78c8-eda2-4b7f-878c-adff2ffbd570",
+  "prevId": "ca40890b-48df-49e8-9796-5fe9c9b1ac41",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fork_args_json": {
+          "name": "fork_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_claude_config_dir": {
+          "name": "default_claude_config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_codex_home": {
+          "name": "default_codex_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_folder_settings": {
+      "name": "tag_folder_settings",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tag_folder_settings_scope_tag_created_by_user_id_pk": {
+          "columns": [
+            "scope",
+            "tag",
+            "created_by_user_id"
+          ],
+          "name": "tag_folder_settings_scope_tag_created_by_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_pull_requests": {
+      "name": "workspace_pull_requests",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_pull_requests_workspace_idx": {
+          "name": "workspace_pull_requests_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_pull_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspace_pull_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_pull_requests_pull_request_id_pull_requests_id_fk": {
+          "name": "workspace_pull_requests_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_pull_requests_workspace_id_pull_request_id_pk": {
+          "columns": [
+            "workspace_id",
+            "pull_request_id"
+          ],
+          "name": "workspace_pull_requests_workspace_id_pull_request_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_tags": {
+      "name": "workspace_tags",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_tags_tag_idx": {
+          "name": "workspace_tags_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_tags_workspace_id_workspaces_id_fk": {
+          "name": "workspace_tags_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_tags",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_tags_workspace_id_tag_created_by_user_id_pk": {
+          "columns": [
+            "workspace_id",
+            "tag",
+            "created_by_user_id"
+          ],
+          "name": "workspace_tags_workspace_id_tag_created_by_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1788418423316,
       "tag": "0030_workspace_last_activity_at",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1788577712009,
+      "tag": "0031_workspace_tag_creator",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1788577712009,
       "tag": "0031_workspace_tag_creator",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1788629868602,
+      "tag": "0032_tag_folder_creator",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -298,6 +298,11 @@ export const tagFolderSettings = sqliteTable(
 	{
 		scope: text().notNull(),
 		tag: text().notNull(),
+		// A folder is personal like the tags it derives from (see
+		// `workspaceTags`): keyed per user so renaming yours never renames a
+		// teammate's folder of the same tag. Same NOT NULL / empty-string
+		// convention: '' = customised before folders had an owner.
+		createdByUserId: text("created_by_user_id").notNull().default(""),
 		displayName: text("display_name"),
 		color: text(),
 		tabOrder: integer("tab_order"),
@@ -305,7 +310,11 @@ export const tagFolderSettings = sqliteTable(
 			.notNull()
 			.$defaultFn(() => Date.now()),
 	},
-	(table) => [primaryKey({ columns: [table.scope, table.tag] })],
+	(table) => [
+		primaryKey({
+			columns: [table.scope, table.tag, table.createdByUserId],
+		}),
+	],
 );
 
 /**

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -313,6 +313,14 @@ export const tagFolderSettings = sqliteTable(
  * stored already-normalized (trimmed + lowercased, see
  * `@superset/shared/workspace-tags`); sidebar folders derive from these
  * rows, so any actor that can tag a workspace can file it.
+ *
+ * A tag belongs to whoever applied it: on a shared host, every user files
+ * the same workspaces into their own folders, and one user's grouping must
+ * not appear in another's sidebar. `created_by_user_id` is part of the key
+ * so two users can each carry the same tag on one workspace. It is NOT NULL
+ * because SQLite treats NULLs inside a primary key as distinct, which would
+ * let duplicate rows through; the empty string is the "creator unknown"
+ * value for rows written by callers that carry no user (visible to all).
  */
 export const workspaceTags = sqliteTable(
 	"workspace_tags",
@@ -321,12 +329,15 @@ export const workspaceTags = sqliteTable(
 			.notNull()
 			.references(() => workspaces.id, { onDelete: "cascade" }),
 		tag: text().notNull(),
+		createdByUserId: text("created_by_user_id").notNull().default(""),
 		createdAt: integer("created_at")
 			.notNull()
 			.$defaultFn(() => Date.now()),
 	},
 	(table) => [
-		primaryKey({ columns: [table.workspaceId, table.tag] }),
+		primaryKey({
+			columns: [table.workspaceId, table.tag, table.createdByUserId],
+		}),
 		index("workspace_tags_tag_idx").on(table.tag),
 	],
 );

--- a/packages/host-service/src/events/types.ts
+++ b/packages/host-service/src/events/types.ts
@@ -1,5 +1,6 @@
 import type { DetectedPort } from "@superset/port-scanner";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
+import type { WorkspaceTagAssignment } from "@superset/shared/workspace-tags";
 import type { FsWatchEvent } from "@superset/workspace-fs/host";
 import type { AgentLifecycleEventType } from "./map-event-type.ts";
 
@@ -88,8 +89,18 @@ export interface WorkspaceSnapshot {
 	 * writes (rename, tags, PR link).
 	 */
 	lastActivityAt: number | null;
-	/** Normalized, sorted tag set; sidebar folders derive from it. */
+	/**
+	 * Every tag on the workspace, normalized and sorted, whoever applied it.
+	 * Consumers that know who they are read `tagAssignments` instead.
+	 */
 	tags: string[];
+	/**
+	 * Each tag with the user who applied it. Tags are personal (see
+	 * `isWorkspaceTagVisibleTo`): a client keeps the ones it can see and
+	 * derives its sidebar folders from those. Absent from hosts that predate
+	 * the field.
+	 */
+	tagAssignments?: WorkspaceTagAssignment[];
 }
 
 export interface WorkspaceChangedMessage {

--- a/packages/host-service/src/tag-folders/tag-folder-store.test.ts
+++ b/packages/host-service/src/tag-folders/tag-folder-store.test.ts
@@ -11,6 +11,7 @@ import type { EventBus } from "../events";
 import type { TagFoldersChangedMessage } from "../events/types";
 import {
 	deleteTagFolderSetting,
+	getAllTagFolderSettings,
 	getTagFolderSettings,
 	hasTagFolderScope,
 	upsertTagFolderSetting,
@@ -69,7 +70,7 @@ describe("tag folder settings store", () => {
 				color: "#ff0000",
 			},
 		);
-		expect(getTagFolderSettings(h.db, PROJECT)).toEqual([
+		expect(getTagFolderSettings(h.db, PROJECT, null)).toEqual([
 			{
 				tag: "perf",
 				displayName: "Perf Work",
@@ -114,7 +115,7 @@ describe("tag folder settings store", () => {
 		);
 		deleteTagFolderSetting({ db: h.db, eventBus: h.eventBus }, PROJECT, "perf");
 		deleteTagFolderSetting({ db: h.db, eventBus: h.eventBus }, PROJECT, "perf");
-		expect(getTagFolderSettings(h.db, PROJECT)).toEqual([]);
+		expect(getTagFolderSettings(h.db, PROJECT, null)).toEqual([]);
 	});
 
 	it("rejects a tag that cannot be normalized", () => {
@@ -141,7 +142,7 @@ describe("tag folder settings store", () => {
 			"backend",
 			{ color: "#00ff00", displayName: "Backend" },
 		);
-		expect(getTagFolderSettings(h.db, SESSIONS_TAG_SCOPE)).toEqual([
+		expect(getTagFolderSettings(h.db, SESSIONS_TAG_SCOPE, null)).toEqual([
 			{
 				tag: "backend",
 				displayName: "Backend",
@@ -162,9 +163,93 @@ describe("tag folder settings store", () => {
 			"api",
 			{ color: "#0000ff" },
 		);
-		expect(getTagFolderSettings(h.db, PROJECT)[0]?.color).toBe("#ff0000");
-		expect(getTagFolderSettings(h.db, SESSIONS_TAG_SCOPE)[0]?.color).toBe(
+		expect(getTagFolderSettings(h.db, PROJECT, null)[0]?.color).toBe("#ff0000");
+		expect(getTagFolderSettings(h.db, SESSIONS_TAG_SCOPE, null)[0]?.color).toBe(
 			"#0000ff",
 		);
+	});
+
+	describe("per-user folders", () => {
+		const me = { userId: "user-a" };
+		const them = { userId: "user-b" };
+
+		it("a customised folder is the customiser's own", () => {
+			const h = createHarness();
+			upsertTagFolderSetting(
+				{ db: h.db, eventBus: h.eventBus, ...me },
+				PROJECT,
+				"perf",
+				{ displayName: "Performance" },
+			);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-a")).toEqual([
+				{
+					tag: "perf",
+					displayName: "Performance",
+					color: null,
+					tabOrder: null,
+				},
+			]);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-b")).toEqual([]);
+			expect(getAllTagFolderSettings(h.db, "user-b")).toEqual([]);
+		});
+
+		it("two users customise the same folder independently", () => {
+			const h = createHarness();
+			upsertTagFolderSetting(
+				{ db: h.db, eventBus: h.eventBus, ...me },
+				PROJECT,
+				"perf",
+				{ color: "#ff0000" },
+			);
+			upsertTagFolderSetting(
+				{ db: h.db, eventBus: h.eventBus, ...them },
+				PROJECT,
+				"perf",
+				{ color: "#0000ff" },
+			);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-a")[0]?.color).toBe(
+				"#ff0000",
+			);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-b")[0]?.color).toBe(
+				"#0000ff",
+			);
+			deleteTagFolderSetting(
+				{ db: h.db, eventBus: h.eventBus, ...me },
+				PROJECT,
+				"perf",
+			);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-a")).toEqual([]);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-b")[0]?.color).toBe(
+				"#0000ff",
+			);
+		});
+
+		it("a legacy row is visible to everyone until someone claims it", () => {
+			const h = createHarness();
+			// Written before folders had owners (no acting user).
+			upsertTagFolderSetting(
+				{ db: h.db, eventBus: h.eventBus },
+				PROJECT,
+				"perf",
+				{ displayName: "Legacy", color: "#00ff00" },
+			);
+			expect(
+				getTagFolderSettings(h.db, PROJECT, "user-b")[0]?.displayName,
+			).toBe("Legacy");
+			upsertTagFolderSetting(
+				{ db: h.db, eventBus: h.eventBus, ...me },
+				PROJECT,
+				"perf",
+				{ displayName: "Mine" },
+			);
+			// The claim keeps what the patch didn't touch and leaves one row.
+			expect(getTagFolderSettings(h.db, PROJECT, "user-a")).toEqual([
+				{ tag: "perf", displayName: "Mine", color: "#00ff00", tabOrder: null },
+			]);
+			expect(getTagFolderSettings(h.db, PROJECT, "user-b")).toEqual([]);
+			expect(h.db.select().from(schema.tagFolderSettings).all()).toHaveLength(
+				1,
+			);
+		});
 	});
 });

--- a/packages/host-service/src/tag-folders/tag-folder-store.ts
+++ b/packages/host-service/src/tag-folders/tag-folder-store.ts
@@ -1,8 +1,9 @@
 import {
+	isWorkspaceTagVisibleTo,
 	normalizeWorkspaceTag,
 	SESSIONS_TAG_SCOPE,
 } from "@superset/shared/workspace-tags";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../db";
 import { projects, tagFolderSettings } from "../db/schema";
 import type { EventBus } from "../events";
@@ -14,12 +15,60 @@ import type {
 export interface TagFolderStoreContext {
 	db: HostDb;
 	eventBus: EventBus;
+	/** The acting user: folders they customise are theirs. */
+	userId?: string;
 }
 
 export interface UpsertTagSettingPatch {
 	displayName?: string | null;
 	color?: string | null;
 	tabOrder?: number | null;
+}
+
+/**
+ * Stored creator for a folder customised before folders had an owner (the
+ * column is NOT NULL so it can sit in the primary key). Visible to everyone
+ * until someone customises the folder again, which claims the row.
+ */
+const UNKNOWN_FOLDER_CREATOR = "";
+
+function toStoredCreator(userId: string | null | undefined): string {
+	return userId ?? UNKNOWN_FOLDER_CREATOR;
+}
+
+function fromStoredCreator(stored: string): string | null {
+	return stored === UNKNOWN_FOLDER_CREATOR ? null : stored;
+}
+
+type TagFolderSettingRow = typeof tagFolderSettings.$inferSelect;
+
+/**
+ * The rows `viewerUserId` sees, one per (scope, tag): their own row wins
+ * over a creator-less one for the same folder. A viewer with no identity
+ * sees everything, so an older caller behaves as before.
+ */
+function visibleRows(
+	rows: TagFolderSettingRow[],
+	viewerUserId: string | null | undefined,
+): TagFolderSettingRow[] {
+	const byFolder = new Map<string, TagFolderSettingRow>();
+	for (const row of rows) {
+		const creator = fromStoredCreator(row.createdByUserId);
+		if (!isWorkspaceTagVisibleTo(creator, viewerUserId)) continue;
+		const key = `${row.scope}:${row.tag}`;
+		const isOwn = creator !== null && creator === viewerUserId;
+		if (!byFolder.has(key) || isOwn) byFolder.set(key, row);
+	}
+	return [...byFolder.values()];
+}
+
+function toSnapshot(row: TagFolderSettingRow): TagSettingSnapshot {
+	return {
+		tag: row.tag,
+		displayName: row.displayName,
+		color: row.color,
+		tabOrder: row.tabOrder,
+	};
 }
 
 /** Sessions is virtual; every other accepted scope must be a local project. */
@@ -35,23 +84,17 @@ export function hasTagFolderScope(db: HostDb, scope: string): boolean {
 }
 
 /**
- * Every folder presentation row on this host, across all scopes. The table
- * holds one row per *customised* folder, so this stays small — the renderer
- * fans it out per host rather than plumbing per-host scope lists.
+ * Every folder presentation row `viewerUserId` can see on this host, across
+ * all scopes. The table holds one row per *customised* folder, so this stays
+ * small — the renderer fans it out per host rather than plumbing per-host
+ * scope lists.
  */
 export function getAllTagFolderSettings(
 	db: HostDb,
+	viewerUserId: string | null | undefined,
 ): TagFolderSettingSnapshot[] {
-	return db
-		.select({
-			scope: tagFolderSettings.scope,
-			tag: tagFolderSettings.tag,
-			displayName: tagFolderSettings.displayName,
-			color: tagFolderSettings.color,
-			tabOrder: tagFolderSettings.tabOrder,
-		})
-		.from(tagFolderSettings)
-		.all()
+	return visibleRows(db.select().from(tagFolderSettings).all(), viewerUserId)
+		.map((row) => ({ scope: row.scope, ...toSnapshot(row) }))
 		.sort(
 			(left, right) =>
 				left.scope.localeCompare(right.scope) ||
@@ -59,29 +102,34 @@ export function getAllTagFolderSettings(
 		);
 }
 
-/** One scope's folder presentation rows, sorted by tag. */
+/** One scope's folder presentation rows as the viewer sees them, by tag. */
 export function getTagFolderSettings(
 	db: HostDb,
 	scope: string,
+	viewerUserId: string | null | undefined,
 ): TagSettingSnapshot[] {
-	return db
-		.select({
-			tag: tagFolderSettings.tag,
-			displayName: tagFolderSettings.displayName,
-			color: tagFolderSettings.color,
-			tabOrder: tagFolderSettings.tabOrder,
-		})
-		.from(tagFolderSettings)
-		.where(eq(tagFolderSettings.scope, scope))
-		.all()
+	return visibleRows(
+		db
+			.select()
+			.from(tagFolderSettings)
+			.where(eq(tagFolderSettings.scope, scope))
+			.all(),
+		viewerUserId,
+	)
+		.map(toSnapshot)
 		.sort((left, right) => left.tag.localeCompare(right.tag));
 }
 
+/**
+ * Tell connected renderers the scope changed; they refetch their own view.
+ * The payload is the actor's view — it is not per recipient, so nothing
+ * should render from it directly.
+ */
 function broadcast(
 	ctx: TagFolderStoreContext,
 	scope: string,
 ): TagSettingSnapshot[] {
-	const settings = getTagFolderSettings(ctx.db, scope);
+	const settings = getTagFolderSettings(ctx.db, scope, ctx.userId);
 	ctx.eventBus.broadcastTagFoldersChanged({
 		scope,
 		settings: settings.map((setting) => ({
@@ -94,10 +142,15 @@ function broadcast(
 }
 
 /**
- * Merge-upsert one folder's presentation and broadcast the scope to connected
- * renderers. Absent patch fields keep their stored value; a row is created on
- * first customisation (never up front). Making the label a row here is what
- * turns rename into ONE update — the tag stays the stable slug agents target.
+ * Merge-upsert one folder's presentation for the acting user and broadcast
+ * the scope to connected renderers. Absent patch fields keep their stored
+ * value; a row is created on first customisation (never up front). Making
+ * the label a row here is what turns rename into ONE update — the tag stays
+ * the stable slug agents target.
+ *
+ * A creator-less row for the folder (customised before folders had owners)
+ * is what the actor was seeing, so customising again claims it rather than
+ * leaving two rows that disagree.
  *
  * The router validates that project scopes exist before calling this store;
  * the Sessions lane is the one valid scope with no project behind it.
@@ -110,46 +163,55 @@ export function upsertTagFolderSetting(
 ): TagSettingSnapshot[] | undefined {
 	const tag = normalizeWorkspaceTag(rawTag);
 	if (tag == null) return undefined;
-	const where = and(
+	const createdByUserId = toStoredCreator(ctx.userId);
+	const ownOrUnclaimed = and(
 		eq(tagFolderSettings.scope, scope),
 		eq(tagFolderSettings.tag, tag),
+		inArray(tagFolderSettings.createdByUserId, [
+			createdByUserId,
+			UNKNOWN_FOLDER_CREATOR,
+		]),
 	);
-	const existing = ctx.db
-		.select()
-		.from(tagFolderSettings)
-		.where(where)
-		.all()[0];
-	if (existing) {
-		ctx.db
-			.update(tagFolderSettings)
-			.set({
-				displayName:
-					patch.displayName !== undefined
-						? patch.displayName
-						: existing.displayName,
-				color: patch.color !== undefined ? patch.color : existing.color,
-				tabOrder:
-					patch.tabOrder !== undefined ? patch.tabOrder : existing.tabOrder,
-				updatedAt: Date.now(),
-			})
-			.where(where)
-			.run();
-	} else {
-		ctx.db
-			.insert(tagFolderSettings)
+	ctx.db.transaction((tx) => {
+		const candidates = tx
+			.select()
+			.from(tagFolderSettings)
+			.where(ownOrUnclaimed)
+			.all();
+		const existing =
+			candidates.find((row) => row.createdByUserId === createdByUserId) ??
+			candidates[0];
+		if (candidates.length > 0) {
+			tx.delete(tagFolderSettings).where(ownOrUnclaimed).run();
+		}
+		tx.insert(tagFolderSettings)
 			.values({
 				scope,
 				tag,
-				displayName: patch.displayName ?? null,
-				color: patch.color ?? null,
-				tabOrder: patch.tabOrder ?? null,
+				createdByUserId,
+				displayName:
+					patch.displayName !== undefined
+						? patch.displayName
+						: (existing?.displayName ?? null),
+				color:
+					patch.color !== undefined ? patch.color : (existing?.color ?? null),
+				tabOrder:
+					patch.tabOrder !== undefined
+						? patch.tabOrder
+						: (existing?.tabOrder ?? null),
+				updatedAt: Date.now(),
 			})
 			.run();
-	}
+	});
 	return broadcast(ctx, scope);
 }
 
-/** Remove one folder's presentation row (folder deletion). Idempotent. */
+/**
+ * Remove the acting user's presentation row for one folder (folder
+ * deletion), along with any creator-less row they were seeing. Idempotent.
+ * Other users' rows for the same tag are theirs and stay; a caller with no
+ * identity removes every row, as before.
+ */
 export function deleteTagFolderSetting(
 	ctx: TagFolderStoreContext,
 	scope: string,
@@ -160,7 +222,16 @@ export function deleteTagFolderSetting(
 	ctx.db
 		.delete(tagFolderSettings)
 		.where(
-			and(eq(tagFolderSettings.scope, scope), eq(tagFolderSettings.tag, tag)),
+			and(
+				eq(tagFolderSettings.scope, scope),
+				eq(tagFolderSettings.tag, tag),
+				ctx.userId == null
+					? undefined
+					: inArray(tagFolderSettings.createdByUserId, [
+							ctx.userId,
+							UNKNOWN_FOLDER_CREATOR,
+						]),
+			),
 		)
 		.run();
 	return broadcast(ctx, scope);

--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -71,7 +71,10 @@ export interface FindByPathCandidate {
 export const projectRouter = router({
 	list: protectedProcedure.query(({ ctx }) => {
 		const tagSettingsByProject = new Map<string, TagSettingSnapshot[]>();
-		for (const { scope, ...setting } of getAllTagFolderSettings(ctx.db)) {
+		for (const { scope, ...setting } of getAllTagFolderSettings(
+			ctx.db,
+			ctx.userId,
+		)) {
 			const settings = tagSettingsByProject.get(scope) ?? [];
 			settings.push(setting);
 			tagSettingsByProject.set(scope, settings);
@@ -143,7 +146,7 @@ export const projectRouter = router({
 				});
 			}
 			const settings = upsertTagFolderSetting(
-				{ db: ctx.db, eventBus: ctx.eventBus },
+				{ db: ctx.db, eventBus: ctx.eventBus, userId: ctx.userId },
 				input.projectId,
 				input.tag,
 				{
@@ -177,7 +180,7 @@ export const projectRouter = router({
 				});
 			}
 			const settings = deleteTagFolderSetting(
-				{ db: ctx.db, eventBus: ctx.eventBus },
+				{ db: ctx.db, eventBus: ctx.eventBus, userId: ctx.userId },
 				input.projectId,
 				input.tag,
 			);

--- a/packages/host-service/src/trpc/router/tag-folders/tag-folders.ts
+++ b/packages/host-service/src/trpc/router/tag-folders/tag-folders.ts
@@ -29,7 +29,10 @@ function assertScopeExists(
  * because the Sessions lane has no project to scope them to.
  */
 export const tagFoldersRouter = router({
-	list: protectedProcedure.query(({ ctx }) => getAllTagFolderSettings(ctx.db)),
+	/** The caller's own folders, plus any customised before folders had owners. */
+	list: protectedProcedure.query(({ ctx }) =>
+		getAllTagFolderSettings(ctx.db, ctx.userId),
+	),
 
 	/** Merge-upsert one folder's presentation. Creates the row on first use. */
 	upsert: protectedProcedure
@@ -45,7 +48,7 @@ export const tagFoldersRouter = router({
 		.mutation(({ ctx, input }) => {
 			assertScopeExists(ctx.db, input.scope);
 			const settings = upsertTagFolderSetting(
-				{ db: ctx.db, eventBus: ctx.eventBus },
+				{ db: ctx.db, eventBus: ctx.eventBus, userId: ctx.userId },
 				input.scope,
 				input.tag,
 				{
@@ -76,7 +79,7 @@ export const tagFoldersRouter = router({
 		.mutation(({ ctx, input }) => {
 			assertScopeExists(ctx.db, input.scope);
 			const settings = deleteTagFolderSetting(
-				{ db: ctx.db, eventBus: ctx.eventBus },
+				{ db: ctx.db, eventBus: ctx.eventBus, userId: ctx.userId },
 				input.scope,
 				input.tag,
 			);

--- a/packages/host-service/src/trpc/router/workspace-creation/shared/adopt-existing-worktree.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/shared/adopt-existing-worktree.ts
@@ -80,6 +80,7 @@ export async function adoptExistingWorktree(
 		api: ctx.api,
 		organizationId: ctx.organizationId,
 		clientMachineId: ctx.clientMachineId,
+		userId: ctx.userId,
 	};
 
 	if (existingWorkspaceId) {

--- a/packages/host-service/src/trpc/router/workspace/workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace/workspace.ts
@@ -67,9 +67,12 @@ export const workspaceRouter = router({
 						project.name || basename(project.repoPath),
 					]),
 			);
+			// Tags are the caller's own: on a shared host each user files the
+			// same workspaces into their own folders.
 			const tagsByWorkspaceId = getWorkspaceTagsByWorkspaceId(
 				ctx.db,
 				rows.map((row) => row.id),
+				ctx.userId,
 			);
 			return rows.map((row) => ({
 				...toCloudShape(row, ctx.organizationId),
@@ -135,11 +138,11 @@ export const workspaceRouter = router({
 			if (Object.keys(patch).length === 0) {
 				return {
 					...toCloudShape(current, ctx.organizationId),
-					tags: getWorkspaceTags(ctx.db, current.id),
+					tags: getWorkspaceTags(ctx.db, current.id, ctx.userId),
 				};
 			}
 			const updated = updateLocalWorkspace(
-				{ db: ctx.db, eventBus: ctx.eventBus },
+				{ db: ctx.db, eventBus: ctx.eventBus, userId: ctx.userId },
 				input.id,
 				patch,
 			);
@@ -162,7 +165,7 @@ export const workspaceRouter = router({
 			}
 			return {
 				...toCloudShape(updated, ctx.organizationId),
-				tags: getWorkspaceTags(ctx.db, updated.id),
+				tags: getWorkspaceTags(ctx.db, updated.id, ctx.userId),
 			};
 		}),
 

--- a/packages/host-service/src/workspaces/local-workspace-store.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.ts
@@ -268,7 +268,11 @@ export function insertLocalWorkspace(
 			})
 			.run();
 		if (tags.length > 0) {
-			const createdByUserId = toStoredTagCreator(values.createdByUserId);
+			// Adoption paths don't stamp the row's creator, but the tags are
+			// still the acting user's — never let them fall through as public.
+			const createdByUserId = toStoredTagCreator(
+				values.createdByUserId ?? ctx.userId,
+			);
 			tx.insert(workspaceTags)
 				.values(
 					tags.map((tag) => ({

--- a/packages/host-service/src/workspaces/local-workspace-store.ts
+++ b/packages/host-service/src/workspaces/local-workspace-store.ts
@@ -3,8 +3,13 @@ import hostServicePackageJson from "@superset/host-service/package.json" with {
 	type: "json",
 };
 import { getHostId } from "@superset/shared/host-info";
-import { normalizeWorkspaceTags } from "@superset/shared/workspace-tags";
-import { eq, inArray } from "drizzle-orm";
+import {
+	isWorkspaceTagVisibleTo,
+	normalizeWorkspaceTags,
+	visibleWorkspaceTags,
+	type WorkspaceTagAssignment,
+} from "@superset/shared/workspace-tags";
+import { and, eq, inArray } from "drizzle-orm";
 import type { HostDb } from "../db";
 import { workspaces, workspaceTags } from "../db/schema";
 import type { EventBus } from "../events";
@@ -24,6 +29,23 @@ export interface WorkspaceStoreContext {
 	api?: ApiClient;
 	organizationId?: string;
 	clientMachineId?: string;
+	/** The acting user; tags they write are theirs (see `workspaceTags`). */
+	userId?: string;
+}
+
+/**
+ * Stored value for a tag whose creator is unknown (`workspaceTags` keeps the
+ * column NOT NULL so it can sit in the primary key). Never leaves the store:
+ * assignments surface it as null.
+ */
+const UNKNOWN_TAG_CREATOR = "";
+
+function toStoredTagCreator(userId: string | null | undefined): string {
+	return userId ?? UNKNOWN_TAG_CREATOR;
+}
+
+function fromStoredTagCreator(stored: string): string | null {
+	return stored === UNKNOWN_TAG_CREATOR ? null : stored;
 }
 
 /**
@@ -82,7 +104,7 @@ export interface CloudShapedWorkspace {
 
 export function toWorkspaceSnapshot(
 	row: HostWorkspaceRow,
-	tags: string[],
+	tagAssignments: WorkspaceTagAssignment[],
 ): WorkspaceSnapshot {
 	return {
 		id: row.id,
@@ -96,34 +118,77 @@ export function toWorkspaceSnapshot(
 		createdAt: row.createdAt,
 		updatedAt: row.updatedAt || row.createdAt,
 		lastActivityAt: row.lastActivityAt,
-		tags,
+		// A broadcast reaches every connected client, whoever they are, so
+		// the snapshot carries who applied each tag and each client keeps its
+		// own. `tags` stays the full union for consumers that predate that.
+		tags: visibleWorkspaceTags(tagAssignments, null),
+		tagAssignments,
 	};
 }
 
-/** A workspace's tags, already-normalized in storage, read back sorted. */
-export function getWorkspaceTags(db: HostDb, workspaceId: string): string[] {
+/** Every tag on a workspace with its creator, whoever is asking. */
+export function getWorkspaceTagAssignments(
+	db: HostDb,
+	workspaceId: string,
+): WorkspaceTagAssignment[] {
 	return db
-		.select({ tag: workspaceTags.tag })
+		.select({
+			tag: workspaceTags.tag,
+			createdByUserId: workspaceTags.createdByUserId,
+		})
 		.from(workspaceTags)
 		.where(eq(workspaceTags.workspaceId, workspaceId))
 		.all()
-		.map((row) => row.tag)
-		.sort();
+		.map((row) => ({
+			tag: row.tag,
+			createdByUserId: fromStoredTagCreator(row.createdByUserId),
+		}));
 }
 
-/** Batch tag lookup for list responses; ids absent from the map have none. */
+/**
+ * A workspace's tags as `viewerUserId` sees them (their own plus any with
+ * no known creator), already-normalized in storage, read back sorted.
+ */
+export function getWorkspaceTags(
+	db: HostDb,
+	workspaceId: string,
+	viewerUserId: string | null | undefined,
+): string[] {
+	return visibleWorkspaceTags(
+		getWorkspaceTagAssignments(db, workspaceId),
+		viewerUserId,
+	);
+}
+
+/**
+ * Batch tag lookup for list responses, scoped to the viewer like
+ * {@link getWorkspaceTags}; ids absent from the map have none they can see.
+ */
 export function getWorkspaceTagsByWorkspaceId(
 	db: HostDb,
 	workspaceIds: string[],
+	viewerUserId: string | null | undefined,
 ): Map<string, string[]> {
 	const byWorkspace = new Map<string, string[]>();
 	if (workspaceIds.length === 0) return byWorkspace;
 	const rows = db
-		.select({ workspaceId: workspaceTags.workspaceId, tag: workspaceTags.tag })
+		.select({
+			workspaceId: workspaceTags.workspaceId,
+			tag: workspaceTags.tag,
+			createdByUserId: workspaceTags.createdByUserId,
+		})
 		.from(workspaceTags)
 		.where(inArray(workspaceTags.workspaceId, workspaceIds))
 		.all();
 	for (const row of rows) {
+		if (
+			!isWorkspaceTagVisibleTo(
+				fromStoredTagCreator(row.createdByUserId),
+				viewerUserId,
+			)
+		) {
+			continue;
+		}
 		const tags = byWorkspace.get(row.workspaceId);
 		if (tags) {
 			tags.push(row.tag);
@@ -203,8 +268,16 @@ export function insertLocalWorkspace(
 			})
 			.run();
 		if (tags.length > 0) {
+			const createdByUserId = toStoredTagCreator(values.createdByUserId);
 			tx.insert(workspaceTags)
-				.values(tags.map((tag) => ({ workspaceId: id, tag, createdAt: now })))
+				.values(
+					tags.map((tag) => ({
+						workspaceId: id,
+						tag,
+						createdByUserId,
+						createdAt: now,
+					})),
+				)
 				.run();
 		}
 	});
@@ -221,7 +294,11 @@ export interface UpdateLocalWorkspacePatch {
 	worktreePath?: string;
 	taskId?: string | null;
 	projectId?: string;
-	/** Full replacement of the tag set; already-normalized by the caller. */
+	/**
+	 * Full replacement of the acting user's tag set (`ctx.userId`); already-
+	 * normalized by the caller. Other users' tags on the workspace are
+	 * untouched — they were never in the set the caller read back.
+	 */
 	tags?: string[];
 }
 
@@ -247,7 +324,23 @@ export function updateLocalWorkspace(
 			.where(eq(workspaces.id, id))
 			.run();
 		if (normalizedTags !== undefined) {
-			tx.delete(workspaceTags).where(eq(workspaceTags.workspaceId, id)).run();
+			const createdByUserId = toStoredTagCreator(ctx.userId);
+			// The caller read back its own tags plus the creator-less ones and
+			// sends the whole set back, so both are what gets replaced; a
+			// caller with no identity read everything and replaces everything.
+			tx.delete(workspaceTags)
+				.where(
+					ctx.userId == null
+						? eq(workspaceTags.workspaceId, id)
+						: and(
+								eq(workspaceTags.workspaceId, id),
+								inArray(workspaceTags.createdByUserId, [
+									createdByUserId,
+									UNKNOWN_TAG_CREATOR,
+								]),
+							),
+				)
+				.run();
 			if (normalizedTags.length > 0) {
 				const now = Date.now();
 				tx.insert(workspaceTags)
@@ -255,6 +348,7 @@ export function updateLocalWorkspace(
 						normalizedTags.map((tag) => ({
 							workspaceId: id,
 							tag,
+							createdByUserId,
 							createdAt: now,
 						})),
 					)
@@ -411,7 +505,10 @@ function emitWorkspaceChanged(
 	ctx.eventBus.broadcastWorkspaceChanged({
 		workspaceId: row.id,
 		eventType,
-		workspace: toWorkspaceSnapshot(row, getWorkspaceTags(ctx.db, row.id)),
+		workspace: toWorkspaceSnapshot(
+			row,
+			getWorkspaceTagAssignments(ctx.db, row.id),
+		),
 		occurredAt: Date.now(),
 	});
 }

--- a/packages/host-service/src/workspaces/workspace-tags.test.ts
+++ b/packages/host-service/src/workspaces/workspace-tags.test.ts
@@ -9,6 +9,7 @@ import { workspaces, workspaceTags } from "../db/schema";
 import type { EventBus } from "../events";
 import type { WorkspaceChangedMessage } from "../events/types";
 import {
+	getWorkspaceTagAssignments,
 	getWorkspaceTags,
 	getWorkspaceTagsByWorkspaceId,
 	insertLocalWorkspace,
@@ -45,7 +46,11 @@ function createTestEventBus(): {
 function seedWorkspace(
 	db: HostDb,
 	eventBus: EventBus,
-	{ id, tags }: { id: string; tags?: string[] },
+	{
+		id,
+		tags,
+		createdByUserId,
+	}: { id: string; tags?: string[]; createdByUserId?: string },
 ) {
 	return insertLocalWorkspace(
 		{ db, eventBus },
@@ -55,6 +60,7 @@ function seedWorkspace(
 			worktreePath: `/tmp/${id}`,
 			branch: id,
 			name: id,
+			createdByUserId,
 			tags,
 		},
 	);
@@ -69,7 +75,7 @@ describe("workspace tags store", () => {
 			tags: ["Perf", " perf ", "Alpha"],
 		});
 		expect(
-			getWorkspaceTags(db, "11111111-1111-4111-8111-111111111111"),
+			getWorkspaceTags(db, "11111111-1111-4111-8111-111111111111", null),
 		).toEqual(["alpha", "perf"]);
 		expect(messages[0]?.workspace?.tags).toEqual(["alpha", "perf"]);
 	});
@@ -79,7 +85,7 @@ describe("workspace tags store", () => {
 		const { eventBus, messages } = createTestEventBus();
 		seedWorkspace(db, eventBus, { id: "22222222-2222-4222-8222-222222222222" });
 		expect(
-			getWorkspaceTags(db, "22222222-2222-4222-8222-222222222222"),
+			getWorkspaceTags(db, "22222222-2222-4222-8222-222222222222", null),
 		).toEqual([]);
 		expect(messages[0]?.workspace?.tags).toEqual([]);
 	});
@@ -91,11 +97,11 @@ describe("workspace tags store", () => {
 		seedWorkspace(db, eventBus, { id, tags: ["old-a", "old-b"] });
 
 		updateLocalWorkspace({ db, eventBus }, id, { tags: ["New", "zeta"] });
-		expect(getWorkspaceTags(db, id)).toEqual(["new", "zeta"]);
+		expect(getWorkspaceTags(db, id, null)).toEqual(["new", "zeta"]);
 		expect(messages.at(-1)?.workspace?.tags).toEqual(["new", "zeta"]);
 
 		updateLocalWorkspace({ db, eventBus }, id, { tags: [] });
-		expect(getWorkspaceTags(db, id)).toEqual([]);
+		expect(getWorkspaceTags(db, id, null)).toEqual([]);
 	});
 
 	it("update without a tags field leaves tags untouched", () => {
@@ -105,7 +111,7 @@ describe("workspace tags store", () => {
 		seedWorkspace(db, eventBus, { id, tags: ["keep"] });
 
 		updateLocalWorkspace({ db, eventBus }, id, { name: "renamed" });
-		expect(getWorkspaceTags(db, id)).toEqual(["keep"]);
+		expect(getWorkspaceTags(db, id, null)).toEqual(["keep"]);
 		expect(messages.at(-1)?.workspace?.tags).toEqual(["keep"]);
 	});
 
@@ -117,11 +123,11 @@ describe("workspace tags store", () => {
 		seedWorkspace(db, eventBus, { id: a, tags: ["zeta", "alpha"] });
 		seedWorkspace(db, eventBus, { id: b, tags: ["solo"] });
 
-		const map = getWorkspaceTagsByWorkspaceId(db, [a, b, "missing"]);
+		const map = getWorkspaceTagsByWorkspaceId(db, [a, b, "missing"], null);
 		expect(map.get(a)).toEqual(["alpha", "zeta"]);
 		expect(map.get(b)).toEqual(["solo"]);
 		expect(map.has("missing")).toBe(false);
-		expect(getWorkspaceTagsByWorkspaceId(db, [])).toEqual(new Map());
+		expect(getWorkspaceTagsByWorkspaceId(db, [], null)).toEqual(new Map());
 	});
 
 	it("deleting a workspace cascades its tag rows", () => {
@@ -139,6 +145,112 @@ describe("workspace tags store", () => {
 		const { eventBus } = createTestEventBus();
 		const id = "88888888-8888-4888-8888-888888888888";
 		seedWorkspace(db, eventBus, { id, tags: ["Dup", "dup", " DUP "] });
-		expect(getWorkspaceTags(db, id)).toEqual(["dup"]);
+		expect(getWorkspaceTags(db, id, null)).toEqual(["dup"]);
+	});
+
+	describe("per-user visibility", () => {
+		const id = "99999999-9999-4999-8999-999999999999";
+
+		it("stamps the workspace creator on tags written at create", () => {
+			const db = createTestDb();
+			const { eventBus, messages } = createTestEventBus();
+			seedWorkspace(db, eventBus, {
+				id,
+				tags: ["perf"],
+				createdByUserId: "user-a",
+			});
+			expect(getWorkspaceTagAssignments(db, id)).toEqual([
+				{ tag: "perf", createdByUserId: "user-a" },
+			]);
+			expect(messages[0]?.workspace?.tagAssignments).toEqual([
+				{ tag: "perf", createdByUserId: "user-a" },
+			]);
+			expect(getWorkspaceTags(db, id, "user-a")).toEqual(["perf"]);
+			expect(getWorkspaceTags(db, id, "user-b")).toEqual([]);
+			expect(getWorkspaceTagsByWorkspaceId(db, [id], "user-b").has(id)).toBe(
+				false,
+			);
+		});
+
+		it("a creator-less tag is visible to everyone", () => {
+			const db = createTestDb();
+			const { eventBus } = createTestEventBus();
+			seedWorkspace(db, eventBus, { id, tags: ["legacy"] });
+			expect(getWorkspaceTagAssignments(db, id)).toEqual([
+				{ tag: "legacy", createdByUserId: null },
+			]);
+			expect(getWorkspaceTags(db, id, "user-b")).toEqual(["legacy"]);
+		});
+
+		it("a user's update replaces only their own set", () => {
+			const db = createTestDb();
+			const { eventBus, messages } = createTestEventBus();
+			seedWorkspace(db, eventBus, {
+				id,
+				tags: ["perf"],
+				createdByUserId: "user-a",
+			});
+
+			updateLocalWorkspace({ db, eventBus, userId: "user-b" }, id, {
+				tags: ["mine"],
+			});
+			expect(getWorkspaceTags(db, id, "user-a")).toEqual(["perf"]);
+			expect(getWorkspaceTags(db, id, "user-b")).toEqual(["mine"]);
+			// The broadcast carries the union with owners, so every client can
+			// keep its own.
+			expect(messages.at(-1)?.workspace?.tags).toEqual(["mine", "perf"]);
+
+			updateLocalWorkspace({ db, eventBus, userId: "user-b" }, id, {
+				tags: [],
+			});
+			expect(getWorkspaceTags(db, id, "user-a")).toEqual(["perf"]);
+			expect(getWorkspaceTags(db, id, "user-b")).toEqual([]);
+		});
+
+		it("two users can carry the same tag on one workspace", () => {
+			const db = createTestDb();
+			const { eventBus } = createTestEventBus();
+			seedWorkspace(db, eventBus, {
+				id,
+				tags: ["perf"],
+				createdByUserId: "user-a",
+			});
+			updateLocalWorkspace({ db, eventBus, userId: "user-b" }, id, {
+				tags: ["perf"],
+			});
+			expect(getWorkspaceTags(db, id, "user-a")).toEqual(["perf"]);
+			expect(getWorkspaceTags(db, id, "user-b")).toEqual(["perf"]);
+			updateLocalWorkspace({ db, eventBus, userId: "user-a" }, id, {
+				tags: [],
+			});
+			expect(getWorkspaceTags(db, id, "user-b")).toEqual(["perf"]);
+		});
+
+		it("a user's update claims creator-less tags they read back", () => {
+			const db = createTestDb();
+			const { eventBus } = createTestEventBus();
+			seedWorkspace(db, eventBus, { id, tags: ["legacy"] });
+			updateLocalWorkspace({ db, eventBus, userId: "user-b" }, id, {
+				tags: ["legacy", "mine"],
+			});
+			expect(getWorkspaceTagAssignments(db, id)).toEqual([
+				{ tag: "legacy", createdByUserId: "user-b" },
+				{ tag: "mine", createdByUserId: "user-b" },
+			]);
+		});
+
+		it("an update with no user replaces everything, as before", () => {
+			const db = createTestDb();
+			const { eventBus } = createTestEventBus();
+			seedWorkspace(db, eventBus, {
+				id,
+				tags: ["perf"],
+				createdByUserId: "user-a",
+			});
+			updateLocalWorkspace({ db, eventBus }, id, { tags: ["all"] });
+			expect(getWorkspaceTagAssignments(db, id)).toEqual([
+				{ tag: "all", createdByUserId: null },
+			]);
+		});
 	});
 });

--- a/packages/host-service/src/workspaces/workspace-tags.test.ts
+++ b/packages/host-service/src/workspaces/workspace-tags.test.ts
@@ -172,6 +172,25 @@ describe("workspace tags store", () => {
 			);
 		});
 
+		it("stamps the acting user when the row itself has no creator", () => {
+			const db = createTestDb();
+			const { eventBus } = createTestEventBus();
+			insertLocalWorkspace(
+				{ db, eventBus, userId: "user-a" },
+				{
+					id,
+					projectId: null,
+					worktreePath: `/tmp/${id}`,
+					branch: id,
+					name: id,
+					tags: ["adopted"],
+				},
+			);
+			expect(getWorkspaceTagAssignments(db, id)).toEqual([
+				{ tag: "adopted", createdByUserId: "user-a" },
+			]);
+		});
+
 		it("a creator-less tag is visible to everyone", () => {
 			const db = createTestDb();
 			const { eventBus } = createTestEventBus();

--- a/packages/host-service/test/migration-0031-backfills-tag-creators.test.ts
+++ b/packages/host-service/test/migration-0031-backfills-tag-creators.test.ts
@@ -1,0 +1,113 @@
+import { Database as BunDatabase } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	cpSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import * as schema from "../src/db/schema";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "..", "drizzle");
+
+/**
+ * Tags became personal in 0031: each row records who applied it and other
+ * users no longer see it. Rows written before that have no creator, so the
+ * rebuild attributes them to the workspace's creator — the one person who
+ * could have filed it back then — and leaves the rest visible to everyone.
+ *
+ * createDb uses better-sqlite3, which Bun can't load, so this reproduces
+ * the identical drizzle-migrator semantics on bun:sqlite (same approach as
+ * the 0019 and 0021 tests).
+ */
+describe("migration 0031 upgrade", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function seedPre0031Db(): { dbPath: string } {
+		const dir = mkdtempSync(join(tmpdir(), "host-migration-0031-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "host.db");
+
+		const isPre0031 = (tag: string) => Number(tag.slice(0, 4)) < 31;
+		const oldMigrations = join(dir, "drizzle-pre-0031");
+		cpSync(MIGRATIONS_DIR, oldMigrations, { recursive: true });
+		const journalPath = join(oldMigrations, "meta", "_journal.json");
+		const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+			entries: Array<{ tag: string }>;
+		};
+		const removed = journal.entries.filter((entry) => !isPre0031(entry.tag));
+		expect(removed.length).toBeGreaterThanOrEqual(1);
+		journal.entries = journal.entries.filter((entry) => isPre0031(entry.tag));
+		writeFileSync(journalPath, JSON.stringify(journal));
+		for (const file of readdirSync(oldMigrations)) {
+			if (/^\d{4}/.test(file) && !isPre0031(file)) {
+				unlinkSync(join(oldMigrations, file));
+			}
+		}
+
+		const sqlite = new BunDatabase(dbPath, { create: true, readwrite: true });
+		migrate(drizzle(sqlite, { schema }), { migrationsFolder: oldMigrations });
+		sqlite.exec(
+			"insert into projects (id, repo_path, created_at) values ('p1', '/tmp/repo', 0)",
+		);
+		sqlite.exec(
+			"insert into workspaces (id, project_id, worktree_path, branch, created_by_user_id, created_at) values ('w-owned', 'p1', '/tmp/repo/a', 'a', 'user-a', 0)",
+		);
+		sqlite.exec(
+			"insert into workspaces (id, project_id, worktree_path, branch, created_at) values ('w-unowned', 'p1', '/tmp/repo/b', 'b', 0)",
+		);
+		sqlite.exec(
+			"insert into workspace_tags (workspace_id, tag, created_at) values ('w-owned', 'perf', 1), ('w-unowned', 'legacy', 2)",
+		);
+		sqlite.close();
+		return { dbPath };
+	}
+
+	test("attributes existing tags to the workspace creator, or to no one", () => {
+		const { dbPath } = seedPre0031Db();
+
+		const sqlite = new BunDatabase(dbPath, { create: false, readwrite: true });
+		sqlite.exec("PRAGMA foreign_keys = OFF");
+		migrate(drizzle(sqlite, { schema }), { migrationsFolder: MIGRATIONS_DIR });
+		const violations = sqlite
+			.query("PRAGMA foreign_key_check")
+			.all() as unknown[];
+		sqlite.exec("PRAGMA foreign_keys = ON");
+
+		const rows = sqlite
+			.query(
+				"select workspace_id, tag, created_by_user_id, created_at from workspace_tags order by workspace_id",
+			)
+			.all();
+		sqlite.close();
+
+		expect(violations).toEqual([]);
+		expect(rows).toEqual([
+			{
+				workspace_id: "w-owned",
+				tag: "perf",
+				created_by_user_id: "user-a",
+				created_at: 1,
+			},
+			{
+				workspace_id: "w-unowned",
+				tag: "legacy",
+				created_by_user_id: "",
+				created_at: 2,
+			},
+		]);
+	});
+});

--- a/packages/host-service/test/migration-0032-keeps-legacy-folder-settings.test.ts
+++ b/packages/host-service/test/migration-0032-keeps-legacy-folder-settings.test.ts
@@ -1,0 +1,91 @@
+import { Database as BunDatabase } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	cpSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import * as schema from "../src/db/schema";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "..", "drizzle");
+
+/**
+ * Folder presentation became per user in 0032. Nothing recorded who
+ * customised a pre-existing row, so the rebuild keeps it as creator-less:
+ * still visible to everyone, claimed by the next person who customises the
+ * folder. Same bun:sqlite reproduction of the drizzle migrator as the other
+ * migration tests.
+ */
+describe("migration 0032 upgrade", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps existing folder settings as creator-less rows", () => {
+		const dir = mkdtempSync(join(tmpdir(), "host-migration-0032-"));
+		tempDirs.push(dir);
+		const dbPath = join(dir, "host.db");
+
+		const isPre0032 = (tag: string) => Number(tag.slice(0, 4)) < 32;
+		const oldMigrations = join(dir, "drizzle-pre-0032");
+		cpSync(MIGRATIONS_DIR, oldMigrations, { recursive: true });
+		const journalPath = join(oldMigrations, "meta", "_journal.json");
+		const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+			entries: Array<{ tag: string }>;
+		};
+		expect(journal.entries.some((entry) => !isPre0032(entry.tag))).toBe(true);
+		journal.entries = journal.entries.filter((entry) => isPre0032(entry.tag));
+		writeFileSync(journalPath, JSON.stringify(journal));
+		for (const file of readdirSync(oldMigrations)) {
+			if (/^\d{4}/.test(file) && !isPre0032(file)) {
+				unlinkSync(join(oldMigrations, file));
+			}
+		}
+
+		let sqlite = new BunDatabase(dbPath, { create: true, readwrite: true });
+		migrate(drizzle(sqlite, { schema }), { migrationsFolder: oldMigrations });
+		sqlite.exec(
+			"insert into tag_folder_settings (scope, tag, display_name, color, tab_order, updated_at) values ('sessions', 'perf', 'Performance', '#ff0000', 3, 7)",
+		);
+		sqlite.close();
+
+		sqlite = new BunDatabase(dbPath, { create: false, readwrite: true });
+		sqlite.exec("PRAGMA foreign_keys = OFF");
+		migrate(drizzle(sqlite, { schema }), { migrationsFolder: MIGRATIONS_DIR });
+		const violations = sqlite
+			.query("PRAGMA foreign_key_check")
+			.all() as unknown[];
+		sqlite.exec("PRAGMA foreign_keys = ON");
+		const rows = sqlite
+			.query(
+				"select scope, tag, created_by_user_id, display_name, color, tab_order, updated_at from tag_folder_settings",
+			)
+			.all();
+		sqlite.close();
+
+		expect(violations).toEqual([]);
+		expect(rows).toEqual([
+			{
+				scope: "sessions",
+				tag: "perf",
+				created_by_user_id: "",
+				display_name: "Performance",
+				color: "#ff0000",
+				tab_order: 3,
+				updated_at: 7,
+			},
+		]);
+	});
+});

--- a/packages/shared/src/workspace-tags.test.ts
+++ b/packages/shared/src/workspace-tags.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+	isWorkspaceTagVisibleTo,
 	normalizeWorkspaceTag,
 	normalizeWorkspaceTags,
 	SESSIONS_TAG_SCOPE,
 	tagFolderScopeInputSchema,
+	visibleWorkspaceTags,
 	WORKSPACE_TAG_MAX_LENGTH,
 	WORKSPACE_TAGS_MAX_PER_WORKSPACE,
 	workspaceTagInputSchema,
@@ -140,5 +142,43 @@ describe("workspaceTagsInputSchema", () => {
 		expect(workspaceTagsInputSchema.parse(tags)).toHaveLength(
 			WORKSPACE_TAGS_MAX_PER_WORKSPACE,
 		);
+	});
+});
+
+describe("isWorkspaceTagVisibleTo", () => {
+	test("a tag is visible to whoever applied it", () => {
+		expect(isWorkspaceTagVisibleTo("user-a", "user-a")).toBe(true);
+		expect(isWorkspaceTagVisibleTo("user-a", "user-b")).toBe(false);
+	});
+
+	test("a tag with no known creator is visible to everyone", () => {
+		expect(isWorkspaceTagVisibleTo(null, "user-b")).toBe(true);
+		expect(isWorkspaceTagVisibleTo(undefined, "user-b")).toBe(true);
+	});
+
+	test("a viewer with no identity sees everything", () => {
+		expect(isWorkspaceTagVisibleTo("user-a", null)).toBe(true);
+		expect(isWorkspaceTagVisibleTo("user-a", undefined)).toBe(true);
+	});
+});
+
+describe("visibleWorkspaceTags", () => {
+	test("filters to the viewer, then normalizes and sorts", () => {
+		expect(
+			visibleWorkspaceTags(
+				[
+					{ tag: "Zeta", createdByUserId: "user-a" },
+					{ tag: "theirs", createdByUserId: "user-b" },
+					{ tag: "legacy", createdByUserId: null },
+					{ tag: "zeta", createdByUserId: null },
+				],
+				"user-a",
+			),
+		).toEqual(["legacy", "zeta"]);
+	});
+
+	test("empty for no assignments", () => {
+		expect(visibleWorkspaceTags(null, "user-a")).toEqual([]);
+		expect(visibleWorkspaceTags(undefined, null)).toEqual([]);
 	});
 });

--- a/packages/shared/src/workspace-tags.ts
+++ b/packages/shared/src/workspace-tags.ts
@@ -91,3 +91,42 @@ export const workspaceTagsInputSchema = z
 	});
 
 export type WorkspaceTagsInput = z.infer<typeof workspaceTagsInputSchema>;
+
+/** One tag on one workspace and who applied it (null = unknown/legacy). */
+export interface WorkspaceTagAssignment {
+	tag: string;
+	createdByUserId: string | null;
+}
+
+/**
+ * Tags are personal: a tag is shown to the user who applied it, so one
+ * person's sidebar grouping never appears in a teammate's. A tag with no
+ * known creator (written before tags had one, or by a caller that carries
+ * no user) stays visible to everyone, and a viewer with no identity sees
+ * everything — both keep single-user hosts behaving as before.
+ */
+export function isWorkspaceTagVisibleTo(
+	createdByUserId: string | null | undefined,
+	viewerUserId: string | null | undefined,
+): boolean {
+	return (
+		createdByUserId == null ||
+		viewerUserId == null ||
+		createdByUserId === viewerUserId
+	);
+}
+
+/** The normalized, sorted tag set a viewer sees on one workspace. */
+export function visibleWorkspaceTags(
+	assignments: readonly WorkspaceTagAssignment[] | null | undefined,
+	viewerUserId: string | null | undefined,
+): string[] {
+	if (assignments == null) return [];
+	return normalizeWorkspaceTags(
+		assignments
+			.filter((assignment) =>
+				isWorkspaceTagVisibleTo(assignment.createdByUserId, viewerUserId),
+			)
+			.map((assignment) => assignment.tag),
+	);
+}


### PR DESCRIPTION
## Problem

Sidebar folders derive from workspace tags, and tags lived on the host with no owner. On a shared host, every user's groupings showed up in every other user's sidebar, and one user moving a workspace to a folder replaced everyone's tags on it.

## Fix

Tags and their folders are personal: a tag is shown to the user who applied it, and a folder's name, color and order belong to the user who set them.

- `workspace_tags` records `created_by_user_id`. Migration 0031 rebuilds the table with the creator in the primary key (so two users can carry the same tag on one workspace) and backfills existing rows from the workspace creator. Rows with no known creator stay visible to everyone.
- `tag_folder_settings` records the creator the same way. Migration 0032 rebuilds it; pre-existing rows stay creator-less (visible to all) until someone customises the folder again, which claims the row. Two users can each rename or colour the same tag's folder independently.
- `workspace.list`, `workspace.update`, `tagFolders.list/upsert/delete` (and the deprecated `project.*TagSetting` twins) read and write only the caller's own rows, keyed on the `x-superset-user-id` the desktop, CLI, and relay already send. A caller with no user sees and replaces everything, as before. Adopted worktrees stamp their tags with the acting user.
- The `workspace:changed` broadcast reaches every connected client and the relay does not carry the user on WebSocket upgrades, so the snapshot now carries `tagAssignments` and the desktop keeps the ones it can see. `tags` stays the full union for older desktops. While the session is unresolved the desktop shows nobody's tags, and every host list refetches once the user is known (which also covers switching accounts). Folder settings already refetch on their change event, so nothing renders from that payload.
- The rule lives in one place, `isWorkspaceTagVisibleTo` in `@superset/shared/workspace-tags`, used by the host and the desktop.

## Verified

- Host store: creator stamping (create and adopt), per-user replace, same tag by two users, creator-less claim, no-user replace; folder store: own rows, independent customisation, legacy claim.
- Migration 0031 and 0032 upgrade tests in the style of the 0019/0021 tests.
- Shared visibility rule and desktop event merge (own tags kept, unresolved session, union fallback for older hosts).
- CDP against the dev app from this worktree: the migration ran on the real host DB, existing folders survived, "Move to group" and "Ungroup" journeys via real mouse input, and `workspace.list` as another user returned none of my tags.

https://claude.ai/code/session_018KXcvv5pzm2fpzV7FBAgMD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace tags and tag-folder settings are now personalized by user.
  * Users can maintain independent tags and folder customizations on shared workspaces.
  * Legacy tags and folder settings remain available as shared, creator-less items.
  * Workspace data refreshes automatically when authentication becomes available or changes.

* **Bug Fixes**
  * Improved tag visibility and synchronization so users see the appropriate tags without overwriting others’ customizations.
  * Preserved compatibility with older hosts that do not provide tag ownership information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->