### PR TITLE
fix(shared): unblock local dev account seeding

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/components/InviteMemberDialog/InviteMemberDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/InviteMemberButton/components/InviteMemberDialog/InviteMemberDialog.tsx
@@ -1,10 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { errorMessage } from "@superset/i18n/errors";
-import {
-	canInvite,
-	type OrganizationRole,
-	organizationRoleName,
-} from "@superset/shared/auth";
+import { canInvite, type OrganizationRole } from "@superset/shared/auth";
 import { Button } from "@superset/ui/button";
 import {
 	Dialog,
@@ -27,6 +23,7 @@ import { toast } from "@superset/ui/sonner";
 import { useState } from "react";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { organizationRoleName } from "../../../../utils/organizationRoleName";
 
 interface InviteMemberDialogProps {
 	open: boolean;

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/components/MemberActions/MemberActions.tsx
@@ -4,7 +4,6 @@ import {
 	getAvailableRoleChanges,
 	getRoleLevel,
 	type OrganizationRole,
-	organizationRoleName,
 } from "@superset/shared/auth";
 import { alert } from "@superset/ui/atoms/Alert";
 import { Button } from "@superset/ui/button";
@@ -27,6 +26,7 @@ import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { TeamMember } from "../../../../types";
+import { organizationRoleName } from "../../utils/organizationRoleName";
 
 export function MemberActions({
 	member,

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/utils/organizationRoleName/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/utils/organizationRoleName/index.ts
@@ -1,0 +1,1 @@
+export { organizationRoleName } from "./organizationRoleName";

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/utils/organizationRoleName/organizationRoleName.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/members/components/MembersSettings/utils/organizationRoleName/organizationRoleName.ts
@@ -1,0 +1,19 @@
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
+import type { OrganizationRole } from "@superset/shared/auth";
+
+/**
+ * The role's display name in the active locale. `ORGANIZATION_ROLES[x].name`
+ * stays plain English: it is stable data (logs, server payloads), so display
+ * code renders this instead.
+ */
+export function organizationRoleName(role: OrganizationRole): string {
+	switch (role) {
+		case "owner":
+			return i18n._(msg({ message: "Owner" }));
+		case "admin":
+			return i18n._(msg({ message: "Admin" }));
+		case "member":
+			return i18n._(msg({ message: "Member" }));
+	}
+}

--- a/packages/shared/src/auth/auth-runtime.test.ts
+++ b/packages/shared/src/auth/auth-runtime.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+
+test("auth imports in a fresh Bun process", async () => {
+	const authUrl = new URL("./index.ts", import.meta.url).href;
+	const childProcess = Bun.spawn({
+		cmd: [
+			process.execPath,
+			"--eval",
+			`await import(${JSON.stringify(authUrl)})`,
+		],
+		stderr: "pipe",
+	});
+
+	const [exitCode, stderr] = await Promise.all([
+		childProcess.exited,
+		new Response(childProcess.stderr).text(),
+	]);
+
+	expect(exitCode, stderr).toBe(0);
+});

--- a/packages/shared/src/auth/roles/roles.ts
+++ b/packages/shared/src/auth/roles/roles.ts
@@ -1,6 +1,3 @@
-import { msg } from "@lingui/core/macro";
-import { i18n } from "../../i18n";
-
 // Role hierarchy from lowest to highest permission
 export const ROLE_HIERARCHY = ["member", "admin", "owner"] as const;
 
@@ -14,22 +11,6 @@ export const ORGANIZATION_ROLES: Record<
 	admin: { id: "admin", name: "Admin" },
 	owner: { id: "owner", name: "Owner" },
 };
-
-/**
- * The role's display name in the active locale. `ORGANIZATION_ROLES[x].name`
- * stays plain English: it is stable data (logs, server payloads), so display
- * code renders this instead.
- */
-export function organizationRoleName(role: OrganizationRole): string {
-	switch (role) {
-		case "owner":
-			return i18n._(msg({ message: "Owner" }));
-		case "admin":
-			return i18n._(msg({ message: "Admin" }));
-		case "member":
-			return i18n._(msg({ message: "Member" }));
-	}
-}
 
 export function getRoleLevel(role: OrganizationRole): number {
 	return ROLE_HIERARCHY.indexOf(role);


### PR DESCRIPTION
## What & why

The documented local setup's [account-seeding step](https://github.com/superset-sh/superset/blob/94056be3a4b209d342fd4c831c8b1514b434ab31/.superset/setup.local.sh#L167) fails under Bun 1.3.14 before it creates the development account or CLI OAuth client. `db:seed-dev` imports the auth server, which imports `@superset/shared/auth`. That barrel loads a compile-time Lingui macro used only to display role names in desktop settings.

Move the display helper beside its two desktop callers. Role data and permission functions are unchanged. The helper retains the same translation messages and i18n instance.

Desktop dev sign-in has a separate account-creation fallback. This PR repairs the seed command; it does not establish a general app-startup failure.

## How I tested it

With dependencies installed, use Bun 1.3.14 from the repository root to reproduce the import failure. This command requires no database or credentials:

```bash
bun --eval 'await import("./packages/shared/src/auth/index.ts")'
```

| Source | Observed result |
| --- | --- |
| Base `94056be3a4b209d342fd4c831c8b1514b434ab31` | Exit 1: `Cannot find package 'babel-plugin-macros'`, loaded by `@lingui/core/macro`. |
| Fix `3424c173292bf0d77e207485c15d4b3e7382bd3f` | Exit 0. |

The added regression runs in the existing test suite. It starts a fresh Bun process because the parent test setup mocks Lingui macros. It passes from both the repo root and the shared package directory. Run it directly with:

```bash
bun test packages/shared/src/auth/auth-runtime.test.ts
```

For the actual seed command, I applied existing migrations to an empty isolated local database and ran `bun run db:seed-dev` twice. Both runs exited 0. Selected output shows creation followed by reuse:

```text
Seeded dev account: admin@local.test
Dev account ready: admin@local.test (onboarded, pro)
Seeded CLI OAuth client: superset-cli

Dev account already exists: admin@local.test
Dev account ready: admin@local.test (onboarded, pro)
Refreshed CLI OAuth client: superset-cli
```

Placeholder local email credentials produced a nonfatal signup-event warning outside this excerpt.

- [All 11 code CI jobs](https://github.com/owieschon/superset/actions/runs/34038245911) pass on the submitted commit, including full tests, typecheck, desktop build, lint, and all four CLI-platform builds.
- Local auth tests (15/15), shared and desktop typechecks, lint, and `bun run check:i18n` pass. Translation catalogs are unchanged.
- [CodeRabbit's review](https://github.com/owieschon/superset/pull/10#issuecomment-5559768830) covers the same commit and reports no actionable findings.

The separate [Neon preview job](https://github.com/owieschon/superset/actions/runs/34038245791/job/101500166776) fails before deployment because the fork lacks `NEON_API_KEY`.

## Checklist

- [x] PR title follows conventional commits.
- [x] `bun run lint` and `bun run typecheck` pass (full typecheck in CI).
- [x] `bun run test` and `bun run check:i18n` pass (full tests in CI; i18n checked locally).
- [x] "Allow edits from maintainers" is checked on this fork PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `db:seed-dev` failing under Bun 1.3.14 by removing a compile-time Lingui macro from the shared auth import path. The macro only displays role names in desktop settings, so that helper moved beside its two callers; auth imports now load in any runtime. Role data and permission functions are unchanged.

- Adds a regression test that imports the auth index in a fresh Bun process.

<sup>Written for commit fa95da9ab3748716b4871a87fe9028d875fd22e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Member settings continue displaying localized organization role names with unchanged role-management behavior.
  - Organization role-name handling is now scoped to member settings instead of shared authentication functionality.

- **Tests**
  - Added validation that authentication functionality loads successfully in a fresh runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->