### PR TITLE
feat(desktop): build and publish a Linux .deb alongside the AppImage

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -323,6 +323,10 @@ jobs:
             echo "::error::No AppImage artifact generated in apps/desktop/release"
             exit 1
           }
+          test -n "$(ls -1 release/*.deb 2>/dev/null)" || {
+            echo "::error::No deb artifact generated in apps/desktop/release"
+            exit 1
+          }
           test -n "$(ls -1 release/*-linux.yml 2>/dev/null)" || {
             echo "::error::No Linux auto-update manifest generated in apps/desktop/release"
             exit 1
@@ -339,6 +343,14 @@ jobs:
         with:
           name: ${{ inputs.artifact_prefix }}-linux-appimage
           path: apps/desktop/release/*.AppImage
+          retention-days: ${{ inputs.artifact_retention_days }}
+          if-no-files-found: error
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.artifact_prefix }}-linux-deb
+          path: apps/desktop/release/*.deb
           retention-days: ${{ inputs.artifact_retention_days }}
           if-no-files-found: error
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -99,6 +99,14 @@ jobs:
               echo "Created stable copy: Superset-${arch}.AppImage"
             fi
           done
+          for file in *.deb; do
+            if [[ -f "$file" ]]; then
+              # Extract architecture from filename (e.g., superset-0.0.1-x64.deb -> x64)
+              arch=$(echo "$file" | sed -E 's/.*-([^-]+)\.deb$/\1/')
+              cp "$file" "Superset-${arch}.deb"
+              echo "Created stable copy: Superset-${arch}.deb"
+            fi
+          done
           # Keep Linux updater manifest at a stable filename for generic provider lookups.
           for file in *-linux.yml; do
             if [[ -f "$file" && "$file" != "latest-linux.yml" ]]; then

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -178,6 +178,32 @@ const config: Configuration = {
 		},
 	},
 
+	// The linux.desktop action above execs AppRun, which only exists inside
+	// the AppImage. FpmTarget merges this block over linux, replacing the
+	// action for debs: the deb postinst puts the executable on PATH
+	// (update-alternatives → /usr/bin), and no --no-sandbox — the deb's
+	// AppArmor userns profile keeps the Chromium sandbox on.
+	deb: {
+		desktop: {
+			entry: {
+				Actions: "new-window;",
+				// electron-builder writes StartupWMClass=<productName>, but
+				// Electron sets the window's WM_CLASS to the lowercased app
+				// name ("superset").
+				// Without the exact match GNOME can't tie the window to this
+				// entry, so the window loses its icon and the action above
+				// never shows.
+				StartupWMClass: "superset",
+			},
+			desktopActions: {
+				"new-window": {
+					Name: "New Window",
+					Exec: "@supersetdesktop --new-window",
+				},
+			},
+		},
+	},
+
 	// Windows
 	win: {
 		...(existsSync(winIconPath) ? { icon: winIconPath } : {}),

--- a/apps/desktop/electron-builder.ts
+++ b/apps/desktop/electron-builder.ts
@@ -150,7 +150,7 @@ const config: Configuration = {
 		...(existsSync(linuxIconPath) ? { icon: linuxIconPath } : {}),
 		category: "Utility",
 		synopsis: pkg.description,
-		target: ["AppImage"],
+		target: ["AppImage", "Deb"],
 		artifactName: `superset-\${version}-\${arch}.\${ext}`,
 		// GNOME's app menus only show their heuristic "New Window" item
 		// intermittently for running apps; an explicit desktop action (the


### PR DESCRIPTION
## What & why
On Ubuntu 24.04+ the AppImage cannot use Chromium's sandbox (AppArmor restricts unprivileged user namespaces and a profile can't be pinned to an AppImage's mount point), so it must run with --no-sandbox. The Deb target ships an AppArmor userns profile via postinst and keeps the sandbox intact.

Producing the deb as a build target also adds it to latest-linux.yml, so deb installs can auto-update via electron-updater's DebUpdater.

- add Deb to the Linux electron-builder targets
- upload release/*.deb from the Linux build job (and verify it exists)
- create a stable-named Superset-<arch>.deb copy for /releases/latest/download/ URLs

## How I tested it

Installed, ran and used a .deb build on Ubuntu 24.04 LTS for over a month and observed no bugs caused by the install method.

Confirmed that auto-install does pick up the .deb correctly and attempts to download from the main repos releases, however no deb is present there so it fails to install. Once this PR is merged that won't be the case.

Have also run, linting, type check etc although this realistically doesn't have anything to do with the package distribution format. Will monitor CI test runs as well for any divergence.

Note: the commit this is based off is currently failing tests, so this will likely fail as well. No runtime code was changed, so this failure is not caused by these changes.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Linux `.deb` build target alongside the AppImage so Ubuntu 24.04+ users keep Chromium's sandbox enabled. The AppImage must run with `--no-sandbox` there because AppArmor restricts unprivileged user namespaces, while the deb ships an AppArmor userns profile via postinst that keeps the sandbox intact. The deb also overrides its desktop entry via `deb.desktop` so GNOME can match the window (`StartupWMClass`) and the New Window action execs the installed binary instead of the AppImage-only `AppRun`.

The deb is uploaded from the build job, gets a stable `Superset-<arch>.deb` copy in the release workflow for direct download URLs, and appears in `latest-linux.yml` so deb installs auto-update via `electron-updater`.

Note: the branch is based on a commit that currently fails tests; no runtime code changed, so the failure isn't caused by these changes.

<sup>Written for commit 332dde21e7b5ec9a7b3e9fae6bb16efe86bdf4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux Debian (`.deb`) packages alongside existing AppImage releases.
  - Linux `.deb` packages are now available as downloadable release artifacts for supported architectures.
  - Added stable, version-independent download filenames for architecture-specific Linux packages, making “latest” download links easier to use.
  - Debian package installations include a dedicated “New Window” launcher action for opening additional app windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->