### PR TITLE
fix(marketing): keep the sitemap under Vercel's ISR size cap

### DIFF
--- a/apps/marketing/src/app/[lang]/utils/fetchLeaderboard/fetchLeaderboard.ts
+++ b/apps/marketing/src/app/[lang]/utils/fetchLeaderboard/fetchLeaderboard.ts
@@ -114,5 +114,10 @@ export async function fetchSearch(
 export async function fetchPublicHandles(): Promise<
 	Array<{ handle: string; lastPublishedAt: Date | null }>
 > {
-	return await leaderboardClient.leaderboard.public.handles.query();
+	try {
+		return await leaderboardClient.leaderboard.public.handles.query();
+	} catch (error) {
+		console.error("[marketing/leaderboard] handles error:", error);
+		return [];
+	}
 }

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -227,6 +227,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		}));
 	};
 
+	// Profiles are listed once at their canonical bare URL. Expanding each of
+	// them across every locale with a full alternates map multiplies the file
+	// by the square of the locale count and blew past Vercel's 19 MB ISR cap.
 	const profilePages: MetadataRoute.Sitemap = (await fetchPublicHandles()).map(
 		(profile) => ({
 			url: `${baseUrl}/${profile.handle}`,
@@ -236,5 +239,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		}),
 	);
 
-	return [...pages.flatMap(expand), ...profilePages.flatMap(expand)];
+	return [...pages.flatMap(expand), ...profilePages];
 }


### PR DESCRIPTION
The production marketing deploy for #7195 (run 34073082041) failed:

```
Error: Oversized Incremental Static Regeneration (ISR) page: sitemap.xml (37.54 MB). Pre-rendered responses that are larger than 19.07 MB result in a failure (FALLBACK_BODY_TOO_LARGE) at runtime.
```

#7195 added every public profile to the sitemap and expanded each one across all 17 locales with a full hreflang alternates map, so 1143 profiles became about 19k entries with 18 alternate links each.

## Changes

- Profiles are listed once at their canonical bare URL, with no locale expansion or alternates. Every other page keeps the existing per-locale expansion.
- `fetchPublicHandles` catches leaderboard errors and returns `[]`, matching the other helpers in the file, so a leaderboard outage cannot fail the whole sitemap response (CodeRabbit flagged this on #7195).

## Verification

`biome check` and `@superset/marketing` typecheck pass. The real check is the Deploy Production run on main after merge.

https://claude.ai/code/session_01DF3Y5qWgxpWucYVmPfkBKA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the marketing sitemap exceeding Vercel's 19 MB ISR size cap. Profiles are now listed once at their canonical bare URL instead of being expanded across all 17 locales, which had grown the sitemap to 37.5 MB and failed the production deploy.

- `fetchPublicHandles` now catches leaderboard errors and returns an empty list, so a leaderboard outage doesn't break the sitemap.

<sup>Written for commit e039ddd83962fc4ea6df132e136c282ab8a26660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leaderboard reliability by returning an empty result when public leaderboard data cannot be retrieved, preventing the error from interrupting the page.
* **Improvements**
  * Updated profile entries in the sitemap to use canonical URLs without locale-specific duplicates, helping keep sitemap files within platform size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->