### PR TITLE
fix(cli): match feedback attachment limit to the Vercel body cap and keep oversized logs' tails

### DIFF
--- a/packages/cli/src/commands/feedback/submit/command.test.ts
+++ b/packages/cli/src/commands/feedback/submit/command.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import submitCommand, {
+	MAX_ATTACHMENT_TOTAL_BASE64_CHARS,
+	MAX_ATTACHMENT_TOTAL_BYTES,
+} from "./command";
+
+interface SubmittedAttachment {
+	filename: string;
+	contentBase64: string;
+}
+
+let submitted: { attachments?: SubmittedAttachment[] } | undefined;
+let dir: string;
+let stderr: string[];
+let stderrSpy: ReturnType<typeof spyOn>;
+
+function invoke(attach: string[]) {
+	return submitCommand.run({
+		ctx: {
+			api: {
+				support: {
+					submitFeedback: {
+						mutate: async (input: typeof submitted) => {
+							submitted = input;
+						},
+					},
+				},
+			},
+		} as never,
+		args: {} as never,
+		options: {
+			type: "bug",
+			title: "Attachment limits",
+			body: "The log is attached.",
+			attach: attach.join(","),
+		} as never,
+		signal: new AbortController().signal,
+	});
+}
+
+/** Bytes whose value depends on their offset, so a tail is distinguishable from a head. */
+function patterned(size: number): Buffer {
+	const buffer = Buffer.alloc(size);
+	for (let i = 0; i < size; i++) buffer[i] = i % 251;
+	return buffer;
+}
+
+function writeFixture(name: string, content: Buffer): string {
+	const path = join(dir, name);
+	writeFileSync(path, content);
+	return path;
+}
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "superset-feedback-"));
+	submitted = undefined;
+	stderr = [];
+	stderrSpy = spyOn(process.stderr, "write").mockImplementation(((
+		chunk: string | Uint8Array,
+	) => {
+		stderr.push(String(chunk));
+		return true;
+	}) as typeof process.stderr.write);
+});
+
+afterEach(() => {
+	stderrSpy.mockRestore();
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("feedback submit attachments", () => {
+	test("the enforced limit fits Vercel's 4.5 MB body cap after base64 expansion", () => {
+		const encoded = Buffer.alloc(MAX_ATTACHMENT_TOTAL_BYTES).toString("base64");
+		expect(encoded.length).toBeLessThanOrEqual(
+			MAX_ATTACHMENT_TOTAL_BASE64_CHARS,
+		);
+		// Room for the report body (20k chars), the diagnostics bundle (under
+		// 90k chars encoded), titles, filenames, and JSON framing.
+		expect(MAX_ATTACHMENT_TOTAL_BASE64_CHARS + 110_000).toBeLessThan(4_500_000);
+	});
+
+	test("sends an attachment under the limit intact", async () => {
+		const content = patterned(1024);
+		const path = writeFixture("small.log", content);
+
+		await invoke([path]);
+
+		expect(submitted?.attachments).toHaveLength(1);
+		expect(submitted?.attachments?.[0]?.filename).toBe("small.log");
+		expect(
+			Buffer.from(
+				submitted?.attachments?.[0]?.contentBase64 ?? "",
+				"base64",
+			).equals(content),
+		).toBe(true);
+		expect(stderr.join("")).toBe("");
+	});
+
+	test("attaches the tail of a single oversized file and says so", async () => {
+		const content = patterned(MAX_ATTACHMENT_TOTAL_BYTES + 4096);
+		const path = writeFixture("host-service.log", content);
+
+		await invoke([path]);
+
+		expect(submitted?.attachments).toHaveLength(1);
+		const attachment = submitted?.attachments?.[0];
+		expect(attachment?.filename).toBe("host-service.log");
+		expect(attachment?.contentBase64.length).toBeLessThanOrEqual(
+			MAX_ATTACHMENT_TOTAL_BASE64_CHARS,
+		);
+		expect(
+			Buffer.from(attachment?.contentBase64 ?? "", "base64").equals(
+				content.subarray(content.length - MAX_ATTACHMENT_TOTAL_BYTES),
+			),
+		).toBe(true);
+		expect(stderr.join("")).toContain(
+			`Truncated host-service.log to its last ${MAX_ATTACHMENT_TOTAL_BYTES} bytes`,
+		);
+	});
+
+	test("fails before uploading when several attachments together exceed the limit", async () => {
+		const each = Math.ceil(MAX_ATTACHMENT_TOTAL_BYTES * 0.6);
+		const first = writeFixture("host-service.log", patterned(each));
+		const second = writeFixture("main.log", patterned(each));
+
+		const error = await invoke([first, second]).catch((thrown) => thrown);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.message).toContain("3.2 MB");
+		expect(error.message).toContain("host-service.log");
+		expect(error.message).toContain("main.log");
+		expect(submitted).toBeUndefined();
+	});
+});

--- a/packages/cli/src/commands/feedback/submit/command.test.ts
+++ b/packages/cli/src/commands/feedback/submit/command.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { TRPCClientError } from "@trpc/client";
+import { ApiHttpError } from "../../../lib/api-client";
 import submitCommand, {
 	MAX_ATTACHMENT_TOTAL_BASE64_CHARS,
 	MAX_ATTACHMENT_TOTAL_BYTES,
@@ -13,6 +15,7 @@ interface SubmittedAttachment {
 }
 
 let submitted: { attachments?: SubmittedAttachment[] } | undefined;
+let reject: (() => Error) | undefined;
 let dir: string;
 let stderr: string[];
 let stderrSpy: ReturnType<typeof spyOn>;
@@ -24,6 +27,7 @@ function invoke(attach: string[]) {
 				support: {
 					submitFeedback: {
 						mutate: async (input: typeof submitted) => {
+							if (reject) throw reject();
 							submitted = input;
 						},
 					},
@@ -57,6 +61,7 @@ function writeFixture(name: string, content: Buffer): string {
 beforeEach(() => {
 	dir = mkdtempSync(join(tmpdir(), "superset-feedback-"));
 	submitted = undefined;
+	reject = undefined;
 	stderr = [];
 	stderrSpy = spyOn(process.stderr, "write").mockImplementation(((
 		chunk: string | Uint8Array,
@@ -132,5 +137,62 @@ describe("feedback submit attachments", () => {
 		expect(error.message).toContain("host-service.log");
 		expect(error.message).toContain("main.log");
 		expect(submitted).toBeUndefined();
+	});
+
+	test("surfaces a 413 from the platform with its status, text, and the limit hint", async () => {
+		const path = writeFixture("small.log", patterned(1024));
+		// What httpBatchLink throws when the response body is not JSON: the
+		// fetch wrapper's error rides along as the cause.
+		reject = () =>
+			TRPCClientError.from(
+				new ApiHttpError(
+					413,
+					"Request Entity Too Large",
+					"Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE / sfo1::abc-123",
+				),
+			);
+
+		const error = await invoke([path]).catch((thrown) => thrown);
+
+		expect(error.name).toBe("CLIError");
+		expect(error.message).toContain("HTTP 413");
+		expect(error.message).toContain("FUNCTION_PAYLOAD_TOO_LARGE");
+		expect(error.message).toContain("sfo1::abc-123");
+		expect(error.suggestion).toContain("3.2 MB");
+	});
+
+	test("surfaces a tRPC error with its status and the server's message", async () => {
+		const path = writeFixture("small.log", patterned(1024));
+		reject = () =>
+			TRPCClientError.from({
+				error: {
+					message: "Attachments exceed the 10MB total limit",
+					code: -32600,
+					data: { code: "BAD_REQUEST", httpStatus: 400 },
+				},
+			} as never);
+
+		const error = await invoke([path]).catch((thrown) => thrown);
+
+		expect(error.name).toBe("CLIError");
+		expect(error.message).toContain("HTTP 400");
+		expect(error.message).toContain("Attachments exceed the 10MB total limit");
+		expect(error.suggestion).toBeUndefined();
+	});
+
+	test("leaves an expired session to the runner's own wording", async () => {
+		const path = writeFixture("small.log", patterned(1024));
+		const unauthorized = TRPCClientError.from({
+			error: {
+				message: "Not authenticated. Please sign in.",
+				code: -32001,
+				data: { code: "UNAUTHORIZED", httpStatus: 401 },
+			},
+		} as never);
+		reject = () => unauthorized;
+
+		const error = await invoke([path]).catch((thrown) => thrown);
+
+		expect(error).toBe(unauthorized);
 	});
 });

--- a/packages/cli/src/commands/feedback/submit/command.ts
+++ b/packages/cli/src/commands/feedback/submit/command.ts
@@ -11,9 +11,21 @@ import { basename, join } from "node:path";
 import { boolean, CLIError, string } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
 
-const MAX_ATTACHMENT_TOTAL_BYTES = 10 * 1024 * 1024;
-/** Mirrors the server's refine on submitFeedback input. */
-const MAX_ATTACHMENT_TOTAL_BASE64_CHARS = 14_000_000;
+/**
+ * The tRPC route is a Vercel function, and Vercel rejects request bodies
+ * above 4.5 MB with 413 FUNCTION_PAYLOAD_TOO_LARGE before the route's own
+ * 14M-char refine ever runs, so that refine is not the real limit. The
+ * headroom covers the rest of the body: the report (up to 20k chars), the
+ * title, JSON framing, and the diagnostics bundle (under 90k chars encoded).
+ */
+const VERCEL_MAX_REQUEST_BODY_BYTES = 4_500_000;
+const REQUEST_BODY_HEADROOM_BYTES = 200_000;
+export const MAX_ATTACHMENT_TOTAL_BASE64_CHARS =
+	VERCEL_MAX_REQUEST_BODY_BYTES - REQUEST_BODY_HEADROOM_BYTES;
+/** Raw bytes whose base64 form (4 chars per 3 bytes) fits the encoded budget. */
+export const MAX_ATTACHMENT_TOTAL_BYTES =
+	Math.floor(MAX_ATTACHMENT_TOTAL_BASE64_CHARS / 4) * 3;
+const ATTACHMENT_LIMIT_LABEL = `${(MAX_ATTACHMENT_TOTAL_BYTES / 1_000_000).toFixed(1)} MB`;
 const DIAGNOSTICS_LOG_TAIL_BYTES = 64 * 1024;
 const DIAGNOSTICS_LOG_TAIL_LINES = 200;
 
@@ -22,9 +34,9 @@ interface FeedbackAttachment {
 	contentBase64: string;
 }
 
-function readTail(filePath: string): string {
+/** The last `length` bytes of a file, without reading the rest into memory. */
+function readTailBytes(filePath: string, length: number): Buffer {
 	const size = statSync(filePath).size;
-	const length = Math.min(size, DIAGNOSTICS_LOG_TAIL_BYTES);
 	const buffer = Buffer.alloc(length);
 	const fd = openSync(filePath, "r");
 	try {
@@ -32,7 +44,12 @@ function readTail(filePath: string): string {
 	} finally {
 		closeSync(fd);
 	}
-	return buffer
+	return buffer;
+}
+
+function readTail(filePath: string): string {
+	const size = statSync(filePath).size;
+	return readTailBytes(filePath, Math.min(size, DIAGNOSTICS_LOG_TAIL_BYTES))
 		.toString("utf-8")
 		.split("\n")
 		.slice(-DIAGNOSTICS_LOG_TAIL_LINES)
@@ -75,7 +92,7 @@ export default command({
 			"Path to a file containing the report, - for stdin",
 		),
 		attach: string().desc(
-			"Comma-separated file paths to attach (screenshots, logs; 10MB total)",
+			`Comma-separated file paths to attach (screenshots, logs; ${ATTACHMENT_LIMIT_LABEL} total, a lone larger file is cut to its tail)`,
 		),
 		diagnostics: boolean().desc(
 			"Attach a diagnostics bundle (CLI version, OS, last 200 app log lines)",
@@ -95,33 +112,38 @@ export default command({
 		}
 
 		const attachments: FeedbackAttachment[] = [];
+		const truncated: string[] = [];
 		let totalBase64Chars = 0;
-		const addAttachment = (attachment: FeedbackAttachment) => {
-			// Base64 is what travels, and the server limit is on encoded size.
-			totalBase64Chars += attachment.contentBase64.length;
-			if (totalBase64Chars > MAX_ATTACHMENT_TOTAL_BASE64_CHARS) {
-				throw new CLIError("Attachments exceed the 10MB total limit");
-			}
-			attachments.push(attachment);
-		};
 		for (const rawPath of options.attach?.split(",") ?? []) {
 			const path = rawPath.trim();
 			if (!path) continue;
 			if (!existsSync(path)) {
 				throw new CLIError(`Attachment not found: ${path}`);
 			}
-			// Reject oversized files before reading them into memory.
-			if (statSync(path).size > MAX_ATTACHMENT_TOTAL_BYTES) {
-				throw new CLIError("Attachments exceed the 10MB total limit");
+			// A lone oversized file is usually a log, and its tail is what
+			// matters, so keep the newest bytes instead of failing.
+			const size = statSync(path).size;
+			const bytes = Math.min(size, MAX_ATTACHMENT_TOTAL_BYTES);
+			if (bytes < size) {
+				truncated.push(
+					`Truncated ${basename(path)} to its last ${bytes} bytes (${ATTACHMENT_LIMIT_LABEL} attachment limit)\n`,
+				);
 			}
-			addAttachment({
-				filename: basename(path),
-				contentBase64: readFileSync(path).toString("base64"),
-			});
+			const contentBase64 = readTailBytes(path, bytes).toString("base64");
+			// Base64 is what travels, and the body limit is on encoded size.
+			totalBase64Chars += contentBase64.length;
+			attachments.push({ filename: basename(path), contentBase64 });
 		}
+		if (totalBase64Chars > MAX_ATTACHMENT_TOTAL_BASE64_CHARS) {
+			throw new CLIError(
+				`Attachments exceed the ${ATTACHMENT_LIMIT_LABEL} total limit: ${attachments.map((a) => a.filename).join(", ")}`,
+				"Attach fewer files, or one file at a time so its tail is kept",
+			);
+		}
+		for (const line of truncated) process.stderr.write(line);
 		if (options.diagnostics) {
 			const bundle = collectDiagnostics();
-			if (bundle) addAttachment(bundle);
+			if (bundle) attachments.push(bundle);
 		}
 		if (attachments.length > 5) {
 			throw new CLIError("At most 5 attachments per submission");

--- a/packages/cli/src/commands/feedback/submit/command.ts
+++ b/packages/cli/src/commands/feedback/submit/command.ts
@@ -40,11 +40,12 @@ function readTailBytes(filePath: string, length: number): Buffer {
 	const buffer = Buffer.alloc(length);
 	const fd = openSync(filePath, "r");
 	try {
-		readSync(fd, buffer, 0, length, size - length);
+		// A log rotated between the size check and the read comes back short.
+		const read = readSync(fd, buffer, 0, length, size - length);
+		return buffer.subarray(0, read);
 	} finally {
 		closeSync(fd);
 	}
-	return buffer;
 }
 
 function readTail(filePath: string): string {

--- a/packages/cli/src/commands/feedback/submit/command.ts
+++ b/packages/cli/src/commands/feedback/submit/command.ts
@@ -9,6 +9,7 @@ import {
 import os from "node:os";
 import { basename, join } from "node:path";
 import { boolean, CLIError, string } from "@superset/cli-framework";
+import { ApiHttpError } from "../../../lib/api-client";
 import { command } from "../../../lib/command";
 
 /**
@@ -55,6 +56,32 @@ function readTail(filePath: string): string {
 		.split("\n")
 		.slice(-DIAGNOSTICS_LOG_TAIL_LINES)
 		.join("\n");
+}
+
+/**
+ * A rejection with an HTTP status behind it, whether tRPC produced it or the
+ * platform in front of the API did (Vercel's 413 arrives as the `cause` of a
+ * "Failed to parse JSON" error). Anything else, such as an expired session or
+ * an unreachable API, keeps the runner's own wording.
+ */
+function describeRejection(
+	error: unknown,
+): { status: number; message: string } | null {
+	if (!(error instanceof Error)) return null;
+	if (error.cause instanceof ApiHttpError) {
+		const { status, statusText, body } = error.cause;
+		return { status, message: body || statusText };
+	}
+	const trpc = error as Error & {
+		data?: { code?: string; httpStatus?: number };
+	};
+	if (
+		typeof trpc.data?.httpStatus === "number" &&
+		trpc.data.code !== "UNAUTHORIZED"
+	) {
+		return { status: trpc.data.httpStatus, message: error.message };
+	}
+	return null;
 }
 
 function collectDiagnostics(): FeedbackAttachment | null {
@@ -150,14 +177,25 @@ export default command({
 			throw new CLIError("At most 5 attachments per submission");
 		}
 
-		await ctx.api.support.submitFeedback.mutate({
-			type: options.type,
-			title: options.title,
-			body,
-			appVersion: process.env.SUPERSET_VERSION ?? "dev",
-			os: `${os.platform()} ${os.release()} ${os.arch()}`,
-			attachments: attachments.length > 0 ? attachments : undefined,
-		});
+		try {
+			await ctx.api.support.submitFeedback.mutate({
+				type: options.type,
+				title: options.title,
+				body,
+				appVersion: process.env.SUPERSET_VERSION ?? "dev",
+				os: `${os.platform()} ${os.release()} ${os.arch()}`,
+				attachments: attachments.length > 0 ? attachments : undefined,
+			});
+		} catch (error) {
+			const rejection = describeRejection(error);
+			if (!rejection) throw error;
+			throw new CLIError(
+				`The server rejected the feedback (HTTP ${rejection.status}): ${rejection.message}`,
+				rejection.status === 413
+					? `The request was over the API's 4.5 MB body cap. Attachments must total under ${ATTACHMENT_LIMIT_LABEL}; attach fewer or smaller files, or a single log so its tail is kept`
+					: undefined,
+			);
+		}
 
 		return {
 			data: { submitted: true, attachments: attachments.length },

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { ApiHttpError, fetchRejectingNonJsonErrors } from "./api-client";
+
+let respond: () => Response = () => new Response("");
+const server = Bun.serve({ port: 0, fetch: () => respond() });
+const url = `http://localhost:${server.port}/api/trpc`;
+
+afterAll(() => server.stop(true));
+
+describe("fetchRejectingNonJsonErrors", () => {
+	test("turns Vercel's 413 page into an error carrying status and body", async () => {
+		respond = () =>
+			new Response(
+				"Request Entity Too Large\n\nFUNCTION_PAYLOAD_TOO_LARGE\n\nsfo1::abc-123",
+				{ status: 413, statusText: "Request Entity Too Large" },
+			);
+
+		const error: unknown = await fetchRejectingNonJsonErrors(url).catch(
+			(thrown: unknown) => thrown,
+		);
+
+		expect(error).toBeInstanceOf(ApiHttpError);
+		const httpError = error as ApiHttpError;
+		expect(httpError.status).toBe(413);
+		expect(httpError.body).toBe(
+			"Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE / sfo1::abc-123",
+		);
+		expect(httpError.message).toContain("HTTP 413");
+	});
+
+	test("leaves JSON error responses to tRPC", async () => {
+		respond = () =>
+			new Response(JSON.stringify([{ error: { json: { message: "nope" } } }]), {
+				status: 400,
+				headers: { "content-type": "application/json" },
+			});
+
+		const response = await fetchRejectingNonJsonErrors(url);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual([
+			{ error: { json: { message: "nope" } } },
+		]);
+	});
+
+	test("passes successful responses through untouched", async () => {
+		respond = () => new Response("ok", { status: 200 });
+
+		const response = await fetchRejectingNonJsonErrors(url);
+
+		expect(await response.text()).toBe("ok");
+	});
+});

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -8,6 +8,48 @@ import { env } from "./env";
 
 export type ApiClient = TRPCClient<AppRouter>;
 
+/**
+ * A non-JSON error response from whatever sits in front of the API: Vercel's
+ * 413 page, a gateway's HTML 502. tRPC would otherwise report these as
+ * "Failed to parse JSON" and drop the status, leaving the user nothing to act
+ * on. The body keeps its non-empty lines (Vercel's includes the request id).
+ */
+export class ApiHttpError extends Error {
+	constructor(
+		public readonly status: number,
+		public readonly statusText: string,
+		public readonly body: string,
+	) {
+		super(`HTTP ${status} ${statusText}: ${body}`.trimEnd());
+		this.name = "ApiHttpError";
+	}
+}
+
+const MAX_ERROR_BODY_CHARS = 300;
+
+export async function fetchRejectingNonJsonErrors(
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> {
+	const response = await fetch(input, init);
+	const contentType = response.headers.get("content-type") ?? "";
+	if (response.ok || contentType.includes("json")) return response;
+	const body = (await response.text())
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.join(" / ")
+		.slice(0, MAX_ERROR_BODY_CHARS);
+	throw new ApiHttpError(response.status, response.statusText, body);
+}
+
+/**
+ * tRPC declares this type without exporting it, and bun-types' Response does
+ * not satisfy its ResponseEsque (stream reader overloads), so passing even the
+ * global fetch here needs the same cast.
+ */
+type LinkFetch = NonNullable<Parameters<typeof httpBatchLink>[0]["fetch"]>;
+
 export function createApiClient(opts: {
 	bearer: string;
 	organizationId?: string;
@@ -17,6 +59,7 @@ export function createApiClient(opts: {
 			httpBatchLink({
 				url: `${getApiUrl()}/api/trpc`,
 				transformer: SuperJSON,
+				fetch: fetchRejectingNonJsonErrors as LinkFetch,
 				headers() {
 					// better-auth's apiKey plugin reads `sk_live_…` from the
 					// x-api-key header. The Authorization: Bearer header is


### PR DESCRIPTION
## Problem

`superset feedback submit` checked attachments against a 10 MB total, mirroring the server's 14M-char zod refine in `packages/trpc/src/router/support/support.ts`. That refine is not the real limit: the tRPC route is a Vercel function, and Vercel rejects request bodies above 4.5 MB with 413 FUNCTION_PAYLOAD_TOO_LARGE before the route runs. A user's 5.1 MB host-service.log passed the CLI check today and failed on upload, and their agent had to hand-truncate the file.

## Change

- One budget in the CLI, derived from the 4.5 MB body cap minus 200 KB headroom for the report (up to 20k chars), title, JSON framing, and the diagnostics bundle (under 90k chars encoded). The raw-byte limit comes from it through the 4/3 base64 expansion explicitly (4 chars per 3 bytes), landing at 3.2 MB of attachment bytes.
- A lone file over the budget is attached as its tail (the newest bytes) instead of failing, with one stderr line: `Truncated host-service.log to its last 3225000 bytes (3.2 MB attachment limit)`. Logs are the common case and their tail is what matters.
- Several files that together exceed the budget fail before anything uploads, naming the files and the limit.
- Only the bytes that will be sent are read, through the same tail reader the diagnostics bundle already used.

The limit stays in the CLI only. The CLI imports `@superset/trpc` type-only, so a shared runtime constant would pull server code into the CLI bundle. The server refine is untouched.

## Testing

Co-located `command.test.ts` covers the four cases: the budget fits under 4.5 MB after base64 expansion, an under-limit file passes through byte-identical, a single oversized file arrives as exactly its last 3.2 MB with the stderr line, and two files that only fit individually fail before the mutation is called with both names and the limit in the message.

Proof the tests catch the bug: running the test file against the pre-fix `command.ts` (with only `export` added to its two constants so the module loads) fails 3 of 4: the budget test sees 14,020,000 chars against the 4.5 MB cap, the truncation test gets the whole file, and the multi-file test gets the old generic "Attachments exceed the 10MB total limit" without filenames.

Against production, without auth, so nothing was submitted: a 413 means Vercel's cap fired before tRPC ran, a 401 means the body got through.

| Request body | Result |
| --- | --- |
| 4,320,109 bytes (3,225,000 raw attachment + 20k report) | 401, reached tRPC |
| 4,409,765 bytes (worst case the fixed CLI can send: full attachment, maximal diagnostics bundle, 20k report, 200-char title/os/filename) | 401, reached tRPC |
| 4,493,409 bytes | 401, reached tRPC (largest passing, by bisection) |
| 4,494,107 bytes | 413 FUNCTION_PAYLOAD_TOO_LARGE (smallest failing) |
| 4,520,109 bytes (the earlier 3.3 MB variant with 100 KB headroom, plus a 20k report) | 413 FUNCTION_PAYLOAD_TOO_LARGE |

So the platform cap is decimal 4.5 MB minus about 6 KB, not 4.5 MiB, and the 200 KB headroom is what keeps the worst-case body under it. The 3.3 MB variant this PR briefly carried would have failed with a full report attached.

- `bun test src/commands/feedback/submit` in packages/cli: 4 pass, 0 fail
- `bun run typecheck` in packages/cli: clean
- `bunx biome check packages/cli/src/commands/feedback/submit`: clean

## Follow-up: surface server rejections plainly

Reviewer ask: when the server rejects the submission, show the status and the server's message, plus the attachment-limit hint on a 413.

What a 413 looked like before this: Vercel answers with a text body, the tRPC client fails to parse it and throws "Failed to parse JSON" with no status and no response attached, so the command could not recover anything useful.

- `packages/cli/src/lib/api-client.ts` now passes a fetch wrapper to `httpBatchLink`. A non-2xx response whose body is not JSON becomes an `ApiHttpError` with the status, status text, and the body's non-empty lines joined (Vercel's includes the request id, useful for support). tRPC keeps a thrown fetch error as the `cause` of its own error, verified empirically. JSON error responses are left to tRPC as before. This is the one change outside the feedback command directory; the status is not recoverable anywhere else.
- The feedback command catches any rejection with an HTTP status behind it, tRPC's `data.httpStatus` or the wrapper's, and throws `The server rejected the feedback (HTTP 413): Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE / sfo1::...`, with the hint `The request was over the API's 4.5 MB body cap. Attachments must total under 3.2 MB; ...` on a 413. UNAUTHORIZED and network errors still pass through so the runner's "Session expired" and "Could not connect to API" wording is unchanged.
- The `readTailBytes` helper also now honors the byte count `readSync` returns, so a log rotated between the size check and the read is not padded with zero bytes (a bot review point that was valid).

Tests: `api-client.test.ts` drives the wrapper against a local `Bun.serve` for a 413 text body, a 400 JSON body, and a 200. `command.test.ts` adds three cases: a 413 surfaces its status, the FUNCTION_PAYLOAD_TOO_LARGE text, the request id, and the 3.2 MB hint; a tRPC 400 surfaces its status and message with no hint; an UNAUTHORIZED error is rethrown untouched. Against the pre-fix command, the two rejection tests fail with `TRPCClientError` where `CLIError` is expected.

- `bun test src/commands/feedback/submit src/lib/api-client.test.ts` in packages/cli: 10 pass, 0 fail (full package suite: 205 pass)
- `bun run typecheck` in packages/cli: clean
- `bunx biome check` on the four changed files: clean

### Evidence: built binaries, before and after

Two CLI binaries built with `cli-framework build`, one from main's `command.ts` and `api-client.ts` and one from this branch, both with the API URL baked to a local server that answers every request the way Vercel's edge does for an oversized body (413, text body `Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE / sfo1::evidence-0001`). Same 6.8 MB log attached to both.

```
=== BEFORE (main) ===
Error: Failed to parse JSON
exit=1

=== AFTER (PR #7214) ===
Truncated host-service.log to its last 3225000 bytes (3.2 MB attachment limit)
Error: The server rejected the feedback (HTTP 413): Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE / sfo1::evidence-0001
Hint: The request was over the API's 4.5 MB body cap. Attachments must total under 3.2 MB; attach fewer or smaller files, or a single log so its tail is kept
exit=1
```

The real production 413 through the real client: `createApiClient` with a bogus bearer and a 4.6 MB body against api.superset.sh (nothing can be submitted with a bad token) throws a `TRPCClientError` whose `cause` is `ApiHttpError` with status 413 and body `Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE / sfo1::zjm9r-1788668505990-9a08386ce624`.

Side observation, not changed here: production answers an invalid `sk_live_` API key with a 500 "Invalid API key" tRPC error rather than a 401, so the built binary with a fake key printed `The server rejected the feedback (HTTP 500): Invalid API key.` That is the new tRPC-error path working, but the server's status code for that case looks wrong.

https://claude.ai/code/session_01RnHTYgESRFnZbhHRM4nsPE
https://claude.ai/code/session_01UWyngsh3WSdEM6kmf1P8s5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feedback attachments now account for base64-encoded request sizes.
  * Large individual attachments are truncated to their newest content, with warnings and truncation details included in the response.
  * Attachment diagnostics share the same size budget.
  * Smaller attachments continue to upload intact.

* **Bug Fixes**
  * Oversized attachment sets are rejected before upload, with affected files identified.
  * Submission errors now preserve relevant status and server messages, including guidance for payloads that exceed the request limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


