### PR TITLE
fix(host-service): stop spawning gh for every repo while GitHub is unreachable

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -910,6 +910,89 @@ describe("PullRequestRuntimeManager refresh", () => {
 	// A permanently failing fetch (payload over maxBuffer, revoked auth) must
 	// not respawn gh at full 60s-TTL cadence forever: consecutive failures
 	// double the cached rejection's TTL, and a success resets the streak.
+	test("holds every GitHub lookup after a transport failure instead of spawning gh per repo", async () => {
+		const t0 = Date.now();
+		setSystemTime(new Date(t0));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			let ghAttempts = 0;
+			let octokitAttempts = 0;
+			const manager = createManager(db, {
+				execGh: async () => {
+					ghAttempts += 1;
+					throw Object.assign(new Error("Command failed: gh api"), {
+						stderr:
+							"error connecting to api.github.com\ndial tcp: lookup api.github.com: no such host",
+					});
+				},
+				github: (async () => {
+					octokitAttempts += 1;
+					throw new Error("octokit should not run on a dead network");
+				}) as never,
+			});
+			const repoOf = (name: string) => ({
+				provider: "github" as const,
+				owner: REPO.owner,
+				name,
+				url: `https://github.com/${REPO.owner}/${name}.git`,
+				remoteName: "origin",
+				defaultBranch: "main",
+			});
+			const fetchOpenPrs = openPullRequestsSweeper(manager);
+			const sweep = (name: string) =>
+				withSilencedWarnings(() => fetchOpenPrs(repoOf(name)).catch(() => {}));
+
+			// The first repo pays one gh spawn. Octokit is skipped: it would hit
+			// the same resolver.
+			await sweep("repo-a");
+			expect(ghAttempts).toBe(1);
+			expect(octokitAttempts).toBe(0);
+
+			// Every other repo is held without a spawn while the gate is closed.
+			await sweep("repo-b");
+			await sweep("repo-c");
+			expect(ghAttempts).toBe(1);
+
+			// The gate reopens after its first window and tries once more.
+			setSystemTime(new Date(t0 + 61_000));
+			await sweep("repo-d");
+			expect(ghAttempts).toBe(2);
+			expect(octokitAttempts).toBe(0);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("still falls back to Octokit when gh fails but GitHub answered", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		let octokitAttempts = 0;
+		const manager = createManager(db, {
+			execGh: async () => {
+				throw Object.assign(new Error("gh: HTTP 403"), {
+					code: 1,
+					stderr: "gh: API rate limit exceeded",
+				});
+			},
+			github: (async () => {
+				octokitAttempts += 1;
+				throw new Error("octokit unavailable");
+			}) as never,
+		});
+		const repo = {
+			provider: "github" as const,
+			owner: REPO.owner,
+			name: REPO.name,
+			url: `https://github.com/${REPO.owner}/${REPO.name}.git`,
+			remoteName: "origin",
+			defaultBranch: "main",
+		};
+		const fetchOpenPrs = openPullRequestsSweeper(manager);
+		await withSilencedWarnings(() => fetchOpenPrs(repo).catch(() => {}));
+		expect(octokitAttempts).toBe(1);
+	});
+
 	test("backs off repeated open-PR sweep failures and resets on success", async () => {
 		const t0 = Date.now();
 		setSystemTime(new Date(t0));

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -11,6 +11,7 @@ import * as schema from "../../db/schema";
 import { pullRequests, workspaces } from "../../db/schema";
 import type { WorkspaceChangedMessage } from "../../events/types";
 import { PullRequestRuntimeManager } from "./pull-requests";
+import { GitHubReachabilityGate } from "./utils/github-reachability";
 import type { WorkspaceRefsSnapshot } from "./utils/workspace-refs";
 
 // All tests run the real manager against a real, migrated, in-memory SQLite
@@ -1061,6 +1062,53 @@ describe("PullRequestRuntimeManager refresh", () => {
 		});
 	});
 
+	test("a successful probe lets a previously held repo retry immediately", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		let ghAttempts = 0;
+		let online = false;
+		const manager = createManager(db, {
+			execGh: async () => {
+				ghAttempts += 1;
+				if (!online) throw Object.assign(new Error("x"), { code: "ENOTFOUND" });
+				return [];
+			},
+			github: (async () => {
+				throw new Error("octokit must not run");
+			}) as never,
+		});
+		const repoOf = (name: string) => ({
+			provider: "github" as const,
+			owner: REPO.owner,
+			name,
+			url: `https://github.com/${REPO.owner}/${name}.git`,
+			remoteName: "origin",
+			defaultBranch: "main",
+		});
+		const accessible = manager as unknown as {
+			getCachedOpenPullRequests(
+				repo: ReturnType<typeof repoOf>,
+				options?: { bypassCache?: boolean },
+			): Promise<unknown[]>;
+		};
+		await withSilencedWarnings(async () => {
+			await accessible.getCachedOpenPullRequests(repoOf("a")).catch(() => {});
+			expect(ghAttempts).toBe(1);
+			// Polling is held.
+			await accessible.getCachedOpenPullRequests(repoOf("b")).catch(() => {});
+			expect(ghAttempts).toBe(1);
+			online = true;
+			await accessible
+				.getCachedOpenPullRequests(repoOf("c"), { bypassCache: true })
+				.catch(() => {});
+			expect(ghAttempts).toBe(2);
+			await expect(
+				accessible.getCachedOpenPullRequests(repoOf("b")),
+			).resolves.toEqual([]);
+			expect(ghAttempts).toBe(3);
+		});
+	});
+
 	test("detail lookups are held during an outage even with a warm head cache", async () => {
 		const db = createRealDb();
 		seedProject(db);
@@ -1120,6 +1168,76 @@ describe("PullRequestRuntimeManager refresh", () => {
 		expect(ghAttempts).toBe(heldAttempts);
 		expect(octokitAttempts).toBe(0);
 	});
+
+	for (const recoveredDetail of ["checks", "queue"] as const) {
+		test(`successful Octokit ${recoveredDetail} fallback resets the outage streak`, async () => {
+			const db = createRealDb();
+			seedProject(db);
+			seedWorkspace(db, {
+				id: "ws",
+				branch: "fix/sidebar",
+				headSha: "abc123",
+				upstreamOwner: REPO.owner,
+				upstreamRepo: REPO.name,
+				upstreamBranch: "fix/sidebar",
+			});
+			let warming = true;
+			const route = routeGh({
+				"fix/sidebar": makePrNode({
+					number: 7,
+					headRef: "fix/sidebar",
+					headSha: "abc123",
+				}),
+			});
+			const manager = createManager(db, {
+				git: defaultBranchGit("main"),
+				execGh: async (args) => {
+					if (warming) return route(args);
+					throw new Error("gh: HTTP 403");
+				},
+				github: (async () => ({
+					rest: {
+						pulls: {
+							listReviews: async () => {
+								if (recoveredDetail !== "checks")
+									throw new Error("reviews unavailable");
+								return { data: [] };
+							},
+						},
+						checks: { listForRef: async () => ({ data: { check_runs: [] } }) },
+						repos: { listCommitStatusesForRef: async () => ({ data: [] }) },
+					},
+					graphql: async () => {
+						if (recoveredDetail !== "queue")
+							throw new Error("queue unavailable");
+						return { repository: { pullRequest: { mergeQueueEntry: null } } };
+					},
+				})) as never,
+			});
+			let now = 0;
+			const gate = new GitHubReachabilityGate({ now: () => now });
+			const accessible = manager as unknown as {
+				githubGate: GitHubReachabilityGate;
+				refreshProject(projectId: string): Promise<void>;
+			};
+			accessible.githubGate = gate;
+			await withSilencedWarnings(() => accessible.refreshProject(PROJECT_ID));
+			expect(getWorkspace(db, "ws")?.pullRequestId).not.toBeNull();
+			warming = false;
+			const offline = Object.assign(new Error("offline"), {
+				code: "ENOTFOUND",
+			});
+			gate.recordFailure(offline);
+			// Advance only the gate clock so the head cache stays warm.
+			// Only the selected Octokit detail fallback can reset the streak.
+			now = 61_000;
+			await withSilencedWarnings(() => accessible.refreshProject(PROJECT_ID));
+			expect(gate.recordFailure(offline)).toEqual({
+				opened: true,
+				holdMs: 60_000,
+			});
+		});
+	}
 
 	test("still falls back to Octokit when gh fails but GitHub answered", async () => {
 		const db = createRealDb();

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -964,6 +964,163 @@ describe("PullRequestRuntimeManager refresh", () => {
 		}
 	});
 
+	test("concurrent failures of one outage open a single hold and log once", async () => {
+		const t0 = Date.now();
+		setSystemTime(new Date(t0));
+		const warns: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (...args: unknown[]) => {
+			warns.push(String(args[0]));
+		};
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			let ghAttempts = 0;
+			const manager = createManager(db, {
+				execGh: async () => {
+					ghAttempts += 1;
+					await new Promise((resolve) => setTimeout(resolve, 5));
+					throw Object.assign(new Error("Command failed"), {
+						stderr:
+							"error connecting to api.github.com\ncheck your internet connection",
+					});
+				},
+				github: (async () => {
+					throw new Error("octokit must not run");
+				}) as never,
+			});
+			const repoOf = (name: string) => ({
+				provider: "github" as const,
+				owner: REPO.owner,
+				name,
+				url: `https://github.com/${REPO.owner}/${name}.git`,
+				remoteName: "origin",
+				defaultBranch: "main",
+			});
+			const fetchOpenPrs = openPullRequestsSweeper(manager);
+
+			// Six repos refresh at once: all pass the gate before the first fails.
+			await Promise.all(
+				["a", "b", "c", "d", "e", "f"].map((name) =>
+					fetchOpenPrs(repoOf(name)).catch(() => {}),
+				),
+			);
+			expect(ghAttempts).toBe(6);
+			expect(
+				warns.filter((w) => w.includes("GitHub unreachable")),
+			).toHaveLength(1);
+
+			// One outage, one streak: the hold is the base minute, not the cap.
+			setSystemTime(new Date(t0 + 61_000));
+			await fetchOpenPrs(repoOf("g")).catch(() => {});
+			expect(ghAttempts).toBe(7);
+		} finally {
+			console.warn = originalWarn;
+			setSystemTime();
+		}
+	});
+
+	test("an explicit refresh probes through an active hold", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		let ghAttempts = 0;
+		const manager = createManager(db, {
+			execGh: async () => {
+				ghAttempts += 1;
+				throw Object.assign(new Error("x"), { code: "ENOTFOUND" });
+			},
+			github: (async () => {
+				throw new Error("octokit must not run");
+			}) as never,
+		});
+		const repoOf = (name: string) => ({
+			provider: "github" as const,
+			owner: REPO.owner,
+			name,
+			url: `https://github.com/${REPO.owner}/${name}.git`,
+			remoteName: "origin",
+			defaultBranch: "main",
+		});
+		const accessible = manager as unknown as {
+			getCachedOpenPullRequests(
+				repo: ReturnType<typeof repoOf>,
+				options?: { bypassCache?: boolean },
+			): Promise<unknown[]>;
+		};
+		await withSilencedWarnings(async () => {
+			await accessible.getCachedOpenPullRequests(repoOf("a")).catch(() => {});
+			expect(ghAttempts).toBe(1);
+			// Polling is held.
+			await accessible.getCachedOpenPullRequests(repoOf("b")).catch(() => {});
+			expect(ghAttempts).toBe(1);
+			// A user-driven refresh is not: it is the probe that can reopen the gate.
+			await accessible
+				.getCachedOpenPullRequests(repoOf("c"), { bypassCache: true })
+				.catch(() => {});
+			expect(ghAttempts).toBe(2);
+		});
+	});
+
+	test("detail lookups are held during an outage even with a warm head cache", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "fix/sidebar",
+			headSha: "abc123",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "fix/sidebar",
+		});
+		let online = true;
+		let ghAttempts = 0;
+		let octokitAttempts = 0;
+		const route = routeGh({
+			"fix/sidebar": makePrNode({
+				number: 7,
+				headRef: "fix/sidebar",
+				headSha: "abc123",
+			}),
+		});
+		const manager = createManager(db, {
+			git: defaultBranchGit("main"),
+			execGh: async (args) => {
+				ghAttempts += 1;
+				if (!online) {
+					throw Object.assign(new Error("Command failed"), {
+						stderr: "error connecting to api.github.com",
+					});
+				}
+				return route(args);
+			},
+			github: (async () => {
+				octokitAttempts += 1;
+				throw new Error("octokit must not run during an outage");
+			}) as never,
+		});
+		const accessible = manager as unknown as {
+			refreshProject(projectId: string): Promise<void>;
+		};
+
+		// Warm every cache while online: head lookup, reviews, checks, queue.
+		await withSilencedWarnings(() => accessible.refreshProject(PROJECT_ID));
+		expect(getWorkspace(db, "ws")?.pullRequestId).not.toBeNull();
+		const warmAttempts = ghAttempts;
+
+		// The network dies. The head lookup is cached, so the detail calls are
+		// the only gh spawns this refresh would make: the first trips the gate.
+		online = false;
+		await withSilencedWarnings(() => accessible.refreshProject(PROJECT_ID));
+		expect(ghAttempts).toBeGreaterThan(warmAttempts);
+		expect(octokitAttempts).toBe(0);
+		const heldAttempts = ghAttempts;
+
+		// While held, a refresh spawns nothing at all.
+		await withSilencedWarnings(() => accessible.refreshProject(PROJECT_ID));
+		expect(ghAttempts).toBe(heldAttempts);
+		expect(octokitAttempts).toBe(0);
+	});
+
 	test("still falls back to Octokit when gh fails but GitHub answered", async () => {
 		const db = createRealDb();
 		seedProject(db);

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -32,6 +32,7 @@ import type {
 	GitHubPullRequestNode,
 	GitHubPullRequestReviewDecision,
 } from "./utils/github-query/types";
+import { GitHubReachabilityGate } from "./utils/github-reachability";
 import {
 	type ChecksStatus,
 	coerceChecksStatus,
@@ -208,6 +209,9 @@ export class PullRequestRuntimeManager {
 	private unsubscribeFromGitWatcher: (() => void) | null = null;
 	private unsubscribeFromWorkspaceEvents: (() => void) | null = null;
 	private readonly inFlightProjects = new Map<string, Promise<void>>();
+	// One gate for every GitHub call the runtime makes: an unreachable GitHub
+	// is a property of this host's network, not of any repo.
+	private readonly githubGate = new GitHubReachabilityGate();
 	private readonly workspaceSyncState = new Map<
 		string,
 		{ running: Promise<void>; rerunPending: boolean }
@@ -1146,6 +1150,52 @@ export class PullRequestRuntimeManager {
 		return rowId;
 	}
 
+	/**
+	 * Runs a GitHub lookup through `gh` with an Octokit fallback, behind the
+	 * reachability gate. A transport failure from `gh` (DNS, timeout, refused)
+	 * skips the fallback: Octokit would hit the same network and hang the same
+	 * way. HTTP failures still fall through to Octokit, which may hold a
+	 * different credential.
+	 */
+	private async fetchFromGitHub<T>(
+		what: string,
+		context: Record<string, unknown>,
+		viaGh: () => Promise<T>,
+		viaOctokit: () => Promise<T>,
+	): Promise<T> {
+		this.githubGate.assertReachable();
+		try {
+			const result = await viaGh();
+			this.githubGate.recordSuccess();
+			return result;
+		} catch (ghError) {
+			if (this.noteGitHubFailure(ghError)) throw ghError;
+			console.warn(
+				`[host-service:pull-request-runtime] gh ${what} failed; falling back to Octokit`,
+				{ ...context, error: ghError },
+			);
+		}
+		try {
+			const result = await viaOctokit();
+			this.githubGate.recordSuccess();
+			return result;
+		} catch (octokitError) {
+			this.noteGitHubFailure(octokitError);
+			throw octokitError;
+		}
+	}
+
+	/** Trips the gate on a transport failure and says so once per hold. */
+	private noteGitHubFailure(error: unknown): boolean {
+		const holdMs = this.githubGate.recordFailure(error);
+		if (holdMs === null) return false;
+		console.warn(
+			`[host-service:pull-request-runtime] GitHub unreachable; holding GitHub lookups for ${Math.round(holdMs / 1000)}s`,
+			{ error },
+		);
+		return true;
+	}
+
 	// Keep failed promises cached for the full TTL so subsequent polls share
 	// the rejection without firing new GitHub calls. Evicting on every error
 	// caused a self-perpetuating storm under rate-limit / abuse-detection
@@ -1214,26 +1264,23 @@ export class PullRequestRuntimeManager {
 			this.pullRequestHeadCache,
 			cacheKey,
 			options,
-			async () => {
-				try {
-					return await fetchPullRequestByHeadFromGh(
-						this.execGh,
-						{ owner: repo.owner, name: repo.name },
-						head,
-					);
-				} catch (ghError) {
-					console.warn(
-						"[host-service:pull-request-runtime] gh PR head lookup failed; falling back to Octokit",
-						{ owner: repo.owner, name: repo.name, head, error: ghError },
-					);
-					const octokit = await this.github();
-					return fetchPullRequestByHead(
-						octokit,
-						{ owner: repo.owner, name: repo.name },
-						head,
-					);
-				}
-			},
+			() =>
+				this.fetchFromGitHub(
+					"PR head lookup",
+					{ owner: repo.owner, name: repo.name, head },
+					() =>
+						fetchPullRequestByHeadFromGh(
+							this.execGh,
+							{ owner: repo.owner, name: repo.name },
+							head,
+						),
+					async () =>
+						fetchPullRequestByHead(
+							await this.github(),
+							{ owner: repo.owner, name: repo.name },
+							head,
+						),
+				),
 		);
 	}
 
@@ -1249,24 +1296,21 @@ export class PullRequestRuntimeManager {
 			this.openPullRequestsCache,
 			cacheKey,
 			options,
-			async () => {
-				try {
-					return await fetchOpenPullRequestsFromGh(this.execGh, {
-						owner: repo.owner,
-						name: repo.name,
-					});
-				} catch (ghError) {
-					console.warn(
-						"[host-service:pull-request-runtime] gh open-PR sweep failed; falling back to Octokit",
-						{ owner: repo.owner, name: repo.name, error: ghError },
-					);
-					const octokit = await this.github();
-					return fetchOpenPullRequests(octokit, {
-						owner: repo.owner,
-						name: repo.name,
-					});
-				}
-			},
+			() =>
+				this.fetchFromGitHub(
+					"open-PR sweep",
+					{ owner: repo.owner, name: repo.name },
+					() =>
+						fetchOpenPullRequestsFromGh(this.execGh, {
+							owner: repo.owner,
+							name: repo.name,
+						}),
+					async () =>
+						fetchOpenPullRequests(await this.github(), {
+							owner: repo.owner,
+							name: repo.name,
+						}),
+				),
 		);
 	}
 

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -1215,7 +1215,8 @@ export class PullRequestRuntimeManager {
 	// caused a self-perpetuating storm under rate-limit / abuse-detection
 	// responses: the failure invalidated the cache, the next 20s tick
 	// retried, hit the same 403, and re-evicted. Network blips heal at the
-	// next TTL boundary instead.
+	// next TTL boundary instead. Gate-held calls are the exception: they never
+	// reached GitHub, and must retry as soon as another lookup restores access.
 	private cachedGitHubFetch<T>(
 		cache: Map<
 			string,
@@ -1249,7 +1250,12 @@ export class PullRequestRuntimeManager {
 			() => {
 				entry.consecutiveFailures = 0;
 			},
-			() => {
+			(error: unknown) => {
+				if (error instanceof GitHubUnreachableError) {
+					// Do not remove a newer bypass-cache request for the same key.
+					if (cache.get(cacheKey) === entry) cache.delete(cacheKey);
+					return;
+				}
 				// Re-anchor at the failure: a fetch that out-lives its own backoff
 				// window before rejecting must not be retried immediately.
 				entry.fetchedAt = Date.now();
@@ -1465,6 +1471,7 @@ export class PullRequestRuntimeManager {
 							),
 							fetchPullRequestChecks(octokit, repo, node.headRefOid),
 						]);
+						this.githubGate.recordSuccess();
 						reviewDecisionByNumber.set(node.number, reviewDecision);
 						checksByNumber.set(node.number, checks);
 					} catch (error) {
@@ -1510,6 +1517,7 @@ export class PullRequestRuntimeManager {
 								node.number,
 							),
 						);
+						this.githubGate.recordSuccess();
 					} catch (error) {
 						this.noteGitHubFailure(error);
 						console.warn(

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -32,7 +32,10 @@ import type {
 	GitHubPullRequestNode,
 	GitHubPullRequestReviewDecision,
 } from "./utils/github-query/types";
-import { GitHubReachabilityGate } from "./utils/github-reachability";
+import {
+	GitHubReachabilityGate,
+	GitHubUnreachableError,
+} from "./utils/github-reachability";
 import {
 	type ChecksStatus,
 	coerceChecksStatus,
@@ -1162,8 +1165,12 @@ export class PullRequestRuntimeManager {
 		context: Record<string, unknown>,
 		viaGh: () => Promise<T>,
 		viaOctokit: () => Promise<T>,
+		options: { probe?: boolean } = {},
 	): Promise<T> {
-		this.githubGate.assertReachable();
+		// An explicit refresh (PR just created, user asked) is allowed through a
+		// hold: it is one call, and its success is what reopens the gate early
+		// once the network is back.
+		if (!options.probe) this.githubGate.assertReachable();
 		try {
 			const result = await viaGh();
 			this.githubGate.recordSuccess();
@@ -1185,14 +1192,21 @@ export class PullRequestRuntimeManager {
 		}
 	}
 
-	/** Trips the gate on a transport failure and says so once per hold. */
+	/**
+	 * Records a failure with the gate. True for a transport failure, in which
+	 * case the caller skips its Octokit fallback. Logs only for the failure
+	 * that opened a hold; the concurrent failures of the same outage are silent.
+	 */
 	private noteGitHubFailure(error: unknown): boolean {
-		const holdMs = this.githubGate.recordFailure(error);
-		if (holdMs === null) return false;
-		console.warn(
-			`[host-service:pull-request-runtime] GitHub unreachable; holding GitHub lookups for ${Math.round(holdMs / 1000)}s`,
-			{ error },
-		);
+		if (error instanceof GitHubUnreachableError) return true;
+		const hold = this.githubGate.recordFailure(error);
+		if (hold === null) return false;
+		if (hold.opened) {
+			console.warn(
+				`[host-service:pull-request-runtime] GitHub unreachable; holding GitHub lookups for ${Math.round(hold.holdMs / 1000)}s`,
+				{ error },
+			);
+		}
 		return true;
 	}
 
@@ -1280,6 +1294,7 @@ export class PullRequestRuntimeManager {
 							{ owner: repo.owner, name: repo.name },
 							head,
 						),
+					{ probe: options.bypassCache === true },
 				),
 		);
 	}
@@ -1310,6 +1325,7 @@ export class PullRequestRuntimeManager {
 							owner: repo.owner,
 							name: repo.name,
 						}),
+					{ probe: options.bypassCache === true },
 				),
 		);
 	}
