### PR TITLE
fix(billing): make failed-payment emails recoverable

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1211,24 +1211,30 @@ export const auth = betterAuth({
 					);
 					const accessEndsAt = subscription.periodEnd ?? new Date();
 
-					const portalSession =
-						await stripeClient.billingPortal.sessions.create({
-							customer: org.stripeCustomerId,
-							return_url: env.NEXT_PUBLIC_WEB_URL,
-						});
+					// periodEnd is the period Stripe was trying to bill for, so on a
+					// collection failure it sits weeks in the future while access has
+					// already stopped. Only a voluntary cancel keeps access until then.
+					const dueToPaymentFailure =
+						(cancellationDetails ?? stripeSubscription.cancellation_details)
+							?.reason === "payment_failed";
 
 					await resend.batch.send(
 						recipients.map((recipient) => ({
 							from: "Superset <noreply@superset.sh>",
 							to: recipient.email,
-							subject: `Your ${subscription.plan} subscription has been cancelled`,
+							subject: dueToPaymentFailure
+								? `Your ${subscription.plan} subscription ended`
+								: `Your ${subscription.plan} subscription has been cancelled`,
 							react: SubscriptionCancelledEmail({
 								recipientName: recipient.name,
 								organizationName: org.name,
 								planName: subscription.plan,
 								accessEndsAt,
-								billingPortalUrl:
-									recipient.role === "owner" ? portalSession.url : undefined,
+								dueToPaymentFailure,
+								resubscribeUrl:
+									recipient.role === "owner"
+										? env.NEXT_PUBLIC_WEB_URL
+										: undefined,
 							}),
 						})),
 					);
@@ -1277,30 +1283,40 @@ export const auth = betterAuth({
 							where: eq(subscriptions.referenceId, org.id),
 						});
 
-						const recipients = await getOrganizationBillingRecipients(org.id);
-						const amount = formatPrice(invoice.amount_due, invoice.currency);
+						const isFinalAttempt = invoice.next_payment_attempt == null;
+						const isFirstAttempt = (invoice.attempt_count ?? 0) <= 1;
 
-						const portalSession =
-							await stripeClient.billingPortal.sessions.create({
-								customer: org.stripeCustomerId,
-								return_url: env.NEXT_PUBLIC_WEB_URL,
-							});
+						// Stripe fires this on every retry. Mailing all of them trains
+						// people to ignore the one that matters, so only the opening
+						// notice and the last-chance notice go out.
+						if (isFirstAttempt || isFinalAttempt) {
+							const recipients = await getOrganizationBillingRecipients(org.id);
+							const amount = formatPrice(invoice.amount_due, invoice.currency);
+							const nextRetryDate = invoice.next_payment_attempt
+								? new Date(invoice.next_payment_attempt * 1000)
+								: null;
 
-						await resend.batch.send(
-							recipients.map((recipient) => ({
-								from: "Superset <noreply@superset.sh>",
-								to: recipient.email,
-								subject: `Payment failed for ${org.name}`,
-								react: PaymentFailedEmail({
-									recipientName: recipient.name,
-									organizationName: org.name,
-									planName: subscription?.plan ?? "Pro",
-									amount,
-									billingPortalUrl:
-										recipient.role === "owner" ? portalSession.url : undefined,
-								}),
-							})),
-						);
+							await resend.batch.send(
+								recipients.map((recipient) => ({
+									from: "Superset <noreply@superset.sh>",
+									to: recipient.email,
+									subject: isFinalAttempt
+										? `Final notice: payment failed for ${org.name}`
+										: `Payment failed for ${org.name}`,
+									react: PaymentFailedEmail({
+										recipientName: recipient.name,
+										organizationName: org.name,
+										planName: subscription?.plan ?? "Pro",
+										amount,
+										nextRetryDate,
+										payInvoiceUrl:
+											recipient.role === "owner"
+												? (invoice.hosted_invoice_url ?? undefined)
+												: undefined,
+									}),
+								})),
+							);
+						}
 
 						const stripeSubId =
 							subscription?.stripeSubscriptionId ??

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1231,10 +1231,6 @@ export const auth = betterAuth({
 								planName: subscription.plan,
 								accessEndsAt,
 								dueToPaymentFailure,
-								resubscribeUrl:
-									recipient.role === "owner"
-										? env.NEXT_PUBLIC_WEB_URL
-										: undefined,
 							}),
 						})),
 					);

