### PR TITLE
fix(desktop): compile i18n catalogs before compile:app so release builds stop failing

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
 		"bundle:cli": "bun run scripts/build-bundled-cli.ts",
 		"predev": "bun run --filter=@superset/i18n build && cross-env NODE_ENV=development bun run clean:dev && bun run generate:icons && bun run bundle:cli && cross-env NODE_ENV=development bun run scripts/clean-launch-services.ts && cross-env NODE_ENV=development bun run scripts/patch-dev-protocol.ts",
 		"dev": "bun scripts/dev.ts",
+		"precompile:app": "bun run --filter=@superset/i18n build",
 		"compile:app": "cross-env NODE_OPTIONS=--max-old-space-size=8192 electron-vite build && bun run bundle:cli && bun run scripts/check-pty-daemon-bundle.ts",
 		"check:pty-daemon-bundle": "bun run scripts/check-pty-daemon-bundle.ts",
 		"profile:terminal-flood": "bun run scripts/cdp-terminal-flood-profile.ts",


### PR DESCRIPTION
## What broke

Every scheduled desktop canary since 09-04 has failed on all three platforms, before packaging:

```
Could not resolve "../locales/en/messages" from "../../packages/i18n/src/index.ts"
```

Runs: 34069505269, 34032242306, 34001052231, 33965201018, 33932509207. The last good canary (a2e9cd396, 09-04 manual dispatch) is the commit right before #7180, and the first scheduled run at #7180's own commit failed.

## Why

#7180 stopped committing the compiled Lingui catalogs and made them build artifacts. It covered postinstall, the `predev` hooks, turbo's `build` pipeline, and gave the CLI a `prebuild:dist` hook because `build-cli.yml` installs with `--ignore-scripts` on Linux.

`build-desktop.yml` has the same shape: `bun install --frozen --ignore-scripts`, then a direct `bun run compile:app`. That script goes through neither turbo nor `predev`, so nothing compiled the catalogs. `release-desktop.yml` uses the same reusable workflow, so the next versioned release would have failed the same way.

## Fix

Add a `precompile:app` hook to `apps/desktop/package.json` that compiles the catalogs, mirroring the CLI's `prebuild:dist`. One hook covers canary, stable release, and the local `bun run build` path (its `prebuild` chain calls `compile:app`).

## Verification

Deleted `packages/i18n/locales/*/messages.ts` and ran CI's exact sequence locally (`clean:dev`, `generate:icons`, `compile:app`). Before the hook: same resolution error as CI. After: the hook regenerated all 17 catalogs, and electron-vite, the CLI bundle, and the pty-daemon bundle check all passed.

https://claude.ai/code/session_018J3Doxr611zyon6Ctm32BW


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `precompile:app` hook to `apps/desktop/package.json` so desktop canary and release builds compile Lingui catalogs before bundling, fixing build failures that began after #7180 made the catalogs build artifacts.

**Bug Fixes**
- Scheduled desktop canaries have failed on all platforms since 09-04 because `compile:app` ran without compiling the catalogs.
- The hook mirrors the CLI's `prebuild:dist` and covers canary, stable release, and local `bun run build` paths.

<sup>Written for commit 713bcff2364ffe4e9f06bf30a345c4f7018060c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-compilation step that builds internationalization resources before the desktop application is compiled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->