### PR TITLE
feat(review-host): keep a Claude session resident so the reviewer sees a pull request

### DIFF
--- a/apps/review-host/check.sh
+++ b/apps/review-host/check.sh
@@ -200,5 +200,44 @@ except Exception:
   esac
 fi
 
+# One Claude session is deliberate, on the workspace that carries acme-demo#1.
+# The pull-request chip renders only when a terminal is open
+# (`showComposer = activeTerminalId !== null`), so with an empty box a reviewer
+# opens the app and there is no pull request anywhere on screen — the diff the
+# listing sells is reachable only by guessing. The resident session puts the chip
+# on the reviewer's first tap. A reboot takes it with it, so check for it.
+PR_WS=$(printf '%s' "$WS_JSON" | python3 -c 'import json,sys
+d = json.load(sys.stdin)["result"]["data"]["json"]
+print(next((w["id"] for w in d if w.get("name") == "Fix input overflow handling"), ""))' 2>/dev/null)
+SESSIONS=$(ssh_box "sudo curl -s -m 20 -G -H 'Authorization: Bearer $SECRET' --data-urlencode 'input={\"json\":{}}' http://127.0.0.1:48800/trpc/terminal.list")
+AGENTS=$(ssh_box "sudo curl -s -m 20 -G -H 'Authorization: Bearer $SECRET' --data-urlencode 'input={\"json\":{}}' http://127.0.0.1:48800/trpc/terminalAgents.list")
+if [ -z "$SESSIONS" ] || [ -z "$AGENTS" ] || [ -z "$PR_WS" ]; then
+  fail "could not read the session list; cannot tell whether the reviewer would see a pull request"
+else
+  RESIDENT=$(printf '%s' "$SESSIONS
+---
+$AGENTS
+---
+$PR_WS" | python3 -c 'import json,sys
+raw = sys.stdin.read().split("\n---\n")
+live = [t for t in json.loads(raw[0])["result"]["data"]["json"]["sessions"] if not t.get("exited")]
+agents = {a["terminalId"]: a.get("agentId") for a in json.loads(raw[1])["result"]["data"]["json"]}
+ws = raw[2].strip()
+here = [t for t in live if t["workspaceId"] == ws and agents.get(t["terminalId"]) == "claude"]
+print(len(here), len(live))' 2>/dev/null)
+  set -- $RESIDENT
+  HERE="${1:-}"
+  LIVE="${2:-}"
+  if [ -z "$HERE" ]; then
+    fail "the session probe did not parse; the resident Claude session is unverified"
+  elif [ "$HERE" = "0" ]; then
+    fail "no Claude session on 'Fix input overflow handling' — without it the pull-request chip never renders and a reviewer sees no pull request anywhere. Restore with agents.run {workspaceId, agent: \"claude\", prompt: \"\"}"
+  elif [ "$LIVE" != "1" ]; then
+    fail "$LIVE live sessions; steady state is exactly one, the Claude session on 'Fix input overflow handling'"
+  else
+    note "sessions: the resident Claude session is up, so the pull-request chip renders"
+  fi
+fi
+
 [ "$FAIL" -eq 0 ] && echo "OK — the review host is serving what the app expects" || echo "review host needs attention"
 exit "$FAIL"

--- a/apps/review-host/setup.sh
+++ b/apps/review-host/setup.sh
@@ -86,8 +86,18 @@ clone_demo() {
   rm -rf "$DIR"
   git clone -q "$URL" "$DIR"
 }
+
+# The resident Claude session recreates .local/ in its worktree forever, and an
+# untracked directory counts toward the home row's diff stat — the row read
+# +27 −2 against a pull request that says +26 −2. Excluding it locally keeps the
+# demo repositories themselves untouched.
+exclude_agent_residue() {
+  grep -qx '.local/' "$1/.git/info/exclude" 2>/dev/null || printf '.local/\n' >> "$1/.git/info/exclude"
+}
 clone_demo /demo/acme https://github.com/superset-sh/acme-demo.git
 clone_demo /demo/acme-ios https://github.com/superset-sh/acme-ios-demo.git
+exclude_agent_residue /demo/acme
+exclude_agent_residue /demo/acme-ios
 git config --global user.email "appreview@superset.sh"
 git config --global user.name "Superset"
 


### PR DESCRIPTION
The pull-request chip renders only while a terminal is open — `WorkspaceScreen` gates the composer on `activeTerminalId !== null`, and the chip lives in its quick-key bar. Steady state was "no sessions anywhere", so a reviewer opened the app and **there was no pull request on screen anywhere**: they had to pick the right one of seven workspaces *and* start a session before the diff the store listing sells existed as far as the UI was concerned. Reachable, but not discoverable — and the listing promises diff review.

## Change

One session is now deliberate: a Claude session on `Fix input overflow handling`, the workspace carrying `acme-demo#1`. Having it running also makes that workspace the first row under `acme`, so the reviewer's first tap lands on a live agent with the chip already in the bar.

`check.sh` asserts it. A reboot takes the session with it and nothing else would notice — the box would pass every other assertion while the feature was invisible. It also fails on a *second* session, which is the drift that already bit us once: a stray agent transcript explaining that the PR could not be opened and `gh` was not authenticated.

## The diff stat

The resident session recreates `.local/` in its worktree forever, and an untracked directory counts toward the home row's diff stat — the row read `+27 −2` against a pull request that says `+26 −2`. `.git/info/exclude` keeps that local, rather than committing a `.gitignore` the reviewer would find in the diff viewer.

## Verification

Cold on the simulator against the live box: relaunch the app, tap the first `acme` row, and both the Claude session and the green chip are there without touching anything. `check.sh` then caught a genuine second session on `acme / main` and failed, as designed.

https://claude.ai/code/session_0126YNrKGh5P6h9a2S9j1YAj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts the review host with a resident Claude session on the workspace carrying `acme-demo#1`, so the pull-request chip renders the moment a reviewer opens the app. Previously there were no sessions at startup, and the diff the store listing sells was only reachable by guessing the right workspace and starting a session. `check.sh` now asserts exactly one live Claude session, catching both a reboot wiping the feature and a second session drifting in.

**Migration**

- Existing review-host boxes need `setup.sh` rerun once so the resident session and `.git/info/exclude` entries are applied.
- Resetting the box loses the session until `setup.sh` runs again.

<sup>Written for commit eb029b883462eec5cf2cfed4a57005286b435bc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added validation to confirm the expected Claude session is active and running in the designated workspace.
  * Added checks for unreadable session information, missing sessions, and unexpected session counts.
  * Updated demo environment setup to exclude recreated local files from repository change statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->