### PR TITLE
fix(billing): stop dunning people who already cancelled

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -91,6 +91,26 @@ const desktopDevOrigins =
 			]
 		: [];
 
+/**
+ * Stripe is the authority here, not our `subscriptions` row: the row is keyed
+ * by organization, so an organization that resubscribed has more than one and
+ * the wrong status can win. On a read failure this answers `false`, which
+ * sends the mail — a duplicate notice beats swallowing a real one.
+ */
+async function isStripeSubscriptionCancelled(stripeSubscriptionId: string) {
+	try {
+		const stripeSubscription =
+			await stripeClient.subscriptions.retrieve(stripeSubscriptionId);
+		return stripeSubscription.status === "canceled";
+	} catch (error) {
+		console.error(
+			"[stripe/payment-failed] Failed to read subscription status:",
+			error,
+		);
+		return false;
+	}
+}
+
 function serializeCancellationDetails(
 	cancellationDetails?: Stripe.Subscription.CancellationDetails | null,
 ) {
@@ -1279,13 +1299,27 @@ export const auth = betterAuth({
 							where: eq(subscriptions.referenceId, org.id),
 						});
 
+						const stripeSubId =
+							subscription?.stripeSubscriptionId ??
+							(invoice.parent?.subscription_details?.subscription as
+								| string
+								| undefined);
+
 						const isFinalAttempt = invoice.next_payment_attempt == null;
 						const isFirstAttempt = (invoice.attempt_count ?? 0) <= 1;
+
+						// Stripe keeps retrying the closing invoice after someone cancels,
+						// so this still fires for subscriptions that are already gone.
+						// Warning them they are about to lose access would be false, and
+						// nagging someone who already left is worse than saying nothing.
+						const alreadyCancelled = stripeSubId
+							? await isStripeSubscriptionCancelled(stripeSubId)
+							: false;
 
 						// Stripe fires this on every retry. Mailing all of them trains
 						// people to ignore the one that matters, so only the opening
 						// notice and the last-chance notice go out.
-						if (isFirstAttempt || isFinalAttempt) {
+						if (!alreadyCancelled && (isFirstAttempt || isFinalAttempt)) {
 							const recipients = await getOrganizationBillingRecipients(org.id);
 							const amount = formatPrice(invoice.amount_due, invoice.currency);
 							const nextRetryDate = invoice.next_payment_attempt
@@ -1305,20 +1339,15 @@ export const auth = betterAuth({
 										planName: subscription?.plan ?? "Pro",
 										amount,
 										nextRetryDate,
-										payInvoiceUrl:
-											recipient.role === "owner"
-												? (invoice.hosted_invoice_url ?? undefined)
-												: undefined,
+										// Anyone holding the link can settle a hosted invoice,
+										// so every billing recipient gets it. The old
+										// owners-only gate existed because this used to be a
+										// billing portal session, which needs ownership.
+										payInvoiceUrl: invoice.hosted_invoice_url ?? undefined,
 									}),
 								})),
 							);
 						}
