### PR TITLE
fix(cli): reject an overflowing feedback attachment list before reading any file

### DIFF
--- a/packages/cli/src/commands/feedback/submit/command.test.ts
+++ b/packages/cli/src/commands/feedback/submit/command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
@@ -7,6 +7,7 @@ import { ApiHttpError } from "../../../lib/api-client";
 import submitCommand, {
 	MAX_ATTACHMENT_TOTAL_BASE64_CHARS,
 	MAX_ATTACHMENT_TOTAL_BYTES,
+	planAttachmentUploads,
 } from "./command";
 
 interface SubmittedAttachment {
@@ -137,6 +138,43 @@ describe("feedback submit attachments", () => {
 		expect(error.message).toContain("host-service.log");
 		expect(error.message).toContain("main.log");
 		expect(submitted).toBeUndefined();
+	});
+
+	test("rejects an overflowing list before reading any of its files", async () => {
+		const each = Math.ceil(MAX_ATTACHMENT_TOTAL_BYTES * 0.6);
+		const first = writeFixture("host-service.log", patterned(each));
+		const second = writeFixture("main.log", patterned(each));
+		// Unreadable after sizing: a read before the rejection fails with
+		// EACCES instead of the limit message.
+		chmodSync(first, 0o000);
+		chmodSync(second, 0o000);
+
+		const error = await invoke([first, second]).catch((thrown) => thrown);
+		expect(error.message).toContain("total limit");
+		expect(error.message).not.toContain("EACCES");
+		expect(submitted).toBeUndefined();
+	});
+
+	test("planAttachmentUploads works from sizes alone", () => {
+		const lone = planAttachmentUploads([
+			{
+				path: "/x/a.log",
+				filename: "a.log",
+				size: MAX_ATTACHMENT_TOTAL_BYTES * 3,
+			},
+		]);
+		expect(lone.files[0]?.bytes).toBe(MAX_ATTACHMENT_TOTAL_BYTES);
+		expect(lone.notices).toHaveLength(1);
+		expect(() =>
+			planAttachmentUploads([
+				{
+					path: "/x/a.log",
+					filename: "a.log",
+					size: MAX_ATTACHMENT_TOTAL_BYTES,
+				},
+				{ path: "/x/b.log", filename: "b.log", size: 10 },
+			]),
+		).toThrow(/total limit.*a\.log, b\.log/);
 	});
 
 	test("surfaces a 413 from the platform with its status, text, and the limit hint", async () => {

--- a/packages/cli/src/commands/feedback/submit/command.test.ts
+++ b/packages/cli/src/commands/feedback/submit/command.test.ts
@@ -8,6 +8,7 @@ import submitCommand, {
 	MAX_ATTACHMENT_TOTAL_BASE64_CHARS,
 	MAX_ATTACHMENT_TOTAL_BYTES,
 	planAttachmentUploads,
+	readTailBytes,
 } from "./command";
 
 interface SubmittedAttachment {
@@ -153,6 +154,15 @@ describe("feedback submit attachments", () => {
 		expect(error.message).toContain("total limit");
 		expect(error.message).not.toContain("EACCES");
 		expect(submitted).toBeUndefined();
+	});
+
+	test("readTailBytes clamps to a file that shrank since it was planned", () => {
+		const path = writeFixture("rotated.log", patterned(1_000));
+		// Planned at a larger size, read after rotation left 1,000 bytes.
+		const tail = readTailBytes(path, 50_000);
+		expect(tail.length).toBe(1_000);
+		expect(Buffer.compare(tail, patterned(1_000))).toBe(0);
+		expect(readTailBytes(path, 0).length).toBe(0);
 	});
 
 	test("planAttachmentUploads works from sizes alone", () => {

--- a/packages/cli/src/commands/feedback/submit/command.ts
+++ b/packages/cli/src/commands/feedback/submit/command.ts
@@ -35,14 +35,19 @@ interface FeedbackAttachment {
 	contentBase64: string;
 }
 
-/** The last `length` bytes of a file, without reading the rest into memory. */
-function readTailBytes(filePath: string, length: number): Buffer {
+/**
+ * The last `length` bytes of a file, without reading the rest into memory.
+ * The file is sized again here: a live log can shrink or rotate between the
+ * planning stat and this read, so the tail is clamped to what exists now and
+ * a short read is honored rather than padded.
+ */
+export function readTailBytes(filePath: string, length: number): Buffer {
 	const size = statSync(filePath).size;
-	const buffer = Buffer.alloc(length);
+	const wanted = Math.min(length, size);
+	const buffer = Buffer.alloc(wanted);
 	const fd = openSync(filePath, "r");
 	try {
-		// A log rotated between the size check and the read comes back short.
-		const read = readSync(fd, buffer, 0, length, size - length);
+		const read = readSync(fd, buffer, 0, wanted, size - wanted);
 		return buffer.subarray(0, read);
 	} finally {
 		closeSync(fd);

--- a/packages/cli/src/commands/feedback/submit/command.ts
+++ b/packages/cli/src/commands/feedback/submit/command.ts
@@ -106,6 +106,55 @@ function collectDiagnostics(): FeedbackAttachment | null {
 	};
 }
 
+export interface AttachmentUploadPlan {
+	files: { path: string; filename: string; bytes: number }[];
+	/** Lines to print before uploading, one per truncated file. */
+	notices: string[];
+}
+
+/** Base64 spends 4 chars per 3 bytes, rounded up to the last group. */
+function base64CharsFor(bytes: number): number {
+	return Math.ceil(bytes / 3) * 4;
+}
+
+/**
+ * Decides what to send from file sizes alone, before any file is read. A lone
+ * file over the budget is cut to its tail (logs are the common case and the
+ * newest bytes are what matter). Several files that together overflow are
+ * rejected here, so nothing is read or encoded only to be thrown away.
+ */
+export function planAttachmentUploads(
+	requested: { path: string; filename: string; size: number }[],
+): AttachmentUploadPlan {
+	const files = requested.map((file) => ({
+		...file,
+		bytes: Math.min(file.size, MAX_ATTACHMENT_TOTAL_BYTES),
+	}));
+	const totalChars = files.reduce(
+		(sum, file) => sum + base64CharsFor(file.bytes),
+		0,
+	);
+	if (totalChars > MAX_ATTACHMENT_TOTAL_BASE64_CHARS) {
+		throw new CLIError(
+			`Attachments exceed the ${ATTACHMENT_LIMIT_LABEL} total limit: ${files.map((file) => file.filename).join(", ")}`,
+			"Attach fewer files, or one file at a time so its tail is kept",
+		);
+	}
+	return {
+		files: files.map(({ path, filename, bytes }) => ({
+			path,
+			filename,
+			bytes,
+		})),
+		notices: files
+			.filter((file) => file.bytes < file.size)
+			.map(
+				(file) =>
+					`Truncated ${file.filename} to its last ${file.bytes} bytes (${ATTACHMENT_LIMIT_LABEL} attachment limit)\n`,
+			),
+	};
+}
+
 export default command({
 	description:
 		"Submit feedback privately to the Superset team (sent from your account so we can reply)",
@@ -139,36 +188,23 @@ export default command({
 			throw new CLIError("Provide the report via --body or --body-file");
 		}
 
-		const attachments: FeedbackAttachment[] = [];
-		const truncated: string[] = [];
-		let totalBase64Chars = 0;
-		for (const rawPath of options.attach?.split(",") ?? []) {
-			const path = rawPath.trim();
-			if (!path) continue;
-			if (!existsSync(path)) {
-				throw new CLIError(`Attachment not found: ${path}`);
-			}
-			// A lone oversized file is usually a log, and its tail is what
-			// matters, so keep the newest bytes instead of failing.
-			const size = statSync(path).size;
-			const bytes = Math.min(size, MAX_ATTACHMENT_TOTAL_BYTES);
-			if (bytes < size) {
-				truncated.push(
-					`Truncated ${basename(path)} to its last ${bytes} bytes (${ATTACHMENT_LIMIT_LABEL} attachment limit)\n`,
-				);
-			}
-			const contentBase64 = readTailBytes(path, bytes).toString("base64");
-			// Base64 is what travels, and the body limit is on encoded size.
-			totalBase64Chars += contentBase64.length;
-			attachments.push({ filename: basename(path), contentBase64 });
-		}
-		if (totalBase64Chars > MAX_ATTACHMENT_TOTAL_BASE64_CHARS) {
-			throw new CLIError(
-				`Attachments exceed the ${ATTACHMENT_LIMIT_LABEL} total limit: ${attachments.map((a) => a.filename).join(", ")}`,
-				"Attach fewer files, or one file at a time so its tail is kept",
-			);
-		}
-		for (const line of truncated) process.stderr.write(line);
+		// Everything is sized before anything is read: a list that cannot fit
+		// is rejected without reading or encoding a byte of it.
+		const requested = (options.attach?.split(",") ?? [])
+			.map((rawPath) => rawPath.trim())
+			.filter(Boolean)
+			.map((path) => {
+				if (!existsSync(path)) {
+					throw new CLIError(`Attachment not found: ${path}`);
+				}
+				return { path, filename: basename(path), size: statSync(path).size };
+			});
+		const plan = planAttachmentUploads(requested);
+		for (const line of plan.notices) process.stderr.write(line);
+		const attachments: FeedbackAttachment[] = plan.files.map((file) => ({
+			filename: file.filename,
+			contentBase64: readTailBytes(file.path, file.bytes).toString("base64"),
+		}));
 		if (options.diagnostics) {
 			const bundle = collectDiagnostics();
 			if (bundle) attachments.push(bundle);


### PR DESCRIPTION
## Problem

Follow-up to #7214, from CodeRabbit's review there. Attachments were sized up front, but each was still read and base64-encoded inside the loop, and the aggregate check ran only afterwards. A list that could never fit was read in full, up to five files already tailed to 3.3 MB each, before the user got the rejection. The PR description claimed otherwise; this makes it true.

## Change

- `planAttachmentUploads(requested)` builds the whole plan from `stat` sizes alone: per-file tail length, truncation notices, and the aggregate check. It throws the same "exceed the total limit" error naming the files before any file is opened.
- The command stats every path, plans, prints notices, and only then reads tails. Behavior for lists that fit is unchanged. Diagnostics accounting stays as shipped, through the 200 KB headroom.

## Testing

- New test makes both fixture files unreadable after creation: a read before the rejection fails with EACCES, the fix yields the limit message. It fails on the merged code and passes here.
- Pure test for the planner (lone oversized file tailed with a notice, two-file overflow rejected naming both).
- `bun test src/commands/feedback/submit` (9 pass), `bun run typecheck` in packages/cli, biome clean.

https://claude.ai/code/session_01UWyngsh3WSdEM6kmf1P8s5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects an overflowing feedback attachment list before reading any of its files.

Previously each attachment was read and base64-encoded inside the loop, so an oversized list was read in full before the total-limit rejection. Now `planAttachmentUploads` builds the whole plan from `stat` sizes alone and throws the same error (naming the files) before any file is opened. Behavior for lists that fit is unchanged.

The tail read now also re-sizes the file and clamps to what currently exists, so a log that shrank or rotated after planning produces a short read instead of a range error.

<sup>Written for commit f65f1c75007d635fc4840877b5ba861a6ba36822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback attachments are validated against individual and combined size limits before upload processing begins.
  * Oversized submissions are rejected earlier with clearer limit handling.
  * Oversized files are safely truncated, with notices accurately reflecting each file’s allowed size.
  * Attachments remain readable when files shrink or rotate during processing, preserving available content without errors.

* **Tests**
  * Added coverage for total-size validation, per-file size calculations, truncation notices, unreadable files, shrinking files, and empty reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->