### PR TITLE
fix(trpc): stop double-counting workspace_created

### DIFF
--- a/packages/trpc/src/router/v2-workspace/v2-workspace.ts
+++ b/packages/trpc/src/router/v2-workspace/v2-workspace.ts
@@ -9,7 +9,6 @@ import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 import { z } from "zod";
 import { env } from "../../env";
-import { posthog } from "../../lib/analytics";
 import { jwtProcedure, protectedProcedure, userError } from "../../trpc";
 
 const resend = new Resend(env.RESEND_API_KEY);
@@ -101,6 +100,9 @@ export const v2WorkspaceRouter = {
 			},
 		),
 
+	// Exits the Resend activation campaign, and captures nothing: the host-service
+	// already emits `workspace_created` for the same workspace, so a capture here
+	// double-counts it.
 	trackCreated: jwtProcedure
 		.input(
 			z.object({
@@ -120,20 +122,6 @@ export const v2WorkspaceRouter = {
 					i18nKey: "serverError.v2Workspace.notAMemberOfThisOrganization",
 				});
 			}
-
-			posthog.capture({
-				distinctId: ctx.userId,
-				event: "workspace_created",
-				properties: {
-					workspace_id: input.workspaceId,
-					project_id: input.projectId,
-					organization_id: input.organizationId,
-					host_id: input.hostId ?? null,
-					branch: input.branch,
-					type: input.type,
-					source: "host-report",
-				},
-			});
 
 			if (input.type !== "main" && ctx.email) {
 				await exitActivationEmailCampaign(ctx.userId, ctx.email);


### PR DESCRIPTION
## What

`v2Workspace.trackCreated` captured a second `workspace_created` event (`source: "host-report"`) for a workspace the host-service had already reported through `analytics.captureEvent` (`source: "host_service"`). Every v2 workspace created since **2026-08-11** fired both.

Measured on PostHog Production, last 7 days:

| Sources on a workspace | Workspaces | Events |
|---|---|---|
| `host-report` + `host_service` | 43,883 | 87,768 |
| `host_service` only | 9,046 | 9,046 |
| `host-report` only | **4** | 4 |

Raw `workspace_created` counts are inflated roughly **1.65x** for 2026-08-11 onward.

## Why it happened

The duplicate arrived with #5938 (`6be6d6617`, 2026-08-10), which added `trackCreated` so the Resend `user.activated` campaign exit could fire on first real workspace — and bundled a PostHog capture into it. The host-service already emits the event from `insertLocalWorkspace` → `trackWorkspaceEvent`, and `registerLocalWorkspace` calls both in sequence.

## The change

Drop the capture, keep `exitActivationEmailCampaign`. The `host_service` event carries a strict superset of the properties (adds `host_kind`, `client_machine_id`, `host_service_version`), and the `host-report`-only case is 4 workspaces a week, so nothing is lost.

Server-side, so it takes effect for every client on deploy — no version-adoption wait.

## What this does and does not fix

**Unaffected — no action needed.** Every `math: "dau"` tile counts unique persons, and the duplicate adds none: **zero users in any week** are reported only by `host-report`. Recomputing DAU with and without it is identical on every day of the last three weeks (2,446 both ways on 3 Sep; one day differs by a single person). That covers DAU/WAU (`7mbktvP7`, `sBQy1KV9`, `jTc2anrd`, `82RAL00l`), activation (`first_time_for_user_with_filters`), every retention grid, and the core-action DAU/WAU/MAU family.

**Still wrong in history — this PR does not backfill.** Tiles that count events or events-per-actor read high for 2026-08-11 → deploy:

- `math: "total"` (~1.65x): `uni4z1Q8` Cumulative workspaces created, `QvYr4PyV` (its "Workspaces created" series), `W1lcHbSM` Depth events, `9SrIRWw1` Workspaces per desktop DAU, `yhFOQgzf` v2 cloud vs v1 local, `xsUaAMJi` Daily Activity Characteristics
- count-per-actor (p90 reads 48 against a true 30): `crHk64hw`, `Kw6Kwwip`
- thresholds on event counts, which silently inflate the *user* count: `Plh1fBBR` 3+ workspaces (3,528 vs 3,216 real), `sM9ryVil` / `sShgKaLJ` 5+ actions/week (2,935 vs 2,565), and the `3vLNTHiF` / `PJ054SQX` / `fkpyzbgy` power-user cohort, whose "p90 = 20+ workspaces" threshold moved mid-series

Fixing those means switching them to `uniq(properties.workspace_id)`; tracked separately.

## Testing

`bun run lint` clean repo-wide, `packages/trpc` typecheck clean, 163 trpc tests pass.

https://claude.ai/code/session_01MQLVGwThmjHb2wMryT9nUt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `v2Workspace.trackCreated` from capturing a duplicate `workspace_created` event. The host-service already emits this event for the same workspace, so every v2 workspace created since 2026-08-11 fired twice and raw counts were inflated roughly 1.65x.

- Keeps the Resend activation-campaign exit; only the PostHog capture is removed.
- The `host_service` event carries a strict superset of properties (`host_kind`, `client_machine_id`, `host_service_version`), so no data is lost.
- Unique-user metrics like DAU/WAU are unaffected; no user is reported only by the removed event.
- Historical data from 2026-08-11 to deploy is not backfilled, so event-count tiles still read high for that window.

<sup>Written for commit c5f2dffcbdf7108e8330d01294add8e1e0fbbc5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace creation no longer records the removed analytics event.
  - Resend activation campaign handling now applies only to non-main workspaces with an available email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->