### PR TITLE
fix(desktop): render local images in workspace markdown files

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/SafeImage.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/SafeImage.tsx
@@ -1,35 +1,28 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { useState } from "react";
 import { LuImageOff } from "react-icons/lu";
+import { useMarkdownResources } from "renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider";
+import { useLocalImageUrl } from "./hooks/useLocalImageUrl";
+import { resolveLocalImagePath } from "./utils/resolveLocalImagePath";
 
 /**
- * Check if an image source is safe to load.
+ * Sources an <img> may load as-is: embedded data URLs and web URLs.
+ * Cleartext http is allowed because https already is — a document that
+ * wants a beacon has one either way, and blocking http only broke images.
  *
- * ALLOWED:
- * - data: URLs (embedded base64 images)
- * - https:// URLs (GitHub user-attachments, avatars, etc.)
- *
- * BLOCKED (everything else):
- * - http:// (cleartext / mixed-content)
- * - file:// URLs (arbitrary local file access)
- * - Absolute paths /... or \... (become file:// in Electron)
- * - Relative paths with .. (can escape repo boundary)
- * - UNC paths //server/share (Windows NTLM credential leak)
- * - Empty or malformed sources
- *
- * Trade-off: https sources can phone home (tracking pixels). Acceptable
- * here because the markdown comes from trusted sources (GitHub PR/issue
- * bodies, user-authored task descriptions) where image embedding is part
- * of the expected UX.
+ * Every other source — relative, absolute, file: — names a file, which
+ * only means something when the markdown itself is a file on disk. Those
+ * go through the workspace filesystem (see MarkdownResourceProvider), never
+ * the DOM: a relative URL here would resolve against the renderer's own
+ * document, and a cloud workspace's files aren't on this machine at all.
  */
