### PR TITLE
feat(skills): add an integrations skill for calling plugin MCP tools

### DIFF
--- a/plugins/superset/skills/10x/SKILL.md
+++ b/plugins/superset/skills/10x/SKILL.md
@@ -35,7 +35,7 @@ For each recommendation in order: a two-sentence pitch, then ask (use the ask_us
 | Terminal remote-control | Read and drive any agent's terminal from anywhere | `superset terminals list / read / send` |
 | Custom slash commands | Your repo's own workflows as commands every agent can run | create `.agents/commands/<name>.md` in their repo |
 | MCP servers | Give every workspace agent the same extra tools | add servers to `.mcp.json` at their repo root |
-| Pages | Turn a report, dashboard, or digest into a link the org can read and pin comments to, versioned on every republish | `superset pages publish report.html --title "..."`, then `superset pages comments list` |
+| Pages | Turn a report, dashboard, or digest into a link the org can read and pin comments to, versioned on every republish | `superset pages publish report.html --workspace <id> --title "..."`, then `superset pages comments list` |
 | Feedback loop | Report bugs or ideas without leaving the agent | the feedback skill |
 
 ## Rules

--- a/plugins/superset/skills/10x/SKILL.md
+++ b/plugins/superset/skills/10x/SKILL.md
@@ -35,6 +35,7 @@ For each recommendation in order: a two-sentence pitch, then ask (use the ask_us
 | Terminal remote-control | Read and drive any agent's terminal from anywhere | `superset terminals list / read / send` |
 | Custom slash commands | Your repo's own workflows as commands every agent can run | create `.agents/commands/<name>.md` in their repo |
 | MCP servers | Give every workspace agent the same extra tools | add servers to `.mcp.json` at their repo root |
+| Pages | Turn a report, dashboard, or digest into a link the org can read and pin comments to, versioned on every republish | `superset pages publish report.html --title "..."`, then `superset pages comments list` |
 | Feedback loop | Report bugs or ideas without leaving the agent | the feedback skill |
 
 ## Rules

--- a/plugins/superset/skills/automate/SKILL.md
+++ b/plugins/superset/skills/automate/SKILL.md
@@ -13,6 +13,13 @@ Turn "I keep doing X every morning" into an automation that does X on a schedule
 
 Pin down: the outcome, the cadence, the inputs it reads, and what "done" looks like. Then draft the automation prompt as instructions for an agent with zero context. If the task has rules that will evolve (triage criteria, formats), put them in a document the automation reads at runtime so they can be edited without touching the prompt.
 
+Nobody watches a run, so a chore whose product is a digest, a report, or a scorecard needs somewhere for that product to land. End the prompt by publishing a page to the same path every run: the user opens one link instead of digging through run logs, and each run adds a version, so the page becomes the history of the thing it tracks.
+
+```
+...then publish the digest: superset pages publish digest.html \
+  --workspace $SUPERSET_WORKSPACE_ID --title "Nightly triage" --label "what changed today"
+```
+
 ## 2. Pick the target
 
 - `superset projects list`: a project target creates a fresh workspace per run (most tasks)
@@ -36,4 +43,4 @@ superset automations create \
 
 (`--workspace <id>` instead of `--project` for reuse mode; `--host <id>` if it should run on another machine; prefer `--prompt-file` for multiline prompts.)
 
-Then trigger a first run now with `superset automations run <id>`, review `superset automations logs <id>` with the user, and refine the prompt via `superset automations prompt set <id>` until the run output is right. An automation isn't done until one real run looked good.
+Then trigger a first run now with `superset automations run <id>`, review `superset automations logs <id>` with the user, and refine the prompt via `superset automations prompt set <id>` until the run output is right. An automation isn't done until one real run looked good. If the prompt publishes a page, open the published page as part of that review, not just the run log.

--- a/plugins/superset/skills/automate/SKILL.md
+++ b/plugins/superset/skills/automate/SKILL.md
@@ -13,12 +13,14 @@ Turn "I keep doing X every morning" into an automation that does X on a schedule
 
 Pin down: the outcome, the cadence, the inputs it reads, and what "done" looks like. Then draft the automation prompt as instructions for an agent with zero context. If the task has rules that will evolve (triage criteria, formats), put them in a document the automation reads at runtime so they can be edited without touching the prompt.
 
-Nobody watches a run, so a chore whose product is a digest, a report, or a scorecard needs somewhere for that product to land. End the prompt by publishing a page to the same path every run: the user opens one link instead of digging through run logs, and each run adds a version, so the page becomes the history of the thing it tracks.
+Nobody watches a run, so a chore whose product is a digest, a report, or a scorecard needs somewhere for that product to land. End the prompt by writing the report to an `.html` file and publishing it, so the user opens one link instead of digging through run logs.
 
 ```
-...then publish the digest: superset pages publish digest.html \
-  --workspace $SUPERSET_WORKSPACE_ID --title "Nightly triage" --label "what changed today"
+...write the digest to digest.html, then publish it:
+superset pages publish digest.html --title "Nightly triage" --label "what changed today"
 ```
+
+A page is identified by its workspace plus its path, so **which target you picked in step 2 decides whether history accumulates**. A project target creates a fresh workspace per run, which means a new page every run rather than a new version of one. For a report meant to build up history, use a workspace target, or capture the page id from the first run and have the prompt pass `--page <id>` from then on.
 
 ## 2. Pick the target
 

--- a/plugins/superset/skills/browser/SKILL.md
+++ b/plugins/superset/skills/browser/SKILL.md
@@ -200,6 +200,13 @@ along at their relative paths, so nothing needs inlining.
 superset pages publish ./evidence/ --workspace <id> --title "Checkout flow: 3 blockers"
 ```
 
+Read every screenshot before it goes up. This browser is signed into the user's
+accounts, so a capture can hold a session token, an email address, a customer
+name, or a dashboard that was never meant to leave the tab. New pages default
+to org-wide visibility. Crop or redact what does not belong in the report, pass
+`--visibility just_me` when the org does not need it, and confirm with the user
+before publishing.
+
 ## Safety
 
 - In-app panes share one browser profile, so `eval` and CDP reach whatever the

--- a/plugins/superset/skills/browser/SKILL.md
+++ b/plugins/superset/skills/browser/SKILL.md
@@ -190,6 +190,16 @@ read back `location.href`, the DOM via `eval`, or a screenshot after each
 meaningful step, and check the console for page errors before declaring
 success.
 
+When the evidence is the deliverable, a bug report or a before-and-after or a
+walkthrough someone else has to read, publish it rather than listing file
+paths nobody can open. Put the screenshots in a directory beside an
+`index.html` that lays them out, and publish the directory: the images ride
+along at their relative paths, so nothing needs inlining.
+
+```bash
+superset pages publish ./evidence/ --workspace <id> --title "Checkout flow: 3 blockers"
+```
+
 ## Safety
 
 - In-app panes share one browser profile, so `eval` and CDP reach whatever the

--- a/plugins/superset/skills/computer/SKILL.md
+++ b/plugins/superset/skills/computer/SKILL.md
@@ -2,7 +2,7 @@
 name: computer
 description: Operate the user's real desktop apps and windows on macOS, Windows, or Linux. Use when the user asks to open or drive a native app, click or type in a desktop UI, inspect or arrange a window, use their signed-in system browser, or verify an end-to-end GUI flow, including "open Settings and turn on dark mode", "click Save in that window", "what's on screen". Uses an accessibility-first driver (Cua Driver by default, Peekaboo on macOS). Not for Superset's in-app browser pane, headless scraping, or anything an API or CLI can do directly.
 argument-hint: the app and what to do in it
-allowed-tools: Bash(cua-driver:*) Bash(peekaboo:*)
+allowed-tools: Bash(cua-driver:*) Bash(peekaboo:*) Bash(superset pages:*)
 ---
 
 # Superset Computer Control
@@ -160,6 +160,15 @@ cua-driver call end_session '{"session":"superset-computer-<unique>"}'
 
 Do not stop a shared driver daemon or close unrelated windows when the task
 ends.
+
+When the screenshots are the point, a verification run someone else has to
+read, publish them instead of leaving a list of paths on their disk. Collect
+them in a directory beside an `index.html` that lays them out, and publish the
+directory so the images ride along at their relative paths:
+
+```bash
+superset pages publish ./evidence/ --workspace <id> --title "Export dialog: verified"
+```
 
 ## Safety
 

--- a/plugins/superset/skills/computer/SKILL.md
+++ b/plugins/superset/skills/computer/SKILL.md
@@ -2,7 +2,7 @@
 name: computer
 description: Operate the user's real desktop apps and windows on macOS, Windows, or Linux. Use when the user asks to open or drive a native app, click or type in a desktop UI, inspect or arrange a window, use their signed-in system browser, or verify an end-to-end GUI flow, including "open Settings and turn on dark mode", "click Save in that window", "what's on screen". Uses an accessibility-first driver (Cua Driver by default, Peekaboo on macOS). Not for Superset's in-app browser pane, headless scraping, or anything an API or CLI can do directly.
 argument-hint: the app and what to do in it
-allowed-tools: Bash(cua-driver:*) Bash(peekaboo:*) Bash(superset pages:*)
+allowed-tools: Bash(cua-driver:*) Bash(peekaboo:*) Bash(superset pages publish:*)
 ---
 
 # Superset Computer Control
@@ -169,6 +169,12 @@ directory so the images ride along at their relative paths:
 ```bash
 superset pages publish ./evidence/ --workspace <id> --title "Export dialog: verified"
 ```
+
+A desktop screenshot catches whatever else was on screen: mail, messages, a
+password manager, another customer's data. Look at each one, drop or crop what
+the report does not need, and pass `--visibility just_me` unless the org needs
+it. Publishing is one of the actions the Safety rules below require you to
+confirm first.
 
 ## Safety
 

--- a/plugins/superset/skills/integrations/SKILL.md
+++ b/plugins/superset/skills/integrations/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: integrations
+description: Discover and call the tools a connected integration exposes — Linear, GitHub, Sentry, Notion, or any other plugin — through `superset mcp`. Use when the user wants something done in a connected service, asks what an integration can do or which tools it has, wants a specific tool called, or asks why an integration's tools are failing.
+argument-hint: what you want done in a connected service
+allowed-tools: Bash(superset mcp:*) Bash(superset plugins:*) Bash(superset skills:*)
+---
+
+# Calling an integration's tools
+
+An integration is an installed plugin with a connected account. Its tools do not run here:
+`superset mcp` hands the call to Superset's API, which attaches the stored credential and
+forwards it to the plugin's MCP server. No token is ever written to this machine, which is
+also why a sandbox with no route to Linear can still file a Linear issue.
+
+Installing, connecting, and marketplaces belong to the `plugins` skill. This one starts once
+something is connected, and it is two steps: list the tools, then call one.
+
+## 1. Find the integration
+
+```bash
+superset plugins list                     # everything installed, one row per connected account
+superset plugins connections --plugin linear
+```
+
+Read the `STATUS` column. `connected: <account>` is callable. `needs connection` means the
+skills are installed but no account is authorized — the tools will fail, and that is a connect
+step, not a bug. `PLUGIN ID` holds the connection id; a plugin with two accounts has two rows
+and two ids.
+
+## 2. List the tools before calling one
+
+```bash
+superset mcp tools linear
+superset mcp tools --connection <id>              # when the name has several accounts
+superset mcp tools linear | jq -r '.[].tool'      # names only; descriptions run long
+```
+
+Names and descriptions come from the plugin's own server, not from anything in this repo, and
+they change between plugin versions. Never call a tool you have not listed.
+
+The listing gives a name and a description — **not an input schema**. The description is where
+the plugin documents its arguments, so read the full description of the tool you are about to
+call rather than the filtered name list. If the shape is still ambiguous, a wrong call comes
+back as a tool error naming the offending field; correct it from there.
+
+## 3. Call it
+
+```bash
+superset mcp call-tool linear list_issues
+superset mcp call-tool linear create_issue '{"team":"ENG","title":"Export 500s"}'
+echo '{"team":"ENG","title":"..."}' | superset mcp call-tool linear create_issue -
+superset mcp call-tool linear create_issue --connection <id> '{"team":"ENG","title":"..."}'
+```
+
+The plugin name is the first positional and the tool name the second, always. `--connection`
+picks the account; it does not stand in for the plugin positional. Arguments are the third
+positional, default `{}`, and `-` reads them from stdin — use stdin for anything secret, since
+an argument is visible in `ps` and in shell history.
+
+What comes back is the MCP result verbatim: a `content` array whose text parts are usually
+themselves JSON strings.
+
+```bash
+superset mcp call-tool linear list_issues | jq -r '.content[0].text' | jq
+```
+
+## Reading a failure
+
+| What you see | What it means |
+| --- | --- |
+| `"x" is not connected. Connect an account first.` | Nothing is authorized under that name. Also what an uninstalled plugin looks like. Run `superset plugins connect x`, or install it first. |
+| `"x" has N connected accounts; choose one:` | The CLI refuses to guess and prints a `--connection <id>` line per account. Ask the user which account, do not take the first. |
+| `Name a plugin, or pass --connection <id>.` | `superset mcp tools` with no target. |
+| `Missing required argument: <tool>` | `call-tool` takes the plugin, then the tool. |
+| `Arguments must be JSON: ...` | The third positional is a JSON object, quoted as one shell word. |
+| 401 or 403 from the tool itself | The stored credential was revoked or expired. Reconnect the account. |
+| `needs connection` in `plugins list` | Installed, unauthorized. Nothing you pass to `mcp` fixes this. |
+
+## Anti-patterns
+
+- Calling a tool without listing tools first. You are guessing at a name and a schema the
+  plugin owns.
+- `--plugin-id`. Deprecated alias for `--connection`.
+- Passing a credential as a command argument when the command reads stdin.
+- Picking one of several connected accounts yourself. Which account acts is the user's call.
+- Reaching for `superset plugins sync` when a call fails on authorization. Sync converges
+  skills on this machine; it has nothing to do with credentials.
+- Installing or connecting a plugin to see what it offers. That writes to the user's account
+  and reaches every machine they sign in on — ask first, and use the `plugins` skill.

--- a/plugins/superset/skills/integrations/SKILL.md
+++ b/plugins/superset/skills/integrations/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: integrations
-description: Discover and call the tools a connected integration exposes — Linear, GitHub, Sentry, Notion, or any other plugin — through `superset mcp`. Use when the user wants something done in a connected service, asks what an integration can do or which tools it has, wants a specific tool called, or asks why an integration's tools are failing.
+description: Discover and call the tools a connected integration exposes, such as Linear, GitHub, Sentry, or Notion, through `superset mcp`. Use when the user wants something done in a connected service, asks what an integration can do or which tools it has, wants a specific tool called, or asks why an integration's tools are failing.
 argument-hint: what you want done in a connected service
 allowed-tools: Bash(superset mcp:*) Bash(superset plugins:*) Bash(superset skills:*)
 ---
 
 # Calling an integration's tools
 
-An integration is an installed plugin with a connected account. Its tools do not run here:
+An integration is an installed plugin with a connected account. Its tools do not run here.
 `superset mcp` hands the call to Superset's API, which attaches the stored credential and
 forwards it to the plugin's MCP server. No token is ever written to this machine, which is
 also why a sandbox with no route to Linear can still file a Linear issue.
@@ -18,13 +18,14 @@ something is connected, and it is two steps: list the tools, then call one.
 ## 1. Find the integration
 
 ```bash
-superset plugins list                     # everything installed, one row per connected account
+superset plugins list                     # one row per connected account, one row if none yet
 superset plugins connections --plugin linear
 ```
 
 Read the `STATUS` column. `connected: <account>` is callable. `needs connection` means the
-skills are installed but no account is authorized — the tools will fail, and that is a connect
-step, not a bug. `PLUGIN ID` holds the connection id; a plugin with two accounts has two rows
+skills are installed but no account is authorized, so its tools will fail until someone
+connects one; that is a connect step, not a bug. `PLUGIN ID` holds the connection id, and it
+is empty on a row with no connection yet. A plugin with two connected accounts has two rows
 and two ids.
 
 ## 2. List the tools before calling one
@@ -38,7 +39,7 @@ superset mcp tools linear | jq -r '.[].tool'      # names only; descriptions run
 Names and descriptions come from the plugin's own server, not from anything in this repo, and
 they change between plugin versions. Never call a tool you have not listed.
 
-The listing gives a name and a description — **not an input schema**. The description is where
+The listing gives a name and a description, but **no input schema**. The description is where
 the plugin documents its arguments, so read the full description of the tool you are about to
 call rather than the filtered name list. If the shape is still ambiguous, a wrong call comes
 back as a tool error naming the offending field; correct it from there.
@@ -54,7 +55,7 @@ superset mcp call-tool linear create_issue --connection <id> '{"team":"ENG","tit
 
 The plugin name is the first positional and the tool name the second, always. `--connection`
 picks the account; it does not stand in for the plugin positional. Arguments are the third
-positional, default `{}`, and `-` reads them from stdin — use stdin for anything secret, since
+positional, default `{}`, and `-` reads them from stdin. Use stdin for anything secret, since
 an argument is visible in `ps` and in shell history.
 
 What comes back is the MCP result verbatim: a `content` array whose text parts are usually
@@ -73,7 +74,7 @@ superset mcp call-tool linear list_issues | jq -r '.content[0].text' | jq
 | `Name a plugin, or pass --connection <id>.` | `superset mcp tools` with no target. |
 | `Missing required argument: <tool>` | `call-tool` takes the plugin, then the tool. |
 | `Arguments must be JSON: ...` | The third positional is a JSON object, quoted as one shell word. |
-| 401 or 403 from the tool itself | The stored credential was revoked or expired. Reconnect the account. |
+| 401 or 403 from the tool itself | Read the error before acting. Reconnect only when it names an invalid, revoked, or expired credential. A 403 that names a scope, a permission, or a resource means the connected account lacks that access, and reconnecting the same account changes nothing. |
 | `needs connection` in `plugins list` | Installed, unauthorized. Nothing you pass to `mcp` fixes this. |
 
 ## Anti-patterns
@@ -83,7 +84,9 @@ superset mcp call-tool linear list_issues | jq -r '.content[0].text' | jq
 - `--plugin-id`. Deprecated alias for `--connection`.
 - Passing a credential as a command argument when the command reads stdin.
 - Picking one of several connected accounts yourself. Which account acts is the user's call.
+- Reconnecting on any 403. Half of them are a permissions problem on the account you already
+  have.
 - Reaching for `superset plugins sync` when a call fails on authorization. Sync converges
   skills on this machine; it has nothing to do with credentials.
 - Installing or connecting a plugin to see what it offers. That writes to the user's account
-  and reaches every machine they sign in on — ask first, and use the `plugins` skill.
+  and reaches every machine they sign in on, so ask first and use the `plugins` skill.

--- a/plugins/superset/skills/integrations/SKILL.md
+++ b/plugins/superset/skills/integrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrations
-description: Discover and call the tools a connected integration exposes, such as Linear, GitHub, Sentry, or Notion, through `superset mcp`. Use when the user wants something done in a connected service, asks what an integration can do or which tools it has, wants a specific tool called, or asks why an integration's tools are failing.
+description: Discover and call the tools a connected integration exposes, such as Linear, GitHub, Sentry, or Notion, through `superset mcp`. Use when the user wants something done in a connected service, asks what an integration can do or which tools it has, wants a specific tool called, asks why an integration's tools are failing, or when another skill expects `mcp__linear__*`-style tools that are not in your tool list.
 argument-hint: what you want done in a connected service
 allowed-tools: Bash(superset mcp:*) Bash(superset plugins:*) Bash(superset skills:*)
 ---
@@ -64,6 +64,26 @@ themselves JSON strings.
 ```bash
 superset mcp call-tool linear list_issues | jq -r '.content[0].text' | jq
 ```
+
+## When another skill expects tools you do not have
+
+A plugin ships its own skills, and they are written against native MCP tools: the Linear,
+GitHub, and Sentry skills declare `allowed-tools: mcp__linear__*` and reach for tools by that
+name. Those tools exist only where the plugin's MCP server was written into this agent's
+config, which installing through the CLI does not do, and which today happens for Claude Code
+and Codex only. On every other agent the tool list will not have them.
+
+That is this skill's job. When the tools a plugin's skill assumes are missing, do not stop and
+do not tell the user the integration is unavailable. The same operations sit on the connected
+account, one command away:
+
+```bash
+superset mcp tools linear                       # what the account can actually do
+superset mcp call-tool linear create_issue '{"team":"ENG","title":"..."}'
+```
+
+Keep following the skill you were reading, since its judgment about what makes a good issue or
+a good triage still applies. Only the transport changes.
 
 ## Reading a failure
 

--- a/plugins/superset/skills/integrations/agents/openai.yaml
+++ b/plugins/superset/skills/integrations/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Superset Integrations"
+  short_description: "List and call the tools your connected integrations expose"
+  default_prompt: "Use $superset-integrations to see what a connected integration can do, or to call one of its tools."

--- a/plugins/superset/skills/orchestrate/SKILL.md
+++ b/plugins/superset/skills/orchestrate/SKILL.md
@@ -146,6 +146,14 @@ For isolated branches, ask each implementation worker to commit or otherwise pro
 
 Summarize each task's outcome, workspace/branch, files changed, checks, blockers, and integration order. Distinguish worker claims from checks the coordinator independently ran.
 
+A run across several workspaces is worth a page. One link carrying every outcome, branch, and
+check reads better than a long terminal block, it survives the session, and reviewers can pin
+a comment to the row they disagree with:
+
+```bash
+superset pages publish run-summary.html --workspace <id> --title "Parallel run: auth refactor"
+```
+
 Keep completed terminals available when the user may want to inspect or continue them. Close a terminal only when cleanup is requested or clearly part of the workflow:
 
 ```bash

--- a/plugins/superset/skills/orchestrate/SKILL.md
+++ b/plugins/superset/skills/orchestrate/SKILL.md
@@ -154,6 +154,9 @@ a comment to the row they disagree with:
 superset pages publish run-summary.html --workspace <id> --title "Parallel run: auth refactor"
 ```
 
+Offer it and publish only once the user agrees. A page is persistent and
+org-visible by default, and a run summary quotes whatever the workers printed.
+
 Keep completed terminals available when the user may want to inspect or continue them. Close a terminal only when cleanup is requested or clearly part of the workflow:
 
 ```bash

--- a/plugins/superset/skills/page/SKILL.md
+++ b/plugins/superset/skills/page/SKILL.md
@@ -24,6 +24,13 @@ Publish a page when the work has a **reader** and wants a **link**: a report
 someone will skim, a dashboard for a standup, a comparison table, a diagram, a
 walkthrough of what you changed.
 
+Other skills produce exactly that and stop at the terminal. A standup digest, a
+summary of a parallel run across several workspaces, a feature scorecard, the
+screenshots from a browser or desktop verification: each has a reader who is not
+in the session, and each is better as a link than as scrollback. Recurring ones
+gain the most, since republishing the same path versions one page rather than
+littering the org with a new one every day.
+
 Don't publish when the artifact belongs in the repo (source, docs, config: put
 those in files and commit them), or when it genuinely needs a server, a
 database, or a login. A page has none of those.

--- a/plugins/superset/skills/page/SKILL.md
+++ b/plugins/superset/skills/page/SKILL.md
@@ -28,8 +28,10 @@ Other skills produce exactly that and stop at the terminal. A standup digest, a
 summary of a parallel run across several workspaces, a feature scorecard, the
 screenshots from a browser or desktop verification: each has a reader who is not
 in the session, and each is better as a link than as scrollback. Recurring ones
-gain the most, since republishing the same path versions one page rather than
-littering the org with a new one every day.
+gain the most, since republishing versions one page rather than littering the
+org with a new one every day. That only holds when the workspace and the path
+both stay the same, which is the identity of a page: a job that runs somewhere
+new each time needs `--page <id>` instead.
 
 Don't publish when the artifact belongs in the repo (source, docs, config: put
 those in files and commit them), or when it genuinely needs a server, a

