### PR TITLE
fix(marketing): break the hero headline before it types, not after it overflows

### DIFF
--- a/apps/marketing/src/app/[lang]/components/HeroSection/HeroSection.tsx
+++ b/apps/marketing/src/app/[lang]/components/HeroSection/HeroSection.tsx
@@ -18,16 +18,22 @@ export function HeroSection() {
 	const headlineSegments = [
 		{
 			id: "lead",
-			// Trailing space separates the two segments as the typewriter runs
+			// Typed newline, not a space: the headline is always two lines, and
+			// the break arrives as part of the animation (the caret drops to the
+			// second line) instead of the second segment starting on line one and
+			// reflowing down once it outgrows the width. Needs the h1's
+			// whitespace-pre-line to render.
 			text: `${t({
 				message: "Bring Any Agent.",
-			})} `,
+			})}\n`,
 		},
 		{
 			id: "emphasis",
 			text: t({
 				message: "Orchestrate Them All.",
 			}),
+			// Beat on the empty second line before the payoff line types
+			delayBefore: 450,
 			// Plain inline (not inline-block): vertical padding on inline boxes
 			// paints the brackets without affecting line height, so the line
 			// can't jump when this segment mounts mid-animation
@@ -60,7 +66,7 @@ export function HeroSection() {
 							</span>
 						</Link>
 						<div className="space-y-4 sm:space-y-6">
-							<h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1] [word-spacing:0.15em] text-foreground relative max-w-6xl mx-auto">
+							<h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-medium tracking-tight leading-[1.1] [word-spacing:0.15em] whitespace-pre-line text-foreground relative max-w-6xl mx-auto">
 								{/* Real headline for screen readers and no-JS crawlers; the
 								    typewriter below is purely visual */}
 								<span className="sr-only">

--- a/apps/marketing/src/app/[lang]/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/[lang]/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -55,7 +55,9 @@ export function TypewriterText({
 	if (segments) {
 		let offset = 0;
 		for (const segment of segments) {
-			if (offset > 0 && offset === displayedText.length) {
+			// Guard on the segment being non-empty, not on offset: an empty
+			// segment shares its successor's offset and would swallow the pause
+			if (segment.text.length > 0 && offset === displayedText.length) {
 				pauseBeforeNext = segment.delayBefore ?? 0;
 				break;
 			}

--- a/apps/marketing/src/app/[lang]/components/HeroSection/components/TypewriterText/TypewriterText.tsx
+++ b/apps/marketing/src/app/[lang]/components/HeroSection/components/TypewriterText/TypewriterText.tsx
@@ -10,6 +10,8 @@ interface TextSegment {
 	render?: (visibleText: string) => React.ReactNode;
 	/** Overrides the caret style while this segment is being typed */
 	cursorClassName?: string;
+	/** Extra pause, in ms, before this segment's first character is typed */
+	delayBefore?: number;
 }
 
 interface TypewriterTextProps {
@@ -47,17 +49,31 @@ export function TypewriterText({
 		return () => clearTimeout(startTimeout);
 	}, [delay]);
 
+	// Kept a plain number so the typing effect below depends only on
+	// primitives; `segments` is rebuilt by the caller on every render
+	let pauseBeforeNext = 0;
+	if (segments) {
+		let offset = 0;
+		for (const segment of segments) {
+			if (offset > 0 && offset === displayedText.length) {
+				pauseBeforeNext = segment.delayBefore ?? 0;
+				break;
+			}
+			offset += segment.text.length;
+		}
+	}
+
 	useEffect(() => {
 		if (!isTyping) return;
 
 		if (displayedText.length < fullText.length) {
 			const timeout = setTimeout(() => {
 				setDisplayedText(fullText.slice(0, displayedText.length + 1));
-			}, speed);
+			}, speed + pauseBeforeNext);
 
 			return () => clearTimeout(timeout);
 		}
-	}, [displayedText, isTyping, speed, fullText]);
+	}, [displayedText, isTyping, speed, fullText, pauseBeforeNext]);
 
 	const isTypingComplete = isTyping && displayedText.length === fullText.length;
 


### PR DESCRIPTION
## Summary

- The hero typewriter now breaks between "Bring Any Agent." and "Orchestrate Them All." as part of the animation, instead of letting the second segment start on line one and reflow down once it outgrew the width.
- Adds a per-segment `delayBefore` to `TypewriterText`; the emphasis segment gets a 450ms beat on the empty second line before it types.

## Why / Context

Reported as "it doesn't break the two halves into two lines by default". The *final* layout was never the problem — it has always been two lines at every width from 375px to 2560px. The bug was mid-animation. Sampling the overlay while it types, at 1440px:

```
1440ms  lines=1  "Bring Any Agent."
1560ms  lines=2  "Bring Any Agent. Or"                     <- on line 1, beside the lead
2160ms  lines=2  "Bring Any Agent. Orchestrate Them"
2280ms  lines=2  "Bring Any Agent. Orchestrate Them Al"    <- snaps down to line 2
```

So "Orchestrate Them" typed out beside the lead for ~700ms and then jumped a whole line.

## How It Works

The lead segment's trailing space became a typed `\n`, rendered by `whitespace-pre-line` on the `h1`. Because the newline is a character *in the typed stream*, the break lands exactly when the first line finishes and the caret drops to line two — rather than appearing at the same instant as the first character of the second line, which is what a `<br>` between segments would have done.

`delayBefore` is resolved into a plain number (`pauseBeforeNext`) before the typing effect, so that effect still depends only on primitives. `headlineSegments` is rebuilt by `HeroSection` on every render, so the array itself can't go in the dependency list without thrashing the timeout.

## Manual QA Checklist

Driven over CDP against `next dev`, measuring the sizer and overlay geometry directly.

### Animation
- [x] Second segment never renders on line one — first paint of "Or" is already at line two
- [x] Caret drops to line two and holds there through the 450ms beat
- [x] No layout jump; `h1` height constant throughout

### Layout unchanged
- [x] Two lines at 375, 414, 640, 768, 820, 1024, 1100, 1152, 1180, 1280, 1440, 1512, 1728, 1920, 2560px
- [x] `h1` height identical to before at desktop / tablet / mobile (158 / 132 / 79px)
- [x] No horizontal overflow at any width (`scrollWidth === innerWidth`)

### Internationalization
- [x] `/tr`, `/fr`, `/ja` render two lines at 1440px and don't overflow at 390px (the emphasis segment is `whitespace-nowrap`, so it was the overflow risk)
- [x] Message ids unchanged — the `\n` is appended outside `t({ message })`, so no catalog re-keying
- [x] Screen-reader `sr-only` headline and the no-JS crawler text still carry the full string

## Testing

- `bun run typecheck` (marketing)
- `bun run lint` (repo-wide, 7124 files)
- `bun run check:i18n` — no missing messages, no catalog drift
- `bun test` (marketing) — 85 pass, 0 fail

## Design Decisions

- **Typed `\n` + `whitespace-pre-line` instead of a `<br>` between segments**: the typewriter renders nothing for a segment that hasn't started, so a `<br>` would appear together with the segment's first character — the caret would sit at the end of line one through the whole pause and then everything would jump. Making the newline part of the typed stream moves the caret first, then pauses.
- **`delayBefore` per segment rather than a hardcoded pause**: keeps `TypewriterText` generic and leaves the timing next to the copy it applies to.

## Notes

Forcing the break shrinks the `h1`'s shrink-to-fit width (it sits in a `flex flex-col items-center`, so its width is content-based) from 1152px to the width of the longer line. Both lines stay centered and the rendered result is pixel-identical; only the box is narrower.

https://claude.ai/code/session_01MqTxMDw2xNQquDs6tZsi3B

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hero typewriter so the headline breaks onto the second line during the animation instead of letting "Orchestrate Them All." type beside "Bring Any Agent." for ~700ms and then jump down once it overflows. The lead segment now ends in a typed newline rendered by `whitespace-pre-line`, so the caret drops to line two before the payoff line starts.

- Adds a per-segment `delayBefore` to `TypewriterText`; the emphasis segment gets a 450ms beat on the empty second line.
- `delayBefore` is now honored on a first segment too — the old guard silently dropped it there. Inert for the hero.
- Final layout is unchanged from 375px to 2560px; the h1's shrink-to-fit box narrows, but the rendered result is pixel-identical.
- i18n message ids are unchanged — the newline is appended outside `t({ message })`, so no catalog re-keying.

<sup>Written for commit d98cbe66f3ac89499e8f1e03316f88c043e3a757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the hero headline typewriter animation to consistently display its content across two lines.
  - The caret now moves naturally to the second line during typing.
  - Added a brief pause before the payoff line appears, creating a more deliberate reveal.
  - Improved headline rendering so line breaks display correctly during the animation.
  - Enhanced timing control for headline segments, including configurable pauses before text begins typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->