### PR TITLE
fix(desktop): stop LeaderboardRank test hardcoding the marketing domain

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/LeaderboardCard/components/LeaderboardRank/LeaderboardRank.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/usage/components/LeaderboardCard/components/LeaderboardRank/LeaderboardRank.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { COMPANY } from "@superset/shared/constants";
 
 // happy-dom is process-wide; unregister in afterAll so the shared mock
 // document is restored for the other renderer suites.
@@ -51,8 +52,8 @@ describe("LeaderboardRank", () => {
 		const links = [...container.querySelectorAll("a")].map((a) =>
 			a.getAttribute("href"),
 		);
-		expect(links).toContain("https://superset.sh/user/kiet");
-		expect(links).toContain("https://superset.sh/leaderboard");
+		expect(links).toContain(`${COMPANY.MARKETING_URL}/user/kiet`);
+		expect(links).toContain(`${COMPANY.MARKETING_URL}/leaderboard`);
 		expect(getByText("kiet")).toBeTruthy();
 	});
 


### PR DESCRIPTION
## Problem

`bun run test` fails at the repository root for anyone who set the project up by following DEVELOPMENT.md:

```
LeaderboardRank > shows the rank and links to the profile and the board

Expected to contain: "https://superset.sh/user/kiet"
Received: [ "http://localhost:3002/leaderboard",
            "http://localhost:3002/user/kiet" ]
```

The test hardcodes `https://superset.sh`, but `LeaderboardRank` builds both hrefs from `COMPANY.MARKETING_URL`, which `packages/shared/src/constants.ts` derives from `NEXT_PUBLIC_MARKETING_URL` and falls back to `NEXT_PUBLIC_ROOT_DOMAIN`.

The chain that makes this bite:

1. `.superset/setup.local.sh` copies `.env.local.example` to `.env`, which sets `NEXT_PUBLIC_MARKETING_URL=http://localhost:3002`.
2. `bun run test` at the root loads that `.env`, and turbo passes the variable down to the `@superset/desktop` task.
3. The component renders localhost hrefs and the assertion fails.

So CONTRIBUTING asks contributors to run `bun run test` before opening a PR, and DEVELOPMENT.md tells them to create the `.env` that makes that command fail. CI has no `.env`, so it passes there and the breakage is local-only. This is not platform specific.

## Fix

Build the expected hrefs from `COMPANY.MARKETING_URL` rather than a literal.

The assertions still cover the paths (`/user/<handle>`, `/leaderboard`), the handle, and that both links are rendered. What they no longer pin is the domain — which `constants.ts` documents as deliberately overridable:

```ts
// Root domain flips the whole brand at cutover. Default keeps superset.sh so
// nothing changes until NEXT_PUBLIC_ROOT_DOMAIN is set (e.g. boid.so).
```

A test that hardcodes the domain contradicts that design and would fail at the cutover it is meant to survive.

## Testing

The single file, under three configurations:

| Environment | Before | After |
|---|---|---|
| `NEXT_PUBLIC_MARKETING_URL` unset (CI) | 5 pass | 5 pass |
| `NEXT_PUBLIC_MARKETING_URL=http://localhost:3002` (local `.env`) | **1 fail** | 5 pass |
| `NEXT_PUBLIC_ROOT_DOMAIN=boid.so` (rebrand) | not previously exercised | 5 pass |

Full `@superset/desktop` suite under the environment that previously failed: **3521 pass, 1 skip, 0 fail** across 380 files.

`bun run lint` and `bunx turbo typecheck --filter=@superset/desktop` both clean.

Found while running the CONTRIBUTING checks on Linux, but neither the bug nor the fix is platform specific. Two unrelated findings from the same setup are in #7235 and #7236.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LeaderboardRank test so it no longer hardcodes the marketing domain, allowing `bun run test` to pass locally when `NEXT_PUBLIC_MARKETING_URL` is set (e.g., via the setup script). The test now builds expected hrefs from `COMPANY.MARKETING_URL` instead of a literal URL.

<sup>Written for commit ce7fb5a6ff49f810bc95ba0ef340fb7775332355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated leaderboard link validation to use the shared company URL configuration, keeping profile and leaderboard URL checks consistent with the application’s configured links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->