--- a/plugins/superset/skills/plugins/SKILL.md
+++ b/plugins/superset/skills/plugins/SKILL.md
@@ -2,7 +2,7 @@
 name: plugins
 description: Install Superset plugins, connect the accounts they need, and call their MCP tools through the credential proxy. Use when the user wants a plugin installed, removed, enabled, or connected, asks what tools a plugin exposes, wants to call one, adds a marketplace, or asks why a plugin's tools are not available.
 argument-hint: what you want to install, connect, or call
-allowed-tools: Bash(superset plugins:*) Bash(superset mcp:*) Bash(superset marketplace:*) Bash(superset skills:*)
+allowed-tools: Bash(superset plugins:*) Bash(superset mcp:*) Bash(superset skills:*)
 ---
 
 # Plugins and their tools
@@ -53,19 +53,22 @@ which they want rather than picking.
 
 ## 4. Call its tools
 
-Address a plugin by the **plugin id** from `superset plugins list`. That is a *connection*
-id, so a plugin with two connected accounts has two, one per account. Pick the account
-deliberately; there is no default.
+Address a plugin by name. When one name has several connected accounts, pass the connection
+id from the `PLUGIN ID` column of `superset plugins list` instead; there is no default
+account, so pick one deliberately.
 
 ```bash
-superset mcp tools --plugin-id <id>
-superset mcp call-tool list_issues --plugin-id <id>
-superset mcp call-tool create_issue --plugin-id <id> '{"team":"ENG","title":"Export 500s"}'
-echo '{"team":"ENG","title":"..."}' | superset mcp call-tool create_issue --plugin-id <id>
+superset mcp tools linear
+superset mcp call-tool linear list_issues
+superset mcp call-tool linear create_issue '{"team":"ENG","title":"Export 500s"}'
+echo '{"team":"ENG","title":"..."}' | superset mcp call-tool linear create_issue -
+superset mcp call-tool linear create_issue --connection <id> '{"team":"ENG","title":"..."}'
 ```
 
 List the tools before calling one. Names and argument schemas come from the plugin's server,
