### PR TITLE
fix(host-service): record the descriptor ceiling macOS actually enforces

### DIFF
--- a/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.ts
+++ b/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { attachErrorDiagnostics } from "../../../error-diagnostics";
 
@@ -69,17 +70,46 @@ function fileDescriptorSoftLimit(): number | string | undefined {
 	return softLimit;
 }
 
+// On macOS RLIMIT_NOFILE is not the ceiling: the kernel also caps a process at
+// kern.maxfilesperproc, and opening stops there. Measured on 26.6, a process
+// reporting a 1,048,576 soft limit took EMFILE after 245,748 descriptors,
+// against a kern.maxfilesperproc of 245,760 — so the number above overstates
+// the real ceiling more than fourfold, and every one of these failures so far
+// has come from macOS. The daemon supervisor raises the soft limit to
+// 1,048,576 before exec, which widens the gap further.
+//
+// Read once in the background at import rather than on the failure path: this
+// costs a spawn, and the thing being diagnosed is a spawn that would not
+// start.
+let enforcedLimit: number | undefined;
+
+if (process.platform === "darwin") {
+	try {
+		execFile("/usr/sbin/sysctl", ["-n", "kern.maxfilesperproc"], (err, out) => {
+			if (err) return;
+			const parsed = Number.parseInt(out.trim(), 10);
+			if (Number.isFinite(parsed)) enforcedLimit = parsed;
+		});
+	} catch {
+		// Diagnostics must never replace the failure they describe.
+	}
+}
+
 /**
  * Record the descriptor table on a git failure that never got as far as
  * running git.
  *
  * These failures report with no first-party frame — the captured stack is
  * entirely simple-git's executor — and nothing in the event says why the
- * spawn was refused. The count against the soft limit separates the two
- * candidates: at the limit is exhaustion, and the leak is ours to find;
- * nowhere near it is a descriptor that went bad while we still held it. See
- * HOST-SERVICE-4E and HOST-SERVICE-1R, where a machine enters this state and
- * every subsequent poll fails the same way for hours.
+ * spawn was refused. The count against the enforced ceiling separates the two
+ * candidates: at the ceiling is exhaustion, and the leak is ours to find;
+ * nowhere near it is a descriptor that went bad while we still held it.
+ *
+ * Read the errno before the count, because it already settles which question
+ * to ask: running out of descriptors is EMFILE, so an EBADF is a descriptor
+ * that went bad and no count will explain it. See HOST-SERVICE-4E and
+ * HOST-SERVICE-1R, where a machine enters this state and every subsequent
+ * poll fails the same way for hours.
  *
  * No-op for anything else, and no-op on the error itself: the message,
  * classification and 500 are exactly what they were.
@@ -90,5 +120,6 @@ export function attachSpawnFailureDiagnostics(error: unknown): void {
 	attachErrorDiagnostics(error, {
 		open_file_descriptors: countOpenFileDescriptors(),
 		file_descriptor_soft_limit: fileDescriptorSoftLimit(),
+		file_descriptor_enforced_limit: enforcedLimit,
 	});
 }


### PR DESCRIPTION
## Why
Chasing HOST-SERVICE-4E (`spawn EBADF`, ~135k events, our largest quota consumer) I went to read the descriptor diagnostics and found the recorded limit is not the one macOS enforces.

`process.report` reports RLIMIT_NOFILE. macOS additionally caps a process at `kern.maxfilesperproc`, and opening stops there. Measured on 26.6:

| | |
|---|---|
| Soft limit the diagnostic records | 1,048,576 |
| Descriptors actually openable | 245,748 |
| `kern.maxfilesperproc` | 245,760 |
| errno at exhaustion | **EMFILE** |

So the number in every event overstates the real ceiling more than fourfold, and every one of these failures so far has come from macOS. `DaemonSupervisor` raises the soft limit to 1,048,576 before exec, which widens the gap further.

This matters because the field exists to answer one question — at the ceiling means exhaustion and a leak of ours, far from it means a descriptor went bad — and it is currently answering it against the wrong number.

## What
- Records `file_descriptor_enforced_limit` from `kern.maxfilesperproc` alongside the soft limit. Read once in the background at import, not on the failure path: that path is a spawn that would not start, so diagnosing it with another spawn is the one place this must not be done.
- Corrects the reading order in the doc comment. **The errno settles which question to ask before the count does.** Running out of descriptors is EMFILE, so the EBADF in HOST-SERVICE-4E is a descriptor that went bad and no count will explain it — the opposite of what the previous wording implied.

## What this does not do
It does not fix HOST-SERVICE-4E. That error is not descriptor exhaustion, which the corrected reading makes clear: the affected machine held 10,269 descriptors against a ceiling in the hundreds of thousands, and exhaustion would have surfaced as EMFILE anyway. The remaining candidate is a descriptor invalidated while still held, which needs either a reproduction or narrower instrumentation than a count.

## Verification
Limit behaviour measured directly rather than assumed: a Node process reporting 1,048,576 took EMFILE after 245,748 opens. Root typecheck 38/38, lint clean, `packages/host-service` 1571 pass including the 5 existing diagnostics tests.

https://claude.ai/code/session_01Lo142KEzAfRh4vfPmmmsEX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS spawn-failure diagnostics so the recorded descriptor ceiling matches what the kernel actually enforces, not the RLIMIT_NOFILE soft limit that overstates it more than fourfold.

- Records `file_descriptor_enforced_limit` from `kern.maxfilesperproc` alongside the soft limit.
- Reads the value once in the background at import, since the failure path is a spawn that would not start.
- Corrects the diagnostic reading order: errno first, then count, so an EBADF is read as a bad descriptor rather than exhaustion.

Does not fix HOST-SERVICE-4E; the corrected reading shows that error is a bad descriptor, not exhaustion.

<sup>Written for commit 1f2ac41febfcbf603b85197ff22c3512c69946e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for process launch failures on macOS by reporting the system-enforced file descriptor ceiling.
  - Clarified file descriptor limit information to distinguish the enforced ceiling from the configured soft limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->