### PR TITLE
ci(relay): only deploy the relay when the push touches its sources

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -505,10 +505,44 @@ jobs:
             --env SECRETS_ENCRYPTION_KEY=$SECRETS_ENCRYPTION_KEY \
             --env ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
 
+  # Every relay deploy restarts every Durable Object, which drops the control
+  # socket of every connected host at once. Only deploy when the push touches
+  # something the relay bundle is built from.
+  relay-changes:
+    name: Detect Relay Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      relay: ${{ steps.filter.outputs.relay }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: |
+            relay:
+              - 'apps/relay/**'
+              - 'packages/shared/src/tunnel-protocol.ts'
+              - 'packages/shared/src/host-routing.ts'
+              - 'patches/**'
+              - '.github/workflows/deploy-production.yml'
+
   deploy-relay:
     name: Deploy Relay to Cloudflare
     runs-on: ubuntu-latest
     environment: production
+    needs: relay-changes
+    # Fail open: a broken detector must not leave a stale relay in production.
+    if: >-
+      !cancelled() && (
+        github.event_name == 'workflow_dispatch'
+        || needs.relay-changes.result != 'success'
+        || needs.relay-changes.outputs.relay == 'true'
+      )
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Why

Every relay Worker deploy restarts every Durable Object, which closes the control socket of every connected host at once. `deploy-relay` ran on every push to `main`, so each merge forced every host through a reconnect and, since placement landed in #7156, a client-visible "host offline" window while other edges caught up on the new placement.

Cloudflare analytics for `superset-relay` today, errors per minute against a baseline of ~250:

| Minute (UTC) | Errors | Deploy |
|---|---|---|
| 01:13 | 898 | 01:12 |
| 01:16 | 1005 | 01:16:19 |
| 01:29–01:30 | 563 + 670 | 01:29:54 |
| 06:06 | 897 | 06:06:20 |
| 06:28 | 839 | 06:28:30 |
| 17:16 | 607 | 17:16:14 |

61 production deploys have run since #7156 merged; one of them changed the relay.

## What

A `relay-changes` job runs `dorny/paths-filter` (v4.0.3, pinned by SHA) over the push, and `deploy-relay` now `needs` it and only runs when the filter reports a change under:

- `apps/relay/**`
- `packages/shared/src/tunnel-protocol.ts`
- `packages/shared/src/host-routing.ts`
- `patches/**`
- `.github/workflows/deploy-production.yml`

`workflow_dispatch` still deploys unconditionally. Those paths are the relay's runtime inputs: `apps/relay/src` imports only `@superset/shared/tunnel-protocol`, `@superset/shared/host-routing`, and a type-only `@superset/trpc`. `bun.lock` is deliberately excluded: the relay's dependencies are pinned to exact versions, so a lockfile-only change can only move transitive deps, and the lockfile changes ~3x a day on main.

https://claude.ai/code/session_01EuEbEBRowvCwaH5DRZDW4J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deployment**
  - Relay deployments are automatically triggered when relay-related changes are detected.
  - Manual production deployment remains available through workflow dispatch.
  - Relay deployments can also proceed if change detection fails, helping avoid skipped deployments.
  - Unrelated changes do not trigger relay deployments.
  - Cancelled workflows remain prevented from deploying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->