### PR TITLE
feat(billing): tell annual subscribers before we charge them

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -11,6 +11,7 @@ import { WelcomeEmail } from "@superset/email/emails/activation/00-welcome";
 import { MemberAddedBillingEmail } from "@superset/email/emails/billing/member-added";
 import { MemberRemovedBillingEmail } from "@superset/email/emails/billing/member-removed";
 import { PaymentFailedEmail } from "@superset/email/emails/billing/payment-failed";
+import { RenewalUpcomingEmail } from "@superset/email/emails/billing/renewal-upcoming";
 import { SubscriptionCancelledEmail } from "@superset/email/emails/billing/subscription-cancelled";
 import { SubscriptionStartedEmail } from "@superset/email/emails/billing/subscription-started";
 import { OrganizationInvitationEmail } from "@superset/email/emails/team/invitation";
@@ -1372,6 +1373,67 @@ export const auth = betterAuth({
 								);
 							}
 						}
+					}
+
+					if (event.type === "invoice.upcoming") {
+						const invoice = event.data.object as Stripe.Invoice;
+
+						const customerId =
+							typeof invoice.customer === "string"
+								? invoice.customer
+								: invoice.customer?.id;
+
+						if (!customerId) return;
+
+						const stripeSubId = invoice.parent?.subscription_details
+							?.subscription as string | undefined;
+
+						if (!stripeSubId) return;
+
+						// Matched on the Stripe id, not the organization: an organization
+						// that resubscribed has several rows and the wrong one can win.
+						const subscription = await db.query.subscriptions.findFirst({
+							where: eq(subscriptions.stripeSubscriptionId, stripeSubId),
+						});
+
+						// Annual only — see RenewalUpcomingEmail for why monthly plans and
+						// seat changes are deliberately left out.
+						if (subscription?.billingInterval !== "yearly") return;
+
+						const renewsAtSeconds =
+							invoice.next_payment_attempt ?? invoice.period_end;
+
+						if (!renewsAtSeconds) return;
+
+						const org = await db.query.organizations.findFirst({
+							where: eq(authSchema.organizations.stripeCustomerId, customerId),
+						});
+
+						if (!org) return;
+
+						const recipients = await getOrganizationBillingRecipients(org.id);
+						// Max, not sum: a proration line carries its own quantity and
+						// adding them together reports more seats than exist.
+						const seatCount = invoice.lines.data.reduce(
+							(largest, line) => Math.max(largest, line.quantity ?? 0),
+							0,
+						);
+
+						await resend.batch.send(
+							recipients.map((recipient) => ({
+								from: "Superset <noreply@superset.sh>",
+								to: recipient.email,
+								subject: `${org.name}'s ${subscription.plan} plan renews soon`,
+								react: RenewalUpcomingEmail({
+									recipientName: recipient.name,
+									organizationName: org.name,
+									planName: subscription.plan,
+									amount: formatPrice(invoice.amount_due, invoice.currency),
+									renewsAt: new Date(renewsAtSeconds * 1000),
+									seatCount: Math.max(1, seatCount),
+								}),
+							})),
+						);
 					}
 
 					if (event.type === "invoice.paid") {

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1431,6 +1431,7 @@ export const auth = betterAuth({
 									amount: formatPrice(invoice.amount_due, invoice.currency),
 									renewsAt: new Date(renewsAtSeconds * 1000),
 									seatCount: Math.max(1, seatCount),
+									isOwner: recipient.role === "owner",
 								}),
 							})),
 						);

--- a/packages/email/src/emails/billing/renewal-upcoming.tsx
+++ b/packages/email/src/emails/billing/renewal-upcoming.tsx
@@ -1,0 +1,73 @@
+import { Heading, Hr, Text } from "@react-email/components";
+import { format } from "date-fns";
+import { DetailRow, EmailLayout } from "../../components";
+
+interface RenewalUpcomingEmailProps {
+	recipientName?: string | null;
+	organizationName: string;
+	planName: string;
+	amount: string;
+	renewsAt: Date;
+	seatCount: number;
+}
+
+/**
+ * Annual plans only. A monthly subscriber is reminded by the charge itself
+ * twelve times a year, and telling them a week early mostly prompts a cancel;
+ * a yearly subscriber has heard nothing since signup and gets a charge an
+ * order of magnitude larger. Seat changes are already covered the moment they
+ * happen by the member-added and member-removed billing emails, which quote
+ * the next invoice exactly.
+ */
+export function RenewalUpcomingEmail({
+	recipientName = "there",
+	organizationName = "Acme Inc",
+	planName = "Pro",
+	amount = "$200.00",
+	renewsAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+	seatCount = 1,
+}: RenewalUpcomingEmailProps) {
+	const formattedRenewalDate = format(renewsAt, "MMMM d, yyyy");
+
+	return (
+		<EmailLayout
+			preview={`${organizationName}'s ${planName} plan renews ${formattedRenewalDate}`}
+		>
+			<Heading className="text-[22px] font-medium leading-8 text-foreground m-0 mb-4">
+				Your plan renews on {formattedRenewalDate}
+			</Heading>
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
+				Hi {recipientName ?? "there"},
+			</Text>
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-2">
+				<strong>{organizationName}</strong>'s annual <strong>{planName}</strong>{" "}
+				subscription renews on {formattedRenewalDate}. Nothing is due yet — this
+				is a heads-up so the charge isn't a surprise.
+			</Text>
+
+			<Hr className="border-border my-4" />
+			<DetailRow label="Renews on" value={formattedRenewalDate} />
+			<DetailRow label="Amount" value={amount} />
+			<DetailRow
+				label="Seats"
+				value={seatCount === 1 ? "1 seat" : `${seatCount} seats`}
+			/>
+			<Hr className="border-border my-4" />
+
+			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
+				We'll charge the payment method on file. If that card has changed since
+				last year, update it before {formattedRenewalDate} so the renewal
+				doesn't fail — open Superset and go to{" "}
+				<strong>Settings → Billing</strong>.
+			</Text>
+
+			<Text className="text-[13px] leading-5 text-muted m-0">
+				You're receiving this because you manage billing for {organizationName}.
+			</Text>
+		</EmailLayout>
+	);
+}
+
+export default RenewalUpcomingEmail;