-
-						const stripeSubId =
-							subscription?.stripeSubscriptionId ??
-							(invoice.parent?.subscription_details?.subscription as
-								| string
-								| undefined);
 
 						if (stripeSubId) {
 							try {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1299,11 +1299,15 @@ export const auth = betterAuth({
 							where: eq(subscriptions.referenceId, org.id),
 						});
 
+						// The invoice names the subscription this event is about, so it
+						// wins. The organization-level row is only a fallback: the lookup
+						// above is unordered and an organization that resubscribed has
+						// several, so preferring it can check — or notify Slack about —
+						// a subscription that has nothing to do with this invoice.
 						const stripeSubId =
-							subscription?.stripeSubscriptionId ??
 							(invoice.parent?.subscription_details?.subscription as
 								| string
-								| undefined);
+								| undefined) ?? subscription?.stripeSubscriptionId;
 
 						const isFinalAttempt = invoice.next_payment_attempt == null;
 						const isFirstAttempt = (invoice.attempt_count ?? 0) <= 1;


### PR DESCRIPTION
Two fixes in the `invoice.payment_failed` handler, both found while auditing what else our billing email gets wrong after #7204.

### Don't dun people who already left

Stripe keeps retrying a subscription's closing invoice **after** the customer cancels, so `invoice.payment_failed` still arrives for subscriptions that are already gone. The final-notice mail then tells someone who deliberately left that they *"lose Pro access today unless this invoice is paid."*

There's one live case: a 5-seat account that cancelled on 27 Aug whose $75.77 expansion invoice is still retrying (attempt 6, next 7 Sep). It would have been mailed when the retries run out. Of the 16 invoices currently retrying, 15 sit behind genuinely `past_due` subscriptions — this is the only one behind a cancelled one, so it's an edge case, not a flood.

The status comes from Stripe rather than our own `subscriptions` row: the row is keyed by organization, so an organization that resubscribed has more than one and the wrong status can win. A read failure answers `false` and sends the mail — a duplicate notice beats swallowing a real one.

Slack notifications are deliberately unchanged; ops still wants every failed charge.

### Give admins the pay link

`BILLING_ROLES` includes admins on purpose:

> *"Owners alone is too narrow: the person holding the card is often an admin, and a payment-failure notice that never reaches them is a notice nobody can act on."*

…and then we gated `payInvoiceUrl` to `role === "owner"`, so admins got exactly that — a notice nobody can act on. The gate was correct when the link was a billing portal session, which requires ownership. A hosted invoice page is payable by anyone holding the link, so the reason left when the portal did in #7204. I preserved the gate mechanically in that PR; this removes it.

## Verification

- `typecheck` clean on auth, trpc, api, web; `lint.sh` clean across 7,213 files; `@superset/auth` tests 8/8.
- Traced the live case: `stripeSubId` resolves, status is `canceled`, email is skipped, Slack still fires.

## Audit notes — gaps I checked and am *not* fixing here

- **`invoice.payment_action_required` fires 0 times in 30 days.** I expected an SCA/3DS gap on renewals and there isn't one — the 8 `payment_intent.requires_action` events are all inside Checkout, which handles authentication inline.
- **The unguarded `resend.batch.send` is fine as-is.** It looked like a robustness bug, but letting it throw returns a non-2xx and Stripe retries the whole event, which gives the mail another attempt. Wrapping it in try/catch would silently drop dunning mail instead. Left alone deliberately.
- **`invoice.upcoming` fires 98×/month and is unhandled** — no renewal notice exists. Relevant for the 141 annual subscriptions and the 72 multi-seat ones whose amount moves when seats change. Not obviously wanted for the 576 monthly $20 subscriptions, where a monthly reminder mostly prompts cancellations.
- **`checkout.session.expired` fires 31×/month against 52 completions — a 37% abandonment rate with no recovery email.**

Those last two are product decisions rather than defects, so they're not in this PR.

https://claude.ai/code/session_01CqWBnJKCMs4b5ZXpSUZvFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `invoice.payment_failed` emails from reaching customers who already cancelled, and gives admins the pay link so dunning emails are actionable.

- Checks Stripe for the subscription's status using the ID carried by the invoice, falling back to our `subscriptions` row, which can be wrong when an organization resubscribed.
- Sends the email if the status read fails; a duplicate notice beats swallowing a real one.
- Removes the owners-only gate on `payInvoiceUrl` — hosted invoices are payable by anyone with the link, and the gate predates the switch from billing portal sessions.
- Slack notifications are unchanged.

<sup>Written for commit d32fe1fabacde44cf6ebdda29c158031afe8bedd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented payment-failure notifications from being sent for subscriptions that have already been cancelled.
  - Payment-failure emails now provide invoice access to all billing recipients, not only organization owners.
  - Improved handling of payment-failure events for invoices associated with cancelled subscriptions, reducing unnecessary repeated notifications while preserving access to hosted invoices for recipients who need to review or pay them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->