### PR TITLE
fix(host-service): stop port-scan sync re-registering sessions it already watches

### DIFF
--- a/packages/host-service/src/terminal/reaper/reaper.test.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.test.ts
@@ -97,6 +97,58 @@ describe("planPortScanSync", () => {
 		expect(plan.register).toEqual([]);
 	});
 
+	it("does not re-register sessions the scanner already watches", () => {
+		const liveSessions = [
+			{ id: "term-1", pid: 4242 },
+			{ id: "term-2", pid: 4343 },
+		];
+		const rowById = new Map([
+			["term-1", { status: "active", originWorkspaceId: "ws-1" }],
+			["term-2", { status: "active", originWorkspaceId: "ws-1" }],
+		]);
+
+		const first = planPortScanSync({
+			liveSessions,
+			rowById,
+			registeredTerminalIds: [],
+			isLive: noneLive,
+		});
+		expect(first.register.map((entry) => entry.terminalId)).toEqual([
+			"term-1",
+			"term-2",
+		]);
+
+		// Second pass with the same live sessions, now that the first pass's
+		// registrations are in the scanner: nothing new to register.
+		const second = planPortScanSync({
+			liveSessions,
+			rowById,
+			registeredTerminalIds: first.register.map((entry) => entry.terminalId),
+			isLive: noneLive,
+		});
+		expect(second.register).toEqual([]);
+		expect(second.unregister).toEqual([]);
+	});
+
+	it("registers only the sessions the scanner is not yet watching", () => {
+		const plan = planPortScanSync({
+			liveSessions: [
+				{ id: "term-1", pid: 4242 },
+				{ id: "term-new", pid: 5555 },
+			],
+			rowById: new Map([
+				["term-1", { status: "active", originWorkspaceId: "ws-1" }],
+				["term-new", { status: "active", originWorkspaceId: "ws-2" }],
+			]),
+			registeredTerminalIds: ["term-1"],
+			isLive: noneLive,
+		});
+
+		expect(plan.register).toEqual([
+			{ terminalId: "term-new", workspaceId: "ws-2", pid: 5555 },
+		]);
+	});
+
 	it("unregisters scanned terminals the daemon no longer reports", () => {
 		const plan = planPortScanSync({
 			liveSessions: [{ id: "term-1", pid: 4242 }],

--- a/packages/host-service/src/terminal/reaper/reaper.ts
+++ b/packages/host-service/src/terminal/reaper/reaper.ts
@@ -111,7 +111,9 @@ export interface PortScanSyncPlan {
  * terminal — e.g. sessions the daemon kept alive across a host-service restart.
  * v1 desktop did this in its startup reconcile; v2 previously only registered
  * terminals a renderer had explicitly opened, so ports were detected less
- * completely.
+ * completely. A session the scanner already watches is skipped, so a pass
+ * with no new sessions plans nothing and the "registered N" log stays quiet
+ * instead of repeating every reap tick.
  *
  * Unregister every currently-watched terminal the daemon no longer reports and
  * that no live in-memory session owns. Sessions adopted here never get the
@@ -132,9 +134,11 @@ export function planPortScanSync({
 	isLive: (terminalId: string) => boolean;
 }): PortScanSyncPlan {
 	const aliveIds = new Set(liveSessions.map((session) => session.id));
+	const registeredIds = new Set(registeredTerminalIds);
 
 	const register: PortScanSyncPlan["register"] = [];
 	for (const session of liveSessions) {
+		if (registeredIds.has(session.id)) continue;
 		if (isLive(session.id)) continue;
 		const row = rowById.get(session.id);
 		if (!row?.originWorkspaceId) continue;


### PR DESCRIPTION
## Problem

`planPortScanSync` in the terminal reaper built its `register` list from every live daemon session that was unattached, active, and workspace-owned, but never consulted `registeredTerminalIds`. So every reap tick and every warm-up pass re-registered the same sessions and logged `port-scan sync: registered N unattached daemon session(s) for scanning`. One user's host-service log contained that line 6,125 times with N between 7 and 16.

I read `PortManager.upsertSession` before changing anything: a re-register with the same pid only rewrites `workspaceId` and calls `ensurePeriodicScanRunning`, which is already running, and it deliberately does not reset the idle clock. So this was log noise plus redundant calls, not a scanning storm.

## Change

`planPortScanSync` now skips any session whose id is already in `registeredTerminalIds`. The plan only receives ids from `getRegisteredTerminalIds`, not pids, so the skip is by id. The `unregister` side is unchanged. The log line already fires only when `plan.register` is non-empty, so it now stays quiet on steady-state passes.

Scope: `packages/host-service/src/terminal/reaper/reaper.ts` and its co-located test only.

## Testing

Two new `planPortScanSync` tests:

- a second pass with the same live sessions and the first pass's registrations produces an empty `register` and `unregister` list
- a pass where one of two live sessions is already registered registers only the new one

Both fail on `main` (the register list comes back with every live session) and pass with the fix. I ran the tests before applying the change to confirm that.

```
bun test src/terminal/reaper   # 29 pass, 0 fail (27 pass, 2 fail before the fix)
bun run typecheck              # clean
bunx biome check reaper.ts reaper.test.ts   # clean
```

https://claude.ai/code/session_01UWyngsh3WSdEM6kmf1P8s5
https://claude.ai/code/session_01Vy53TU6o6FoBm8yFqkNqCA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the terminal reaper's port-scan sync from re-registering sessions it already watches, so the "port-scan sync: registered N" log stays quiet on steady-state passes.

- The register list previously included every unattached, active, workspace-owned daemon session, even ones already watched; one host-service log had the line 6,125 times.
- Re-registering the same pid was already a no-op in `PortManager.upsertSession`, so this removes redundant calls without changing scan behavior.
- Sessions whose id is already in `registeredTerminalIds` are now skipped; the unregister side is unchanged, and two new tests cover the steady-state and partial-registration cases.

<sup>Written for commit fc498ee9ad28a586df49e7e6aa52a23c028d5c59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented already-registered terminal sessions from being registered again during repeated synchronization scans.
  - Reduced unnecessary registration activity and logging when no new active sessions are found.

- **Tests**
  - Added coverage for repeated scans and partial adoption of active terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->