--- a/packages/email/src/emails/billing/renewal-upcoming.tsx
+++ b/packages/email/src/emails/billing/renewal-upcoming.tsx
@@ -9,6 +9,8 @@ interface RenewalUpcomingEmailProps {
 	amount: string;
 	renewsAt: Date;
 	seatCount: number;
+	/** Payment methods are owner-only, so an admin gets told to ask one. */
+	isOwner?: boolean;
 }
 
 /**
@@ -26,6 +28,7 @@ export function RenewalUpcomingEmail({
 	amount = "$200.00",
 	renewsAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
 	seatCount = 1,
+	isOwner = true,
 }: RenewalUpcomingEmailProps) {
 	const formattedRenewalDate = format(renewsAt, "MMMM d, yyyy");
 
@@ -58,9 +61,18 @@ export function RenewalUpcomingEmail({
 
 			<Text className="text-[15px] leading-6 text-foreground m-0 mb-4">
 				We'll charge the payment method on file. If that card has changed since
-				last year, update it before {formattedRenewalDate} so the renewal
-				doesn't fail — open Superset and go to{" "}
-				<strong>Settings → Billing</strong>.
+				last year,{" "}
+				{isOwner ? (
+					<>
+						update it before {formattedRenewalDate} so the renewal doesn't fail
+						— open Superset and go to <strong>Settings → Billing</strong>.
+					</>
+				) : (
+					<>
+						ask an owner to update it before {formattedRenewalDate} so the
+						renewal doesn't fail. Only owners can change the payment method.
+					</>
+				)}
 			</Text>
 
 			<Text className="text-[13px] leading-5 text-muted m-0">


### PR DESCRIPTION
**Stacked on #7217** — base is `billing-email-gaps`, since both touch the same `onEvent` region. Retarget to `main` once that merges.

A yearly subscriber hears from us at signup and then **nothing for twelve months**, until a charge an order of magnitude larger than a monthly one lands. Stripe fires `invoice.upcoming` **7.0 days** ahead (measured across the last 30 days, not assumed) and we were ignoring it — 413 a month, none handled.

## Annual only, on purpose

**Not monthly.** 363 of those 413 events are flat $20 monthlies. A weekly heads-up before a charge people already expect mostly reminds them to cancel.

**Not seat changes**, even though that was the original motivation. `MemberAddedBillingEmail` and `MemberRemovedBillingEmail` already fire the moment seats change, to the same billing recipients, quoting seat count, new total, proration, and the exact next invoice via `previewNextInvoice` — whose own comment names the failure this would have duplicated:

> *"A seat-change email stating a total the customer will not be charged is how a card limit gets set too low, which is the whole reason this exists."*

That leaves the genuine gap: **141 live annual subscriptions** with no signal between signup and renewal.

## Details worth reviewing

- **No CTA.** Nothing is payable yet — it's a renewal notice, not an invoice. Also sidesteps the missing web billing route.
- **Subscription matched on the Stripe id**, not the organization: an organization that resubscribed has several `subscriptions` rows and the wrong one can win. Same reasoning as the guard in #7217.
- **Seats take the max quantity across lines, not the sum** — a proration line carries its own quantity, and summing reports more seats than exist.
- **Interval comes from our `billingInterval` column**, because on the current API version invoice lines carry only a price *id* (`pricing.price_details.price`), with no expanded `recurring.interval` to read.
- Goes to `BILLING_ROLES` (owners + admins), not the whole team.

## Verification

- Rendered the email and read the output; preview sent to Satya for copy review before this ships.
- `lint.sh` clean across 7,214 files. `typecheck` clean on auth, email, trpc, api, web. `@superset/auth` tests 8/8.
- Payload shape confirmed against a real `invoice.upcoming` event rather than assumed.

https://claude.ai/code/session_01CqWBnJKCMs4b5ZXpSUZvFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends annual subscribers a renewal notice before we charge them by handling Stripe's `invoice.upcoming` events, which we previously ignored. Only yearly plans get the email; monthly plans and seat changes are deliberately excluded because they already receive timely notifications or the charge is expected.

**Details**
- Subscriptions are matched on the Stripe subscription id, not the organization, to avoid hitting the wrong row for resubscribed organizations.
- Seat count uses the max quantity across invoice lines instead of the sum, because proration lines double-count.
- The email goes to billing roles (owners and admins) and contains no call to action since nothing is due yet.
- Owners are told to update the card in Settings → Billing; admins are told to ask an owner, since payment methods are owner-only.

<sup>Written for commit c7ec186d2daa49370d0f5901a8adca13f6a428ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added renewal reminder emails for annual subscriptions before the upcoming renewal date.
  - Reminders include the organization, plan, renewal amount, renewal date, and seat count.
  - Payment-method instructions are tailored for account owners and administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->