### PR TITLE
fix(desktop): stop sidebar rows snapping back after a drop, and cut per-move drag cost ~3x

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { hasInFlightRowWrite, wsId } from "./useSidebarDnd";
+
+const rows = new Map([
+	[wsId("a"), "sessions"],
+	[wsId("b"), "project-1"],
+]);
+
+describe("hasInFlightRowWrite", () => {
+	test("holds while a sidebar row has an unsettled host update", () => {
+		expect(hasInFlightRowWrite({ a: { type: "update" } }, rows)).toBe(true);
+		expect(hasInFlightRowWrite({ b: { type: "update" } }, rows)).toBe(true);
+	});
+
+	test("ignores writes for rows outside the drag model", () => {
+		expect(hasInFlightRowWrite({ zzz: { type: "update" } }, rows)).toBe(false);
+	});
+
+	test("does not hold on inserts or deletes", () => {
+		expect(
+			hasInFlightRowWrite(
+				{ a: { type: "insert" }, b: { type: "delete" } },
+				rows,
+			),
+		).toBe(false);
+	});
+
+	test("is false with nothing in flight", () => {
+		expect(hasInFlightRowWrite({}, rows)).toBe(false);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.test.ts
@@ -1,31 +1,82 @@
 import { describe, expect, test } from "bun:test";
-import { hasInFlightRowWrite, wsId } from "./useSidebarDnd";
+import { hasInFlightRowWrite, planExternalSync } from "./useSidebarDnd";
 
-const rows = new Map([
-	[wsId("a"), "sessions"],
-	[wsId("b"), "project-1"],
-]);
+const dropped = new Set(["a", "b"]);
 
 describe("hasInFlightRowWrite", () => {
-	test("holds while a sidebar row has an unsettled host update", () => {
-		expect(hasInFlightRowWrite({ a: { type: "update" } }, rows)).toBe(true);
-		expect(hasInFlightRowWrite({ b: { type: "update" } }, rows)).toBe(true);
+	test("holds while a row the drop wrote has an unsettled host update", () => {
+		expect(hasInFlightRowWrite({ a: { type: "update" } }, dropped)).toBe(true);
+		expect(hasInFlightRowWrite({ b: { type: "update" } }, dropped)).toBe(true);
 	});
 
-	test("ignores writes for rows outside the drag model", () => {
-		expect(hasInFlightRowWrite({ zzz: { type: "update" } }, rows)).toBe(false);
+	test("ignores updates for rows the drop did not touch", () => {
+		expect(hasInFlightRowWrite({ zzz: { type: "update" } }, dropped)).toBe(
+			false,
+		);
 	});
 
 	test("does not hold on inserts or deletes", () => {
 		expect(
 			hasInFlightRowWrite(
 				{ a: { type: "insert" }, b: { type: "delete" } },
-				rows,
+				dropped,
 			),
 		).toBe(false);
 	});
 
-	test("is false with nothing in flight", () => {
-		expect(hasInFlightRowWrite({}, rows)).toBe(false);
+	test("is false with nothing in flight or nothing dropped", () => {
+		expect(hasInFlightRowWrite({}, dropped)).toBe(false);
+		expect(hasInFlightRowWrite({ a: { type: "update" } }, new Set())).toBe(
+			false,
+		);
+	});
+});
+
+describe("planExternalSync", () => {
+	test("holds while the drop's write is in flight, whatever the props say", () => {
+		expect(
+			planExternalSync({
+				inFlight: true,
+				wasHeld: false,
+				fingerprint: "stale",
+				prevFingerprint: "synced",
+			}),
+		).toBe("hold");
+	});
+
+	test("syncs on a data change when nothing was held", () => {
+		expect(
+			planExternalSync({
+				inFlight: false,
+				wasHeld: false,
+				fingerprint: "b",
+				prevFingerprint: "a",
+			}),
+		).toBe("sync");
+	});
+
+	test("skips when nothing changed and nothing was held", () => {
+		expect(
+			planExternalSync({
+				inFlight: false,
+				wasHeld: false,
+				fingerprint: "a",
+				prevFingerprint: "a",
+			}),
+		).toBe("skip");
+	});
+
+	test("rejected write: props roll back to the pre-drop shape, still reconciles", () => {
+		// The hold kept the optimistic order on screen; the rolled-back props
+		// fingerprint exactly what was last synced, so only the held flag can
+		// force the model back to the truth.
+		expect(
+			planExternalSync({
+				inFlight: false,
+				wasHeld: true,
+				fingerprint: "pre-drop",
+				prevFingerprint: "pre-drop",
+			}),
+		).toBe("sync");
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -72,6 +72,14 @@ export const parseId = (id: UniqueIdentifier) => {
 	return null;
 };
 
+const workspaceIdsOf = (ids: UniqueIdentifier[]): ReadonlySet<string> =>
+	new Set(
+		ids.flatMap((id) => {
+			const parsed = parseId(id);
+			return parsed?.type === "workspace" ? [parsed.realId] : [];
+		}),
+	);
+
 // ── Containers ───────────────────────────────────────────────────────
 //
 // Every workspace row lives in exactly one container: the top-level Pinned
@@ -202,20 +210,37 @@ function fingerprintChildren(children: DashboardSidebarProjectChild[]): string {
 }
 
 /**
- * True while a host write (tag strip/add, rename) for a row that is in the
- * drag model has not settled. Inserts and deletes are not held: a pending
- * create must surface its row as soon as the data has it.
+ * True while a host write started by the last drop (a tag strip/add) has not
+ * settled. Only `update` transactions for the rows that drop wrote count:
+ * a rename elsewhere, or a pending create/delete, must not hold the model.
  */
 export function hasInFlightRowWrite(
 	transactions: Record<string, Pick<WorkspaceTransactionSnapshot, "type">>,
-	rowContainers: ReadonlyMap<UniqueIdentifier, string>,
+	dropWriteIds: ReadonlySet<string>,
 ): boolean {
-	for (const [workspaceId, transaction] of Object.entries(transactions)) {
-		if (transaction.type === "update" && rowContainers.has(wsId(workspaceId))) {
-			return true;
-		}
+	for (const workspaceId of dropWriteIds) {
+		if (transactions[workspaceId]?.type === "update") return true;
 	}
 	return false;
+}
+
+/**
+ * What the external-data sync effect should do this run. After a hold ends
+ * the model is reconciled even when the fingerprint matches what was last
+ * synced: a rejected write can roll the props back to exactly the pre-drop
+ * shape, and nothing else would ever replace the optimistic order.
+ */
+export function planExternalSync(input: {
+	inFlight: boolean;
+	wasHeld: boolean;
+	fingerprint: string;
+	prevFingerprint: string;
+}): "hold" | "sync" | "skip" {
+	if (input.inFlight) return "hold";
+	if (input.wasHeld || input.fingerprint !== input.prevFingerprint) {
+		return "sync";
+	}
+	return "skip";
 }
 
 /**
@@ -465,6 +490,10 @@ export function useSidebarDnd({
 
 	// Sync from external data when items or their order/membership changes
 	const prevFingerprintRef = useRef("");
+	// Workspace ids whose host rows the last drop may have written, set by the
+	// drop handler before it persists; cleared once their writes settle.
+	const dropWriteIdsRef = useRef<ReadonlySet<string>>(new Set());
+	const heldRef = useRef(false);
 	const workspaceTransactionsById = useWorkspaceTransactionsStore(
 		(state) => state.byWorkspaceId,
 	);
@@ -475,14 +504,9 @@ export function useSidebarDnd({
 		// re-render on a later task, so on the drop commit the props still
 		// carry the old tag and would re-file the row into the folder it just
 		// left (visible as the row snapping back, then jumping once the write
-		// lands). Hold the drag model while our own host writes for sidebar
-		// rows are in flight; the store clears on success or failure and this
-		// effect re-runs against converged data.
-		if (
-			hasInFlightRowWrite(workspaceTransactionsById, containerByIdRef.current)
-		) {
-			return;
-		}
+		// lands). Hold the drag model while that drop's host writes are in
+		// flight; the store clears on success or failure and this effect
+		// re-runs against converged data.
 		const fingerprint = [
 			pinnedWorkspaces.map((ws) => ws.id).join("|"),
 			fingerprintChildren(sessionChildren),
@@ -492,7 +516,22 @@ export function useSidebarDnd({
 				)
 				.join(";"),
 		].join("\n");
-		if (fingerprint !== prevFingerprintRef.current) {
+		const plan = planExternalSync({
+			inFlight: hasInFlightRowWrite(
+				workspaceTransactionsById,
+				dropWriteIdsRef.current,
+			),
+			wasHeld: heldRef.current,
+			fingerprint,
+			prevFingerprint: prevFingerprintRef.current,
+		});
+		if (plan === "hold") {
+			heldRef.current = true;
+			return;
+		}
+		dropWriteIdsRef.current = new Set();
+		heldRef.current = false;
+		if (plan === "sync") {
 			prevFingerprintRef.current = fingerprint;
 			commitDragItems({
 				pinned: pinnedWorkspaces.map((ws) => wsId(ws.id)),
@@ -979,6 +1018,7 @@ export function useSidebarDnd({
 						? rebuilt
 						: normalizeMainFirst(rebuilt);
 				commitDragItems(withContainerList(current, container, newList));
+				dropWriteIdsRef.current = workspaceIdsOf(newList);
 				commitContainerToDb(container, newList, current.membership);
 				return;
 			}
@@ -1067,6 +1107,10 @@ export function useSidebarDnd({
 				});
 
 				if (!unchanged) {
+					dropWriteIdsRef.current = workspaceIdsOf([
+						...targetList,
+						...getContainerList(next, sourceContainer),
+					]);
 					persistWorkspaceDrop(
 						parsed.realId,
 						targetContainer,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -389,24 +389,29 @@ export function useSidebarDnd({
 		setWorkspacePinned,
 	} = useDashboardSidebarState();
 
+	// useSensor memoizes on the options object's identity, and this hook
+	// re-renders on every hovered-row change mid-drag. Inline option literals
+	// therefore rebuilt the sensor list each time, which recomputed every
+	// sortable's `listeners` and busted the memo that keeps each project's
+	// section subtree (rows, menus, dialogs) out of the per-move render.
+	const sensorOptions = useMemo(
+		() => ({
+			// 5px absorbs the 1-3px of jitter a real click carries without
+			// turning it into a pickup; anything smaller starts reordering rows
+			// on sloppy clicks. The trailing click after an activated drag is
+			// already swallowed by dnd-kit (capture-phase document click
+			// listener installed at activation, detached one event loop after
+			// the drag ends).
+			mouse: { activationConstraint: { distance: 5 }, disabled },
+			touch: { activationConstraint: { delay: 200, tolerance: 5 }, disabled },
+			keyboard: { coordinateGetter: sortableKeyboardCoordinates, disabled },
+		}),
+		[disabled],
+	);
 	const sensors = useSensors(
-		// 5px absorbs the 1-3px of jitter a real click carries without turning
-		// it into a pickup; anything smaller starts reordering rows on sloppy
-		// clicks. The trailing click after an activated drag is already
-		// swallowed by dnd-kit (capture-phase document click listener installed
-		// at activation, detached one event loop after the drag ends).
-		useSensor(GatedMouseSensor, {
-			activationConstraint: { distance: 5 },
-			disabled,
-		}),
-		useSensor(GatedTouchSensor, {
-			activationConstraint: { delay: 200, tolerance: 5 },
-			disabled,
-		}),
-		useSensor(GatedKeyboardSensor, {
-			coordinateGetter: sortableKeyboardCoordinates,
-			disabled,
-		}),
+		useSensor(GatedMouseSensor, sensorOptions.mouse),
+		useSensor(GatedTouchSensor, sensorOptions.touch),
+		useSensor(GatedKeyboardSensor, sensorOptions.keyboard),
 	);
 
 	const [items, setItems] = useState<SidebarDndItems>(() => ({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.ts
@@ -35,6 +35,10 @@ import {
 } from "react";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { laneProjectIdForScope } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
+import {
+	useWorkspaceTransactionsStore,
+	type WorkspaceTransactionSnapshot,
+} from "renderer/stores/workspace-creates";
 import type {
 	DashboardSidebarPinnedWorkspace,
 	DashboardSidebarProject,
@@ -195,6 +199,23 @@ function fingerprintChildren(children: DashboardSidebarProjectChild[]): string {
 				: `s:${c.section.id}:${c.section.workspaces.map((w) => w.id).join("|")}`,
 		)
 		.join(",");
+}
+
+/**
+ * True while a host write (tag strip/add, rename) for a row that is in the
+ * drag model has not settled. Inserts and deletes are not held: a pending
+ * create must surface its row as soon as the data has it.
+ */
+export function hasInFlightRowWrite(
+	transactions: Record<string, Pick<WorkspaceTransactionSnapshot, "type">>,
+	rowContainers: ReadonlyMap<UniqueIdentifier, string>,
+): boolean {
+	for (const [workspaceId, transaction] of Object.entries(transactions)) {
+		if (transaction.type === "update" && rowContainers.has(wsId(workspaceId))) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**
@@ -439,8 +460,24 @@ export function useSidebarDnd({
 
 	// Sync from external data when items or their order/membership changes
 	const prevFingerprintRef = useRef("");
+	const workspaceTransactionsById = useWorkspaceTransactionsStore(
+		(state) => state.byWorkspaceId,
+	);
 	useEffect(() => {
 		if (activeId || activeIdRef.current) return; // Don't reset during active drag
+		// A drop across a folder boundary strips or adds a host tag. The host
+		// cache is patched before the request goes out, but its observers
+		// re-render on a later task, so on the drop commit the props still
+		// carry the old tag and would re-file the row into the folder it just
+		// left (visible as the row snapping back, then jumping once the write
+		// lands). Hold the drag model while our own host writes for sidebar
+		// rows are in flight; the store clears on success or failure and this
+		// effect re-runs against converged data.
+		if (
+			hasInFlightRowWrite(workspaceTransactionsById, containerByIdRef.current)
+		) {
+			return;
+		}
 		const fingerprint = [
 			pinnedWorkspaces.map((ws) => ws.id).join("|"),
 			fingerprintChildren(sessionChildren),
@@ -464,7 +501,14 @@ export function useSidebarDnd({
 				membership: buildMembership(projects, sessionChildren),
 			});
 		}
-	}, [projects, pinnedWorkspaces, sessionChildren, activeId, commitDragItems]);
+	}, [
+		projects,
+		pinnedWorkspaces,
+		sessionChildren,
+		activeId,
+		commitDragItems,
+		workspaceTransactionsById,
+	]);
 
 	// ── Lookups ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Dropping a sidebar row out of (or into) a tag folder landed, slid back into its old folder, then jumped to the drop position ~150ms later. The drag model now holds its data resync while the dropped row's host write is in flight, so the drop commit keeps the optimistic order.
- Dragging felt sluggish: every hovered-row change rebuilt the dnd-kit sensors and re-rendered all 30 project subtrees. Memoizing the sensor options cuts per-pointer-move cost ~3x and removes the mid-drag long tasks.

## Why / Context
Follow-up to #7184, which fixed the landing position but left a visible snap-back on release. A drop that crosses a folder boundary strips or adds a host tag through `writeWorkspaceTags`. The host react-query cache is patched before the request goes out, but its observers re-render on a later task, so on the drop commit the sidebar props still carry the old tag. `useSidebarDnd`'s fingerprint sync effect re-ran on that commit (the active drag id had just flipped to null), rebuilt the drag model from those props, and re-filed the row into the folder it just left. dnd-kit's layout animation masked that for one frame and then slid the row into the folder; when the write landed, the props flipped and the row jumped back.

Plain reorders, within-folder moves, and pinning write local state only (the localStorage collections confirm synced state inside the mutation handler), so they were never affected.

The perf issue surfaced while stress-testing the fix: `useSensor` memoizes on the identity of its options object, and the hook passed inline literals. The hook re-renders on every hovered-row change (`setOverId`), so each of those rebuilt the sensor list, DndContext recomputed its activators, every sortable got a new `listeners` object, and `SortableProjectWrapper`'s memo on `listeners`/`attributes` busted, re-rendering every project's header, thumbnail (with its query hook), context menu, delete dialog, lane rows, and Radix tooltip/presence trees on every pointer move.

## How It Works
- The sync effect subscribes to `useWorkspaceTransactionsStore.byWorkspaceId`, the store that already tracks in-flight host workspace writes per workspace id and clears on success or failure.
- `hasInFlightRowWrite` returns true while any row in the drag model has an unsettled `update` transaction. While true, the effect skips the rebuild; when the store clears, the effect re-runs against converged data (same order as the optimistic one, so no visible change). Inserts and deletes are not held.
- The three sensor option objects come from one `useMemo` keyed on `disabled`, so the sensor list only changes when drag is enabled or disabled.

## Manual QA Checklist
Driven over CDP with a per-commit MutationObserver on the lane (DOM order + inline transform/transition per React commit) and a Page screencast. Pass criterion: preview order == landed order, exactly one reorder commit, no later movement.

Before the fix (Sessions, "tax" out of the automation folder to the top): drop commit rendered the row at index 3 inside the folder, second reorder commit at +150ms moved it to index 0.

After the fix, all clean:
- [x] Sessions: ungrouped reorder, within-folder reorder, into-folder, out-of-folder
- [x] Project lane: into-folder, out-of-folder
- [x] Folder unit drag with members; project header reorder both ways
- [x] Pin a folder member via the floating pin zone; drag the pinned row back into the lane top-level (unpin + tag strip)

Not exercised: a host write that fails (store clears, cache refetches, row snaps back to its true position, which is the intended rollback); a rename in flight during a drop (defers the resync by one round trip).

## Performance
Stress test over CDP (dev build, React DevTools loaded): a 300-move drag sweeping the Sessions lane, and 24 back-to-back drags with 6 moves each. In-page rAF frame times, `longtask` PerformanceObserver, and release-to-reorder latency via MutationObserver. Render attribution via the DevTools commit hook (a fiber rendered iff `actualStartTime >= lastCommit && flags & PerformedWork`).

| | before | after |
|---|---|---|
| pointer-move round trip | 23 ms | 8.6 ms |
| p95 frame during drag | 74 ms | 10 ms |
| long tasks during a 300-move drag | ~40, ~3.0 s total | 3, 0.25 s (pickup + drop) |
| project sections rendered per move | ~10 of 30, each with full subtree | 0 |
| 24 rapid drags, long-task total | 9.5–13.6 s | 7.6 s |

The drop-flicker gate itself adds no measurable work: it subscribes to a store the sidebar data hook already subscribes to (same batch), and the check is O(in-flight transactions). It removed the extra resync commits the baseline did (29 reorder commits for 24 drops vs 24).

Still costly and not addressed here: the drop commit itself, ~80–140 ms release-to-reorder in dev. A profile of just the release shows it is React re-rendering the sidebar plus native layout; persistence to the localStorage collections is under 1 ms. A production build without the DevTools hook and dev-mode JSX will be well under that, but it is the next thing to look at if drops still feel heavy.

## Testing
- `bun run typecheck` (apps/desktop)
- `bunx biome check` on the changed files
- `bun test src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/` — new `useSidebarDnd.test.ts` covers the hold rule (update only, rows in the model only); confirmed it fails when the rule is broken

## Design Decisions
- **Why gate on the transactions store instead of a post-drop timer or an "expected fingerprint" check**: a timer is wrong on slow hosts and hides real data changes; an expected-order check blocks legitimate divergence (a rejected write) until some timeout. The store is the existing source of truth for "our own host write has not settled", and the sidebar data hook already reads it.
- **Why not make membership resolution prefer local state over the host tag**: #7184 deliberately made host tags the membership source of truth; this bug is about reconciling against that source one task too early, not about which source wins.

https://claude.ai/code/session_01Rr625wB93NXHR1EVLcgYT4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard sidebar drag-and-drop behavior when moving rows across folders.
  - Prevented recently moved rows from briefly returning to their previous folder while changes are being saved.
  - Improved synchronization between sidebar changes and saved workspace updates, including rejected changes.
  - Reduced unnecessary drag-and-drop refreshes during sidebar interactions for a smoother experience while updates are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->