### PR TITLE
feat(desktop): put pinned model releases behind a submenu

### DIFF
--- a/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
+++ b/apps/desktop/src/renderer/components/AgentModelSelect/AgentModelSelect.tsx
@@ -1,18 +1,28 @@
-import type { AgentModelOption } from "@superset/shared/agent-models";
 import {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectLabel,
-	SelectSeparator,
-	SelectTrigger,
-	SelectValue,
-} from "@superset/ui/select";
+	type AgentModelOption,
+	splitModelCatalog,
+} from "@superset/shared/agent-models";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { cn } from "@superset/ui/utils";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import { groupModelOptions } from "./groupModelOptions";
 
-// Radix Select reserves "" for clearing, so "Default" needs a sentinel.
-const DEFAULT_MODEL_VALUE = "__default_model__";
+// The agent picker beside this one is still a Radix Select, and the two read
+// as one row of pills, so the trigger carries SelectTrigger's classes. Select
+// itself can't host this menu: it has no submenus.
+const TRIGGER_CLASS =
+	"border-input [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 h-9 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4";
 
 interface AgentModelSelectProps {
 	models: AgentModelOption[];
@@ -26,6 +36,32 @@ interface AgentModelSelectProps {
 	defaultLabel?: string;
 }
 
+function ModelItem({
+	model,
+	selected,
+	onSelect,
+}: {
+	model: AgentModelOption;
+	selected: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<DropdownMenuItem onSelect={onSelect} className="pr-8">
+			{model.label}
+			{selected && (
+				<CheckIcon className="absolute right-2 size-4 text-foreground" />
+			)}
+		</DropdownMenuItem>
+	);
+}
+
+/**
+ * The picker for one launch option: the catalog's first section inline and
+ * every later one behind a submenu, mirroring the mobile options screen.
+ * Claude's four aliases sit at the top level and its ten pinned releases a
+ * level down, where they no longer push the menu off the bottom of the
+ * window.
+ */
 export function AgentModelSelect({
 	models,
 	value,
@@ -35,50 +71,73 @@ export function AgentModelSelect({
 	contentClassName,
 	defaultLabel = "Default",
 }: AgentModelSelectProps) {
-	const selectedValue =
-		value !== null && models.some((model) => model.id === value)
-			? value
-			: DEFAULT_MODEL_VALUE;
-
-	const handleValueChange = (nextValue: string) => {
-		onValueChange(nextValue === DEFAULT_MODEL_VALUE ? null : nextValue);
-	};
+	const selected =
+		value !== null ? models.find((model) => model.id === value) : undefined;
+	const { inline, groups } = splitModelCatalog(models);
 
 	return (
-		<Select
-			value={selectedValue}
-			onValueChange={handleValueChange}
-			disabled={disabled}
-		>
-			<SelectTrigger className={triggerClassName}>
-				<SelectValue placeholder={defaultLabel} />
-			</SelectTrigger>
-			<SelectContent className={contentClassName}>
-				<SelectItem value={DEFAULT_MODEL_VALUE}>{defaultLabel}</SelectItem>
-				{groupModelOptions(models).map((group, index) => (
-					// Index-qualified: a catalog may return to an earlier header
-					// (groupModelOptions keeps those as separate sections), and a
-					// bare label would then collide as a React key.
-					<SelectGroup key={`${group.label ?? "ungrouped"}-${index}`}>
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild disabled={disabled}>
+				<button type="button" className={cn(TRIGGER_CLASS, triggerClassName)}>
+					<span className="truncate">{selected?.label ?? defaultLabel}</span>
+					<ChevronDownIcon className="size-4 opacity-50" />
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start" className={contentClassName}>
+				<ModelItem
+					model={{ id: "", label: defaultLabel }}
+					selected={selected === undefined}
+					onSelect={() => onValueChange(null)}
+				/>
+				{groupModelOptions(inline).map((group, index) => (
+					<DropdownMenuGroup key={`${group.label ?? "ungrouped"}-${index}`}>
 						{group.label !== null && (
 							<>
 								{/* Every kind-change gets a rule, including the one
 								    between the default escape hatch and the first
 								    section — it is not a member of that section. */}
-								<SelectSeparator />
-								<SelectLabel className="text-xs text-muted-foreground">
+								<DropdownMenuSeparator />
+								<DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
 									{group.label}
-								</SelectLabel>
+								</DropdownMenuLabel>
 							</>
 						)}
 						{group.options.map((model) => (
-							<SelectItem key={model.id} value={model.id}>
-								{model.label}
-							</SelectItem>
+							<ModelItem
+								key={model.id}
+								model={model}
+								selected={model.id === selected?.id}
+								onSelect={() => onValueChange(model.id)}
+							/>
 						))}
-					</SelectGroup>
+					</DropdownMenuGroup>
 				))}
-			</SelectContent>
-		</Select>
+				{groups.length > 0 && <DropdownMenuSeparator />}
+				{groups.map((group) => (
+					<DropdownMenuSub key={group}>
+						<DropdownMenuSubTrigger>
+							{group}
+							{selected?.group === group && (
+								<span className="ml-auto text-muted-foreground">
+									{selected.label}
+								</span>
+							)}
+						</DropdownMenuSubTrigger>
+						<DropdownMenuSubContent>
+							{models
+								.filter((model) => model.group === group)
+								.map((model) => (
+									<ModelItem
+										key={model.id}
+										model={model}
+										selected={model.id === selected?.id}
+										onSelect={() => onValueChange(model.id)}
+									/>
+								))}
+						</DropdownMenuSubContent>
+					</DropdownMenuSub>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }

--- a/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/AgentOptionsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/components/AgentOptionsScreen/AgentOptionsScreen.tsx
@@ -1,6 +1,6 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useLingui } from "@lingui/react/macro";
-import type { AgentModelOption } from "@superset/shared/agent-models";
+import { splitModelCatalog } from "@superset/shared/agent-models";
 import { type Href, Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { Pressable, ScrollView } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -11,33 +11,6 @@ import { useNewSessionPreferencesStore } from "@/screens/(authenticated)/(home)/
 import { OptionRow } from "@/screens/(authenticated)/components/OptionRow";
 import { useAgentLaunchPreferences } from "@/screens/(authenticated)/hooks/useAgentLaunchPreferences";
 import { SectionLabel } from "./components/SectionLabel";
-
-/**
- * The short list is everything up to and including the catalog's first
- * group — the aliases that track the newest release. Every later group is
- * a row of its own that opens that group's list: a dozen pinned versions
- * would bury the four picks almost everyone wants.
- */
-export function splitModelCatalog(models: AgentModelOption[]): {
-	inline: AgentModelOption[];
-	groups: string[];
-} {
-	const firstGroup = models.find((option) => option.group)?.group;
-	const inline = models.filter(
-		(option) => !option.group || option.group === firstGroup,
-	);
-	const groups: string[] = [];
-	for (const option of models) {
-		if (
-			option.group &&
-			option.group !== firstGroup &&
-			!groups.includes(option.group)
-		) {
-			groups.push(option.group);
-		}
-	}
-	return { inline, groups };
-}
 
 /**
  * An agent's launch settings on one screen: the model, with the older pinned

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -25,6 +25,34 @@ export interface AgentModelOption {
 	group?: string;
 }
 
+/**
+ * Split a catalog into the picks a menu shows inline and the groups it keeps
+ * a level down. Inline is everything up to and including the first group —
+ * the aliases that track the newest release — and every later group gets a
+ * row of its own that opens that group: a dozen pinned versions would bury
+ * the four picks almost everyone wants.
+ */
+export function splitModelCatalog(models: readonly AgentModelOption[]): {
+	inline: AgentModelOption[];
+	groups: string[];
+} {
+	const firstGroup = models.find((option) => option.group)?.group;
+	const inline = models.filter(
+		(option) => !option.group || option.group === firstGroup,
+	);
+	const groups: string[] = [];
+	for (const option of models) {
+		if (
+			option.group &&
+			option.group !== firstGroup &&
+			!groups.includes(option.group)
+		) {
+			groups.push(option.group);
+		}
+	}
+	return { inline, groups };
+}
+
 export interface AgentModelSupport {
 	presetId: string;
 	modelFlag: string | null;


### PR DESCRIPTION
## Why

The new-workspace model picker listed Claude's four aliases and ten pinned releases in one flat menu: sixteen rows that ran off the bottom of the window.

## What

- `AgentModelSelect` moves from Radix Select (no submenus) to DropdownMenu. The catalog's first section stays inline; every later section becomes a submenu row. With a pinned model picked, the row reads "Pinned releases  Opus 4.8" and the submenu checks it, matching the mobile options screen.
- The trigger keeps the Select pill classes so it still matches the agent picker beside it. Effort and mode pickers share the component and have no groups, so they render flat as before.
- `splitModelCatalog` moves from the mobile screen into `@superset/shared/agent-models`; mobile imports it, no behaviour change there.

Side effect of the shared rule: cursor-agent's OpenAI and Other sections and Codex's retiring section also go behind a row, which is what mobile already does.

## Verified

Driven over CDP in the dev app with real mouse input: top level went from 16 rows to 6, the submenu lists all ten pinned releases, picking one updates the pill and the persisted per-preset preference, reopening echoes the pick, and picking the default clears it. No console errors. Shared and desktop typecheck, biome, and the shared and picker suites pass.

https://claude.ai/code/session_01NP4w85hLom6GtPos98xJPz


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the new-workspace model picker overflowing the window by moving pinned releases behind submenus. The picker is now a dropdown menu: the first section (Claude's aliases) stays inline, each later group (pinned releases) becomes a submenu row that echoes the current pick, matching the mobile options screen. The shared split logic moves to `@superset/shared/agent-models` so both platforms read the catalog the same way. This also applies to other catalogs (OpenAI, Other, Codex retiring) on the desktop, consistent with mobile.

<sup>Written for commit 3a145e6c5ab0b13dc434fbf9724f9dce164ba39b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the desktop agent model picker with a streamlined dropdown menu.
  * Models are organized into inline options and grouped submenus for easier browsing.
  * Added clear selection support through a visible “Default” option.
  * The currently selected model is now indicated with a checkmark.
* **Improvements**
  * Standardized model organization across desktop and mobile agent settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->