-not from anything in this repo, and they change between versions.
+not from anything in this repo, and they change between versions. The `integrations` skill
+covers this end in full — reading a tool's arguments, choosing an account, parsing the
+result.
 
 The call goes out from Superset's API, which attaches the credential. That is why this
 works with no token on the machine, and why a network-restricted sandbox can still reach a
@@ -83,13 +86,14 @@ plugin's tools.
 ## 5. Turn things off
 
 ```bash
-superset plugins remove linear        # uninstall, and reap the skills it provisioned
-superset marketplace list
-superset marketplace install owner/repo          # add a third-party marketplace
-superset marketplace remove <name>
+superset plugins uninstall linear     # uninstall, and reap the skills it provisioned
+superset plugins disable linear       # keep the install, stop provisioning its skills
+superset plugins marketplace list
+superset plugins marketplace add owner/repo      # add a third-party marketplace
+superset plugins marketplace remove <name>
 ```
 
-`remove` reaps only what the plugin provisioned; hand-written skills in the same directory
+`uninstall` reaps only what the plugin provisioned; hand-written skills in the same directory
 are left alone.
 
 ## Anti-patterns

--- a/plugins/superset/skills/plugins/SKILL.md
+++ b/plugins/superset/skills/plugins/SKILL.md
@@ -67,7 +67,7 @@ superset mcp call-tool linear create_issue --connection <id> '{"team":"ENG","tit
 
 List the tools before calling one. Names and argument schemas come from the plugin's server,
 not from anything in this repo, and they change between versions. The `integrations` skill
