### PR TITLE
docs(development): document Linux setup prerequisites

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,10 +8,88 @@ This guide is for contributors building Superset from source. If you just want t
 |:-----|:--------|
 | [Bun](https://bun.sh/) v1.3.14+ (pinned in `.bun-version`) | `curl -fsSL https://bun.sh/install \| bash` |
 | [Docker](https://docs.docker.com/get-docker/) | Docker Desktop or OrbStack |
-| `jq` | `brew install jq` |
-| Git 2.20+ and [`gh`](https://cli.github.com/) | `brew install gh` |
+| `jq` | `brew install jq` (Linux: `sudo apt-get install -y jq`) |
+| Git 2.20+ and [`gh`](https://cli.github.com/) | `brew install gh` (Linux: [gh apt repo](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)) |
 
-macOS is the primary supported platform. Windows / Linux are untested.
+macOS is the primary supported platform. Windows is untested. Linux works, but
+needs the extra setup in [Linux prerequisites](#linux-prerequisites) first.
+
+## Linux prerequisites
+
+Verified on Ubuntu 24.04 / X11. Do all of this before `./.superset/setup.local.sh`,
+except the Electron sandbox step, which needs `node_modules` to exist.
+
+Install `bun` at the version in `.bun-version` rather than the latest release, so
+`bun.lock` doesn't churn:
+
+```bash
+curl -fsSL https://bun.sh/install | bash -s "bun-v$(cat .bun-version)"
+```
+
+**X11 headers for `native-keymap`.** Without them `bun install` fails in the
+`@superset/desktop` postinstall with `Package 'xkbfile', required by 'virtual:world', not found`:
+
+```bash
+sudo apt-get install -y libxkbfile-dev
+```
+
+**A hosts entry for `db.localtest.me`.** The name resolves to `127.0.0.1` in public
+DNS, but systemd-resolved drops answers that point at loopback, so the neon-proxy
+connection string fails with `ConnectionRefused` even though the container is
+healthy:
+
+```bash
+echo '127.0.0.1 db.localtest.me' | sudo tee -a /etc/hosts
+```
+
+**A higher inotify instance limit.** The default of 128 is not enough for the
+Next.js, Vite, and Electron watchers running at once. `inotify_init` reports
+exhaustion as `EMFILE`, which surfaces as a misleading
+`TurbopackInternalError: Too many open files (os error 24)` — misleading because
+`ulimit -n` is already high enough and is not the limit being hit:
+
+```bash
+echo 'fs.inotify.max_user_instances=1024' | sudo tee /etc/sysctl.d/99-superset-inotify.conf
+sudo sysctl --system
+```
+
+**Enough swap to run the whole stack.** `bun run dev` starts three Next.js/Turbopack
+servers plus Vite plus Electron, which together hold several GiB of anonymous
+memory. The kernel can only reclaim that if there is somewhere to page it out, so a
+small swapfile stalls the machine under memory pressure even with RAM free — on a
+15 GiB box with a 512 MiB swapfile this killed the dev servers mid-build, with no
+kernel OOM kill in `dmesg` to explain it. 6 GiB is comfortable:
+
+```bash
+sudo swapoff /swapfile
+sudo rm /swapfile
+sudo fallocate -l 6G /swapfile   # on btrfs use dd and chattr +C instead
+sudo chmod 600 /swapfile         # swapon refuses a world-readable swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+```
+
+Run those with the dev servers stopped: `swapoff` pages everything back into RAM
+first. If `/etc/fstab` already lists `/swapfile`, resizing in place needs no edit
+there. `bun run dev:desktop` (api + desktop, no web app) is the lighter alternative
+if you would rather not grow swap.
+
+**A setuid Electron sandbox helper**, after `bun install` has run. Electron ships
+`chrome-sandbox` mode 755 owned by the installing user; Chromium requires it to be
+root-owned and setuid, and aborts at startup rather than run unsandboxed. Ubuntu
+24.04 and later also set `kernel.apparmor_restrict_unprivileged_userns=1`, which
+blocks the namespace sandbox Electron would otherwise fall back to, so fixing the
+binary is the fix. Do not pass `--no-sandbox` instead — that disables the renderer
+sandbox for the whole dev app:
+
+```bash
+sandbox="$(find node_modules -path '*electron/dist/chrome-sandbox' | head -1)"
+sudo chown root:root "$sandbox"
+sudo chmod 4755 "$sandbox"
+```
+
+This lives in `node_modules`, so reinstalling or bumping Electron resets it and you
+run those three lines again.
 
 ## Run it from a Superset workspace
 
@@ -100,6 +178,7 @@ See [`AGENTS.md`](./AGENTS.md) for repo structure, monorepo conventions, and dat
 - **Port collision**: `setup.local.sh` allocates a fresh port window per worktree. If you ran the script before this change landed, re-run it to migrate.
 - **DB connection errors after pulling main**: re-run `./.superset/setup.local.sh`; it's idempotent and will apply any new migrations.
 - **Stuck Docker stack**: `./.superset/teardown.local.sh` then re-run setup.
+- **Linux: build or startup fails in a way this list doesn't cover**: check [Linux prerequisites](#linux-prerequisites) first. `Too many open files`, `ConnectionRefused` against a healthy container, a `chrome-sandbox` abort, and dev servers dying mid-build all have Linux-specific causes documented there.
 
 ## Contributing
 


### PR DESCRIPTION
## Problem

DEVELOPMENT.md said "Windows / Linux are untested". Setting the stack up on Ubuntu 24.04 / X11 turned up five distinct blockers. All are fixable in a few minutes each, but three report errors that point away from their actual cause, so finding them took much longer than fixing them.

## What this adds

A `## Linux prerequisites` section covering:

| Blocker | Symptom it produces |
|---|---|
| `libxkbfile-dev` missing | `bun install` fails in the `@superset/desktop` postinstall: `Package 'xkbfile', required by 'virtual:world', not found` |
| `db.localtest.me` does not resolve | `ConnectionRefused` against neon-proxy **while the container is healthy** |
| `fs.inotify.max_user_instances` too low (128) | `TurbopackInternalError: Too many open files (os error 24)` |
| Swapfile too small | Dev servers killed mid-build, **no OOM kill in `dmesg`** |
| `chrome-sandbox` not setuid root | Electron aborts at startup rather than run unsandboxed |

The three misleading ones are worth calling out, since they are where the time goes:

- **`db.localtest.me`** resolves to `127.0.0.1` in public DNS, but systemd-resolved drops loopback answers as rebind protection. The container is healthy and the port is open, so everything looks fine except the connection.
- **The inotify limit** is reported by `inotify_init` as `EMFILE`, which surfaces as "Too many open files". That reads as a file-descriptor limit, but `ulimit -n` was already 1048576 and is not the limit being hit.
- **Swap.** A 512 MiB swapfile on a 15 GiB machine leaves the kernel no room to reclaim anonymous memory, so it thrashes page cache instead. The dev servers get killed on memory pressure with no kernel OOM kill to explain it.

Each entry records the error text it produces, so searching for the message lands on the fix.

The `chrome-sandbox` entry says explicitly **not** to use `--no-sandbox`, which is the first workaround most search results suggest and which disables the renderer sandbox for the whole dev app. Ubuntu 24.04+ also sets `kernel.apparmor_restrict_unprivileged_userns=1`, blocking the namespace sandbox Electron would otherwise fall back to, so fixing the binary is the actual fix rather than a preference.

Also in this PR:

- apt equivalents on the `jq` and `gh` prerequisite rows, which previously gave only `brew` commands
- the bun install line uses `bash -s "bun-v$(cat .bun-version)"` so the pinned version is installed and `bun.lock` does not churn
- a Troubleshooting cross-link, so someone who lands there first gets pointed at the Linux section

## Testing

Followed the resulting instructions on a clean Ubuntu 24.04 / X11 machine. `./.superset/setup.local.sh` completes, `bun run dev` starts api, web and the Electron desktop app, and the app loads to its sign-in screen.

Docs only, no code changes. One caveat on scope: this is verified on Ubuntu 24.04 / X11 specifically, which the section states rather than claiming Linux generally. Other distributions will differ in package names, and Wayland is untested.

Separately, `bun run db:seed-dev` fails on a clean install for a reason that is **not** Linux specific; that fix is in #7235 and is deliberately kept out of this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents Linux setup prerequisites in DEVELOPMENT.md, which previously said Linux was untested. Adds a Linux prerequisites section covering five blockers found on Ubuntu 24.04 / X11.

- Each entry records the error text it produces, since three of the errors point away from their actual cause.
- Warns against passing `--no-sandbox` to Electron, which disables the renderer sandbox for the whole app.
- Adds apt commands to the `jq` and `gh` rows, which previously only gave `brew` commands.
- Pins the bun install step to the version in `.bun-version` so `bun.lock` doesn't churn.
- Cross-links the Troubleshooting list to the new section.
- Docs only; verified on Ubuntu 24.04 / X11, not other distributions or Wayland.

<sup>Written for commit 839789a63a62d3df186c18d2b8994b97392ce59a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Linux installation commands for required tools.
  * Documented Linux-specific setup steps, including runtime installation, system packages, host configuration, file watcher limits, swap sizing, and sandbox permissions.
  * Updated platform support guidance to clarify that Linux works with additional setup while Windows remains untested.
  * Added troubleshooting guidance directing users to the Linux prerequisites when builds or startup fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->