--- a/packages/email/src/emails/billing/payment-failed.tsx
+++ b/packages/email/src/emails/billing/payment-failed.tsx
@@ -1,4 +1,5 @@
 import { Heading, Link, Section, Text } from "@react-email/components";
+import { format } from "date-fns";
 import { Button, EmailLayout } from "../../components";
 
 interface PaymentFailedEmailProps {
@@ -6,8 +7,11 @@ interface PaymentFailedEmailProps {
 	organizationName: string;
 	planName: string;
 	amount: string;
+	/** Stripe's next scheduled retry, or null when this was the last attempt. */
 	nextRetryDate?: Date | null;
-	billingPortalUrl?: string;
+	/** Stripe's hosted invoice page. Unlike a billing portal session it stays
+	 * valid for 30 days, which is the point of putting it in an email. */
+	payInvoiceUrl?: string;
 }
 
 export function PaymentFailedEmail({
@@ -15,13 +19,15 @@ export function PaymentFailedEmail({
 	organizationName = "Acme Inc",
 	planName = "Pro",
 	amount = "$50.00",
-	nextRetryDate = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
-	billingPortalUrl,
+	nextRetryDate = null,
+	payInvoiceUrl,
 }: PaymentFailedEmailProps) {
+	const isFinalAttempt = nextRetryDate == null;
+
 	return (
 		<EmailLayout preview={`Payment failed for ${organizationName}`}>
 			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
-				Payment failed
+				{isFinalAttempt ? "Final payment attempt failed" : "Payment failed"}
 			</Heading>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
@@ -36,14 +42,18 @@ export function PaymentFailedEmail({
 
 			<Section className="bg-[#fef2f2] border border-solid border-[#fecaca] rounded-lg p-4 mb-4">
 				<Text className="text-[14px] leading-5 text-[#991b1b] m-0">
-					<strong>Action required:</strong> Update your payment method so your
-					team doesn't lose {planName} access.
+					<strong>
+						{isFinalAttempt ? "Final notice:" : "Action required:"}
+					</strong>{" "}
+					{isFinalAttempt
+						? `This was our last attempt. ${organizationName} loses ${planName} access today unless this invoice is paid.`
+						: `Update your payment method so your team doesn't lose ${planName} access.`}
 				</Text>
 			</Section>
 
 			{nextRetryDate && (
 				<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
-					We'll automatically retry the payment in a few days.
+					We'll try again on {format(nextRetryDate, "MMMM d, yyyy")}.
 				</Text>
 			)}
 
@@ -58,9 +68,9 @@ export function PaymentFailedEmail({
 				<br />• Incorrect billing information
 			</Text>
 
-			{billingPortalUrl && (
+			{payInvoiceUrl && (
 				<Section className="mb-6">
-					<Button href={billingPortalUrl}>Update Payment Method</Button>
+					<Button href={payInvoiceUrl}>Pay now</Button>
 				</Section>
 			)}
 

--- a/packages/email/src/emails/billing/subscription-cancelled.tsx
+++ b/packages/email/src/emails/billing/subscription-cancelled.tsx
@@ -1,6 +1,6 @@
-import { Heading, Hr, Link, Section, Text } from "@react-email/components";
+import { Heading, Hr, Link, Text } from "@react-email/components";
 import { format } from "date-fns";
-import { Button, DetailRow, EmailLayout } from "../../components";
+import { DetailRow, EmailLayout } from "../../components";
 
 interface SubscriptionCancelledEmailProps {
 	recipientName?: string | null;
@@ -10,16 +10,17 @@ interface SubscriptionCancelledEmailProps {
 	/** Stripe gave up collecting and cancelled the subscription. Access is
 	 * already gone, so none of the "until <date>" copy applies. */
 	dueToPaymentFailure?: boolean;
-	resubscribeUrl?: string;
 }
 
+// Resubscribing only exists on the desktop billing page — there is no web
+// route for it — so this email points there in words rather than shipping a
+// button that lands on the agents page.
 export function SubscriptionCancelledEmail({
 	recipientName = "there",
 	organizationName = "Acme Inc",
 	planName = "Pro",
 	accessEndsAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
 	dueToPaymentFailure = false,
-	resubscribeUrl,
 }: SubscriptionCancelledEmailProps) {
 	const formattedEndDate = format(accessEndsAt, "MMMM d, yyyy");
 
@@ -49,8 +50,9 @@ export function SubscriptionCancelledEmail({
 					</Text>
 
 					<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
-						Nothing has been deleted. Resubscribe with a working card and{" "}
-						{planName} turns straight back on.
+						Nothing has been deleted. Open Superset and go to{" "}
+						<strong>Settings → Billing</strong> to resubscribe with a working
+						card — {planName} turns straight back on.
 					</Text>
 				</>
 			) : (
@@ -72,15 +74,9 @@ export function SubscriptionCancelledEmail({
 
 					<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
 						Changed your mind? You can resubscribe anytime before your access
-						ends.
+						ends from <strong>Settings → Billing</strong> in Superset.
 					</Text>
 				</>
-			)}
-
-			{resubscribeUrl && (
-				<Section className="mb-6">
-					<Button href={resubscribeUrl}>Resubscribe</Button>
-				</Section>
 			)}
 
 			<Text className="text-[13px] leading-5 text-muted m-0">

--- a/packages/email/src/emails/billing/subscription-cancelled.tsx
+++ b/packages/email/src/emails/billing/subscription-cancelled.tsx
@@ -7,7 +7,10 @@ interface SubscriptionCancelledEmailProps {
 	organizationName: string;
 	planName: string;
 	accessEndsAt: Date;
-	billingPortalUrl?: string;
+	/** Stripe gave up collecting and cancelled the subscription. Access is
+	 * already gone, so none of the "until <date>" copy applies. */
+	dueToPaymentFailure?: boolean;
+	resubscribeUrl?: string;
 }
 
 export function SubscriptionCancelledEmail({
@@ -15,42 +18,68 @@ export function SubscriptionCancelledEmail({
 	organizationName = "Acme Inc",
 	planName = "Pro",
 	accessEndsAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-	billingPortalUrl,
+	dueToPaymentFailure = false,
+	resubscribeUrl,
 }: SubscriptionCancelledEmailProps) {
 	const formattedEndDate = format(accessEndsAt, "MMMM d, yyyy");
 
 	return (
-		<EmailLayout preview={`Your ${planName} subscription has been cancelled`}>
+		<EmailLayout
+			preview={
+				dueToPaymentFailure
+					? `Your ${planName} subscription ended`
+					: `Your ${planName} subscription has been cancelled`
+			}
+		>
 			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
-				Subscription cancelled
+				{dueToPaymentFailure ? "Subscription ended" : "Subscription cancelled"}
 			</Heading>
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				Hi {recipientName ?? "there"},
 			</Text>
 
-			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
-				Your <strong>{planName}</strong> subscription for{" "}
-				<strong>{organizationName}</strong> has been cancelled.
-			</Text>
+			{dueToPaymentFailure ? (
+				<>
+					<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
+						We tried several times to charge the payment method on file for{" "}
+						<strong>{organizationName}</strong>'s <strong>{planName}</strong>{" "}
+						subscription and couldn't, so the subscription has ended and the
+						organization is now on the free plan.
+					</Text>
 
-			<Hr className="border-border my-4" />
-			<DetailRow label="Access until" value={formattedEndDate} />
-			<Hr className="border-border my-4" />
+					<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+						Nothing has been deleted. Resubscribe with a working card and{" "}
+						{planName} turns straight back on.
+					</Text>
+				</>
+			) : (
+				<>
+					<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
+						Your <strong>{planName}</strong> subscription for{" "}
+						<strong>{organizationName}</strong> has been cancelled.
+					</Text>
 
-			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
-				You'll continue to have access to all {planName} features until{" "}
-				{formattedEndDate}. After that, your organization moves to the free
-				plan.
-			</Text>
+					<Hr className="border-border my-4" />
+					<DetailRow label="Access until" value={formattedEndDate} />
+					<Hr className="border-border my-4" />
 
-			<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
-				Changed your mind? You can resubscribe anytime before your access ends.
-			</Text>
+					<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
+						You'll continue to have access to all {planName} features until{" "}
+						{formattedEndDate}. After that, your organization moves to the free
+						plan.
+					</Text>
 
-			{billingPortalUrl && (
+					<Text className="text-[15px] leading-6 text-foreground m-0 mb-6">
+						Changed your mind? You can resubscribe anytime before your access
+						ends.
+					</Text>
+				</>
+			)}
+
+			{resubscribeUrl && (
 				<Section className="mb-6">
-					<Button href={billingPortalUrl}>Resubscribe</Button>
+					<Button href={resubscribeUrl}>Resubscribe</Button>
 				</Section>
 			)}
 


### PR DESCRIPTION
Involuntary churn — subscriptions Stripe cancels after it gives up collecting — is now **33% of all cancellations**, up from 10% in June. That's 21 subscriptions and $420 MRR last month, $2,360 MRR (~$28k ARR) cumulative.

Stripe's own recovery emails are **disabled** on the account, so our emails are the only dunning mail these customers get. All three defects below were in that one path.

### The pay link was dead on arrival

Both emails embedded a `billingPortal.sessions.create` URL created at send time. Stripe documents those as [short-lived](https://docs.stripe.com/api/customer_portal/sessions/object), expiring if the customer doesn't visit them — so by the time anyone opened the mail, the button was spent.

Now uses the invoice's hosted page: valid 30 days, and it takes the payment directly instead of routing through a portal. The in-app `usePaymentFailedCard` already did exactly this.

### The retry line was always wrong

`nextRetryDate` was never passed from the handler, so the template's default (`now + 3d`) made it truthy and **"We'll automatically retry the payment in a few days" rendered on every attempt — including the ninth and final one**, when the subscription was about to be canceled.

Now passes Stripe's real `next_payment_attempt`. When it's `null`, the mail becomes a final notice with the actual consequence instead of a false reassurance.

### The cancellation mail told churned users they still had access

`accessEndsAt` comes from `subscription.periodEnd`, which better-auth sets from `current_period_end` — the period Stripe was *trying* to bill. So every payment-failure cancel promised access *"until"* a date **~17 days in the future** (verified across the last 10) while the subscription was already canceled and the org back on free. It also read as a voluntary-cancel confirmation ("Changed your mind?"), wasting the best win-back moment.

Involuntary cancels now get their own copy — no access-until row, accurate explanation, and a resubscribe link that doesn't expire.

### Also

Stopped mailing on all nine retries. Stripe fires `invoice.payment_failed` per attempt (225 events across 58 invoices in the last 30 days, mean 3.9, max 9); now only the first and final go out. Slack notifications are unchanged.

## Verification

- Rendered all four variants (first attempt / final attempt / involuntary cancel / voluntary cancel); links resolve to the hosted invoice and app URL, no `billing.stripe.com` session anywhere.
- Voluntary-cancel copy is byte-identical to before.
- `typecheck` clean on auth, email, trpc, api, web. `lint.sh` clean. `@superset/auth` tests 8/8.
- No other consumers of the renamed props.

## Not in this PR

- **Enable Stripe's recovery emails / hosted recovery surface** — both off today. Worth turning on, but they'd overlap with these emails, so that's a deliberate choice about which channel owns dunning rather than a code change.
- **126 open invoices, $2,927 outstanding**, 110 of which Stripe has abandoned (`auto_advance: false`). A one-off win-back list, not a code fix.
- **The in-app card disappears at cancellation** — it keys off `past_due`, so the moment access is actually lost there's no in-app signal at all.

https://claude.ai/code/session_01CqWBnJKCMs4b5ZXpSUZvFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failed-payment email path so customers on the verge of involuntary churn get working links and honest copy instead of expired pay links, a false retry promise, and reassurance that access continues after it's already gone.

**Bug Fixes**
- Emails now link to Stripe's hosted invoice page (valid 30 days, pays directly) instead of a short-lived billing portal session created at send time.
- Passes Stripe's real next payment attempt; the final notice states access is lost today instead of claiming an automatic retry is coming.
- Involuntary cancels get dedicated copy with no future "access until" date and resubscribe instructions pointing to Settings → Billing in-app; voluntary-cancel copy is unchanged.
- Payment-failed emails now go out only on the first and final attempts instead of on all nine retries.

<sup>Written for commit e8a267b5811125c780d2c6c0a3c5fef58ae9b49e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Payment failure emails now indicate whether another payment attempt is scheduled or the subscription has ended.
  - Retryable notices include the next retry date.
  - Recipients can use a **Pay now** link to access the hosted invoice.
  - Subscription cancellation emails distinguish payment-failure cancellations from voluntary cancellations and direct recipients to Settings → Billing for billing actions.
  - Cancellation emails no longer include resubscription links or access-expiration details for payment-failure cancellations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->