### PR TITLE
fix(host-service): timestamp every host-service.log line

### DIFF
--- a/packages/host-service/src/log-timestamps.test.ts
+++ b/packages/host-service/src/log-timestamps.test.ts
@@ -29,7 +29,7 @@ describe("installConsoleTimestamps", () => {
 			(["log", "info", "warn", "error", "debug"] as const).map((method) => [
 				method,
 				(...args: unknown[]) => {
-					(calls[method] ??= []).push(args);
+					calls[method] = [...(calls[method] ?? []), args];
 				},
 			]),
 		) as Pick<Console, "log" | "info" | "warn" | "error" | "debug">;

--- a/packages/host-service/src/log-timestamps.test.ts
+++ b/packages/host-service/src/log-timestamps.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { installConsoleTimestamps, stampArgs } from "./log-timestamps";
+
+const NOW = new Date("2026-09-05T20:39:15.000Z");
+
+describe("stampArgs", () => {
+	test("extends a leading string so format directives still apply", () => {
+		expect(stampArgs(NOW, ["[host-service] %s ready", "daemon"])).toEqual([
+			"2026-09-05T20:39:15.000Z [host-service] %s ready",
+			"daemon",
+		]);
+	});
+
+	test("prepends the stamp when the first argument is not a string", () => {
+		const error = new Error("boom");
+		expect(stampArgs(NOW, [error, { id: 1 }])).toEqual([
+			"2026-09-05T20:39:15.000Z",
+			error,
+			{ id: 1 },
+		]);
+		expect(stampArgs(NOW, [])).toEqual(["2026-09-05T20:39:15.000Z"]);
+	});
+});
+
+describe("installConsoleTimestamps", () => {
+	test("stamps every console method and leaves the original arguments intact", () => {
+		const calls: Record<string, unknown[][]> = {};
+		const fake = Object.fromEntries(
+			(["log", "info", "warn", "error", "debug"] as const).map((method) => [
+				method,
+				(...args: unknown[]) => {
+					(calls[method] ??= []).push(args);
+				},
+			]),
+		) as Pick<Console, "log" | "info" | "warn" | "error" | "debug">;
+
+		installConsoleTimestamps(fake, () => NOW);
+		fake.log("[host-service] starting");
+		fake.warn("[git] slow", { ms: 15_000 });
+		fake.error(new Error("x"));
+
+		expect(calls.log).toEqual([
+			["2026-09-05T20:39:15.000Z [host-service] starting"],
+		]);
+		expect(calls.warn).toEqual([
+			["2026-09-05T20:39:15.000Z [git] slow", { ms: 15_000 }],
+		]);
+		expect(calls.error?.[0]?.[0]).toBe("2026-09-05T20:39:15.000Z");
+		expect(calls.error?.[0]?.[1]).toBeInstanceOf(Error);
+	});
+});

--- a/packages/host-service/src/log-timestamps.test.ts
+++ b/packages/host-service/src/log-timestamps.test.ts
@@ -36,11 +36,19 @@ describe("installConsoleTimestamps", () => {
 
 		installConsoleTimestamps(fake, () => NOW);
 		fake.log("[host-service] starting");
+		fake.info("[host-service] info");
 		fake.warn("[git] slow", { ms: 15_000 });
 		fake.error(new Error("x"));
+		fake.debug("[host-service] debug");
 
 		expect(calls.log).toEqual([
 			["2026-09-05T20:39:15.000Z [host-service] starting"],
+		]);
+		expect(calls.info).toEqual([
+			["2026-09-05T20:39:15.000Z [host-service] info"],
+		]);
+		expect(calls.debug).toEqual([
+			["2026-09-05T20:39:15.000Z [host-service] debug"],
 		]);
 		expect(calls.warn).toEqual([
 			["2026-09-05T20:39:15.000Z [git] slow", { ms: 15_000 }],

--- a/packages/host-service/src/log-timestamps.ts
+++ b/packages/host-service/src/log-timestamps.ts
@@ -1,0 +1,35 @@
+/**
+ * Prefixes every console line with a UTC timestamp.
+ *
+ * host-service.log is the child's raw stdout/stderr, written through by
+ * whoever spawned it (desktop coordinator, CLI). Nothing on that path adds
+ * time, so a log full of git timeouts and watcher batches cannot be lined up
+ * with the freeze the user saw or with the desktop's own main.log. Installed
+ * once at process start, before the first line is written.
+ *
+ * A leading string argument is extended rather than displaced so
+ * `console.log("%s ...", x)` keeps its format semantics; any other first
+ * argument gets the stamp as its own leading argument.
+ */
+
+const METHODS = ["log", "info", "warn", "error", "debug"] as const;
+
+export function stampArgs(now: Date, args: unknown[]): unknown[] {
+	const stamp = now.toISOString();
+	if (typeof args[0] === "string") {
+		return [`${stamp} ${args[0]}`, ...args.slice(1)];
+	}
+	return [stamp, ...args];
+}
+
+export function installConsoleTimestamps(
+	target: Pick<Console, (typeof METHODS)[number]> = console,
+	now: () => Date = () => new Date(),
+): void {
+	for (const method of METHODS) {
+		const original = target[method].bind(target);
+		target[method] = (...args: unknown[]) => {
+			original(...stampArgs(now(), args));
+		};
+	}
+}

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -2,6 +2,7 @@ import { serve } from "@hono/node-server";
 import { createApp } from "./app";
 import { getSupervisor, startDaemonBootstrap } from "./daemon";
 import { env } from "./env";
+import { installConsoleTimestamps } from "./log-timestamps";
 import {
 	ConfigFileSessionTokenSource,
 	JwtApiAuthProvider,
@@ -21,6 +22,7 @@ import { startTerminalReaper } from "./terminal/reaper";
 import { connectRelay } from "./tunnel";
 
 async function main(): Promise<void> {
+	installConsoleTimestamps();
 	initSentry({ organizationId: env.ORGANIZATION_ID });
 	console.log(
 		`[host-service] starting (org=${env.ORGANIZATION_ID}, port=${env.PORT}, NODE_ENV=${process.env.NODE_ENV ?? "unset"})`,


### PR DESCRIPTION
## Problem

`host-service.log` is the child's raw stdout/stderr, written through by the desktop coordinator or the CLI, and nothing on that path adds time. A user sent a 2.4 MB tail full of git worker timeouts, DNS failures, and watcher batches, and none of it could be lined up with the freezes they reported or with the desktop's `main.log`, which is timestamped.

## Change

- New `installConsoleTimestamps()` (`src/log-timestamps.ts`) wraps `console.log/info/warn/error/debug` to prefix each call with `new Date().toISOString()`. A leading string argument is extended in place so `console.log("%s ...", x)` keeps its format semantics; any other first argument gets the stamp as its own leading argument.
- Installed as the first line of `main()` in `serve.ts`, before the startup banner.

Nothing parses host-service stdout by line prefix (checked the coordinator and the CLI spawn path); the crash-report tail is raw text and is unaffected.

## Testing

- Unit tests for the argument stamping and the install (3 tests).
- `bun run typecheck`, the no-main-loop-blocking and no-electron-coupling guards, biome clean.

https://claude.ai/code/session_01UWyngsh3WSdEM6kmf1P8s5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Timestamps every line of `host-service.log` so the child process output can be lined up with the desktop's `main.log` and with reported freezes.

- Installs a console wrapper at process start that prefixes each line with a UTC timestamp.
- A leading string argument is extended so format directives like `%s` still work; other first arguments get the stamp as their own leading argument.

<sup>Written for commit 5d6c7614c0eb762792828793d71796a05c69758c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UTC timestamps to host-service console output.
  * Timestamps are applied consistently to log, info, warning, error, and debug messages.
  * Existing formatted messages and console arguments remain intact.
  * Timestamping is enabled automatically when the host service starts.

* **Tests**
  * Added coverage for timestamp formatting, empty or non-string arguments, format directives, and all supported console methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->