-covers this end in full — reading a tool's arguments, choosing an account, parsing the
+covers this end in full: reading a tool's arguments, choosing an account, parsing the
 result.
 
 The call goes out from Superset's API, which attaches the credential. That is why this
@@ -94,7 +94,10 @@ superset plugins marketplace remove <name>
 ```
 
 `uninstall` reaps only what the plugin provisioned; hand-written skills in the same directory
-are left alone.
+are left alone. It removes the plugin locally even when the account call fails, and says so.
+Read that message: the stored credential is revoked as part of the account removal, so an
+unconfirmed removal means the skills are gone from this machine while the connection lives
+on. Check with `superset plugins connections --plugin <name>` and run `uninstall` again.
 
 ## Anti-patterns
 

--- a/plugins/superset/skills/standup/SKILL.md
+++ b/plugins/superset/skills/standup/SKILL.md
@@ -29,15 +29,17 @@ The last screen of a terminal shows whether the agent finished, asked a question
 Lead with what needs the user, one line per item: workspace, agent, state, and the next action. Then in-flight, then completed, then stale-workspace cleanup suggestions. Keep the whole digest scannable: no terminal dumps, quote at most the single relevant line an agent printed.
 
 Offer the digest as a page when someone other than the user will read it, or when they want it
-to persist past the scrollback. Publishing the same path every morning versions one page
-instead of scattering a new one each day, so the history becomes the record of the week.
+to persist past the scrollback. Write the report you just composed to an `.html` file inside a
+workspace, then publish that file: the CLI publishes a document, not your terminal output.
 
 ```bash
 superset pages publish standup.html --workspace <id> --title "Standup" --label "what shipped overnight"
 ```
 
-A digest often runs from outside any workspace, and a publish with no workspace is refused, so
-pass `--workspace` explicitly. Offer it; never publish one unasked.
+Publishing the same file from the same workspace each morning versions one page instead of
+scattering a new one daily, so the history becomes the record of the week. A digest often runs
+from outside any workspace, and a publish with no workspace is refused, so pass `--workspace`
+explicitly. Offer it; never publish one unasked.
 
 ## Rules
 

--- a/plugins/superset/skills/standup/SKILL.md
+++ b/plugins/superset/skills/standup/SKILL.md
@@ -28,6 +28,17 @@ The last screen of a terminal shows whether the agent finished, asked a question
 
 Lead with what needs the user, one line per item: workspace, agent, state, and the next action. Then in-flight, then completed, then stale-workspace cleanup suggestions. Keep the whole digest scannable: no terminal dumps, quote at most the single relevant line an agent printed.
 
+Offer the digest as a page when someone other than the user will read it, or when they want it
+to persist past the scrollback. Publishing the same path every morning versions one page
+instead of scattering a new one each day, so the history becomes the record of the week.
+
+```bash
+superset pages publish standup.html --workspace <id> --title "Standup" --label "what shipped overnight"
+```
+
+A digest often runs from outside any workspace, and a publish with no workspace is refused, so
+pass `--workspace` explicitly. Offer it; never publish one unasked.
+
 ## Rules
 
 Never send input to a terminal, modify tasks, or clean anything up as part of the digest. Offer those as follow-ups and act only when asked.


### PR DESCRIPTION
## Summary
- New `plugins/superset/skills/integrations/SKILL.md`: how to find a connected integration, list the tools it exposes, and call one through `superset mcp`. Its description is written to fire on integration questions ("do X in Linear", "what tools do I have", "why is this tool failing").
- Fixes the stale command surface in the `plugins` skill and points its "Call its tools" section at the new skill.

## Why / Context
The `plugins` skill covers install → connect → marketplace. Nothing covered the other half: an agent that has a connected integration and needs to actually use it. Worse, the four `superset mcp` lines that skill did carry no longer match the CLI, so an agent following them writes a failing command.

Verified against the live CLI, not just the source:

| Skill said | CLI today |
| --- | --- |
| `superset mcp tools --plugin-id <id>` | `superset mcp tools <plugin>`; `--plugin-id` is a deprecated alias for `--connection` |
| `superset mcp call-tool <tool> --plugin-id <id>` | `call-tool <plugin> <tool> [json]` — plugin first, and `--connection` does not stand in for it (`Missing required argument: <tool>`) |
| `superset marketplace list/install/remove` | `superset plugins marketplace list/add/remove` — the old form errors with `Unknown command: marketplace` |
| `superset plugins remove` | `uninstall` (`remove` survives as an alias) |

## How It Works
The bundled `superset` plugin ships every directory under `plugins/superset/skills/` automatically — `packages/agent-setup/src/managed-skills.ts:300` enumerates them, so a new skill needs no code change, no version bump, and no marketplace publish (it is a built-in marketplace, absent from `.agent-marketplace.json`).

The new skill deliberately stops where the `plugins` skill starts: it never installs or connects anything, it hands that back. Content worth flagging for review:

- `superset mcp tools` returns name and description only — **no input schema**. The skill says so and tells the agent to read the full description rather than the `jq`-filtered name list.
- A plugin with several connected accounts has no default; the CLI refuses to guess and prints one `--connection <id>` line per account. The skill makes choosing an account the user's call.
- Results come back as an MCP `content` array whose text parts are themselves JSON strings, so the skill shows the `jq -r '.content[0].text' | jq` unwrap.

## Manual QA
Every command in both skills was run against the real CLI in this workspace:

- [x] `superset mcp tools linear` lists tools; `jq -r '.[].tool'` filters them
- [x] `superset mcp call-tool linear list_agent_skills` returns a result; the `'{}'` third positional parses
- [x] `superset mcp call-tool --connection <id> list_agent_skills` fails with `Missing required argument: <tool>` — confirms the plugin positional is required alongside `--connection`
- [x] `superset mcp tools github` (not connected) → `"github" is not connected. Connect an account first.`
- [x] `superset mcp tools` (no target) → `Name a plugin, or pass --connection <id>.`
- [x] `superset plugins marketplace list` works; `superset marketplace list` → `Unknown command: marketplace`
- [x] Multi-account and 401/403 rows in the failure table read from `packages/cli/src/lib/plugins/connection-ref.ts` rather than reproduced live
- [x] "disable keeps the install but stops provisioning skills" checked against `packages/agent-setup/src/installed-plugins.ts:48`

## Testing
- `bun test` in `packages/agent-setup` → 304 pass. This suite validates every bundled skill (`bundled-skills.test.ts`), and I wrongly skipped it on the first push as "markdown, no code" — it caught three real failures: em dashes (a repo prose rule) in both files, and a missing `agents/openai.yaml` for the new skill. Fixed in 021f0ce.
- `bun run check:plugins` → "All plugins are valid and published."

## Review feedback (021f0ce)
All three CodeRabbit findings were valid and are applied:
- `plugins list` prints a row for an installed plugin with **no** connection yet (`list/command.ts` returns `pluginId: ""` for it), so "one row per connected account" hid exactly the integration that needs connecting.
- A tool's 401/403 is not always an expired credential. A 403 naming a scope or resource is a permissions problem on the account you already have, and reconnecting it changes nothing. The table and anti-patterns now say so.
- `uninstall` removes the plugin locally even when the account call fails (`uninstall/command.ts:19-46`). Since the credential is revoked only as part of that account call (`plugins.ts:532-557` clears the tokens), an unconfirmed removal leaves the connection live. The skill now says to re-check and re-run.

## Known Limitations
- The failure table's multi-account and expired-credential rows are read from the source, not reproduced — I have one connected account and did not want to revoke a credential to see the error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `integrations` skill so agents can discover and call the MCP tools of a connected plugin, updates the `plugins` skill's CLI examples to match the current `superset` CLI, and points report-producing skills at `superset pages` so their output persists as a link instead of scrollback.

- The `integrations` skill covers listing tools, picking an account, unwrapping MCP `content` results, and landing agents when a plugin's skill expects native `mcp__*__` tools that aren't available; it stops at install and connect.
- Failure guidance now distinguishes permission-based 403s from expired credentials and covers partially-completed uninstalls.
- The `plugins` skill now uses plugin-first `call-tool` syntax, `--connection` for account selection, and current `uninstall`, `disable`, and `plugins marketplace` subcommands.

**Publishing behavior**
- Page identity is workspace plus path; history accumulates only when the workspace stays constant or `--page <id>` is passed.
- `standup` and `automate` render the report to `.html` before publishing.
- `browser` and `computer` require reading captures, cropping, and `--visibility just_me` unless org-wide is intended; `computer`'s grant is narrowed to `superset pages publish`.

No code changes; the bundled `superset` plugin auto-loads every skill in its directory, and an `agents/openai.yaml` ships with the new skill.

<sup>Written for commit 59d1cfedf6d5d385b39484bc87bdbbac9f187ed3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for discovering connected integrations, available tools, account selection, secure secret handling, and fallback behavior.
  - Clarified integration authentication, argument, JSON, and permission errors, including when reconnection is appropriate.
  - Updated plugin workflows, management commands, and local uninstall behavior.
  - Added OpenAI integration skill guidance for discovering and using tools.
  - Documented publishing reports, screenshots, walkthroughs, run summaries, and recurring digests as shareable pages with comments and versioning.
  - Added guidance for workspace-based page identity, evidence redaction, visibility controls, and publishing confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
