### PR TITLE
fix(billing): stop the lapsed card saying the amount twice

### DIFF
--- a/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
+++ b/apps/desktop/src/renderer/components/SidebarCardSlot/cards/usePaymentFailedCard/usePaymentFailedCard.ts
@@ -74,13 +74,14 @@ export function usePaymentFailedCard({
 			id: "payment-failed",
 			badge: "Action needed",
 			title: amount ? `Pro ended — ${amount} unpaid` : "Pro ended",
+			// The title already carries the amount, so the body does not repeat it.
 			// Stated as two facts rather than one cause. A voluntary cancellation
 			// can also leave its closing invoice unpaid, and telling someone who
 			// chose to leave that a failed charge is why they lost Pro would be
 			// the same wrong-reason bug this card exists to stop.
 			description: isOwner
-				? `This organization is on the free plan and its triggers have stopped running.${amount ? ` ${amount} from the last billing period was never collected.` : ""} Restart Pro to turn them back on.`
-				: `This organization is on the free plan and its triggers have stopped running.${amount ? ` ${amount} from the last billing period was never collected.` : ""} Ask an owner to restart Pro.`,
+				? "This organization is on the free plan and its triggers have stopped running. Restart Pro to turn them back on."
+				: "This organization is on the free plan and its triggers have stopped running. Ask an owner to restart Pro.",
 			actionLabel: isOwner ? "Restart Pro" : undefined,
 			onAction: isOwner
 				? () => {


### PR DESCRIPTION
Follow-up to #7220, from actually driving the card in the running app rather than reasoning about it.

## What the render showed

Both states work. Verified over CDP against the real API and the workspace database, signed in as satya@superset.sh, switching organisations through the real UI:

| State | Renders |
|---|---|
| `past_due` | "Payment failed — $20.00 due" / **Pay now** → hosted invoice. Unchanged from before #7220. |
| `lapsed` | "Pro ended — $20.00 unpaid" / **Restart Pro** → Billing. The new state. |

No console errors in either.

## The one thing worth fixing

The amount appeared **twice**: once in the title, then again in the body as "$20.00 from the last billing period was never collected". In a sidebar card that narrow it was four lines saying one thing.

The body now drops the amount and keeps only what the title cannot carry: the plan is gone, and the triggers stopped. Three lines instead of four.

## Verification

- Rendered both states end to end, screenshots captured.
- `lint.sh` clean across 7,239 files, desktop typecheck clean.
- Desktop suite **3513 pass / 1 fail**, identical with this change stashed, so that failure is pre-existing on main.
- Database state restored afterwards and the dev stack shut down.

## Note for whoever reads this next

The workspace `.env` has **two** `DATABASE_URL` entries pointing at different Neon branches (`ep-green-salad` → `admin-prod-data-test`, `ep-bitter-union` → `vanilla-whistle`). The API reads the second. Writing to the first looks like it works and then the app shows stale data. Cost me a debugging cycle; worth knowing.

The API also runs on **9161**, not the `3001` in `NEXT_PUBLIC_API_URL`, and CSP only allows 9161.

https://claude.ai/code/session_01CqWBnJKCMs4b5ZXpSUZvFA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the repeated amount from the lapsed payment-failed card so the sidebar no longer states the same dollar figure twice.

The title already carries the amount ("Pro ended — $20.00 unpaid"); the body now keeps only the facts the title can't carry — the plan is gone and the triggers stopped. Both `past_due` and `lapsed` states render without console errors.

<sup>Written for commit 90d169cc23a406cbb3dc335a3567cf04d5e04078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated payment-failure messaging to clearly explain when an organization has moved to the free plan and automated triggers have stopped.
  * Added guidance for restarting Pro or contacting an owner to restore the plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->