### PR TITLE
fix(skills,cli,trpc): make /feedback reports land on the right thread with the right versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -647,6 +647,10 @@
         "wrangler": "4.118.0",
       },
     },
+    "apps/review-host": {
+      "name": "review-host",
+      "version": "0.0.0",
+    },
     "apps/streams": {
       "name": "streams",
       "version": "0.0.0",
@@ -918,6 +922,7 @@
         "@types/node": "24.12.0",
         "@types/react": "19.2.14",
         "@types/tailwindcss": "3.1.0",
+        "bun-types": "1.3.14",
         "react-email": "5.0.7",
         "typescript": "6.0.3",
       },
@@ -5964,6 +5969,8 @@
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "review-host": ["review-host@workspace:apps/review-host"],
 
     "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
 

--- a/packages/cli/src/commands/feedback/submit/command.ts
+++ b/packages/cli/src/commands/feedback/submit/command.ts
@@ -11,6 +11,14 @@ import { basename, join } from "node:path";
 import { boolean, CLIError, string } from "@superset/cli-framework";
 import { ApiHttpError } from "../../../lib/api-client";
 import { command } from "../../../lib/command";
+import { env, isDesktopBundled } from "../../../lib/env";
+import { checkHostHealth } from "../../../lib/host/health";
+import {
+	hostServiceLogPath,
+	isProcessAlive,
+	readManifest,
+} from "../../../lib/host/manifest";
+import { resolveOrganizationFromContext } from "../../../lib/resolve-org";
 
 /**
  * The tRPC route is a Vercel function, and Vercel rejects request bodies
@@ -89,21 +97,72 @@ function describeRejection(
 	return null;
 }
 
-function collectDiagnostics(): FeedbackAttachment | null {
+/** electron-log's default main.log location for the desktop app. */
+function appLogPath(): string {
+	const home = os.homedir();
+	switch (process.platform) {
+		case "darwin":
+			return join(home, "Library", "Logs", "Superset", "main.log");
+		case "win32":
+			return join(
+				process.env.APPDATA ?? join(home, "AppData", "Roaming"),
+				"Superset",
+				"logs",
+				"main.log",
+			);
+		default:
+			return join(
+				process.env.XDG_CONFIG_HOME ?? join(home, ".config"),
+				"Superset",
+				"logs",
+				"main.log",
+			);
+	}
+}
+
+async function describeHostService(
+	organizationId: string | undefined,
+): Promise<string> {
+	const manifest = organizationId ? readManifest(organizationId) : null;
+	if (!manifest) return "Host service: not running";
+	// A crashed host leaves its manifest behind; don't probe a dead endpoint
+	// and call it "not responding".
+	if (!isProcessAlive(manifest.pid)) {
+		return `Host service: not running (stale manifest, pid ${manifest.pid} is dead)`;
+	}
+	const health = await checkHostHealth(manifest.endpoint, manifest.authToken);
+	if (!health.healthy) return "Host service: running but not responding";
+	const parts = [
+		`version ${health.version ?? "unknown"}`,
+		`cloudRegistered=${health.cloudRegistered ?? "unknown"}`,
+	];
+	if (health.registrationError) {
+		parts.push(`registrationError=${health.registrationError}`);
+	}
+	return `Host service: ${parts.join(", ")}`;
+}
+
+async function collectDiagnostics(
+	organizationId: string | undefined,
+): Promise<FeedbackAttachment> {
 	const lines = [
 		`Collected: ${new Date().toISOString()}`,
-		`CLI version: ${process.env.SUPERSET_VERSION ?? "dev"}`,
+		`CLI version: ${env.VERSION} (${isDesktopBundled() ? "bundled with the desktop app" : "standalone"})`,
 		`OS: ${os.platform()} ${os.release()} ${os.arch()}`,
+		await describeHostService(organizationId),
 	];
-	const logPath = join(os.homedir(), "Library", "Logs", "Superset", "main.log");
-	if (process.platform === "darwin" && existsSync(logPath)) {
-		lines.push(
-			"",
-			`--- last ${DIAGNOSTICS_LOG_TAIL_LINES} lines of ${logPath} ---`,
-			readTail(logPath),
-		);
-	} else {
-		lines.push("", "(no app log found on this machine)");
+	const logPaths = [appLogPath()];
+	if (organizationId) logPaths.push(hostServiceLogPath(organizationId));
+	for (const logPath of logPaths) {
+		if (existsSync(logPath)) {
+			lines.push(
+				"",
+				`--- last ${DIAGNOSTICS_LOG_TAIL_LINES} lines of ${logPath} ---`,
+				readTail(logPath),
+			);
+		} else {
+			lines.push("", `(no log at ${logPath})`);
+		}
 	}
 	return {
 		filename: "feedback-diagnostics.txt",
@@ -177,7 +236,7 @@ export default command({
 			`Comma-separated file paths to attach (screenshots, logs; ${ATTACHMENT_LIMIT_LABEL} total, a lone larger file is cut to its tail)`,
 		),
 		diagnostics: boolean().desc(
-			"Attach a diagnostics bundle (CLI version, OS, last 200 app log lines)",
+			"Attach a diagnostics bundle (versions, OS, last 200 lines of the app and host-service logs)",
 		),
 	},
 	run: async ({ ctx, options }) => {
@@ -211,8 +270,16 @@ export default command({
 			contentBase64: readTailBytes(file.path, file.bytes).toString("base64"),
 		}));
 		if (options.diagnostics) {
-			const bundle = collectDiagnostics();
-			if (bundle) attachments.push(bundle);
+			// Best effort: an unreachable API must not block a report, so fall
+			// back to the org id stored locally.
+			const organizationId = await resolveOrganizationFromContext(
+				ctx.api,
+				ctx.config.organizationId,
+				undefined,
+			)
+				.then((organization) => organization.id)
+				.catch(() => ctx.config.organizationId);
+			attachments.push(await collectDiagnostics(organizationId));
 		}
 		if (attachments.length > 5) {
 			throw new CLIError("At most 5 attachments per submission");
@@ -223,7 +290,7 @@ export default command({
 				type: options.type,
 				title: options.title,
 				body,
-				appVersion: process.env.SUPERSET_VERSION ?? "dev",
+				appVersion: env.VERSION,
 				os: `${os.platform()} ${os.release()} ${os.arch()}`,
 				attachments: attachments.length > 0 ? attachments : undefined,
 			});
@@ -241,7 +308,7 @@ export default command({
 		return {
 			data: { submitted: true, attachments: attachments.length },
 			message:
-				"Feedback sent to the Superset team. A copy was CC'd to your account email; replies land there too.",
+				"Feedback sent to the Superset team. A copy was CC'd to your account email; reply there with any follow-up so it stays on the same thread.",
 		};
 	},
 });

--- a/packages/cli/src/commands/status/command.ts
+++ b/packages/cli/src/commands/status/command.ts
@@ -3,49 +3,9 @@ import { getHostId } from "@superset/shared/host-info";
 import { formatDistanceToNowStrict } from "date-fns";
 import type { ApiClient } from "../../lib/api-client";
 import { command } from "../../lib/command";
+import { checkHostHealth } from "../../lib/host/health";
 import { isProcessAlive, readManifest } from "../../lib/host/manifest";
 import { resolveOrganizationFromContext } from "../../lib/resolve-org";
-
-type HealthResult = {
-	healthy: boolean;
-	/** undefined = host-service predates the field (pre-#6415). */
-	cloudRegistered?: boolean;
-	registrationError?: string | null;
-};
-
-async function checkHealth(
-	endpoint: string,
-	authToken: string,
-): Promise<HealthResult> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), 2_000);
-	try {
-		const res = await fetch(`${endpoint}/trpc/health.check`, {
-			signal: controller.signal,
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
-		if (!res.ok) return { healthy: false };
-		const body = (await res.json()) as {
-			result?: { data?: { json?: Record<string, unknown> } };
-		};
-		const payload = body.result?.data?.json;
-		return {
-			healthy: true,
-			cloudRegistered:
-				typeof payload?.cloudRegistered === "boolean"
-					? payload.cloudRegistered
-					: undefined,
-			registrationError:
-				typeof payload?.registrationError === "string"
-					? payload.registrationError
-					: undefined,
-		};
-	} catch {
-		return { healthy: false };
-	} finally {
-		clearTimeout(timeout);
-	}
-}
 
 async function fetchHostName(
 	api: ApiClient,
@@ -103,7 +63,7 @@ export default command({
 		}
 
 		const [health, cloudHost] = await Promise.all([
-			checkHealth(manifest.endpoint, manifest.authToken),
+			checkHostHealth(manifest.endpoint, manifest.authToken),
 			fetchHostName(ctx.api, organization.id, localHostId),
 		]);
 		const uptime = formatDistanceToNowStrict(new Date(manifest.startedAt));
@@ -132,6 +92,7 @@ export default command({
 				organizationId: organization.id,
 				hostId: localHostId,
 				hostName: cloudHost.name,
+				...(health.version ? { hostServiceVersion: health.version } : {}),
 				...(cloudRegistered === undefined ? {} : { cloudRegistered }),
 				...(health.registrationError
 					? { registrationError: health.registrationError }

--- a/packages/cli/src/lib/host/health.ts
+++ b/packages/cli/src/lib/host/health.ts
@@ -1,0 +1,47 @@
+export type HostHealth = {
+	healthy: boolean;
+	/** undefined = host-service predates the field (pre-#6415). */
+	cloudRegistered?: boolean;
+	registrationError?: string | null;
+	/**
+	 * Build serving requests. Equals the desktop app's version when the app
+	 * spawned the service, which is how a standalone CLI learns the app version.
+	 */
+	version?: string;
+};
+
+export async function checkHostHealth(
+	endpoint: string,
+	authToken: string,
+): Promise<HostHealth> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 2_000);
+	try {
+		const res = await fetch(`${endpoint}/trpc/health.check`, {
+			signal: controller.signal,
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		if (!res.ok) return { healthy: false };
+		const body = (await res.json()) as {
+			result?: { data?: { json?: Record<string, unknown> } };
+		};
+		const payload = body.result?.data?.json;
+		return {
+			healthy: true,
+			cloudRegistered:
+				typeof payload?.cloudRegistered === "boolean"
+					? payload.cloudRegistered
+					: undefined,
+			registrationError:
+				typeof payload?.registrationError === "string"
+					? payload.registrationError
+					: undefined,
+			version:
+				typeof payload?.version === "string" ? payload.version : undefined,
+		};
+	} catch {
+		return { healthy: false };
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/packages/cli/src/lib/host/manifest.ts
+++ b/packages/cli/src/lib/host/manifest.ts
@@ -38,6 +38,10 @@ export function ensureManifestDir(organizationId: string): string {
 	return dir;
 }
 
+export function hostServiceLogPath(organizationId: string): string {
+	return join(manifestDir(organizationId), "host-service.log");
+}
+
 export function writeManifest(manifest: HostServiceManifest): void {
 	ensureManifestDir(manifest.organizationId);
 	const path = manifestPath(manifest.organizationId);

--- a/packages/cli/src/lib/host/spawn.ts
+++ b/packages/cli/src/lib/host/spawn.ts
@@ -14,6 +14,7 @@ import {
 	ensureManifestDir,
 	type HostServiceManifest,
 	hostDbPath,
+	hostServiceLogPath,
 	writeManifest,
 } from "./manifest";
 import { getRelayUrl } from "./relay-url";
@@ -118,9 +119,10 @@ export async function spawnHostService(
 	// Daemon output goes to the same per-org host-service.log the desktop
 	// writes — with stdio ignored, a failed cloud registration was logged
 	// nowhere on CLI-only installs (issue #6415).
+	if (options.daemon) ensureManifestDir(options.organizationId);
 	const logFd = options.daemon
 		? openRotatingLogFd(
-				join(ensureManifestDir(options.organizationId), "host-service.log"),
+				hostServiceLogPath(options.organizationId),
 				MAX_HOST_LOG_BYTES,
 			)
 		: -1;

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -7,6 +7,7 @@
 		"@types/node": "24.12.0",
 		"@types/react": "19.2.14",
 		"@types/tailwindcss": "3.1.0",
+		"bun-types": "1.3.14",
 		"react-email": "5.0.7",
 		"typescript": "6.0.3"
 	},
@@ -20,6 +21,7 @@
 		"dev": "NEXT_PUBLIC_MARKETING_URL=$(grep NEXT_PUBLIC_MARKETING_URL ../../.env | cut -d '=' -f2) email dev --dir src/emails",
 		"export": "email export --dir src/emails",
 		"sync:automations": "bun scripts/sync-automations.ts",
+		"test": "bun test",
 		"typecheck": "tsc --noEmit"
 	},
 	"type": "module",

--- a/packages/email/src/emails/feedback-report.test.ts
+++ b/packages/email/src/emails/feedback-report.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { feedbackReportText } from "./feedback-report";
+
+const report = {
+	type: "bug" as const,
+	title: "Terminal: pane goes blank after waking from sleep",
+	body: "Summary\n- Pane goes blank\n- Every time\n\nSteps to reproduce\n1. Sleep\n2. Wake",
+	userName: "Jane Doe",
+	userEmail: "jane@example.com",
+	userId: "user-1",
+	accountCreated: "2026-07-09T00:00:00.000Z",
+	organizationName: "Acme",
+	organizationId: "org-1",
+	plan: "pro (active)",
+	appVersion: "1.26.0",
+	os: "darwin 25.5.0 arm64",
+};
+
+describe("feedbackReportText", () => {
+	test("keeps the report's line breaks intact", () => {
+		const text = feedbackReportText(report);
+		expect(text).toContain("Summary\n- Pane goes blank\n- Every time\n\n");
+		expect(text).toContain("Steps to reproduce\n1. Sleep\n2. Wake");
+	});
+
+	test("carries the same metadata as the HTML email", () => {
+		const text = feedbackReportText(report);
+		expect(text.startsWith("Bug report · pro (active)\n")).toBe(true);
+		expect(text).toContain("Reporter: Jane Doe <jane@example.com>");
+		expect(text).toContain("Organization: Acme");
+		expect(text).toContain("Customer since: Jul 9, 2026");
+		expect(text).toContain("Environment: 1.26.0 · darwin 25.5.0 arm64");
+		expect(text).toContain("User ID user-1 · Org ID org-1");
+	});
+
+	test("drops optional lines that have no value", () => {
+		const text = feedbackReportText({
+			...report,
+			userName: undefined,
+			organizationName: undefined,
+			organizationId: undefined,
+			accountCreated: undefined,
+		});
+		expect(text).not.toContain("Organization:");
+		expect(text).not.toContain("Customer since:");
+		expect(text).not.toContain("Org ID");
+		expect(text).toContain("respond to the reporter directly");
+		expect(text).toContain("Reporter: jane@example.com");
+	});
+});

--- a/packages/email/src/emails/feedback-report.tsx
+++ b/packages/email/src/emails/feedback-report.tsx
@@ -9,7 +9,7 @@ import {
 	Text,
 } from "@react-email/components";
 
-interface FeedbackReportEmailProps {
+export interface FeedbackReportEmailProps {
 	type: "bug" | "feature" | "general";
 	title: string;
 	body: string;
@@ -30,6 +30,67 @@ const TYPE_LABELS: Record<FeedbackReportEmailProps["type"], string> = {
 	general: "Feedback",
 };
 
+function formatReporter(userName: string | undefined, userEmail: string) {
+	return userName ? `${userName} <${userEmail}>` : userEmail;
+}
+
+function formatAccountSince(accountCreated: string | undefined) {
+	return accountCreated
+		? new Date(accountCreated).toLocaleDateString("en-US", {
+				year: "numeric",
+				month: "short",
+				day: "numeric",
+				// Pin the zone so the HTML and text parts agree wherever they render.
+				timeZone: "UTC",
+			})
+		: undefined;
+}
+
+/**
+ * Plain-text twin of the React email. Resend's automatic text conversion
+ * collapses the report's line breaks, which turns "Summary" bullets into one
+ * run-on paragraph in text-only clients and quoted replies.
+ */
+export function feedbackReportText({
+	type,
+	title,
+	body,
+	userName,
+	userEmail,
+	userId,
+	accountCreated,
+	organizationName,
+	organizationId,
+	plan,
+	appVersion,
+	os,
+}: FeedbackReportEmailProps): string {
+	const accountSince = formatAccountSince(accountCreated);
+	const divider = "-".repeat(40);
+	return [
+		`${TYPE_LABELS[type]} · ${plan}`,
+		"",
+		title,
+		"",
+		body,
+		"",
+		divider,
+		"",
+		`Reply to this email to respond to ${userName || "the reporter"} directly (${userEmail}).`,
+		"",
+		`Reporter: ${formatReporter(userName, userEmail)}`,
+		organizationName ? `Organization: ${organizationName}` : null,
+		accountSince ? `Customer since: ${accountSince}` : null,
+		`Environment: ${appVersion ?? "unknown version"} · ${os ?? "unknown OS"}`,
+		"",
+		divider,
+		"",
+		`User ID ${userId}${organizationId ? ` · Org ID ${organizationId}` : ""}`,
+	]
+		.filter((line) => line !== null)
+		.join("\n");
+}
+
 export function FeedbackReportEmail({
 	type = "bug",
 	title = "Terminal detaches on sleep",
@@ -44,14 +105,8 @@ export function FeedbackReportEmail({
 	appVersion = "1.20.0",
 	os = "darwin 25.6.0 arm64",
 }: FeedbackReportEmailProps) {
-	const reporter = userName ? `${userName} <${userEmail}>` : userEmail;
-	const accountSince = accountCreated
-		? new Date(accountCreated).toLocaleDateString("en-US", {
-				year: "numeric",
-				month: "short",
-				day: "numeric",
-			})
-		: undefined;
+	const reporter = formatReporter(userName, userEmail);
+	const accountSince = formatAccountSince(accountCreated);
 
 	return (
 		<Html>

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "@superset/typescript/base.json",
 	"compilerOptions": {
 		"lib": ["ES2022"],
+		"types": ["bun-types"],
 		"jsx": "react-jsx",
 		"moduleResolution": "bundler"
 	},

--- a/packages/host-service/src/trpc/router/health/health.ts
+++ b/packages/host-service/src/trpc/router/health/health.ts
@@ -1,5 +1,10 @@
+import hostServicePackageJson from "@superset/host-service/package.json" with {
+	type: "json",
+};
 import { getRegistrationState } from "../../../tunnel/registration-state";
 import { publicProcedure, router } from "../../index";
+
+const HOST_SERVICE_VERSION: string = hostServicePackageJson.version;
 
 export const healthRouter = router({
 	check: publicProcedure.query(() => {
@@ -9,6 +14,9 @@ export const healthRouter = router({
 		const registration = getRegistrationState();
 		return {
 			status: "ok" as const,
+			// The desktop app spawns its own bundled build, so this doubles as
+			// the app version for a standalone CLI collecting diagnostics.
+			version: HOST_SERVICE_VERSION,
 			cloudRegistered: registration.registered,
 			registrationError: registration.lastError,
 		};

--- a/packages/host-service/test/integration/smoke.integration.test.ts
+++ b/packages/host-service/test/integration/smoke.integration.test.ts
@@ -17,6 +17,7 @@ describe("host-service smoke", () => {
 		const result = await host.unauthenticatedTrpc.health.check.query();
 		expect(result).toEqual({
 			status: "ok",
+			version: expect.stringMatching(/^\d+\.\d+\.\d+/),
 			cloudRegistered: false,
 			registrationError: null,
 		});
@@ -26,6 +27,7 @@ describe("host-service smoke", () => {
 		const result = await host.trpc.health.check.query();
 		expect(result).toEqual({
 			status: "ok",
+			version: expect.stringMatching(/^\d+\.\d+\.\d+/),
 			cloudRegistered: false,
 			registrationError: null,
 		});

--- a/packages/trpc/src/router/support/support.ts
+++ b/packages/trpc/src/router/support/support.ts
@@ -5,7 +5,10 @@ import {
 	subscriptions,
 	users,
 } from "@superset/db/schema";
-import { FeedbackReportEmail } from "@superset/email/emails/feedback-report";
+import {
+	FeedbackReportEmail,
+	feedbackReportText,
+} from "@superset/email/emails/feedback-report";
 import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
 import { COMPANY } from "@superset/shared/constants";
 import { Ratelimit } from "@upstash/ratelimit";
@@ -263,6 +266,25 @@ export const supportRouter = createTRPCRouter({
 				content: attachment.contentBase64,
 			}));
 
+			const report = {
+				type: input.type,
+				title: safeTitle,
+				body: input.body,
+				userName: safeName || undefined,
+				userEmail: user.email,
+				userId: user.id,
+				accountCreated: userRow?.createdAt?.toISOString(),
+				organizationName: orgRow
+					? sanitizeEmailBodyLine(orgRow.name)
+					: undefined,
+				organizationId: organizationId ?? undefined,
+				plan: planLabel,
+				appVersion: input.appVersion
+					? sanitizeEmailBodyLine(input.appVersion)
+					: undefined,
+				os: input.os ? sanitizeEmailBodyLine(input.os) : undefined,
+			};
+
 			try {
 				// Resend reports API failures via the resolved `error` field, not by
 				// throwing — without this check a rejected email would "succeed".
@@ -274,24 +296,11 @@ export const supportRouter = createTRPCRouter({
 					replyTo: user.email,
 					subject: `[Feedback: ${input.type}] ${safeTitle}`,
 					attachments,
-					react: FeedbackReportEmail({
-						type: input.type,
-						title: safeTitle,
-						body: input.body,
-						userName: safeName || undefined,
-						userEmail: user.email,
-						userId: user.id,
-						accountCreated: userRow?.createdAt?.toISOString(),
-						organizationName: orgRow
-							? sanitizeEmailBodyLine(orgRow.name)
-							: undefined,
-						organizationId: organizationId ?? undefined,
-						plan: planLabel,
-						appVersion: input.appVersion
-							? sanitizeEmailBodyLine(input.appVersion)
-							: undefined,
-						os: input.os ? sanitizeEmailBodyLine(input.os) : undefined,
-					}),
+					// Resend derives the text/plain part from the HTML and collapses
+					// the report's line breaks; supply it explicitly so Summary
+					// bullets survive in plain-text clients and quoted replies.
+					text: feedbackReportText(report),
+					react: FeedbackReportEmail(report),
 				});
 				if (error) throw error;
 			} catch (error) {

--- a/plugins/superset/skills/feedback/SKILL.md
+++ b/plugins/superset/skills/feedback/SKILL.md
@@ -11,23 +11,47 @@ Turn the user's feedback about Superset into a short, scannable report and submi
 
 The reader is a Superset engineer triaging dozens of reports. They should get the point from the title, the full picture from the summary bullets, and only read further when they need detail. Cut everything that doesn't help them reproduce or decide.
 
+## 0. Is this a follow-up?
+
+Every private submission CCs the reporter, so they already have a copy in their inbox with a subject starting `[Feedback: ...]`. A reply to that email lands on the same thread; a new submission opens a new one and the team has to reconcile them by hand.
+
+If the seed reads like a continuation ("follow-up", "again", "still happening", "update on", "retraction", "root cause", "I already sent", "third time"), or the user filed something on this topic earlier in the session, ask whether they already sent a report about it. If they did, tell them to reply to that email with the new information and stop here. Only file fresh when they confirm it's a different issue.
+
+Never title a report "Follow-up:", "ROOT CAUSE:", or "RETRACTION"; those belong in a reply.
+
 ## 1. Gather context (best effort, never block)
 
 Run in parallel; skip anything that fails:
 
 - `superset --version` and `uname -sm` for the environment line
 - `superset auth whoami` for the signed-in user/org (private submissions only)
+- `superset status --json` for the host service; its `hostServiceVersion` is the desktop app's version when the app spawned the service
 
 Don't include repository contents, terminal output, or logs unless the user explicitly agrees when asked; they can contain private paths and code.
 
-For **bugs**, also offer (never assume):
+### Version check
+
+Many reports describe bugs already fixed in a newer release. Desktop, CLI, and host service share one version number, so compare what's running against the latest release:
+
+- Latest: `superset update --check --json` (standalone CLI). If it says the CLI is bundled with the desktop app, the CLI version is the app version; get the latest from `gh release download cli-latest -R superset-sh/superset -p version.txt -O -` instead.
+- Running: the CLI version, and `hostServiceVersion` from `superset status --json` if it differs.
+
+If anything is behind, say so before drafting and ask whether they want to update first (the desktop app updates itself from its menu; a standalone CLI with `superset update`). If they'd rather file now, note the versions in the report.
+
+### Bugs about hosts, automations, terminals, or remote workspaces
+
+Symptoms like "host not registered", "hosts list is empty", "automations create fails", "host shows offline", "terminal won't attach", or "workspace missing from the sidebar" are the most common reports and usually have a known cause. Before drafting, run the doctor skill's snapshot (`superset status`, `superset auth whoami`, `superset hosts list`) and apply its signature table. If that fixes it, there's nothing to report. If it doesn't, keep the `superset status --json` output for the report; it's what the team asks for first.
+
+### Evidence (bugs only, offer, never assume)
 
 - **Screenshot**: if the bug is visual and you can capture one, offer to attach it. Evidence beats prose.
-- **Diagnostics**: offer to attach a diagnostics bundle (CLI version, OS, last 200 app log lines) via the `--diagnostics` flag. Tell the user logs can contain file paths and project names before they agree.
+- **Diagnostics**: offer the `--diagnostics` bundle: versions, OS, and the last 200 lines of the app log and the host-service log. Tell the user logs can contain file paths and project names before they agree. Prefer the bundle over attaching raw log files; attach a file only when the tail isn't enough. Attachments must total under about 3 MB; a single larger log is cut to its tail automatically.
 
 ## 2. Classify and draft
 
 Classify as **bug**, **feature request**, or **general feedback** from their words; ask only if genuinely ambiguous.
+
+**One report per root issue, one request per ask.** Two symptoms of the same failure are one bug. Three unrelated wishes are three feature requests; offer to split them, then file each separately. Don't file a second report for a different symptom of something the user just filed.
 
 ### Title
 
@@ -42,9 +66,9 @@ Bad: `Bug with terminal`, `Terminal rendering broken because xterm loses WebGL c
 
 ### Body
 
-Plain text that also reads well as markdown: section labels on their own line, `-` bullets, numbered steps. No headings, bold, or tables; the private path is delivered as a plain-text email. Keep the user's own words where they're precise, tighten where they ramble.
+Plain text that also reads well as markdown: section labels on their own line, `-` bullets, numbered steps. No headings, bold, or tables; the private path is delivered as a plain-text email. Keep the user's own words where they're precise, tighten where they ramble. A one-line seed still gets Summary bullets.
 
-Every report starts with a **Summary** of 2-4 bullets that stand alone. Someone reading only those bullets should know what's wrong (or wanted), how bad it is, and how often it happens.
+Every report starts with a **Summary** of 2-4 bullets that stand alone. Someone reading only those bullets should know what's wrong (or wanted), how bad it is, and how often it happens. Summary bullets are observations, never hypotheses.
 
 Bug:
 
@@ -65,9 +89,20 @@ The terminal repaints and keeps its scrollback.
 Actual
 The pane is solid black until the window is reloaded.
 
+Investigation
+Hypothesis: main.log shows "WebGL context lost" at the moment of wake, so the renderer may not be reacquiring it.
+
+Host status
+{"running":true,"healthy":true,"cloudRegistered":false,...}
+
 Environment
 Superset 1.21.0, macOS 26.0 arm64
 ```
+
+- **Investigation** is optional and only for findings the user or you actually made: a log line, a measurement, a code path read from the repo. Label guesses `Hypothesis:`. Never promote them into the title or Summary; reporters have been confidently wrong, and a wrong cause in the title sends triage down the wrong path.
+- **Host status** is the `superset status --json` output, only for the bug classes in step 1.
+- **Environment** goes in the body only on the public path, or when the desktop app version differs from the CLI version; the private path already appends the CLI version and OS.
+- Never submit a checklist with unanswered items ("not yet checked"). Either get the answer or drop the question.
 
 Feature request:
 
@@ -85,7 +120,7 @@ A pin action in the automation's context menu, pinned items listed first.
 
 General feedback: Summary bullets, then one short paragraph of detail if there's more to say.
 
-Omit any section with nothing to say. Steps, Expected, Actual, and Environment are for bugs only. Target under 150 words; go longer only when the extra words help reproduce.
+Omit any section with nothing to say. Steps, Expected, Actual, Investigation, Host status, and Environment are for bugs only. Target under 150 words; go longer only when the extra words help reproduce.
 
 ## 3. Ask where to send it
 
@@ -107,7 +142,7 @@ Never submit anything before the user explicitly picks 1 or 2. Loop on edits.
   <drafted report>
   EOF
   ```
-  Only when the user agreed to them in step 1, add `--attach /path/to/screenshot.png` (comma-separated paths, 10MB total) and/or `--diagnostics`. The submission is sent from the user's Superset account, a copy is CC'd to them, and the team replies to their account email.
+  Only when the user agreed to them in step 1, add `--attach /path/to/screenshot.png` (comma-separated paths, about 3 MB total) and/or `--diagnostics`. The submission is sent from the user's Superset account, a copy is CC'd to them, and the team replies to their account email.
 - If the CLI is missing or not logged in (`superset auth whoami` fails), offer `superset auth login` first; if declined, fall back to email: give the user a clickable mailto link (`mailto:support@superset.sh?subject=<url-encoded title>&body=<url-encoded body>`) and also print the raw draft so they can copy it.
 
 **Public path:**
@@ -117,4 +152,4 @@ Never submit anything before the user explicitly picks 1 or 2. Loop on edits.
 
 ## 5. Confirm
 
-Report back the issue URL (public) or a confirmation of what was sent and to whom (private). If anything failed, show the draft so the user's writing is never lost.
+Report back the issue URL (public) or a confirmation of what was sent and to whom (private). Remind them that more information on the same issue goes as a reply to the CC'd email, not a new report. If anything failed, show the draft so the user's writing is never lost.


### PR DESCRIPTION
## Summary
- Rewrite the `/feedback` skill around what an audit of ~200 private reports showed: follow-ups and retractions open new threads, ~15% of bugs are the host-registration cluster `/doctor` already covers, reports arrive from stale versions, and wrong root causes land in titles.
- Fix two pipeline gaps found along the way: the diagnostics bundle was macOS-only and never included host-service.log, and the email's plain-text part collapsed every line break.

## Why / Context
The skill's report format is fine; nearly every team reply opens "thanks for the detailed report." The waste is before and after drafting. Concrete cases from the inbox: one user filed three reports in an hour for one relay cutover, another filed a "RETRACTION" report, several filed twice within minutes for one root cause, a feature request asked for folders on 1.22 after they shipped in 1.26, and one "ROOT CAUSE:" title named a file:line that was wrong.

The attachment-size 413 the audit also surfaced was fixed on main by #7214 and #7224 while this was in flight; this PR is rebased on those and only describes that behavior in the skill.

## How It Works

**Skill** (`plugins/superset/skills/feedback/SKILL.md`)
- Step 0: if the seed reads like a continuation, ask whether they already sent a report and point them at the CC'd email so it threads.
- Version check: `superset update --check --json` for a standalone CLI; the desktop-bundled CLI refuses that command, so fall back to `gh release download cli-latest -p version.txt -O -` (verified: prints `1.26.0`). `hostServiceVersion` from `superset status --json` covers the app version when the CLI is standalone.
- Host/automation/terminal bugs run the doctor snapshot first and carry the status JSON into a "Host status" section.
- One report per root issue, one request per ask. Findings go in an "Investigation" section labeled `Hypothesis:`, never in the title or Summary. No unanswered checklists. Environment only on the public path.

**Pipeline**
- Diagnostics bundle records the CLI channel, host-service version and registration state, and tails both the app log (macOS, Linux, Windows electron-log paths) and the per-org `host-service.log`. A stale manifest from a crashed host is reported as dead rather than probed.
- `health.check` returns `version`; `superset status --json` exposes it as `hostServiceVersion`. The health probe moves to `lib/host/health.ts` so status and feedback share it.
- `feedbackReportText` builds the text/plain part with real newlines and is passed as `text` next to `react`. The "customer since" date is pinned to UTC so both parts agree in any timezone.

## Manual QA Checklist
- [ ] `superset feedback submit --diagnostics` on a machine with a running host: bundle lists CLI channel, host-service version, and both log tails
- [ ] Same with no host running: bundle says "Host service: not running" and still submits
- [ ] Same with a leftover manifest from a crashed host: bundle says "stale manifest, pid N is dead"
- [ ] `superset status --json` against a host-service from this build shows `hostServiceVersion`; against an older host-service the key is absent
- [ ] Received email: plain-text alternative keeps Summary bullets on separate lines

## Testing
- `tsc --noEmit` in cli, trpc, email, host-service
- `biome check` on changed files, `sherif` clean
- `bun test` in packages/cli (feedback, status, host lib: 15 pass) and packages/host-service trpc (697 pass)
- New test `feedback-report.test.ts` (text part keeps line breaks, metadata parity, optional lines dropped), also run under `TZ=America/Los_Angeles`
- `packages/email` had no `test` script or bun types; added both so the new test typechecks and runs in CI

## Known Limitations
- The email template's `toLocaleDateString("en-US")` predates this PR; I moved it into a helper shared by both renderers and pinned the zone, but did not change the locale.
- The superset plugin's skills ship with desktop releases and are not gated by `check:plugins`, so users see the new skill text on their next app update.

https://claude.ai/code/session_01DhL3LXZu9TuGRwwx1gmraw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feedback submissions now support smarter attachment handling, including size limits and tail-preserved oversized files.
  - Diagnostic reports include relevant desktop and host-service details across platforms.
  - Host status checks now report host-service version information.
  - Feedback reports now include a matching plain-text email format.

- **Bug Fixes**
  - Improved handling and messaging for rejected feedback requests.
  - Host health checks now behave consistently, including during timeouts and connection failures.

- **Documentation**
  - Updated feedback guidance with host troubleshooting, diagnostics, follow-up detection, and attachment instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->