-function isSafeImageSrc(src: string | undefined): boolean {
-	if (!src) return false;
-	const trimmed = src.trim();
-	if (trimmed.length === 0) return false;
-	const lower = trimmed.toLowerCase();
-
-	if (lower.startsWith("data:")) return true;
-	if (lower.startsWith("https://")) return true;
-	return false;
+function loadsDirectly(src: string): boolean {
+	const lower = src.trim().toLowerCase();
+	return (
+		lower.startsWith("data:") ||
+		lower.startsWith("https://") ||
+		lower.startsWith("http://")
+	);
 }
 
 interface SafeImageProps {
@@ -38,37 +31,51 @@ interface SafeImageProps {
 	className?: string;
 }
 
-/**
- * Safe image component for markdown content.
- *
- * Renders data: and http(s):// images. file://, absolute paths, UNC paths,
- * and traversal sources are blocked to prevent local-filesystem access from
- * malicious markdown content.
- */
 export function SafeImage({ src, alt, className }: SafeImageProps) {
 	const { t } = useLingui();
-	if (!isSafeImageSrc(src)) {
-		return (
-			<div
-				className={`inline-flex items-center gap-2 px-3 py-2 rounded-md bg-muted text-muted-foreground text-sm ${className ?? ""}`}
-				title={t({
-					message: `Image blocked: ${src ?? "(empty)"}`,
-				})}
-			>
-				<LuImageOff className="w-4 h-4 flex-shrink-0" />
-				<span className="truncate max-w-[300px]">
-					<Trans>Image blocked</Trans>
-				</span>
-			</div>
-		);
+	const resources = useMarkdownResources();
+	const localPath =
+		resources && src ? resolveLocalImagePath(src, resources) : null;
+	const local = useLocalImageUrl(localPath, resources?.readFile);
+	// Bytes that arrived but aren't an image (an HTML file named .png, a
+	// text file, an empty file) would otherwise sit there as a broken icon.
+	const [undecodableUrl, setUndecodableUrl] = useState<string | null>(null);
+	const imageClassName = className ?? "max-w-full h-auto rounded-md my-4";
+
+	if (localPath !== null) {
+		if (local.status === "loading") return null;
+		if (local.status === "ready" && local.url !== undecodableUrl) {
+			return (
+				<img
+					src={local.url}
+					alt={alt}
+					className={imageClassName}
+					onError={() => setUndecodableUrl(local.url)}
+				/>
+			);
+		}
+	} else if (src && loadsDirectly(src)) {
+		return <img src={src} alt={alt} className={imageClassName} />;
 	}
 
-	// Safe to render - embedded data: URL
+	const failedToLoad = localPath !== null;
 	return (
-		<img
-			src={src}
-			alt={alt}
-			className={className ?? "max-w-full h-auto rounded-md my-4"}
-		/>
+		<div
+			className={`inline-flex items-center gap-2 px-3 py-2 rounded-md bg-muted text-muted-foreground text-sm ${className ?? ""}`}
+			title={
+				failedToLoad
+					? localPath
+					: t({ message: `Image blocked: ${src ?? "(empty)"}` })
+			}
+		>
+			<LuImageOff className="w-4 h-4 flex-shrink-0" />
+			<span className="truncate max-w-[300px]">
+				{failedToLoad ? (
+					<Trans>Could not load image</Trans>
+				) : (
+					<Trans>Image blocked</Trans>
+				)}
+			</span>
+		</div>
 	);
 }

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/SafeImage.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/SafeImage.tsx
@@ -7,8 +7,9 @@ import { resolveLocalImagePath } from "./utils/resolveLocalImagePath";
 
 /**
  * Sources an <img> may load as-is: embedded data URLs and web URLs.
- * Cleartext http is allowed because https already is — a document that
- * wants a beacon has one either way, and blocking http only broke images.
+ * Cleartext http only for markdown on disk — from a PR comment it would let
+ * a stranger make this app GET localhost or LAN services, which https can't
+ * reach; for your own files it's a dev server's screenshot.
  *
  * Every other source — relative, absolute, file: — names a file, which
  * only means something when the markdown itself is a file on disk. Those
@@ -16,12 +17,12 @@ import { resolveLocalImagePath } from "./utils/resolveLocalImagePath";
  * the DOM: a relative URL here would resolve against the renderer's own
  * document, and a cloud workspace's files aren't on this machine at all.
  */
-function loadsDirectly(src: string): boolean {
+function loadsDirectly(src: string, fromDisk: boolean): boolean {
 	const lower = src.trim().toLowerCase();
 	return (
 		lower.startsWith("data:") ||
 		lower.startsWith("https://") ||
-		lower.startsWith("http://")
+		(fromDisk && lower.startsWith("http://"))
 	);
 }
 
@@ -36,7 +37,11 @@ export function SafeImage({ src, alt, className }: SafeImageProps) {
 	const resources = useMarkdownResources();
 	const localPath =
 		resources && src ? resolveLocalImagePath(src, resources) : null;
-	const local = useLocalImageUrl(localPath, resources?.readFile);
+	const local = useLocalImageUrl(
+		localPath,
+		resources?.readFile,
+		resources?.revision,
+	);
 	// Bytes that arrived but aren't an image (an HTML file named .png, a
 	// text file, an empty file) would otherwise sit there as a broken icon.
 	const [undecodableUrl, setUndecodableUrl] = useState<string | null>(null);
@@ -54,7 +59,7 @@ export function SafeImage({ src, alt, className }: SafeImageProps) {
 				/>
 			);
 		}
-	} else if (src && loadsDirectly(src)) {
+	} else if (src && loadsDirectly(src, resources !== null)) {
 		return <img src={src} alt={alt} className={imageClassName} />;
 	}
 

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/index.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/index.ts
@@ -1,0 +1,1 @@
+export { useLocalImageUrl } from "./useLocalImageUrl";

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/useLocalImageUrl.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/useLocalImageUrl.ts
@@ -11,22 +11,23 @@ type LocalImageState =
 export function useLocalImageUrl(
 	absolutePath: string | null,
 	readFile: MarkdownResources["readFile"] | undefined,
+	revision: string | undefined,
 ): LocalImageState {
 	const [loaded, setLoaded] = useState<{ path: string; url: string | null }>();
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: revision is the retry signal — a moved disk revision re-reads the image
 	useEffect(() => {
 		if (!absolutePath || !readFile) return;
 		let cancelled = false;
-		let objectUrl: string | null = null;
 		readFile(absolutePath).then(
 			(bytes) => {
 				if (cancelled) return;
-				objectUrl = URL.createObjectURL(
+				const url = URL.createObjectURL(
 					new Blob([bytes as BlobPart], {
 						type: getImageMimeType(absolutePath) ?? "image/png",
 					}),
 				);
-				setLoaded({ path: absolutePath, url: objectUrl });
+				setLoaded({ path: absolutePath, url });
 			},
 			() => {
 				if (!cancelled) setLoaded({ path: absolutePath, url: null });
@@ -34,9 +35,16 @@ export function useLocalImageUrl(
 		);
 		return () => {
 			cancelled = true;
-			if (objectUrl) URL.revokeObjectURL(objectUrl);
 		};
-	}, [absolutePath, readFile]);
+	}, [absolutePath, readFile, revision]);
+
+	// The previous URL stays valid until the next read lands, so a re-read
+	// swaps images without a broken frame in between.
+	useEffect(() => {
+		const url = loaded?.url;
+		if (!url) return;
+		return () => URL.revokeObjectURL(url);
+	}, [loaded]);
 
 	if (!absolutePath || loaded?.path !== absolutePath) {
 		return { status: "loading" };

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/useLocalImageUrl.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/useLocalImageUrl.ts
@@ -17,7 +17,12 @@ export function useLocalImageUrl(
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: revision is the retry signal — a moved disk revision re-reads the image
 	useEffect(() => {
-		if (!absolutePath || !readFile) return;
+		if (!absolutePath || !readFile) {
+			// Drop the blob once the source stops being a local file, rather
+			// than holding it until unmount.
+			setLoaded(undefined);
+			return;
+		}
 		let cancelled = false;
 		readFile(absolutePath).then(
 			(bytes) => {

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/useLocalImageUrl.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/hooks/useLocalImageUrl/useLocalImageUrl.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import type { MarkdownResources } from "renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider";
+import { getImageMimeType } from "shared/file-types";
+
+type LocalImageState =
+	| { status: "loading" }
+	| { status: "ready"; url: string }
+	| { status: "error" };
+
+/** Read a workspace image into an object URL an <img> can show. */
+export function useLocalImageUrl(
+	absolutePath: string | null,
+	readFile: MarkdownResources["readFile"] | undefined,
+): LocalImageState {
+	const [loaded, setLoaded] = useState<{ path: string; url: string | null }>();
+
+	useEffect(() => {
+		if (!absolutePath || !readFile) return;
+		let cancelled = false;
+		let objectUrl: string | null = null;
+		readFile(absolutePath).then(
+			(bytes) => {
+				if (cancelled) return;
+				objectUrl = URL.createObjectURL(
+					new Blob([bytes as BlobPart], {
+						type: getImageMimeType(absolutePath) ?? "image/png",
+					}),
+				);
+				setLoaded({ path: absolutePath, url: objectUrl });
+			},
+			() => {
+				if (!cancelled) setLoaded({ path: absolutePath, url: null });
+			},
+		);
+		return () => {
+			cancelled = true;
+			if (objectUrl) URL.revokeObjectURL(objectUrl);
+		};
+	}, [absolutePath, readFile]);
+
+	if (!absolutePath || loaded?.path !== absolutePath) {
+		return { status: "loading" };
+	}
+	return loaded.url
+		? { status: "ready", url: loaded.url }
+		: { status: "error" };
+}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/index.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/index.ts
@@ -1,0 +1,1 @@
+export { resolveLocalImagePath } from "./resolveLocalImagePath";

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.test.ts
@@ -48,6 +48,8 @@ describe("resolveLocalImagePath", () => {
 		["..\\assets\\logo.png", "C:\\repo\\assets\\logo.png"],
 		["/img/x.png", "C:\\repo\\img\\x.png"],
 		["D:\\other\\x.png", "D:\\other\\x.png"],
+		["C:\\repo\\image.png?raw=true#top", "C:\\repo\\image.png"],
+		["C:%5Crepo%5Cx.png", "C:\\repo\\x.png"],
 		["file:///C:/Users/me/x.png", "C:\\Users\\me\\x.png"],
 		["../../../../x.png", "C:\\x.png"],
 	])("keeps Windows separators and drive roots for %s", (source, expected) => {

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.test.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { resolveLocalImagePath } from "./resolveLocalImagePath";
+
+const posix = { documentDirectory: "/repo/docs", rootPath: "/repo" };
+const noRoot = { documentDirectory: "/home/me/.claude/skills/x" };
+const windows = { documentDirectory: "C:\\repo\\docs", rootPath: "C:\\repo" };
+
+describe("resolveLocalImagePath", () => {
+	test.each([
+		["shot.png", "/repo/docs/shot.png"],
+		["./img/shot.png", "/repo/docs/img/shot.png"],
+		["../assets/logo.svg", "/repo/assets/logo.svg"],
+		["../../../../etc/passwd", "/etc/passwd"],
+		["/img/x.png", "/repo/img/x.png"],
+		["my%20shot.png?raw=true#frag", "/repo/docs/my shot.png"],
+		["file:///Users/me/a%20b.png", "/Users/me/a b.png"],
+	])("resolves %s against the document and workspace", (source, expected) => {
+		expect(resolveLocalImagePath(source, posix)).toBe(expected);
+	});
+
+	test("a leading slash is a filesystem path when there is no root", () => {
+		expect(resolveLocalImagePath("/img/x.png", noRoot)).toBe("/img/x.png");
+	});
+
+	test.each([
+		"//evil.local/share/x.png",
+		"\\\\evil.local\\share\\x.png",
+		"/\\evil.local\\share\\x.png",
+		"file://evil.local/share/x.png",
+	])("refuses UNC share %s", (source) => {
+		expect(resolveLocalImagePath(source, posix)).toBeNull();
+	});
+
+	test.each([
+		"https://example.com/a.png",
+		"http://example.com/a.png",
+		"data:image/png;base64,AAAA",
+		"javascript:alert(1)",
+		"C:foo.png",
+		"",
+		"   ",
+	])("leaves non-file source %j to the caller", (source) => {
+		expect(resolveLocalImagePath(source, posix)).toBeNull();
+	});
+
+	test.each([
+		["shot.png", "C:\\repo\\docs\\shot.png"],
+		["..\\assets\\logo.png", "C:\\repo\\assets\\logo.png"],
+		["/img/x.png", "C:\\repo\\img\\x.png"],
+		["D:\\other\\x.png", "D:\\other\\x.png"],
+		["file:///C:/Users/me/x.png", "C:\\Users\\me\\x.png"],
+		["../../../../x.png", "C:\\x.png"],
+	])("keeps Windows separators and drive roots for %s", (source, expected) => {
+		expect(resolveLocalImagePath(source, windows)).toBe(expected);
+	});
+});

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.ts
@@ -1,0 +1,105 @@
+export interface LocalImageBase {
+	/** Directory of the markdown file; relative sources resolve against it. */
+	documentDirectory: string;
+	/**
+	 * Workspace root. A leading-slash source resolves against it, the way a
+	 * README renders on GitHub; without a root it is a filesystem path.
+	 */
+	rootPath?: string;
+}
+
+const SCHEME_PREFIX = /^[a-z][a-z0-9+.-]*:/i;
+const WINDOWS_DRIVE_PATH = /^[a-z]:[\\/]/i;
+const WINDOWS_DRIVE_ROOT = /^[a-z]:\//i;
+const WINDOWS_DRIVE = /^[a-z]:$/i;
+
+/**
+ * Turn a markdown image source into an absolute path on the workspace's
+ * filesystem, or null when it isn't a local file: a URL with a scheme
+ * (http, https, data, …) or a UNC share, which on Windows would make the
+ * host authenticate against a remote SMB server just to fetch the bytes.
+ */
+export function resolveLocalImagePath(
+	source: string,
+	base: LocalImageBase,
+): string | null {
+	const trimmed = source.trim();
+	if (!trimmed) return null;
+
+	// A file: URL or a drive path is already a filesystem path; a bare
+	// leading slash is workspace-relative, the way GitHub renders it.
+	let path: string | null;
+	let filesystemAbsolute = false;
+	if (/^file:/i.test(trimmed)) {
+		path = fileUrlToPath(trimmed);
+		filesystemAbsolute = true;
+	} else if (WINDOWS_DRIVE_PATH.test(trimmed)) {
+		path = trimmed;
+		filesystemAbsolute = true;
+	} else if (SCHEME_PREFIX.test(trimmed)) {
+		return null;
+	} else {
+		path = percentDecode(trimmed.split(/[?#]/, 1)[0] ?? "");
+	}
+	if (!path) return null;
+
+	const slashed = path.replace(/\\/g, "/");
+	if (slashed.startsWith("//")) return null;
+	const directory = base.documentDirectory.replace(/\\/g, "/");
+	const root = base.rootPath?.replace(/\\/g, "/");
+
+	let joined: string;
+	if (filesystemAbsolute || WINDOWS_DRIVE_ROOT.test(slashed)) {
+		joined = slashed;
+	} else if (slashed.startsWith("/")) {
+		joined = root ? joinPath(root, slashed) : slashed;
+	} else {
+		if (!directory) return null;
+		joined = joinPath(directory, slashed);
+	}
+
+	const collapsed = collapseDotSegments(joined);
+	return base.documentDirectory.includes("\\")
+		? collapsed.replace(/\//g, "\\")
+		: collapsed;
+}
+
+function fileUrlToPath(url: string): string | null {
+	try {
+		const parsed = new URL(url);
+		// file://server/share is a UNC share in disguise.
+		if (parsed.hostname && parsed.hostname !== "localhost") return null;
+		const pathname = percentDecode(parsed.pathname);
+		return /^\/[a-z]:\//i.test(pathname) ? pathname.slice(1) : pathname;
+	} catch {
+		return null;
+	}
+}
+
+function percentDecode(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}
+
+function joinPath(directory: string, relative: string): string {
+	return `${directory.replace(/[\\/]+$/, "")}/${relative.replace(/^\/+/, "")}`;
+}
+
+/** Collapse `.` and `..` on a `/`-separated path without popping its root. */
+function collapseDotSegments(path: string): string {
+	const [first = "", ...rest] = path.split("/");
+	const root = first === "" || WINDOWS_DRIVE.test(first) ? first : null;
+	const out: string[] = [];
+	for (const segment of root === null ? [first, ...rest] : rest) {
+		if (segment === "" || segment === ".") continue;
+		if (segment === "..") {
+			out.pop();
+			continue;
+		}
+		out.push(segment);
+	}
+	return root === null ? out.join("/") : `${root}/${out.join("/")}`;
+}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/SafeImage/utils/resolveLocalImagePath/resolveLocalImagePath.ts
@@ -33,13 +33,18 @@ export function resolveLocalImagePath(
 	if (/^file:/i.test(trimmed)) {
 		path = fileUrlToPath(trimmed);
 		filesystemAbsolute = true;
-	} else if (WINDOWS_DRIVE_PATH.test(trimmed)) {
-		path = trimmed;
-		filesystemAbsolute = true;
-	} else if (SCHEME_PREFIX.test(trimmed)) {
-		return null;
 	} else {
-		path = percentDecode(trimmed.split(/[?#]/, 1)[0] ?? "");
+		// markdown-it percent-encodes whatever it doesn't consider URL-safe,
+		// backslashes included, so decode before looking at the shape.
+		const bare = percentDecode(trimmed.split(/[?#]/, 1)[0] ?? "");
+		if (WINDOWS_DRIVE_PATH.test(bare)) {
+			path = bare;
+			filesystemAbsolute = true;
+		} else if (SCHEME_PREFIX.test(bare)) {
+			return null;
+		} else {
+			path = bare;
+		}
 	}
 	if (!path) return null;
 

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/components/TipTapMarkdownRenderer/createMarkdownExtensions.ts
@@ -250,7 +250,9 @@ export function createMarkdownExtensions({
 				rel: "noopener noreferrer",
 			},
 		}),
-		SafeImage,
+		// markdown-it already restricts data: sources to data:image/*; without
+		// this the image extension drops them and the paragraph renders empty.
+		SafeImage.configure({ allowBase64: true }),
 		// Individual table nodes (not TableKit) so a GFM markdown serializer can be
 		// attached to the `table` node's `storage.markdown`, replacing
 		// tiptap-markdown's built-in serializer that emits `[table]`. The

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider/MarkdownResourceProvider.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider/MarkdownResourceProvider.tsx
@@ -1,0 +1,39 @@
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+
+export interface MarkdownResources {
+	/** Directory of the markdown file; relative image sources resolve against it. */
+	documentDirectory: string;
+	/** Workspace root; a leading-slash source resolves against it, the way GitHub renders a README. */
+	rootPath?: string;
+	/** Read a file on the workspace's filesystem — local disk or a cloud sandbox. */
+	readFile: (absolutePath: string) => Promise<Uint8Array>;
+}
+
+const MarkdownResourceContext = createContext<MarkdownResources | null>(null);
+
+/**
+ * Marks the markdown below as a file on disk, so images that point at other
+ * files — `./shot.png`, `../assets/logo.svg`, `/docs/img.png` — resolve and
+ * load. Without it (GitHub bodies, notices) those sources stay blocked:
+ * there is nothing to resolve them against.
+ */
+export function MarkdownResourceProvider({
+	documentDirectory,
+	rootPath,
+	readFile,
+	children,
+}: MarkdownResources & { children: ReactNode }) {
+	const value = useMemo(
+		() => ({ documentDirectory, rootPath, readFile }),
+		[documentDirectory, rootPath, readFile],
+	);
+	return (
+		<MarkdownResourceContext.Provider value={value}>
+			{children}
+		</MarkdownResourceContext.Provider>
+	);
+}
+
+export function useMarkdownResources(): MarkdownResources | null {
+	return useContext(MarkdownResourceContext);
+}

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider/MarkdownResourceProvider.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider/MarkdownResourceProvider.tsx
@@ -7,6 +7,12 @@ export interface MarkdownResources {
 	rootPath?: string;
 	/** Read a file on the workspace's filesystem — local disk or a cloud sandbox. */
 	readFile: (absolutePath: string) => Promise<Uint8Array>;
+	/**
+	 * The markdown file's on-disk revision. Images are read again when it
+	 * moves (save, reload, external change), so one that was missing or
+	 * replaced shows up without reopening the pane.
+	 */
+	revision?: string;
 }
 
 const MarkdownResourceContext = createContext<MarkdownResources | null>(null);
@@ -21,11 +27,12 @@ export function MarkdownResourceProvider({
 	documentDirectory,
 	rootPath,
 	readFile,
+	revision,
 	children,
 }: MarkdownResources & { children: ReactNode }) {
 	const value = useMemo(
-		() => ({ documentDirectory, rootPath, readFile }),
-		[documentDirectory, rootPath, readFile],
+		() => ({ documentDirectory, rootPath, readFile, revision }),
+		[documentDirectory, rootPath, readFile, revision],
 	);
 	return (
 		<MarkdownResourceContext.Provider value={value}>

--- a/apps/desktop/src/renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider/index.ts
+++ b/apps/desktop/src/renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider/index.ts
@@ -1,0 +1,5 @@
+export {
+	MarkdownResourceProvider,
+	type MarkdownResources,
+	useMarkdownResources,
+} from "./MarkdownResourceProvider";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -1,9 +1,15 @@
 import { useLingui } from "@lingui/react/macro";
 import type { RendererContext } from "@superset/panes";
 import { alert } from "@superset/ui/atoms/Alert";
+import { useWorkspaceClient, workspaceTrpc } from "@superset/workspace-client";
 import { useCallback, useEffect } from "react";
+import { MarkdownResourceProvider } from "renderer/components/MarkdownRenderer/providers/MarkdownResourceProvider";
 import { getBaseName } from "renderer/lib/pathBasename";
-import { useSharedFileDocument } from "../../../../state/fileDocumentStore";
+import { getPathDirectory } from "shared/absolute-paths";
+import {
+	decodeBase64,
+	useSharedFileDocument,
+} from "../../../../state/fileDocumentStore";
 import type { FilePaneData, PaneViewerData } from "../../../../types";
 import { ErrorState } from "./components/ErrorState";
 import { LoadingState } from "./components/LoadingState";
@@ -25,6 +31,27 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 		workspaceId,
 		absolutePath: filePath,
 	});
+
+	// Images a markdown file points at load through the workspace
+	// filesystem, so they work for cloud sandboxes and never put a raw path
+	// in the DOM. Root-relative ones need the worktree path, host-only data
+	// the cloud-shaped workspace row doesn't carry.
+	const { trpcClient } = useWorkspaceClient();
+	const workspaceQuery = workspaceTrpc.workspace.get.useQuery({
+		id: workspaceId,
+	});
+	const readFile = useCallback(
+		async (absolutePath: string) => {
+			const result = await trpcClient.filesystem.readFile.query({
+				workspaceId,
+				absolutePath,
+			});
+			return typeof result.content === "string"
+				? decodeBase64(result.content)
+				: result.content;
+		},
+		[trpcClient, workspaceId],
+	);
 
 	// Follow the underlying file if it's renamed on disk — the store migrates
 	// the entry, document.absolutePath returns the new path, and we reconcile
@@ -151,15 +178,21 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 				/>
 			)}
 			<div className="min-h-0 min-w-0 flex-1">
-				<ViewRenderer
-					document={document}
-					filePath={filePath}
-					workspaceId={workspaceId}
-					paneId={context.pane.id}
-					isActive={context.isActive}
-					onChangeView={handleChangeView}
-					onForceView={handleForceView}
-				/>
+				<MarkdownResourceProvider
+					documentDirectory={getPathDirectory(document.absolutePath)}
+					rootPath={workspaceQuery.data?.worktreePath ?? undefined}
+					readFile={readFile}
+				>
+					<ViewRenderer
+						document={document}
+						filePath={filePath}
+						workspaceId={workspaceId}
+						paneId={context.pane.id}
+						isActive={context.isActive}
+						onChangeView={handleChangeView}
+						onForceView={handleForceView}
+					/>
+				</MarkdownResourceProvider>
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/FilePane/FilePane.tsx
@@ -182,6 +182,11 @@ export function FilePane({ context, workspaceId }: FilePaneProps) {
 					documentDirectory={getPathDirectory(document.absolutePath)}
 					rootPath={workspaceQuery.data?.worktreePath ?? undefined}
 					readFile={readFile}
+					revision={
+						"revision" in document.content
+							? document.content.revision
+							: undefined
+					}
 				>
 					<ViewRenderer
 						document={document}

--- a/apps/desktop/src/shared/absolute-paths.ts
+++ b/apps/desktop/src/shared/absolute-paths.ts
@@ -98,6 +98,18 @@ export function getPathBaseName(path: string): string {
 	return segments[segments.length - 1] || path;
 }
 
+export function getPathDirectory(path: string): string {
+	const normalizedPath = path.replace(/[\\/]+$/, "");
+	const index = Math.max(
+		normalizedPath.lastIndexOf("/"),
+		normalizedPath.lastIndexOf("\\"),
+	);
+	if (index === -1) return "";
+	return index === 0
+		? normalizedPath.slice(0, 1)
+		: normalizedPath.slice(0, index);
+}
+
 export function normalizeComparablePath(path: string): string {
 	return path
 		.replace(/[\\/]+/g, "/")

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Nepodařilo se načíst prostředí"
 msgid "Could not load environments."
 msgstr "Nepodařilo se načíst prostředí."
 
+msgid "Could not load image"
+msgstr "Obrázek se nepodařilo načíst"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Pluginy se nepodařilo načíst. Zkontrolujte připojení a zkuste to znovu."
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Umgebungen konnten nicht geladen werden"
 msgid "Could not load environments."
 msgstr "Umgebungen konnten nicht geladen werden."
 
+msgid "Could not load image"
+msgstr "Bild konnte nicht geladen werden"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Plugins konnten nicht geladen werden. Prüfe deine Verbindung und versuche es erneut."
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Could not load environments"
 msgid "Could not load environments."
 msgstr "Could not load environments."
 
+msgid "Could not load image"
+msgstr "Could not load image"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Could not load plugins. Check your connection and try again."
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -3818,6 +3818,9 @@ msgstr "No se pudieron cargar los entornos"
 msgid "Could not load environments."
 msgstr "No se pudieron cargar los entornos."
 
+msgid "Could not load image"
+msgstr "No se pudo cargar la imagen"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "No se pudieron cargar los plugins. Comprueba tu conexión e inténtalo de nuevo."
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Impossible de charger les environnements"
 msgid "Could not load environments."
 msgstr "Impossible de charger les environnements."
 
+msgid "Could not load image"
+msgstr "Impossible de charger l'image"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Impossible de charger les plugins. Vérifiez votre connexion et réessayez."
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Tidak dapat memuat environment"
 msgid "Could not load environments."
 msgstr "Tidak dapat memuat environment."
 
+msgid "Could not load image"
+msgstr "Gambar tidak dapat dimuat"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Tidak dapat memuat plugin. Periksa koneksi Anda dan coba lagi."
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Impossibile caricare gli ambienti"
 msgid "Could not load environments."
 msgstr "Impossibile caricare gli ambienti."
 
+msgid "Could not load image"
+msgstr "Impossibile caricare l'immagine"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Impossibile caricare i plugin. Controlla la connessione e riprova."
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -3818,6 +3818,9 @@ msgstr "環境を読み込めませんでした"
 msgid "Could not load environments."
 msgstr "環境を読み込めませんでした。"
 
+msgid "Could not load image"
+msgstr "画像を読み込めませんでした"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "プラグインを読み込めませんでした。接続を確認して再試行してください。"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -3818,6 +3818,9 @@ msgstr "환경을 불러오지 못했습니다"
 msgid "Could not load environments."
 msgstr "환경을 불러오지 못했습니다."
 
+msgid "Could not load image"
+msgstr "이미지를 불러올 수 없음"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "플러그인을 불러오지 못했습니다. 연결을 확인하고 다시 시도하세요."
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Kan omgevingen niet laden"
 msgid "Could not load environments."
 msgstr "Kon omgevingen niet laden."
 
+msgid "Could not load image"
+msgstr "Afbeelding kon niet worden geladen"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Plugins konden niet worden geladen. Controleer je verbinding en probeer het opnieuw."
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Nie udało się wczytać środowisk"
 msgid "Could not load environments."
 msgstr "Nie udało się wczytać środowisk."
 
+msgid "Could not load image"
+msgstr "Nie udało się załadować obrazu"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Nie udało się wczytać wtyczek. Sprawdź połączenie i spróbuj ponownie."
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Não foi possível carregar os ambientes"
 msgid "Could not load environments."
 msgstr "Não foi possível carregar os ambientes."
 
+msgid "Could not load image"
+msgstr "Não foi possível carregar a imagem"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Não foi possível carregar os plugins. Verifique sua conexão e tente novamente."
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Не удалось загрузить окружения"
 msgid "Could not load environments."
 msgstr "Не удалось загрузить окружения."
 
+msgid "Could not load image"
+msgstr "Не удалось загрузить изображение"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Не удалось загрузить плагины. Проверьте подключение и попробуйте снова."
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Ortamlar yüklenemedi"
 msgid "Could not load environments."
 msgstr "Ortamlar yüklenemedi."
 
+msgid "Could not load image"
+msgstr "Görsel yüklenemedi"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Eklentiler yüklenemedi. Bağlantınızı kontrol edip tekrar deneyin."
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -3818,6 +3818,9 @@ msgstr "Không thể tải environment"
 msgid "Could not load environments."
 msgstr "Không thể tải environments."
 
+msgid "Could not load image"
+msgstr "Không thể tải ảnh"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "Không tải được plugin. Hãy kiểm tra kết nối và thử lại."
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -3818,6 +3818,9 @@ msgstr "无法加载环境"
 msgid "Could not load environments."
 msgstr "无法加载环境。"
 
+msgid "Could not load image"
+msgstr "无法加载图片"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "无法加载插件。请检查网络连接后重试。"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -3818,6 +3818,9 @@ msgstr "無法載入環境"
 msgid "Could not load environments."
 msgstr "無法載入環境。"
 
+msgid "Could not load image"
+msgstr "無法載入圖片"
+
 msgid "Could not load plugins. Check your connection and try again."
 msgstr "無法載入外掛。請檢查連線後再試一次。"
 


### PR DESCRIPTION
## What & why

Markdown files opened in the workspace pane showed **"Image blocked"** for every image that named a file — `![](./shot.png)`, `![](docs/img.png)`, `![](/assets/logo.svg)`. `SafeImage` only allowed `data:` and `https:` sources, and nothing resolved a relative path against the file's directory anyway: the production renderer's own document is the app bundle, so a raw relative `src` would have pointed into `Superset.app/Contents/…`, and a cloud sandbox's files aren't on this machine at all.

The policy is now **by surface**, not by path shape:

- **File viewer (markdown on disk).** `FilePane` wraps its views in a `MarkdownResourceProvider` — the file's directory, the workspace root, and a `readFile` over the workspace fs tRPC. `SafeImage` resolves file references through it and shows them as a `blob:` URL; a raw path never enters the DOM. Relative paths resolve against the file's directory; a leading `/` against the workspace root (the way a README renders on GitHub); `file:` and drive paths stay absolute. There is **no workspace-root or `..` confinement** — terminals and `readFile` already grant full machine access, so that boundary protected nothing.
- **GitHub bodies, comments, notices** get no provider and keep blocking local paths: there is nothing to resolve them against.
- **UNC shares stay refused everywhere** (`\\host\share`, `//host/share`, `file://host/…`): on Windows they trigger an SMB authentication and leak an NTLM hash, no script needed.
- **`http:` is allowed** alongside `https:` — the beacon was already accepted, blocking `http` only broke images.

Two more fixes the verification turned up:
- TipTap's image extension drops `data:` sources unless `allowBase64` is on, so `![](data:image/png;base64,…)` rendered as an empty paragraph. markdown-it already limits these to `data:image/*`.
- Undecodable bytes (an HTML file named `.png`, a text file, an empty file) sat as a silent broken icon; an `onError` now swaps in the chip, whose tooltip carries the resolved path.

The v1 file viewer is untouched (it's being deleted). The skill preview dialog renders the same view outside any workspace and keeps today's behavior.

## How I tested it

- **Real app, 36 scenarios**, dev build driven over CDP through the actual journey (sidebar → ⌘P → `README.md` → Enter), every scenario classified from the live DOM with console errors, dialogs, and exceptions hooked. Every "should show" form renders: relative, `./`, nested, `..` inside and outside the workspace, root-relative, `%20` and `<angle bracket>` spaces, `?query#frag`, uppercase extension, SVG, `data:`, `https:`, `http:`. Every "shouldn't" doesn't: UNC in all spellings blocked; `javascript:`/`file:`/raw `<img>`/`<svg>`/`<iframe>` never reach the DOM. An SVG file carrying `<script>`, `onload`, and a remote `<image>` painted with **zero script execution and zero network requests**. Missing file, directory, HTML-as-PNG, empty file, 30 MB blob, and a symlink out of the workspace (refused by the fs layer's realpath guard, by design) all show the chip.
- `resolveLocalImagePath.test.ts` — 25 cases: UNC spellings, `file:` with a host, Windows drives and separators, percent-decoding, `..` above the root.
- `tsc`, `lint:fix`, `check:i18n` (catalogs regenerated on this base), desktop package suite (3541 pass; the two remaining failures are pre-existing and env-dependent: `LeaderboardRank` passes in isolation, `useSidebarDnd` is a React mock leak).
- Full matrix with per-scenario crops: https://app.superset.sh/page/markdown-image-policy-stress-test-sr4bef

Known and accepted: no size cap on embedded images (a 30 MB file is read, then fails to decode); Windows paths are unit-tested but not exercised on Windows.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

https://claude.ai/code/session_01Cfwdahc9HuUPk6NtanJ3My

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local images in workspace markdown files so relative, absolute, and `file:` references render instead of showing "Image blocked".

**Bug Fixes**
- File-viewer markdown resolves image paths against the file's directory or workspace root and loads them as `blob:` URLs through the workspace filesystem.
- `data:` images render again after enabling TipTap's `allowBase64`; undecodable files now show an error chip instead of a silent broken icon.
- Windows drive paths are percent-decoded and stripped of query/fragment; images re-read when the file's disk revision changes, and their `blob:` URLs are released when the source stops being local.

**Security**
- UNC shares (`\\host\share`, `//host/share`, `file://host/...`) stay blocked everywhere; `http:` loads only for markdown on disk, not GitHub bodies, comments, or notices.
- No `..` confinement is added — it would protect nothing because terminals and `readFile` already grant full machine access.

<sup>Written for commit 8d4882561001133ab3018f0520a382e9cf758b6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown images can load from workspace- and document-relative file paths.
  * Disk-based markdown supports cleartext HTTP and base64 image sources.
  * Images refresh when their source files change or move.
  * Image loading errors now provide clearer feedback, including localized messages.

* **Bug Fixes**
  * Improved handling of Windows, POSIX, file URL, relative, encoded, and traversal-normalized image paths.

* **Tests**
  * Expanded coverage for local path resolution and platform-specific cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->