### PR TITLE
fix(cli): mark --host/--local as required in command help

### DIFF
--- a/packages/cli/src/commands/agents/list/command.ts
+++ b/packages/cli/src/commands/agents/list/command.ts
@@ -5,8 +5,8 @@ import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
 export default command({
 	description: "List agents configured on a host",
 	options: {
-		host: string().desc("Target host machineId"),
-		local: boolean().desc("Target this machine"),
+		host: string().desc("Target host machineId (required unless --local)"),
+		local: boolean().desc("Target this machine (required unless --host)"),
 	},
 	display: (data) =>
 		table(

--- a/packages/cli/src/commands/projects/create/command.ts
+++ b/packages/cli/src/commands/projects/create/command.ts
@@ -5,8 +5,8 @@ import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
 export default command({
 	description: "Create a project on a host",
 	options: {
-		host: string().desc("Target host machineId"),
-		local: boolean().desc("Target this machine"),
+		host: string().desc("Target host machineId (required unless --local)"),
+		local: boolean().desc("Target this machine (required unless --host)"),
 		name: string().required().desc("Project name"),
 		clone: string().desc(
 			"Git remote URL to clone (requires --parent-dir). Mutually exclusive with --import",

--- a/packages/cli/src/commands/projects/setup/command.ts
+++ b/packages/cli/src/commands/projects/setup/command.ts
@@ -17,8 +17,8 @@ export default command({
 		"Adopt an existing project on a host (clone its repo or import a folder)",
 	args: [positional("id").desc("Project UUID to adopt")],
 	options: {
-		host: string().desc("Target host machineId"),
-		local: boolean().desc("Target this machine"),
+		host: string().desc("Target host machineId (required unless --local)"),
+		local: boolean().desc("Target this machine (required unless --host)"),
 		project: string().desc("Project UUID to adopt"),
 		path: string().desc(
 			"Existing local repo path on the target host (alias for --import)",

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -7,8 +7,12 @@ import { createCloudWorkspace } from "./createCloudWorkspace";
 export default command({
 	description: "Create a workspace on a host, or a cloud sandbox with --cloud",
 	options: {
-		host: string().desc("Target host machineId (required unless --local)"),
-		local: boolean().desc("Target this machine (required unless --host)"),
+		host: string().desc(
+			"Target host machineId (required unless --local or --cloud)",
+		),
+		local: boolean().desc(
+			"Target this machine (required unless --host or --cloud)",
+		),
 		cloud: boolean().desc(
 			"Provision a cloud sandbox instead of using one of your machines",
 		),

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -7,8 +7,8 @@ import { createCloudWorkspace } from "./createCloudWorkspace";
 export default command({
 	description: "Create a workspace on a host, or a cloud sandbox with --cloud",
 	options: {
-		host: string().desc("Target host machineId"),
-		local: boolean().desc("Target this machine"),
+		host: string().desc("Target host machineId (required unless --local)"),
+		local: boolean().desc("Target this machine (required unless --host)"),
 		cloud: boolean().desc(
 			"Provision a cloud sandbox instead of using one of your machines",
 		),


### PR DESCRIPTION
## What & why

`workspaces create`, `projects create`, `projects setup` and `agents list` all resolve their target host through `requireHostTarget`, which throws when neither `--host` nor `--local` is given:

```
$ superset ws create --project <id> --name fix-x --branch fix/x --base-branch main
Error: Target host required
Hint: Pass --local for this machine, or --host <id> for a specific host.
```

Their help text gave no hint that one of the two was mandatory:

```
--host <string>         Target host machineId
--local                 Target this machine
--project <string>      Project ID. Omit to create a project-less session (a managed scratch folder)
```

`--project` explicitly documents that omitting it is fine, which makes the two flags above read as equally optional. You find out otherwise at runtime.

This is inconsistent with the rest of the CLI rather than a matter of taste. **Every** command where the host target really is optional already says so in the description:

| command | description |
| --- | --- |
| `terminals read/list/send/create/close` | `Host the workspace lives on (default: this machine)` |
| `workspaces get` / `workspaces update` | `Host the workspace lives on (default: this machine)` |
| `workspaces list` | `List workspaces on this machine (the default)` |
| `workspaces delete` | `Target this machine (the default)` |
| `projects list` | `List projects on this machine (the default)` |

And the published CLI reference already documents the four commands in this PR as required — `apps/docs/content/docs/cli/cli-reference.mdx`:

> `--host <id>` — Target host machineId. Mutually exclusive with `--local`; one is required.

So the docs and the runtime already agreed; `--help` was the only place that didn't. This aligns it, using the same parenthetical style the surrounding flags use:

```diff
-host: string().desc("Target host machineId"),
-local: boolean().desc("Target this machine"),
+host: string().desc("Target host machineId (required unless --local)"),
+local: boolean().desc("Target this machine (required unless --host)"),
```

I hit this building a browser extension that files UI bugs into a workspace — context in #7226, though this PR stands on its own.

## How I tested it

In a workspace off current `main` (`c0c3a5776`):

- `bun run lint` — clean, no fixes applied, 7225 files checked
- `bun run typecheck` — 38/38 tasks successful
- `bun run test` — 12/14 tasks successful. **One pre-existing failure unrelated to this change:** `@superset/trpc` fails 1 of 177 tests with `error: Invalid environment variables`, because `setup.local.sh` could not complete in my workspace (`✗ Root .env file not found`). I confirmed it is pre-existing by reverting this diff (`git checkout -- packages/cli`) and re-running that package: identical result, 176 pass / 1 fail. Re-applied afterwards.

No screenshot: this is CLI help text, and the before/after is the diff above plus the real `--help` output quoted at the top, captured from the released CLI (v1.25.1). I was not able to boot the dev CLI inside the workspace to capture the "after" verbatim — `bunx cli-framework dev` fails there with `Cannot find package 'babel-plugin-macros'`, downstream of the same incomplete `setup.local.sh`. Happy to add captured output if a maintainer can point me at the right way to run it, or if you'd rather see it built.

Only the four `.desc()` strings changed — no behaviour change, so nothing to add tests for.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsdetZKZpBtiucVzvPESEA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `--help` text for `workspaces create`, `projects create`, `projects setup`, and `agents list` so `--host` and `--local` are clearly required. These commands already throw at runtime when neither flag is passed, but the old help output made both look optional; the new descriptions match the published CLI reference, and `workspaces create` also notes that `--cloud` removes the requirement.

<sup>Written for commit 406162d97f60e3f92b64636989e038c190dd8c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified CLI help text for host and local options across agent, project, and workspace commands.
  - Help now explains that one option is required unless the alternative option is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->