### PR TITLE
fix(host-service): preserve consumed Claude prompts in handoffs

### DIFF
--- a/packages/host-service/src/terminal/harness-transcript.test.ts
+++ b/packages/host-service/src/terminal/harness-transcript.test.ts
@@ -35,6 +35,89 @@ afterEach(() => {
 });
 
 describe("readHarnessTranscript", () => {
+	test("preserves a consumed busy-session follow-up in conversation order", () => {
+		// Claude Code 2.1.263: a prompt entered during a tool call is first
+		// queued, then recorded as queued_command when the turn consumes it.
+		const prompt = "Keep the existing API.\nAdd a regression for empty input.";
+		const { worktreePath, sessionId } = seedClaudeSession([
+			JSON.stringify({ type: "user", message: { content: "Fix the parser." } }),
+			JSON.stringify({
+				type: "queue-operation",
+				operation: "enqueue",
+				content: prompt,
+			}),
+			JSON.stringify({
+				type: "queue-operation",
+				operation: "remove",
+				reason: "absorbed_mid_turn",
+				content: prompt,
+			}),
+			JSON.stringify({
+				type: "attachment",
+				attachment: {
+					type: "queued_command",
+					commandMode: "prompt",
+					prompt,
+					source_uuid: "follow-up",
+					origin: { kind: "human" },
+				},
+			}),
+			JSON.stringify({
+				type: "assistant",
+				message: { content: "Kept the API and added the regression." },
+			}),
+		]);
+
+		expect(
+			readHarnessTranscript({
+				agentId: "claude",
+				agentSessionId: sessionId,
+				worktreePath,
+			})?.text,
+		).toBe(
+			`User: Fix the parser.\n\nUser: ${prompt}\n\nAssistant: Kept the API and added the regression.`,
+		);
+	});
+
+	test("excludes unconsumed queue operations and unrelated attachments", () => {
+		const { worktreePath, sessionId } = seedClaudeSession([
+			JSON.stringify({
+				type: "user",
+				message: { content: "Keep this instruction." },
+			}),
+			JSON.stringify({
+				type: "queue-operation",
+				operation: "enqueue",
+				content: "Pending instruction",
+			}),
+			JSON.stringify({
+				type: "queue-operation",
+				operation: "remove",
+				content: "Removed instruction",
+			}),
+			...[
+				undefined,
+				{ type: "other", commandMode: "prompt", prompt: "Unrelated" },
+				{ type: "queued_command", commandMode: "bash", prompt: "echo shell" },
+				{ type: "queued_command", commandMode: "prompt", prompt: "  " },
+				{ type: "queued_command", commandMode: "prompt", prompt: null },
+				{
+					type: "queued_command",
+					commandMode: "prompt",
+					prompt: { text: "Malformed" },
+				},
+			].map((attachment) => JSON.stringify({ type: "attachment", attachment })),
+		]);
+
+		expect(
+			readHarnessTranscript({
+				agentId: "claude",
+				agentSessionId: sessionId,
+				worktreePath,
+			})?.text,
+		).toBe("User: Keep this instruction.");
+	});
+
 	test("reads the conversation out of Claude's own store", () => {
 		const { worktreePath, sessionId } = seedClaudeSession([
 			JSON.stringify({ type: "mode", mode: "normal" }),

--- a/packages/host-service/src/terminal/harness-transcript.ts
+++ b/packages/host-service/src/terminal/harness-transcript.ts
@@ -97,6 +97,11 @@ export function readFileTail(path: string, maxBytes: number): string | null {
 
 interface ClaudeEvent {
 	type?: string;
+	attachment?: {
+		type?: string;
+		commandMode?: string;
+		prompt?: unknown;
+	};
 	message?: {
 		role?: string;
 		content?: string | Array<{ type?: string; text?: string }>;
@@ -132,6 +137,20 @@ function readClaudeTranscript(
 			event = JSON.parse(line) as ClaudeEvent;
 		} catch {
 			continue; // a partially written final line while the session runs
+		}
+		// Claude records consumed busy-session prompts as attachments. Queue
+		// operations alone can describe input the user later removes.
+		if (event.type === "attachment") {
+			const attachment = event.attachment;
+			if (
+				attachment?.type === "queued_command" &&
+				attachment.commandMode === "prompt" &&
+				typeof attachment.prompt === "string" &&
+				attachment.prompt.trim()
+			) {
+				turns.push(`User: ${attachment.prompt.trim()}`);
+			}
+			continue;
 		}
 		if (event.type !== "user" && event.type !== "assistant") continue;
 		const text = textOf(event);


### PR DESCRIPTION
## What & why

I found this while testing Claude Code inside Superset: if you send another instruction while Claude is busy, Claude can receive it and respond, but Superset leaves that instruction out of the conversation it passes to another agent.

For example, you might tell Claude to leave a particular file alone. If you later hand the work to another agent, that agent could receive Claude's response without your instruction to leave the file alone.

This fix keeps those instructions in the conversation Superset prepares for the next agent. Claude saves instructions received while busy in a different format, which Superset was skipping. The fix reads that format and includes instructions Claude has consumed; it excludes input that is only queued or has been removed.

## How I tested it

- Bun 1.3.14: 21 focused transcript tests pass.
- The new consumed-follow-up regression fails against unchanged upstream main; the other 13 harness-reader tests pass there.
- Replayed a native Claude Code 2.1.263 trace captured through Superset: main retains the response but omits the consumed follow-up; the candidate retains both. The same difference is verified through the shared handoff prompt builder.
- Tests cover consumed prompt ordering, exclusion of queue-only records, unrelated attachments, empty and malformed prompt values, and existing transcript behavior.
- Repository lint passes locally. All 11 [exact-commit CI jobs](https://github.com/owieschon/superset/actions/runs/34081588175) pass: tests, terminal node-tests, typechecking, desktop build, lint/i18n/plugin checks, release checks, and four CLI builds.
- CodeRabbit reviewed commit `89e57c310e3a74130e1c5d6784e2bc443cf669dd` with no actionable comments.

The native trace was replayed through the reader and shared prompt builder. A live destination agent and the desktop handoff dialog were not exercised. No UI layout changes are included. Local broad typechecking was stopped under memory pressure; hosted CI runs the full checks. The separate preview deployment cannot run because this fork has no Neon API key.

## Checklist

- [x] PR title follows conventional commits
- [x] One independently useful behavior; two files changed
- [x] Failing-before / passing-after evidence
- [x] Full repository validation complete in exact-commit hosted CI

Validated against upstream main at `b4e5d618e5f44309b80f735a7a3448cb3681089a`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Code handoffs dropping prompts received while Claude was busy, so the next agent now sees those instructions in the conversation.

- Reads consumed busy-session prompts from `queued_command` attachments.
- Still excludes input that was only queued, removed, or malformed.

<sup>Written for commit 8df7acc35eb3a36cc206a96a552ca6174a5efaa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Claude conversation transcripts now preserve valid queued follow-up prompts in the correct order.
  - Non-prompt commands, unrelated attachments, blank or null prompts, and malformed prompt entries are excluded from transcripts.
  - Transcript history more accurately reflects the conversation by including only valid user prompts and relevant assistant exchanges.

- **Tests**
  - Added regression coverage for queued follow-up handling, conversation ordering, and transcript filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->