### PR TITLE
fix(agent-setup): preserve Cursor identity through tool execution

### DIFF
--- a/packages/agent-setup/src/agent-wrappers-cursor.ts
+++ b/packages/agent-setup/src/agent-wrappers-cursor.ts
@@ -55,6 +55,8 @@ const CURSOR_MANAGED_EVENT_ARGS: Record<string, string> = {
 	stop: "Stop",
 	beforeShellExecution: "PermissionRequest",
 	beforeMCPExecution: "PermissionRequest",
+	postToolUse: "Start",
+	postToolUseFailure: "Start",
 };
 
 function cursorHooksSpec(
@@ -68,7 +70,16 @@ function cursorHooksSpec(
 		desiredEntriesByEvent: Object.fromEntries(
 			Object.entries(CURSOR_MANAGED_EVENT_ARGS).map(([eventName, arg]) => [
 				eventName,
-				[{ command: `${hookScriptPath} ${arg}` }],
+				[
+					{
+						command: `${hookScriptPath} ${arg}`,
+						// Only these tools have managed before-hooks that set PermissionRequest.
+						...(eventName === "postToolUse" ||
+						eventName === "postToolUseFailure"
+							? { matcher: "^(Shell|MCP:.+)$" }
+							: {}),
+					},
+				],
 			]),
 		),
 		cleanEntry: (entry) =>

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -26,7 +26,7 @@ let mockedHomeDir = path.join(TEST_ROOT, "home");
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v9",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v10",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -792,7 +792,7 @@ exit 0
 		const content2 = requireContent(getCursorHooksJsonContent(currentHookPath));
 
 		const parsed = JSON.parse(content) as {
-			hooks: Record<string, Array<{ command: string }>>;
+			hooks: Record<string, Array<{ command: string; matcher?: string }>>;
 		};
 		const beforeSubmitPrompt = parsed.hooks.beforeSubmitPrompt;
 
@@ -822,8 +822,183 @@ exit 0
 		).toBe(true);
 		expect(Array.isArray(parsed.hooks.beforeShellExecution)).toBe(true);
 		expect(Array.isArray(parsed.hooks.beforeMCPExecution)).toBe(true);
+		for (const event of ["postToolUse", "postToolUseFailure"]) {
+			expect(parsed.hooks[event]).toEqual([
+				{ command: `${currentHookPath} Start`, matcher: "^(Shell|MCP:.+)$" },
+			]);
+		}
+		for (const event of ["postToolUse", "postToolUseFailure"]) {
+			const matcher = new RegExp(
+				requireContent(parsed.hooks[event][0].matcher ?? null),
+			);
+			for (const tool of ["Shell", "MCP:audit_echo", "MCP:audit_failure"])
+				expect(matcher.test(tool)).toBe(true);
+			for (const tool of [
+				"Read",
+				"Edit",
+				"Grep",
+				"Task",
+				"AskQuestion",
+				"ShellOther",
+				"OtherMCP:test",
+			])
+				expect(matcher.test(tool)).toBe(false);
+		}
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
 	});