@@ -1421,6 +1437,7 @@ export class PullRequestRuntimeManager {
 		await Promise.all(
 			Array.from(latestByKey.values()).map(async (node) => {
 				try {
+					this.githubGate.assertReachable();
 					const [reviewDecision, checks] = await Promise.all([
 						fetchPullRequestReviewDecisionFromGh(
 							this.execGh,
@@ -1430,9 +1447,13 @@ export class PullRequestRuntimeManager {
 						),
 						fetchPullRequestChecksFromGh(this.execGh, repo, node.headRefOid),
 					]);
+					this.githubGate.recordSuccess();
 					reviewDecisionByNumber.set(node.number, reviewDecision);
 					checksByNumber.set(node.number, checks);
 				} catch (ghError) {
+					// A held gate or a transport failure: Octokit would hit the same
+					// network. Last-known review, checks, and queue state stand.
+					if (this.noteGitHubFailure(ghError)) return;
 					try {
 						const octokit = await getOctokit();
 						const [reviewDecision, checks] = await Promise.all([
@@ -1447,6 +1468,7 @@ export class PullRequestRuntimeManager {
 						reviewDecisionByNumber.set(node.number, reviewDecision);
 						checksByNumber.set(node.number, checks);
 					} catch (error) {
+						this.noteGitHubFailure(error);
 						console.warn(
 							"[host-service:pull-request-runtime] Failed to fetch PR review/check state",
 							{
@@ -1467,6 +1489,7 @@ export class PullRequestRuntimeManager {
 				// review/checks fetch above would let that failure stale their data.
 				if (node.state !== "OPEN" || node.isDraft) return;
 				try {
+					this.githubGate.assertReachable();
 					mergeQueueByNumber.set(
 						node.number,
 						await fetchPullRequestMergeQueueStateFromGh(
@@ -1475,7 +1498,9 @@ export class PullRequestRuntimeManager {
 							node.number,
 						),
 					);
+					this.githubGate.recordSuccess();
 				} catch (ghError) {
+					if (this.noteGitHubFailure(ghError)) return;
 					try {
 						mergeQueueByNumber.set(
 							node.number,
@@ -1486,6 +1511,7 @@ export class PullRequestRuntimeManager {
 							),
 						);
 					} catch (error) {
+						this.noteGitHubFailure(error);
 						console.warn(
 							"[host-service:pull-request-runtime] Failed to fetch PR merge-queue state",
 							{

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import {
+	GitHubReachabilityGate,
+	GitHubUnreachableError,
+	isGitHubUnreachableError,
+} from "./github-reachability";
+
+describe("isGitHubUnreachableError", () => {
+	test("matches Node transport codes, including through a cause chain", () => {
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("x"), { code: "ENOTFOUND" }),
+			),
+		).toBe(true);
+		const wrapped = new Error("request failed", {
+			cause: Object.assign(new Error("getaddrinfo EAI_AGAIN api.github.com"), {
+				code: "EAI_AGAIN",
+			}),
+		});
+		expect(isGitHubUnreachableError(wrapped)).toBe(true);
+	});
+
+	test("matches gh's stderr phrasing and an execFile timeout kill", () => {
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("Command failed: gh api"), {
+					stderr:
+						"error connecting to api.github.com\ndial tcp: lookup api.github.com: no such host",
+				}),
+			),
+		).toBe(true);
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("Command failed"), {
+					killed: true,
+					signal: "SIGTERM",
+				}),
+			),
+		).toBe(true);
+	});
+
+	test("does not match answers from GitHub", () => {
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("Not Found"), { status: 404 }),
+			),
+		).toBe(false);
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("gh: HTTP 403: API rate limit exceeded"), {
+					code: 1,
+					stderr: "gh: API rate limit exceeded",
+				}),
+			),
+		).toBe(false);
+		expect(isGitHubUnreachableError("string")).toBe(false);
+		expect(isGitHubUnreachableError(null)).toBe(false);
+	});
+});
+
+describe("GitHubReachabilityGate", () => {
+	const dns = () => Object.assign(new Error("x"), { code: "ENOTFOUND" });
+
+	test("stays open until a transport failure, then holds with doubling windows", () => {
+		let now = 1_000_000;
+		const gate = new GitHubReachabilityGate({ now: () => now });
+		expect(() => gate.assertReachable()).not.toThrow();
+
+		expect(gate.recordFailure(dns())).toBe(60_000);
+		expect(() => gate.assertReachable()).toThrow(GitHubUnreachableError);
+		expect(gate.retryAfterMs()).toBe(60_000);
+
+		now += 60_000;
+		expect(() => gate.assertReachable()).not.toThrow();
+		expect(gate.recordFailure(dns())).toBe(120_000);
+		expect(gate.recordFailure(dns())).toBe(240_000);
+	});
+
+	test("caps the hold at 30 minutes", () => {
+		const gate = new GitHubReachabilityGate({ now: () => 0 });
+		let block = 0;
+		for (let i = 0; i < 12; i++) block = gate.recordFailure(dns()) ?? 0;
+		expect(block).toBe(30 * 60_000);
+	});
+
+	test("ignores answers from GitHub and resets on success", () => {
+		let now = 0;
+		const gate = new GitHubReachabilityGate({ now: () => now });
+		expect(
+			gate.recordFailure(
+				Object.assign(new Error("Not Found"), { status: 404 }),
+			),
+		).toBeNull();
+		expect(() => gate.assertReachable()).not.toThrow();
+
+		gate.recordFailure(dns());
+		gate.recordFailure(dns());
+		gate.recordSuccess();
+		expect(() => gate.assertReachable()).not.toThrow();
+		// A fresh streak starts from the base window again.
+		now = 10;
+		expect(gate.recordFailure(dns())).toBe(60_000);
+	});
+});

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
@@ -20,6 +20,27 @@ describe("isGitHubUnreachableError", () => {
 		expect(isGitHubUnreachableError(wrapped)).toBe(true);
 	});
 
+	test("matches what gh 2.98 prints for a dead resolver and a refused proxy", () => {
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("Command failed: gh api repos/o/r/pulls"), {
+					code: 1,
+					stderr:
+						"error connecting to github.invalid\ncheck your internet connection or https://githubstatus.com\n",
+				}),
+			),
+		).toBe(true);
+		expect(
+			isGitHubUnreachableError(
+				Object.assign(new Error("Command failed"), {
+					code: 1,
+					stderr:
+						'Get "https://api.github.com/repos/o/r/pulls?state=open": proxyconnect tcp: dial tcp 127.0.0.1:1: connect: connection refused',
+				}),
+			),
+		).toBe(true);
+	});
+
 	test("matches gh's stderr phrasing and an execFile timeout kill", () => {
 		expect(
 			isGitHubUnreachableError(

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
@@ -126,12 +126,11 @@ describe("GitHubReachabilityGate", () => {
 	});
 
 	test("caps the hold at 30 minutes", () => {
-		const gate = new GitHubReachabilityGate({ now: () => 0 });
 		let block = 0;
 		let now = 0;
-		const gate2 = new GitHubReachabilityGate({ now: () => now });
+		const gate = new GitHubReachabilityGate({ now: () => now });
 		for (let i = 0; i < 12; i++) {
-			block = gate2.recordFailure(dns())?.holdMs ?? 0;
+			block = gate.recordFailure(dns())?.holdMs ?? 0;
 			now += block;
 		}
 		expect(block).toBe(30 * 60_000);

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.test.ts
@@ -87,20 +87,53 @@ describe("GitHubReachabilityGate", () => {
 		const gate = new GitHubReachabilityGate({ now: () => now });
 		expect(() => gate.assertReachable()).not.toThrow();
 
-		expect(gate.recordFailure(dns())).toBe(60_000);
+		expect(gate.recordFailure(dns())).toEqual({ opened: true, holdMs: 60_000 });
 		expect(() => gate.assertReachable()).toThrow(GitHubUnreachableError);
 		expect(gate.retryAfterMs()).toBe(60_000);
 
 		now += 60_000;
 		expect(() => gate.assertReachable()).not.toThrow();
-		expect(gate.recordFailure(dns())).toBe(120_000);
-		expect(gate.recordFailure(dns())).toBe(240_000);
+		expect(gate.recordFailure(dns())).toEqual({
+			opened: true,
+			holdMs: 120_000,
+		});
+		now += 120_000;
+		expect(gate.recordFailure(dns())).toEqual({
+			opened: true,
+			holdMs: 240_000,
+		});
+	});
+
+	test("failures that land while a hold is active neither extend it nor reopen it", () => {
+		let now = 0;
+		const gate = new GitHubReachabilityGate({ now: () => now });
+		expect(gate.recordFailure(dns())).toEqual({ opened: true, holdMs: 60_000 });
+		// Five concurrent lookups that were already in flight all fail too.
+		for (let i = 0; i < 5; i++) {
+			now += 100;
+			expect(gate.recordFailure(dns())).toEqual({
+				opened: false,
+				holdMs: 60_000 - now,
+			});
+		}
+		expect(gate.retryAfterMs()).toBe(60_000 - now);
+		// The streak is still one: the next window is two minutes, not the cap.
+		now = 60_000;
+		expect(gate.recordFailure(dns())).toEqual({
+			opened: true,
+			holdMs: 120_000,
+		});
 	});
 
 	test("caps the hold at 30 minutes", () => {
 		const gate = new GitHubReachabilityGate({ now: () => 0 });
 		let block = 0;
-		for (let i = 0; i < 12; i++) block = gate.recordFailure(dns()) ?? 0;
+		let now = 0;
+		const gate2 = new GitHubReachabilityGate({ now: () => now });
+		for (let i = 0; i < 12; i++) {
+			block = gate2.recordFailure(dns())?.holdMs ?? 0;
+			now += block;
+		}
 		expect(block).toBe(30 * 60_000);
 	});
 
@@ -115,11 +148,12 @@ describe("GitHubReachabilityGate", () => {
 		expect(() => gate.assertReachable()).not.toThrow();
 
 		gate.recordFailure(dns());
+		now = 60_000;
 		gate.recordFailure(dns());
 		gate.recordSuccess();
 		expect(() => gate.assertReachable()).not.toThrow();
 		// A fresh streak starts from the base window again.
-		now = 10;
-		expect(gate.recordFailure(dns())).toBe(60_000);
+		now = 60_010;
+		expect(gate.recordFailure(dns())).toEqual({ opened: true, holdMs: 60_000 });
 	});
 });

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.ts
@@ -1,0 +1,129 @@
+/**
+ * Circuit breaker for the PR runtime's GitHub calls.
+ *
+ * When GitHub cannot be reached at all (DNS down, VPN dropped, captive
+ * portal), every lookup fails the same way, and each one costs a `gh` spawn
+ * that sits on its 10s timeout before we fall back to Octokit and fail again.
+ * With dozens of repos polled on a cadence, one broken resolver turned into
+ * thousands of spawned-and-killed `gh` processes on a machine that was already
+ * struggling to exec anything. Per-repo cache backoff never helped: the
+ * failure is per network, not per repo.
+ *
+ * The gate trips on the first transport-level failure and holds every GitHub
+ * call for a growing window (1 min, doubling, capped at 30 min). Any success
+ * closes it. HTTP-level failures (404, 403 rate limit, 5xx) never trip it:
+ * those mean GitHub answered, and the per-repo cache backoff already covers
+ * them.
+ */
+
+const BASE_BLOCK_MS = 60_000;
+const MAX_BLOCK_MS = 30 * 60_000;
+
+/**
+ * Node and undici codes meaning the request never reached GitHub. Same family
+ * as the cloud-API unreachable list, minus the TLS-interception codes: a
+ * corporate proxy that re-signs github.com is a reason to stop retrying too,
+ * but it reports as a different problem and is left to surface as one.
+ */
+const UNREACHABLE_CODES = new Set([
+	"ECONNREFUSED",
+	"ECONNRESET",
+	"ETIMEDOUT",
+	"ENOTFOUND",
+	"EAI_AGAIN",
+	"EHOSTUNREACH",
+	"ENETUNREACH",
+	"UND_ERR_CONNECT_TIMEOUT",
+	"UND_ERR_HEADERS_TIMEOUT",
+	"UND_ERR_SOCKET",
+]);
+
+// `gh` reports transport failures as prose on stderr. These are Go's net
+// package phrasings, stable across gh releases.
+const UNREACHABLE_STDERR =
+	/no such host|dial tcp|i\/o timeout|connect timeout|tls handshake timeout|network is unreachable|connection refused|connection reset|getaddrinfo/i;
+
+const MAX_CAUSE_DEPTH = 8;
+
+function codeOf(value: unknown): string | null {
+	if (typeof value !== "object" || value === null) return null;
+	const code = (value as { code?: unknown }).code;
+	return typeof code === "string" ? code : null;
+}
+
+function textOf(value: unknown): string {
+	if (typeof value !== "object" || value === null) return "";
+	const { stderr, message } = value as { stderr?: unknown; message?: unknown };
+	return [stderr, message]
+		.filter((part): part is string => typeof part === "string")
+		.join("\n");
+}
+
+export function isGitHubUnreachableError(error: unknown): boolean {
+	let current: unknown = error;
+	for (let depth = 0; depth < MAX_CAUSE_DEPTH && current; depth++) {
+		const code = codeOf(current);
+		if (code && UNREACHABLE_CODES.has(code)) return true;
+		// execFile's timeout: the child was killed before it produced a result.
+		// For `gh` that is a hung network call; a fast failure exits on its own.
+		const { killed, signal } = current as {
+			killed?: unknown;
+			signal?: unknown;
+		};
+		if (killed === true && typeof signal === "string") return true;
+		if (UNREACHABLE_STDERR.test(textOf(current))) return true;
+		current = (current as { cause?: unknown }).cause;
+	}
+	return false;
+}
+
+export class GitHubUnreachableError extends Error {
+	constructor(public readonly retryAfterMs: number) {
+		super(
+			`GitHub is unreachable from this host; skipping the lookup for ${Math.ceil(retryAfterMs / 1000)}s`,
+		);
+		this.name = "GitHubUnreachableError";
+	}
+}
+
+export class GitHubReachabilityGate {
+	private streak = 0;
+	private blockedUntil = 0;
+	private readonly now: () => number;
+
+	constructor(options: { now?: () => number } = {}) {
+		this.now = options.now ?? Date.now;
+	}
+
+	/** Milliseconds until the gate reopens; 0 when calls may proceed. */
+	retryAfterMs(): number {
+		return Math.max(0, this.blockedUntil - this.now());
+	}
+
+	/** Throws while the gate is holding calls. */
+	assertReachable(): void {
+		const wait = this.retryAfterMs();
+		if (wait > 0) throw new GitHubUnreachableError(wait);
+	}
+
+	/**
+	 * Records a failed call. Returns the hold window it opened when the error
+	 * was a transport failure, or null when the error means GitHub answered
+	 * and the gate should stay out of it.
+	 */
+	recordFailure(error: unknown): number | null {
+		if (!isGitHubUnreachableError(error)) return null;
+		this.streak += 1;
+		const block = Math.min(
+			BASE_BLOCK_MS * 2 ** (this.streak - 1),
+			MAX_BLOCK_MS,
+		);
+		this.blockedUntil = this.now() + block;
+		return block;
+	}
+
+	recordSuccess(): void {
+		this.streak = 0;
+		this.blockedUntil = 0;
+	}
+}

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.ts
@@ -38,10 +38,12 @@ const UNREACHABLE_CODES = new Set([
 	"UND_ERR_SOCKET",
 ]);
 
-// `gh` reports transport failures as prose on stderr. These are Go's net
-// package phrasings, stable across gh releases.
+// `gh` reports transport failures as prose on stderr. A resolver failure is
+// wrapped by gh itself ("error connecting to <host> / check your internet
+// connection", verified on gh 2.98); the rest are Go's net package phrasings
+// that surface for refused, reset, and timed-out connections.
 const UNREACHABLE_STDERR =
-	/no such host|dial tcp|i\/o timeout|connect timeout|tls handshake timeout|network is unreachable|connection refused|connection reset|getaddrinfo/i;
+	/error connecting to|check your internet connection|no such host|dial tcp|i\/o timeout|connect timeout|tls handshake timeout|network is unreachable|connection refused|connection reset|getaddrinfo/i;
 
 const MAX_CAUSE_DEPTH = 8;
 

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/github-reachability.ts
@@ -109,19 +109,24 @@ export class GitHubReachabilityGate {
 	}
 
 	/**
-	 * Records a failed call. Returns the hold window it opened when the error
-	 * was a transport failure, or null when the error means GitHub answered
-	 * and the gate should stay out of it.
+	 * Records a failed call. Returns null when the error means GitHub answered
+	 * and the gate should stay out of it. For a transport failure it returns
+	 * the hold in force: `opened` is true only for the failure that opened it.
+	 * Lookups run concurrently, so several can pass `assertReachable()` before
+	 * the first one fails; the later failures belong to the same outage and
+	 * must neither extend the hold nor log again.
 	 */
-	recordFailure(error: unknown): number | null {
+	recordFailure(error: unknown): { opened: boolean; holdMs: number } | null {
 		if (!isGitHubUnreachableError(error)) return null;
+		const remaining = this.retryAfterMs();
+		if (remaining > 0) return { opened: false, holdMs: remaining };
 		this.streak += 1;
 		const block = Math.min(
 			BASE_BLOCK_MS * 2 ** (this.streak - 1),
 			MAX_BLOCK_MS,
 		);
 		this.blockedUntil = this.now() + block;
-		return block;
+		return { opened: true, holdMs: block };
 	}
 
 	recordSuccess(): void {

--- a/packages/host-service/src/runtime/pull-requests/utils/github-reachability/index.ts
+++ b/packages/host-service/src/runtime/pull-requests/utils/github-reachability/index.ts
@@ -1,0 +1,5 @@
+export {
+	GitHubReachabilityGate,
+	GitHubUnreachableError,
+	isGitHubUnreachableError,
+} from "./github-reachability";


### PR DESCRIPTION
## Problem

A user's host-service log showed thousands of `getaddrinfo ENOTFOUND api.github.com` failures. Each one was a `gh` spawn that sat on its 10 s timeout, got SIGTERMed, fell back to Octokit, and failed again on the same resolver. The per-repo cache backoff in `cachedGitHubFetch` can't help here: the failure is a property of the host's network, not of any repo, and with 39 projects polled on a cadence the spawn rate stayed high for as long as DNS was broken. On a machine already slow to exec (endpoint security, VPN), that is a lot of extra load on the process that carries terminal I/O.

## Change

- Add one reachability gate across the PR runtime's head lookups, open-PR sweeps, reviews, checks, and merge-queue lookups. Transport failures hold polling for one minute, doubling to a 30-minute cap. Concurrent failures during one hold neither extend it nor produce additional hold logs.
- Recognize Node/undici transport errors, actual gh resolver-failure wording, and killed gh requests. Transport failures skip the Octokit fallback; HTTP failures retain it.
- Explicit refreshes bypass the hold. Successful gh and Octokit lookups reset it. Gate-blocked cache entries are discarded so they can retry immediately after recovery; ordinary failed requests retain their existing cache backoff.

## Testing

- Runtime suite: 77 pass, 0 fail. Host-service typecheck, full repository lint, and plugin validation pass.
- Three new recovery regressions were run before and after the final fix: held repo → successful probe → immediate normal retry, plus separate successful Octokit review/check and merge-queue fallbacks resetting the next hold to one minute. All three failed before the fix and pass afterward.
- Earlier real-gh outage harness evidence is in the PR comments: real manager and migrated SQLite, real gh 2.98 with a per-process invalid GitHub hostname. Eight concurrent failures produced one hold; a ninth held request spawned nothing; an explicit probe passed through; the next outage window doubled; HTTP errors still fell back.
- The final recovery tests use simulated providers and clocks. This is host-runtime verification, not a CDP UI test or a CPU profile.

https://claude.ai/code/session_01UWyngsh3WSdEM6kmf1P8s5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the PR runtime from spawning `gh` for every repo while GitHub is unreachable. A reachability gate now holds all GitHub lookups on transport failures, backing off from 1 to 30 minutes, instead of each repo paying a 10-second `gh` timeout plus a doomed Octokit fallback.

**Bug Fixes**
- Transport failures (Node/undici codes, `gh` stderr phrasings, exec timeout) trip the gate and skip the Octokit fallback since it would hit the same broken network. gh 2.98's own resolver wording ("error connecting to", "check your internet connection") is now recognized too, so a dead resolver trips the gate on the first `gh` call rather than after the fallback.
- HTTP failures (404, 403, 5xx) never trip the gate and still fall back to Octokit.
- Concurrent failures of one outage open a single hold and log once; failures during an active hold don't extend it.
- Review/checks/merge-queue lookups in polling now go through the gate too. Explicit refreshes probe through an active hold, so a user-driven action can reopen the gate early.

<sup>Written for commit 13a0e93290f46abb3e8e7f7de1cb2354c2401844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request lookups during GitHub network outages by temporarily suppressing repeated requests.
  * Added automatic retries with progressively longer wait periods after connectivity failures.
  * Restored normal lookups promptly after a successful connectivity check or fallback response.
  * Preserved fallback behavior for GitHub API responses, including rate limits, missing resources, and other HTTP errors.
  * Allowed explicit refreshes to bypass an active outage hold when requested.
* **Tests**
  * Added coverage for outage detection, retry timing, concurrent failures, transport failures, detail lookups, and API fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
