### PR TITLE
fix(host-service,cli): register with the cloud even when Remote Access is off

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -149,10 +149,13 @@ async function main(): Promise<void> {
 				manifestReclaimTimer.unref();
 			}
 
-			if (env.RELAY_URL && env.ORGANIZATION_ID) {
+			// The coordinator strips RELAY_URL when Remote Access is off. The
+			// host still registers with the cloud so hosts list and the
+			// automations UI can see it; only the tunnel is skipped (#7223).
+			if (env.ORGANIZATION_ID) {
 				void connectRelay({
 					api,
-					relayUrl: env.RELAY_URL,
+					relayUrl: env.RELAY_URL ?? null,
 					localPort: info.port,
 					organizationId: env.ORGANIZATION_ID,
 					authProvider,

--- a/packages/cli/src/commands/automations/resolveAutomationTarget.test.ts
+++ b/packages/cli/src/commands/automations/resolveAutomationTarget.test.ts
@@ -17,7 +17,17 @@ function apiWithHosts(hostIds: string[]): ApiClient {
 const BASE = {
 	organizationId: "org-1",
 	userJwt: "jwt",
+	checkLocalHost: async () => null,
 };
+
+function localHost(relayEnabled: boolean | null) {
+	return async () => ({
+		healthy: true,
+		cloudRegistered: true,
+		registrationError: null,
+		relayEnabled,
+	});
+}
 
 describe("resolveAutomationTarget host preflight", () => {
 	it("rejects session mode when this machine is not registered", async () => {
@@ -48,5 +58,48 @@ describe("resolveAutomationTarget host preflight", () => {
 			targetHostId: getHostId(),
 			v2ProjectId: null,
 		});
+	});
+});
+
+// A host with Remote Access off registers (so the preflight above passes)
+// but never opens the relay, and every run would be skipped as offline —
+// the CLI must say so, not create the automation (#7223).
+describe("resolveAutomationTarget Remote Access preflight", () => {
+	it("refuses this machine when its host-service reports the relay disabled", async () => {
+		const promise = resolveAutomationTarget({
+			...BASE,
+			api: apiWithHosts([getHostId()]),
+			checkLocalHost: localHost(false),
+		});
+		await expect(promise).rejects.toThrow(CLIError);
+		await expect(promise).rejects.toThrow(
+			/Remote Access is off for this machine/,
+		);
+		await expect(promise).rejects.toMatchObject({
+			suggestion: expect.stringMatching(/Settings → Remote Access/),
+		});
+	});
+
+	it("passes when the relay is enabled or its state is not settled yet", async () => {
+		for (const relayEnabled of [true, null]) {
+			await expect(
+				resolveAutomationTarget({
+					...BASE,
+					api: apiWithHosts([getHostId()]),
+					checkLocalHost: localHost(relayEnabled),
+				}),
+			).resolves.toEqual({ targetHostId: getHostId(), v2ProjectId: null });
+		}
+	});
+
+	it("does not consult this machine for an explicit --host", async () => {
+		await expect(
+			resolveAutomationTarget({
+				...BASE,
+				api: apiWithHosts(["other-host"]),
+				hostId: "other-host",
+				checkLocalHost: localHost(false),
+			}),
+		).resolves.toEqual({ targetHostId: "other-host", v2ProjectId: null });
 	});
 });

--- a/packages/cli/src/commands/automations/resolveAutomationTarget.ts
+++ b/packages/cli/src/commands/automations/resolveAutomationTarget.ts
@@ -1,6 +1,7 @@
 import { CLIError } from "@superset/cli-framework";
 import { getHostId } from "@superset/shared/host-info";
 import type { ApiClient } from "../../lib/api-client";
+import { checkLocalHostHealth, type HostHealth } from "../../lib/host/health";
 import { resolveHostTarget } from "../../lib/host-target";
 import { findWorkspaceOnHost } from "../../lib/host-workspaces";
 
@@ -18,8 +19,11 @@ export async function resolveAutomationTarget(args: {
 	hostId?: string;
 	workspaceId?: string;
 	projectId?: string;
+	/** Health of this machine's host-service; injectable for tests. */
+	checkLocalHost?: (organizationId: string) => Promise<HostHealth | null>;
 }): Promise<{ targetHostId: string; v2ProjectId: string | null }> {
 	const targetHostId = args.hostId ?? getHostId();
+	const checkLocalHost = args.checkLocalHost ?? checkLocalHostHealth;
 
 	// The cloud rejects automations whose target host has no v2Hosts row
 	// (the host-service registers one at startup, and that registration can
@@ -38,6 +42,20 @@ export async function resolveAutomationTarget(args: {
 				? "Run: superset hosts list"
 				: "Restart the host service (superset stop && superset start), then check: superset hosts list",
 		);
+	}
+
+	// Runs dispatch through the relay, so a registered host with Remote
+	// Access off would accept the automation and then skip every run as
+	// offline. Only this machine's host-service can tell that apart from a
+	// transient disconnect, so ask it (#7223).
+	if (!args.hostId) {
+		const local = await checkLocalHost(args.organizationId);
+		if (local?.relayEnabled === false) {
+			throw new CLIError(
+				"Remote Access is off for this machine, so automations can't run on it",
+				"Turn it on in the Superset app under Settings → Remote Access, then retry",
+			);
+		}
 	}
 
 	if (args.workspaceId) {

--- a/packages/cli/src/commands/status/command.ts
+++ b/packages/cli/src/commands/status/command.ts
@@ -3,49 +3,9 @@ import { getHostId } from "@superset/shared/host-info";
 import { formatDistanceToNowStrict } from "date-fns";
 import type { ApiClient } from "../../lib/api-client";
 import { command } from "../../lib/command";
+import { checkHostHealth } from "../../lib/host/health";
 import { isProcessAlive, readManifest } from "../../lib/host/manifest";
 import { resolveOrganizationFromContext } from "../../lib/resolve-org";
-
-type HealthResult = {
-	healthy: boolean;
-	/** undefined = host-service predates the field (pre-#6415). */
-	cloudRegistered?: boolean;
-	registrationError?: string | null;
-};
-
-async function checkHealth(
-	endpoint: string,
-	authToken: string,
-): Promise<HealthResult> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), 2_000);
-	try {
-		const res = await fetch(`${endpoint}/trpc/health.check`, {
-			signal: controller.signal,
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
-		if (!res.ok) return { healthy: false };
-		const body = (await res.json()) as {
-			result?: { data?: { json?: Record<string, unknown> } };
-		};
-		const payload = body.result?.data?.json;
-		return {
-			healthy: true,
-			cloudRegistered:
-				typeof payload?.cloudRegistered === "boolean"
-					? payload.cloudRegistered
-					: undefined,
-			registrationError:
-				typeof payload?.registrationError === "string"
-					? payload.registrationError
-					: undefined,
-		};
-	} catch {
-		return { healthy: false };
-	} finally {
-		clearTimeout(timeout);
-	}
-}
 
 async function fetchHostName(
 	api: ApiClient,
@@ -103,7 +63,7 @@ export default command({
 		}
 
 		const [health, cloudHost] = await Promise.all([
-			checkHealth(manifest.endpoint, manifest.authToken),
+			checkHostHealth(manifest.endpoint, manifest.authToken),
 			fetchHostName(ctx.api, organization.id, localHostId),
 		]);
 		const uptime = formatDistanceToNowStrict(new Date(manifest.startedAt));
@@ -115,12 +75,19 @@ export default command({
 		const cloudRegistered =
 			health.cloudRegistered ??
 			(cloudHost.listed === null ? undefined : cloudHost.listed);
-		const registrationWarning =
-			health.healthy && cloudRegistered === false
+		// Remote Access off is a setting, not a failure: the host registers but
+		// never opens the relay tunnel, so it shows offline and automations
+		// can't reach it (#7223). Say that instead of the registration hints,
+		// which would send the user chasing a retry that isn't happening.
+		const registrationWarning = !health.healthy
+			? ""
+			: cloudRegistered === false
 				? `\nWarning: not registered with the cloud for ${organization.name}${
 						health.registrationError ? ` (${health.registrationError})` : ""
 					} — hosts list and automations won't see this machine\nHint: check host-service.log; registration retries automatically, or run: superset stop && superset start`
-				: "";
+				: health.relayEnabled === false
+					? "\nWarning: Remote Access is off for this machine — it shows offline in hosts list and automations can't run on it\nHint: turn it on in the Superset app under Settings → Remote Access"
+					: "";
 
 		return {
 			data: {
@@ -135,6 +102,9 @@ export default command({
 				...(cloudRegistered === undefined ? {} : { cloudRegistered }),
 				...(health.registrationError
 					? { registrationError: health.registrationError }
+					: {}),
+				...(typeof health.relayEnabled === "boolean"
+					? { relayEnabled: health.relayEnabled }
 					: {}),
 				uptimeSec: Math.floor((Date.now() - manifest.startedAt) / 1000),
 			},

--- a/packages/cli/src/lib/host/health.ts
+++ b/packages/cli/src/lib/host/health.ts
@@ -1,0 +1,65 @@
+import { isProcessAlive, readManifest } from "./manifest";
+
+export type HostHealth = {
+	healthy: boolean;
+	/** undefined = host-service predates the field (pre-#6415). */
+	cloudRegistered?: boolean;
+	registrationError?: string | null;
+	/**
+	 * false = the host was started without a relay URL (Remote Access off):
+	 * registered, but offline for hosts list and unreachable for automations.
+	 * null = not settled yet; undefined = host-service predates the field.
+	 */
+	relayEnabled?: boolean | null;
+};
+
+export async function checkHostHealth(
+	endpoint: string,
+	authToken: string,
+): Promise<HostHealth> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 2_000);
+	try {
+		const res = await fetch(`${endpoint}/trpc/health.check`, {
+			signal: controller.signal,
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		if (!res.ok) return { healthy: false };
+		const body = (await res.json()) as {
+			result?: { data?: { json?: Record<string, unknown> } };
+		};
+		const payload = body.result?.data?.json;
+		return {
+			healthy: true,
+			cloudRegistered:
+				typeof payload?.cloudRegistered === "boolean"
+					? payload.cloudRegistered
+					: undefined,
+			registrationError:
+				typeof payload?.registrationError === "string"
+					? payload.registrationError
+					: undefined,
+			relayEnabled:
+				typeof payload?.relayEnabled === "boolean" ||
+				payload?.relayEnabled === null
+					? payload.relayEnabled
+					: undefined,
+		};
+	} catch {
+		return { healthy: false };
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+/**
+ * Health of the host-service running on this machine for the org, or null
+ * when there is none to ask (no manifest, or its process is gone).
+ */
+export async function checkLocalHostHealth(
+	organizationId: string,
+): Promise<HostHealth | null> {
+	const manifest = readManifest(organizationId);
+	if (!manifest || !isProcessAlive(manifest.pid)) return null;
+	return checkHostHealth(manifest.endpoint, manifest.authToken);
+}

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -134,10 +134,13 @@ async function main(): Promise<void> {
 		// agent's terminal the way they would on their own machine.
 		void launchSandboxAgent();
 
-		if (env.RELAY_URL && env.SUPERSET_HOST_RUN_MODE !== "sandbox") {
+		// Register with the cloud even without a relay URL (Remote Access off)
+		// so the host exists server-side; only the tunnel needs RELAY_URL
+		// (#7223). Sandboxes never register — see SUPERSET_HOST_RUN_MODE.
+		if (env.SUPERSET_HOST_RUN_MODE !== "sandbox") {
 			void connectRelay({
 				api,
-				relayUrl: env.RELAY_URL,
+				relayUrl: env.RELAY_URL ?? null,
 				localPort: info.port,
 				organizationId: env.ORGANIZATION_ID,
 				authProvider,

--- a/packages/host-service/src/trpc/router/health/health.ts
+++ b/packages/host-service/src/trpc/router/health/health.ts
@@ -5,12 +5,14 @@ export const healthRouter = router({
 	check: publicProcedure.query(() => {
 		// A locally-healthy host that failed cloud registration is invisible
 		// to hosts list/automations with no symptom of its own — expose the
-		// registration outcome so `superset status` can report it (#6415).
+		// registration outcome so `superset status` can report it (#6415),
+		// and whether the relay is off by configuration (#7223).
 		const registration = getRegistrationState();
 		return {
 			status: "ok" as const,
 			cloudRegistered: registration.registered,
 			registrationError: registration.lastError,
+			relayEnabled: registration.relayEnabled,
 		};
 	}),
 });

--- a/packages/host-service/src/tunnel/connect.ts
+++ b/packages/host-service/src/tunnel/connect.ts
@@ -10,8 +10,13 @@ import { TunnelClient } from "./tunnel-client";
 
 export interface ConnectRelayOptions {
 	api: ApiClient;
-	/** Fallback when the API can't be reached; the API's answer wins. */
-	relayUrl: string;
+	/**
+	 * Fallback when the API can't be reached; the API's answer wins. `null`
+	 * means the host was started without a relay URL (Remote Access off): it
+	 * still registers with the cloud so `hosts list` and the desktop can see
+	 * it, but no tunnel is opened.
+	 */
+	relayUrl: string | null;
 	localPort: number;
 	organizationId: string;
 	authProvider: JwtApiAuthProvider;
@@ -51,6 +56,10 @@ export async function connectRelay(
 	// failure at boot permanently stranding the host as locally-healthy but
 	// cloud-invisible (issue #6415) — so retry with backoff until it lands,
 	// and record the outcome where health.check can report it.
+	//
+	// Registration does not depend on the relay: gating it on RELAY_URL left
+	// every desktop with Remote Access off silently unregistered (issue
+	// #7223). Only the tunnel below needs a relay URL.
 	for (let attempt = 0; ; attempt++) {
 		try {
 			const host = await options.api.host.ensure.mutate({
@@ -58,10 +67,18 @@ export async function connectRelay(
 				machineId: getHostId(),
 				name: getHostName(),
 			});
-			recordRegistrationSuccess();
+			recordRegistrationSuccess({ relayEnabled: options.relayUrl !== null });
 			console.log(`[host-service] registered as host ${host.machineId}`);
 
-			const relayUrl = await resolveRelayUrl(options.api, options.relayUrl);
+			if (options.relayUrl === null) {
+				console.log(
+					"[host-service] relay disabled (no RELAY_URL: Remote Access is off) — not connecting; this host shows offline in hosts list and automations can't run on it until Remote Access is turned on",
+				);
+				return null;
+			}
+
+			const fallbackRelayUrl = options.relayUrl;
+			const relayUrl = await resolveRelayUrl(options.api, fallbackRelayUrl);
 			console.log(`[host-service] relay: ${relayUrl}`);
 
 			const clientOptions = {
@@ -70,7 +87,7 @@ export async function connectRelay(
 				getAuthToken: () => options.authProvider.getJwt(),
 				localPort: options.localPort,
 				hostServiceSecret: options.hostServiceSecret,
-				resolveRelayUrl: () => resolveRelayUrl(options.api, options.relayUrl),
+				resolveRelayUrl: () => resolveRelayUrl(options.api, fallbackRelayUrl),
 			};
 
 			const tunnel = new TunnelClient(clientOptions);

--- a/packages/host-service/src/tunnel/registration-state.ts
+++ b/packages/host-service/src/tunnel/registration-state.ts
@@ -6,27 +6,38 @@
  * serving locally and looks healthy, so the failure must be queryable —
  * health.check exposes this state and `superset status` reports it
  * (issue #6415).
+ *
+ * The relay is tracked separately: a host started without a relay URL
+ * (Remote Access off) registers but never opens the tunnel, so it shows
+ * offline and automations can't reach it. That is a deliberate setting, not
+ * a failure, and `superset status` must be able to say so (issue #7223).
  */
 export type RegistrationState = {
 	registered: boolean;
 	lastError: string | null;
 	lastAttemptAt: number | null;
+	/** null until registration settles; false = started without a relay URL. */
+	relayEnabled: boolean | null;
 };
 
 const state: RegistrationState = {
 	registered: false,
 	lastError: null,
 	lastAttemptAt: null,
+	relayEnabled: null,
 };
 
 export function getRegistrationState(): RegistrationState {
 	return { ...state };
 }
 
-export function recordRegistrationSuccess(): void {
+export function recordRegistrationSuccess(options: {
+	relayEnabled: boolean;
+}): void {
 	state.registered = true;
 	state.lastError = null;
 	state.lastAttemptAt = Date.now();
+	state.relayEnabled = options.relayEnabled;
 }
 
 export function recordRegistrationFailure(error: unknown): void {

--- a/packages/host-service/test/integration/cloud-registration-without-relay.integration.test.ts
+++ b/packages/host-service/test/integration/cloud-registration-without-relay.integration.test.ts
@@ -1,0 +1,225 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * Issue #7223: a host started without RELAY_URL (what the desktop does when
+ * Remote Access is off) must still register itself with the cloud, or it is
+ * invisible to `hosts list` and automations while every local check passes.
+ *
+ * Black-box on purpose: it boots the real `serve.ts` entry the way the
+ * desktop coordinator's child env does, against a fake cloud that records
+ * `host.ensure` calls. Runs under Electron-as-Node because better-sqlite3 is
+ * compiled against the Electron ABI (same reason as scripts/test-e2e.ts).
+ */
+
+const repoRoot = path.resolve(import.meta.dir, "../../../..");
+const hostServiceRoot = path.resolve(import.meta.dir, "../..");
+const desktopRequire = createRequire(
+	path.join(repoRoot, "apps/desktop/package.json"),
+);
+const electronBin = desktopRequire("electron") as string;
+// tsx's main export is its ESM loader (dist/loader.mjs).
+const tsxLoader = desktopRequire.resolve("tsx");
+
+const ORG_ID = "11111111-2222-4333-8444-555555555555";
+const HOST_SECRET = "test-host-secret";
+
+type EnsureCall = { organizationId: string; machineId: string; name: string };
+const ensureCalls: EnsureCall[] = [];
+
+function trpcOk(json: unknown) {
+	return { result: { data: { json } } };
+}
+
+function handleProcedure(procedure: string, input: unknown): unknown {
+	switch (procedure) {
+		case "host.ensure": {
+			const host = input as EnsureCall;
+			ensureCalls.push(host);
+			return trpcOk({ ...host, createdByUserId: "user-1", wakeCommand: null });
+		}
+		case "host.relayEndpoint":
+			return trpcOk({ url: "wss://relay.invalid" });
+		default:
+			return {
+				error: {
+					json: {
+						message: `fake cloud: unhandled ${procedure}`,
+						code: -32004,
+						data: { code: "NOT_FOUND", httpStatus: 404 },
+					},
+				},
+			};
+	}
+}
+
+async function freePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.on("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			const port = typeof address === "object" && address ? address.port : 0;
+			server.close(() => resolve(port));
+		});
+	});
+}
+
+async function waitFor(
+	predicate: () => Promise<boolean> | boolean,
+	timeoutMs: number,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return true;
+		await Bun.sleep(250);
+	}
+	return false;
+}
+
+let cloud: ReturnType<typeof Bun.serve>;
+let child: ChildProcess | null = null;
+let tempHome = "";
+let hostPort = 0;
+let childOutput = "";
+
+async function healthCheck(): Promise<{
+	status: string;
+	cloudRegistered: boolean;
+	registrationError: string | null;
+} | null> {
+	try {
+		const res = await fetch(`http://127.0.0.1:${hostPort}/trpc/health.check`, {
+			headers: { Authorization: `Bearer ${HOST_SECRET}` },
+		});
+		if (!res.ok) return null;
+		const body = (await res.json()) as {
+			result?: { data?: { json?: never } };
+		};
+		return body.result?.data?.json ?? null;
+	} catch {
+		return null;
+	}
+}
+
+beforeAll(async () => {
+	cloud = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		async fetch(req) {
+			const url = new URL(req.url);
+			if (!url.pathname.startsWith("/api/trpc/")) {
+				return new Response("not found", { status: 404 });
+			}
+			const procedures = url.pathname.slice("/api/trpc/".length).split(",");
+			const rawInputs =
+				req.method === "GET"
+					? (url.searchParams.get("input") ?? "{}")
+					: (await req.text()) || "{}";
+			const inputs = JSON.parse(rawInputs) as Record<
+				string,
+				{ json?: unknown }
+			>;
+			return Response.json(
+				procedures.map((procedure, index) =>
+					handleProcedure(procedure, inputs[String(index)]?.json),
+				),
+			);
+		},
+	});
+
+	// HOME is redirected too: serve.ts provisions agent hooks into the
+	// user's real agent config dirs, which a test must never touch.
+	tempHome = mkdtempSync(path.join(tmpdir(), "hs-registration-"));
+	const supersetHome = path.join(tempHome, ".superset");
+	const orgDir = path.join(supersetHome, "host", ORG_ID);
+	hostPort = await freePort();
+
+	// Mirrors apps/desktop/src/main/lib/host-service-coordinator.ts buildEnv
+	// with exposeHostServiceViaRelay=false: every var the child reads, and
+	// RELAY_URL deleted.
+	const env: Record<string, string> = {
+		...(process.env as Record<string, string>),
+		HOME: tempHome,
+		NODE_ENV: "development",
+		ELECTRON_RUN_AS_NODE: "1",
+		ORGANIZATION_ID: ORG_ID,
+		HOST_SERVICE_SECRET: HOST_SECRET,
+		HOST_SERVICE_PORT: String(hostPort),
+		PORT: String(hostPort),
+		HOST_MANIFEST_DIR: orgDir,
+		HOST_DB_PATH: path.join(orgDir, "host.db"),
+		HOST_MIGRATIONS_FOLDER: path.join(hostServiceRoot, "drizzle"),
+		SUPERSET_HOME_DIR: supersetHome,
+		// JWT-shaped so JwtApiAuthProvider passes it through untouched.
+		AUTH_TOKEN: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyLTEifQ.c2ln",
+		SUPERSET_API_URL: `http://127.0.0.1:${cloud.port}`,
+		HOST_PARENT_PID: String(process.pid),
+	};
+	delete env.RELAY_URL;
+	delete env.SUPERSET_AUTH_CONFIG_PATH;
+
+	child = spawn(
+		electronBin,
+		["--import", tsxLoader, path.join(hostServiceRoot, "src/serve.ts")],
+		{ cwd: hostServiceRoot, env, stdio: ["ignore", "pipe", "pipe"] },
+	);
+	child.stdout?.on("data", (chunk) => {
+		childOutput += String(chunk);
+	});
+	child.stderr?.on("data", (chunk) => {
+		childOutput += String(chunk);
+	});
+
+	const listening = await waitFor(
+		async () => (await healthCheck()) !== null,
+		30_000,
+	);
+	if (!listening) {
+		throw new Error(
+			`host-service never answered health.check:\n${childOutput}`,
+		);
+	}
+});
+
+afterAll(async () => {
+	if (child && child.exitCode === null) {
+		const exited = new Promise<void>((resolve) =>
+			child?.once("exit", () => resolve()),
+		);
+		child.kill("SIGTERM");
+		await Promise.race([exited, Bun.sleep(5_000)]);
+		if (child.exitCode === null) child.kill("SIGKILL");
+	}
+	cloud?.stop(true);
+	if (tempHome) rmSync(tempHome, { recursive: true, force: true });
+});
+
+test(
+	"registers with the cloud when started without RELAY_URL (Remote Access off)",
+	async () => {
+		const registered = await waitFor(() => ensureCalls.length > 0, 10_000);
+		expect(
+			registered,
+			`host.ensure was never called. host-service output:\n${childOutput}`,
+		).toBe(true);
+		expect(ensureCalls[0]?.organizationId).toBe(ORG_ID);
+
+		await waitFor(
+			async () => (await healthCheck())?.cloudRegistered === true,
+			5_000,
+		);
+		expect(await healthCheck()).toMatchObject({
+			status: "ok",
+			cloudRegistered: true,
+			registrationError: null,
+		});
+		expect(childOutput).toContain("[host-service] registered as host");
+	},
+	{ timeout: 60_000 },
+);

--- a/packages/host-service/test/integration/smoke.integration.test.ts
+++ b/packages/host-service/test/integration/smoke.integration.test.ts
@@ -19,6 +19,7 @@ describe("host-service smoke", () => {
 			status: "ok",
 			cloudRegistered: false,
 			registrationError: null,
+			relayEnabled: null,
 		});
 	});
 
@@ -28,6 +29,7 @@ describe("host-service smoke", () => {
 			status: "ok",
 			cloudRegistered: false,
 			registrationError: null,
+			relayEnabled: null,
 		});
 	});
 

--- a/plans/7223-evidence-after.md
+++ b/plans/7223-evidence-after.md
@@ -1,0 +1,130 @@
+# #7223 evidence, AFTER the fix
+
+Same reproduction as `plans/7223-evidence-before.md`: `serve.ts` under Electron-as-Node with the desktop
+coordinator's Remote-Access-off child env (`RELAY_URL` deleted), fake cloud at `127.0.0.1:4999` recording
+`host.ensure`, scratch `SUPERSET_HOME_DIR`, CLI binary rebuilt from the fixed source with the fake API URL
+baked in. Fake cloud state was reset before the relaunch.
+
+One repro-harness correction versus the before run: this workspace terminal exports
+`SUPERSET_ORGANIZATION_ID` for the real org, and the CLI honours it over `config.json`. The CLI runs below
+unset it so `automations create` resolves the fake org (the before-run failure was at the registration
+check and is unaffected by that).
+
+## (a) host-service log: registration happens, relay skip is logged explicitly
+
+```
+2026-09-06T17:12:28.792Z [host-service] starting (org=11111111-2222-4333-8444-555555555555, port=4877, NODE_ENV=development)
+2026-09-06T17:12:28.793Z [supervisor] kicking off bootstrap for org=11111111-2222-4333-8444-555555555555
+2026-09-06T17:12:28.820Z [host-service:db] Initialized at /private/tmp/claude-501/-Users-kietho--superset-worktrees-1c99c8eb-1b31-4f04-9ac4-61a2760c74b6-fix-7223-host-registration-remote-access-off/f4bf6181-b6a3-480c-8e9d-5b636a4966fa/scratchpad/home/host/11111111-2222-4333-8444-555555555555/host.db, migrations from /Users/kietho/.superset/worktrees/1c99c8eb-1b31-4f04-9ac4-61a2760c74b6/fix/7223-host-registration-remote-access-off/packages/host-service/drizzle
+2026-09-06T17:12:28.829Z [host-service] listening on http://127.0.0.1:4877
+2026-09-06T17:12:28.861Z [host-service] registered as host 300d922f3b90fd4955ae39163bda4431
+2026-09-06T17:12:28.861Z [host-service] relay disabled (no RELAY_URL: Remote Access is off) — not connecting; this host shows offline in hosts list and automations can't run on it until Remote Access is turned on
+2026-09-06T17:12:28.866Z [pty-daemon:11111111-2222-4333-8444-555555555555] spawning /Users/kietho/.superset/worktrees/1c99c8eb-1b31-4f04-9ac4-61a2760c74b6/fix/7223-host-registration-remote-access-off/packages/pty-daemon/dist/pty-daemon.js → /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock (log: /private/tmp/claude-501/-Users-kietho--superset-worktrees-1c99c8eb-1b31-4f04-9ac4-61a2760c74b6-fix-7223-host-registration-remote-access-off/f4bf6181-b6a3-480c-8e9d-5b636a4966fa/scratchpad/home/host/11111111-2222-4333-8444-555555555555/pty-daemon.log)
+
+
+
+
+
+
+[ptyd:11111111] [pty-daemon] listening on /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock (v0.3.3, host=Kiets-Spaceship.local)
+2026-09-06T17:12:28.969Z [pty-daemon:11111111-2222-4333-8444-555555555555] spawned pid=91089 socket=/var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock
+2026-09-06T17:12:28.969Z {"component":"pty-daemon-supervisor","event":"pty_daemon_spawn","organizationId":"11111111-2222-4333-8444-555555555555","pid":91089,"socketPath":"/var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock","daemonVersion":"0.3.3"}
+2026-09-06T17:12:28.969Z [supervisor] bootstrap OK for org=11111111-2222-4333-8444-555555555555 pid=91089 version=0.3.3
+```
+
+Fake cloud:
+
+```
+$ curl -s http://127.0.0.1:4999/__state
+{
+    "ensureCalls": [
+        {
+            "at": "2026-09-06T17:12:28.856Z",
+            "input": {
+                "organizationId": "11111111-2222-4333-8444-555555555555",
+                "machineId": "300d922f3b90fd4955ae39163bda4431",
+                "name": "Kiets-Spaceship"
+            }
+        }
+    ],
+    "requests": [
+        "2026-09-06T17:12:28.856Z POST host.ensure"
+    ]
+}
+```
+
+`host.ensure` was called once, 32 ms after listen. No relay endpoint lookup, no tunnel, as intended.
+
+## (b) health.check: registered, relay reported as disabled
+
+```
+$ curl -s -H "Authorization: Bearer repro-secret-7223" http://127.0.0.1:4877/trpc/health.check
+{"result":{"data":{"json":{"status":"ok","cloudRegistered":true,"registrationError":null,"relayEnabled":false}}}}
+```
+
+## (c) CLI against this host
+
+`superset status` (text mode):
+
+```
+Repro Org: Kiets-Spaceship (300d922f…) running (pid 91028, up 3 minutes)
+Warning: Remote Access is off for this machine — it shows offline in hosts list and automations can't run on it
+Hint: turn it on in the Superset app under Settings → Remote Access
+```
+
+`superset status --json`:
+
+```
+{
+  "running": true,
+  "healthy": true,
+  "pid": 91028,
+  "port": 4877,
+  "endpoint": "http://127.0.0.1:4877",
+  "organizationId": "11111111-2222-4333-8444-555555555555",
+  "hostId": "300d922f3b90fd4955ae39163bda4431",
+  "hostName": "Kiets-Spaceship",
+  "cloudRegistered": true,
+  "relayEnabled": false,
+  "uptimeSec": 1
+}
+```
+
+`superset hosts list` (the machine now exists server-side; `local` is what the CLI prints for this
+machine when it has no relay presence):
+
+```
+NAME             ONLINE  ID
+Kiets-Spaceship  local   300d922f3b90fd4955ae39163bda4431
+```
+
+`superset automations create --name repro-7223 --prompt "say hi" --rrule "FREQ=DAILY"`:
+
+```
+Error: Remote Access is off for this machine, so automations can't run on it
+Hint: Turn it on in the Superset app under Settings → Remote Access, then retry
+exit=1
+```
+
+The fake cloud received no `automation.create` for this run. The explicit `--host` path is unchanged:
+
+```
+$ superset automations create ... --host deadbeef
+Error: Host deadbeef is not registered in this organization
+Hint: Run: superset hosts list
+exit=1
+```
+
+## (d) The previously failing test now passes
+
+```
+$ cd packages/host-service && bun test test/integration/cloud-registration-without-relay.integration.test.ts
+bun test v1.3.11 (af24e281)
+ 1 pass
+ 0 fail
+ 4 expect() calls
+Ran 1 test across 1 file. [2.08s]
+```
+
+Plus the new CLI cases in `packages/cli/src/commands/automations/resolveAutomationTarget.test.ts`
+(6 pass) and the updated smoke test (6 pass).

--- a/plans/7223-evidence-before.md
+++ b/plans/7223-evidence-before.md
@@ -1,0 +1,130 @@
+# #7223 evidence, BEFORE the fix
+
+Captured 2026-09-06 on branch `fix/7223-host-registration-remote-access-off` at commit `94056be3a4`.
+
+## Setup
+
+The host-service was started the way the desktop coordinator starts it with Remote Access off:
+`packages/host-service/src/serve.ts` under Electron-as-Node (better-sqlite3 is built for the Electron ABI),
+with the coordinator's child env mirrored (`ORGANIZATION_ID`, `HOST_SERVICE_SECRET`, `HOST_SERVICE_PORT`,
+`HOST_DB_PATH`, `HOST_MIGRATIONS_FOLDER`, `SUPERSET_HOME_DIR`, `AUTH_TOKEN`, `SUPERSET_API_URL`,
+`HOST_PARENT_PID`) and **`RELAY_URL` deleted**, which is what `buildEnv` in
+`apps/desktop/src/main/lib/host-service-coordinator.ts` does when `exposeHostServiceViaRelay` is false.
+
+`SUPERSET_API_URL` pointed at a local fake of api.superset.sh (`scratchpad/fake-cloud.ts`) that speaks the
+tRPC batch envelope and records every `host.ensure` call, so "was registration ever attempted" is a fact
+read back from `/__state`, not an inference. `SUPERSET_HOME_DIR` was a scratch dir, and the org id a fake
+uuid, so nothing touched the desktop's real hosts or pty-daemons.
+
+Launcher: `scratchpad/run-host.sh`. CLI: `packages/cli/dist/superset-7223`, built with
+`SUPERSET_API_URL=http://127.0.0.1:4999` baked in (the CLI bakes its API URL at build time), run with
+`SUPERSET_HOME_DIR` set to the scratch home that holds a manifest for this host.
+
+## (a) host-service log: bootstrap OK, no registration attempt, nothing logged about it
+
+```
+2026-09-06T17:04:22.900Z [host-service] starting (org=11111111-2222-4333-8444-555555555555, port=4877, NODE_ENV=development)
+2026-09-06T17:04:22.901Z [supervisor] kicking off bootstrap for org=11111111-2222-4333-8444-555555555555
+2026-09-06T17:04:22.915Z [host-service:db] Initialized at /private/tmp/claude-501/-Users-kietho--superset-worktrees-1c99c8eb-1b31-4f04-9ac4-61a2760c74b6-fix-7223-host-registration-remote-access-off/f4bf6181-b6a3-480c-8e9d-5b636a4966fa/scratchpad/home/host/11111111-2222-4333-8444-555555555555/host.db, migrations from /Users/kietho/.superset/worktrees/1c99c8eb-1b31-4f04-9ac4-61a2760c74b6/fix/7223-host-registration-remote-access-off/packages/host-service/drizzle
+2026-09-06T17:04:22.925Z [host-service] listening on http://127.0.0.1:4877
+2026-09-06T17:04:22.943Z [pty-daemon:11111111-2222-4333-8444-555555555555] spawning /Users/kietho/.superset/worktrees/1c99c8eb-1b31-4f04-9ac4-61a2760c74b6/fix/7223-host-registration-remote-access-off/packages/pty-daemon/dist/pty-daemon.js → /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock (log: /private/tmp/claude-501/-Users-kietho--superset-worktrees-1c99c8eb-1b31-4f04-9ac4-61a2760c74b6-fix-7223-host-registration-remote-access-off/f4bf6181-b6a3-480c-8e9d-5b636a4966fa/scratchpad/home/host/11111111-2222-4333-8444-555555555555/pty-daemon.log)
+
+
+
+
+
+
+[ptyd:11111111] [pty-daemon] listening on /var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock (v0.3.3, host=Kiets-Spaceship.local)
+2026-09-06T17:04:23.247Z [pty-daemon:11111111-2222-4333-8444-555555555555] spawned pid=55448 socket=/var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock
+2026-09-06T17:04:23.247Z {"component":"pty-daemon-supervisor","event":"pty_daemon_spawn","organizationId":"11111111-2222-4333-8444-555555555555","pid":55448,"socketPath":"/var/folders/6p/h3cw025x0z38clvxby6gqylh0000gn/T/superset-ptyd-7fbd8678bfca.sock","daemonVersion":"0.3.3"}
+2026-09-06T17:04:23.247Z [supervisor] bootstrap OK for org=11111111-2222-4333-8444-555555555555 pid=55448 version=0.3.3
+```
+
+Zero `registered as host`, `failed to register`, or `relay:` lines. Same pattern the issue reports
+(`[supervisor] bootstrap OK` + port-scan/reaper lines only).
+
+Fake cloud after the host had been up for over a minute:
+
+```
+$ curl -s http://127.0.0.1:4999/__state
+{"ensureCalls":[],"hosts":{},"requests":[]}
+```
+
+The host-service made **no request at all** to the API. Registration was never attempted.
+
+## (b) health.check: cloudRegistered false, registrationError null
+
+```
+$ curl -s -H "Authorization: Bearer repro-secret-7223" http://127.0.0.1:4877/trpc/health.check
+{"result":{"data":{"json":{"status":"ok","cloudRegistered":false,"registrationError":null}}}}
+```
+
+"Never attempted" is indistinguishable from "attempt in flight".
+
+## (c) CLI against this host
+
+`superset status` (text mode):
+
+```
+Repro Org: host 300d922f… running (pid 55229, up 3 minutes)
+Warning: not registered with the cloud for Repro Org — hosts list and automations won't see this machine
+Hint: check host-service.log; registration retries automatically, or run: superset stop && superset start
+```
+
+Both hints are wrong in this state: nothing is retrying, and host-service.log has nothing to check.
+
+`superset status --json`:
+
+```
+{
+  "running": true,
+  "healthy": true,
+  "pid": 55229,
+  "port": 4877,
+  "endpoint": "http://127.0.0.1:4877",
+  "organizationId": "11111111-2222-4333-8444-555555555555",
+  "hostId": "300d922f3b90fd4955ae39163bda4431",
+  "hostName": null,
+  "cloudRegistered": false,
+  "uptimeSec": 1
+}
+```
+
+`superset hosts list`:
+
+```
+[]
+```
+
+`superset automations create --name repro-7223 --prompt "say hi" --rrule "FREQ=DAILY"`:
+
+```
+Error: This machine (host 300d922f3b90fd4955ae39163bda4431) isn't registered with the cloud
+Hint: Restart the host service (superset stop && superset start), then check: superset hosts list
+exit=1
+```
+
+Restarting does nothing: the toggle is persisted and re-applied on every spawn.
+
+## (d) Failing automated test
+
+`packages/host-service/test/integration/cloud-registration-without-relay.integration.test.ts` boots the real
+`serve.ts` entry with the coordinator's Remote-Access-off env against a fake cloud and asserts `host.ensure`
+is called. Before the fix:
+
+```
+$ cd packages/host-service && bun test test/integration/cloud-registration-without-relay.integration.test.ts
+error: host.ensure was never called. host-service output:
+2026-09-06T17:07:44.098Z [host-service] starting (org=11111111-2222-4333-8444-555555555555, port=61302, NODE_ENV=development)
+2026-09-06T17:07:44.099Z [supervisor] kicking off bootstrap for org=11111111-2222-4333-8444-555555555555
+2026-09-06T17:07:44.124Z [host-service:db] Initialized at .../host.db, migrations from .../packages/host-service/drizzle
+2026-09-06T17:07:44.146Z [host-service] listening on http://127.0.0.1:61302
+2026-09-06T17:07:44.158Z [pty-daemon:11111111-...] spawning .../packages/pty-daemon/dist/pty-daemon.js → /var/folders/.../superset-ptyd-cf4c4732fd3b.sock
+2026-09-06T17:07:44.265Z [pty-daemon:11111111-...] spawned pid=72171 socket=...
+2026-09-06T17:07:44.265Z [supervisor] bootstrap OK for org=11111111-2222-4333-8444-555555555555 pid=72171 version=0.3.3
+Expected: true
+Received: false
+(fail) registers with the cloud when started without RELAY_URL (Remote Access off) [10076.39ms]
+ 0 pass
+ 1 fail
+```

--- a/plans/7223-report.md
+++ b/plans/7223-report.md
@@ -1,0 +1,117 @@
+# #7223 report: host service running but never registers with cloud
+
+Branch `fix/7223-host-registration-remote-access-off`. No PR opened, nothing merged.
+
+## Root cause
+
+Cloud registration (`host.ensure`, the only call that creates the `v2Hosts` row that `hosts list` and
+automations depend on) lived inside `connectRelay`, and both entry points only called `connectRelay` when
+`RELAY_URL` was set:
+
+- `packages/host-service/src/serve.ts` (standalone/CLI-launched host)
+- `apps/desktop/src/main/host-service/index.ts` (desktop-spawned host)
+
+The desktop coordinator (`apps/desktop/src/main/lib/host-service-coordinator.ts`, `buildEnv`) deletes
+`RELAY_URL` from the child env whenever the Remote Access setting (`exposeHostServiceViaRelay`, default
+false) is off. So every desktop with Remote Access off started a host that never attempted registration,
+logged nothing about it, and reported `cloudRegistered: false` with no error, which is byte-identical to
+"first attempt still in flight". `superset status` then told the user that registration retries
+automatically, which was false, and `automations create` told them to restart the host, which cannot help
+because the setting is persisted and re-applied on every spawn. This is why #6415's fix (retry with backoff
+plus a status warning) did not cover it: that fix only helps once an attempt is made.
+
+Verified, not assumed: the reproduction in `plans/7223-evidence-before.md` shows a host with the
+coordinator's exact env making zero API requests while healthy locally.
+
+## Can the cloud dispatch automations to a host that is not on the relay?
+
+No. `packages/trpc/src/router/automation/dispatch.ts` picks an online host via relay presence
+(`fetchRelayPresence`) and sends the run through `relayMutation`; a host with no relay socket is
+`skipped_offline`. So the relay is genuinely required for runs, but not for registration: `host.ensure`
+in `packages/trpc/src/router/host/host.ts` only inserts the host row and the owner link, and `host.list`
+already tolerates rows with no presence (it reports them `online: false`). Registration without the relay
+is meaningful: it makes the machine visible, and it turns the failure from silent into a stated setting.
+
+## The fix
+
+Decouple registration from the tunnel, make the relay skip a real, reported state, and have the CLI say so.
+
+- `packages/host-service/src/tunnel/connect.ts`: `relayUrl` is now `string | null`. Registration (with its
+  retry loop) always runs; when `relayUrl` is null it records the relay as disabled, logs
+  `relay disabled (no RELAY_URL: Remote Access is off) — not connecting ...`, and returns without opening a
+  tunnel.
+- `packages/host-service/src/tunnel/registration-state.ts`: new `relayEnabled: boolean | null` field, set
+  on registration success.
+- `packages/host-service/src/trpc/router/health/health.ts`: `health.check` returns `relayEnabled`.
+- `packages/host-service/src/serve.ts` and `apps/desktop/src/main/host-service/index.ts`: call
+  `connectRelay` whenever there is an org (sandbox mode still never registers), passing
+  `env.RELAY_URL ?? null`.
+- `packages/cli/src/lib/host/health.ts` (new): the health probe moved out of `status` so
+  `automations create` can use it, plus `checkLocalHostHealth(orgId)` which reads this machine's manifest.
+- `packages/cli/src/commands/status/command.ts`: when the host reports `relayEnabled: false`, prints
+  "Remote Access is off for this machine ... turn it on in the Superset app under Settings → Remote Access"
+  instead of the registration warning. The "registration retries automatically" hint is now only reachable
+  when an attempt has actually been made. `--json` gains `relayEnabled`.
+- `packages/cli/src/commands/automations/resolveAutomationTarget.ts`: for the local machine (no `--host`),
+  after the registration preflight, asks the local host-service; if it reports the relay disabled it refuses
+  with the same Settings hint rather than creating an automation whose every run would be skipped.
+
+The desktop coordinator is untouched: stripping `RELAY_URL` is the correct way to keep the tunnel closed,
+and the host now does the right thing with that env. A side effect worth noting: the desktop's
+`RelayOfflineNotice` in the automations UI returns null when the local host has no cloud row
+(`localHostIsOnline === null`); with the host now registered, that becomes `false` and the existing
+"enable relay access" affordance renders in exactly this state, without touching renderer code. I did not
+verify that in the running app (see below).
+
+Not done, on purpose: no rename of `connectRelay`, no restructuring of the retry loop, no change to the
+dispatch path.
+
+## Evidence
+
+- Before: `plans/7223-evidence-before.md` (log, `health.check`, fake-cloud request ledger, `status`,
+  `hosts list`, `automations create`, failing test output).
+- After: `plans/7223-evidence-after.md` (same reproduction, registration observed, explicit log line,
+  new `status` and `automations create` output, test passing).
+
+## Tests
+
+- New, failed before the fix and passes after:
+  `packages/host-service/test/integration/cloud-registration-without-relay.integration.test.ts`. It boots
+  the real `serve.ts` under Electron-as-Node (better-sqlite3 is built for the Electron ABI, same as
+  `scripts/test-e2e.ts`) with the coordinator's Remote-Access-off env against a fake cloud, and asserts
+  `host.ensure` is called and `health.check` reports registered. HOME and SUPERSET_HOME_DIR are
+  redirected to a temp dir because `serve.ts` provisions agent hooks into the user's agent config dirs.
+- New CLI cases in `packages/cli/src/commands/automations/resolveAutomationTarget.test.ts` (relay disabled
+  refuses with the Settings hint; enabled or unsettled passes; explicit `--host` does not consult the
+  local host). The probe is injected there because `SUPERSET_HOME_DIR` is read at module load and bun
+  caches modules across test files.
+- `smoke.integration.test.ts` updated for the new `relayEnabled` field.
+
+## Checks run
+
+| Check | Result |
+| --- | --- |
+| `packages/host-service`: `bun test test/integration/cloud-registration-without-relay.integration.test.ts` | 1 pass (was 1 fail) |
+| `packages/host-service`: `bun test test/integration/smoke.integration.test.ts` | 6 pass |
+| `packages/host-service`: `bun run typecheck` | clean |
+| `packages/cli`: `bun test` (whole package) | 232 pass |
+| `packages/cli`: `bun run typecheck` | clean |
+| `apps/desktop`: `bun run typecheck` | clean |
+| `biome check` on every changed file | clean |
+
+## Not verified
+
+- The desktop app itself was not rebuilt or run with Remote Access off; the desktop entry change is
+  covered by typecheck and by the identical gate in `serve.ts` being exercised by the integration test.
+  The `RelayOfflineNotice` now rendering is reasoned from `useWorkspaceHostOptions`, not observed.
+- The real API was not hit. The fake cloud implements `host.ensure`/`host.list` from the router's shape;
+  `host.ensure` on the real server is an idempotent insert with `onConflictDoNothing`, so repeated
+  registrations from hosts that previously never registered should be harmless, but I did not run it.
+- The integration test was run on macOS only. It resolves the Electron binary through the `electron`
+  package from `apps/desktop`, which should work on Linux CI under `ELECTRON_RUN_AS_NODE`, but that run has
+  not happened.
+- `bun run check:i18n` was not run: the CLI messages touched are plain strings like the existing ones in
+  those files, and host-service log lines are not user-facing catalog strings.
+- Side effect of the manual reproduction on this machine: `serve.ts` re-provisioned the managed agent hook
+  entries (for example in `~/.claude/settings.json`). They reference `$SUPERSET_HOME_DIR` by env, so the
+  content is identical to what the desktop writes; nothing was left pointing at the scratch home.


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/7223 (related: #6415, #6417)
- Report and evidence on the branch: `plans/7223-report.md`, `plans/7223-evidence-before.md`, `plans/7223-evidence-after.md`

## Summary
- Hosts started without `RELAY_URL` (every desktop with Remote Access off, the default) now register with the cloud; only the relay tunnel is gated on the URL. They appear in `hosts list` and the automations UI instead of being silently invisible.
- The relay skip is logged in host-service.log and reported by `health.check` as `relayEnabled: false`.
- `superset status` and `superset automations create` say "Remote Access is off for this machine" and point at Settings → Remote Access, instead of claiming registration is retrying or telling the user to restart.

## Why / Context
`host.ensure`, the only call that creates a host's `v2Hosts` row, lived inside `connectRelay`, and both entries (`packages/host-service/src/serve.ts`, `apps/desktop/src/main/host-service/index.ts`) only called it when `RELAY_URL` was set. The desktop coordinator deletes `RELAY_URL` from the child env whenever `exposeHostServiceViaRelay` is off. So those hosts never attempted registration, logged nothing, and reported `cloudRegistered: false, registrationError: null`, which is byte-identical to "first attempt in flight". #6415's retry-with-backoff fix never covered this because no attempt was ever made.

Reproduced at the host-service level with the coordinator's exact env against a fake cloud that records `host.ensure`: the host bootstrapped and answered health, and the fake cloud received zero requests.

## How It Works
- `connectRelay` takes `relayUrl: string | null`. Registration (with its existing retry loop) always runs. With `null` it records `relayEnabled: false`, logs `relay disabled (no RELAY_URL: Remote Access is off) — not connecting ...`, and returns without a tunnel.
- `registration-state.ts` gains `relayEnabled: boolean | null`; `health.check` exposes it.
- The CLI's health probe moves from `status` into `packages/cli/src/lib/host/health.ts` so `automations create` can also ask the local host-service. For the local machine (no `--host`), a `relayEnabled: false` answer refuses with the Settings hint rather than creating an automation whose every run would be `skipped_offline`.
- Dispatch is unchanged and still genuinely relay-bound (`packages/trpc/src/router/automation/dispatch.ts` picks online hosts via relay presence). `host.ensure` is an idempotent insert plus owner link and `host.list` already tolerates rows with no presence, so registering without the relay is safe server-side.
- The coordinator is untouched: stripping `RELAY_URL` remains the way to keep the tunnel closed.

## Manual QA Checklist
Done against `serve.ts` under Electron-as-Node with the coordinator's Remote-Access-off env and a local fake API (details in the evidence files):
- [x] Before: no `host.ensure` request, no registration line in the log, `cloudRegistered: false` with no error
- [x] After: one `host.ensure` 32 ms after listen, explicit relay-disabled log line, `health.check` → `cloudRegistered: true, relayEnabled: false`
- [x] `superset status` prints the Remote Access warning and Settings hint; `--json` includes `relayEnabled: false`
- [x] `superset hosts list` shows the machine
- [x] `superset automations create` refuses with "Remote Access is off for this machine" and does not call `automation.create`; `--host <other>` path unchanged
- [ ] Not done: running the desktop app itself with Remote Access off. The desktop entry change is typechecked and mirrors the `serve.ts` gate exercised by the integration test. `RelayOfflineNotice` should now render for these hosts (the local host row exists with `isOnline: false`) but that is reasoned, not observed.

## Testing
- New `packages/host-service/test/integration/cloud-registration-without-relay.integration.test.ts`: boots the real `serve.ts` under Electron-as-Node against a fake cloud and asserts `host.ensure` is called. Failed before this change, passes after. HOME and SUPERSET_HOME_DIR are redirected to a temp dir because `serve.ts` provisions agent hooks into the user's agent config dirs. Run on macOS only so far.
- `packages/cli/src/commands/automations/resolveAutomationTarget.test.ts`: three new cases (relay disabled refuses with the hint; enabled or unsettled passes; explicit `--host` does not consult the local host).
- `packages/host-service`: `bun test` on the new test and `smoke.integration.test.ts`, `bun run typecheck`
- `packages/cli`: `bun test` (232 pass), `bun run typecheck`
- `apps/desktop`: `bun run typecheck`
- `biome check` on every changed file

## Known Limitations
- The real API was not exercised; the fake implements `host.ensure`/`host.list` from the router's shape.
- `check:i18n` not run: the touched CLI messages are plain strings like their neighbours in those files.

## Risks / Rollout
- Risk: every default-config desktop now calls `host.ensure` once at boot (idempotent, retried with the existing backoff) and shows up offline in `hosts list` and the device picker. Older CLIs reading `health.check` ignore the extra field.
- Rollback: revert; no schema or data changes.

https://claude.ai/code/session_017a434T4pm8bBnbqfUsJM6n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosts started without `RELAY_URL` (Remote Access off, the desktop default) now register with the cloud; only the relay tunnel is gated on the URL. They appear in `hosts list` and the automations UI instead of being silently invisible, and `health.check` reports `relayEnabled: false`. `superset status` and `superset automations create` now say Remote Access is off and point at Settings → Remote Access, instead of claiming registration is retrying or asking for a restart.

**Notes**

- New integration test boots the real `serve.ts` with the coordinator's Remote-Access-off env and asserts `host.ensure` is called; it failed before this change.
- Every default-config desktop now calls idempotent `host.ensure` once at boot and shows as offline in `hosts list` and the device picker.
- No schema or data changes; rollback is a revert.

<sup>Written for commit 8f19f4ad5588e61df933da6ff93b9f347c955d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hosts now register with the cloud even when Remote Access is disabled.
  - Host status accurately reports whether Remote Access is enabled or disabled.
  - Status commands provide a clear Remote Access hint when it is unavailable.
  - Local automation sessions now prevent use when Remote Access is disabled and suggest enabling it in Settings.
  - Explicitly selected remote hosts continue to work as before.

- **Tests**
  - Added coverage for cloud registration, host health reporting, and automation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->