### PR TITLE
fix(host-service): stop polling a workspace whose git reads keep timing out

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -10,6 +10,10 @@ import type { HostDb } from "../../db";
 import * as schema from "../../db/schema";
 import { pullRequests, workspaces } from "../../db/schema";
 import type { WorkspaceChangedMessage } from "../../events/types";
+import {
+	WORKER_TASK_TIMEOUT_CODE,
+	WorkerTaskError,
+} from "../../workers/WorkerTaskRunner";
 import { PullRequestRuntimeManager } from "./pull-requests";
 import type { WorkspaceRefsSnapshot } from "./utils/workspace-refs";
 
@@ -1288,6 +1292,94 @@ async function waitFor(
 		await new Promise((resolve) => setTimeout(resolve, 10));
 	}
 }
+
+// Typed handle on the private per-workspace sync so the cooldown can be
+// driven directly, without timers or watcher events.
+function workspaceSyncer(manager: PullRequestRuntimeManager) {
+	const accessible = manager as unknown as {
+		syncOneWorkspace(workspaceId: string): Promise<void>;
+	};
+	return accessible.syncOneWorkspace.bind(accessible);
+}
+
+function refsTimeoutError() {
+	const message = 'Task "git/readWorkspaceRefs" timed out after 15000ms';
+	return new WorkerTaskError(message, {
+		name: "WorkerTaskTimeoutError",
+		message,
+		code: WORKER_TASK_TIMEOUT_CODE,
+	});
+}
+
+describe("refs read timeout cooldown", () => {
+	test("sits a workspace out after two consecutive timeouts and resumes after the window", async () => {
+		const t0 = Date.now();
+		setSystemTime(new Date(t0));
+		try {
+			const db = createRealDb();
+			seedProject(db);
+			seedWorkspace(db, { id: "ws-slow", branch: "feat/slow" });
+			let reads = 0;
+			let timingOut = true;
+			const manager = createManager(db, {
+				readWorkspaceRefs: async () => {
+					reads += 1;
+					if (timingOut) throw refsTimeoutError();
+					return { branch: "feat/slow", headSha: "sha-slow", upstream: null };
+				},
+			});
+			const sync = () =>
+				withSilencedWarnings(() => workspaceSyncer(manager)("ws-slow"));
+
+			await sync();
+			await sync();
+			expect(reads).toBe(2);
+
+			// Third and fourth polls inside the 5 min window never reach git.
+			await sync();
+			setSystemTime(new Date(t0 + 4 * 60_000));
+			await sync();
+			expect(reads).toBe(2);
+
+			// The window ends, one more attempt is allowed, and it times out
+			// again: the next window doubles to 10 min.
+			setSystemTime(new Date(t0 + 5 * 60_000 + 1_000));
+			await sync();
+			expect(reads).toBe(3);
+			setSystemTime(new Date(t0 + 12 * 60_000));
+			await sync();
+			expect(reads).toBe(3);
+
+			// A successful read clears the streak entirely.
+			timingOut = false;
+			setSystemTime(new Date(t0 + 16 * 60_000));
+			await sync();
+			await sync();
+			expect(reads).toBe(5);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("a non-timeout failure does not start a cooldown", async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, { id: "ws-broken", branch: "feat/broken" });
+		let reads = 0;
+		const manager = createManager(db, {
+			readWorkspaceRefs: async () => {
+				reads += 1;
+				throw new Error("fatal: not a git repository");
+			},
+		});
+		const sync = () =>
+			withSilencedWarnings(() => workspaceSyncer(manager)("ws-broken"));
+		await sync();
+		await sync();
+		await sync();
+		expect(reads).toBe(3);
+	});
+});
 
 describe("workspace-created event trigger", () => {
 	// The manager only consumes workspaceId (it re-reads the row from the DB),

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -13,6 +13,7 @@ import {
 import type { EventBus } from "../../events/event-bus";
 import type { GitWatcher } from "../../events/git-watcher";
 import type { ExecGh } from "../../trpc/router/workspace-creation/utils/exec-gh";
+import { isWorkerTaskTimeout } from "../../workers/WorkerTaskRunner";
 import { type GitFactory, resolveDefaultBranchName } from "../git";
 import {
 	fetchOpenPullRequests,
@@ -72,6 +73,16 @@ const REPO_PULL_REQUEST_CACHE_MAX_TTL_MS = 30 * 60_000;
 // Re-probe cadence for worktrees observed missing on disk. existsSync-only —
 // cheap enough to run every tick; spawning git against a missing dir is not.
 const MISSING_WORKTREE_PROBE_INTERVAL_MS = 30_000;
+
+// A workspace whose refs read keeps blowing its worker budget is not going to
+// answer the next poll either: on the machines this happens on (endpoint
+// security inspecting every exec, a repo on a slow disk) each attempt costs
+// 15s of a worker slot and more git processes queued behind the ones already
+// stuck. After two consecutive timeouts the workspace sits out for a growing
+// window (5 min doubling to 1 h). Any successful read clears it.
+const REFS_TIMEOUT_TRIP_COUNT = 2;
+const REFS_TIMEOUT_COOLDOWN_BASE_MS = 5 * 60_000;
+const REFS_TIMEOUT_COOLDOWN_MAX_MS = 60 * 60_000;
 // Dedup + link-assignment key. Branch stays case-sensitive: `feature` and
 // `Feature` are distinct branches with distinct PRs, so collapsing them here
 // would mislink. Case drift is tolerated only in the fallback in
@@ -237,6 +248,11 @@ export class PullRequestRuntimeManager {
 	// spawn no git; the probe timer re-enters the normal sync path when the
 	// directory reappears. One log line per transition, never per attempt.
 	private readonly missingWorktrees = new Map<string, string>();
+	/** workspaceId -> consecutive refs-read timeouts and the cooldown they earned. */
+	private readonly refsTimeouts = new Map<
+		string,
+		{ streak: number; skipUntil: number }
+	>();
 	private missingWorktreeProbeTimer: ReturnType<typeof setInterval> | null =
 		null;
 
@@ -690,10 +706,12 @@ export class PullRequestRuntimeManager {
 			return null;
 		}
 		this.noteWorktreePresent(workspace.id);
+		if (this.isRefsReadCoolingDown(workspace.id)) return null;
 		try {
 			const { branch, headSha, upstream } = await this.readWorkspaceRefs(
 				workspace.worktreePath,
 			);
+			this.refsTimeouts.delete(workspace.id);
 			if (!branch) return null;
 
 			const upstreamOwner = upstream?.owner ?? null;
@@ -736,6 +754,9 @@ export class PullRequestRuntimeManager {
 
 			return workspace.projectId;
 		} catch (error) {
+			if (isWorkerTaskTimeout(error)) {
+				this.noteRefsReadTimeout(workspace.id, workspace.worktreePath);
+			}
 			console.warn(
 				"[host-service:pull-request-runtime] Failed to sync workspace branch",
 				{
@@ -746,6 +767,31 @@ export class PullRequestRuntimeManager {
 			);
 			return null;
 		}
+	}
+
+	private isRefsReadCoolingDown(workspaceId: string): boolean {
+		const entry = this.refsTimeouts.get(workspaceId);
+		return entry !== undefined && Date.now() < entry.skipUntil;
+	}
+
+	private noteRefsReadTimeout(workspaceId: string, worktreePath: string): void {
+		const streak = (this.refsTimeouts.get(workspaceId)?.streak ?? 0) + 1;
+		if (streak < REFS_TIMEOUT_TRIP_COUNT) {
+			this.refsTimeouts.set(workspaceId, { streak, skipUntil: 0 });
+			return;
+		}
+		const cooldownMs = Math.min(
+			REFS_TIMEOUT_COOLDOWN_BASE_MS * 2 ** (streak - REFS_TIMEOUT_TRIP_COUNT),
+			REFS_TIMEOUT_COOLDOWN_MAX_MS,
+		);
+		this.refsTimeouts.set(workspaceId, {
+			streak,
+			skipUntil: Date.now() + cooldownMs,
+		});
+		console.warn(
+			`[host-service:pull-request-runtime] git is not answering for a workspace; pausing its branch sync for ${Math.round(cooldownMs / 60_000)}m`,
+			{ workspaceId, worktreePath, consecutiveTimeouts: streak },
+		);
 	}
 
 	private noteWorktreeMissing(workspaceId: string, worktreePath: string): void {

--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -24,6 +24,15 @@ export class WorkerTaskError extends Error {
 	}
 }
 
+/** `code` carried by the rejection a task gets when its budget expires. */
+export const WORKER_TASK_TIMEOUT_CODE = "WORKER_TASK_TIMEOUT";
+
+export function isWorkerTaskTimeout(error: unknown): boolean {
+	return (
+		error instanceof WorkerTaskError && error.code === WORKER_TASK_TIMEOUT_CODE
+	);
+}
+
 export class WorkerTaskAbortedError extends Error {
 	constructor(message = "Worker task aborted") {
 		super(message);
@@ -490,11 +499,14 @@ export class WorkerTaskRunner {
 		// that the budget expired, and the worker is retired right below, so
 		// this is the sole record of what was still running.
 		const phaseSuffix = task.phase ? ` in phase "${task.phase}"` : "";
+		const message = `[${this.name}] Task "${task.taskType}" timed out after ${task.timeoutMs}ms${phaseSuffix}`;
 		this.rejectTask(
 			taskId,
-			new WorkerTaskError(
-				`[${this.name}] Task "${task.taskType}" timed out after ${task.timeoutMs}ms${phaseSuffix}`,
-			),
+			new WorkerTaskError(message, {
+				name: "WorkerTaskTimeoutError",
+				message,
+				code: WORKER_TASK_TIMEOUT_CODE,
+			}),
 		);
 
 		if (task.slotId) {


### PR DESCRIPTION
## Problem

A user's host-service log showed `git/readWorkspaceRefs` timing out at its 15 s worker budget 170 times, plus 25 more at 30 s. That task runs local git only (`config`, `rev-parse`, `remote get-url`), and the budget starts at dispatch, so plain git was taking over 15 s on that machine. Every timeout still cost a worker slot for the full 15 s and left a git process behind, and the PR runtime kept scheduling the same workspace again on the next watcher event and the 5 min sweep. On a host already slow to exec, that is load stacked on the process carrying terminal I/O.

## Change

- `WorkerTaskRunner` tags a budget expiry: the rejection now carries `code: WORKER_TASK_TIMEOUT` (`isWorkerTaskTimeout` exported). The message is unchanged.
- `PullRequestRuntimeManager.syncWorkspaceRow` tracks consecutive timeouts per workspace. After two in a row the workspace sits out its branch sync for 5 min, doubling per further timeout up to 1 h. Any successful read clears the streak. Non-timeout git failures behave as before.
- Logged once per cooldown: `git is not answering for a workspace; pausing its branch sync for Nm`.

Both the watcher path and the 5 min sweep go through `syncWorkspaceRow`, so both are covered.

## Testing

- New tests: two timeouts start the cooldown and later polls never reach git, the window doubles after the next timeout, a success clears it; a non-timeout failure never starts one. The cooldown test was checked to fail with the check disabled.
- `bun test src/runtime/pull-requests` (63 pass), `bun test src/workers` (14 pass), `bun run typecheck`, biome clean.

https://claude.ai/code/session_01UWyngsh3WSdEM6kmf1P8s5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops re-polling a workspace whose git reads keep timing out. Previously each timeout cost a worker slot for the full 15-second budget and the watcher plus 5-minute sweep kept rescheduling the same workspace; now after two consecutive timeouts the workspace pauses its branch sync for a window that doubles from 5 minutes up to an hour, and a successful read clears the streak.

**Bug Fixes**
- Worker timeout rejections now carry `code: WORKER_TASK_TIMEOUT`; `isWorkerTaskTimeout` identifies them.
- Non-timeout git failures still behave as before.

<sup>Written for commit 0325868f17c3767bff2df029577fa315eb94185c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request synchronization resilience when workspace branch reads repeatedly time out.
  - Automatically pauses affected synchronization briefly after repeated timeouts, with progressively longer cooldowns up to one hour.
  - Resumes normal synchronization after a successful read.
  - Non-timeout errors continue to be handled without triggering the cooldown behavior.

- **Tests**
  - Added coverage for timeout cooldowns, recovery, and non-timeout failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->