### PR TITLE
fix(desktop): paint browser-pane overlays above the hoisted webview

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/BrowserPane.tsx
@@ -3,6 +3,7 @@ import type { RendererContext, Tab } from "@superset/panes";
 import { useParams } from "@tanstack/react-router";
 import { GlobeIcon, SquareDashedMousePointer, XIcon } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { ImportHistoryDialog } from "renderer/components/ImportHistoryDialog";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
@@ -74,7 +75,10 @@ export function BrowserPane({
 	const { t } = useLingui();
 	const paneId = ctx.pane.id;
 	const state = useBrowserState(paneId);
-	const { placeholderRef, reload } = usePersistentWebview({ paneId, ctx });
+	const { placeholderRef, reload, overlayContainer } = usePersistentWebview({
+		paneId,
+		ctx,
+	});
 	const { workspaceId } = useParams({ strict: false });
 	const designMode = useDesignModeState(paneId);
 	const isFindBarOpen = useFindBarOpen(paneId);
@@ -99,6 +103,7 @@ export function BrowserPane({
 	// composer's own Esc handler covers its textarea. Scoped to keystrokes that
 	// belong to this pane (or to nothing — body): Esc aimed at a portal
 	// (dropdown, dialog, the composer's agent picker) must close that instead.
+	// The pane's overlay layer counts as the pane: the composer lives there.
 	useEffect(() => {
 		if (designMode.phase === "idle") return;
 		const phase = designMode.phase;
@@ -116,7 +121,10 @@ export function BrowserPane({
 			const root = rootRef.current;
 			const inScope =
 				target === document.body ||
-				(root != null && target != null && root.contains(target));
+				(root != null && target != null && root.contains(target)) ||
+				(overlayContainer != null &&
+					target != null &&
+					overlayContainer.contains(target));
 			if (!inScope) return;
 			e.preventDefault();
 			e.stopPropagation();
@@ -128,7 +136,7 @@ export function BrowserPane({
 		};
 		window.addEventListener("keydown", handleKeyDown, true);
 		return () => window.removeEventListener("keydown", handleKeyDown, true);
-	}, [designMode.phase, paneId]);
+	}, [designMode.phase, paneId, overlayContainer]);
 
 	// A full navigation replaces the document a capture described — drop the
 	// composer instead of staging a payload (selector, bounds, verify hints)
@@ -148,12 +156,12 @@ export function BrowserPane({
 		? { width: deviceForToolbar.height, height: deviceForToolbar.width }
 		: { width: deviceForToolbar.width, height: deviceForToolbar.height };
 
-	// Anchor the composer under the clicked element: the capture's viewport
-	// rect is in guest CSS pixels, which map 1:1 onto the placeholder's box
-	// (the webview mirrors the placeholder rect, and the pane root is the
-	// offset parent of both the placeholder and the popover). Computed in a
-	// layout effect (refs are unset during the first render of a remount) and
-	// re-clamped when the pane resizes so the card stays inside it.
+	// Anchor the composer under the clicked element. The composer renders in
+	// the pane's overlay layer, which mirrors the placeholder's box, so the
+	// capture's viewport rect (guest CSS pixels) is already in its coordinate
+	// space. Computed in a layout effect (refs are unset during the first
+	// render of a remount) and re-clamped when the page area resizes so the
+	// card stays inside it.
 	const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({
 		top: 12,
 		left: 12,
@@ -164,31 +172,27 @@ export function BrowserPane({
 			: undefined;
 	useLayoutEffect(() => {
 		if (!confirmingRect) return;
-		const root = rootRef.current;
-		if (!root) return;
+		const placeholder = placeholderRef.current;
+		if (!placeholder) return;
 		const compute = () => {
-			const placeholder = placeholderRef.current;
-			if (!placeholder) return;
-			const width = Math.min(420, root.clientWidth - 16);
+			const areaWidth = placeholder.clientWidth;
+			const areaHeight = placeholder.clientHeight;
+			const width = Math.min(420, areaWidth - 16);
 			const estimatedHeight = 170;
 			const left = Math.min(
-				Math.max(placeholder.offsetLeft + confirmingRect.x, 8),
-				Math.max(8, root.clientWidth - width - 8),
+				Math.max(confirmingRect.x, 8),
+				Math.max(8, areaWidth - width - 8),
 			);
-			const below =
-				placeholder.offsetTop + confirmingRect.y + confirmingRect.height + 4;
+			const below = confirmingRect.y + confirmingRect.height + 4;
 			const top =
-				below + estimatedHeight > root.clientHeight
-					? Math.max(
-							8,
-							placeholder.offsetTop + confirmingRect.y - estimatedHeight - 4,
-						)
+				below + estimatedHeight > areaHeight
+					? Math.max(8, confirmingRect.y - estimatedHeight - 4)
 					: below;
 			setPopoverStyle({ top, left, width });
 		};
 		compute();
 		const observer = new ResizeObserver(compute);
-		observer.observe(root);
+		observer.observe(placeholder);
 		return () => observer.disconnect();
 	}, [confirmingRect, placeholderRef]);
 
@@ -234,9 +238,7 @@ export function BrowserPane({
 		// follows the placeholder rect, painting over the neighbor pane.
 		<div ref={rootRef} className="relative flex h-full min-w-0 flex-1 flex-col">
 			{designMode.phase !== "idle" && (
-				// relative z-20: must stay clickable above the confirming-phase
-				// click-catcher (z-10) so the exit button keeps working.
-				<div className="relative z-20 flex shrink-0 items-center gap-2 border-b border-border/60 bg-[#0d99ff]/10 px-3 py-1.5 text-xs text-foreground/90">
+				<div className="flex shrink-0 items-center gap-2 border-b border-border/60 bg-[#0d99ff]/10 px-3 py-1.5 text-xs text-foreground/90">
 					<SquareDashedMousePointer className="size-3.5 shrink-0 text-[#0d99ff]" />
 					<span className="min-w-0 flex-1 truncate">
 						{designMode.phase === "selecting" ? (
@@ -308,59 +310,68 @@ export function BrowserPane({
 					}
 				/>
 			</div>
-			{isFindBarOpen && (
-				<BrowserFindBar
-					paneId={paneId}
-					onClose={() => findBarStore.close(paneId)}
-				/>
-			)}
-			{designMode.phase === "confirming" &&
-				designMode.payload &&
-				workspaceId && (
+			{/* Everything that must paint over the page goes through the registry's
+			    overlay layer: the webview is hoisted out of the pane tree, so no
+			    z-index in here can reach above it. */}
+			{overlayContainer &&
+				createPortal(
 					<>
-						{/* Click-catcher: the guest overlay froze pointer events on
-						    selection, so without this a stray page click would
-						    navigate out from under the open composer. */}
-						<button
-							type="button"
-							aria-label={t({
-								message: "Discard captured element",
-							})}
-							onClick={() => designModeStore.rearm(paneId)}
-							className="absolute inset-0 z-10 cursor-default"
-						/>
-						<DesignModePopover
-							workspaceId={workspaceId}
-							paneId={paneId}
-							payload={designMode.payload}
-							style={popoverStyle}
-							onDismiss={() => designModeStore.rearm(paneId)}
-							onSent={() => designModeStore.exit(paneId)}
-							onCreateNewAgentSession={onCreateNewAgentSession}
-							onFocusAgentTerminal={onFocusAgentTerminal}
-						/>
-					</>
+						{isFindBarOpen && (
+							<BrowserFindBar
+								paneId={paneId}
+								onClose={() => findBarStore.close(paneId)}
+							/>
+						)}
+						{designMode.phase === "confirming" &&
+							designMode.payload &&
+							workspaceId && (
+								<>
+									{/* Click-catcher: the guest overlay froze pointer events on
+									    selection, so without this a stray page click would
+									    navigate out from under the open composer. */}
+									<button
+										type="button"
+										aria-label={t({
+											message: "Discard captured element",
+										})}
+										onClick={() => designModeStore.rearm(paneId)}
+										className="pointer-events-auto absolute inset-0 z-10 cursor-default"
+									/>
+									<DesignModePopover
+										workspaceId={workspaceId}
+										paneId={paneId}
+										payload={designMode.payload}
+										style={popoverStyle}
+										onDismiss={() => designModeStore.rearm(paneId)}
+										onSent={() => designModeStore.exit(paneId)}
+										onCreateNewAgentSession={onCreateNewAgentSession}
+										onFocusAgentTerminal={onFocusAgentTerminal}
+									/>
+								</>
+							)}
+						{state.error && !state.isLoading && (
+							<BrowserErrorOverlay error={state.error} onRetry={reload} />
+						)}
+						{isBlankPage && !state.isLoading && !state.error && (
+							<div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-background">
+								<div className="flex w-full max-w-sm flex-col items-center gap-5 px-6">
+									<div className="flex size-14 items-center justify-center rounded-2xl bg-muted/50">
+										<GlobeIcon className="size-7 text-muted-foreground" />
+									</div>
+									<div className="text-center">
+										<p className="text-base font-medium text-foreground">
+											<Trans>Start browsing</Trans>
+										</p>
+										<p className="mt-1.5 text-sm text-muted-foreground">
+											<Trans>Enter a URL into the search bar above.</Trans>
+										</p>
+									</div>
+								</div>
+							</div>
+						)}
+					</>,
+					overlayContainer,
 				)}
-			{state.error && !state.isLoading && (
-				<BrowserErrorOverlay error={state.error} onRetry={reload} />
-			)}
-			{isBlankPage && !state.isLoading && !state.error && (
-				<div className="absolute inset-0 z-10 flex items-center justify-center bg-background">
-					<div className="flex w-full max-w-sm flex-col items-center gap-5 px-6">
-						<div className="flex size-14 items-center justify-center rounded-2xl bg-muted/50">
-							<GlobeIcon className="size-7 text-muted-foreground" />
-						</div>
-						<div className="text-center">
-							<p className="text-base font-medium text-foreground">
-								<Trans>Start browsing</Trans>
-							</p>
-							<p className="mt-1.5 text-sm text-muted-foreground">
-								<Trans>Enter a URL into the search bar above.</Trans>
-							</p>
-						</div>
-					</div>
-				</div>
-			)}
 			<ImportHistoryDialog open={isImportOpen} onOpenChange={setIsImportOpen} />
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
@@ -24,6 +24,7 @@ describe("browserRuntimeRegistry detached persistence", () => {
 		const onPersist = (state: { url: string }) => persisted.push(state.url);
 		const entry = {
 			webview: { style: { visibility: "visible" } },
+			overlay: { style: { visibility: "visible" } },
 			state: {},
 			onPersist,
 			webContentsId: null,
@@ -52,6 +53,7 @@ describe("browserRuntimeRegistry detached persistence", () => {
 	test("hidden-webview eviction spares panes with a live CDP session", async () => {
 		const makeEntry = (lastUsedAt: number) => ({
 			webview: { remove: () => {}, style: { visibility: "hidden" } },
+			overlay: { remove: () => {}, style: { visibility: "hidden" } },
 			state: {},
 			onPersist: null,
 			webContentsId: null,
@@ -99,6 +101,7 @@ describe("browserRuntimeRegistry detached persistence", () => {
 		const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 		const entry = {
 			webview: { remove: () => {} },
+			overlay: { remove: () => {} },
 			onPersist: () => {},
 			detachHandlers: () => {},
 			resizeObserver: { disconnect: () => {} },
@@ -127,6 +130,7 @@ describe("browserRuntimeRegistry host popover passthrough", () => {
 	test("keeps webviews passed through until the last open popover closes", () => {
 		const makeEntry = () => ({
 			webview: { style: { pointerEvents: "auto" } },
+			overlay: { style: {} },
 			visible: true,
 		});
 		const a = makeEntry();
@@ -158,5 +162,59 @@ describe("browserRuntimeRegistry host popover passthrough", () => {
 			registryInternals.entries.delete("popover-pane-a");
 			registryInternals.entries.delete("popover-pane-b");
 		}
+	});
+});
+
+describe("browserRuntimeRegistry overlay layer", () => {
+	const makeEntry = () => ({
+		webview: { style: {} as Record<string, string> },
+		overlay: { style: {} as Record<string, string> },
+		placeholder: {
+			getBoundingClientRect: () => ({
+				top: 40,
+				left: 300,
+				width: 800,
+				height: 600,
+			}),
+		},
+		resizeObserver: { disconnect: () => {} },
+		visible: true,
+		lastUsedAt: 1,
+	});
+	const registryInternals = browserRuntimeRegistry as unknown as {
+		entries: Map<string, ReturnType<typeof makeEntry>>;
+		updateLayout: (entry: ReturnType<typeof makeEntry>) => void;
+	};
+
+	test("mirrors the placeholder rect onto the overlay as well as the webview", () => {
+		const entry = makeEntry();
+		registryInternals.updateLayout(entry);
+		for (const style of [entry.webview.style, entry.overlay.style]) {
+			expect(style.top).toBe("40px");
+			expect(style.left).toBe("300px");
+			expect(style.width).toBe("800px");
+			expect(style.height).toBe("600px");
+		}
+	});
+
+	test("hides the overlay with the webview on detach", () => {
+		const paneId = "overlay-detach-pane";
+		const entry = makeEntry();
+		entry.overlay.style.visibility = "visible";
+		registryInternals.entries.set(paneId, entry);
+		try {
+			browserRuntimeRegistry.detach(paneId);
+			expect(entry.webview.style.visibility).toBe("hidden");
+			expect(entry.overlay.style.visibility).toBe("hidden");
+			expect(browserRuntimeRegistry.getOverlayContainer(paneId)).toBe(
+				entry.overlay as unknown as HTMLElement,
+			);
+		} finally {
+			registryInternals.entries.delete(paneId);
+		}
+	});
+
+	test("reports no overlay for an unknown pane", () => {
+		expect(browserRuntimeRegistry.getOverlayContainer("nope")).toBeNull();
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -27,6 +27,16 @@ export interface PersistableBrowserState {
 
 interface RegistryEntry {
 	webview: Electron.WebviewTag;
+	/**
+	 * Host layer painted directly above this pane's webview, mirroring its
+	 * rect and visibility. The webview is hoisted to a body-level container,
+	 * so nothing inside the pane tree can paint over it: the pane tree is its
+	 * own stacking context (isolated so resize handles stay under dialogs),
+	 * and z-index never crosses one. Pane UI that must cover the page (the
+	 * design-mode composer, find bar, load-error and blank states) portals
+	 * in here instead of competing from inside the tree.
+	 */
+	overlay: HTMLDivElement;
 	state: BrowserRuntimeState;
 	onPersist: ((state: PersistableBrowserState) => void) | null;
 	/** Owning workspace — sent on register so the main process scopes pane ops. */
@@ -185,6 +195,7 @@ class BrowserRuntimeRegistryImpl {
 			style.visibility = "hidden";
 			style.opacity = "";
 		}
+		entry.overlay.style.visibility = "hidden";
 	}
 
 	private setWindowDragPassthrough(passthrough: boolean) {
@@ -230,11 +241,17 @@ class BrowserRuntimeRegistryImpl {
 	private updateLayout(entry: RegistryEntry) {
 		if (!entry.placeholder) return;
 		const rect = entry.placeholder.getBoundingClientRect();
-		const w = entry.webview;
-		w.style.top = `${rect.top}px`;
-		w.style.left = `${rect.left}px`;
-		w.style.width = `${rect.width}px`;
-		w.style.height = `${rect.height}px`;
+		for (const style of [entry.webview.style, entry.overlay.style]) {
+			style.top = `${rect.top}px`;
+			style.left = `${rect.left}px`;
+			style.width = `${rect.width}px`;
+			style.height = `${rect.height}px`;
+		}
+	}
+
+	/** Host layer above the pane's webview; null until the pane has attached. */
+	getOverlayContainer(paneId: string): HTMLElement | null {
+		return this.entries.get(paneId)?.overlay ?? null;
 	}
 
 	private notify(paneId: string) {
@@ -314,8 +331,22 @@ class BrowserRuntimeRegistryImpl {
 		webview.style.pointerEvents = "auto";
 		webview.src = sanitizeUrl(initialUrl);
 
+		// Click-through by default so the page stays interactive; whatever is
+		// portalled in opts back into pointer events itself. z-index 1 keeps it
+		// above every webview in the container, including ones appended later.
+		const overlay = document.createElement("div");
+		overlay.style.position = "fixed";
+		overlay.style.top = "0";
+		overlay.style.left = "0";
+		overlay.style.width = "0";
+		overlay.style.height = "0";
+		overlay.style.zIndex = "1";
+		overlay.style.pointerEvents = "none";
+		overlay.style.visibility = "hidden";
+
 		const entry: RegistryEntry = {
 			webview,
+			overlay,
 			state: { ...EMPTY_STATE, currentUrl: initialUrl },
 			onPersist: null,
 			workspaceId,
@@ -503,6 +534,7 @@ class BrowserRuntimeRegistryImpl {
 			entry = this.createEntry(paneId, initialUrl, workspaceId);
 			this.entries.set(paneId, entry);
 			root.appendChild(entry.webview);
+			root.appendChild(entry.overlay);
 		} else {
 			// A reused pane can move between workspaces (the attach effect keys on
 			// workspaceId). Keep the registration's workspace current so main-side
@@ -541,6 +573,7 @@ class BrowserRuntimeRegistryImpl {
 		this.updateLayout(entry);
 		entry.webview.style.visibility = "visible";
 		entry.webview.style.opacity = "";
+		entry.overlay.style.visibility = "visible";
 		this.applyPointerPassthrough();
 	}
 
@@ -593,6 +626,7 @@ class BrowserRuntimeRegistryImpl {
 		entry.resizeObserver?.disconnect();
 		entry.detachHandlers();
 		entry.webview.remove();
+		entry.overlay.remove();
 		this.entries.delete(paneId);
 		this.listenersByPaneId.delete(paneId);
 		this.foundInPageListenersByPaneId.delete(paneId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserErrorOverlay/BrowserErrorOverlay.tsx
@@ -133,7 +133,7 @@ export function BrowserErrorOverlay({
 	}, [detailsText, copyToClipboard]);
 
 	return (
-		<div className="absolute inset-0 flex items-center justify-center bg-background z-10">
+		<div className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center bg-background">
 			<div className="flex flex-col items-start gap-4 w-80">
 				<GlobeIcon className="size-10 text-muted-foreground/30" />
 				<div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserFindBar/BrowserFindBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserFindBar/BrowserFindBar.tsx
@@ -71,7 +71,7 @@ export function BrowserFindBar({ paneId, onClose }: BrowserFindBarProps) {
 	};
 
 	return (
-		<div className="absolute right-3 top-3 z-30 flex items-center gap-1 rounded-md border border-border bg-popover px-2 py-1 text-xs shadow-md">
+		<div className="pointer-events-auto absolute right-3 top-3 z-30 flex items-center gap-1 rounded-md border border-border bg-popover px-2 py-1 text-xs shadow-md">
 			<input
 				ref={inputRef}
 				value={query}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/DesignModePopover/DesignModePopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/DesignModePopover/DesignModePopover.tsx
@@ -175,7 +175,7 @@ export function DesignModePopover({
 	};
 
 	return (
-		<div className="absolute z-20" style={style}>
+		<div className="pointer-events-auto absolute z-20" style={style}>
 			<form
 				className="overflow-hidden rounded-xl border border-border/80 bg-popover text-popover-foreground shadow-[0_4px_16px_-4px_rgba(0,0,0,0.25),0_2px_4px_-2px_rgba(0,0,0,0.12)]"
 				onSubmit={(e) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,6 +1,6 @@
 import type { RendererContext } from "@superset/panes";
 import { useParams } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	getDispatchChord,
 	type HotkeyId,
@@ -52,6 +52,11 @@ export function usePersistentWebview({
 	ctx,
 }: UsePersistentWebviewOptions) {
 	const placeholderRef = useRef<HTMLDivElement | null>(null);
+	// The registry's host layer above this pane's webview; pane UI that must
+	// cover the page portals into it. Null until attached.
+	const [overlayContainer, setOverlayContainer] = useState<HTMLElement | null>(
+		null,
+	);
 	const ctxRef = useRef(ctx);
 	ctxRef.current = ctx;
 	// Workspace scoping for the browser bridge (CLI/agent control). Panes only
@@ -92,9 +97,11 @@ export function usePersistentWebview({
 				});
 			},
 		);
+		setOverlayContainer(browserRuntimeRegistry.getOverlayContainer(paneId));
 
 		return () => {
 			browserRuntimeRegistry.detach(paneId);
+			setOverlayContainer(null);
 		};
 	}, [paneId, workspaceId]);
 
@@ -225,6 +232,7 @@ export function usePersistentWebview({
 
 	return {
 		placeholderRef,
+		overlayContainer,
 		goBack,
 		goForward,
 		reload,


### PR DESCRIPTION
## Problem

Design mode in the browser pane looked broken: click the Design toggle, pick an element, and the banner flips to "Element captured" but no composer appears. The composer *was* rendered. It was painted underneath the page.

The webview is hoisted into a body-level container so it survives pane remounts. #6891 made the pane tree an isolated stacking context so resize handles stop painting above dialogs. Once the pane is its own stacking context, no z-index inside it can reach above a body-level sibling, so the composer (`absolute z-20`) and its click-catcher lost to the webview layer. Design mode shipped six days before #6891 and worked only because nothing between the pane and body created a stacking context.

The find bar and the load-error overlay were hidden the same way.

## Fix

Each pane now gets an overlay layer in `browserRuntimeRegistry`: a sibling element appended directly after its webview, mirroring its rect (same `updateLayout`) and visibility (attach / detach / park / destroy). `usePersistentWebview` exposes it and `BrowserPane` portals everything that must cover the page into it:

- design-mode composer + click-catcher
- find bar
- load-error overlay
- blank-page "Start browsing" state

Layering is now relative to the webview instead of relying on the pane tree's stacking. `isolate` on the pane tree stays. The composer's position math simplifies since the layer's box is the placeholder's box.

## Verification (CDP against the dev app)

Before: after picking an element, `elementFromPoint` at the composer's center returned `WEBVIEW`. Removing `isolate` from the pane tree live made it return the composer, confirming the cause.

After, under the same journey (Design toggle, hover, click in the page, all via real input on the host renderer):

| Overlay | hit-test at center | interaction |
| --- | --- | --- |
| Composer | inside composer | typed text lands in the textarea |
| Click-catcher | catcher button | click re-arms picking |
| Error overlay (`http://127.0.0.1:1/`) | inside overlay | Show Details / Restart Browser present |
| Blank state (new pane) | inside overlay | |
| Find bar (Find in page) | inside find bar | input focused, "Card" → 1/4 |

No `console.error` during any step. Registry tests cover the overlay mirroring the rect and hiding on detach.

https://claude.ai/code/session_013znM5EPkdfUU9q5ttZ6F7F


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes design-mode overlays painting beneath the hoisted webview, which made the composer, find bar, and error/blank states invisible behind the page.

- The webview lives in a body-level container and the pane tree is an isolated stacking context, so no z-index inside a pane can reach above the webview.
- `browserRuntimeRegistry` now appends a fixed overlay layer for each pane directly after its webview, mirroring its rect and visibility.
- `BrowserPane` portals the design-mode composer, click-catcher, find bar, error overlay, and blank state into that layer.
- Overlays are click-through by default and each opt back into pointer events themselves.
- Verified against the dev app via CDP: every overlay hit-tests to itself and accepts real input.

<sup>Written for commit 50820040408fdfa5b3527269a5c2a37ed8ab74fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser pane overlays so find-in-page, design-mode controls, error messages, and blank-page states appear correctly above embedded web content.
  * Restored interaction with overlay controls, including clicking and typing.
  * Improved design-mode popover positioning and Escape-key behavior.
  * Kept overlay layers aligned and hidden appropriately as browser panes are moved or detached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->