### PR TITLE
fix(billing): keep warning people after the subscription is gone

### DIFF
--- a/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
+++ b/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
@@ -8,9 +8,20 @@ import { electronTrpc } from "renderer/lib/electron-trpc";
 import type { SidebarCardEntry } from "../../types";
 
 /**
- * Stripe keeps retrying for ~14 days before canceling, and access continues
- * for that whole window, so a failed charge is otherwise invisible in-app
- * until the plan abruptly disappears. Returns no `onDismiss` for that reason.
+ * Two states, because a failed charge is otherwise invisible in-app.
+ *
+ * `past_due` — Stripe is still retrying and access continues, so the card
+ * warns while paying the invoice still saves the subscription.
+ *
+ * `lapsed` — Stripe gave up, cancelled, and the organization dropped to free.
+ * Keying only on `past_due` meant the card vanished at exactly that moment:
+ * every one of the 87 organizations this happened to recorded zero
+ * `payment_failed_banner_shown`. They were never told, they just quietly lost
+ * their triggers. Paying the old invoice cannot undo it either — Stripe will
+ * not reactivate a cancelled subscription — so this state sends people to
+ * Billing to resubscribe instead of to the invoice.
+ *
+ * Neither state gets an `onDismiss`.
  */
 export function usePaymentFailedCard({
 	surface,
@@ -20,27 +31,33 @@ export function usePaymentFailedCard({
 	const { data: session } = authClient.useSession();
 	const { data: activePlan } = cloudTrpc.billing.activePlan.useQuery(undefined);
 	const isFailing = isPaymentFailingStatus(activePlan?.status);
+	// `lapsed` is decided server-side from rows activePlan already reads, so
+	// the two queries below stay off for everyone still paying and for
+	// everyone who never paid. Gating them on `plan === "free"` instead would
+	// put a Stripe round-trip on every app load for every past customer.
+	const mayHaveLapsed = activePlan?.lapsed === true;
+	const isRelevant = isFailing || mayHaveLapsed;
 	// Ownership is judged against the org being billed, which is the org THIS
 	// window shows. The session's active organization is shared by every
 	// window, so its membership could belong to whatever org another window
 	// last switched to. This list is scoped server-side by the window's org header.
 	const { data: members } = cloudTrpc.organization.listMembers.useQuery(
 		{ includeDeactivated: false },
-		{ enabled: isFailing },
+		{ enabled: isRelevant },
 	);
 	// The amount is the whole point of the card: "a payment failed" without it
 	// sends people hunting for a number the app never shows them.
 	const { data: outstandingInvoice } =
 		cloudTrpc.billing.outstandingInvoice.useQuery(undefined, {
-			enabled: isFailing,
+			enabled: isRelevant,
 		});
 	const openUrl = electronTrpc.external.openUrl.useMutation();
 	const navigate = useNavigate();
 
-	if (!isFailing) return null;
+	const hasLapsed = mayHaveLapsed && Boolean(outstandingInvoice);
 
-	// Non-owners are rejected by requireBillingOwner at the portal, so they get
-	// the warning without an action that would dead-end.
+	if (!isFailing && !hasLapsed) return null;
+
 	const isOwner =
 		members?.find((m) => m.userId === session?.user?.id)?.role === "owner";
 
@@ -48,7 +65,33 @@ export function usePaymentFailedCard({
 		? formatPrice(outstandingInvoice.amountDue, outstandingInvoice.currency)
 		: null;
 	const hostedInvoiceUrl = outstandingInvoice?.hostedInvoiceUrl ?? null;
+	const state = hasLapsed ? "lapsed" : "past_due";
 
+	// Lapsed: the subscription is gone and paying the old invoice will not
+	// bring it back, so the only honest action is starting a new one.
+	if (hasLapsed) {
+		return {
+			id: "payment-failed",
+			badge: "Action needed",
+			title: amount ? `Pro ended — ${amount} unpaid` : "Pro ended",
+			description: isOwner
+				? `We couldn't collect ${amount ?? "your last payment"}, so this organization is on the free plan and its triggers have stopped running. Restart Pro to turn them back on.`
+				: `This organization's last payment couldn't be collected, so it's on the free plan and its triggers have stopped running. Ask an owner to restart Pro.`,
+			actionLabel: isOwner ? "Restart Pro" : undefined,
+			onAction: isOwner
+				? () => {
+						track("payment_failed_banner_clicked", { surface, state });
+						navigate({ to: "/settings/billing" });
+					}
+				: undefined,
+			className: "border-warning/50",
+			onShown: () =>
+				track("payment_failed_banner_shown", { surface, isOwner, state }),
+		};
+	}
+
+	// Non-owners are rejected by requireBillingOwner at the portal, so they get
+	// the warning without an action that would dead-end.
 	const ownerDescription = amount
 		? `We couldn't charge ${amount}. Update your payment method to keep your plan.`
 		: "We couldn't charge your payment method. Update it to keep your plan.";
@@ -68,7 +111,7 @@ export function usePaymentFailedCard({
 			: undefined,
 		onAction: isOwner
 			? () => {
-					track("payment_failed_banner_clicked", { surface });
+					track("payment_failed_banner_clicked", { surface, state });
 					// Straight to the invoice when we have one — the billing portal
 					// is several clicks from the same place.
 					if (hostedInvoiceUrl) {
@@ -79,6 +122,7 @@ export function usePaymentFailedCard({
 				}
 			: undefined,
 		className: "border-warning/50",
-		onShown: () => track("payment_failed_banner_shown", { surface, isOwner }),
+		onShown: () =>
+			track("payment_failed_banner_shown", { surface, isOwner, state }),
 	};
 }

--- a/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
+++ b/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
@@ -74,9 +74,13 @@ export function usePaymentFailedCard({
 			id: "payment-failed",
 			badge: "Action needed",
 			title: amount ? `Pro ended — ${amount} unpaid` : "Pro ended",
+			// Stated as two facts rather than one cause. A voluntary cancellation
+			// can also leave its closing invoice unpaid, and telling someone who
+			// chose to leave that a failed charge is why they lost Pro would be
+			// the same wrong-reason bug this card exists to stop.
 			description: isOwner
-				? `We couldn't collect ${amount ?? "your last payment"}, so this organization is on the free plan and its triggers have stopped running. Restart Pro to turn them back on.`
-				: `This organization's last payment couldn't be collected, so it's on the free plan and its triggers have stopped running. Ask an owner to restart Pro.`,
+				? `This organization is on the free plan and its triggers have stopped running.${amount ? ` ${amount} from the last billing period was never collected.` : ""} Restart Pro to turn them back on.`
+				: `This organization is on the free plan and its triggers have stopped running.${amount ? ` ${amount} from the last billing period was never collected.` : ""} Ask an owner to restart Pro.`,
 			actionLabel: isOwner ? "Restart Pro" : undefined,
 			onAction: isOwner
 				? () => {

--- a/packages/trpc/src/router/billing/billing.ts
+++ b/packages/trpc/src/router/billing/billing.ts
@@ -71,6 +71,14 @@ const EMPTY_ACTIVE_PLAN = {
 	periodStart: null,
 	periodEnd: null,
 	billingInterval: null,
+	/**
+	 * Free because a subscription ended, not because there never was one. The
+	 * distinction has to be made here, from rows we already read: the caller
+	 * uses it to decide whether to ask Stripe about an unpaid invoice, and
+	 * doing that for every free organization would put a Stripe round-trip on
+	 * every app load for everyone who ever paid us.
+	 */
+	lapsed: false,
 };
 
 function isUnpaid(invoice: Stripe.Invoice): boolean {
@@ -129,7 +137,21 @@ export const billingRouter = {
 		});
 
 		if (!subscription) {
-			return EMPTY_ACTIVE_PLAN;
+			const previous = await db.query.subscriptions.findFirst({
+				where: eq(subscriptions.referenceId, activeOrgId),
+				orderBy: desc(subscriptions.createdAt),
+				columns: { status: true },
+			});
+
+			// `unpaid` as well as `canceled`: which one Stripe lands on after it
+			// stops retrying is a dashboard setting, and checking only for
+			// `canceled` would make this silently stop working if that changed.
+			// `incomplete` is excluded on purpose — that subscription never began.
+			return {
+				...EMPTY_ACTIVE_PLAN,
+				lapsed:
+					previous?.status === "canceled" || previous?.status === "unpaid",
+			};
 		}
 
 		return {
@@ -139,6 +161,7 @@ export const billingRouter = {
 			periodStart: subscription.periodStart,
 			periodEnd: subscription.periodEnd,
 			billingInterval: subscription.billingInterval,
+			lapsed: false,
 		};
 	}),
 


### PR DESCRIPTION
**Draft — I have not seen this render.** Typechecked, linted, tests at baseline, but the card itself is unverified in a running app. See "What still needs proving" below before merging.

## The gap

`usePaymentFailedCard` keyed on `past_due`, so it vanished at exactly the moment it mattered: when Stripe stops retrying, cancels, and the organization drops to free.

**All 87 organizations this happened to recorded zero `payment_failed_banner_shown`** (PostHog, 90 days). They weren't ignoring a warning — they were never shown one. 40 of them are still active in the last 30 days, and many are hitting the Pro paywall repeatedly, unaware their triggers stopped because a card failed months ago.

## Why the lapsed state says something different

Paying the old invoice **cannot** undo a cancellation — Stripe: *"You can't reactivate a canceled subscription."* So a "Pay now" button here would lead nowhere useful. The lapsed card offers **Restart Pro** into Billing instead, and its copy names the actual consequence (triggers stopped), which is what these users are visibly running into.

The `past_due` path is unchanged.

## The load decision, because I got it wrong first

My first version gated the client on `plan === "free"`. That's every free user, and `outstandingInvoice` makes a live Stripe call for any org with a customer id — a Stripe round-trip on every app load for every past customer, a set that only grows.

Now `activePlan` decides `lapsed` server-side from rows it already reads, so the extra queries stay off for everyone still paying *and* everyone who never paid. It counts `unpaid` as well as `canceled`, because which one Stripe lands on after retries is a dashboard setting and checking only `canceled` would let this silently stop working. `incomplete` is excluded — that subscription never began.

## Verification so far

- `typecheck` clean on desktop and trpc; `lint.sh` clean; `check:i18n` compiles.
- Desktop suite **3516 pass / 2 fail**, and those 2 (`LeaderboardRank`) fail identically with this change stashed — pre-existing and env-dependent, confirmed by running both ways.

## What still needs proving

I have not seen either state render. Doing it properly needs the desktop app built from this branch plus an organization in the lapsed state — a cancelled subscription with an unpaid invoice — which I can't seed without database access. The only Superset running locally is shipped Canary, which per `cdp-verification`'s first rule isn't equivalent.

Worth exercising both states before this merges: `past_due` (should be unchanged) and lapsed (new).

https://claude.ai/code/session_01CqWBnJKCMs4b5ZXpSUZvFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the payment-failed warning card so it stays visible after Stripe cancels the subscription and the organization drops to free, instead of vanishing at that exact moment.

- `activePlan` returns a `lapsed` flag computed server-side from rows it already reads, avoiding extra Stripe calls for users still paying or who never paid.
- Lapsed is true for both `canceled` and `unpaid` statuses; `incomplete` is excluded.
- The lapsed card offers "Restart Pro" to Billing instead of a "Pay now" that leads nowhere, since Stripe won't reactivate a cancelled subscription.
- Its copy states the plan ended and the amount went uncollected as two facts, not one cause, because voluntary cancellations can also land on `canceled` with an unpaid closing invoice.
- The `past_due` card behavior and its direct-to-invoice link are unchanged; both states track `payment_failed_banner_shown` and `payment_failed_banner_clicked` with a `state` field.

<sup>Written for commit 0f858b34f36d9ccf87b3f9de123146bed72ca718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added billing notices for organizations with lapsed subscriptions.
  * Lapsed subscription notices guide owners to restart Pro instead of paying an outdated invoice.
  * Billing status now distinguishes between lapsed subscriptions and past-due payments.
  * Notices clarify that the organization is on the free plan and that automated triggers have stopped.
  * Unpaid invoice amounts are shown only when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->