### PR TITLE
feat(cli): list, edit, and delete terminal scripts; add --upsert

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/cli-terminal-script-import.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/cli-terminal-script-import.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { TerminalPreset } from "@superset/local-db";
-import { clearImportedCliTerminalScripts } from "./cli-terminal-script-import";
+import {
+	acknowledgeCliTerminalScripts,
+	isPendingCliTerminalScript,
+} from "./cli-terminal-script-import";
 
 const pendingScript = (
 	overrides: Partial<TerminalPreset> = {},
@@ -14,14 +17,33 @@ const pendingScript = (
 	...overrides,
 });
 
-describe("clearImportedCliTerminalScripts", () => {
+describe("isPendingCliTerminalScript", () => {
+	test("matches import markers and delete tombstones for the organization", () => {
+		expect(isPendingCliTerminalScript(pendingScript(), "org-a")).toBe(true);
+		expect(
+			isPendingCliTerminalScript(
+				pendingScript({ cliImportPending: undefined, cliDeletePending: true }),
+				"org-a",
+			),
+		).toBe(true);
+		expect(isPendingCliTerminalScript(pendingScript(), "org-b")).toBe(false);
+		expect(
+			isPendingCliTerminalScript(
+				pendingScript({ cliImportPending: undefined }),
+				"org-a",
+			),
+		).toBe(false);
+	});
+});
+
+describe("acknowledgeCliTerminalScripts", () => {
 	test("keeps the row for v1 but drops the import markers", () => {
 		const regular = pendingScript({
 			id: "regular",
 			cliImportPending: undefined,
 			cliTargetOrganizationId: undefined,
 		});
-		const result = clearImportedCliTerminalScripts({
+		const result = acknowledgeCliTerminalScripts({
 			scripts: [pendingScript(), regular],
 			organizationId: "org-a",
 			ids: ["script-a"],
@@ -34,9 +56,25 @@ describe("clearImportedCliTerminalScripts", () => {
 		]);
 	});
 
+	test("drops delete tombstones entirely", () => {
+		const tombstone = pendingScript({
+			id: "gone",
+			cliImportPending: undefined,
+			cliDeletePending: true,
+		});
+		const result = acknowledgeCliTerminalScripts({
+			scripts: [pendingScript(), tombstone],
+			organizationId: "org-a",
+			ids: ["gone"],
+		});
+
+		expect(result.changed).toBe(true);
+		expect(result.scripts).toEqual([pendingScript()]);
+	});
+
 	test("preserves pending scripts for another organization", () => {
 		const script = pendingScript();
-		const result = clearImportedCliTerminalScripts({
+		const result = acknowledgeCliTerminalScripts({
 			scripts: [script],
 			organizationId: "org-b",
 			ids: [script.id],
@@ -47,7 +85,7 @@ describe("clearImportedCliTerminalScripts", () => {
 
 	test("ignores ids that are not pending", () => {
 		const script = pendingScript({ cliImportPending: undefined });
-		const result = clearImportedCliTerminalScripts({
+		const result = acknowledgeCliTerminalScripts({
 			scripts: [script],
 			organizationId: "org-a",
 			ids: [script.id],

--- a/apps/desktop/src/lib/trpc/routers/settings/cli-terminal-script-import.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/cli-terminal-script-import.ts
@@ -1,22 +1,28 @@
 import type { TerminalPreset } from "@superset/local-db";
 
+/**
+ * A row the CLI flagged for this organization: either a new/edited script to
+ * copy into v2 (cliImportPending) or a tombstone whose v2 copy must go
+ * (cliDeletePending).
+ */
 export function isPendingCliTerminalScript(
 	script: TerminalPreset,
 	organizationId: string,
 ): boolean {
 	return (
-		script.cliImportPending === true &&
+		(script.cliImportPending === true || script.cliDeletePending === true) &&
 		script.cliTargetOrganizationId === organizationId
 	);
 }
 
 /**
- * Clear the one-shot CLI import markers once v2 has copied the scripts. The
- * rows stay in the legacy store (v1 keeps showing them, same as presets
- * brought over by the v1 import modal); only the marker goes, so a script
- * deleted in v2 is never re-imported.
+ * Settle the one-shot CLI markers once v2 has applied them. Imported rows
+ * stay in the legacy store (v1 keeps showing them, same as presets brought
+ * over by the v1 import modal); only the marker goes, so a script deleted in
+ * v2 is never re-imported. Tombstones are dropped entirely: the user deleted
+ * the script, and `superset scripts list` reads this store.
  */
-export function clearImportedCliTerminalScripts({
+export function acknowledgeCliTerminalScripts({
 	scripts,
 	organizationId,
 	ids,
@@ -27,19 +33,23 @@ export function clearImportedCliTerminalScripts({
 }): { scripts: TerminalPreset[]; changed: boolean } {
 	const acknowledgedIds = new Set(ids);
 	let changed = false;
-	const nextScripts = scripts.map((script) => {
+	const nextScripts: TerminalPreset[] = [];
+	for (const script of scripts) {
 		if (
 			!acknowledgedIds.has(script.id) ||
 			!isPendingCliTerminalScript(script, organizationId)
-		)
-			return script;
+		) {
+			nextScripts.push(script);
+			continue;
+		}
 		changed = true;
+		if (script.cliDeletePending) continue;
 		const {
 			cliImportPending: _pending,
 			cliTargetOrganizationId: _target,
 			...rest
 		} = script;
-		return rest;
-	});
+		nextScripts.push(rest);
+	}
 	return { scripts: nextScripts, changed };
 }

--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -83,7 +83,7 @@ import {
 	updateCustomAgentInputSchema,
 } from "./agent-preset-router.utils";
 import {
-	clearImportedCliTerminalScripts,
+	acknowledgeCliTerminalScripts,
 	isPendingCliTerminalScript,
 } from "./cli-terminal-script-import";
 import {
@@ -304,7 +304,7 @@ export const createSettingsRouter = () => {
 				// land between this read and write or its row would be dropped.
 				localDb.transaction(
 					() => {
-						const result = clearImportedCliTerminalScripts({
+						const result = acknowledgeCliTerminalScripts({
 							scripts: getNormalizedTerminalPresets(),
 							organizationId: input.organizationId,
 							ids: input.ids,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCliTerminalScriptImport/applyCliTerminalScriptEdit.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCliTerminalScriptImport/applyCliTerminalScriptEdit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { applyCliTerminalScriptEdit } from "./applyCliTerminalScriptEdit";
+
+describe("applyCliTerminalScriptEdit", () => {
+	test("overwrites CLI-editable fields and keeps app-owned ones", () => {
+		const createdAt = new Date("2026-01-01T00:00:00Z");
+		const draft: V2TerminalPresetRow = {
+			id: "script-a",
+			name: "Old",
+			description: "old description",
+			cwd: "apps/web",
+			commands: ["bun run old"],
+			projectIds: ["project-a"],
+			pinnedToBar: true,
+			useAsWorkspaceRun: true,
+			applyOnWorkspaceCreated: true,
+			executionMode: "split-pane",
+			tabOrder: 4,
+			createdAt,
+			agentId: "agent-1",
+		};
+
+		applyCliTerminalScriptEdit(draft, {
+			id: "script-a",
+			name: "New",
+			cwd: "",
+			commands: ["bun run new", "bun run worker"],
+			pinnedToBar: false,
+			cliImportPending: true,
+			cliTargetOrganizationId: "org-a",
+		});
+
+		expect(draft).toEqual({
+			id: "script-a",
+			name: "New",
+			description: undefined,
+			cwd: "",
+			commands: ["bun run new", "bun run worker"],
+			projectIds: null,
+			pinnedToBar: false,
+			useAsWorkspaceRun: undefined,
+			applyOnWorkspaceCreated: true,
+			executionMode: "new-tab",
+			tabOrder: 4,
+			createdAt,
+			agentId: "agent-1",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCliTerminalScriptImport/applyCliTerminalScriptEdit.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCliTerminalScriptImport/applyCliTerminalScriptEdit.ts
@@ -1,0 +1,35 @@
+import type { TerminalPreset } from "@superset/local-db";
+import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+
+/** The subset of a v2 row the CLI owns; the collection's update draft is typed looser than the row. */
+type CliEditableFields = Partial<
+	Pick<
+		V2TerminalPresetRow,
+		| "name"
+		| "description"
+		| "cwd"
+		| "commands"
+		| "projectIds"
+		| "pinnedToBar"
+		| "useAsWorkspaceRun"
+		| "executionMode"
+	>
+>;
+
+/**
+ * Apply the fields the CLI can set onto an existing v2 row. Bar position,
+ * creation time, and any agent link stay as the app has them.
+ */
+export function applyCliTerminalScriptEdit(
+	draft: CliEditableFields,
+	script: TerminalPreset,
+): void {
+	draft.name = script.name;
+	draft.description = script.description;
+	draft.cwd = script.cwd;
+	draft.commands = script.commands;
+	draft.projectIds = script.projectIds ?? null;
+	draft.pinnedToBar = script.pinnedToBar;
+	draft.useAsWorkspaceRun = script.useAsWorkspaceRun;
+	draft.executionMode = script.executionMode ?? "new-tab";
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCliTerminalScriptImport/useCliTerminalScriptImport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/useCliTerminalScriptImport/useCliTerminalScriptImport.ts
@@ -3,14 +3,17 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import { buildV2TerminalPresetRow } from "renderer/lib/v1-migration";
 import { getNextTabOrder } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
 import { useCollections } from "../../../../providers/CollectionsProvider";
+import { applyCliTerminalScriptEdit } from "./applyCliTerminalScriptEdit";
 
 /**
- * One-shot import of terminal scripts authored by `superset scripts add`. The
- * CLI can only write the legacy local.db store, so it leaves rows flagged for
- * this organization; we copy them into the v2 collection and then clear the
- * flags so a script deleted in v2 is never re-imported. A script whose insert
- * fails is NOT acknowledged: its marker survives, and the next refetch of the
- * pending query (focus, /settings-changed nudge) retries it.
+ * One-shot sync of terminal scripts changed by `superset scripts add|edit|
+ * delete`. The CLI can only write the legacy local.db store, so it leaves
+ * rows flagged for this organization: new scripts are copied into the v2
+ * collection, edited ones update their v2 row in place, and delete
+ * tombstones remove the v2 row. The flags are then cleared so a script
+ * deleted in v2 is never re-imported. A script whose write fails is NOT
+ * acknowledged: its marker survives, and the next refetch of the pending
+ * query (focus, /settings-changed nudge) retries it.
  */
 export function useCliTerminalScriptImport(
 	organizationId: string | null,
@@ -39,38 +42,42 @@ export function useCliTerminalScriptImport(
 		// Non-reactive snapshot: localStorage collections hydrate at
 		// construction, and reading `.state` imperatively keeps this
 		// app-lifetime hook from subscribing to every preset change just to
-		// serve a rare one-shot import.
+		// serve a rare one-shot sync.
 		const v2Presets = [...collections.v2TerminalPresets.state.values()];
 		const existingIds = new Set(v2Presets.map((preset) => preset.id));
 		let tabOrder = getNextTabOrder(v2Presets);
-		const importedIds: string[] = [];
+		const appliedIds: string[] = [];
 		for (const script of pendingScripts) {
-			if (existingIds.has(script.id)) {
-				importedIds.push(script.id);
-				continue;
-			}
 			try {
-				collections.v2TerminalPresets.insert(
-					// No agent resolution: the user's explicit command must not be
-					// swapped for a live agent launch command.
-					buildV2TerminalPresetRow(
-						script,
-						tabOrder++,
-						{ v2Name: script.name, linkedAgentId: undefined },
-						{ id: script.id, useAsWorkspaceRun: script.useAsWorkspaceRun },
-					),
-				);
-				importedIds.push(script.id);
+				if (script.cliDeletePending) {
+					if (existingIds.has(script.id))
+						collections.v2TerminalPresets.delete(script.id);
+				} else if (existingIds.has(script.id)) {
+					collections.v2TerminalPresets.update(script.id, (draft) =>
+						applyCliTerminalScriptEdit(draft, script),
+					);
+				} else {
+					collections.v2TerminalPresets.insert(
+						// No agent resolution: the user's explicit command must not be
+						// swapped for a live agent launch command.
+						buildV2TerminalPresetRow(
+							script,
+							tabOrder++,
+							{ v2Name: script.name, linkedAgentId: undefined },
+							{ id: script.id, useAsWorkspaceRun: script.useAsWorkspaceRun },
+						),
+					);
+				}
+				appliedIds.push(script.id);
 			} catch (error) {
 				console.error(
-					`[useCliTerminalScriptImport] Import failed for ${script.id}:`,
+					`[useCliTerminalScriptImport] Sync failed for ${script.id}:`,
 					error,
 				);
 			}
 		}
 
-		if (importedIds.length > 0)
-			acknowledge({ organizationId, ids: importedIds });
+		if (appliedIds.length > 0) acknowledge({ organizationId, ids: appliedIds });
 	}, [
 		acknowledge,
 		collections.v2TerminalPresets,

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -49,22 +49,101 @@ lifecycle scripts. The legacy `presets` command name remains an alias.
 		{ flag: "--execution-mode <mode>", description: "new-tab, split-pane, new-tab-split-pane, or sequential." },
 		{ flag: "--hidden", description: "Do not show the script in the Scripts bar." },
 		{ flag: "--workspace-run", description: "Use the script for the matching project's Run action." },
+		{ flag: "--upsert", description: "Replace the script with this name instead of adding a duplicate. Fails if the name is already duplicated." },
 	]}
 >
 Add a terminal script to the desktop app on this machine. The desktop app must
 have been launched once so its local database exists, and the CLI must have an
 active organization so the script is imported into the correct v2 profile.
+When iterating on one script, pass `--upsert` so each revision replaces the
+last instead of piling up copies in the Scripts bar.
 
 ```bash
 superset scripts add --name dev --command "bun run dev"
 superset presets add --name services \
   --command "docker compose up" --command "bun run dev" \
   --execution-mode split-pane
+superset scripts add --name "Open in GitHub" --command "gh pr view --web" --upsert
 ```
 
 <CommandReturns>
 The created terminal script, including its generated ID.
 </CommandReturns>
+</Command>
+
+<Command
+	name="superset scripts list"
+	output={`Array<{
+  id: string;
+  name: string;
+  description?: string;
+  cwd: string;
+  commands: string[];
+  projectIds: string[] | null;
+  pinnedToBar?: boolean;
+  useAsWorkspaceRun?: boolean;
+  executionMode?: string;
+  status: "ready" | "importing" | "deleting";
+}>`}
+>
+List the terminal scripts on this machine with the id each other command
+takes. `status` is `importing` or `deleting` while a change is waiting for the
+desktop app to open or refocus with the same organization active. Scripts
+created in the desktop app's Settings are stored in the app profile only and
+do not appear here.
+
+```bash
+superset scripts list
+superset scripts list --json
+```
+</Command>
+
+<Command
+	name="superset scripts edit <id>"
+	args={[
+		{ name: "id", required: true, description: "Script ID from `superset scripts list`." },
+	]}
+	options={[
+		{ flag: "--name <name>", description: "New display name." },
+		{ flag: "--command <command...>", description: "Replace the commands. Repeat to launch multiple commands." },
+		{ flag: "--description <text>", description: "New description. Pass an empty string to clear it." },
+		{ flag: "--cwd <path>", description: "Workspace-relative working directory." },
+		{ flag: "--project <uuid...>", description: "Replace the project list. Mutually exclusive with --all-projects." },
+		{ flag: "--all-projects", description: "Make the script available in every project." },
+		{ flag: "--execution-mode <mode>", description: "new-tab, split-pane, new-tab-split-pane, or sequential." },
+		{ flag: "--hidden / --no-hidden", description: "Hide the script from the Scripts bar, or show it again." },
+		{ flag: "--workspace-run / --no-workspace-run", description: "Use the script as the project's Run action, or stop." },
+	]}
+	output="Terminal script"
+>
+Change fields on an existing script. Unspecified fields keep their values, and
+the desktop app updates its copy in place, so the script keeps its position in
+the Scripts bar. Edits made in the desktop app's Settings do not flow back to
+the CLI: an edit here replaces the app's copy with what `superset scripts list`
+shows plus your changes.
+
+```bash
+superset scripts edit <id> --command "gh pr view --web"
+superset scripts edit <id> --name "Open PR" --hidden
+superset scripts edit <id> --all-projects --no-hidden
+```
+</Command>
+
+<Command
+	name="superset scripts delete <id>"
+	args={[
+		{ name: "id", required: true, description: "Script ID from `superset scripts list`." },
+	]}
+	output="Terminal script"
+>
+Delete a script. A script the desktop app has not picked up yet disappears
+immediately. One it already shows is removed from the app the next time it
+opens or refocuses with the same organization active; until then it lists
+with status `deleting`.
+
+```bash
+superset scripts delete <id>
+```
 </Command>
 
 ---

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -136,10 +136,9 @@ superset scripts edit <id> --all-projects --no-hidden
 	]}
 	output="Terminal script"
 >
-Delete a script. A script the desktop app has not picked up yet disappears
-immediately. One it already shows is removed from the app the next time it
-opens or refocuses with the same organization active; until then it lists
-with status `deleting`.
+Delete a script. The desktop app removes its copy the next time it opens or
+refocuses with the same organization active (immediately when it is running);
+until then the script lists with status `deleting`.
 
 ```bash
 superset scripts delete <id>

--- a/apps/docs/content/docs/terminal-scripts.mdx
+++ b/apps/docs/content/docs/terminal-scripts.mdx
@@ -61,6 +61,22 @@ superset scripts add \
   --execution-mode split-pane
 ```
 
+To change or remove a script from the same terminal, use its id from
+`superset scripts list`:
+
+```bash
+superset scripts list
+superset scripts edit <id> --command "gh pr view --web"
+superset scripts delete <id>
+```
+
+When you are iterating on one script, `superset scripts add --upsert` replaces
+the script with the same name instead of adding another copy to the Scripts
+bar. Changes made with the CLI reach the app the next time it opens or
+refocuses with the same organization active, and the running app picks them up
+immediately. Scripts created in Settings live in the app profile only, so they
+do not show up in `superset scripts list`.
+
 `superset presets add` remains an alias for compatibility. See the
 [CLI reference](/cli/cli-reference#scripts) for every option.
 

--- a/packages/cli/src/commands/scripts/add/command.ts
+++ b/packages/cli/src/commands/scripts/add/command.ts
@@ -1,12 +1,18 @@
-import { boolean, CLIError, string } from "@superset/cli-framework";
+import { boolean, string } from "@superset/cli-framework";
 import { EXECUTION_MODES } from "@superset/local-db";
 import { command } from "../../../lib/command";
-import { readConfig, resolveOrganizationId } from "../../../lib/config";
 import { notifyDesktopSettingsChanged } from "../../../lib/settings/notify";
-import { createTerminalScript } from "../../../lib/terminal-scripts";
-
-const UUID_PATTERN =
-	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+import {
+	createTerminalScript,
+	findTerminalScriptByName,
+	toPublicTerminalScript,
+	updateTerminalScript,
+} from "../../../lib/terminal-scripts";
+import {
+	assertProjectIds,
+	desktopSyncNote,
+	requireOrganizationId,
+} from "../shared";
 
 export default command({
 	description: "Add a reusable terminal script",
@@ -26,52 +32,53 @@ export default command({
 			.desc("How multiple commands open"),
 		hidden: boolean().desc("Create without showing it in the Scripts bar"),
 		workspaceRun: boolean().desc("Use as the project's Run action"),
+		upsert: boolean().desc(
+			"Replace the script with this name instead of adding a duplicate",
+		),
 	},
 	skipMiddleware: true,
 	run: async ({ options }) => {
-		const organizationId = resolveOrganizationId(readConfig());
-		if (!organizationId) {
-			throw new CLIError("No active organization", "Run: superset auth login");
-		}
-		const invalidProjectId = options.project?.find(
-			(projectId) => !UUID_PATTERN.test(projectId),
-		);
-		if (invalidProjectId) {
-			throw new CLIError(
-				`Invalid project UUID: ${invalidProjectId}`,
-				"Pass the project UUID shown by `superset projects list`.",
-			);
-		}
+		const organizationId = requireOrganizationId();
+		assertProjectIds(options.project);
 
-		const script = createTerminalScript({
-			organizationId,
-			name: options.name,
-			description: options.description,
-			cwd: options.cwd,
-			commands: options.command,
-			projectIds: options.project,
-			pinnedToBar: !options.hidden,
-			useAsWorkspaceRun: options.workspaceRun,
-			executionMode: options.executionMode ?? "new-tab",
-		});
+		const existing = options.upsert
+			? findTerminalScriptByName(options.name)
+			: undefined;
+		const script = existing
+			? updateTerminalScript({
+					organizationId,
+					id: existing.id,
+					patch: {
+						name: options.name,
+						description: options.description ?? "",
+						cwd: options.cwd ?? "",
+						commands: options.command,
+						projectIds: options.project ?? null,
+						pinnedToBar: !options.hidden,
+						useAsWorkspaceRun: options.workspaceRun ?? false,
+						executionMode: options.executionMode ?? "new-tab",
+					},
+				})
+			: createTerminalScript({
+					organizationId,
+					name: options.name,
+					description: options.description,
+					cwd: options.cwd,
+					commands: options.command,
+					projectIds: options.project,
+					pinnedToBar: !options.hidden,
+					useAsWorkspaceRun: options.workspaceRun,
+					executionMode: options.executionMode ?? "new-tab",
+				});
 		const refreshed = await notifyDesktopSettingsChanged();
-		const {
-			cliImportPending: _,
-			cliTargetOrganizationId: __,
-			...publicScript
-		} = script;
 
 		const workspaceRunNote = options.workspaceRun
 			? " Run precedence is: matching project script, project lifecycle Run command, then global script; the first matching script wins."
 			: "";
 
 		return {
-			data: publicScript,
-			message: `Added terminal script ${script.name} (${script.id}). ${
-				refreshed
-					? "The running desktop app refreshed immediately."
-					: "It will import when the desktop app opens or refocuses with this organization active."
-			}${workspaceRunNote}`,
+			data: toPublicTerminalScript(script),
+			message: `${existing ? "Updated" : "Added"} terminal script ${script.name} (${script.id}). ${desktopSyncNote(refreshed)}${workspaceRunNote}`,
 		};
 	},
 });

--- a/packages/cli/src/commands/scripts/delete/command.ts
+++ b/packages/cli/src/commands/scripts/delete/command.ts
@@ -1,0 +1,27 @@
+import { positional } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import { notifyDesktopSettingsChanged } from "../../../lib/settings/notify";
+import {
+	deleteTerminalScript,
+	toPublicTerminalScript,
+} from "../../../lib/terminal-scripts";
+import { desktopSyncNote, requireOrganizationId } from "../shared";
+
+export default command({
+	description: "Delete a terminal script",
+	args: [positional("id").required().desc("Script id from `scripts list`")],
+	skipMiddleware: true,
+	run: async ({ args }) => {
+		const organizationId = requireOrganizationId();
+		const id = args.id as string;
+		const { script, removed } = deleteTerminalScript({ organizationId, id });
+		const refreshed = await notifyDesktopSettingsChanged();
+
+		return {
+			data: toPublicTerminalScript(script),
+			message: removed
+				? `Deleted terminal script ${script.name} (${script.id}).`
+				: `Deleted terminal script ${script.name} (${script.id}). ${desktopSyncNote(refreshed)}`,
+		};
+	},
+});

--- a/packages/cli/src/commands/scripts/delete/command.ts
+++ b/packages/cli/src/commands/scripts/delete/command.ts
@@ -14,14 +14,12 @@ export default command({
 	run: async ({ args }) => {
 		const organizationId = requireOrganizationId();
 		const id = args.id as string;
-		const { script, removed } = deleteTerminalScript({ organizationId, id });
+		const script = deleteTerminalScript({ organizationId, id });
 		const refreshed = await notifyDesktopSettingsChanged();
 
 		return {
 			data: toPublicTerminalScript(script),
-			message: removed
-				? `Deleted terminal script ${script.name} (${script.id}).`
-				: `Deleted terminal script ${script.name} (${script.id}). ${desktopSyncNote(refreshed)}`,
+			message: `Deleted terminal script ${script.name} (${script.id}). ${desktopSyncNote(refreshed)}`,
 		};
 	},
 });

--- a/packages/cli/src/commands/scripts/edit/command.ts
+++ b/packages/cli/src/commands/scripts/edit/command.ts
@@ -1,0 +1,81 @@
+import { boolean, CLIError, positional, string } from "@superset/cli-framework";
+import { EXECUTION_MODES } from "@superset/local-db";
+import { command } from "../../../lib/command";
+import { notifyDesktopSettingsChanged } from "../../../lib/settings/notify";
+import {
+	type TerminalScriptPatch,
+	toPublicTerminalScript,
+	updateTerminalScript,
+} from "../../../lib/terminal-scripts";
+import {
+	assertProjectIds,
+	desktopSyncNote,
+	requireOrganizationId,
+} from "../shared";
+
+export default command({
+	description: "Edit a terminal script in place",
+	args: [positional("id").required().desc("Script id from `scripts list`")],
+	options: {
+		name: string().desc("New display name"),
+		command: string()
+			.variadic()
+			.desc("Replace the commands; repeat to launch multiple commands"),
+		description: string().desc("New description (empty string clears it)"),
+		cwd: string().desc("Working directory relative to the workspace"),
+		project: string()
+			.variadic()
+			.desc("Replace the project list with these UUIDs; repeatable"),
+		allProjects: boolean().desc("Make the script available in every project"),
+		executionMode: string()
+			.enum(...EXECUTION_MODES)
+			.desc("How multiple commands open"),
+		hidden: boolean().desc(
+			"Hide from the Scripts bar (--no-hidden shows it again)",
+		),
+		workspaceRun: boolean().desc(
+			"Use as the project's Run action (--no-workspace-run stops)",
+		),
+	},
+	skipMiddleware: true,
+	run: async ({ args, options }) => {
+		const organizationId = requireOrganizationId();
+		const id = args.id as string;
+		if (options.project?.length && options.allProjects) {
+			throw new CLIError(
+				"Cannot combine --project and --all-projects",
+				"Pass one or the other",
+			);
+		}
+		assertProjectIds(options.project);
+
+		const patch: TerminalScriptPatch = {
+			name: options.name,
+			commands: options.command,
+			description: options.description,
+			cwd: options.cwd,
+			projectIds: options.allProjects
+				? null
+				: options.project?.length
+					? options.project
+					: undefined,
+			executionMode: options.executionMode,
+			pinnedToBar: options.hidden === undefined ? undefined : !options.hidden,
+			useAsWorkspaceRun: options.workspaceRun,
+		};
+		if (Object.values(patch).every((value) => value === undefined)) {
+			throw new CLIError(
+				"No fields to update",
+				"Pass --name, --command, --description, --cwd, --project, --all-projects, --execution-mode, --hidden, or --workspace-run",
+			);
+		}
+
+		const script = updateTerminalScript({ organizationId, id, patch });
+		const refreshed = await notifyDesktopSettingsChanged();
+
+		return {
+			data: toPublicTerminalScript(script),
+			message: `Updated terminal script ${script.name} (${script.id}). ${desktopSyncNote(refreshed)}`,
+		};
+	},
+});

--- a/packages/cli/src/commands/scripts/list/command.ts
+++ b/packages/cli/src/commands/scripts/list/command.ts
@@ -1,0 +1,31 @@
+import { table } from "@superset/cli-framework";
+import { command } from "../../../lib/command";
+import {
+	listTerminalScripts,
+	type PublicTerminalScript,
+	toPublicTerminalScript,
+} from "../../../lib/terminal-scripts";
+
+export default command({
+	description: "List terminal scripts on this machine",
+	skipMiddleware: true,
+	display: (data) =>
+		table(
+			(data as PublicTerminalScript[]).map((script) => ({
+				id: script.id,
+				name: script.name,
+				commands: script.commands.join(" ; "),
+				projects: script.projectIds
+					? `${script.projectIds.length} project${script.projectIds.length === 1 ? "" : "s"}`
+					: "all",
+				pinned: script.pinnedToBar === false ? "no" : "yes",
+				status: script.status,
+			})),
+			["id", "name", "commands", "projects", "pinned", "status"],
+			["ID", "NAME", "COMMANDS", "PROJECTS", "PINNED", "STATUS"],
+			[36, 24, 60, 10, 6, 9],
+		),
+	run: async () => ({
+		data: listTerminalScripts().map(toPublicTerminalScript),
+	}),
+});

--- a/packages/cli/src/commands/scripts/manage.test.ts
+++ b/packages/cli/src/commands/scripts/manage.test.ts
@@ -181,7 +181,7 @@ describe("scripts edit", () => {
 });
 
 describe("scripts delete", () => {
-	test("drops a script the desktop has not imported yet", async () => {
+	test("tombstones a script the desktop has not acknowledged yet", async () => {
 		const added = await run(addCommand, {
 			options: { name: "Temp", command: ["echo temp"] },
 		});
@@ -190,10 +190,13 @@ describe("scripts delete", () => {
 			args: { id: added.data.id },
 		});
 
-		expect(result.message).toBe(
-			`Deleted terminal script Temp (${added.data.id}).`,
-		);
-		expect(readSettingsRow()?.terminalPresets).toEqual([]);
+		expect(result.data).toMatchObject({
+			id: added.data.id,
+			status: "deleting",
+		});
+		const stored = readSettingsRow()?.terminalPresets?.[0];
+		expect(stored?.cliDeletePending).toBe(true);
+		expect(stored?.cliImportPending).toBeUndefined();
 	});
 
 	test("tombstones an imported script until the desktop removes its copy", async () => {

--- a/packages/cli/src/commands/scripts/manage.test.ts
+++ b/packages/cli/src/commands/scripts/manage.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readSettingsRow } from "../../lib/settings";
+import { writeSettings } from "../../lib/settings/local-settings";
+import {
+	createLocalSettingsDb,
+	withTempSupersetHome,
+} from "../../lib/settings/test-helpers";
+
+let activeOrganizationId: string | undefined = "org-a";
+let desktopRefreshed = false;
+
+const realConfig = await import("../../lib/config");
+mock.module("../../lib/config", () => ({
+	...realConfig,
+	readConfig: () => ({ organizationId: activeOrganizationId }),
+}));
+
+mock.module("../../lib/settings/notify", () => ({
+	notifyDesktopSettingsChanged: async () => desktopRefreshed,
+}));
+
+const { default: addCommand } = await import("./add/command");
+const { default: listCommand } = await import("./list/command");
+const { default: editCommand } = await import("./edit/command");
+const { default: deleteCommand } = await import("./delete/command");
+
+const home = withTempSupersetHome("superset-cli-scripts-manage-");
+let previousOrgOverride: string | undefined;
+
+type Result = { data: Record<string, unknown>; message?: string };
+
+function run(
+	cmd: { run: (input: never) => unknown },
+	input: { args?: Record<string, unknown>; options?: Record<string, unknown> },
+) {
+	return cmd.run({
+		ctx: {} as never,
+		args: (input.args ?? {}) as never,
+		options: (input.options ?? {}) as never,
+		signal: new AbortController().signal,
+	} as never) as Promise<Result>;
+}
+
+const PROJECT_ID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+function seedImported() {
+	writeSettings({
+		terminalPresets: [
+			{
+				id: "gh-1",
+				name: "Open in GitHub",
+				cwd: "",
+				commands: ["gh pr view"],
+				pinnedToBar: true,
+			},
+		],
+	});
+}
+
+beforeEach(() => {
+	previousOrgOverride = process.env.SUPERSET_ORGANIZATION_ID;
+	delete process.env.SUPERSET_ORGANIZATION_ID;
+	activeOrganizationId = "org-a";
+	desktopRefreshed = false;
+	createLocalSettingsDb(home.dir);
+});
+
+afterEach(() => {
+	if (previousOrgOverride === undefined)
+		delete process.env.SUPERSET_ORGANIZATION_ID;
+	else process.env.SUPERSET_ORGANIZATION_ID = previousOrgOverride;
+});
+
+describe("scripts list", () => {
+	test("shows every stored script with its sync status", async () => {
+		seedImported();
+		await run(addCommand, {
+			options: { name: "Dev", command: ["bun run dev"] },
+		});
+
+		const result = (await run(listCommand, {})) as unknown as {
+			data: Array<Record<string, unknown>>;
+		};
+
+		expect(result.data.map((s) => [s.name, s.status])).toEqual([
+			["Open in GitHub", "ready"],
+			["Dev", "importing"],
+		]);
+		expect(result.data[0]).not.toHaveProperty("cliImportPending");
+		expect(listCommand.display?.(result.data)).toContain("Open in GitHub");
+	});
+
+	test("renders an empty table without a database row", async () => {
+		const result = (await run(listCommand, {})) as unknown as {
+			data: unknown[];
+		};
+		expect(result.data).toEqual([]);
+		expect(listCommand.display?.(result.data)).toBe("No results.");
+	});
+});
+
+describe("scripts edit", () => {
+	test("patches the row and re-flags it for the desktop", async () => {
+		seedImported();
+		desktopRefreshed = true;
+
+		const result = await run(editCommand, {
+			args: { id: "gh-1" },
+			options: {
+				command: ["gh pr view --web"],
+				project: [PROJECT_ID],
+				hidden: true,
+			},
+		});
+
+		expect(result.data).toMatchObject({
+			id: "gh-1",
+			commands: ["gh pr view --web"],
+			projectIds: [PROJECT_ID],
+			pinnedToBar: false,
+			status: "importing",
+		});
+		expect(result.message).toContain("refreshed immediately");
+		expect(readSettingsRow()?.terminalPresets?.[0]).toMatchObject({
+			cliImportPending: true,
+			cliTargetOrganizationId: "org-a",
+		});
+	});
+
+	test("--no-hidden and --all-projects undo earlier choices", async () => {
+		seedImported();
+		await run(editCommand, {
+			args: { id: "gh-1" },
+			options: { project: [PROJECT_ID], hidden: true, workspaceRun: true },
+		});
+
+		const result = await run(editCommand, {
+			args: { id: "gh-1" },
+			options: { allProjects: true, hidden: false, workspaceRun: false },
+		});
+
+		expect(result.data).toMatchObject({
+			projectIds: null,
+			pinnedToBar: true,
+			useAsWorkspaceRun: undefined,
+		});
+	});
+
+	test("rejects empty patches, bad ids, and conflicting project flags", async () => {
+		seedImported();
+		await expect(
+			run(editCommand, { args: { id: "gh-1" }, options: {} }),
+		).rejects.toThrow(/No fields to update/);
+		await expect(
+			run(editCommand, {
+				args: { id: "gh-1" },
+				options: { project: [PROJECT_ID], allProjects: true },
+			}),
+		).rejects.toThrow(/Cannot combine/);
+		await expect(
+			run(editCommand, {
+				args: { id: "gh-1" },
+				options: { project: ["nope"] },
+			}),
+		).rejects.toThrow(/Invalid project UUID/);
+		await expect(
+			run(editCommand, { args: { id: "missing" }, options: { name: "x" } }),
+		).rejects.toThrow(/not found/);
+		expect(readSettingsRow()?.terminalPresets?.[0]?.cliImportPending).toBe(
+			undefined,
+		);
+	});
+
+	test("requires an active organization", async () => {
+		seedImported();
+		activeOrganizationId = undefined;
+		await expect(
+			run(editCommand, { args: { id: "gh-1" }, options: { name: "x" } }),
+		).rejects.toThrow(/No active organization/);
+	});
+});
+
+describe("scripts delete", () => {
+	test("drops a script the desktop has not imported yet", async () => {
+		const added = await run(addCommand, {
+			options: { name: "Temp", command: ["echo temp"] },
+		});
+
+		const result = await run(deleteCommand, {
+			args: { id: added.data.id },
+		});
+
+		expect(result.message).toBe(
+			`Deleted terminal script Temp (${added.data.id}).`,
+		);
+		expect(readSettingsRow()?.terminalPresets).toEqual([]);
+	});
+
+	test("tombstones an imported script until the desktop removes its copy", async () => {
+		seedImported();
+
+		const result = await run(deleteCommand, { args: { id: "gh-1" } });
+
+		expect(result.data).toMatchObject({ id: "gh-1", status: "deleting" });
+		expect(result.message).toContain("when the desktop app opens");
+		expect(readSettingsRow()?.terminalPresets?.[0]).toMatchObject({
+			cliDeletePending: true,
+			cliTargetOrganizationId: "org-a",
+		});
+	});
+
+	test("rejects unknown ids", async () => {
+		await expect(
+			run(deleteCommand, { args: { id: "missing" } }),
+		).rejects.toThrow(/not found/);
+	});
+});
+
+describe("scripts add --upsert", () => {
+	test("replaces the script with the same name instead of duplicating it", async () => {
+		seedImported();
+
+		const result = await run(addCommand, {
+			options: {
+				name: "Open in GitHub",
+				command: ["gh pr view --web"],
+				hidden: true,
+				upsert: true,
+			},
+		});
+
+		expect(result.message).toMatch(
+			/^Updated terminal script Open in GitHub \(gh-1\)/,
+		);
+		expect(readSettingsRow()?.terminalPresets).toEqual([
+			{
+				id: "gh-1",
+				name: "Open in GitHub",
+				description: undefined,
+				cwd: "",
+				commands: ["gh pr view --web"],
+				projectIds: null,
+				pinnedToBar: false,
+				useAsWorkspaceRun: undefined,
+				executionMode: "new-tab",
+				cliImportPending: true,
+				cliTargetOrganizationId: "org-a",
+			},
+		]);
+	});
+
+	test("adds normally when no script has that name", async () => {
+		seedImported();
+
+		const result = await run(addCommand, {
+			options: { name: "Other", command: ["echo"], upsert: true },
+		});
+
+		expect(result.message).toMatch(/^Added terminal script Other/);
+		expect(readSettingsRow()?.terminalPresets).toHaveLength(2);
+	});
+
+	test("refuses when the name is already duplicated", async () => {
+		writeSettings({
+			terminalPresets: [
+				{ id: "a", name: "Dup", cwd: "", commands: ["echo"] },
+				{ id: "b", name: "Dup", cwd: "", commands: ["echo"] },
+			],
+		});
+
+		await expect(
+			run(addCommand, {
+				options: { name: "Dup", command: ["echo 2"], upsert: true },
+			}),
+		).rejects.toThrow(/2 scripts are named Dup/);
+		expect(readSettingsRow()?.terminalPresets).toHaveLength(2);
+	});
+});

--- a/packages/cli/src/commands/scripts/shared.ts
+++ b/packages/cli/src/commands/scripts/shared.ts
@@ -1,0 +1,32 @@
+import { CLIError } from "@superset/cli-framework";
+import { readConfig, resolveOrganizationId } from "../../lib/config";
+
+export const PROJECT_UUID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function requireOrganizationId(): string {
+	const organizationId = resolveOrganizationId(readConfig());
+	if (!organizationId) {
+		throw new CLIError("No active organization", "Run: superset auth login");
+	}
+	return organizationId;
+}
+
+export function assertProjectIds(projectIds: string[] | undefined): void {
+	const invalidProjectId = projectIds?.find(
+		(projectId) => !PROJECT_UUID_PATTERN.test(projectId),
+	);
+	if (invalidProjectId) {
+		throw new CLIError(
+			`Invalid project UUID: ${invalidProjectId}`,
+			"Pass the project UUID shown by `superset projects list`.",
+		);
+	}
+}
+
+/** How to read the message after a write, given whether the app picked it up. */
+export function desktopSyncNote(refreshed: boolean): string {
+	return refreshed
+		? "The running desktop app refreshed immediately."
+		: "It will apply when the desktop app opens or refocuses with this organization active.";
+}

--- a/packages/cli/src/lib/terminal-scripts.test.ts
+++ b/packages/cli/src/lib/terminal-scripts.test.ts
@@ -163,7 +163,7 @@ describe("updateTerminalScript", () => {
 });
 
 describe("deleteTerminalScript", () => {
-	test("removes a script the desktop never imported", () => {
+	test("tombstones a script even when its import is still pending", () => {
 		const script = createTerminalScript({
 			organizationId: "org-a",
 			name: "Fresh",
@@ -175,8 +175,9 @@ describe("deleteTerminalScript", () => {
 			id: script.id,
 		});
 
-		expect(result.removed).toBe(true);
-		expect(readSettingsRow()?.terminalPresets).toEqual([]);
+		expect(result.cliDeletePending).toBe(true);
+		expect(result.cliImportPending).toBeUndefined();
+		expect(readSettingsRow()?.terminalPresets).toEqual([result]);
 	});
 
 	test("leaves a tombstone for a script the desktop already imported", () => {
@@ -186,12 +187,8 @@ describe("deleteTerminalScript", () => {
 			],
 		});
 
-		const result = deleteTerminalScript({
-			organizationId: "org-a",
-			id: "imported",
-		});
+		deleteTerminalScript({ organizationId: "org-a", id: "imported" });
 
-		expect(result.removed).toBe(false);
 		expect(readSettingsRow()?.terminalPresets).toEqual([
 			{
 				id: "imported",
@@ -207,7 +204,7 @@ describe("deleteTerminalScript", () => {
 			organizationId: "org-a",
 			id: "imported",
 		});
-		expect(again.removed).toBe(false);
+		expect(again.cliDeletePending).toBe(true);
 		expect(readSettingsRow()?.terminalPresets).toHaveLength(1);
 	});
 

--- a/packages/cli/src/lib/terminal-scripts.test.ts
+++ b/packages/cli/src/lib/terminal-scripts.test.ts
@@ -5,7 +5,14 @@ import {
 	createLocalSettingsDb,
 	withTempSupersetHome,
 } from "./settings/test-helpers";
-import { createTerminalScript } from "./terminal-scripts";
+import {
+	createTerminalScript,
+	deleteTerminalScript,
+	findTerminalScriptByName,
+	listTerminalScripts,
+	toPublicTerminalScript,
+	updateTerminalScript,
+} from "./terminal-scripts";
 
 const home = withTempSupersetHome("superset-cli-scripts-");
 
@@ -62,5 +69,224 @@ describe("createTerminalScript", () => {
 			["Existing", "New"],
 		);
 		expect(readSettingsRow()?.terminalPresets?.[1]?.pinnedToBar).toBe(false);
+	});
+});
+
+describe("updateTerminalScript", () => {
+	test("patches only the given fields and re-flags the row for import", () => {
+		writeSettings({
+			terminalPresets: [
+				{
+					id: "existing",
+					name: "Existing",
+					description: "keep me",
+					cwd: "apps/web",
+					commands: ["echo existing"],
+					projectIds: ["project-a"],
+					pinnedToBar: false,
+					executionMode: "split-pane",
+				},
+			],
+		});
+
+		const updated = updateTerminalScript({
+			organizationId: "org-a",
+			id: "existing",
+			patch: { commands: [" gh pr view --web "], pinnedToBar: true },
+		});
+
+		expect(updated).toEqual({
+			id: "existing",
+			name: "Existing",
+			description: "keep me",
+			cwd: "apps/web",
+			commands: ["gh pr view --web"],
+			projectIds: ["project-a"],
+			pinnedToBar: true,
+			useAsWorkspaceRun: undefined,
+			executionMode: "split-pane",
+			cliImportPending: true,
+			cliTargetOrganizationId: "org-a",
+		});
+		expect(readSettingsRow()?.terminalPresets).toEqual([updated]);
+	});
+
+	test("clears description, projects, and run flag when asked", () => {
+		writeSettings({
+			terminalPresets: [
+				{
+					id: "existing",
+					name: "Existing",
+					description: "old",
+					cwd: "",
+					commands: ["echo existing"],
+					projectIds: ["project-a"],
+					useAsWorkspaceRun: true,
+				},
+			],
+		});
+
+		const updated = updateTerminalScript({
+			organizationId: "org-a",
+			id: "existing",
+			patch: { description: "", projectIds: null, useAsWorkspaceRun: false },
+		});
+
+		expect(updated.description).toBeUndefined();
+		expect(updated.projectIds).toBeNull();
+		expect(updated.useAsWorkspaceRun).toBeUndefined();
+	});
+
+	test("rejects unknown ids, empty values, and scripts being deleted", () => {
+		writeSettings({
+			terminalPresets: [
+				{ id: "a", name: "A", cwd: "", commands: ["echo a"] },
+				{
+					id: "gone",
+					name: "Gone",
+					cwd: "",
+					commands: ["echo gone"],
+					cliDeletePending: true,
+					cliTargetOrganizationId: "org-a",
+				},
+			],
+		});
+		const update = (id: string, patch: Record<string, unknown>) => () =>
+			updateTerminalScript({ organizationId: "org-a", id, patch });
+
+		expect(update("missing", { name: "x" })).toThrow(/not found/);
+		expect(update("a", { name: "  " })).toThrow(/name cannot be empty/);
+		expect(update("a", { commands: [""] })).toThrow(/commands cannot be empty/);
+		expect(update("gone", { name: "x" })).toThrow(/scheduled for deletion/);
+		expect(readSettingsRow()?.terminalPresets?.[0]?.name).toBe("A");
+	});
+});
+
+describe("deleteTerminalScript", () => {
+	test("removes a script the desktop never imported", () => {
+		const script = createTerminalScript({
+			organizationId: "org-a",
+			name: "Fresh",
+			commands: ["echo fresh"],
+		});
+
+		const result = deleteTerminalScript({
+			organizationId: "org-a",
+			id: script.id,
+		});
+
+		expect(result.removed).toBe(true);
+		expect(readSettingsRow()?.terminalPresets).toEqual([]);
+	});
+
+	test("leaves a tombstone for a script the desktop already imported", () => {
+		writeSettings({
+			terminalPresets: [
+				{ id: "imported", name: "Imported", cwd: "", commands: ["echo"] },
+			],
+		});
+
+		const result = deleteTerminalScript({
+			organizationId: "org-a",
+			id: "imported",
+		});
+
+		expect(result.removed).toBe(false);
+		expect(readSettingsRow()?.terminalPresets).toEqual([
+			{
+				id: "imported",
+				name: "Imported",
+				cwd: "",
+				commands: ["echo"],
+				cliDeletePending: true,
+				cliTargetOrganizationId: "org-a",
+			},
+		]);
+
+		const again = deleteTerminalScript({
+			organizationId: "org-a",
+			id: "imported",
+		});
+		expect(again.removed).toBe(false);
+		expect(readSettingsRow()?.terminalPresets).toHaveLength(1);
+	});
+
+	test("rejects unknown ids", () => {
+		expect(() =>
+			deleteTerminalScript({ organizationId: "org-a", id: "missing" }),
+		).toThrow(/not found/);
+	});
+});
+
+describe("findTerminalScriptByName", () => {
+	test("matches the trimmed name and ignores tombstones", () => {
+		writeSettings({
+			terminalPresets: [
+				{ id: "a", name: "Open in GitHub", cwd: "", commands: ["echo"] },
+				{
+					id: "gone",
+					name: "Open in GitHub",
+					cwd: "",
+					commands: ["echo"],
+					cliDeletePending: true,
+					cliTargetOrganizationId: "org-a",
+				},
+			],
+		});
+
+		expect(findTerminalScriptByName(" Open in GitHub ")?.id).toBe("a");
+		expect(findTerminalScriptByName("Other")).toBeUndefined();
+	});
+
+	test("refuses to pick between duplicates", () => {
+		writeSettings({
+			terminalPresets: [
+				{ id: "a", name: "Dup", cwd: "", commands: ["echo"] },
+				{ id: "b", name: "Dup", cwd: "", commands: ["echo"] },
+			],
+		});
+
+		expect(() => findTerminalScriptByName("Dup")).toThrow(
+			/2 scripts are named Dup: a, b/,
+		);
+	});
+});
+
+describe("listTerminalScripts", () => {
+	test("returns every stored row with a public status", () => {
+		expect(listTerminalScripts()).toEqual([]);
+		writeSettings({
+			terminalPresets: [
+				{ id: "a", name: "A", cwd: "", commands: ["echo a"] },
+				{
+					id: "b",
+					name: "B",
+					cwd: "",
+					commands: ["echo b"],
+					cliImportPending: true,
+					cliTargetOrganizationId: "org-a",
+				},
+				{
+					id: "c",
+					name: "C",
+					cwd: "",
+					commands: ["echo c"],
+					cliDeletePending: true,
+					cliTargetOrganizationId: "org-a",
+				},
+			],
+		});
+
+		expect(listTerminalScripts().map(toPublicTerminalScript)).toEqual([
+			{ id: "a", name: "A", cwd: "", commands: ["echo a"], status: "ready" },
+			{
+				id: "b",
+				name: "B",
+				cwd: "",
+				commands: ["echo b"],
+				status: "importing",
+			},
+			{ id: "c", name: "C", cwd: "", commands: ["echo c"], status: "deleting" },
+		]);
 	});
 });

--- a/packages/cli/src/lib/terminal-scripts.ts
+++ b/packages/cli/src/lib/terminal-scripts.ts
@@ -1,6 +1,6 @@
 import { CLIError } from "@superset/cli-framework";
 import type { ExecutionMode, TerminalPreset } from "@superset/local-db";
-import { updateSettingsAtomically } from "./settings";
+import { readSettingsRow, updateSettingsAtomically } from "./settings";
 
 export interface CreateTerminalScriptInput {
 	organizationId: string;
@@ -14,6 +14,101 @@ export interface CreateTerminalScriptInput {
 	executionMode?: ExecutionMode;
 }
 
+/** Fields `superset scripts edit` can change; undefined leaves a field alone. */
+export interface TerminalScriptPatch {
+	name?: string;
+	description?: string;
+	cwd?: string;
+	commands?: string[];
+	/** `null` makes the script available in every project. */
+	projectIds?: string[] | null;
+	pinnedToBar?: boolean;
+	useAsWorkspaceRun?: boolean;
+	executionMode?: ExecutionMode;
+}
+
+export type TerminalScriptStatus = "ready" | "importing" | "deleting";
+
+/** A script as the CLI shows it: storage markers replaced by one status. */
+export type PublicTerminalScript = Omit<
+	TerminalPreset,
+	"cliImportPending" | "cliTargetOrganizationId" | "cliDeletePending"
+> & { status: TerminalScriptStatus };
+
+function normalizeName(name: string): string {
+	const trimmed = name.trim();
+	if (!trimmed) {
+		throw new CLIError("Script name cannot be empty", "Pass --name <name>.");
+	}
+	return trimmed;
+}
+
+function normalizeCommands(commands: string[]): string[] {
+	const trimmed = commands.map((command) => command.trim());
+	if (trimmed.length === 0 || trimmed.some((command) => !command)) {
+		throw new CLIError(
+			"Script commands cannot be empty",
+			"Pass one or more non-empty --command values.",
+		);
+	}
+	return trimmed;
+}
+
+function normalizeProjectIds(
+	projectIds: string[] | null | undefined,
+): string[] | null {
+	return projectIds && projectIds.length > 0 ? [...new Set(projectIds)] : null;
+}
+
+export function getTerminalScriptStatus(
+	script: TerminalPreset,
+): TerminalScriptStatus {
+	if (script.cliDeletePending) return "deleting";
+	if (script.cliImportPending) return "importing";
+	return "ready";
+}
+
+export function toPublicTerminalScript(
+	script: TerminalPreset,
+): PublicTerminalScript {
+	const {
+		cliImportPending: _pending,
+		cliTargetOrganizationId: _target,
+		cliDeletePending: _deleting,
+		...rest
+	} = script;
+	return { ...rest, status: getTerminalScriptStatus(script) };
+}
+
+/**
+ * Every script in the desktop's shared local store — the ones the CLI added
+ * plus any the app wrote there itself. Scripts created in the desktop's v2
+ * Settings live only in the app and are not visible here.
+ */
+export function listTerminalScripts(): TerminalPreset[] {
+	return readSettingsRow()?.terminalPresets ?? [];
+}
+
+/** Scripts still visible to the user: delete tombstones excluded. */
+function liveScripts(scripts: TerminalPreset[]): TerminalPreset[] {
+	return scripts.filter((script) => !script.cliDeletePending);
+}
+
+function requireScript(
+	scripts: TerminalPreset[],
+	id: string,
+): { index: number; script: TerminalPreset } {
+	const index = scripts.findIndex((script) => script.id === id);
+	const script = scripts[index];
+	if (!script) {
+		throw new CLIError(
+			`Terminal script ${id} not found`,
+			"Run `superset scripts list` to see script ids.",
+		);
+	}
+	return { index, script };
+}
+
 /**
  * Persist a user-authored terminal script in the desktop's legacy-compatible
  * terminal_presets field. "Preset" remains the storage/API term so current
@@ -22,27 +117,15 @@ export interface CreateTerminalScriptInput {
 export function createTerminalScript(
 	input: CreateTerminalScriptInput,
 ): TerminalPreset {
-	const name = input.name.trim();
-	if (!name) {
-		throw new CLIError("Script name cannot be empty", "Pass --name <name>.");
-	}
-	const commands = input.commands.map((command) => command.trim());
-	if (commands.length === 0 || commands.some((command) => !command)) {
-		throw new CLIError(
-			"Script commands cannot be empty",
-			"Pass one or more non-empty --command values.",
-		);
-	}
+	const name = normalizeName(input.name);
+	const commands = normalizeCommands(input.commands);
 	const script: TerminalPreset = {
 		id: crypto.randomUUID(),
 		name,
 		description: input.description?.trim() || undefined,
 		cwd: input.cwd?.trim() ?? "",
 		commands,
-		projectIds:
-			input.projectIds && input.projectIds.length > 0
-				? [...new Set(input.projectIds)]
-				: null,
+		projectIds: normalizeProjectIds(input.projectIds),
 		pinnedToBar: input.pinnedToBar ?? true,
 		useAsWorkspaceRun: input.useAsWorkspaceRun || undefined,
 		executionMode: input.executionMode ?? "new-tab",
@@ -54,4 +137,134 @@ export function createTerminalScript(
 		patch: { terminalPresets: [...(row?.terminalPresets ?? []), script] },
 		result: script,
 	}));
+}
+
+/**
+ * Change fields on an existing script and re-flag it for import, so the
+ * desktop app updates its copy in place (keeping bar position) instead of
+ * adding a duplicate.
+ */
+export function updateTerminalScript({
+	organizationId,
+	id,
+	patch,
+}: {
+	organizationId: string;
+	id: string;
+	patch: TerminalScriptPatch;
+}): TerminalPreset {
+	const name = patch.name === undefined ? undefined : normalizeName(patch.name);
+	const commands =
+		patch.commands === undefined
+			? undefined
+			: normalizeCommands(patch.commands);
+
+	return updateSettingsAtomically((row) => {
+		const scripts = row?.terminalPresets ?? [];
+		const { index, script } = requireScript(scripts, id);
+		if (script.cliDeletePending) {
+			throw new CLIError(
+				`Terminal script ${id} is scheduled for deletion`,
+				"Add it again with `superset scripts add`.",
+			);
+		}
+		const updated: TerminalPreset = {
+			...script,
+			name: name ?? script.name,
+			description:
+				patch.description === undefined
+					? script.description
+					: patch.description.trim() || undefined,
+			cwd: patch.cwd === undefined ? script.cwd : patch.cwd.trim(),
+			commands: commands ?? script.commands,
+			projectIds:
+				patch.projectIds === undefined
+					? (script.projectIds ?? null)
+					: normalizeProjectIds(patch.projectIds),
+			pinnedToBar: patch.pinnedToBar ?? script.pinnedToBar ?? true,
+			useAsWorkspaceRun:
+				(patch.useAsWorkspaceRun ?? script.useAsWorkspaceRun) || undefined,
+			executionMode: patch.executionMode ?? script.executionMode ?? "new-tab",
+			cliImportPending: true,
+			cliTargetOrganizationId: organizationId,
+		};
+		const next = [...scripts];
+		next[index] = updated;
+		return { patch: { terminalPresets: next }, result: updated };
+	});
+}
+
+export interface DeleteTerminalScriptResult {
+	script: TerminalPreset;
+	/** True when the row is gone already; false while the desktop must still remove its copy. */
+	removed: boolean;
+}
+
+/**
+ * Remove a script. One the desktop never imported disappears immediately;
+ * otherwise the row stays as a tombstone until the desktop app deletes its
+ * copy and drops the row (see cliDeletePending).
+ */
+export function deleteTerminalScript({
+	organizationId,
+	id,
+}: {
+	organizationId: string;
+	id: string;
+}): DeleteTerminalScriptResult {
+	return updateSettingsAtomically<DeleteTerminalScriptResult>((row) => {
+		const scripts = row?.terminalPresets ?? [];
+		const { index, script } = requireScript(scripts, id);
+		if (script.cliDeletePending) {
+			return {
+				patch: { terminalPresets: scripts },
+				result: { script, removed: false },
+			};
+		}
+		if (script.cliImportPending) {
+			const next = scripts.filter((_, i) => i !== index);
+			return {
+				patch: { terminalPresets: next },
+				result: { script, removed: true },
+			};
+		}
+		const {
+			cliImportPending: _pending,
+			cliTargetOrganizationId: _target,
+			...rest
+		} = script;
+		const tombstone: TerminalPreset = {
+			...rest,
+			cliDeletePending: true,
+			cliTargetOrganizationId: organizationId,
+		};
+		const next = [...scripts];
+		next[index] = tombstone;
+		return {
+			patch: { terminalPresets: next },
+			result: { script: tombstone, removed: false },
+		};
+	});
+}
+
+/**
+ * Exact-name lookup for `scripts add --upsert`. Throws when the name is
+ * ambiguous: silently picking one would edit the wrong script.
+ */
+export function findTerminalScriptByName(
+	name: string,
+): TerminalPreset | undefined {
+	const target = normalizeName(name);
+	const matches = liveScripts(listTerminalScripts()).filter(
+		(script) => script.name === target,
+	);
+	if (matches.length > 1) {
+		throw new CLIError(
+			`${matches.length} scripts are named ${target}: ${matches
+				.map((script) => script.id)
+				.join(", ")}`,
+			"Delete the extras with `superset scripts delete <id>`, then retry.",
+		);
+	}
+	return matches[0];
 }

--- a/packages/cli/src/lib/terminal-scripts.ts
+++ b/packages/cli/src/lib/terminal-scripts.ts
@@ -194,16 +194,11 @@ export function updateTerminalScript({
 	});
 }
 
-export interface DeleteTerminalScriptResult {
-	script: TerminalPreset;
-	/** True when the row is gone already; false while the desktop must still remove its copy. */
-	removed: boolean;
-}
-
 /**
- * Remove a script. One the desktop never imported disappears immediately;
- * otherwise the row stays as a tombstone until the desktop app deletes its
- * copy and drops the row (see cliDeletePending).
+ * Remove a script. The row always stays as a tombstone until the desktop app
+ * has deleted its copy and drops the row (see cliDeletePending): an
+ * import-pending marker cannot tell a never-imported script from one being
+ * edited, and even a fresh add may already be copied but not yet acknowledged.
  */
 export function deleteTerminalScript({
 	organizationId,
@@ -211,22 +206,12 @@ export function deleteTerminalScript({
 }: {
 	organizationId: string;
 	id: string;
-}): DeleteTerminalScriptResult {
-	return updateSettingsAtomically<DeleteTerminalScriptResult>((row) => {
+}): TerminalPreset {
+	return updateSettingsAtomically((row) => {
 		const scripts = row?.terminalPresets ?? [];
 		const { index, script } = requireScript(scripts, id);
 		if (script.cliDeletePending) {
-			return {
-				patch: { terminalPresets: scripts },
-				result: { script, removed: false },
-			};
-		}
-		if (script.cliImportPending) {
-			const next = scripts.filter((_, i) => i !== index);
-			return {
-				patch: { terminalPresets: next },
-				result: { script, removed: true },
-			};
+			return { patch: { terminalPresets: scripts }, result: script };
 		}
 		const {
 			cliImportPending: _pending,
@@ -240,10 +225,7 @@ export function deleteTerminalScript({
 		};
 		const next = [...scripts];
 		next[index] = tombstone;
-		return {
-			patch: { terminalPresets: next },
-			result: { script: tombstone, removed: false },
-		};
+		return { patch: { terminalPresets: next }, result: tombstone };
 	});
 }
 

--- a/packages/local-db/src/schema/zod.ts
+++ b/packages/local-db/src/schema/zod.ts
@@ -125,6 +125,12 @@ export const terminalPresetSchema = z.object({
 	cliImportPending: z.boolean().optional(),
 	/** Organization-scoped destination for the v2 one-shot import. */
 	cliTargetOrganizationId: z.string().optional(),
+	/**
+	 * Tombstone left by `superset scripts delete`. V2 removes its copy, then
+	 * drops the row from this store. Kept as a marker rather than an immediate
+	 * removal so a script the desktop already imported is deleted there too.
+	 */
+	cliDeletePending: z.boolean().optional(),
 });
 
 export type TerminalPreset = z.infer<typeof terminalPresetSchema>;


### PR DESCRIPTION
## Summary
- Adds `superset scripts list`, `scripts edit <id>`, and `scripts delete <id>`, plus `scripts add --upsert` to replace a same-named script instead of adding a duplicate.
- Extends the desktop's CLI import bridge so edited rows update their v2 preset in place and deleted rows remove the v2 copy.

## Why / Context
`superset scripts` only supported `add`, so every revision of a script from the CLI piled up another pinned copy in the Scripts bar, and the only way to clean up was the desktop app. Reported on 1.26.0: five "Open in GitHub" presets after tweaking one command.

## How It Works
The CLI can only write the legacy `terminalPresets` column in local.db; v2 scripts live in renderer localStorage per organization. Every CLI change is therefore a marker on the legacy row that the desktop's `useCliTerminalScriptImport` hook settles on the next refetch (focus, or the existing `/settings-changed` nudge when the app is running):

- **add / edit / upsert** set `cliImportPending` as before. The hook now updates an existing v2 row in place (bar position, `createdAt`, and any agent link are kept) instead of skipping it.
- **delete** removes a row the desktop never imported immediately. Otherwise it leaves a new `cliDeletePending` tombstone; the hook deletes the v2 copy and the acknowledgement drops the row from the shared store.
- **list** reads the shared store and replaces the markers with one `status` column: `ready`, `importing`, or `deleting`.
- **`--upsert`** looks up the exact name among live rows and refuses when the name is already duplicated, listing the ids to delete.

No v2 → legacy write-through was added: the legacy store is still read by v1, so desktop-side edits stay out of it.

## Manual QA Checklist
Run against the built binary (`bun run build` in `packages/cli`) with `SUPERSET_HOME_DIR` pointed at a scratch local.db:

- [x] `scripts add` twice with the same name, then `scripts list` shows both with status `importing`
- [x] `scripts add --upsert` on a duplicated name fails and lists both ids
- [x] `scripts delete <id>` on a never-imported script removes the row immediately
- [x] `scripts add --hidden --upsert` replaces the remaining script in place (same id, `pinnedToBar: false`)
- [x] `scripts edit <id> --no-hidden --description "Opens the PR" --execution-mode split-pane` patches only those fields
- [x] `scripts edit <id>` with no flags, an unknown id, and `--project` + `--all-projects` together each fail with a hint
- [x] After simulating the desktop acknowledgement (markers stripped), `scripts delete <id>` tombstones the row: `list` shows `deleting`, and `edit` on it is refused
- [x] `scripts list --no-json` renders the table; `--json` returns the public rows
- [x] `scripts --help` and `scripts edit --help` list the new commands and flags
- [x] Desktop hook, driven live over CDP against the dev desktop app (signed-in dev profile, CLI pointed at its local.db and notifications port):
  - `scripts add` → v2 row appeared in `v2-terminal-presets-<org>` within 500 ms, "CLI Drive Test" visible in the Scripts bar, legacy row back to `ready`
  - `scripts edit` (rename + new command) → same v2 row updated in place (same id, `tabOrder`, `createdAt`; no duplicate), and clicking it in the bar ran the new command (`echo edited from cli` printed in the launched terminal)
  - `scripts delete` → v2 row removed, Scripts bar back to its four original entries, legacy row dropped, `list` back to the profile's original scripts

## Testing
- `bunx tsc --noEmit` in `packages/cli`, `packages/local-db`, and `apps/desktop`
- `bunx biome check` on changed files
- `bun test` in `packages/cli` (216 pass) and the touched desktop suites (`cli-terminal-script-import`, `applyCliTerminalScriptEdit`)

## Known Limitations
- `scripts list` cannot see scripts created in the desktop's Settings: they live only in the app profile.
- Edits made in the desktop do not flow back to the CLI. A CLI edit replaces the app copy with what `list` shows plus the requested changes. Documented in the CLI reference.
- Presets migrated from v1 carry different ids in v2, so deleting one of those from the CLI only drops the shared row.
- An older desktop build ignores `cliDeletePending`; the row then stays listed as `deleting` until the app updates.

## Compatibility
- The desktop change ships with the CLI change. A new CLI against an older desktop degrades as described above; an older CLI against the new desktop is unaffected.

https://claude.ai/code/session_016e5Fr4cwZtQMx3MMETkqHD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `superset scripts list`, `scripts edit <id>`, and `scripts delete <id>`, plus `--upsert` on `scripts add`, so revising a script from the CLI replaces it instead of stacking duplicate pinned copies in the Scripts bar. The desktop import bridge now updates or removes the matching v2 preset when the CLI edits or deletes a script; changes reach the app on next open or refocus, or immediately if it's already running.

**Compatibility**
- `scripts list` only shows scripts in the shared local store, not ones created in the desktop app's Settings.
- A CLI edit overwrites the desktop's copy with what `list` shows plus the requested changes; desktop-side edits do not flow back to the CLI.
- `scripts delete` always leaves a tombstone, and the app drops the row only after removing its v2 copy; an older desktop build ignores the tombstone, so the script stays listed as `deleting` until the app updates.
- An older CLI against the new desktop is unaffected.

<sup>Written for commit 955a5155eb9449edb1613d6498380787c2e224c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI commands to list, edit, and delete terminal scripts.
  - Added `--upsert` support to replace scripts by name without creating duplicates.
  - Terminal script changes now synchronize with the desktop app, including additions, edits, and deletions.
  - Added status reporting for synchronization and script availability.
- **Bug Fixes**
  - Improved retry handling for failed synchronization attempts.
  - Prevented ambiguous duplicate-name updates.
- **Documentation**
  - Documented terminal script commands, options, statuses, and synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