+
+	it.each([
+		"beforeShellExecution",
+		"beforeMCPExecution",
+	])("keeps Cursor identity through %s and native tool outcomes", async (beforeEvent) => {
+		const cursorPath = path.join(TEST_HOOKS_DIR, "cursor-hook.sh");
+		const notifyPath = path.join(TEST_HOOKS_DIR, "notify.sh");
+		mkdirSync(TEST_HOOKS_DIR, { recursive: true });
+		for (const [name, target] of [
+			["cursor-hook", cursorPath],
+			["notify-hook", notifyPath],
+		]) {
+			const template = readFileSync(
+				new URL(`../templates/${name}.template.sh`, import.meta.url),
+				"utf-8",
+			);
+			writeFileSync(
+				target,
+				template
+					.replaceAll("{{MARKER}}", "# test hook")
+					.replaceAll("{{DEFAULT_PORT}}", "0"),
+				{ mode: 0o755 },
+			);
+		}
+		const { hooks } = JSON.parse(
+			requireContent(getCursorHooksJsonContent(cursorPath)),
+		) as {
+			hooks: Record<string, Array<{ command: string; matcher?: string }>>;
+		};
+		const reports: Array<{
+			terminalId: string;
+			eventType: string;
+			agent: { agentId: string; sessionId: string };
+		}> = [];
+		const server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				const body = (await request.json()) as {
+					json: (typeof reports)[number];
+				};
+				reports.push(body.json);
+				return Response.json({
+					result: { data: { json: { ignored: false } } },
+				});
+			},
+		});
+		const identity = { agentId: "cursor-agent", sessionId: "cursor-session" };
+		// Async children keep the in-process receiver responsive to curl.
+		const invoke = async (
+			command: string,
+			event: string,
+			imported = false,
+			extra = {},
+		) => {
+			const proc = Bun.spawn(["bash", "-c", command], {
+				env: {
+					PATH: process.env.PATH,
+					CURL_HOME: TEST_ROOT,
+					SUPERSET_HOME_DIR: TEST_ROOT,
+					SUPERSET_TERMINAL_ID: "cursor-terminal",
+					SUPERSET_HOST_AGENT_HOOK_URL: `http://127.0.0.1:${server.port}/trpc/notifications.hook`,
+					SUPERSET_AGENT_ID: imported ? "claude" : identity.agentId,
+					CURSOR_VERSION: "2026.09.02-c22c1a3",
+				},
+				stdin: new Blob([
+					JSON.stringify({
+						session_id: identity.sessionId,
+						hook_event_name: event,
+						...extra,
+					}),
+				]),
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [code, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			expect(code).toBe(0);
+			expect(stderr).toBe("");
+			return stdout;
+		};
+		const native = async (
+			event: string,
+			extra: Record<string, unknown> = {},
+		) => {
+			for (const hook of hooks[event] ?? []) {
+				if (
+					hook.matcher &&
+					!new RegExp(hook.matcher).test(String(extra.tool_name ?? ""))
+				)
+					continue;
+				await invoke(hook.command, event, false, extra);
+			}
+		};
+		try {
+			for (const [outcome, extra] of [
+				["postToolUse", {}],
+				["postToolUseFailure", { is_interrupt: false }],
+				["postToolUseFailure", { is_interrupt: true }],
+			] as const) {
+				reports.length = 0;
+				await native("beforeSubmitPrompt");
+				await invoke(notifyPath, "beforeSubmitPrompt", true);
+				await native(beforeEvent);
+				expect(reports.at(-1)).toMatchObject({
+					eventType: "PermissionRequest",
+					agent: identity,
+				});
+				// A child file tool must not overwrite a parent waiting on shell/MCP.
+				await native(outcome, {
+					...extra,
+					tool_name: "Read",
+					session_id: "child-session",
+				});
+				expect(reports.at(-1)).toMatchObject({
+					eventType: "PermissionRequest",
+					agent: identity,
+				});
+				await native(outcome, {
+					...extra,
+					tool_name:
+						beforeEvent === "beforeShellExecution" ? "Shell" : "MCP:audit_echo",
+				});
+				// Cursor imports Claude PostToolUse, but not PostToolUseFailure.
+				if (outcome === "postToolUse")
+					await invoke(notifyPath, "postToolUse", true);
+				expect(reports.at(-1)).toMatchObject({
+					eventType: "Start",
+					agent: identity,
+				});
+				await native("stop", { status: "completed" });
+				await invoke(notifyPath, "stop", true);
+				expect(reports.map(({ eventType }) => eventType)).toEqual([
+					"Start",
+					"PermissionRequest",
+					"Start",
+					"Stop",
+				]);
+				expect(
+					reports.every(
+						({ agent }) =>
+							agent.agentId === identity.agentId &&
+							agent.sessionId === identity.sessionId,
+					),
+				).toBe(true);
+			}
+		} finally {
+			server.stop(true);
+		}
+	}, 60_000);
 
 	it("replaces stale Gemini hook commands from old superset paths", () => {
 		const geminiSettingsPath = path.join(

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -15,6 +15,15 @@ function readNotifyHookTemplate(): string {
 // points at an empty home.
 const emptyHome = mkdtempSync(path.join(tmpdir(), "notify-hook-empty-home-"));
 
+// Non-C locales expose range collation in the hook's /bin/bash interpreter.
+const availableLocales = Bun.spawnSync(["locale", "-a"])
+	.stdout.toString()
+	.split(/\s+/);
+const hookLocales = [
+	"C",
+	...availableLocales.filter((locale) => /^en_US\.utf-?8$/i.test(locale)),
+];
+
 function renderNotifyHookScript(): string {
 	return readNotifyHookTemplate()
 		.replaceAll("{{MARKER}}", NOTIFY_SCRIPT_MARKER)
@@ -37,7 +46,7 @@ function runNotifyHook(
 	envOverrides: Record<string, string> = {},
 ) {
 	return Bun.spawnSync({
-		cmd: ["bash", "-c", renderNotifyHookScript()],
+		cmd: ["/bin/bash", "-c", renderNotifyHookScript()],
 		env: hookEnv(envOverrides),
 		stdin: Buffer.from(JSON.stringify(input)),
 		stdout: "pipe",
@@ -55,7 +64,7 @@ async function runNotifyHookAsync(
 	envOverrides: Record<string, string> = {},
 ) {
 	const proc = Bun.spawn({
-		cmd: ["bash", "-c", renderNotifyHookScript()],
+		cmd: ["/bin/bash", "-c", renderNotifyHookScript()],
 		env: hookEnv(envOverrides),
 		stdin: Buffer.from(JSON.stringify(input)),
 		stdout: "pipe",
@@ -172,7 +181,9 @@ describe("getNotifyScriptContent", () => {
 		expect(script).toContain('V1_EVENT_TYPE="Stop"');
 	});
 
-	it("suppresses Cursor events imported into Claude's hook", async () => {
+	it.each(
+		hookLocales,
+	)("suppresses Cursor events imported into Claude's hook (%s)", async (locale) => {
 		const host = fakeHostService(false);
 		const v1 = fakeV1Service();
 		const cursorEvents = [
@@ -193,6 +204,7 @@ describe("getNotifyScriptContent", () => {
 					{
 						SUPERSET_AGENT_ID: "claude",
 						CURSOR_VERSION: "2026.09.02",
+						LC_ALL: locale,
 						SUPERSET_HOST_AGENT_HOOK_URL: `${host.url}/trpc/notifications.hook`,
 					},
 				);
@@ -209,6 +221,7 @@ describe("getNotifyScriptContent", () => {
 				{
 					SUPERSET_AGENT_ID: "claude",
 					CURSOR_VERSION: "2026.09.02",
+					LC_ALL: locale,
 					SUPERSET_TERMINAL_ID: "",
 					SUPERSET_TAB_ID: "tab-test",
 					SUPERSET_HOST_AGENT_HOOK_URL: "",
@@ -223,7 +236,9 @@ describe("getNotifyScriptContent", () => {
 		}
 	});
 
-	it("keeps Claude and other non-Cursor hook events dispatching", async () => {
+	it.each(
+		hookLocales,
+	)("keeps Claude and other non-Cursor hook events dispatching (%s)", async (locale) => {
 		const host = fakeHostService(false);
 		const endpoint = `${host.url}/trpc/notifications.hook`;
 		try {
@@ -238,6 +253,7 @@ describe("getNotifyScriptContent", () => {
 					{
 						SUPERSET_AGENT_ID: "claude",
 						CURSOR_VERSION: "2026.09.02",
+						LC_ALL: locale,
 						SUPERSET_HOST_AGENT_HOOK_URL: endpoint,
 					},
 				);

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -70,7 +70,13 @@ async function runNotifyHookAsync(
 
 /** Fake host-service answering notifications.hook like the real router. */
 function fakeHostService(ignored: boolean) {
-	const requests: Array<{ json: { terminalId?: string } }> = [];
+	const requests: Array<{
+		json: {
+			terminalId?: string;
+			eventType?: string;
+			agent?: { agentId?: string; sessionId?: string };
+		};
+	}> = [];
 	const server = Bun.serve({
 		port: 0,
 		fetch: async (req) => {
@@ -85,6 +91,18 @@ function fakeHostService(ignored: boolean) {
 		url: `http://127.0.0.1:${server.port}`,
 		stop: () => server.stop(true),
 	};
+}
+
+function fakeV1Service() {
+	const requests: Request[] = [];
+	const server = Bun.serve({
+		port: 0,
+		fetch: (req) => {
+			requests.push(req);
+			return new Response(null, { status: 200 });
+		},
+	});
+	return { requests, port: server.port, stop: () => server.stop(true) };
 }
 
 function writeHookManifest(home: string, orgId: string, endpoint: string) {
@@ -104,7 +122,7 @@ function writeHookManifest(home: string, orgId: string, endpoint: string) {
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v9");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v10");
 	});
 
 	it("ignores hooks fired inside a subagent (agent_id present)", () => {
@@ -151,6 +169,110 @@ describe("getNotifyScriptContent", () => {
 		);
 		expect(script).toContain('V1_EVENT_TYPE="$EVENT_TYPE"');
 		expect(script).toContain('V1_EVENT_TYPE="Stop"');
+	});
+
+	it("suppresses Cursor events imported into Claude's hook", async () => {
+		const host = fakeHostService(false);
+		const v1 = fakeV1Service();
+		const cursorEvents = [
+			"beforeSubmitPrompt",
+			"preToolUse",
+			"postToolUse",
+			"stop",
+			"sessionStart",
+			"sessionEnd",
+			"subagentStop",
+			"preCompact",
+		];
+		try {
+			const results = [];
+			for (const hook_event_name of cursorEvents) {
+				const result = await runNotifyHookAsync(
+					{ hook_event_name, session_id: "cursor-session" },
+					{
+						SUPERSET_AGENT_ID: "claude",
+						CURSOR_VERSION: "2026.09.02",
+						SUPERSET_HOST_AGENT_HOOK_URL: `${host.url}/trpc/notifications.hook`,
+					},
+				);
+				results.push(result);
+			}
+			expect(host.requests).toHaveLength(0);
+			for (const result of results) {
+				expect(result.exitCode).toBe(0);
+				expect(result.stderr).toBe("");
+			}
+
+			const v1Result = await runNotifyHookAsync(
+				{ hook_event_name: "stop", session_id: "cursor-session" },
+				{
+					SUPERSET_AGENT_ID: "claude",
+					CURSOR_VERSION: "2026.09.02",
+					SUPERSET_TERMINAL_ID: "",
+					SUPERSET_TAB_ID: "tab-test",
+					SUPERSET_HOST_AGENT_HOOK_URL: "",
+					SUPERSET_PORT: String(v1.port),
+				},
+			);
+			expect(v1Result.exitCode).toBe(0);
+			expect(v1.requests).toHaveLength(0);
+		} finally {
+			host.stop();
+			v1.stop();
+		}
+	});
+
+	it("keeps Claude and other non-Cursor hook events dispatching", async () => {
+		const host = fakeHostService(false);
+		const endpoint = `${host.url}/trpc/notifications.hook`;
+		try {
+			for (const [hook_event_name, eventType] of [
+				["Stop", "Stop"],
+				["UserPromptSubmit", "Start"],
+				["PostToolUse", "PostToolUse"],
+				["PermissionRequest", "PermissionRequest"],
+			] as const) {
+				const result = await runNotifyHookAsync(
+					{ hook_event_name, session_id: "claude-session" },
+					{
+						SUPERSET_AGENT_ID: "claude",
+						CURSOR_VERSION: "2026.09.02",
+						SUPERSET_HOST_AGENT_HOOK_URL: endpoint,
+					},
+				);
+				expect(result.exitCode).toBe(0);
+				expect(host.requests.at(-1)?.json).toMatchObject({
+					eventType,
+					agent: { agentId: "claude" },
+				});
+			}
+
+			for (const envOverrides of [
+				{ SUPERSET_AGENT_ID: "claude", CURSOR_VERSION: "" },
+				{ SUPERSET_AGENT_ID: "grok", CURSOR_VERSION: "2026.09.02" },
+			]) {
+				const result = await runNotifyHookAsync(
+					{ hook_event_name: "stop", session_id: "other-session" },
+					{ ...envOverrides, SUPERSET_HOST_AGENT_HOOK_URL: endpoint },
+				);
+				expect(result.exitCode).toBe(0);
+			}
+			expect(host.requests).toHaveLength(6);
+			expect(host.requests.slice(-2).map(({ json }) => json)).toEqual([
+				{
+					terminalId: "terminal-test",
+					eventType: "stop",
+					agent: { agentId: "claude", sessionId: "other-session" },
+				},
+				{
+					terminalId: "terminal-test",
+					eventType: "stop",
+					agent: { agentId: "grok", sessionId: "other-session" },
+				},
+			]);
+		} finally {
+			host.stop();
+		}
 	});
 
 	it("gives the v2 host-service hook enough time to deliver", () => {

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -93,6 +93,7 @@ function fakeHostService(ignored: boolean) {
 	};
 }
 
+/** Fake v1 host-service endpoint that records incoming requests and returns 200. */
 function fakeV1Service() {
 	const requests: Request[] = [];
 	const server = Bun.serve({

--- a/packages/agent-setup/src/notify-hook.ts
+++ b/packages/agent-setup/src/notify-hook.ts
@@ -5,7 +5,7 @@ import { getHooksDir } from "./paths";
 import { writeFileIfChanged } from "./write-file-if-changed";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v9";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v10";
 
 export function getNotifyScriptPath(): string {
 	return path.join(getHooksDir(), NOTIFY_SCRIPT_NAME);

--- a/packages/agent-setup/templates/notify-hook.template.sh
+++ b/packages/agent-setup/templates/notify-hook.template.sh
@@ -60,7 +60,7 @@ fi
 # Cursor-specific hook, so do not dispatch them under the imported Claude id.
 if [ "$SUPERSET_AGENT_ID" = "claude" ] && [ -n "$CURSOR_VERSION" ]; then
   case "$EVENT_TYPE" in
-    [a-z]*) exit 0 ;;
+    [[:lower:]]*) exit 0 ;;
   esac
 fi
 

--- a/packages/agent-setup/templates/notify-hook.template.sh
+++ b/packages/agent-setup/templates/notify-hook.template.sh
@@ -56,6 +56,14 @@ if [ -z "$EVENT_TYPE" ]; then
   esac
 fi
 
+# Cursor imports Claude hook settings. Its lifecycle events are handled by the
+# Cursor-specific hook, so do not dispatch them under the imported Claude id.
+if [ "$SUPERSET_AGENT_ID" = "claude" ] && [ -n "$CURSOR_VERSION" ]; then
+  case "$EVENT_TYPE" in
+    [a-z]*) exit 0 ;;
+  esac
+fi
+
 # Grok serializes its configured Notification event as lowercase
 # "notification". Only subtypes where the agent is blocked waiting on the
 # user count: permission_prompt (tool/plan approval) and elicitation_dialog


### PR DESCRIPTION
## What & why

Cursor imports Claude hook settings. Superset’s imported command sets `SUPERSET_AGENT_ID=claude`, so a duplicate event can relabel a Cursor terminal as Claude and change its runtime identity. This reproduces with a GPT model selected in Cursor; the terminal label identifies the agent application, not the model.

Suppress imported events only when the command identifies Claude, `CURSOR_VERSION` is present, and the event uses Cursor’s lowercase naming. Genuine Claude events remain supported, including Claude launched from Cursor’s environment. Bump the generated notification hook marker to v10.

Register native `postToolUse` and `postToolUseFailure` as `Start` so shell/MCP activity does not remain at `PermissionRequest` after the imported duplicate is suppressed. Match only `Shell` and `MCP:<tool>`, whose existing before-hooks set that state. Existing user hooks are preserved.

Cursor documents [third-party hook imports](https://cursor.com/docs/reference/third-party-hooks) and [native hook matchers](https://cursor.com/docs/hooks).

## How I tested it

Real interactive Cursor CLI `2026.09.02-c22c1a3`, launched inside Superset with `gpt-5.6-terra-low`. The same terminal shows Claude after a completed turn with the base notification hook, then Cursor with the candidate hooks. Captures are cropped to the terminal header and response; private metadata is omitted.

**Before: Cursor running, Claude icon**

![Cursor incorrectly labeled Claude](https://raw.githubusercontent.com/owieschon/superset/f6713aa580e96c005df838d6795e95d44c714e6f/cursor-before.png)

**After: Cursor running, Cursor icon**

![Cursor identity preserved after completion](https://raw.githubusercontent.com/owieschon/superset/f6713aa580e96c005df838d6795e95d44c714e6f/cursor-after.png)

- Native CLI tool runs verified shell success/nonzero exit, MCP success/error results, file-read exclusion, and session-end detachment against host bindings. Temporary hook configuration was restored byte-for-byte. Tool qualification used print mode; completed-turn captures used the interactive CLI.
- Regression fails before the post-tool registrations: `PermissionRequest` remains where `Start` is required. Removing the matcher in an isolated test copy fails both child Read assertions.
- Bun **1.3.14**, current commit `a0ee299`: **303 package tests passed**, 1,262 assertions across 14 files. Repository lint and all 38 typecheck tasks passed locally. Executable hook tests also cover interruption, duplicate imports, genuine Claude events, and other providers. Interruption is replay coverage, not a live user-cancel claim.
- [CI on the current commit `a0ee299`](https://github.com/owieschon/superset/actions/runs/34077476906): **all 11 jobs passed**, including lint, tests, typecheck, desktop build, and four CLI builds.
- Locale regression: on macOS `/bin/bash` 3.2.57 with `en_US.UTF-8`, the old `[a-z]` range also suppressed uppercase Claude events. The regression fails before the correction and passes with `[[:lower:]]`. Hook tests now use the production shebang interpreter and exercise C plus an installed US English UTF-8 locale.
- [CodeRabbit review](https://github.com/owieschon/superset/pull/11#pullrequestreview-5127393072) completed. Its suggestion to bypass the matcher in the child test was checked against the failing matcher-removal mutation; the test retains the provider boundary.

<details>
<summary>Scope and validation limits</summary>

Existing Cursor shell/MCP child hooks can overwrite a parent terminal’s session binding; captured child events reproduce this through the unchanged base hook. This change does not establish parent/child isolation or alter terminal-turn failure classification. Cursor IDE behavior is unverified.

The fork preview cannot deploy because its Neon `api_key` is absent. Local full-repository tests stop on missing service environment variables in four unchanged tRPC test files. A Bun 1.4.0 package run failed an existing endpoint fast-path test; the repository-pinned Bun 1.3.14 package run and current commit `a0ee299`’s full CI passed.

</details>

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass on the current commit in CI
- [x] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cursor terminals being relabeled as Claude when Cursor imports Claude hook settings, so Cursor's runtime identity is preserved through tool execution.

- Suppresses imported lowercase Cursor events only when `SUPERSET_AGENT_ID=claude` and `CURSOR_VERSION` is present; genuine Claude events still dispatch.
- Registers native `postToolUse` and `postToolUseFailure` as `Start` events with a matcher for Shell and MCP tools so tool activity doesn't remain at `PermissionRequest`.
- Bumps the notification hook marker to v10; existing user hooks are preserved.

<sup>Written for commit de4279947147b6edefd927f6b4df370d0f9e1aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Cursor integration by limiting post-tool notifications to Shell and MCP tool events.
  - Prevented duplicate or incorrect lifecycle notifications when Cursor invokes Claude hooks.
  - Preserved accurate event types and agent identity in notifications across supported tools and environments.
  - Updated generated notification hooks so newer installations correctly recognize and apply the latest hook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
