### PR TITLE
feat(mobile): pick the agent's model and effort when starting a session

### DIFF
--- a/apps/mobile/app/(authenticated)/(home)/new-session/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/(home)/new-session/_layout.tsx
@@ -24,6 +24,13 @@ export default function NewSessionLayout() {
 				}}
 			/>
 			<Stack.Screen
+				name="model"
+				options={{
+					title: t({ message: "Model" }),
+				}}
+			/>
+			<Stack.Screen name="model-group" />
+			<Stack.Screen
 				name="project"
 				options={{
 					title: t({ message: "Project" }),

--- a/apps/mobile/app/(authenticated)/(home)/new-session/model-group.tsx
+++ b/apps/mobile/app/(authenticated)/(home)/new-session/model-group.tsx
@@ -1,0 +1,3 @@
+import { ModelGroupScreen } from "@/screens/(authenticated)/components/ModelGroupScreen";
+
+export default ModelGroupScreen;

--- a/apps/mobile/app/(authenticated)/(home)/new-session/model.tsx
+++ b/apps/mobile/app/(authenticated)/(home)/new-session/model.tsx
@@ -1,0 +1,12 @@
+import { AgentOptionsScreen } from "@/screens/(authenticated)/components/AgentOptionsScreen";
+
+export default function NewSessionModelRoute() {
+	return (
+		<AgentOptionsScreen
+			groupHref={(params) => ({
+				pathname: "/(authenticated)/(home)/new-session/model-group",
+				params,
+			})}
+		/>
+	);
+}

--- a/apps/mobile/modules/composer/ios/ComposerModel.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModel.swift
@@ -38,6 +38,10 @@ final class ComposerModel {
   /// `ComposerModelPicker`.
   var selectedModel: ComposerMenuOption?
 
+  /// Per-agent launch settings drawn after the agent — model, effort — each a
+  /// chevron button reporting its id. Empty for agents that have none.
+  var launchOptions: [ComposerMenuOption] = []
+
   /// A submit is in flight. The caller owns this — only it knows when delivery
   /// finished — and while it is true the send button shows a spinner and the
   /// mic gets out of the way.
@@ -112,6 +116,7 @@ final class ComposerModel {
   /// round trip.
   @ObservationIgnored var onDictationError: ((String) -> Void)?
   @ObservationIgnored var onModelPress: (() -> Void)?
+  @ObservationIgnored var onLaunchOptionPress: ((String) -> Void)?
   @ObservationIgnored var onChipPress: ((String) -> Void)?
   @ObservationIgnored var onQuickKeyPress: ((String) -> Void)?
   /// The session strip reports by id and knows nothing else. Selecting swaps

--- a/apps/mobile/modules/composer/ios/ComposerModelPicker.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModelPicker.swift
@@ -36,3 +36,27 @@ struct ComposerModelPicker: View {
     }
   }
 }
+
+/// One launch setting beside the agent — "Opus ⌄", "High ⌄" — drawn like a
+/// header chip. Same contract as the model picker: reports the press, and the
+/// list it opens lives in React Native.
+struct ComposerLaunchOptionButton: View {
+  let option: ComposerMenuOption
+  let onPress: () -> Void
+
+  var body: some View {
+    Button(action: onPress) {
+      HStack(spacing: 4) {
+        Text(option.label)
+          .font(.system(size: ComposerMetrics.chromeFontSize))
+          .foregroundStyle(option.muted ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
+        Image(systemName: "chevron.down")
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.secondary)
+      }
+      .lineLimit(1)
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(option.label)
+  }
+}

--- a/apps/mobile/modules/composer/ios/ComposerModule.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModule.swift
@@ -12,6 +12,7 @@ public final class ComposerModule: Module {
         "onAttachmentsPress",
         "onDictationError",
         "onModelPress",
+        "onLaunchOptionPress",
         "onChipPress",
         "onQuickKeyPress",
         "onSessionTabPress",
@@ -56,6 +57,12 @@ public final class ComposerModule: Module {
       Prop("selectedModel") { (view: ComposerAnchorView, model: ComposerMenuOption?) in
         withAnimation(ComposerMetrics.controlSwap) {
           view.overlay.model.selectedModel = model
+        }
+      }
+
+      Prop("launchOptions") { (view: ComposerAnchorView, options: [ComposerMenuOption]) in
+        withAnimation(ComposerMetrics.controlSwap) {
+          view.overlay.model.launchOptions = options
         }
       }
 
@@ -177,6 +184,7 @@ final class ComposerAnchorView: ExpoView {
   private let onAttachmentsPress = EventDispatcher()
   private let onDictationError = EventDispatcher()
   private let onModelPress = EventDispatcher()
+  private let onLaunchOptionPress = EventDispatcher()
   private let onChipPress = EventDispatcher()
   private let onQuickKeyPress = EventDispatcher()
   private let onSessionTabPress = EventDispatcher()
@@ -201,6 +209,9 @@ final class ComposerAnchorView: ExpoView {
       self?.onDictationError(["message": message])
     }
     overlay.model.onModelPress = { [weak self] in self?.onModelPress([:]) }
+    overlay.model.onLaunchOptionPress = { [weak self] id in
+      self?.onLaunchOptionPress(["id": id])
+    }
     overlay.model.onQuickKeyPress = { [weak self] id in
       self?.onQuickKeyPress(["id": id])
     }

--- a/apps/mobile/modules/composer/ios/ComposerRootView.swift
+++ b/apps/mobile/modules/composer/ios/ComposerRootView.swift
@@ -640,11 +640,20 @@ struct ComposerRootView: View {
       .onTapGesture { expand() }
   }
 
+  /// The agent, then its launch settings: `✱ Claude ⌄ · Opus ⌄ · High ⌄`.
   private var modelPicker: some View {
-    ComposerModelPicker(
-      selected: model.selectedModel,
-      onPress: { model.onModelPress?() }
-    )
+    HStack(spacing: ComposerMetrics.chipSpacing) {
+      ComposerModelPicker(
+        selected: model.selectedModel,
+        onPress: { model.onModelPress?() }
+      )
+      ForEach(model.launchOptions) { option in
+        ComposerLaunchOptionButton(
+          option: option,
+          onPress: { model.onLaunchOptionPress?(option.id) }
+        )
+      }
+    }
     .padding(.leading, ComposerMetrics.pickerGap - ComposerMetrics.rowSpacing)
     .padding(.trailing, ComposerMetrics.textInset)
   }

--- a/apps/mobile/modules/composer/src/index.tsx
+++ b/apps/mobile/modules/composer/src/index.tsx
@@ -16,6 +16,7 @@ interface NativeComposerViewProps {
 	backdrop?: ComposerBackdrop;
 	attachments?: ComposerAttachment[];
 	selectedModel?: ComposerMenuOption;
+	launchOptions?: ComposerMenuOption[];
 	headerChips?: ComposerMenuOption[];
 	quickKeys?: ComposerQuickKey[];
 	sessionTabs?: ComposerSessionTab[];
@@ -30,6 +31,7 @@ interface NativeComposerViewProps {
 	onAttachmentsPress?: () => void;
 	onDictationError?: (event: { nativeEvent: { message: string } }) => void;
 	onModelPress?: () => void;
+	onLaunchOptionPress?: (event: { nativeEvent: { id: string } }) => void;
 	onChipPress?: (event: { nativeEvent: { id: string } }) => void;
 	onQuickKeyPress?: (event: { nativeEvent: { id: string } }) => void;
 	onSessionTabPress?: (event: { nativeEvent: { id: string } }) => void;
@@ -270,6 +272,12 @@ interface ComposerBaseProps {
 	 * the real pickers are `formSheet` routes with searchable lists.
 	 */
 	selectedModel?: ComposerMenuOption;
+	/**
+	 * The selected agent's launch settings, drawn after it as their own
+	 * chevron buttons — model, effort. Each reports its id on press; the
+	 * lists stay in React Native like the agent's. Omit for agents with none.
+	 */
+	launchOptions?: ComposerMenuOption[];
 	/** Frame 4's header row. Empty on the session surface (frame 13). */
 	headerChips?: ComposerMenuOption[];
 	/**
@@ -317,6 +325,7 @@ interface ComposerBaseProps {
 	 */
 	onDictationError?: (message: string) => void;
 	onModelPress?: () => void;
+	onLaunchOptionPress?: (id: string) => void;
 	onChipPress?: (id: string) => void;
 	onQuickKeyPress?: (id: string) => void;
 	/** A tab was tapped — attach that session. */
@@ -398,6 +407,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 			backdrop = "dim",
 			attachments,
 			selectedModel,
+			launchOptions,
 			headerChips,
 			quickKeys,
 			sessionTabs,
@@ -411,6 +421,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 			onAttachmentsPress,
 			onDictationError,
 			onModelPress,
+			onLaunchOptionPress,
 			onChipPress,
 			onQuickKeyPress,
 			onSessionTabPress,
@@ -445,6 +456,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 				backdrop={backdrop}
 				attachments={attachments}
 				selectedModel={selectedModel}
+				launchOptions={launchOptions}
 				headerChips={headerChips}
 				quickKeys={quickKeys}
 				sessionTabs={sessionTabs}
@@ -463,6 +475,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 					onDictationError?.(event.nativeEvent.message)
 				}
 				onModelPress={onModelPress}
+				onLaunchOptionPress={(event) =>
+					onLaunchOptionPress?.(event.nativeEvent.id)
+				}
 				onChipPress={(event) => onChipPress?.(event.nativeEvent.id)}
 				onQuickKeyPress={(event) => onQuickKeyPress?.(event.nativeEvent.id)}
 				onSessionTabPress={(event) => onSessionTabPress?.(event.nativeEvent.id)}

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -135,10 +135,13 @@ export function NewChatWidget({
 		: agentId;
 	const agentIconUri = useAgentIconUri(selectedAgent?.iconId ?? agentId);
 	// Remembered per launch preset; null means the agent's own default and
-	// nothing rides the launch.
+	// nothing rides the launch. Until the host's configs answer the preset id
+	// stands in for the launch preset, so a send made before they arrive
+	// still carries the pick — the two only differ for a config whose
+	// executable is not its preset's.
 	const launchPresetId = selectedAgent
 		? agentLaunchPresetId(selectedAgent)
-		: null;
+		: agentId;
 	const launch = useAgentLaunchPreferences(launchPresetId);
 	const model = launch.model?.id ?? null;
 	const effort = launch.effort?.id ?? null;

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -15,6 +15,10 @@ import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { posthog } from "@/lib/posthog";
 import { apiClient } from "@/lib/trpc/client";
 import { useWorkspaceScope } from "@/screens/(authenticated)/(home)/hooks/useWorkspaceScope";
+import {
+	agentLaunchPresetId,
+	useAgentLaunchPreferences,
+} from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
 import { useAttachmentsSheet } from "@/screens/(authenticated)/hooks/useAttachmentsSheet";
 import { useComposerDraft } from "@/screens/(authenticated)/hooks/useComposerDraft";
 import { useCreateTerminalWorkspace } from "@/screens/(authenticated)/hooks/useCreateTerminalWorkspace";
@@ -37,6 +41,7 @@ function cloudAgentConfig(agentId: string | null) {
 				presetId: preset.presetId,
 				label: preset.label,
 				iconId: preset.presetId,
+				command: preset.command,
 			}
 		: undefined;
 }
@@ -129,6 +134,26 @@ export function NewChatWidget({
 		? (selectedAgent?.presetId ?? "claude")
 		: agentId;
 	const agentIconUri = useAgentIconUri(selectedAgent?.iconId ?? agentId);
+	// Remembered per launch preset; null means the agent's own default and
+	// nothing rides the launch.
+	const launchPresetId = selectedAgent
+		? agentLaunchPresetId(selectedAgent)
+		: null;
+	const launch = useAgentLaunchPreferences(launchPresetId);
+	const model = launch.model?.id ?? null;
+	const effort = launch.effort?.id ?? null;
+	// One dropdown after the agent, naming the model; the sheet it opens also
+	// holds the effort. An agent with only an effort flag names that instead,
+	// and one with neither shows nothing.
+	const launchOptionLabel =
+		launch.models !== undefined
+			? (launch.model?.label ?? t({ message: "Default model" }))
+			: launch.efforts.length > 0
+				? (launch.effort?.label ?? t({ message: "Default effort" }))
+				: null;
+	const launchOptions = launchOptionLabel
+		? [{ id: "launch", label: launchOptionLabel }]
+		: [];
 	// Null until the branch list resolves. The previous fallback was the literal
 	// string "default", which reads as a branch name and is not one.
 	const branchLabel = baseBranch ?? branchData?.defaultBranch ?? null;
@@ -163,6 +188,8 @@ export function NewChatWidget({
 			message_length: message.text.trim().length,
 			draft_restored: initialDraft.length > 0,
 			agent: effectiveAgentId,
+			model,
+			effort,
 			destination: isCloudTarget ? "new_cloud_workspace" : "new_workspace",
 		});
 		if (!selectedTarget) {
@@ -179,6 +206,8 @@ export function NewChatWidget({
 					branch: baseBranch ?? branchData?.defaultBranch ?? null,
 					environmentId: selectedEnvironment?.id ?? null,
 					agent: effectiveAgentId,
+					model,
+					effort,
 					message,
 				})
 				.then(() => {
@@ -195,6 +224,8 @@ export function NewChatWidget({
 				branchLabel,
 				agentId,
 				agentLabel: selectedAgent?.label ?? "Claude",
+				model,
+				effort,
 				message,
 			})
 			.then(() => {
@@ -259,6 +290,18 @@ export function NewChatWidget({
 			}))}
 			headerChips={headerChips}
 			selectedModel={selectedModel}
+			launchOptions={launchOptions}
+			onLaunchOptionPress={() => {
+				if (!launchPresetId) return;
+				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+				router.push({
+					pathname: "/(authenticated)/(home)/new-session/model",
+					params: {
+						presetId: launchPresetId,
+						agentLabel: selectedAgent?.label ?? "",
+					},
+				});
+			}}
 			onSubmit={(text) => submit({ text, attachments: draft.attachments })}
 			onDraftChange={draft.setText}
 			onRemoveAttachment={(id) => draft.remove(id)}

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
@@ -17,6 +17,9 @@ interface CreateCloudWorkspaceArgs {
 	environmentId: string | null;
 	/** Built-in agent to launch with the message as its prompt; null for none. */
 	agent: string | null;
+	/** Null launches the agent's own default. Ignored without an agent. */
+	model: string | null;
+	effort: string | null;
 	message: PromptInputMessage;
 }
 
@@ -37,6 +40,8 @@ export function useCreateCloudWorkspace() {
 			branch,
 			environmentId,
 			agent,
+			model,
+			effort,
 			message,
 		}: CreateCloudWorkspaceArgs) => {
 			if (!organizationId) throw new Error("No active organization");
@@ -52,6 +57,8 @@ export function useCreateCloudWorkspace() {
 					"Attachments are not supported for cloud workspaces yet",
 				);
 			}
+			// Only with something to say: an empty prompt leaves it idle.
+			const launchAgent = agent && message.text.trim() ? agent : undefined;
 			return apiClient.cloudWorkspace.create.mutate({
 				organizationId,
 				environmentId,
@@ -59,11 +66,15 @@ export function useCreateCloudWorkspace() {
 				// Omitted when unresolved: the server falls back to the repo's
 				// actual default branch, which the client must not guess.
 				branch: branch ?? undefined,
-				// Only with something to say: an empty prompt leaves it idle.
-				agent: agent && message.text.trim() ? agent : undefined,
+				agent: launchAgent,
+				model: launchAgent ? (model ?? undefined) : undefined,
+				effort: launchAgent ? (effort ?? undefined) : undefined,
 			});
 		},
-		onSuccess: (row: CloudWorkspaceRow, { branch, agent, message }) => {
+		onSuccess: (
+			row: CloudWorkspaceRow,
+			{ branch, agent, model, effort, message },
+		) => {
 			// The API emits `workspace_created`; this is only the client asking.
 			posthog.capture("workspace_create_requested", {
 				workspace_id: row.id,
@@ -72,6 +83,8 @@ export function useCreateCloudWorkspace() {
 				source: "mobile_composer",
 				base_branch: branch,
 				agent: agent && message.text.trim() ? agent : null,
+				model,
+				effort,
 			});
 			// Seed the list before navigating: the workspace screen decides
 			// between "provisioning" and "not found" off this cache, and even

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useStartWorkspaceTerminal/useStartWorkspaceTerminal.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useStartWorkspaceTerminal/useStartWorkspaceTerminal.ts
@@ -32,10 +32,15 @@ export function useStartWorkspaceTerminal(workspaces: HostWorkspaceItem[]) {
 			target,
 			message,
 			agentId,
+			model,
+			effort,
 		}: {
 			target: WorkspaceTerminalTarget;
 			message: PromptInputMessage;
 			agentId: string;
+			/** Null launches the agent's own default. */
+			model: string | null;
+			effort: string | null;
 		}) => {
 			const workspace = workspaces.find(
 				(item) => item.id === target.workspaceId,
@@ -54,6 +59,8 @@ export function useStartWorkspaceTerminal(workspaces: HostWorkspaceItem[]) {
 				workspaceId: target.workspaceId,
 				agent: agentId,
 				prompt: text,
+				model: model ?? undefined,
+				effort: effort ?? undefined,
 			});
 			if (result.kind !== "terminal") {
 				throw new Error(`${result.label} did not start a terminal session`);
@@ -64,9 +71,14 @@ export function useStartWorkspaceTerminal(workspaces: HostWorkspaceItem[]) {
 				hostId: target.hostId,
 			};
 		},
-		onSuccess: ({ workspaceId, terminalId, hostId }, { agentId }) => {
+		onSuccess: (
+			{ workspaceId, terminalId, hostId },
+			{ agentId, model, effort },
+		) => {
 			posthog.capture("agent_session_launch", {
 				agent_type: agentId,
+				model,
+				effort,
 				workspace_id: workspaceId,
 				result: "launched",
 			});

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore/newSessionPreferencesStore.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore/newSessionPreferencesStore.ts
@@ -13,12 +13,34 @@ interface NewSessionPreferencesStore {
 	baseBranch: string | null;
 	/** Cloud only. Null until picked; create falls back to the first. */
 	environmentId: string | null;
+	/**
+	 * Last-picked model and effort per launch preset ("claude", "codex", …).
+	 * No entry means the agent's own default: nothing is sent at launch. Keyed
+	 * by preset rather than host config id so a pick survives host switches,
+	 * same as the desktop's per-preset maps.
+	 */
+	modelByAgent: Record<string, string>;
+	effortByAgent: Record<string, string>;
 	/** False until AsyncStorage has answered — the saved picks aren't here yet. */
 	hasHydrated: boolean;
 	setAgentId: (agentId: string) => void;
 	setTargetKey: (targetKey: string) => void;
 	setBaseBranch: (baseBranch: string | null) => void;
 	setEnvironmentId: (environmentId: string) => void;
+	/** Null clears the pick back to the agent default. */
+	setModel: (presetId: string, model: string | null) => void;
+	setEffort: (presetId: string, effort: string | null) => void;
+}
+
+function withPick(
+	picks: Record<string, string>,
+	presetId: string,
+	pick: string | null,
+): Record<string, string> {
+	const rest = Object.fromEntries(
+		Object.entries(picks).filter(([key]) => key !== presetId),
+	);
+	return pick ? { ...rest, [presetId]: pick } : rest;
 }
 
 export const useNewSessionPreferencesStore =
@@ -29,11 +51,21 @@ export const useNewSessionPreferencesStore =
 				targetKey: null,
 				baseBranch: null,
 				environmentId: null,
+				modelByAgent: {},
+				effortByAgent: {},
 				hasHydrated: false,
 				setAgentId: (agentId) => set({ agentId }),
 				setTargetKey: (targetKey) => set({ targetKey, baseBranch: null }),
 				setBaseBranch: (baseBranch) => set({ baseBranch }),
 				setEnvironmentId: (environmentId) => set({ environmentId }),
+				setModel: (presetId, model) =>
+					set((state) => ({
+						modelByAgent: withPick(state.modelByAgent, presetId, model),
+					})),
+				setEffort: (presetId, effort) =>
+					set((state) => ({
+						effortByAgent: withPick(state.effortByAgent, presetId, effort),
+					})),
 			}),
 			{
 				name: "new-session-preferences",
@@ -42,6 +74,8 @@ export const useNewSessionPreferencesStore =
 					agentId: state.agentId,
 					targetKey: state.targetKey,
 					environmentId: state.environmentId,
+					modelByAgent: state.modelByAgent,
+					effortByAgent: state.effortByAgent,
 				}),
 				// Same async-rehydration window as the filter store: until this
 				// flips, the composer would fall back to a default target instead

--- a/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/AgentOptionsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/AgentOptionsScreen.tsx
@@ -1,0 +1,181 @@
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { useLingui } from "@lingui/react/macro";
+import type { AgentModelOption } from "@superset/shared/agent-models";
+import { type Href, Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { Pressable, ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Text } from "@/components/ui/text";
+import { useTheme } from "@/hooks/useTheme";
+import { posthog } from "@/lib/posthog";
+import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
+import { OptionRow } from "@/screens/(authenticated)/components/OptionRow";
+import { useAgentLaunchPreferences } from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
+import { SectionLabel } from "./components/SectionLabel";
+
+/**
+ * The short list is everything up to and including the catalog's first
+ * group — the aliases that track the newest release. Every later group is
+ * a row of its own that opens that group's list: a dozen pinned versions
+ * would bury the four picks almost everyone wants.
+ */
+export function splitModelCatalog(models: AgentModelOption[]): {
+	inline: AgentModelOption[];
+	groups: string[];
+} {
+	const firstGroup = models.find((option) => option.group)?.group;
+	const inline = models.filter(
+		(option) => !option.group || option.group === firstGroup,
+	);
+	const groups: string[] = [];
+	for (const option of models) {
+		if (
+			option.group &&
+			option.group !== firstGroup &&
+			!groups.includes(option.group)
+		) {
+			groups.push(option.group);
+		}
+	}
+	return { inline, groups };
+}
+
+/**
+ * An agent's launch settings on one screen: the model, with the older pinned
+ * releases a level down, and the reasoning effort under it. A pick sticks
+ * immediately as the agent's remembered default; "Default" sends nothing and
+ * the agent decides.
+ */
+export function AgentOptionsScreen({
+	groupHref,
+}: {
+	/** Where a "Pinned releases ›" row goes — this stack's group screen. */
+	groupHref: (params: { presetId: string; group: string }) => Href;
+}) {
+	const { t } = useLingui();
+	const router = useRouter();
+	const theme = useTheme();
+	const insets = useSafeAreaInsets();
+	const { presetId, agentLabel } = useLocalSearchParams<{
+		presetId?: string;
+		agentLabel?: string;
+	}>();
+	const launchPresetId = presetId || null;
+	const { models, model, efforts, effort } =
+		useAgentLaunchPreferences(launchPresetId);
+	const setModel = useNewSessionPreferencesStore((state) => state.setModel);
+	const setEffort = useNewSessionPreferencesStore((state) => state.setEffort);
+	const { inline, groups } = splitModelCatalog(models ?? []);
+
+	const pickModel = (id: string | null) => {
+		if (!launchPresetId) return;
+		setModel(launchPresetId, id);
+		posthog.capture("new_session_model_selected", {
+			agent: launchPresetId,
+			model: id,
+		});
+	};
+	const pickEffort = (id: string | null) => {
+		if (!launchPresetId) return;
+		setEffort(launchPresetId, id);
+		posthog.capture("new_session_effort_selected", {
+			agent: launchPresetId,
+			effort: id,
+		});
+	};
+
+	return (
+		<ScrollView
+			className="bg-background flex-1 px-6"
+			contentContainerStyle={{
+				flexGrow: 1,
+				paddingBottom: insets.bottom + 8,
+			}}
+		>
+			<Stack.Screen
+				options={{ title: agentLabel || t({ message: "Model" }) }}
+			/>
+			<Stack.Toolbar placement="left">
+				<Stack.Toolbar.Button icon="xmark" onPress={() => router.back()} />
+			</Stack.Toolbar>
+			{models !== undefined ? (
+				<>
+					<SectionLabel label={t({ message: "Model" })} />
+					<OptionRow
+						label={t({ message: "Default" })}
+						isSelected={model === null}
+						onPress={() => pickModel(null)}
+						phLabel="new-session-model-row"
+					/>
+					{inline.map((option) => (
+						<OptionRow
+							key={option.id}
+							label={option.label}
+							isSelected={option.id === model?.id}
+							onPress={() => pickModel(option.id)}
+							phLabel="new-session-model-row"
+						/>
+					))}
+					{groups.map((group) => (
+						<Pressable
+							key={group}
+							onPress={() =>
+								router.push(
+									groupHref({ presetId: launchPresetId ?? "", group }),
+								)
+							}
+							className="flex-row items-center gap-2.5 py-2.5"
+							ph-label="new-session-model-group-row"
+						>
+							<Text
+								className="flex-1 text-sm font-medium"
+								style={{ color: theme.foreground }}
+							>
+								{group}
+							</Text>
+							{model?.group === group ? (
+								<>
+									<Text
+										className="text-sm"
+										style={{ color: theme.mutedForeground }}
+									>
+										{model.label}
+									</Text>
+									<Ionicons
+										name="checkmark-circle"
+										size={18}
+										color={theme.primary}
+									/>
+								</>
+							) : null}
+							<Ionicons
+								name="chevron-forward"
+								size={16}
+								color={theme.mutedForeground}
+							/>
+						</Pressable>
+					))}
+				</>
+			) : null}
+			{efforts.length > 0 ? (
+				<>
+					<SectionLabel label={t({ message: "Effort" })} />
+					<OptionRow
+						label={t({ message: "Default" })}
+						isSelected={effort === null}
+						onPress={() => pickEffort(null)}
+						phLabel="new-session-effort-row"
+					/>
+					{efforts.map((option) => (
+						<OptionRow
+							key={option.id}
+							label={option.label}
+							isSelected={option.id === effort?.id}
+							onPress={() => pickEffort(option.id)}
+							phLabel="new-session-effort-row"
+						/>
+					))}
+				</>
+			) : null}
+		</ScrollView>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/components/SectionLabel/SectionLabel.tsx
+++ b/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/components/SectionLabel/SectionLabel.tsx
@@ -1,0 +1,18 @@
+import { View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useTheme } from "@/hooks/useTheme";
+
+/** Small muted header over a run of option rows. */
+export function SectionLabel({ label }: { label: string }) {
+	const theme = useTheme();
+	return (
+		<View className="pt-4 pb-1">
+			<Text
+				className="text-xs uppercase"
+				style={{ color: theme.mutedForeground }}
+			>
+				{label}
+			</Text>
+		</View>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/components/SectionLabel/index.ts
+++ b/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/components/SectionLabel/index.ts
@@ -1,0 +1,1 @@
+export { SectionLabel } from "./SectionLabel";

--- a/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/index.ts
+++ b/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/index.ts
@@ -1,0 +1,1 @@
+export { AgentOptionsScreen } from "./AgentOptionsScreen";

--- a/apps/mobile/screens/(authenticated)/components/ModelGroupScreen/ModelGroupScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/components/ModelGroupScreen/ModelGroupScreen.tsx
@@ -1,0 +1,54 @@
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { posthog } from "@/lib/posthog";
+import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
+import { OptionRow } from "@/screens/(authenticated)/components/OptionRow";
+import { useAgentLaunchPreferences } from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
+
+/**
+ * One group of the model catalog — the pinned releases the main list keeps
+ * behind a row. Picking returns to that list with the pick shown on the row.
+ */
+export function ModelGroupScreen() {
+	const router = useRouter();
+	const insets = useSafeAreaInsets();
+	const { presetId, group } = useLocalSearchParams<{
+		presetId?: string;
+		group?: string;
+	}>();
+	const launchPresetId = presetId || null;
+	const { models, model } = useAgentLaunchPreferences(launchPresetId);
+	const setModel = useNewSessionPreferencesStore((state) => state.setModel);
+	const options = (models ?? []).filter((option) => option.group === group);
+
+	return (
+		<ScrollView
+			className="bg-background flex-1 px-6"
+			contentContainerStyle={{
+				flexGrow: 1,
+				paddingTop: 8,
+				paddingBottom: insets.bottom + 8,
+			}}
+		>
+			<Stack.Screen options={{ title: group ?? "" }} />
+			{options.map((option) => (
+				<OptionRow
+					key={option.id}
+					label={option.label}
+					isSelected={option.id === model?.id}
+					onPress={() => {
+						if (!launchPresetId) return;
+						setModel(launchPresetId, option.id);
+						posthog.capture("new_session_model_selected", {
+							agent: launchPresetId,
+							model: option.id,
+						});
+						router.back();
+					}}
+					phLabel="new-session-model-row"
+				/>
+			))}
+		</ScrollView>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/components/ModelGroupScreen/index.ts
+++ b/apps/mobile/screens/(authenticated)/components/ModelGroupScreen/index.ts
@@ -1,0 +1,1 @@
+export { ModelGroupScreen } from "./ModelGroupScreen";

--- a/apps/mobile/screens/(authenticated)/components/OptionRow/OptionRow.tsx
+++ b/apps/mobile/screens/(authenticated)/components/OptionRow/OptionRow.tsx
@@ -1,0 +1,36 @@
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { Pressable } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useTheme } from "@/hooks/useTheme";
+
+/** One pick in an option list, drawn like the new-session agent rows. */
+export function OptionRow({
+	label,
+	isSelected,
+	onPress,
+	phLabel,
+}: {
+	label: string;
+	isSelected: boolean;
+	onPress: () => void;
+	phLabel: string;
+}) {
+	const theme = useTheme();
+	return (
+		<Pressable
+			onPress={onPress}
+			className="flex-row items-center gap-2.5 py-2.5"
+			ph-label={phLabel}
+		>
+			<Text
+				className="flex-1 text-sm font-medium"
+				style={{ color: theme.foreground }}
+			>
+				{label}
+			</Text>
+			{isSelected ? (
+				<Ionicons name="checkmark-circle" size={18} color={theme.primary} />
+			) : null}
+		</Pressable>
+	);
+}

--- a/apps/mobile/screens/(authenticated)/components/OptionRow/OptionRow.tsx
+++ b/apps/mobile/screens/(authenticated)/components/OptionRow/OptionRow.tsx
@@ -19,6 +19,8 @@ export function OptionRow({
 	return (
 		<Pressable
 			onPress={onPress}
+			accessibilityRole="button"
+			accessibilityState={{ selected: isSelected }}
 			className="flex-row items-center gap-2.5 py-2.5"
 			ph-label={phLabel}
 		>

--- a/apps/mobile/screens/(authenticated)/components/OptionRow/index.ts
+++ b/apps/mobile/screens/(authenticated)/components/OptionRow/index.ts
@@ -1,0 +1,1 @@
+export { OptionRow } from "./OptionRow";

--- a/apps/mobile/screens/(authenticated)/hooks/useAgentLaunchPreferences/index.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useAgentLaunchPreferences/index.ts
@@ -1,0 +1,7 @@
+export {
+	type AgentLaunchPreferences,
+	agentLaunchPresetId,
+	describeAgentLaunchPreferences,
+	resolveAgentLaunchPreferences,
+	useAgentLaunchPreferences,
+} from "./useAgentLaunchPreferences";

--- a/apps/mobile/screens/(authenticated)/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts
@@ -1,0 +1,87 @@
+import {
+	type AgentEffortOption,
+	type AgentModelOption,
+	getAgentEfforts,
+	getAgentModelSupport,
+	resolveAgentLaunchPresetId,
+} from "@superset/shared/agent-models";
+import { useMemo } from "react";
+import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
+
+export interface AgentLaunchPreferences {
+	/** Curated models the preset offers; undefined when it has no model flag. */
+	models: AgentModelOption[] | undefined;
+	/** Efforts the preset offers next to `model`; empty when it has none. */
+	efforts: AgentEffortOption[];
+	/** The remembered pick, or null for the agent's own default. */
+	model: AgentModelOption | null;
+	effort: AgentEffortOption | null;
+}
+
+const NO_PREFERENCES: AgentLaunchPreferences = {
+	models: undefined,
+	efforts: [],
+	model: null,
+	effort: null,
+};
+
+/**
+ * The catalog key for an agent config: its preset, except that a config whose
+ * executable is OMP launches with OMP's options — the same resolution the host
+ * applies before validating a launch.
+ */
+export function agentLaunchPresetId(config: {
+	presetId: string;
+	command?: string;
+}): string {
+	return config.command
+		? resolveAgentLaunchPresetId(config.presetId, config.command)
+		: config.presetId;
+}
+
+/**
+ * The remembered model and effort for a launch preset, checked against the
+ * curated catalog. A pick that fell out of the catalog, or an effort the
+ * picked model rejects, reads as the default: the host would refuse it, and
+ * "Default" beats a launch that fails.
+ */
+export function resolveAgentLaunchPreferences(
+	presetId: string | null,
+	modelByAgent: Record<string, string>,
+	effortByAgent: Record<string, string>,
+): AgentLaunchPreferences {
+	if (!presetId) return NO_PREFERENCES;
+	const models = getAgentModelSupport(presetId)?.models;
+	const model =
+		models?.find((option) => option.id === modelByAgent[presetId]) ?? null;
+	const efforts = getAgentEfforts(presetId, model?.id);
+	const effort =
+		efforts.find((option) => option.id === effortByAgent[presetId]) ?? null;
+	return { models, efforts, model, effort };
+}
+
+/** "Opus · High" — what a launch adds to the agent's default; null for nothing. */
+export function describeAgentLaunchPreferences({
+	model,
+	effort,
+}: AgentLaunchPreferences): string | null {
+	const parts = [model?.label, effort?.label].filter((label): label is string =>
+		Boolean(label),
+	);
+	return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+export function useAgentLaunchPreferences(
+	presetId: string | null,
+): AgentLaunchPreferences {
+	const modelByAgent = useNewSessionPreferencesStore(
+		(state) => state.modelByAgent,
+	);
+	const effortByAgent = useNewSessionPreferencesStore(
+		(state) => state.effortByAgent,
+	);
+	return useMemo(
+		() => resolveAgentLaunchPreferences(presetId, modelByAgent, effortByAgent),
+		[presetId, modelByAgent, effortByAgent],
+	);
+}

--- a/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
@@ -48,7 +48,7 @@ export function useCreateTerminalWorkspace() {
 
 	return useMutation({
 		mutationFn: async ({ replace, ...input }: CreateTerminalWorkspaceArgs) => {
-			const { target, baseBranch, agentId, message } = input;
+			const { target, baseBranch, agentId, model, effort, message } = input;
 			const workspaceId = randomUUID();
 			startPending({
 				workspaceId,
@@ -85,6 +85,8 @@ export function useCreateTerminalWorkspace() {
 							prompt: message.text.trim(),
 							attachmentIds:
 								attachmentIds.length > 0 ? attachmentIds : undefined,
+							model: model ?? undefined,
+							effort: effort ?? undefined,
 						},
 					],
 				};
@@ -117,6 +119,8 @@ export function useCreateTerminalWorkspace() {
 					source: "mobile_composer",
 					base_branch: baseBranch,
 					agent: agentId,
+					model,
+					effort,
 				});
 				return { workspaceId };
 			} catch (error) {

--- a/apps/mobile/screens/(authenticated)/stores/pendingWorkspaceCreatesStore/pendingWorkspaceCreatesStore.ts
+++ b/apps/mobile/screens/(authenticated)/stores/pendingWorkspaceCreatesStore/pendingWorkspaceCreatesStore.ts
@@ -23,6 +23,9 @@ export interface PendingWorkspaceCreateInput {
 	branchLabel: string | null;
 	agentId: string;
 	agentLabel: string;
+	/** Null launches the agent's own default. */
+	model: string | null;
+	effort: string | null;
 	message: PromptInputMessage;
 }
 

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
@@ -75,8 +75,9 @@ export function FinishReviewSheet() {
 	const agentConfig = agentConfigs.data?.find(
 		(config) => config.presetId === agentId,
 	);
+	// The preset id stands in until the configs answer (see NewChatWidget).
 	const launch = useAgentLaunchPreferences(
-		agentConfig ? agentLaunchPresetId(agentConfig) : null,
+		agentConfig ? agentLaunchPresetId(agentConfig) : agentId,
 	);
 
 	const terminalRows = useMemo(

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
@@ -19,6 +19,11 @@ import {
 } from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
 import { PressableScale } from "@/screens/(authenticated)/components/PressableScale";
 import {
+	agentLaunchPresetId,
+	useAgentLaunchPreferences,
+} from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
+import { useHostAgentConfigs } from "@/screens/(authenticated)/hooks/useHostAgentConfigs";
+import {
 	type DraftComment,
 	NO_COMMENTS,
 	useDraftCommentsStore,
@@ -63,6 +68,16 @@ export function FinishReviewSheet() {
 	);
 	const startWorkspaceTerminal = useStartWorkspaceTerminal(widgetWorkspaces);
 	const agentId = useNewSessionPreferencesStore((state) => state.agentId);
+	const agentConfigs = useHostAgentConfigs({
+		machineId: host?.machineId ?? null,
+		hostUrl: host ? hostServiceUrl(host.organizationId, host.machineId) : null,
+	});
+	const agentConfig = agentConfigs.data?.find(
+		(config) => config.presetId === agentId,
+	);
+	const launch = useAgentLaunchPreferences(
+		agentConfig ? agentLaunchPresetId(agentConfig) : null,
+	);
 
 	const terminalRows = useMemo(
 		() => (workspaceId ? (terminalsByWorkspace.get(workspaceId) ?? []) : []),
@@ -92,6 +107,8 @@ export function FinishReviewSheet() {
 						},
 						message: { text: prompt, attachments: [] },
 						agentId,
+						model: launch.model?.id ?? null,
+						effort: launch.effort?.id ?? null,
 					},
 					{
 						onSuccess: () => {

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
@@ -12,14 +12,22 @@ import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
 } from "@/lib/host-service/client";
+import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 import { getHostTerminalsQueryKey } from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
 import { AgentMark } from "@/screens/(authenticated)/(home)/new-session/agent";
 import { ListRow } from "@/screens/(authenticated)/components/ListRow";
+import {
+	agentLaunchPresetId,
+	describeAgentLaunchPreferences,
+	resolveAgentLaunchPreferences,
+} from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
 import { useHostAgentConfigs } from "@/screens/(authenticated)/hooks/useHostAgentConfigs";
 
 /**
  * Bottom sheet for the tab strip's + — the host's agent presets plus a plain
- * shell, each row launching a new session and landing on its tab.
+ * shell, each row launching a new session and landing on its tab. An agent
+ * launches with the model and effort the home composer remembered for it,
+ * shown under its name so the row says what it starts.
  */
 export function NewSessionSheet() {
 	const { t } = useLingui();
@@ -37,6 +45,18 @@ export function NewSessionSheet() {
 		hostUrl,
 	});
 	const presets = presetsQuery.data ?? [];
+	const modelByAgent = useNewSessionPreferencesStore(
+		(state) => state.modelByAgent,
+	);
+	const effortByAgent = useNewSessionPreferencesStore(
+		(state) => state.effortByAgent,
+	);
+	const launchFor = (preset: (typeof presets)[number]) =>
+		resolveAgentLaunchPreferences(
+			agentLaunchPresetId(preset),
+			modelByAgent,
+			effortByAgent,
+		);
 
 	// The launching row shows a spinner; every row locks until the launch
 	// resolves so a double-tap can't start two sessions.
@@ -66,22 +86,25 @@ export function NewSessionSheet() {
 		}
 	}
 
-	const launch = async (agentId: string | null) => {
+	const launch = async (preset: (typeof presets)[number] | null) => {
 		if (!workspace || !hostUrl || launchingKey !== null) return;
-		setLaunchingKey(agentId ?? "shell");
+		setLaunchingKey(preset?.presetId ?? "shell");
 		try {
 			const client = getHostServiceClientByUrl(hostUrl);
 			let terminalId: string;
-			if (agentId === null) {
+			if (preset === null) {
 				const created = await client.terminal.createSession.mutate({
 					workspaceId: workspace.id,
 				});
 				terminalId = created.terminalId;
 			} else {
+				const { model, effort } = launchFor(preset);
 				const result = await client.agents.run.mutate({
 					workspaceId: workspace.id,
-					agent: agentId,
+					agent: preset.presetId,
 					prompt: "",
+					model: model?.id,
+					effort: effort?.id,
 				});
 				if (result.kind !== "terminal") {
 					throw new Error(`${result.label} did not start a terminal session`);
@@ -152,8 +175,11 @@ export function NewSessionSheet() {
 						/>
 					}
 					label={preset.label}
+					subtitle={
+						describeAgentLaunchPreferences(launchFor(preset)) ?? undefined
+					}
 					trailing={launchingKey === preset.presetId ? spinner : undefined}
-					onPress={() => void launch(preset.presetId)}
+					onPress={() => void launch(preset)}
 				/>
 			))}
 			{presets.length > 0 ? (

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
@@ -38,8 +38,9 @@ export function useAskAgent({ workspaceId }: { workspaceId: string | null }) {
 	const agentConfig = agentConfigs.data?.find(
 		(config) => config.presetId === agentId,
 	);
+	// The preset id stands in until the configs answer (see NewChatWidget).
 	const launch = useAgentLaunchPreferences(
-		agentConfig ? agentLaunchPresetId(agentConfig) : null,
+		agentConfig ? agentLaunchPresetId(agentConfig) : agentId,
 	);
 	const [busyAction, setBusyAction] = useState<AgentActionId | null>(null);
 

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
@@ -11,6 +11,11 @@ import {
 } from "@/lib/host-service/client";
 import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/home/components/NewChatWidget/stores/newSessionPreferencesStore";
 import { getHostTerminalsQueryKey } from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
+import {
+	agentLaunchPresetId,
+	useAgentLaunchPreferences,
+} from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
+import { useHostAgentConfigs } from "@/screens/(authenticated)/hooks/useHostAgentConfigs";
 import type { PullRequestDetail } from "../../../../utils/pullRequest";
 import { agentPrompt } from "../../utils/agentPrompt";
 import type { AgentActionId } from "../../utils/pullRequestState";
@@ -19,13 +24,23 @@ import type { AgentActionId } from "../../utils/pullRequestState";
  * The "… with Agent" buttons: one tap starts a fresh agent session in this
  * workspace with the instruction already sent — there is no edit step — and
  * lands on its tab to watch it work. The agent is whichever one the composer
- * last used.
+ * last used, with the model and effort remembered for it.
  */
 export function useAskAgent({ workspaceId }: { workspaceId: string | null }) {
 	const router = useRouter();
 	const queryClient = useQueryClient();
 	const { workspace, host } = useWorkspaceHost(workspaceId);
 	const agentId = useNewSessionPreferencesStore((state) => state.agentId);
+	const agentConfigs = useHostAgentConfigs({
+		machineId: host?.machineId ?? null,
+		hostUrl: host ? hostServiceUrl(host.organizationId, host.machineId) : null,
+	});
+	const agentConfig = agentConfigs.data?.find(
+		(config) => config.presetId === agentId,
+	);
+	const launch = useAgentLaunchPreferences(
+		agentConfig ? agentLaunchPresetId(agentConfig) : null,
+	);
 	const [busyAction, setBusyAction] = useState<AgentActionId | null>(null);
 
 	const mutation = useMutation({
@@ -38,6 +53,8 @@ export function useAskAgent({ workspaceId }: { workspaceId: string | null }) {
 					workspaceId: workspace.id,
 					agent: agentId,
 					prompt,
+					model: launch.model?.id ?? undefined,
+					effort: launch.effort?.id ?? undefined,
 				},
 			);
 			if (result.kind !== "terminal") {

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor a workflow"
 msgid "Editor typography"
 msgstr "Typografie editoru"
 
+msgid "Effort"
+msgstr "Úsilí"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Svázané s Electronem/tRPC, proto jen odkazované, ne vykreslené. Odznak = dnešní místa importu; vysoká čísla jsou kandidáti na přesun do packages/ui"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor & Workflow"
 msgid "Editor typography"
 msgstr "Editor-Typografie"
 
+msgid "Effort"
+msgstr "Aufwand"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "An Electron/tRPC gekoppelt, daher nur referenziert statt gerendert. Badge = heutige Import-Stellen; hohe Zahlen sind Kandidaten für packages/ui"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor & Workflow"
 msgid "Editor typography"
 msgstr "Editor typography"
 
+msgid "Effort"
+msgstr "Effort"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor y flujo de trabajo"
 msgid "Editor typography"
 msgstr "Tipografía del editor"
 
+msgid "Effort"
+msgstr "Esfuerzo"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Acoplados a Electron/tRPC, así que se referencian en vez de renderizarse. La insignia = puntos de importación actuales; los valores altos son candidatos a promoverse a packages/ui"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Éditeur et flux de travail"
 msgid "Editor typography"
 msgstr "Typographie de l'éditeur"
 
+msgid "Effort"
+msgstr "Effort"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Couplés à Electron/tRPC, donc référencés plutôt que rendus. Le badge = les sites d'import actuels ; les compteurs élevés sont candidats à une promotion vers packages/ui"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -5131,7 +5131,7 @@ msgid "Editor typography"
 msgstr "Tipografi editor"
 
 msgid "Effort"
-msgstr "Effort"
+msgstr "Upaya"
 
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Terikat Electron/tRPC, jadi dirujuk alih-alih dirender. Badge = jumlah tempat impor saat ini; angka tinggi adalah kandidat untuk dipromosikan ke packages/ui"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor & Alur Kerja"
 msgid "Editor typography"
 msgstr "Tipografi editor"
 
+msgid "Effort"
+msgstr "Effort"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Terikat Electron/tRPC, jadi dirujuk alih-alih dirender. Badge = jumlah tempat impor saat ini; angka tinggi adalah kandidat untuk dipromosikan ke packages/ui"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor e flusso di lavoro"
 msgid "Editor typography"
 msgstr "Tipografia dell'editor"
 
+msgid "Effort"
+msgstr "Effort"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Accoppiati a Electron/tRPC, quindi solo referenziati e non renderizzati. Il badge = i punti di import odierni; i conteggi alti sono candidati alla promozione in packages/ui"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -5130,6 +5130,9 @@ msgstr "エディタとワークフロー"
 msgid "Editor typography"
 msgstr "エディタのタイポグラフィ"
 
+msgid "Effort"
+msgstr "エフォート"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Electron/tRPCに依存するため、描画せず参照のみです。バッジは現在のインポート箇所数で、数が多いものはpackages/uiへの昇格候補です"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -5131,7 +5131,7 @@ msgid "Editor typography"
 msgstr "エディタのタイポグラフィ"
 
 msgid "Effort"
-msgstr "エフォート"
+msgstr "推論の強度"
 
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Electron/tRPCに依存するため、描画せず参照のみです。バッジは現在のインポート箇所数で、数が多いものはpackages/uiへの昇格候補です"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -5130,6 +5130,9 @@ msgstr "편집기 및 워크플로"
 msgid "Editor typography"
 msgstr "편집기 타이포그래피"
 
+msgid "Effort"
+msgstr "추론 강도"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Electron/tRPC에 묶여 있어 렌더링하지 않고 참조만 합니다. 배지는 현재 import 지점 수이며, 수가 많으면 packages/ui로 승격할 후보입니다"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor en workflow"
 msgid "Editor typography"
 msgstr "Editortypografie"
 
+msgid "Effort"
+msgstr "Effort"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Gekoppeld aan Electron/tRPC, dus alleen genoemd in plaats van gerenderd. Badge = huidige importplekken; hoge aantallen zijn kandidaten voor promotie naar packages/ui"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Edytor i workflow"
 msgid "Editor typography"
 msgstr "Typografia edytora"
 
+msgid "Effort"
+msgstr "Wysiłek"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Powiązane z Electronem/tRPC, więc tylko wymienione, nie renderowane. Plakietka = obecne miejsca importu; wysokie liczby to kandydaci do przeniesienia do packages/ui"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Editor e fluxo de trabalho"
 msgid "Editor typography"
 msgstr "Tipografia do editor"
 
+msgid "Effort"
+msgstr "Esforço"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Acoplados a Electron/tRPC, então são referenciados em vez de renderizados. O selo = pontos de import hoje; contagens altas são candidatos a promoção para packages/ui"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Редактор и процесс"
 msgid "Editor typography"
 msgstr "Типографика редактора"
 
+msgid "Effort"
+msgstr "Уровень усилий"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Завязаны на Electron/tRPC, поэтому только упомянуты, а не отрисованы. Значок = количество мест импорта сегодня; высокие значения — кандидаты на переезд в packages/ui"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Düzenleyici ve iş akışı"
 msgid "Editor typography"
 msgstr "Düzenleyici tipografisi"
 
+msgid "Effort"
+msgstr "Çaba"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Electron/tRPC'ye bağlı olduğu için işlenmek yerine referans veriliyor. Rozet = bugünkü içe aktarma noktaları; yüksek sayılar packages/ui'ye taşınma adayıdır"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -5130,6 +5130,9 @@ msgstr "Trình soạn thảo & Quy trình"
 msgid "Editor typography"
 msgstr "Kiểu chữ trình soạn thảo"
 
+msgid "Effort"
+msgstr "Mức nỗ lực"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "Gắn với Electron/tRPC nên chỉ được nhắc tới chứ không dựng. Badge = số nơi import hiện tại; số cao là ứng viên đưa lên packages/ui"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -5130,6 +5130,9 @@ msgstr "编辑器与工作流"
 msgid "Editor typography"
 msgstr "编辑器排版"
 
+msgid "Effort"
+msgstr "推理强度"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "与Electron/tRPC耦合，因此只做引用而不实际渲染。徽章=当前的导入处数量；数量高的可以考虑提升到packages/ui"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -5130,6 +5130,9 @@ msgstr "編輯器與工作流"
 msgid "Editor typography"
 msgstr "編輯器排版"
 
+msgid "Effort"
+msgstr "推理強度"
+
 msgid "Electron/tRPC-coupled, so referenced rather than rendered. Badge = import sites today; high counts are promotion candidates for packages/ui"
 msgstr "與Electron/tRPC耦合，因此只做引用而不實際渲染。徽章=目前的匯入處數量；數量高的可以考慮提升到packages/ui"
 


### PR DESCRIPTION
## Summary
- The iOS home composer gets a model dropdown after the agent (`✱ Claude ⌄ Opus ⌄`). It opens a sheet titled with the agent: a short model list, the pinned releases behind a "Pinned releases ›" row, and the reasoning effort below.
- Picks persist per launch preset and apply to every launch of that agent from the phone: new workspaces (host and cloud), the workspace "+" sheet (which shows the pick under the agent), the PR "Ask agent" buttons and finish-review.
- Unset sends nothing, so the agent's own default is unchanged.

## Why / Context
Slack request from an iOS user whose Fable credit ran out mid-day with no way to switch to Opus from the phone. The desktop's new-workspace form already has model and effort pickers; the phone had none.

## How It Works
- No new API. The host's `agents.run` and `workspaces.create*` agent entries and `cloudWorkspace.create` already accept `model`/`effort` and validate them against `packages/shared/src/agent-models.ts`. The app reads that same catalog, so the pickers are per-preset and dynamic (Codex's per-model effort ladder included), and a Pi config running OMP resolves to OMP's options the way the host does.
- `newSessionPreferencesStore` gains `modelByAgent`/`effortByAgent`, keyed by launch preset id like the desktop's per-preset maps. `useAgentLaunchPreferences` resolves a pick against the catalog; an id that fell out, or an effort the picked model rejects, reads as Default rather than a failing launch.
- Native Composer gains a `launchOptions` prop plus `onLaunchOptionPress`, rendered after the agent button in the expanded toolbar.
- `AgentOptionsScreen` shows the catalog up to and including its first group inline (Claude: Fable, Opus, Sonnet, Haiku); every later group is a row that pushes `ModelGroupScreen`. Picks stick immediately; the sheet stays open.

## Manual QA Checklist
Verified on an iPhone 17 Pro simulator against prod (App Review org, acme-devbox):
- [x] Composer shows `Claude ⌄ Default model ⌄`; picking Opus and High updates the dropdown to `Opus`
- [x] Sheet: Model section with Default/Fable/Opus/Sonnet/Haiku, Pinned releases › (shows the picked pinned name + check), Effort section Default…Max
- [x] Workspace "+" sheet shows "Claude / Opus" and the launched session's Claude Code banner reads "Opus 5"
- [x] Agents without an effort flag show no Effort section; agents without a model flag show no dropdown
- [x] Preference survives app relaunch
- [ ] Cloud workspace launch with a pick (not exercised; same `cloudWorkspace.create` fields the desktop sends)

## Testing
- `bun run typecheck` (apps/mobile; needs `bun run build:types` in packages/host-service first in a fresh worktree)
- `bun run lint`
- `bun run test` (apps/mobile, 66 pass)
- `bun run check:i18n` ("Effort" is the only new string, translated in all 16 locales)
- `xcodebuild` Debug simulator build of the app

## Design Decisions
- **Picks apply to every launch of that agent, not only new workspaces**: the requester's credit ran out, so a pick covering only the home composer would still burn on "Ask agent" and finish-review. The workspace "+" sheet reflects the pick rather than offering its own picker.
- **No change to running sessions**: Claude Code and Codex already expose `/model` in the terminal composer's slash-command list, which keeps the conversation. A restart-in-place path was prototyped and dropped.
- **Short list + grouped sub-screen** instead of the desktop's flat select: twelve pinned versions buried the four aliases almost everyone wants.

## Known Limitations
- The Claude "Latest" aliases (`opus`, `fable`) resolve on the host's CLI, so a pick means whatever that CLI calls Opus today. Same as the desktop.

https://claude.ai/code/session_01X7E4Rre3GzgfkQCPjJPzQ1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model and effort pickers to the iOS composer so you can start an agent on a specific model instead of its default. Picks persist per launch preset and apply to every launch of that agent from the phone, including new host/cloud workspaces, the workspace "+" sheet, PR "Ask agent", and finish-review. Leaving a pick unset sends nothing, so the agent's own default is unchanged.

**Notes**
- Agents without model or effort support show no picker.
- A remembered pick that is no longer valid falls back to Default instead of failing the launch.
- Picks still apply before the host's agent configs load; the preset id stands in until then.
- No new API; launches reuse the existing `model` and `effort` fields.

<sup>Written for commit 7755db46644f6a62dac69f87257dd6957c2cafde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added model and reasoning-effort selection when starting agent sessions.
  - Users can browse available models, model groups, or restore default settings.
  - Selected preferences are remembered per launch preset and shown in session controls.
  - Model and effort choices apply to cloud, terminal, review, and follow-up agent sessions.
  - Added localized “Effort” labels across supported languages.

- **Improvements**
  - Added clearer indicators for selected options and launch preferences.
  - Added navigation from the new-session flow to model and preference screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->