### PR TITLE
feat(desktop): regroup the terminal link menu and rename the Open in destinations

### DIFF
--- a/apps/desktop/src/renderer/lib/clickPolicy/actionLabel.ts
+++ b/apps/desktop/src/renderer/lib/clickPolicy/actionLabel.ts
@@ -10,13 +10,9 @@ const FILE_LABELS: Record<LinkAction, MessageDescriptor> = {
 };
 
 const URL_LABELS: Record<LinkAction, MessageDescriptor> = {
-	pane: msg({ message: "Open in in-app browser" }),
-	newTab: msg({
-		message: "Open in new browser tab",
-	}),
-	external: msg({
-		message: "Open in default browser",
-	}),
+	pane: msg({ message: "Open in split pane" }),
+	newTab: msg({ message: "Open in new tab" }),
+	external: msg({ message: "Open in external browser" }),
 };
 
 export function actionLabel(action: LinkAction, surface: Surface): string {
@@ -40,11 +36,9 @@ const SHORT_FILE_LABELS: Record<LinkAction, MessageDescriptor> = {
 };
 
 const SHORT_URL_LABELS: Record<LinkAction, MessageDescriptor> = {
-	pane: msg({ message: "in-app browser" }),
+	pane: msg({ message: "split pane" }),
 	newTab: msg({ message: "new tab" }),
-	external: msg({
-		message: "default browser",
-	}),
+	external: msg({ message: "external browser" }),
 };
 
 export function shortActionLabel(action: LinkAction, surface: Surface): string {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -558,6 +558,9 @@ export function usePaneRegistry({
 					// menu drops that default rather than offering both.
 					const linkAt = (ctx: RendererContext<PaneViewerData>) =>
 						terminalContextMenuLinkStore.get(ctx.pane.id)?.link ?? null;
+					// A URL, or a file/folder the host resolved. A file link that never
+					// resolved has nowhere to open and nothing to copy, so the section
+					// stays hidden rather than showing an empty submenu.
 					const copyableLinkText = (
 						ctx: RendererContext<PaneViewerData>,
 					): string | null => {
@@ -565,12 +568,19 @@ export function usePaneRegistry({
 						if (!link) return null;
 						return link.kind === "url" ? link.url : (link.resolvedPath ?? null);
 					};
+					const copyLinkText = (ctx: RendererContext<PaneViewerData>) => {
+						const text = copyableLinkText(ctx);
+						if (!text) return;
+						navigator.clipboard.writeText(text).catch(() => {
+							toast.error(t({ message: "Copy failed" }));
+						});
+					};
 					const linkActions: ContextMenuActionConfig<PaneViewerData>[] = [
 						{
 							key: "open-link-in",
 							label: t({ message: "Open in" }),
 							icon: <LuExternalLink />,
-							hidden: (ctx) => !linkAt(ctx),
+							hidden: (ctx) => !copyableLinkText(ctx),
 							children: openInActions,
 						},
 						{
@@ -578,10 +588,7 @@ export function usePaneRegistry({
 							label: t({ message: "Copy Link" }),
 							icon: <LuLink />,
 							hidden: (ctx) => linkAt(ctx)?.kind !== "url",
-							onSelect: (ctx) => {
-								const text = copyableLinkText(ctx);
-								if (text) navigator.clipboard.writeText(text);
-							},
+							onSelect: copyLinkText,
 						},
 						{
 							key: "copy-path",
@@ -591,15 +598,12 @@ export function usePaneRegistry({
 								const link = linkAt(ctx);
 								return link?.kind !== "file" || !link.resolvedPath;
 							},
-							onSelect: (ctx) => {
-								const text = copyableLinkText(ctx);
-								if (text) navigator.clipboard.writeText(text);
-							},
+							onSelect: copyLinkText,
 						},
 						{
 							key: "sep-open-link-in",
 							type: "separator",
-							hidden: (ctx) => !linkAt(ctx),
+							hidden: (ctx) => !copyableLinkText(ctx),
 						},
 					];
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -27,6 +27,7 @@ import {
 	LuClipboardCopy,
 	LuEraser,
 	LuExternalLink,
+	LuLink,
 	LuPower,
 } from "react-icons/lu";
 import { useWorkspaceHostTarget } from "renderer/hooks/host-service/useWorkspaceHostUrl";
@@ -475,21 +476,7 @@ export function usePaneRegistry({
 					/>
 				),
 				contextMenuActions: (_ctx, defaults) => {
-					const hasLink = (ctx: RendererContext<PaneViewerData>) =>
-						Boolean(terminalContextMenuLinkStore.get(ctx.pane.id)?.link);
 					const terminalActions: ContextMenuActionConfig<PaneViewerData>[] = [
-						{
-							key: "open-link-in",
-							label: t({ message: "Open in" }),
-							icon: <LuExternalLink />,
-							hidden: (ctx) => !hasLink(ctx),
-							children: openInActions,
-						},
-						{
-							key: "sep-open-link-in",
-							type: "separator",
-							hidden: (ctx) => !hasLink(ctx),
-						},
 						{
 							key: "copy",
 							label: t({ message: "Copy" }),
@@ -566,16 +553,68 @@ export function usePaneRegistry({
 						{ key: "sep-terminal-defaults", type: "separator" },
 					];
 
-					const modifiedDefaults = defaults.map((d) =>
-						d.key === "close-pane"
-							? {
-									...d,
-									label: t({
-										message: "Close Terminal",
-									}),
-								}
-							: d,
-					);
+					// Only present when the right-click landed on a link. "Open in"
+					// covers what "Split with New Browser" did for a URL, so the terminal
+					// menu drops that default rather than offering both.
+					const linkAt = (ctx: RendererContext<PaneViewerData>) =>
+						terminalContextMenuLinkStore.get(ctx.pane.id)?.link ?? null;
+					const copyableLinkText = (
+						ctx: RendererContext<PaneViewerData>,
+					): string | null => {
+						const link = linkAt(ctx);
+						if (!link) return null;
+						return link.kind === "url" ? link.url : (link.resolvedPath ?? null);
+					};
+					const linkActions: ContextMenuActionConfig<PaneViewerData>[] = [
+						{
+							key: "open-link-in",
+							label: t({ message: "Open in" }),
+							icon: <LuExternalLink />,
+							hidden: (ctx) => !linkAt(ctx),
+							children: openInActions,
+						},
+						{
+							key: "copy-link",
+							label: t({ message: "Copy Link" }),
+							icon: <LuLink />,
+							hidden: (ctx) => linkAt(ctx)?.kind !== "url",
+							onSelect: (ctx) => {
+								const text = copyableLinkText(ctx);
+								if (text) navigator.clipboard.writeText(text);
+							},
+						},
+						{
+							key: "copy-path",
+							label: t({ message: "Copy Path" }),
+							icon: <LuLink />,
+							hidden: (ctx) => {
+								const link = linkAt(ctx);
+								return link?.kind !== "file" || !link.resolvedPath;
+							},
+							onSelect: (ctx) => {
+								const text = copyableLinkText(ctx);
+								if (text) navigator.clipboard.writeText(text);
+							},
+						},
+						{
+							key: "sep-open-link-in",
+							type: "separator",
+							hidden: (ctx) => !linkAt(ctx),
+						},
+					];
+
+					const modifiedDefaults = defaults
+						.filter((d) => d.key !== "split-with-browser")
+						.map((d) =>
+							d.key === "close-pane"
+								? {
+										...d,
+										label: t({
+											message: "Close Terminal",
+										}),
+									}
+								: d,
+						);
 
 					const killAction: ContextMenuActionConfig<PaneViewerData> = {
 						key: "kill-terminal-session",
@@ -596,6 +635,7 @@ export function usePaneRegistry({
 
 					return [
 						...terminalActions,
+						...linkActions,
 						...modifiedDefaults,
 						{ key: "sep-terminal-kill", type: "separator" },
 						killAction,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/utils/openInActions/openInActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/utils/openInActions/openInActions.ts
@@ -14,9 +14,9 @@ import {
 // They name the same three targets as Settings → Links, so the menu and the
 // modifier-click bindings describe one set of destinations.
 const URL_LABELS = [
-	msg({ message: "In-App Browser" }),
-	msg({ message: "New Browser Tab" }),
-	msg({ message: "Default Browser" }),
+	msg({ message: "Split Pane" }),
+	msg({ message: "New Tab" }),
+	msg({ message: "External Browser" }),
 ] as const;
 
 const FILE_LABELS = [

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Kopírovat klíč"
 msgid "Copy link"
 msgstr "Kopírovat odkaz"
 
+msgid "Copy Link"
+msgstr "Kopírovat odkaz"
+
 msgid "Copy Link Address"
 msgstr "Kopírovat adresu odkazu"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Výchozí ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "výchozí prohlížeč"
-
-msgid "Default Browser"
-msgstr "Výchozí prohlížeč"
 
 msgid "Default effort"
 msgstr "Výchozí úsilí"
@@ -5551,6 +5548,12 @@ msgstr "Externí"
 
 msgid "External Application"
 msgstr "Externí aplikace"
+
+msgid "external browser"
+msgstr "externí prohlížeč"
+
+msgid "External Browser"
+msgstr "Externí prohlížeč"
 
 msgid "External editor"
 msgstr "Externí editor"
@@ -7049,12 +7052,6 @@ msgstr "V desktopové aplikaci Superset otevřete <0>Nastavení → Vzhled → M
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "V desktopové aplikaci Superset otevřete Nastavení → Vzdálený přístup a zapněte „Povolit vzdálený přístup k tomuto zařízení přes relay“."
 
-msgid "in-app browser"
-msgstr "vestavěný prohlížeč"
-
-msgid "In-App Browser"
-msgstr "Vestavěný prohlížeč"
-
 msgid "In-app PR merge"
 msgstr "Slučování PR přímo v aplikaci"
 
@@ -8514,9 +8511,6 @@ msgstr "Nová automatizace"
 msgid "New Browser"
 msgstr "Nový prohlížeč"
 
-msgid "New Browser Tab"
-msgstr "Nová karta prohlížeče"
-
 msgid "new challengers"
 msgstr "noví vyzyvatelé"
 
@@ -9631,9 +9625,6 @@ msgstr "Otevřít v aktuální kartě"
 msgid "Open in Cursor"
 msgstr "Otevřít v Cursor"
 
-msgid "Open in default browser"
-msgstr "Otevřít ve výchozím prohlížeči"
-
 msgid "Open in Desktop App"
 msgstr "Otevřít v desktopové aplikaci"
 
@@ -9649,6 +9640,9 @@ msgstr "Otevřít v editoru"
 msgid "Open in Editor"
 msgstr "Otevřít v editoru"
 
+msgid "Open in external browser"
+msgstr "Otevřít v externím prohlížeči"
+
 msgid "Open in File pane"
 msgstr "Otevřít v panelu souboru"
 
@@ -9661,14 +9655,8 @@ msgstr "Otevřít ve Finderu"
 msgid "Open in GitHub"
 msgstr "Otevřít na GitHubu"
 
-msgid "Open in in-app browser"
-msgstr "Otevřít ve vestavěném prohlížeči"
-
 msgid "Open in Linear"
 msgstr "Otevřít v Linearu"
-
-msgid "Open in new browser tab"
-msgstr "Otevřít na nové kartě prohlížeče"
 
 msgid "Open in new tab"
 msgstr "Otevřít na nové kartě"
@@ -12997,7 +12985,13 @@ msgstr "Rozdělit dolů"
 msgid "Split Horizontally"
 msgstr "Rozdělit vodorovně"
 
+msgid "split pane"
+msgstr "rozdělený panel"
+
 msgid "Split pane"
+msgstr "Rozdělený panel"
+
+msgid "Split Pane"
 msgstr "Rozdělený panel"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Schlüssel kopieren"
 msgid "Copy link"
 msgstr "Link kopieren"
 
+msgid "Copy Link"
+msgstr "Link kopieren"
+
 msgid "Copy Link Address"
 msgstr "Linkadresse kopieren"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Standard ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "Standardbrowser"
-
-msgid "Default Browser"
-msgstr "Standardbrowser"
 
 msgid "Default effort"
 msgstr "Standard-Aufwand"
@@ -5551,6 +5548,12 @@ msgstr "Extern"
 
 msgid "External Application"
 msgstr "Externe Anwendung"
+
+msgid "external browser"
+msgstr "externer Browser"
+
+msgid "External Browser"
+msgstr "Externer Browser"
 
 msgid "External editor"
 msgstr "Externer Editor"
@@ -7049,12 +7052,6 @@ msgstr "Öffne in der Superset-Desktop-App <0>Einstellungen → Darstellung → 
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Öffne in der Superset-Desktop-App Einstellungen → Fernzugriff und aktiviere „Fernzugriff auf dieses Gerät über den Relay erlauben“."
 
-msgid "in-app browser"
-msgstr "In-App-Browser"
-
-msgid "In-App Browser"
-msgstr "In-App-Browser"
-
 msgid "In-app PR merge"
 msgstr "PR-Merge in der App"
 
@@ -8514,9 +8511,6 @@ msgstr "Neue Automatisierung"
 msgid "New Browser"
 msgstr "Neuer Browser"
 
-msgid "New Browser Tab"
-msgstr "Neuer Browser-Tab"
-
 msgid "new challengers"
 msgstr "neue Herausforderer"
 
@@ -9631,9 +9625,6 @@ msgstr "Im aktuellen Tab öffnen"
 msgid "Open in Cursor"
 msgstr "In Cursor öffnen"
 
-msgid "Open in default browser"
-msgstr "Im Standardbrowser öffnen"
-
 msgid "Open in Desktop App"
 msgstr "In der Desktop-App öffnen"
 
@@ -9649,6 +9640,9 @@ msgstr "Im Editor öffnen"
 msgid "Open in Editor"
 msgstr "Im Editor öffnen"
 
+msgid "Open in external browser"
+msgstr "Im externen Browser öffnen"
+
 msgid "Open in File pane"
 msgstr "Im Dateibereich öffnen"
 
@@ -9661,14 +9655,8 @@ msgstr "Im Finder öffnen"
 msgid "Open in GitHub"
 msgstr "In GitHub öffnen"
 
-msgid "Open in in-app browser"
-msgstr "Im In-App-Browser öffnen"
-
 msgid "Open in Linear"
 msgstr "In Linear öffnen"
-
-msgid "Open in new browser tab"
-msgstr "In neuem Browser-Tab öffnen"
 
 msgid "Open in new tab"
 msgstr "In neuem Tab öffnen"
@@ -12997,7 +12985,13 @@ msgstr "Nach unten teilen"
 msgid "Split Horizontally"
 msgstr "Horizontal teilen"
 
+msgid "split pane"
+msgstr "geteilter Bereich"
+
 msgid "Split pane"
+msgstr "Geteilter Bereich"
+
+msgid "Split Pane"
 msgstr "Geteilter Bereich"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Copy key"
 msgid "Copy link"
 msgstr "Copy link"
 
+msgid "Copy Link"
+msgstr "Copy Link"
+
 msgid "Copy Link Address"
 msgstr "Copy Link Address"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Default ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "default browser"
-
-msgid "Default Browser"
-msgstr "Default Browser"
 
 msgid "Default effort"
 msgstr "Default effort"
@@ -5551,6 +5548,12 @@ msgstr "External"
 
 msgid "External Application"
 msgstr "External Application"
+
+msgid "external browser"
+msgstr "external browser"
+
+msgid "External Browser"
+msgstr "External Browser"
 
 msgid "External editor"
 msgstr "External editor"
@@ -7049,12 +7052,6 @@ msgstr "In the Superset desktop app, open <0>Settings → Appearance → Theme</
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 
-msgid "in-app browser"
-msgstr "in-app browser"
-
-msgid "In-App Browser"
-msgstr "In-App Browser"
-
 msgid "In-app PR merge"
 msgstr "In-app PR merge"
 
@@ -8514,9 +8511,6 @@ msgstr "New automation"
 msgid "New Browser"
 msgstr "New Browser"
 
-msgid "New Browser Tab"
-msgstr "New Browser Tab"
-
 msgid "new challengers"
 msgstr "new challengers"
 
@@ -9631,9 +9625,6 @@ msgstr "Open in current tab"
 msgid "Open in Cursor"
 msgstr "Open in Cursor"
 
-msgid "Open in default browser"
-msgstr "Open in default browser"
-
 msgid "Open in Desktop App"
 msgstr "Open in Desktop App"
 
@@ -9649,6 +9640,9 @@ msgstr "Open in editor"
 msgid "Open in Editor"
 msgstr "Open in Editor"
 
+msgid "Open in external browser"
+msgstr "Open in external browser"
+
 msgid "Open in File pane"
 msgstr "Open in File pane"
 
@@ -9661,14 +9655,8 @@ msgstr "Open in Finder"
 msgid "Open in GitHub"
 msgstr "Open in GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Open in in-app browser"
-
 msgid "Open in Linear"
 msgstr "Open in Linear"
-
-msgid "Open in new browser tab"
-msgstr "Open in new browser tab"
 
 msgid "Open in new tab"
 msgstr "Open in new tab"
@@ -12997,8 +12985,14 @@ msgstr "Split Down"
 msgid "Split Horizontally"
 msgstr "Split Horizontally"
 
+msgid "split pane"
+msgstr "split pane"
+
 msgid "Split pane"
 msgstr "Split pane"
+
+msgid "Split Pane"
+msgstr "Split Pane"
 
 msgid "Split Pane Auto"
 msgstr "Split Pane Auto"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Copiar la clave"
 msgid "Copy link"
 msgstr "Copiar enlace"
 
+msgid "Copy Link"
+msgstr "Copiar enlace"
+
 msgid "Copy Link Address"
 msgstr "Copiar la dirección del enlace"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Predeterminada ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "navegador predeterminado"
-
-msgid "Default Browser"
-msgstr "Navegador predeterminado"
 
 msgid "Default effort"
 msgstr "Esfuerzo predeterminado"
@@ -5551,6 +5548,12 @@ msgstr "Externo"
 
 msgid "External Application"
 msgstr "Aplicación externa"
+
+msgid "external browser"
+msgstr "navegador externo"
+
+msgid "External Browser"
+msgstr "Navegador externo"
 
 msgid "External editor"
 msgstr "Editor externo"
@@ -7049,12 +7052,6 @@ msgstr "En la app de escritorio de Superset, abre <0>Configuración → Aparienc
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "En la app de escritorio de Superset, abre Configuración → Acceso remoto y activa “Permitir el acceso remoto a este dispositivo a través del relay”."
 
-msgid "in-app browser"
-msgstr "navegador integrado"
-
-msgid "In-App Browser"
-msgstr "Navegador integrado"
-
 msgid "In-app PR merge"
 msgstr "Fusión de PR desde la app"
 
@@ -8514,9 +8511,6 @@ msgstr "Nueva automatización"
 msgid "New Browser"
 msgstr "Nuevo navegador"
 
-msgid "New Browser Tab"
-msgstr "Pestaña nueva del navegador"
-
 msgid "new challengers"
 msgstr "nuevos rivales"
 
@@ -9631,9 +9625,6 @@ msgstr "Abrir en la pestaña actual"
 msgid "Open in Cursor"
 msgstr "Abrir en Cursor"
 
-msgid "Open in default browser"
-msgstr "Abrir en el navegador predeterminado"
-
 msgid "Open in Desktop App"
 msgstr "Abrir en la app de escritorio"
 
@@ -9649,6 +9640,9 @@ msgstr "Abrir en el editor"
 msgid "Open in Editor"
 msgstr "Abrir en el editor"
 
+msgid "Open in external browser"
+msgstr "Abrir en el navegador externo"
+
 msgid "Open in File pane"
 msgstr "Abrir en el panel de archivos"
 
@@ -9661,14 +9655,8 @@ msgstr "Abrir en Finder"
 msgid "Open in GitHub"
 msgstr "Abrir en GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Abrir en el navegador integrado"
-
 msgid "Open in Linear"
 msgstr "Abrir en Linear"
-
-msgid "Open in new browser tab"
-msgstr "Abrir en una pestaña nueva del navegador"
 
 msgid "Open in new tab"
 msgstr "Abrir en una pestaña nueva"
@@ -12997,8 +12985,14 @@ msgstr "Dividir hacia abajo"
 msgid "Split Horizontally"
 msgstr "Dividir horizontalmente"
 
+msgid "split pane"
+msgstr "panel dividido"
+
 msgid "Split pane"
 msgstr "Dividir panel"
+
+msgid "Split Pane"
+msgstr "Panel dividido"
 
 msgid "Split Pane Auto"
 msgstr "Dividir panel automáticamente"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Copier la clé"
 msgid "Copy link"
 msgstr "Copier le lien"
 
+msgid "Copy Link"
+msgstr "Copier le lien"
+
 msgid "Copy Link Address"
 msgstr "Copier l'adresse du lien"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Par défaut ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "navigateur par défaut"
-
-msgid "Default Browser"
-msgstr "Navigateur par défaut"
 
 msgid "Default effort"
 msgstr "Effort par défaut"
@@ -5551,6 +5548,12 @@ msgstr "Externe"
 
 msgid "External Application"
 msgstr "Application externe"
+
+msgid "external browser"
+msgstr "navigateur externe"
+
+msgid "External Browser"
+msgstr "Navigateur externe"
 
 msgid "External editor"
 msgstr "Éditeur externe"
@@ -7049,12 +7052,6 @@ msgstr "Dans l'application de bureau Superset, ouvrez <0>Paramètres → Apparen
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Dans l'application de bureau Superset, ouvrez Paramètres → Accès distant et activez « Autoriser l'accès distant à cet appareil via le relais »."
 
-msgid "in-app browser"
-msgstr "navigateur intégré"
-
-msgid "In-App Browser"
-msgstr "Navigateur intégré"
-
 msgid "In-app PR merge"
 msgstr "Fusion des pull requests dans l'application"
 
@@ -8514,9 +8511,6 @@ msgstr "Nouvelle automatisation"
 msgid "New Browser"
 msgstr "Nouveau navigateur"
 
-msgid "New Browser Tab"
-msgstr "Nouvel onglet du navigateur"
-
 msgid "new challengers"
 msgstr "nouveaux adversaires"
 
@@ -9631,9 +9625,6 @@ msgstr "Ouvrir dans l'onglet actuel"
 msgid "Open in Cursor"
 msgstr "Ouvrir dans Cursor"
 
-msgid "Open in default browser"
-msgstr "Ouvrir dans le navigateur par défaut"
-
 msgid "Open in Desktop App"
 msgstr "Ouvrir dans l'application de bureau"
 
@@ -9649,6 +9640,9 @@ msgstr "Ouvrir dans l'éditeur"
 msgid "Open in Editor"
 msgstr "Ouvrir dans l'éditeur"
 
+msgid "Open in external browser"
+msgstr "Ouvrir dans un navigateur externe"
+
 msgid "Open in File pane"
 msgstr "Ouvrir dans le volet Fichier"
 
@@ -9661,14 +9655,8 @@ msgstr "Ouvrir dans le Finder"
 msgid "Open in GitHub"
 msgstr "Ouvrir dans GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Ouvrir dans le navigateur intégré"
-
 msgid "Open in Linear"
 msgstr "Ouvrir dans Linear"
-
-msgid "Open in new browser tab"
-msgstr "Ouvrir dans un nouvel onglet du navigateur"
 
 msgid "Open in new tab"
 msgstr "Ouvrir dans un nouvel onglet"
@@ -12997,7 +12985,13 @@ msgstr "Fractionner vers le bas"
 msgid "Split Horizontally"
 msgstr "Fractionner horizontalement"
 
+msgid "split pane"
+msgstr "volet divisé"
+
 msgid "Split pane"
+msgstr "Volet divisé"
+
+msgid "Split Pane"
 msgstr "Volet divisé"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Salin kunci"
 msgid "Copy link"
 msgstr "Salin tautan"
 
+msgid "Copy Link"
+msgstr "Salin tautan"
+
 msgid "Copy Link Address"
 msgstr "Salin Alamat Tautan"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Bawaan ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "browser bawaan"
-
-msgid "Default Browser"
-msgstr "Browser bawaan"
 
 msgid "Default effort"
 msgstr "Effort bawaan"
@@ -5551,6 +5548,12 @@ msgstr "Eksternal"
 
 msgid "External Application"
 msgstr "Aplikasi Eksternal"
+
+msgid "external browser"
+msgstr "browser eksternal"
+
+msgid "External Browser"
+msgstr "Browser Eksternal"
 
 msgid "External editor"
 msgstr "Editor eksternal"
@@ -7049,12 +7052,6 @@ msgstr "Di aplikasi desktop Superset, buka <0>Pengaturan → Tampilan → Tema</
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Di aplikasi desktop Superset, buka Pengaturan → Akses Jarak Jauh dan aktifkan “Izinkan akses jarak jauh ke perangkat ini melalui relay”."
 
-msgid "in-app browser"
-msgstr "browser dalam aplikasi"
-
-msgid "In-App Browser"
-msgstr "Browser dalam aplikasi"
-
 msgid "In-app PR merge"
 msgstr "Merge PR di dalam aplikasi"
 
@@ -8514,9 +8511,6 @@ msgstr "Otomatisasi baru"
 msgid "New Browser"
 msgstr "Browser Baru"
 
-msgid "New Browser Tab"
-msgstr "Tab browser baru"
-
 msgid "new challengers"
 msgstr "penantang baru"
 
@@ -9631,9 +9625,6 @@ msgstr "Buka di tab saat ini"
 msgid "Open in Cursor"
 msgstr "Buka di Cursor"
 
-msgid "Open in default browser"
-msgstr "Buka di browser bawaan"
-
 msgid "Open in Desktop App"
 msgstr "Buka di Aplikasi Desktop"
 
@@ -9649,6 +9640,9 @@ msgstr "Buka di editor"
 msgid "Open in Editor"
 msgstr "Buka di Editor"
 
+msgid "Open in external browser"
+msgstr "Buka di browser eksternal"
+
 msgid "Open in File pane"
 msgstr "Buka di panel File"
 
@@ -9661,14 +9655,8 @@ msgstr "Buka di Finder"
 msgid "Open in GitHub"
 msgstr "Buka di GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Buka di browser dalam aplikasi"
-
 msgid "Open in Linear"
 msgstr "Buka di Linear"
-
-msgid "Open in new browser tab"
-msgstr "Buka di tab browser baru"
 
 msgid "Open in new tab"
 msgstr "Buka di tab baru"
@@ -12997,8 +12985,14 @@ msgstr "Bagi ke Bawah"
 msgid "Split Horizontally"
 msgstr "Bagi Horizontal"
 
+msgid "split pane"
+msgstr "panel terpisah"
+
 msgid "Split pane"
 msgstr "Panel terbagi"
+
+msgid "Split Pane"
+msgstr "Panel Terpisah"
 
 msgid "Split Pane Auto"
 msgstr "Bagi Panel Otomatis"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Copia la chiave"
 msgid "Copy link"
 msgstr "Copia il link"
 
+msgid "Copy Link"
+msgstr "Copia il link"
+
 msgid "Copy Link Address"
 msgstr "Copia l'indirizzo del link"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Predefinita ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "browser predefinito"
-
-msgid "Default Browser"
-msgstr "Browser predefinito"
 
 msgid "Default effort"
 msgstr "Effort predefinito"
@@ -5551,6 +5548,12 @@ msgstr "Esterno"
 
 msgid "External Application"
 msgstr "Applicazione esterna"
+
+msgid "external browser"
+msgstr "browser esterno"
+
+msgid "External Browser"
+msgstr "Browser esterno"
 
 msgid "External editor"
 msgstr "Editor esterno"
@@ -7049,12 +7052,6 @@ msgstr "Nell'app desktop di Superset, apri <0>Impostazioni → Aspetto → Tema<
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Nell'app desktop di Superset, apri Impostazioni → Accesso remoto e attiva “Consenti l'accesso remoto a questo dispositivo tramite relay”."
 
-msgid "in-app browser"
-msgstr "browser interno"
-
-msgid "In-App Browser"
-msgstr "Browser interno"
-
 msgid "In-app PR merge"
 msgstr "Merge delle PR nell'app"
 
@@ -8514,9 +8511,6 @@ msgstr "Nuova automazione"
 msgid "New Browser"
 msgstr "Nuovo browser"
 
-msgid "New Browser Tab"
-msgstr "Nuova scheda del browser"
-
 msgid "new challengers"
 msgstr "nuovi sfidanti"
 
@@ -9631,9 +9625,6 @@ msgstr "Apri nella scheda corrente"
 msgid "Open in Cursor"
 msgstr "Apri in Cursor"
 
-msgid "Open in default browser"
-msgstr "Apri nel browser predefinito"
-
 msgid "Open in Desktop App"
 msgstr "Apri nell'app desktop"
 
@@ -9649,6 +9640,9 @@ msgstr "Apri nell'editor"
 msgid "Open in Editor"
 msgstr "Apri nell'editor"
 
+msgid "Open in external browser"
+msgstr "Apri nel browser esterno"
+
 msgid "Open in File pane"
 msgstr "Apri nel pannello File"
 
@@ -9661,14 +9655,8 @@ msgstr "Apri nel Finder"
 msgid "Open in GitHub"
 msgstr "Apri in GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Apri nel browser interno"
-
 msgid "Open in Linear"
 msgstr "Apri in Linear"
-
-msgid "Open in new browser tab"
-msgstr "Apri in una nuova scheda del browser"
 
 msgid "Open in new tab"
 msgstr "Apri in una nuova scheda"
@@ -12997,7 +12985,13 @@ msgstr "Dividi in basso"
 msgid "Split Horizontally"
 msgstr "Dividi orizzontalmente"
 
+msgid "split pane"
+msgstr "pannello diviso"
+
 msgid "Split pane"
+msgstr "Pannello diviso"
+
+msgid "Split Pane"
 msgstr "Pannello diviso"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -3768,6 +3768,9 @@ msgstr "キーをコピー"
 msgid "Copy link"
 msgstr "リンクをコピー"
 
+msgid "Copy Link"
+msgstr "リンクをコピー"
+
 msgid "Copy Link Address"
 msgstr "リンクアドレスをコピー"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "デフォルト({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "既定のブラウザ"
-
-msgid "Default Browser"
-msgstr "既定のブラウザ"
 
 msgid "Default effort"
 msgstr "デフォルトのエフォート"
@@ -5551,6 +5548,12 @@ msgstr "外部"
 
 msgid "External Application"
 msgstr "外部アプリケーション"
+
+msgid "external browser"
+msgstr "外部ブラウザ"
+
+msgid "External Browser"
+msgstr "外部ブラウザ"
 
 msgid "External editor"
 msgstr "外部エディタ"
@@ -7049,12 +7052,6 @@ msgstr "Supersetデスクトップアプリで<0>設定 → 外観 → テーマ
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Supersetデスクトップアプリで設定 → リモートアクセスを開き、「リレー経由でこのデバイスへのリモートアクセスを許可」をオンにしてください。"
 
-msgid "in-app browser"
-msgstr "アプリ内ブラウザ"
-
-msgid "In-App Browser"
-msgstr "アプリ内ブラウザ"
-
 msgid "In-app PR merge"
 msgstr "アプリ内でのPRマージ"
 
@@ -8514,9 +8511,6 @@ msgstr "新規オートメーション"
 msgid "New Browser"
 msgstr "新規ブラウザ"
 
-msgid "New Browser Tab"
-msgstr "新しいブラウザタブ"
-
 msgid "new challengers"
 msgstr "別の対戦相手"
 
@@ -9631,9 +9625,6 @@ msgstr "現在のタブで開く"
 msgid "Open in Cursor"
 msgstr "Cursorで開く"
 
-msgid "Open in default browser"
-msgstr "既定のブラウザで開く"
-
 msgid "Open in Desktop App"
 msgstr "デスクトップアプリで開く"
 
@@ -9649,6 +9640,9 @@ msgstr "エディタで開く"
 msgid "Open in Editor"
 msgstr "エディタで開く"
 
+msgid "Open in external browser"
+msgstr "外部ブラウザで開く"
+
 msgid "Open in File pane"
 msgstr "ファイルペインで開く"
 
@@ -9661,14 +9655,8 @@ msgstr "Finderで開く"
 msgid "Open in GitHub"
 msgstr "GitHubで開く"
 
-msgid "Open in in-app browser"
-msgstr "アプリ内ブラウザで開く"
-
 msgid "Open in Linear"
 msgstr "Linearで開く"
-
-msgid "Open in new browser tab"
-msgstr "新しいブラウザタブで開く"
 
 msgid "Open in new tab"
 msgstr "新しいタブで開く"
@@ -12997,7 +12985,13 @@ msgstr "下に分割"
 msgid "Split Horizontally"
 msgstr "水平に分割"
 
+msgid "split pane"
+msgstr "分割ペイン"
+
 msgid "Split pane"
+msgstr "分割ペイン"
+
+msgid "Split Pane"
 msgstr "分割ペイン"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -3768,6 +3768,9 @@ msgstr "키 복사"
 msgid "Copy link"
 msgstr "링크 복사"
 
+msgid "Copy Link"
+msgstr "링크 복사"
+
 msgid "Copy Link Address"
 msgstr "링크 주소 복사"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "기본값({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "기본 브라우저"
-
-msgid "Default Browser"
-msgstr "기본 브라우저"
 
 msgid "Default effort"
 msgstr "기본 강도"
@@ -5551,6 +5548,12 @@ msgstr "외부"
 
 msgid "External Application"
 msgstr "외부 애플리케이션"
+
+msgid "external browser"
+msgstr "외부 브라우저"
+
+msgid "External Browser"
+msgstr "외부 브라우저"
 
 msgid "External editor"
 msgstr "외부 편집기"
@@ -7049,12 +7052,6 @@ msgstr "Superset 데스크톱 앱에서 <0>설정 → 모양 → 테마</0>를 �
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Superset 데스크톱 앱에서 설정 → 원격 액세스을 열고 “릴레이를 통해 이 기기에 원격 액세스 허용”을 켜세요."
 
-msgid "in-app browser"
-msgstr "앱 내 브라우저"
-
-msgid "In-App Browser"
-msgstr "앱 내 브라우저"
-
 msgid "In-app PR merge"
 msgstr "앱 내 PR 머지"
 
@@ -8514,9 +8511,6 @@ msgstr "새 자동화"
 msgid "New Browser"
 msgstr "새 브라우저"
 
-msgid "New Browser Tab"
-msgstr "새 브라우저 탭"
-
 msgid "new challengers"
 msgstr "새 도전자"
 
@@ -9631,9 +9625,6 @@ msgstr "현재 탭에서 열기"
 msgid "Open in Cursor"
 msgstr "Cursor에서 열기"
 
-msgid "Open in default browser"
-msgstr "기본 브라우저에서 열기"
-
 msgid "Open in Desktop App"
 msgstr "데스크톱 앱에서 열기"
 
@@ -9649,6 +9640,9 @@ msgstr "에디터에서 열기"
 msgid "Open in Editor"
 msgstr "에디터에서 열기"
 
+msgid "Open in external browser"
+msgstr "외부 브라우저에서 열기"
+
 msgid "Open in File pane"
 msgstr "파일 패널에서 열기"
 
@@ -9661,14 +9655,8 @@ msgstr "Finder에서 열기"
 msgid "Open in GitHub"
 msgstr "GitHub에서 열기"
 
-msgid "Open in in-app browser"
-msgstr "앱 내 브라우저에서 열기"
-
 msgid "Open in Linear"
 msgstr "Linear에서 열기"
-
-msgid "Open in new browser tab"
-msgstr "새 브라우저 탭에서 열기"
 
 msgid "Open in new tab"
 msgstr "새 탭에서 열기"
@@ -12997,7 +12985,13 @@ msgstr "아래로 분할"
 msgid "Split Horizontally"
 msgstr "가로로 분할"
 
+msgid "split pane"
+msgstr "분할 패널"
+
 msgid "Split pane"
+msgstr "분할 패널"
+
+msgid "Split Pane"
 msgstr "분할 패널"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Sleutel kopiëren"
 msgid "Copy link"
 msgstr "Link kopiëren"
 
+msgid "Copy Link"
+msgstr "Link kopiëren"
+
 msgid "Copy Link Address"
 msgstr "Linkadres kopiëren"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Standaard ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "standaardbrowser"
-
-msgid "Default Browser"
-msgstr "Standaardbrowser"
 
 msgid "Default effort"
 msgstr "Standaard-effort"
@@ -5551,6 +5548,12 @@ msgstr "Extern"
 
 msgid "External Application"
 msgstr "Externe applicatie"
+
+msgid "external browser"
+msgstr "externe browser"
+
+msgid "External Browser"
+msgstr "Externe browser"
 
 msgid "External editor"
 msgstr "Externe editor"
@@ -7049,12 +7052,6 @@ msgstr "Open in de Superset-desktopapp <0>Instellingen → Uiterlijk → Thema</
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Open in de Superset-desktopapp Instellingen → Externe toegang en zet “Externe toegang tot dit apparaat via de relay toestaan” aan."
 
-msgid "in-app browser"
-msgstr "ingebouwde browser"
-
-msgid "In-App Browser"
-msgstr "Ingebouwde browser"
-
 msgid "In-app PR merge"
 msgstr "PR's mergen in de app"
 
@@ -8514,9 +8511,6 @@ msgstr "Nieuwe automatisering"
 msgid "New Browser"
 msgstr "Nieuwe browser"
 
-msgid "New Browser Tab"
-msgstr "Nieuw browsertabblad"
-
 msgid "new challengers"
 msgstr "nieuwe uitdagers"
 
@@ -9631,9 +9625,6 @@ msgstr "Openen in huidig tabblad"
 msgid "Open in Cursor"
 msgstr "Openen in Cursor"
 
-msgid "Open in default browser"
-msgstr "Openen in standaardbrowser"
-
 msgid "Open in Desktop App"
 msgstr "Openen in desktop-app"
 
@@ -9649,6 +9640,9 @@ msgstr "Openen in editor"
 msgid "Open in Editor"
 msgstr "Openen in editor"
 
+msgid "Open in external browser"
+msgstr "Openen in externe browser"
+
 msgid "Open in File pane"
 msgstr "Openen in bestandspaneel"
 
@@ -9661,14 +9655,8 @@ msgstr "Openen in Finder"
 msgid "Open in GitHub"
 msgstr "Openen in GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Openen in ingebouwde browser"
-
 msgid "Open in Linear"
 msgstr "Openen in Linear"
-
-msgid "Open in new browser tab"
-msgstr "Openen in nieuw browsertabblad"
 
 msgid "Open in new tab"
 msgstr "Openen in nieuw tabblad"
@@ -12997,7 +12985,13 @@ msgstr "Naar beneden splitsen"
 msgid "Split Horizontally"
 msgstr "Horizontaal splitsen"
 
+msgid "split pane"
+msgstr "gesplitst paneel"
+
 msgid "Split pane"
+msgstr "Gesplitst paneel"
+
+msgid "Split Pane"
 msgstr "Gesplitst paneel"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Kopiuj klucz"
 msgid "Copy link"
 msgstr "Kopiuj link"
 
+msgid "Copy Link"
+msgstr "Kopiuj link"
+
 msgid "Copy Link Address"
 msgstr "Kopiuj adres linku"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Domyślny ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "domyślna przeglądarka"
-
-msgid "Default Browser"
-msgstr "Domyślna przeglądarka"
 
 msgid "Default effort"
 msgstr "Domyślny wysiłek"
@@ -5551,6 +5548,12 @@ msgstr "Zewnętrzny"
 
 msgid "External Application"
 msgstr "Aplikacja zewnętrzna"
+
+msgid "external browser"
+msgstr "zewnętrzna przeglądarka"
+
+msgid "External Browser"
+msgstr "Zewnętrzna przeglądarka"
 
 msgid "External editor"
 msgstr "Zewnętrzny edytor"
@@ -7049,12 +7052,6 @@ msgstr "W aplikacji Superset otwórz <0>Ustawienia → Wygląd → Motyw</0>."
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "W aplikacji Superset na komputerze otwórz Ustawienia → Dostęp zdalny i włącz „Zezwól na zdalny dostęp do tego urządzenia przez przekaźnik”."
 
-msgid "in-app browser"
-msgstr "przeglądarka w aplikacji"
-
-msgid "In-App Browser"
-msgstr "Przeglądarka w aplikacji"
-
 msgid "In-app PR merge"
 msgstr "Scalanie PR w aplikacji"
 
@@ -8514,9 +8511,6 @@ msgstr "Nowa automatyzacja"
 msgid "New Browser"
 msgstr "Nowa przeglądarka"
 
-msgid "New Browser Tab"
-msgstr "Nowa karta przeglądarki"
-
 msgid "new challengers"
 msgstr "nowi przeciwnicy"
 
@@ -9631,9 +9625,6 @@ msgstr "Otwórz w bieżącej karcie"
 msgid "Open in Cursor"
 msgstr "Otwórz w Cursor"
 
-msgid "Open in default browser"
-msgstr "Otwórz w domyślnej przeglądarce"
-
 msgid "Open in Desktop App"
 msgstr "Otwórz w aplikacji desktopowej"
 
@@ -9649,6 +9640,9 @@ msgstr "Otwórz w edytorze"
 msgid "Open in Editor"
 msgstr "Otwórz w edytorze"
 
+msgid "Open in external browser"
+msgstr "Otwórz w zewnętrznej przeglądarce"
+
 msgid "Open in File pane"
 msgstr "Otwórz w panelu Plik"
 
@@ -9661,14 +9655,8 @@ msgstr "Otwórz w Finderze"
 msgid "Open in GitHub"
 msgstr "Otwórz w GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Otwórz w przeglądarce w aplikacji"
-
 msgid "Open in Linear"
 msgstr "Otwórz w Linear"
-
-msgid "Open in new browser tab"
-msgstr "Otwórz w nowej karcie przeglądarki"
 
 msgid "Open in new tab"
 msgstr "Otwórz w nowej karcie"
@@ -12997,7 +12985,13 @@ msgstr "Podziel w dół"
 msgid "Split Horizontally"
 msgstr "Podziel poziomo"
 
+msgid "split pane"
+msgstr "podzielony panel"
+
 msgid "Split pane"
+msgstr "Podzielony panel"
+
+msgid "Split Pane"
 msgstr "Podzielony panel"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Copiar chave"
 msgid "Copy link"
 msgstr "Copiar link"
 
+msgid "Copy Link"
+msgstr "Copiar link"
+
 msgid "Copy Link Address"
 msgstr "Copiar endereço do link"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Padrão ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "navegador padrão"
-
-msgid "Default Browser"
-msgstr "Navegador padrão"
 
 msgid "Default effort"
 msgstr "Esforço padrão"
@@ -5551,6 +5548,12 @@ msgstr "Externo"
 
 msgid "External Application"
 msgstr "Aplicativo externo"
+
+msgid "external browser"
+msgstr "navegador externo"
+
+msgid "External Browser"
+msgstr "Navegador externo"
 
 msgid "External editor"
 msgstr "Editor externo"
@@ -7049,12 +7052,6 @@ msgstr "No app de desktop do Superset, abra <0>Configurações → Aparência �
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "No app de desktop do Superset, abra Configurações → Acesso remoto e ative “Permitir acesso remoto a este dispositivo via relay”."
 
-msgid "in-app browser"
-msgstr "navegador do app"
-
-msgid "In-App Browser"
-msgstr "Navegador do app"
-
 msgid "In-app PR merge"
 msgstr "Merge de PR dentro do app"
 
@@ -8514,9 +8511,6 @@ msgstr "Nova automação"
 msgid "New Browser"
 msgstr "Novo navegador"
 
-msgid "New Browser Tab"
-msgstr "Nova aba do navegador"
-
 msgid "new challengers"
 msgstr "novos desafiantes"
 
@@ -9631,9 +9625,6 @@ msgstr "Abrir na aba atual"
 msgid "Open in Cursor"
 msgstr "Abrir no Cursor"
 
-msgid "Open in default browser"
-msgstr "Abrir no navegador padrão"
-
 msgid "Open in Desktop App"
 msgstr "Abrir no app de desktop"
 
@@ -9649,6 +9640,9 @@ msgstr "Abrir no editor"
 msgid "Open in Editor"
 msgstr "Abrir no editor"
 
+msgid "Open in external browser"
+msgstr "Abrir no navegador externo"
+
 msgid "Open in File pane"
 msgstr "Abrir no painel de Arquivos"
 
@@ -9661,14 +9655,8 @@ msgstr "Abrir no Finder"
 msgid "Open in GitHub"
 msgstr "Abrir no GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Abrir no navegador do app"
-
 msgid "Open in Linear"
 msgstr "Abrir no Linear"
-
-msgid "Open in new browser tab"
-msgstr "Abrir em nova aba do navegador"
 
 msgid "Open in new tab"
 msgstr "Abrir em nova aba"
@@ -12997,7 +12985,13 @@ msgstr "Dividir para baixo"
 msgid "Split Horizontally"
 msgstr "Dividir na horizontal"
 
+msgid "split pane"
+msgstr "painel dividido"
+
 msgid "Split pane"
+msgstr "Painel dividido"
+
+msgid "Split Pane"
 msgstr "Painel dividido"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Скопировать ключ"
 msgid "Copy link"
 msgstr "Скопировать ссылку"
 
+msgid "Copy Link"
+msgstr "Скопировать ссылку"
+
 msgid "Copy Link Address"
 msgstr "Скопировать адрес ссылки"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "По умолчанию ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "браузер по умолчанию"
-
-msgid "Default Browser"
-msgstr "Браузер по умолчанию"
 
 msgid "Default effort"
 msgstr "Уровень усилий по умолчанию"
@@ -5551,6 +5548,12 @@ msgstr "Внешний"
 
 msgid "External Application"
 msgstr "Внешнее приложение"
+
+msgid "external browser"
+msgstr "внешний браузер"
+
+msgid "External Browser"
+msgstr "Внешний браузер"
 
 msgid "External editor"
 msgstr "Внешний редактор"
@@ -7049,12 +7052,6 @@ msgstr "В приложении Superset откройте <0>Настройки 
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "В десктопном приложении Superset откройте Настройки → Удалённый доступ и включите «Разрешить удалённый доступ к этому устройству через реле»."
 
-msgid "in-app browser"
-msgstr "встроенный браузер"
-
-msgid "In-App Browser"
-msgstr "Встроенный браузер"
-
 msgid "In-app PR merge"
 msgstr "Слияние PR внутри приложения"
 
@@ -8514,9 +8511,6 @@ msgstr "Новая автоматизация"
 msgid "New Browser"
 msgstr "Новый браузер"
 
-msgid "New Browser Tab"
-msgstr "Новая вкладка браузера"
-
 msgid "new challengers"
 msgstr "другие соперники"
 
@@ -9631,9 +9625,6 @@ msgstr "Открыть в текущей вкладке"
 msgid "Open in Cursor"
 msgstr "Открыть в Cursor"
 
-msgid "Open in default browser"
-msgstr "Открыть в браузере по умолчанию"
-
 msgid "Open in Desktop App"
 msgstr "Открыть в десктопном приложении"
 
@@ -9649,6 +9640,9 @@ msgstr "Открыть в редакторе"
 msgid "Open in Editor"
 msgstr "Открыть в редакторе"
 
+msgid "Open in external browser"
+msgstr "Открыть во внешнем браузере"
+
 msgid "Open in File pane"
 msgstr "Открыть в панели файла"
 
@@ -9661,14 +9655,8 @@ msgstr "Открыть в Finder"
 msgid "Open in GitHub"
 msgstr "Открыть в GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Открыть во встроенном браузере"
-
 msgid "Open in Linear"
 msgstr "Открыть в Linear"
-
-msgid "Open in new browser tab"
-msgstr "Открыть в новой вкладке браузера"
 
 msgid "Open in new tab"
 msgstr "Открыть в новой вкладке"
@@ -12997,7 +12985,13 @@ msgstr "Разделить вниз"
 msgid "Split Horizontally"
 msgstr "Разделить по горизонтали"
 
+msgid "split pane"
+msgstr "разделённая панель"
+
 msgid "Split pane"
+msgstr "Разделённая панель"
+
+msgid "Split Pane"
 msgstr "Разделённая панель"
 
 msgid "Split Pane Auto"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Anahtarı kopyala"
 msgid "Copy link"
 msgstr "Bağlantıyı kopyala"
 
+msgid "Copy Link"
+msgstr "Bağlantıyı kopyala"
+
 msgid "Copy Link Address"
 msgstr "Bağlantı adresini kopyala"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Varsayılan ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "varsayılan tarayıcı"
-
-msgid "Default Browser"
-msgstr "Varsayılan tarayıcı"
 
 msgid "Default effort"
 msgstr "Varsayılan çaba"
@@ -5551,6 +5548,12 @@ msgstr "Harici"
 
 msgid "External Application"
 msgstr "Harici uygulama"
+
+msgid "external browser"
+msgstr "harici tarayıcı"
+
+msgid "External Browser"
+msgstr "Harici Tarayıcı"
 
 msgid "External editor"
 msgstr "Harici düzenleyici"
@@ -7049,12 +7052,6 @@ msgstr "Superset masaüstü uygulamasında <0>Ayarlar → Görünüm → Tema</0
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Superset masaüstü uygulamasında Ayarlar → Uzaktan erişim bölümünü açın ve “Bu cihaza röle üzerinden uzaktan erişime izin ver” seçeneğini açın."
 
-msgid "in-app browser"
-msgstr "uygulama içi tarayıcı"
-
-msgid "In-App Browser"
-msgstr "Uygulama içi tarayıcı"
-
 msgid "In-app PR merge"
 msgstr "Uygulama içi PR birleştirme"
 
@@ -8514,9 +8511,6 @@ msgstr "Yeni otomasyon"
 msgid "New Browser"
 msgstr "Yeni tarayıcı"
 
-msgid "New Browser Tab"
-msgstr "Yeni tarayıcı sekmesi"
-
 msgid "new challengers"
 msgstr "yeni rakipler"
 
@@ -9631,9 +9625,6 @@ msgstr "Geçerli sekmede aç"
 msgid "Open in Cursor"
 msgstr "Cursor'da aç"
 
-msgid "Open in default browser"
-msgstr "Varsayılan tarayıcıda aç"
-
 msgid "Open in Desktop App"
 msgstr "Masaüstü uygulamasında aç"
 
@@ -9649,6 +9640,9 @@ msgstr "Düzenleyicide aç"
 msgid "Open in Editor"
 msgstr "Düzenleyicide aç"
 
+msgid "Open in external browser"
+msgstr "Harici tarayıcıda aç"
+
 msgid "Open in File pane"
 msgstr "Dosya bölmesinde aç"
 
@@ -9661,14 +9655,8 @@ msgstr "Finder'da aç"
 msgid "Open in GitHub"
 msgstr "GitHub'da aç"
 
-msgid "Open in in-app browser"
-msgstr "Uygulama içi tarayıcıda aç"
-
 msgid "Open in Linear"
 msgstr "Linear'da aç"
-
-msgid "Open in new browser tab"
-msgstr "Yeni tarayıcı sekmesinde aç"
 
 msgid "Open in new tab"
 msgstr "Yeni sekmede aç"
@@ -12997,8 +12985,14 @@ msgstr "Aşağı böl"
 msgid "Split Horizontally"
 msgstr "Yatay böl"
 
+msgid "split pane"
+msgstr "bölünmüş bölme"
+
 msgid "Split pane"
 msgstr "Bölünmüş bölme"
+
+msgid "Split Pane"
+msgstr "Bölünmüş Bölme"
 
 msgid "Split Pane Auto"
 msgstr "Bölmeyi otomatik böl"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -3768,6 +3768,9 @@ msgstr "Sao chép khóa"
 msgid "Copy link"
 msgstr "Sao chép liên kết"
 
+msgid "Copy Link"
+msgstr "Sao chép liên kết"
+
 msgid "Copy Link Address"
 msgstr "Sao chép địa chỉ liên kết"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "Mặc định ({defaultWorktreePath})"
-
-msgid "default browser"
-msgstr "trình duyệt mặc định"
-
-msgid "Default Browser"
-msgstr "Trình duyệt mặc định"
 
 msgid "Default effort"
 msgstr "Mức nỗ lực mặc định"
@@ -5551,6 +5548,12 @@ msgstr "Bên ngoài"
 
 msgid "External Application"
 msgstr "Ứng dụng bên ngoài"
+
+msgid "external browser"
+msgstr "trình duyệt ngoài"
+
+msgid "External Browser"
+msgstr "Trình duyệt ngoài"
 
 msgid "External editor"
 msgstr "Trình soạn thảo ngoài"
@@ -7049,12 +7052,6 @@ msgstr "Trong ứng dụng Superset trên máy tính, mở <0>Cài đặt → Gi
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "Trong ứng dụng Superset trên máy tính, mở Cài đặt → Truy cập từ xa và bật “Cho phép truy cập từ xa vào thiết bị này qua relay”."
 
-msgid "in-app browser"
-msgstr "trình duyệt trong ứng dụng"
-
-msgid "In-App Browser"
-msgstr "Trình duyệt của ứng dụng"
-
 msgid "In-app PR merge"
 msgstr "Merge PR ngay trong ứng dụng"
 
@@ -8514,9 +8511,6 @@ msgstr "Tự động hóa mới"
 msgid "New Browser"
 msgstr "Trình duyệt mới"
 
-msgid "New Browser Tab"
-msgstr "Tab trình duyệt mới"
-
 msgid "new challengers"
 msgstr "đối thủ mới"
 
@@ -9631,9 +9625,6 @@ msgstr "Mở ở tab hiện tại"
 msgid "Open in Cursor"
 msgstr "Mở trong Cursor"
 
-msgid "Open in default browser"
-msgstr "Mở trong trình duyệt mặc định"
-
 msgid "Open in Desktop App"
 msgstr "Mở trong ứng dụng máy tính"
 
@@ -9649,6 +9640,9 @@ msgstr "Mở trong editor"
 msgid "Open in Editor"
 msgstr "Mở trong editor"
 
+msgid "Open in external browser"
+msgstr "Mở trong trình duyệt ngoài"
+
 msgid "Open in File pane"
 msgstr "Mở trong khung Tệp"
 
@@ -9661,14 +9655,8 @@ msgstr "Mở trong Finder"
 msgid "Open in GitHub"
 msgstr "Mở trong GitHub"
 
-msgid "Open in in-app browser"
-msgstr "Mở trong trình duyệt của ứng dụng"
-
 msgid "Open in Linear"
 msgstr "Mở trong Linear"
-
-msgid "Open in new browser tab"
-msgstr "Mở ở tab trình duyệt mới"
 
 msgid "Open in new tab"
 msgstr "Mở ở tab mới"
@@ -12997,8 +12985,14 @@ msgstr "Chia xuống"
 msgid "Split Horizontally"
 msgstr "Chia theo chiều ngang"
 
+msgid "split pane"
+msgstr "khung chia"
+
 msgid "Split pane"
 msgstr "Chia khung"
+
+msgid "Split Pane"
+msgstr "Khung chia"
 
 msgid "Split Pane Auto"
 msgstr "Chia khung tự động"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -3768,6 +3768,9 @@ msgstr "复制密钥"
 msgid "Copy link"
 msgstr "复制链接"
 
+msgid "Copy Link"
+msgstr "复制链接"
+
 msgid "Copy Link Address"
 msgstr "复制链接地址"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "默认（{defaultWorktreePath}）"
-
-msgid "default browser"
-msgstr "默认浏览器"
-
-msgid "Default Browser"
-msgstr "默认浏览器"
 
 msgid "Default effort"
 msgstr "默认推理强度"
@@ -5551,6 +5548,12 @@ msgstr "外部"
 
 msgid "External Application"
 msgstr "外部应用"
+
+msgid "external browser"
+msgstr "外部浏览器"
+
+msgid "External Browser"
+msgstr "外部浏览器"
 
 msgid "External editor"
 msgstr "外部编辑器"
@@ -7049,12 +7052,6 @@ msgstr "在Superset桌面应用中打开<0>设置 → 外观 → 主题</0>。"
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "在Superset桌面应用中打开“设置 → 远程访问”，开启“允许通过中继远程访问本设备”。"
 
-msgid "in-app browser"
-msgstr "应用内浏览器"
-
-msgid "In-App Browser"
-msgstr "应用内浏览器"
-
 msgid "In-app PR merge"
 msgstr "应用内合并PR"
 
@@ -8514,9 +8511,6 @@ msgstr "新建自动化"
 msgid "New Browser"
 msgstr "新建浏览器"
 
-msgid "New Browser Tab"
-msgstr "新建浏览器标签页"
-
 msgid "new challengers"
 msgstr "换对手"
 
@@ -9631,9 +9625,6 @@ msgstr "在当前标签页打开"
 msgid "Open in Cursor"
 msgstr "在Cursor中打开"
 
-msgid "Open in default browser"
-msgstr "在默认浏览器中打开"
-
 msgid "Open in Desktop App"
 msgstr "在桌面应用中打开"
 
@@ -9649,6 +9640,9 @@ msgstr "在编辑器中打开"
 msgid "Open in Editor"
 msgstr "在编辑器中打开"
 
+msgid "Open in external browser"
+msgstr "在外部浏览器中打开"
+
 msgid "Open in File pane"
 msgstr "在“文件”面板中打开"
 
@@ -9661,14 +9655,8 @@ msgstr "在Finder中打开"
 msgid "Open in GitHub"
 msgstr "在GitHub中打开"
 
-msgid "Open in in-app browser"
-msgstr "在应用内浏览器中打开"
-
 msgid "Open in Linear"
 msgstr "在Linear中打开"
-
-msgid "Open in new browser tab"
-msgstr "在新浏览器标签页中打开"
 
 msgid "Open in new tab"
 msgstr "在新标签页打开"
@@ -12997,8 +12985,14 @@ msgstr "向下拆分"
 msgid "Split Horizontally"
 msgstr "水平拆分"
 
+msgid "split pane"
+msgstr "分割窗格"
+
 msgid "Split pane"
 msgstr "拆分窗格"
+
+msgid "Split Pane"
+msgstr "分割窗格"
 
 msgid "Split Pane Auto"
 msgstr "自动拆分窗格"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -3768,6 +3768,9 @@ msgstr "複製金鑰"
 msgid "Copy link"
 msgstr "複製連結"
 
+msgid "Copy Link"
+msgstr "複製連結"
+
 msgid "Copy Link Address"
 msgstr "複製連結地址"
 
@@ -4511,12 +4514,6 @@ msgstr "default · secondary · outline · ghost · link · destructive"
 
 msgid "Default ({defaultWorktreePath})"
 msgstr "預設（{defaultWorktreePath}）"
-
-msgid "default browser"
-msgstr "預設瀏覽器"
-
-msgid "Default Browser"
-msgstr "預設瀏覽器"
 
 msgid "Default effort"
 msgstr "預設推理強度"
@@ -5551,6 +5548,12 @@ msgstr "外部"
 
 msgid "External Application"
 msgstr "外部應用"
+
+msgid "external browser"
+msgstr "外部瀏覽器"
+
+msgid "External Browser"
+msgstr "外部瀏覽器"
 
 msgid "External editor"
 msgstr "外部編輯器"
@@ -7049,12 +7052,6 @@ msgstr "在Superset桌面應用程式中開啟<0>設定 → 外觀 → 主題</0
 msgid "In the Superset desktop app, open Settings → Remote Access and turn on “Allow remote access to this device via relay”."
 msgstr "在Superset桌面應用程式中開啟「設定 → 遠端存取」，開啟「允許遠端工作區通過中繼存取此裝置」。"
 
-msgid "in-app browser"
-msgstr "應用程式內瀏覽器"
-
-msgid "In-App Browser"
-msgstr "應用程式內瀏覽器"
-
 msgid "In-app PR merge"
 msgstr "應用程式內合併PR"
 
@@ -8514,9 +8511,6 @@ msgstr "新建自動化"
 msgid "New Browser"
 msgstr "新建瀏覽器"
 
-msgid "New Browser Tab"
-msgstr "新瀏覽器分頁"
-
 msgid "new challengers"
 msgstr "換對手"
 
@@ -9631,9 +9625,6 @@ msgstr "在目前分頁開啟"
 msgid "Open in Cursor"
 msgstr "在Cursor中開啟"
 
-msgid "Open in default browser"
-msgstr "在預設瀏覽器中開啟"
-
 msgid "Open in Desktop App"
 msgstr "在桌面應用程式中開啟"
 
@@ -9649,6 +9640,9 @@ msgstr "在編輯器中開啟"
 msgid "Open in Editor"
 msgstr "在編輯器中開啟"
 
+msgid "Open in external browser"
+msgstr "在外部瀏覽器中開啟"
+
 msgid "Open in File pane"
 msgstr "在「檔案」面板中開啟"
 
@@ -9661,14 +9655,8 @@ msgstr "在Finder中開啟"
 msgid "Open in GitHub"
 msgstr "在GitHub中開啟"
 
-msgid "Open in in-app browser"
-msgstr "在應用程式內瀏覽器中開啟"
-
 msgid "Open in Linear"
 msgstr "在Linear中開啟"
-
-msgid "Open in new browser tab"
-msgstr "在新瀏覽器分頁中開啟"
 
 msgid "Open in new tab"
 msgstr "在新分頁開啟"
@@ -12997,8 +12985,14 @@ msgstr "向下拆分"
 msgid "Split Horizontally"
 msgstr "水平拆分"
 
+msgid "split pane"
+msgstr "分割窗格"
+
 msgid "Split pane"
 msgstr "拆分窗格"
+
+msgid "Split Pane"
+msgstr "分割窗格"
 
 msgid "Split Pane Auto"
 msgstr "自動拆分窗格"


### PR DESCRIPTION
## What

Terminal right-click menu, when the click lands on a link:

- The link section moves from the top of the menu to just above the splits: Copy / Paste → Clear Terminal / Scroll to Bottom → **Open in ▸ / Copy Link** → splits. It is hidden entirely (separator included) when there is no link under the pointer.
- **Copy Link** is a new one-click item under "Open in". File and folder links get **Copy Path** instead.
- **Split with New Browser** is removed from the terminal menu. For a URL, "Open in → Split Pane" already does that. It stays on browser and file panes and on ⌘⇧S.

URL destination labels, changed in the shared table in `actionLabel.ts` so Settings → Links, the hover tooltip, and the submenu agree:

| before | after |
|---|---|
| In-App Browser / in-app browser | Split Pane / split pane |
| New Browser Tab / new browser tab | New Tab / new tab |
| Default Browser / default browser | External Browser / external browser |

"New Tab" is what the action does: it opens a new workspace tab holding a browser pane, not a tab in an outside browser.

## i18n

New strings translated in all 16 locales; `bun run check:i18n` is clean. "Open in split pane" already existed with translations.

## Verified

Driven over CDP in the dev app: real right-click on an echoed URL, menu item order asserted from the DOM, screenshots of the menu and the expanded submenu. Right-click on blank terminal hides the link section. Desktop typecheck and test suite pass.

Not changed: the browser pane's own right-click menu (Electron main) still says "Open Link in Default Browser". One-line follow-up if we want the whole app on "external".

https://claude.ai/code/session_01QQjxbBasZK5EHA99YVqRgd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regroups the terminal right-click menu for links: the link section moves to just above the split actions, appears only when the click landed on a link, and adds one-click "Copy Link" for URLs or "Copy Path" for file/folder links. "Split with New Browser" is removed from the terminal menu but stays on browser and file panes and on ⌘⇧S.

Renames the URL destination labels across Settings → Links, the hover tooltip, and the submenu: "in-app browser" → "split pane", "new browser tab" → "new tab", and "default browser" → "external browser". "New tab" reflects what it opens — a workspace tab holding a browser pane, not a tab in an outside browser.

The link section is hidden entirely when the link has nowhere to open, such as a file link the host never resolved. Copy Link and Copy Path show a "Copy failed" toast when the clipboard write is rejected.

Translations are updated in all locales and `bun run check:i18n` is clean. Not changed: the browser pane's own context menu still says "Open Link in Default Browser".

<sup>Written for commit 17fb6b085198cf102ec5f6d39333bc4c264a6cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal link actions for opening detected links, copying URLs, and copying resolved file paths.
* **Updates**
  * Renamed link destinations to “Split Pane,” “New Tab,” and “External Browser.”
  * Added localized “Copy Link” and external browser terminology across supported languages.
* **Bug Fixes**
  * Improved terminal context menus by grouping link-specific actions separately from terminal actions.
  * Added clearer failure feedback when copying links or file paths fails.
  * Hid unavailable “Open in” options when no copyable link destination exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->