### PR TITLE
fix(port-scanner): detect detached agent dev servers

### DIFF
--- a/packages/port-scanner/src/detached.test.ts
+++ b/packages/port-scanner/src/detached.test.ts
@@ -102,7 +102,7 @@ describe("DetachedProcessResolver", () => {
 		expect(reads).toHaveLength(0);
 	});
 
-	it("caches environment per pid and evicts on exit or reparent", async () => {
+	it("refreshes environment each scan and follows exits and reparenting", async () => {
 		const { resolver, reads, env } = harness(new Map([[500, TERMINAL]]));
 		const args = { excludePids: tree, terminalIds: new Set([TERMINAL]) };
 
@@ -110,7 +110,7 @@ describe("DetachedProcessResolver", () => {
 		expect(reads).toHaveLength(1);
 
 		await resolver.resolve({ table, ...args });
-		expect(reads).toHaveLength(1);
+		expect(reads).toHaveLength(2);
 
 		// 900 exits, 901 appears, and 501's parent dies so it reparents to 1.
 		const next = table
@@ -119,10 +119,39 @@ describe("DetachedProcessResolver", () => {
 			.concat([{ pid: 901, ppid: 1 }]);
 		env.set(501, TERMINAL);
 		const resolved = await resolver.resolve({ table: next, ...args });
-		expect(reads).toHaveLength(2);
-		expect(reads[1]).toEqual([501, 901]);
+		expect(reads).toHaveLength(3);
+		expect(reads[2]).toEqual([1, 50, 501, 502, 901]);
 		expect(resolved.get(501)).toBe(TERMINAL);
 		expect(resolved.get(502)).toBe(TERMINAL);
+	});
+
+	it("does not retain ownership when a PID is reused with the same parent", async () => {
+		const { resolver, reads, env } = harness(new Map([[500, TERMINAL]]));
+		const args = {
+			table,
+			excludePids: tree,
+			terminalIds: new Set([TERMINAL, OTHER]),
+		};
+		expect((await resolver.resolve(args)).get(502)).toBe(TERMINAL);
+
+		// PID 500 exits and is reused between snapshots, still parented to PID 1.
+		env.set(500, OTHER);
+		const replaced = await resolver.resolve(args);
+		expect(replaced.get(500)).toBe(OTHER);
+		expect(replaced.get(502)).toBe(OTHER);
+		expect(reads).toHaveLength(2);
+
+		// Another replacement has no terminal owner at all.
+		env.delete(500);
+		expect((await resolver.resolve(args)).size).toBe(0);
+	});
+
+	it("retries an unreadable environment on the next scan", async () => {
+		const { resolver, env } = harness(new Map());
+		const args = { table, excludePids: tree, terminalIds: new Set([TERMINAL]) };
+		expect((await resolver.resolve(args)).size).toBe(0);
+		env.set(500, TERMINAL);
+		expect((await resolver.resolve(args)).get(500)).toBe(TERMINAL);
 	});
 
 	it("passes the abort signal to the reader", async () => {

--- a/packages/port-scanner/src/detached.test.ts
+++ b/packages/port-scanner/src/detached.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import { DetachedProcessResolver } from "./detached.ts";
+
+const TERMINAL = "11111111-1111-1111-1111-111111111111";
+const OTHER = "22222222-2222-2222-2222-222222222222";
+
+interface Harness {
+	resolver: DetachedProcessResolver;
+	reads: number[][];
+	env: Map<number, string | null>;
+}
+
+function harness(env: Map<number, string | null>): Harness {
+	const reads: number[][] = [];
+	const resolver = new DetachedProcessResolver(async (pids) => {
+		reads.push(pids);
+		return new Map(pids.map((pid) => [pid, env.get(pid) ?? null]));
+	});
+	return { resolver, reads, env };
+}
+
+/**
+ * shell 100 (tree: 100, 101) · orphaned server root 500 → 501 → 502 with
+ * only the root's environment readable · unrelated daemon 900.
+ */
+const table = [
+	{ pid: 1, ppid: 0 },
+	{ pid: 50, ppid: 1 },
+	{ pid: 100, ppid: 50 },
+	{ pid: 101, ppid: 100 },
+	{ pid: 500, ppid: 1 },
+	{ pid: 501, ppid: 500 },
+	{ pid: 502, ppid: 501 },
+	{ pid: 900, ppid: 1 },
+];
+const tree = new Set([100, 101]);
+
+describe("DetachedProcessResolver", () => {
+	it("attributes an orphaned root and its descendants via the root's environment", async () => {
+		const { resolver } = harness(new Map([[500, TERMINAL]]));
+		const resolved = await resolver.resolve({
+			table,
+			excludePids: tree,
+			terminalIds: new Set([TERMINAL]),
+		});
+		expect([...resolved.entries()]).toEqual([
+			[500, TERMINAL],
+			[501, TERMINAL],
+			[502, TERMINAL],
+		]);
+	});
+
+	it("never reads the environment of tree pids, and skips them in the result", async () => {
+		const { resolver, reads } = harness(new Map([[100, TERMINAL]]));
+		const resolved = await resolver.resolve({
+			table,
+			excludePids: tree,
+			terminalIds: new Set([TERMINAL]),
+		});
+		expect(reads[0]).not.toContain(100);
+		expect(reads[0]).not.toContain(101);
+		expect(resolved.size).toBe(0);
+	});
+
+	it("the nearest ancestor's id wins over a farther one", async () => {
+		// 501 was launched with a different terminal id than its parent 500 —
+		// e.g. a nested Superset's own shells. 502 inherits from 501.
+		const { resolver } = harness(
+			new Map([
+				[500, TERMINAL],
+				[501, OTHER],
+			]),
+		);
+		const resolved = await resolver.resolve({
+			table,
+			excludePids: tree,
+			terminalIds: new Set([TERMINAL, OTHER]),
+		});
+		expect(resolved.get(500)).toBe(TERMINAL);
+		expect(resolved.get(501)).toBe(OTHER);
+		expect(resolved.get(502)).toBe(OTHER);
+	});
+
+	it("drops ids that are not registered terminals", async () => {
+		const { resolver } = harness(new Map([[500, OTHER]]));
+		const resolved = await resolver.resolve({
+			table,
+			excludePids: tree,
+			terminalIds: new Set([TERMINAL]),
+		});
+		expect(resolved.size).toBe(0);
+	});
+
+	it("returns nothing and reads nothing when no terminals are registered", async () => {
+		const { resolver, reads } = harness(new Map([[500, TERMINAL]]));
+		const resolved = await resolver.resolve({
+			table,
+			excludePids: tree,
+			terminalIds: new Set(),
+		});
+		expect(resolved.size).toBe(0);
+		expect(reads).toHaveLength(0);
+	});
+
+	it("caches environment per pid and evicts on exit or reparent", async () => {
+		const { resolver, reads, env } = harness(new Map([[500, TERMINAL]]));
+		const args = { excludePids: tree, terminalIds: new Set([TERMINAL]) };
+
+		await resolver.resolve({ table, ...args });
+		expect(reads).toHaveLength(1);
+
+		await resolver.resolve({ table, ...args });
+		expect(reads).toHaveLength(1);
+
+		// 900 exits, 901 appears, and 501's parent dies so it reparents to 1.
+		const next = table
+			.filter((row) => row.pid !== 900 && row.pid !== 500)
+			.map((row) => (row.pid === 501 ? { pid: 501, ppid: 1 } : row))
+			.concat([{ pid: 901, ppid: 1 }]);
+		env.set(501, TERMINAL);
+		const resolved = await resolver.resolve({ table: next, ...args });
+		expect(reads).toHaveLength(2);
+		expect(reads[1]).toEqual([501, 901]);
+		expect(resolved.get(501)).toBe(TERMINAL);
+		expect(resolved.get(502)).toBe(TERMINAL);
+	});
+
+	it("passes the abort signal to the reader", async () => {
+		let seen: AbortSignal | undefined;
+		const resolver = new DetachedProcessResolver(async (pids, signal) => {
+			seen = signal;
+			return new Map(pids.map((pid) => [pid, null]));
+		});
+		const controller = new AbortController();
+		await resolver.resolve({
+			table,
+			excludePids: tree,
+			terminalIds: new Set([TERMINAL]),
+			signal: controller.signal,
+		});
+		expect(seen).toBe(controller.signal);
+	});
+});

--- a/packages/port-scanner/src/detached.test.ts
+++ b/packages/port-scanner/src/detached.test.ts
@@ -36,6 +36,45 @@ const table = [
 const tree = new Set([100, 101]);
 
 describe("DetachedProcessResolver", () => {
+	it("fails closed when an unreadable listener loses its last readable ancestor", async () => {
+		const { resolver, env } = harness(new Map([[500, TERMINAL]]));
+		const args = { excludePids: tree, terminalIds: new Set([TERMINAL]) };
+		expect((await resolver.resolve({ table, ...args })).get(501)).toBe(
+			TERMINAL,
+		);
+		env.delete(500);
+		const orphaned = table
+			.filter((row) => row.pid !== 500)
+			.map((row) => (row.pid === 501 ? { ...row, ppid: 1 } : row));
+		// Without readable provenance, guessing would risk attributing another process.
+		expect((await resolver.resolve({ table: orphaned, ...args })).size).toBe(0);
+	});
+
+	it("resolves a large snapshot once per scan without mixing terminal owners", async () => {
+		const rows = Array.from({ length: 10000 }, (_, i) => ({
+			pid: i + 1000,
+			ppid: i % 2 === 0 ? 500 : 600,
+		}));
+		const largeTable = [{ pid: 500, ppid: 1 }, { pid: 600, ppid: 1 }, ...rows];
+		const { resolver, reads } = harness(
+			new Map([
+				[500, TERMINAL],
+				[600, OTHER],
+			]),
+		);
+		const args = {
+			table: largeTable,
+			excludePids: new Set<number>(),
+			terminalIds: new Set([TERMINAL, OTHER]),
+		};
+		for (let scan = 0; scan < 3; scan++) {
+			const result = await resolver.resolve(args);
+			expect(result.size).toBe(10002);
+			for (const row of rows)
+				expect(result.get(row.pid)).toBe(row.ppid === 500 ? TERMINAL : OTHER);
+		}
+		expect(reads).toHaveLength(3);
+	});
 	it("attributes an orphaned root and its descendants via the root's environment", async () => {
 		const { resolver } = harness(new Map([[500, TERMINAL]]));
 		const resolved = await resolver.resolve({

--- a/packages/port-scanner/src/detached.ts
+++ b/packages/port-scanner/src/detached.ts
@@ -1,0 +1,115 @@
+import type { ProcessTableEntry } from "./scanner.ts";
+import { readTerminalIdsFromEnv } from "./terminal-env.ts";
+
+export type TerminalEnvReader = (
+	pids: number[],
+	signal?: AbortSignal,
+) => Promise<Map<number, string | null>>;
+
+interface CacheEntry {
+	ppid: number;
+	terminalId: string | null;
+}
+
+/** Bound the ancestor walk; a real process chain is never this deep. */
+const MAX_ANCESTOR_DEPTH = 64;
+
+/**
+ * Attributes processes that live outside every session's process tree to the
+ * terminal whose environment they inherited.
+ *
+ * Agents routinely start dev servers detached: Claude Code's background Bash
+ * and Codex's background shells spawn with a fresh session and no controlling
+ * TTY, and once the wrapper shell exits the server is reparented to PID 1.
+ * The ppid walk from the terminal's shell can't see it, but every descendant
+ * still carries SUPERSET_TERMINAL_ID.
+ *
+ * Environment is read once per pid and cached — a process's environment is
+ * fixed at exec — and re-read only when the pid leaves the table or changes
+ * parent (reparenting, or pid reuse). A pid whose own environment is
+ * unreadable inherits the nearest ancestor's id, which covers processes that
+ * clobber their argv area on macOS (see readTerminalIdsFromEnv).
+ */
+export class DetachedProcessResolver {
+	private readonly cache = new Map<number, CacheEntry>();
+	private readonly readEnv: TerminalEnvReader;
+
+	constructor(readEnv: TerminalEnvReader = readTerminalIdsFromEnv) {
+		this.readEnv = readEnv;
+	}
+
+	/**
+	 * pid → terminal id for every process in `table` that is not in
+	 * `excludePids` (the session trees) and resolves to one of `terminalIds`.
+	 */
+	async resolve({
+		table,
+		excludePids,
+		terminalIds,
+		signal,
+	}: {
+		table: ProcessTableEntry[];
+		excludePids: Set<number>;
+		terminalIds: Set<string>;
+		signal?: AbortSignal;
+	}): Promise<Map<number, string>> {
+		const resolved = new Map<number, string>();
+		if (terminalIds.size === 0) return resolved;
+
+		const ppidByPid = new Map<number, number>();
+		for (const { pid, ppid } of table) ppidByPid.set(pid, ppid);
+
+		for (const [pid, entry] of this.cache) {
+			const ppid = ppidByPid.get(pid);
+			if (ppid === undefined || ppid !== entry.ppid) this.cache.delete(pid);
+		}
+
+		const uncached: number[] = [];
+		for (const { pid } of table) {
+			if (excludePids.has(pid) || this.cache.has(pid)) continue;
+			uncached.push(pid);
+		}
+		if (uncached.length > 0) {
+			const read = await this.readEnv(uncached, signal);
+			for (const pid of uncached) {
+				const ppid = ppidByPid.get(pid);
+				if (ppid === undefined) continue;
+				this.cache.set(pid, { ppid, terminalId: read.get(pid) ?? null });
+			}
+		}
+
+		const memo = new Map<number, string | null>();
+		const lookup = (startPid: number): string | null => {
+			const path: number[] = [];
+			let pid = startPid;
+			let found: string | null = null;
+			for (let depth = 0; depth < MAX_ANCESTOR_DEPTH; depth++) {
+				const memoized = memo.get(pid);
+				if (memoized !== undefined) {
+					found = memoized;
+					break;
+				}
+				path.push(pid);
+				const terminalId = this.cache.get(pid)?.terminalId ?? null;
+				if (terminalId !== null) {
+					found = terminalId;
+					break;
+				}
+				const ppid = ppidByPid.get(pid);
+				if (ppid === undefined || ppid <= 1 || ppid === pid) break;
+				pid = ppid;
+			}
+			for (const visited of path) memo.set(visited, found);
+			return found;
+		};
+
+		for (const { pid } of table) {
+			if (excludePids.has(pid)) continue;
+			const terminalId = lookup(pid);
+			if (terminalId !== null && terminalIds.has(terminalId)) {
+				resolved.set(pid, terminalId);
+			}
+		}
+		return resolved;
+	}
+}

--- a/packages/port-scanner/src/detached.ts
+++ b/packages/port-scanner/src/detached.ts
@@ -6,11 +6,6 @@ export type TerminalEnvReader = (
 	signal?: AbortSignal,
 ) => Promise<Map<number, string | null>>;
 
-interface CacheEntry {
-	ppid: number;
-	terminalId: string | null;
-}
-
 /** Bound the ancestor walk; a real process chain is never this deep. */
 const MAX_ANCESTOR_DEPTH = 64;
 
@@ -24,14 +19,14 @@ const MAX_ANCESTOR_DEPTH = 64;
  * The ppid walk from the terminal's shell can't see it, but every descendant
  * still carries SUPERSET_TERMINAL_ID.
  *
- * Environment is read once per pid and cached — a process's environment is
- * fixed at exec — and re-read only when the pid leaves the table or changes
- * parent (reparenting, or pid reuse). A pid whose own environment is
+ * Environment is read afresh each scan. PID and PPID alone cannot identify a
+ * process instance: a PID may be reused with the same parent between scans.
+ * Without a stable instance identifier, caching could assign an unrelated
+ * listener to a terminal and expose it for termination. A pid whose environment is
  * unreadable inherits the nearest ancestor's id, which covers processes that
  * clobber their argv area on macOS (see readTerminalIdsFromEnv).
  */
 export class DetachedProcessResolver {
-	private readonly cache = new Map<number, CacheEntry>();
 	private readonly readEnv: TerminalEnvReader;
 
 	constructor(readEnv: TerminalEnvReader = readTerminalIdsFromEnv) {
@@ -59,24 +54,13 @@ export class DetachedProcessResolver {
 		const ppidByPid = new Map<number, number>();
 		for (const { pid, ppid } of table) ppidByPid.set(pid, ppid);
 
-		for (const [pid, entry] of this.cache) {
-			const ppid = ppidByPid.get(pid);
-			if (ppid === undefined || ppid !== entry.ppid) this.cache.delete(pid);
-		}
-
-		const uncached: number[] = [];
-		for (const { pid } of table) {
-			if (excludePids.has(pid) || this.cache.has(pid)) continue;
-			uncached.push(pid);
-		}
-		if (uncached.length > 0) {
-			const read = await this.readEnv(uncached, signal);
-			for (const pid of uncached) {
-				const ppid = ppidByPid.get(pid);
-				if (ppid === undefined) continue;
-				this.cache.set(pid, { ppid, terminalId: read.get(pid) ?? null });
-			}
-		}
+		const candidates = table
+			.filter(({ pid }) => !excludePids.has(pid))
+			.map(({ pid }) => pid);
+		const terminalIdByPid =
+			candidates.length > 0
+				? await this.readEnv(candidates, signal)
+				: new Map<number, string | null>();
 
 		const memo = new Map<number, string | null>();
 		const lookup = (startPid: number): string | null => {
@@ -90,7 +74,7 @@ export class DetachedProcessResolver {
 					break;
 				}
 				path.push(pid);
-				const terminalId = this.cache.get(pid)?.terminalId ?? null;
+				const terminalId = terminalIdByPid.get(pid) ?? null;
 				if (terminalId !== null) {
 					found = terminalId;
 					break;

--- a/packages/port-scanner/src/exec.test.ts
+++ b/packages/port-scanner/src/exec.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { runTolerant } from "./exec.ts";
+
+const options = { maxBuffer: 1024, timeout: 5000 };
+
+describe("runTolerant", () => {
+	it("returns stdout on success", async () => {
+		expect(
+			await runTolerant(
+				process.execPath,
+				["-e", 'process.stdout.write("ok")'],
+				options,
+			),
+		).toBe("ok");
+	});
+
+	it("preserves partial results from a numeric nonzero exit", async () => {
+		expect(
+			await runTolerant(
+				process.execPath,
+				["-e", 'process.stdout.write("partial"); process.exitCode = 1'],
+				options,
+			),
+		).toBe("partial");
+	});
+
+	it("rejects truncated output on maxBuffer overflow", async () => {
+		await expect(
+			runTolerant(
+				process.execPath,
+				["-e", 'process.stdout.write("x".repeat(4096))'],
+				{ ...options, maxBuffer: 1 },
+			),
+		).rejects.toThrow();
+	});
+
+	it("rejects spawn failures instead of returning empty stdout", async () => {
+		await expect(
+			runTolerant("/nonexistent-superset-test-executable", [], options),
+		).rejects.toThrow();
+	});
+
+	it("propagates cancellation", async () => {
+		await expect(
+			runTolerant(process.execPath, ["-e", ""], {
+				...options,
+				signal: AbortSignal.abort(),
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/port-scanner/src/exec.ts
+++ b/packages/port-scanner/src/exec.ts
@@ -1,0 +1,48 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Timeout for shell commands to prevent hanging (ms) */
+export const EXEC_TIMEOUT_MS = 5000;
+
+/**
+ * Run execFile and tolerate a plain non-zero exit by returning its stdout.
+ * lsof exits 1 when no PIDs match the filter, and ps exits 1 when any listed
+ * pid is gone — both are legitimate partial results. Aborts, timeouts, and
+ * signal-kills are NOT tolerated: partial stdout from a killed child is not a
+ * trustworthy snapshot, so rethrow and let the caller's outer catch turn it
+ * into an empty result.
+ */
+export async function runTolerant(
+	file: string,
+	args: string[],
+	options: { maxBuffer: number; timeout: number; signal?: AbortSignal },
+): Promise<string> {
+	try {
+		const { stdout } = await execFileAsync(file, args, options);
+		return stdout;
+	} catch (err) {
+		if (err && typeof err === "object") {
+			const execErr = err as {
+				stdout?: string | Buffer;
+				code?: unknown;
+				killed?: boolean;
+				signal?: unknown;
+				name?: string;
+			};
+			if (
+				execErr.name === "AbortError" ||
+				execErr.code === "ABORT_ERR" ||
+				execErr.killed ||
+				execErr.signal
+			) {
+				throw err;
+			}
+			if ("stdout" in execErr) {
+				return String(execErr.stdout ?? "");
+			}
+		}
+		throw err;
+	}
+}

--- a/packages/port-scanner/src/exec.ts
+++ b/packages/port-scanner/src/exec.ts
@@ -39,7 +39,7 @@ export async function runTolerant(
 			) {
 				throw err;
 			}
-			if ("stdout" in execErr) {
+			if (typeof execErr.code === "number" && "stdout" in execErr) {
 				return String(execErr.stdout ?? "");
 			}
 		}

--- a/packages/port-scanner/src/index.ts
+++ b/packages/port-scanner/src/index.ts
@@ -4,13 +4,17 @@ export {
 	type PortManagerOptions,
 } from "./port-manager.ts";
 export {
+	buildProcessTrees,
 	getListeningPortsForPids,
 	getProcessTreesForPids,
 	type PortInfo,
+	type ProcessTableEntry,
+	readProcessTable,
 } from "./scanner.ts";
 export {
 	parseStaticPortsConfig,
 	type StaticPortLabel,
 	type StaticPortsParseResult,
 } from "./static-ports.ts";
+export { readTerminalIdsFromEnv } from "./terminal-env.ts";
 export type { DetectedPort } from "./types.ts";

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -70,6 +70,8 @@ let lsofDelayMs = 0;
 let listeningPorts: MockPortInfo[] = [];
 /** When set, the table-read mock blocks until the test resolves this promise. */
 let treeGate: Promise<void> | null = null;
+let envGate: Promise<void> | null = null;
+let envError: Error | null = null;
 /**
  * Process table seen by the detached-process pass. Session trees are mocked
  * separately (root → [root, root+1]), so this only needs the extra rows a
@@ -122,6 +124,8 @@ mock.module("./terminal-env", () => ({
 	readTerminalIdsFromEnv: async (pids: number[]) => {
 		spy.envReads++;
 		spy.lastEnvReadPids = pids;
+		if (envGate) await envGate;
+		if (envError) throw envError;
 		return new Map(pids.map((pid) => [pid, terminalIdEnv.get(pid) ?? null]));
 	},
 }));
@@ -170,6 +174,8 @@ function resetSpy(): void {
 	lsofDelayMs = 0;
 	listeningPorts = [];
 	treeGate = null;
+	envGate = null;
+	envError = null;
 }
 
 beforeEach(() => {
@@ -376,6 +382,10 @@ describe("PortManager — killPort", () => {
 		});
 
 		killManager.upsertSession("p1", "ws1", 1000);
+		processTable = [
+			{ pid: 1000, ppid: 500 },
+			{ pid: 1001, ppid: 1000 },
+		];
 		listeningPorts = [
 			{ port: 3000, pid: 1001, address: "127.0.0.1", processName: "node" },
 		];
@@ -716,6 +726,191 @@ describe("PortManager — detached servers (agent background processes)", () => 
 			[7000, "some-other-terminal"],
 		]);
 	}
+
+	it("treats a sibling port as already closed when an earlier kill stopped the shared process", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				processTable = processTable.filter((row) => row.pid !== pid);
+				listeningPorts = [];
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [3000, 3001].map((port) => ({
+			port,
+			pid: 5000,
+			address: "127.0.0.1",
+			processName: "node",
+		}));
+		await manager.forceScan();
+		for (const port of [3000, 3001]) {
+			expect(
+				(
+					await manager.killPort({
+						terminalId: TERMINAL,
+						workspaceId: "ws1",
+						port,
+					})
+				).success,
+			).toBe(true);
+		}
+		expect(killed).toEqual([5000]);
+	});
+
+	it("does not kill a detached PID whose owner changed since the last scan", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		terminalIdEnv.set(5000, "some-other-terminal");
+		// Deliberately do not rescan before clicking the stale control.
+		expect(
+			(
+				await manager.killPort({
+					terminalId: TERMINAL,
+					workspaceId: "ws1",
+					port: 3000,
+				})
+			).success,
+		).toBe(false);
+		expect(killed).toEqual([]);
+	});
+
+	it("does not kill a PID that stopped listening, even if ownership still matches", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		listeningPorts = [];
+		expect(
+			(
+				await manager.killPort({
+					terminalId: TERMINAL,
+					workspaceId: "ws1",
+					port: 3000,
+				})
+			).success,
+		).toBe(false);
+		expect(killed).toEqual([]);
+	});
+
+	it("does not authorize a kill when environment inspection fails", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		envError = new Error("ps timed out");
+		expect(
+			(
+				await manager.killPort({
+					terminalId: TERMINAL,
+					workspaceId: "ws1",
+					port: 3000,
+				})
+			).success,
+		).toBe(false);
+		expect(killed).toEqual([]);
+	});
+
+	it("preserves ports and retries after a failed environment snapshot", async () => {
+		detachedServerTable();
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		const session = pmInternals().sessions.get(TERMINAL);
+		if (!session) throw new Error("missing session");
+		session.lastScannedAt = 1;
+		envError = new Error("ps timed out");
+		await expect(manager.forceScan()).rejects.toThrow("ps timed out");
+		expect(manager.getAllPorts()).toHaveLength(1);
+		expect(session.lastScannedAt).toBe(1);
+		envError = null;
+		await manager.forceScan();
+		expect(manager.getAllPorts()).toHaveLength(1);
+		expect(session.lastScannedAt).toBeGreaterThan(1);
+	});
+
+	it("discards results when a terminal is replaced during environment inspection", async () => {
+		detachedServerTable();
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		let release!: () => void;
+		envGate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const scanning = manager.forceScan();
+		await sleep(0);
+		expect(spy.envReads).toBe(1);
+		manager.upsertSession(TERMINAL, "ws1", 2000);
+		release();
+		await scanning;
+		expect(manager.getAllPorts()).toHaveLength(0);
+		expect(pmInternals().sessions.get(TERMINAL)?.lastScannedAt).toBe(0);
+	});
+
+	it("does not kill if the terminal is replaced while validating the request", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		let release!: () => void;
+		envGate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const killing = manager.killPort({
+			terminalId: TERMINAL,
+			workspaceId: "ws1",
+			port: 3000,
+		});
+		await sleep(0);
+		manager.upsertSession(TERMINAL, "ws1", 2000);
+		release();
+		expect((await killing).success).toBe(false);
+		expect(killed).toEqual([]);
+	});
 
 	it("attributes a reparented server to the terminal in its environment", async () => {
 		detachedServerTable();

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -12,8 +12,10 @@ import type { DetectedPort } from "./types";
 // mock.module leaks across test files in the same bun process — hold the real
 // module and restore it after this file so scanner.test.ts tests the real one.
 const realScanner = { ...(await import("./scanner.ts")) };
+const realTerminalEnv = { ...(await import("./terminal-env.ts")) };
 afterAll(() => {
 	mock.module("./scanner", () => realScanner);
+	mock.module("./terminal-env", () => realTerminalEnv);
 });
 
 /**
@@ -34,6 +36,9 @@ afterAll(() => {
 interface ScannerSpy {
 	getProcessTrees: number;
 	lastTreeRootPids: number[];
+	lastListeningPids: number[];
+	envReads: number;
+	lastEnvReadPids: number[];
 	getListeningPortsForPids: number;
 	inFlight: number;
 	maxInFlight: number;
@@ -51,6 +56,9 @@ interface MockPortInfo {
 const spy: ScannerSpy = {
 	getProcessTrees: 0,
 	lastTreeRootPids: [],
+	lastListeningPids: [],
+	envReads: 0,
+	lastEnvReadPids: [],
 	getListeningPortsForPids: 0,
 	inFlight: 0,
 	maxInFlight: 0,
@@ -60,18 +68,33 @@ const spy: ScannerSpy = {
 
 let lsofDelayMs = 0;
 let listeningPorts: MockPortInfo[] = [];
-/** When set, the tree mock blocks until the test resolves this promise. */
+/** When set, the table-read mock blocks until the test resolves this promise. */
 let treeGate: Promise<void> | null = null;
+/**
+ * Process table seen by the detached-process pass. Session trees are mocked
+ * separately (root → [root, root+1]), so this only needs the extra rows a
+ * test cares about.
+ */
+let processTable: { pid: number; ppid: number }[] = [];
+/** pid → terminal id the mocked environment reader reports. */
+let terminalIdEnv = new Map<number, string | null>();
 
 mock.module("./scanner", () => ({
-	getProcessTreesForPids: async (rootPids: number[]) => {
+	readProcessTable: async () => {
 		spy.getProcessTrees++;
-		spy.lastTreeRootPids = rootPids;
 		if (treeGate) await treeGate;
+		return processTable;
+	},
+	buildProcessTrees: (
+		_table: { pid: number; ppid: number }[],
+		rootPids: number[],
+	) => {
+		spy.lastTreeRootPids = rootPids;
 		return new Map(rootPids.map((pid) => [pid, [pid, pid + 1]]));
 	},
-	getListeningPortsForPids: async (_pids: number[], signal?: AbortSignal) => {
+	getListeningPortsForPids: async (pids: number[], signal?: AbortSignal) => {
 		spy.getListeningPortsForPids++;
+		spy.lastListeningPids = pids;
 		spy.inFlight++;
 		spy.maxInFlight = Math.max(spy.maxInFlight, spy.inFlight);
 		spy.lastSignal = signal;
@@ -92,6 +115,14 @@ mock.module("./scanner", () => ({
 		} finally {
 			spy.inFlight--;
 		}
+	},
+}));
+
+mock.module("./terminal-env", () => ({
+	readTerminalIdsFromEnv: async (pids: number[]) => {
+		spy.envReads++;
+		spy.lastEnvReadPids = pids;
+		return new Map(pids.map((pid) => [pid, terminalIdEnv.get(pid) ?? null]));
 	},
 }));
 
@@ -126,7 +157,12 @@ const pmInternals = () =>
 function resetSpy(): void {
 	spy.getProcessTrees = 0;
 	spy.lastTreeRootPids = [];
+	spy.lastListeningPids = [];
+	spy.envReads = 0;
+	spy.lastEnvReadPids = [];
 	spy.getListeningPortsForPids = 0;
+	processTable = [];
+	terminalIdEnv = new Map();
 	spy.inFlight = 0;
 	spy.maxInFlight = 0;
 	spy.lastSignal = undefined;
@@ -654,5 +690,119 @@ describe("PortManager — idle decay (sessions without output scan rarely)", () 
 
 		expect(manager.getAllPorts()).toHaveLength(0);
 		expect(session("p1").lastScannedAt).toBe(0);
+	});
+});
+
+describe("PortManager — detached servers (agent background processes)", () => {
+	const TERMINAL = "term-a";
+
+	/**
+	 * Shell 1000 → tree [1000, 1001]. An agent's background `bun dev` (5000)
+	 * was setsid'd and reparented to PID 1 once its wrapper shell exited; the
+	 * actual listener (5001) is its child and, having set a process title, has
+	 * an unreadable environment on macOS.
+	 */
+	function detachedServerTable(): void {
+		processTable = [
+			{ pid: 1000, ppid: 500 },
+			{ pid: 1001, ppid: 1000 },
+			{ pid: 5000, ppid: 1 },
+			{ pid: 5001, ppid: 5000 },
+			{ pid: 7000, ppid: 1 },
+		];
+		terminalIdEnv = new Map([
+			[5000, TERMINAL],
+			[5001, null],
+			[7000, "some-other-terminal"],
+		]);
+	}
+
+	it("attributes a reparented server to the terminal in its environment", async () => {
+		detachedServerTable();
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5001, address: "127.0.0.1", processName: "node" },
+		];
+
+		await manager.forceScan();
+
+		// Tree pids are never read from the environment; everything else is.
+		expect(spy.lastEnvReadPids).toEqual([5000, 5001, 7000]);
+		expect(spy.lastListeningPids).toEqual([1000, 1001, 5000, 5001]);
+		const ports = manager.getAllPorts();
+		expect(ports).toHaveLength(1);
+		expect(ports[0]).toMatchObject({
+			port: 3000,
+			pid: 5001,
+			terminalId: TERMINAL,
+			workspaceId: "ws1",
+		});
+	});
+
+	it("ignores processes owned by a terminal that is not registered", async () => {
+		detachedServerTable();
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 4000, pid: 7000, address: "127.0.0.1", processName: "node" },
+		];
+
+		await manager.forceScan();
+		expect(spy.lastListeningPids).not.toContain(7000);
+		expect(manager.getAllPorts()).toHaveLength(0);
+	});
+
+	it("does not attach detached pids to a session that is not due this scan", async () => {
+		detachedServerTable();
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		const entry = pmInternals().sessions.get(TERMINAL);
+		if (!entry) throw new Error("missing session");
+		entry.lastActivityAt = Date.now() - IDLE_AFTER_MS - 1;
+		entry.lastScannedAt = Date.now();
+
+		await pmInternals().scanAllSessions();
+		expect(spy.envReads).toBe(0);
+		expect(spy.getListeningPortsForPids).toBe(0);
+	});
+
+	it("reads each pid's environment once and re-reads only newcomers", async () => {
+		detachedServerTable();
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+
+		await manager.forceScan();
+		expect(spy.envReads).toBe(1);
+
+		await manager.forceScan();
+		expect(spy.envReads).toBe(1);
+
+		processTable.push({ pid: 5002, ppid: 5000 });
+		await manager.forceScan();
+		expect(spy.envReads).toBe(2);
+		expect(spy.lastEnvReadPids).toEqual([5002]);
+		// The newcomer inherits its parent's terminal even with no env of its own.
+		expect(spy.lastListeningPids).toContain(5002);
+	});
+
+	it("kills a detached server through the port's own pid", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5001, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+
+		const result = await manager.killPort({
+			terminalId: TERMINAL,
+			workspaceId: "ws1",
+			port: 3000,
+		});
+		expect(result.success).toBe(true);
+		expect(killed).toEqual([5001]);
 	});
 });

--- a/packages/port-scanner/src/port-manager.test.ts
+++ b/packages/port-scanner/src/port-manager.test.ts
@@ -764,7 +764,7 @@ describe("PortManager — detached servers (agent background processes)", () => 
 		expect(spy.getListeningPortsForPids).toBe(0);
 	});
 
-	it("reads each pid's environment once and re-reads only newcomers", async () => {
+	it("refreshes detached environments each scan, including newcomers", async () => {
 		detachedServerTable();
 		manager.upsertSession(TERMINAL, "ws1", 1000);
 
@@ -772,14 +772,43 @@ describe("PortManager — detached servers (agent background processes)", () => 
 		expect(spy.envReads).toBe(1);
 
 		await manager.forceScan();
-		expect(spy.envReads).toBe(1);
+		expect(spy.envReads).toBe(2);
 
 		processTable.push({ pid: 5002, ppid: 5000 });
 		await manager.forceScan();
-		expect(spy.envReads).toBe(2);
-		expect(spy.lastEnvReadPids).toEqual([5002]);
+		expect(spy.envReads).toBe(3);
+		expect(spy.lastEnvReadPids).toEqual([5000, 5001, 7000, 5002]);
 		// The newcomer inherits its parent's terminal even with no env of its own.
 		expect(spy.lastListeningPids).toContain(5002);
+	});
+
+	it("removes a reused PID from the old terminal's ports and kill controls", async () => {
+		detachedServerTable();
+		const killed: number[] = [];
+		manager = new PortManager({
+			killFn: async ({ pid }) => {
+				killed.push(pid);
+				return { success: true };
+			},
+		});
+		manager.upsertSession(TERMINAL, "ws1", 1000);
+		listeningPorts = [
+			{ port: 3000, pid: 5000, address: "127.0.0.1", processName: "node" },
+		];
+		await manager.forceScan();
+		expect(manager.getAllPorts()).toHaveLength(1);
+
+		// A new listener reuses both PID and parent between process snapshots.
+		terminalIdEnv.set(5000, null);
+		await manager.forceScan();
+		expect(manager.getAllPorts()).toHaveLength(0);
+		expect(spy.lastListeningPids).not.toContain(5000);
+		await manager.killPort({
+			terminalId: TERMINAL,
+			workspaceId: "ws1",
+			port: 3000,
+		});
+		expect(killed).toEqual([]);
 	});
 
 	it("kills a detached server through the port's own pid", async () => {

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -110,10 +110,13 @@ interface SessionEntry {
 }
 
 interface ScanState {
-	terminalPortMap: Map<string, { workspaceId: string; pids: number[] }>;
+	terminalPortMap: Map<
+		string,
+		{ workspaceId: string; pids: number[]; session: SessionEntry }
+	>;
 	pidOwnerMap: Map<number, { terminalId: string; workspaceId: string }>;
 	allPids: Set<number>;
-	emptyTreeTerminals: Set<string>;
+	emptyTreeTerminals: Map<string, SessionEntry>;
 }
 
 /**
@@ -161,11 +164,16 @@ export class PortManager extends EventEmitter {
 		pid: number | null,
 	): void {
 		const existing = this.sessions.get(terminalId);
-		if (existing && existing.pid === pid) {
+		if (
+			existing &&
+			existing.pid === pid &&
+			existing.workspaceId === workspaceId
+		) {
 			// Re-upserts (e.g. the reaper's periodic sync of unattached daemon
 			// sessions) must not reset the idle clock.
 			existing.workspaceId = workspaceId;
 		} else {
+			this.removePortsForTerminal(terminalId);
 			this.sessions.set(terminalId, {
 				workspaceId,
 				pid,
@@ -273,14 +281,14 @@ export class PortManager extends EventEmitter {
 		return {
 			terminalPortMap: new Map<
 				string,
-				{ workspaceId: string; pids: number[] }
+				{ workspaceId: string; pids: number[]; session: SessionEntry }
 			>(),
 			pidOwnerMap: new Map<
 				number,
 				{ terminalId: string; workspaceId: string }
 			>(),
 			allPids: new Set<number>(),
-			emptyTreeTerminals: new Set<string>(),
+			emptyTreeTerminals: new Map<string, SessionEntry>(),
 		};
 	}
 
@@ -299,11 +307,15 @@ export class PortManager extends EventEmitter {
 		force: boolean,
 	): Promise<void> {
 		const now = Date.now();
-		const dueSessions: { terminalId: string; pid: number }[] = [];
+		const dueSessions: {
+			terminalId: string;
+			pid: number;
+			session: SessionEntry;
+		}[] = [];
 		for (const [terminalId, entry] of this.sessions) {
 			if (entry.pid === null) continue;
 			if (!force && !this.isSessionDue(entry, now)) continue;
-			dueSessions.push({ terminalId, pid: entry.pid });
+			dueSessions.push({ terminalId, pid: entry.pid, session: entry });
 		}
 		if (dueSessions.length === 0) return;
 
@@ -312,21 +324,24 @@ export class PortManager extends EventEmitter {
 			table,
 			dueSessions.map((session) => session.pid),
 		);
-		for (const { terminalId, pid } of dueSessions) {
+		for (const { terminalId, pid, session } of dueSessions) {
 			const entry = this.sessions.get(terminalId);
 			// The session may have been replaced (new pid) or unregistered while
 			// the table read was in flight; its tree is stale — don't apply it.
-			if (!entry || entry.pid !== pid) continue;
-			entry.lastScannedAt = now;
+			if (entry !== session) continue;
 
 			const pids = trees.get(pid) ?? [];
 			if (pids.length === 0) {
 				// Root pid absent from the process table — the session exited.
-				scanState.emptyTreeTerminals.add(terminalId);
+				scanState.emptyTreeTerminals.set(terminalId, entry);
 				continue;
 			}
 			const { workspaceId } = entry;
-			scanState.terminalPortMap.set(terminalId, { workspaceId, pids });
+			scanState.terminalPortMap.set(terminalId, {
+				workspaceId,
+				pids,
+				session: entry,
+			});
 			this.addTerminalPids({ terminalId, workspaceId, pids, scanState });
 		}
 
@@ -418,14 +433,20 @@ export class PortManager extends EventEmitter {
 		terminalPortMap: ScanState["terminalPortMap"];
 		portsByTerminal: Map<string, PortInfo[]>;
 	}): void {
-		for (const [terminalId, { workspaceId }] of terminalPortMap) {
+		for (const [terminalId, { workspaceId, session }] of terminalPortMap) {
+			if (this.sessions.get(terminalId) !== session) continue;
+			session.lastScannedAt = Date.now();
 			const portInfos = portsByTerminal.get(terminalId) ?? [];
 			this.updatePortsForTerminal({ terminalId, workspaceId, portInfos });
 		}
 	}
 
-	private clearEmptyTreeTerminals(emptyTreeTerminals: Set<string>): void {
-		for (const terminalId of emptyTreeTerminals) {
+	private clearEmptyTreeTerminals(
+		emptyTreeTerminals: Map<string, SessionEntry>,
+	): void {
+		for (const [terminalId, session] of emptyTreeTerminals) {
+			if (this.sessions.get(terminalId) !== session) continue;
+			session.lastScannedAt = Date.now();
 			this.removePortsForTerminal(terminalId);
 		}
 	}
@@ -584,10 +605,10 @@ export class PortManager extends EventEmitter {
 	/**
 	 * Kill the process listening on a tracked port.
 	 * Refuses to kill the terminal's own shell — that would close the terminal.
-	 * A dev server is always a descendant (different PID), so `killFn` with the
-	 * port's owning PID correctly tears down the server without touching the shell.
+	 * Tree descendants and detached servers must still have matching ownership
+	 * and a matching listening socket immediately before invoking the kill function.
 	 */
-	killPort({
+	async killPort({
 		terminalId,
 		workspaceId,
 		port,
@@ -629,6 +650,65 @@ export class PortManager extends EventEmitter {
 			});
 		}
 
+		const session = this.sessions.get(terminalId);
+		if (
+			!session ||
+			session.pid === null ||
+			session.workspaceId !== workspaceId
+		) {
+			return { success: false };
+		}
+
+		// Do not use forceScan here: it can return early when another scan is
+		// already running. Validate this request directly, independent of idle cadence.
+		const signal = this.ensureScanAbort().signal;
+		try {
+			const table = await readProcessTable();
+			// Another close request may already have stopped a shared server.
+			// A missing PID needs no signal; do not turn "Close all" into an error.
+			if (!table.some(({ pid }) => pid === detectedPort.pid))
+				return { success: true };
+			const roots = [...this.sessions.values()].flatMap(({ pid }) =>
+				pid === null ? [] : [pid],
+			);
+			if (roots.includes(detectedPort.pid)) return { success: false };
+			const trees = buildProcessTrees(table, roots);
+			const tree = trees.get(session.pid);
+			if (!tree) return { success: false };
+			if (!tree.includes(detectedPort.pid)) {
+				const owners = await this.detachedResolver.resolve({
+					table,
+					excludePids: new Set([...trees.values()].flat()),
+					terminalIds: new Set([terminalId]),
+					signal,
+				});
+				if (owners.get(detectedPort.pid) !== terminalId)
+					return { success: false };
+			}
+			const listeners = await getListeningPortsForPids(
+				[detectedPort.pid],
+				signal,
+			);
+			const stillListening = listeners.some(
+				(info) =>
+					info.pid === detectedPort.pid &&
+					info.port === port &&
+					info.address === detectedPort.address &&
+					info.processName === detectedPort.processName,
+			);
+			if (
+				!stillListening ||
+				signal.aborted ||
+				this.sessions.get(terminalId) !== session ||
+				this.ports.get(key) !== detectedPort
+			)
+				return { success: false };
+		} catch {
+			// Inspection failures must never authorize a destructive operation.
+			return { success: false };
+		}
+		// PID-based OS signalling is not atomic with inspection; this narrows the
+		// stale-observation window but cannot replace a kernel process handle.
 		return this.killFn({ pid: detectedPort.pid });
 	}
 }

--- a/packages/port-scanner/src/port-manager.ts
+++ b/packages/port-scanner/src/port-manager.ts
@@ -1,8 +1,10 @@
 import { EventEmitter } from "node:events";
+import { DetachedProcessResolver } from "./detached.ts";
 import {
+	buildProcessTrees,
 	getListeningPortsForPids,
-	getProcessTreesForPids,
 	type PortInfo,
+	readProcessTable,
 } from "./scanner.ts";
 import type { DetectedPort } from "./types.ts";
 
@@ -141,6 +143,7 @@ export class PortManager extends EventEmitter {
 	/** Aborts any in-flight scan children (lsof/netstat) on teardown. */
 	private scanAbort: AbortController | null = null;
 	private readonly killFn: KillFn;
+	private readonly detachedResolver = new DetachedProcessResolver();
 
 	constructor(options: PortManagerOptions) {
 		super();
@@ -304,7 +307,9 @@ export class PortManager extends EventEmitter {
 		}
 		if (dueSessions.length === 0) return;
 
-		const trees = await getProcessTreesForPids(
+		const table = await readProcessTable();
+		const trees = buildProcessTrees(
+			table,
 			dueSessions.map((session) => session.pid),
 		);
 		for (const { terminalId, pid } of dueSessions) {
@@ -323,6 +328,38 @@ export class PortManager extends EventEmitter {
 			const { workspaceId } = entry;
 			scanState.terminalPortMap.set(terminalId, { workspaceId, pids });
 			this.addTerminalPids({ terminalId, workspaceId, pids, scanState });
+		}
+
+		await this.collectDetachedPids(scanState, table);
+	}
+
+	/**
+	 * Servers that agents start detached (setsid, reparented to PID 1) are not
+	 * in any session tree, but still carry the terminal's id in their
+	 * environment. Fold them into their owning session's pid set so the port
+	 * scan and kill both see them.
+	 */
+	private async collectDetachedPids(
+		scanState: ScanState,
+		table: Awaited<ReturnType<typeof readProcessTable>>,
+	): Promise<void> {
+		if (scanState.terminalPortMap.size === 0) return;
+		const detached = await this.detachedResolver.resolve({
+			table,
+			excludePids: scanState.allPids,
+			terminalIds: new Set(scanState.terminalPortMap.keys()),
+			signal: this.ensureScanAbort().signal,
+		});
+		for (const [pid, terminalId] of detached) {
+			const owner = scanState.terminalPortMap.get(terminalId);
+			if (!owner) continue;
+			owner.pids.push(pid);
+			this.addTerminalPids({
+				terminalId,
+				workspaceId: owner.workspaceId,
+				pids: [pid],
+				scanState,
+			});
 		}
 	}
 

--- a/packages/port-scanner/src/procfs.test.ts
+++ b/packages/port-scanner/src/procfs.test.ts
@@ -1,5 +1,50 @@
-import { describe, expect, test } from "bun:test";
-import { parseIPv4Hex, parseIPv6Hex, parseProcNetLine } from "./procfs";
+import { describe, expect, spyOn, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import {
+	parseIPv4Hex,
+	parseIPv6Hex,
+	parseProcNetLine,
+	readEnvValuesLinuxProcfs,
+} from "./procfs";
+
+describe("readEnvValuesLinuxProcfs", () => {
+	test("forwards cancellation to active reads and does not swallow it", async () => {
+		const controller = new AbortController();
+		const reason = new Error("scan cancelled");
+		const read = spyOn(fs, "readFile").mockImplementation(async () => {
+			controller.abort(reason);
+			throw reason;
+		});
+		try {
+			await expect(
+				readEnvValuesLinuxProcfs(
+					[123],
+					["SUPERSET_TERMINAL_ID"],
+					controller.signal,
+				),
+			).rejects.toBe(reason);
+			expect(read).toHaveBeenCalledWith("/proc/123/environ", {
+				encoding: "utf-8",
+				signal: controller.signal,
+			});
+		} finally {
+			read.mockRestore();
+		}
+	});
+
+	test("continues to treat ordinary read failures as unreadable environments", async () => {
+		const read = spyOn(fs, "readFile").mockRejectedValue(
+			new Error("permission denied"),
+		);
+		try {
+			expect(
+				await readEnvValuesLinuxProcfs([123], ["SUPERSET_TERMINAL_ID"]),
+			).toEqual(new Map([[123, null]]));
+		} finally {
+			read.mockRestore();
+		}
+	});
+});
 
 describe("parseIPv4Hex", () => {
 	test("decodes little-endian hex to dotted quad", () => {

--- a/packages/port-scanner/src/procfs.ts
+++ b/packages/port-scanner/src/procfs.ts
@@ -146,7 +146,7 @@ async function readProcNetFile(
 	return listeners;
 }
 
-function createLimiter(
+export function createLimiter(
 	concurrency: number,
 ): <T>(fn: () => Promise<T>) => Promise<T> {
 	let active = 0;
@@ -289,4 +289,61 @@ export async function getListeningPortsLinuxProcfs(
 		if (signal?.aborted) throw err;
 		return [];
 	}
+}
+
+/** Keep /proc/<pid>/environ reads bounded across all scanned PIDs. */
+const ENVIRON_READ_CONCURRENCY = 64;
+
+/**
+ * Linux-only: read `/proc/<pid>/environ` for each pid and pick the first
+ * value found for any of `keys` (in priority order). A pid whose environment
+ * can't be read (exited, or owned by another user) maps to null.
+ */
+export async function readEnvValuesLinuxProcfs(
+	pids: number[],
+	keys: readonly string[],
+	signal?: AbortSignal,
+): Promise<Map<number, string | null>> {
+	const values = new Map<number, string | null>();
+	const limit = createLimiter(ENVIRON_READ_CONCURRENCY);
+	await Promise.all(
+		pids.map((pid) =>
+			limit(async () => {
+				signal?.throwIfAborted();
+				let content: string;
+				try {
+					content = await fs.readFile(`/proc/${pid}/environ`, "utf-8");
+				} catch {
+					values.set(pid, null);
+					return;
+				}
+				values.set(pid, pickEnvValue(content.split("\0"), keys));
+			}),
+		),
+	);
+	return values;
+}
+
+/**
+ * First `KEY=value` entry matching `keys` in priority order, or null.
+ * Shared by the procfs and `ps -E` readers.
+ */
+export function pickEnvValue(
+	entries: Iterable<string>,
+	keys: readonly string[],
+): string | null {
+	const found = new Map<string, string>();
+	for (const entry of entries) {
+		const eq = entry.indexOf("=");
+		if (eq <= 0) continue;
+		const key = entry.slice(0, eq);
+		if (!keys.includes(key) || found.has(key)) continue;
+		const value = entry.slice(eq + 1);
+		if (value) found.set(key, value);
+	}
+	for (const key of keys) {
+		const value = found.get(key);
+		if (value !== undefined) return value;
+	}
+	return null;
 }

--- a/packages/port-scanner/src/procfs.ts
+++ b/packages/port-scanner/src/procfs.ts
@@ -312,8 +312,12 @@ export async function readEnvValuesLinuxProcfs(
 				signal?.throwIfAborted();
 				let content: string;
 				try {
-					content = await fs.readFile(`/proc/${pid}/environ`, "utf-8");
-				} catch {
+					content = await fs.readFile(`/proc/${pid}/environ`, {
+						encoding: "utf-8",
+						signal,
+					});
+				} catch (err) {
+					if (signal?.aborted) throw err;
 					values.set(pid, null);
 					return;
 				}

--- a/packages/port-scanner/src/scanner.ts
+++ b/packages/port-scanner/src/scanner.ts
@@ -2,52 +2,10 @@ import { execFile } from "node:child_process";
 import os from "node:os";
 import { promisify } from "node:util";
 import pidtree from "pidtree";
+import { EXEC_TIMEOUT_MS, runTolerant } from "./exec.ts";
 import { getListeningPortsLinuxProcfs } from "./procfs.ts";
 
 const execFileAsync = promisify(execFile);
-
-/**
- * Run execFile and tolerate a plain non-zero exit by returning its stdout.
- * lsof exits 1 when no PIDs match the filter — a legitimate "empty" result.
- * Aborts, timeouts, and signal-kills are NOT tolerated: partial stdout from a
- * killed child is not a trustworthy snapshot, so rethrow and let the caller's
- * outer catch turn it into `[]`.
- */
-async function runTolerant(
-	file: string,
-	args: string[],
-	options: { maxBuffer: number; timeout: number; signal?: AbortSignal },
-): Promise<string> {
-	try {
-		const { stdout } = await execFileAsync(file, args, options);
-		return stdout;
-	} catch (err) {
-		if (err && typeof err === "object") {
-			const execErr = err as {
-				stdout?: string | Buffer;
-				code?: unknown;
-				killed?: boolean;
-				signal?: unknown;
-				name?: string;
-			};
-			if (
-				execErr.name === "AbortError" ||
-				execErr.code === "ABORT_ERR" ||
-				execErr.killed ||
-				execErr.signal
-			) {
-				throw err;
-			}
-			if ("stdout" in execErr) {
-				return String(execErr.stdout ?? "");
-			}
-		}
-		throw err;
-	}
-}
-
-/** Timeout for shell commands to prevent hanging (ms) */
-const EXEC_TIMEOUT_MS = 5000;
 
 export interface PortInfo {
 	port: number;
@@ -56,23 +14,35 @@ export interface PortInfo {
 	processName: string;
 }
 
+export interface ProcessTableEntry {
+	pid: number;
+	ppid: number;
+}
+
+/**
+ * One system-wide process-table read. pidtree spawns a full `ps`/`wmic` per
+ * invocation, so a scan reads the table once and derives everything (session
+ * trees, detached-process attribution) from that single snapshot.
+ *
+ * Throws when the table can't be read, so callers can keep previous state
+ * instead of treating every session as exited.
+ */
+export async function readProcessTable(): Promise<ProcessTableEntry[]> {
+	const table = await pidtree(-1, { advanced: true });
+	return table.map(({ pid, ppid }) => ({ pid, ppid }));
+}
+
 /**
  * Get the process tree (root + descendants) for each of the given root PIDs
- * using a single system-wide process-table read. pidtree spawns a full
- * `ps`/`wmic` per invocation, so calling it once per session made scan cost
- * scale linearly with session count.
- *
- * Roots that are no longer running are absent from the returned map. Throws
- * when the process table itself can't be read, so callers can keep previous
- * state instead of treating every session as exited.
+ * from a process-table snapshot. Roots that are not in the table are absent
+ * from the returned map.
  */
-export async function getProcessTreesForPids(
+export function buildProcessTrees(
+	table: ProcessTableEntry[],
 	rootPids: number[],
-): Promise<Map<number, number[]>> {
+): Map<number, number[]> {
 	const trees = new Map<number, number[]>();
 	if (rootPids.length === 0) return trees;
-
-	const table = await pidtree(-1, { advanced: true });
 
 	const childrenByPpid = new Map<number, number[]>();
 	const alivePids = new Set<number>();
@@ -100,6 +70,16 @@ export async function getProcessTreesForPids(
 	}
 
 	return trees;
+}
+
+/**
+ * Convenience wrapper: one table read, then trees for the given roots.
+ */
+export async function getProcessTreesForPids(
+	rootPids: number[],
+): Promise<Map<number, number[]>> {
+	if (rootPids.length === 0) return new Map();
+	return buildProcessTrees(await readProcessTable(), rootPids);
 }
 
 /**

--- a/packages/port-scanner/src/terminal-env.test.ts
+++ b/packages/port-scanner/src/terminal-env.test.ts
@@ -43,7 +43,10 @@ describe("parsePsEnvOutput", () => {
 			" 80076 next-server (v16.2.11)",
 			"    12 /sbin/launchd",
 		].join("\n");
-		const parsed = parsePsEnvOutput(output);
+		const parsed = parsePsEnvOutput(
+			output,
+			" 79737 bun run dev\n 80076 next-server (v16.2.11)\n 12 /sbin/launchd",
+		);
 		expect(parsed.get(79737)).toBe(TERMINAL);
 		expect(parsed.get(80076)).toBeNull();
 		expect(parsed.get(12)).toBeNull();
@@ -51,22 +54,98 @@ describe("parsePsEnvOutput", () => {
 	});
 
 	it("does not mistake a command argument for the variable", () => {
-		// `env SUPERSET_TERMINAL_ID=x cmd` is semantically the same intent, so it
-		// is accepted; a mere substring is not.
+		const commands =
+			" 1 grep --SUPERSET_TERMINAL_ID=abc file\n 2 node app.js SUPERSET_TERMINAL_ID=abc\n";
+		const parsed = parsePsEnvOutput(commands, commands);
+		expect(parsed.get(1)).toBeNull();
+		expect(parsed.get(2)).toBeNull();
+	});
+
+	it("uses the real environment even when argv mentions a different terminal", () => {
+		expect(
+			parsePsEnvOutput(
+				" 1 node app.js SUPERSET_TERMINAL_ID=fake SUPERSET_TERMINAL_ID=real",
+				" 1 node app.js SUPERSET_TERMINAL_ID=fake",
+			).get(1),
+		).toBe("real");
+	});
+
+	it("fails closed when the command changes or was not observed", () => {
 		const parsed = parsePsEnvOutput(
-			" 1 grep --SUPERSET_TERMINAL_ID=abc file\n 2 env SUPERSET_TERMINAL_ID=abc node\n",
+			" 1 new-command SUPERSET_TERMINAL_ID=term\n 2 node SUPERSET_TERMINAL_ID=term",
+			" 1 old-command",
 		);
 		expect(parsed.get(1)).toBeNull();
-		expect(parsed.get(2)).toBe("abc");
+		expect(parsed.get(2)).toBeNull();
 	});
 
 	it("handles empty output", () => {
-		expect(parsePsEnvOutput("").size).toBe(0);
+		expect(parsePsEnvOutput("", "").size).toBe(0);
 	});
 });
 
 describe("readTerminalIdsFromEnv (real processes)", () => {
 	const supported = os.platform() === "darwin" || os.platform() === "linux";
+
+	it.skipIf(os.platform() !== "darwin")(
+		"propagates a failed ps snapshot instead of returning null owners",
+		async () => {
+			const previousPath = process.env.PATH;
+			try {
+				process.env.PATH = "/nonexistent-superset-test-bin";
+				await expect(readTerminalIdsFromEnv([process.pid])).rejects.toThrow();
+			} finally {
+				if (previousPath === undefined) delete process.env.PATH;
+				else process.env.PATH = previousPath;
+			}
+		},
+	);
+
+	it.skipIf(!supported)(
+		"ignores an argument-only ID in both targeted and whole-table reads",
+		async () => {
+			const fake = Bun.spawn(
+				[
+					process.execPath,
+					"-e",
+					"setTimeout(() => {}, 10000)",
+					`SUPERSET_TERMINAL_ID=${TERMINAL}`,
+				],
+				{
+					env: { SUPERSET_TERMINAL_ID: "", SUPERSET_PANE_ID: "" },
+					stdout: "ignore",
+					stderr: "ignore",
+				},
+			);
+			const real = Bun.spawn(
+				[
+					process.execPath,
+					"-e",
+					"setTimeout(() => {}, 10000)",
+					"SUPERSET_TERMINAL_ID=argument-only",
+				],
+				{
+					env: { SUPERSET_TERMINAL_ID: TERMINAL, SUPERSET_PANE_ID: "" },
+					stdout: "ignore",
+					stderr: "ignore",
+				},
+			);
+			try {
+				for (const pids of [
+					[fake.pid, real.pid],
+					[...Array<number>(201).fill(fake.pid), real.pid],
+				]) {
+					const ids = await readTerminalIdsFromEnv(pids);
+					expect(ids.get(fake.pid)).toBeNull();
+					expect(ids.get(real.pid)).toBe(TERMINAL);
+				}
+			} finally {
+				fake.kill();
+				real.kill();
+				await Promise.all([fake.exited, real.exited]);
+			}
+		},
+	);
 
 	it.skipIf(!supported)(
 		"reads the id from a child spawned with it and null from one without",

--- a/packages/port-scanner/src/terminal-env.test.ts
+++ b/packages/port-scanner/src/terminal-env.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import os from "node:os";
+import { pickEnvValue } from "./procfs.ts";
+import {
+	parsePsEnvOutput,
+	readTerminalIdsFromEnv,
+	TERMINAL_ID_ENV_KEYS,
+} from "./terminal-env.ts";
+
+const TERMINAL = "df6750e5-5242-405c-8b9f-71564b916ace";
+
+describe("pickEnvValue", () => {
+	it("prefers keys in priority order", () => {
+		expect(
+			pickEnvValue(
+				["SUPERSET_PANE_ID=pane", "SUPERSET_TERMINAL_ID=term"],
+				TERMINAL_ID_ENV_KEYS,
+			),
+		).toBe("term");
+	});
+
+	it("falls back to the desktop's pane id", () => {
+		expect(
+			pickEnvValue(["FOO=bar", "SUPERSET_PANE_ID=pane"], TERMINAL_ID_ENV_KEYS),
+		).toBe("pane");
+	});
+
+	it("ignores empty values and unrelated keys", () => {
+		expect(
+			pickEnvValue(
+				["SUPERSET_TERMINAL_ID=", "SUPERSET_TERMINAL_ID_X=nope", "=weird"],
+				TERMINAL_ID_ENV_KEYS,
+			),
+		).toBeNull();
+	});
+});
+
+describe("parsePsEnvOutput", () => {
+	it("maps each pid to the terminal id in its environment", () => {
+		const output = [
+			` 79737 bun run dev TERM=xterm-256color SUPERSET_WORKSPACE_ID=ws SUPERSET_TERMINAL_ID=${TERMINAL} HOME=/Users/x`,
+			// A process that overwrote its argv area: ps shows only the title.
+			" 80076 next-server (v16.2.11)",
+			"    12 /sbin/launchd",
+		].join("\n");
+		const parsed = parsePsEnvOutput(output);
+		expect(parsed.get(79737)).toBe(TERMINAL);
+		expect(parsed.get(80076)).toBeNull();
+		expect(parsed.get(12)).toBeNull();
+		expect(parsed.size).toBe(3);
+	});
+
+	it("does not mistake a command argument for the variable", () => {
+		// `env SUPERSET_TERMINAL_ID=x cmd` is semantically the same intent, so it
+		// is accepted; a mere substring is not.
+		const parsed = parsePsEnvOutput(
+			" 1 grep --SUPERSET_TERMINAL_ID=abc file\n 2 env SUPERSET_TERMINAL_ID=abc node\n",
+		);
+		expect(parsed.get(1)).toBeNull();
+		expect(parsed.get(2)).toBe("abc");
+	});
+
+	it("handles empty output", () => {
+		expect(parsePsEnvOutput("").size).toBe(0);
+	});
+});
+
+describe("readTerminalIdsFromEnv (real processes)", () => {
+	const supported = os.platform() === "darwin" || os.platform() === "linux";
+
+	it.skipIf(!supported)(
+		"reads the id from a child spawned with it and null from one without",
+		async () => {
+			const spawn = (env: Record<string, string>) =>
+				Bun.spawn([process.execPath, "-e", "setTimeout(() => {}, 5000)"], {
+					env: { ...process.env, ...env },
+				});
+			// The test runner may itself be inside a Superset terminal, so clear
+			// the inherited ids explicitly rather than relying on their absence.
+			const withId = spawn({
+				SUPERSET_TERMINAL_ID: TERMINAL,
+				SUPERSET_PANE_ID: "",
+			});
+			const withPane = spawn({
+				SUPERSET_TERMINAL_ID: "",
+				SUPERSET_PANE_ID: "pane-1",
+			});
+			const without = spawn({ SUPERSET_TERMINAL_ID: "", SUPERSET_PANE_ID: "" });
+			// A pid that existed and has exited: the realistic race between the
+			// table read and the environment read. (An out-of-range pid is not
+			// realistic — macOS `ps` rejects the whole batch for one.)
+			const exited = Bun.spawn([process.execPath, "-e", ""]);
+			await exited.exited;
+			try {
+				const ids = await readTerminalIdsFromEnv([
+					withId.pid,
+					withPane.pid,
+					without.pid,
+					exited.pid,
+				]);
+				expect(ids.get(withId.pid)).toBe(TERMINAL);
+				expect(ids.get(withPane.pid)).toBe("pane-1");
+				expect(ids.get(without.pid)).toBeNull();
+				expect(ids.get(exited.pid)).toBeNull();
+				expect(ids.size).toBe(4);
+			} finally {
+				withId.kill();
+				withPane.kill();
+				without.kill();
+			}
+		},
+	);
+
+	it("returns an empty map for no pids", async () => {
+		expect((await readTerminalIdsFromEnv([])).size).toBe(0);
+	});
+});

--- a/packages/port-scanner/src/terminal-env.ts
+++ b/packages/port-scanner/src/terminal-env.ts
@@ -17,7 +17,7 @@ const PS_PID_BATCH = 200;
 
 /**
  * Above this many pids, one whole-table `ps -ax` is cheaper than `-p` lookups
- * (a cold cache on a busy machine is ~1500 pids: ~80ms for the table, ~400ms
+ * (a scan on a busy machine is ~1500 pids: ~80ms for the table, ~400ms
  * via -p batches).
  */
 const PS_WHOLE_TABLE_THRESHOLD = PS_PID_BATCH;

--- a/packages/port-scanner/src/terminal-env.ts
+++ b/packages/port-scanner/src/terminal-env.ts
@@ -1,0 +1,125 @@
+import os from "node:os";
+import { EXEC_TIMEOUT_MS, runTolerant } from "./exec.ts";
+import { pickEnvValue, readEnvValuesLinuxProcfs } from "./procfs.ts";
+
+/**
+ * Environment keys that carry the owning terminal's id, in priority order.
+ * host-service PTYs set SUPERSET_TERMINAL_ID; the desktop's own PTY path sets
+ * SUPERSET_PANE_ID with the same value it registers the session under.
+ */
+export const TERMINAL_ID_ENV_KEYS = [
+	"SUPERSET_TERMINAL_ID",
+	"SUPERSET_PANE_ID",
+] as const;
+
+/** `ps -p` takes a comma list; keep each invocation's argv comfortably short. */
+const PS_PID_BATCH = 200;
+
+/**
+ * Above this many pids, one whole-table `ps -ax` is cheaper than `-p` lookups
+ * (a cold cache on a busy machine is ~1500 pids: ~80ms for the table, ~400ms
+ * via -p batches).
+ */
+const PS_WHOLE_TABLE_THRESHOLD = PS_PID_BATCH;
+
+/**
+ * Read the owning terminal id from each process's environment.
+ *
+ * Every terminal's shell is spawned with SUPERSET_TERMINAL_ID, and every
+ * descendant inherits it — including servers that agents such as Claude Code
+ * or Codex start in the background with a new session (setsid) and that are
+ * reparented to PID 1 once their wrapper shell exits. Walking the ppid tree
+ * from the shell loses those; the environment does not.
+ *
+ * Every requested pid is present in the result. null means the process has no
+ * such variable or its environment can't be read: another user's process, or
+ * on macOS a process that overwrote its argv area to set a title (Node's
+ * `process.title`, zsh), which `ps -E` then can't decode. Callers propagate
+ * ids from ancestors to cover the latter.
+ */
+export async function readTerminalIdsFromEnv(
+	pids: number[],
+	signal?: AbortSignal,
+): Promise<Map<number, string | null>> {
+	const values = new Map<number, string | null>();
+	if (pids.length === 0) return values;
+
+	const platform = os.platform();
+	let read: Map<number, string | null>;
+	try {
+		if (platform === "linux") {
+			read = await readEnvValuesLinuxProcfs(pids, TERMINAL_ID_ENV_KEYS, signal);
+		} else if (platform === "darwin") {
+			read = await readTerminalIdsDarwin(pids, signal);
+		} else {
+			read = new Map();
+		}
+	} catch (err) {
+		if (signal?.aborted) throw err;
+		read = new Map();
+	}
+
+	for (const pid of pids) values.set(pid, read.get(pid) ?? null);
+	return values;
+}
+
+async function readTerminalIdsDarwin(
+	pids: number[],
+	signal?: AbortSignal,
+): Promise<Map<number, string | null>> {
+	// -E: append the environment to the command column
+	// -ww: unlimited width so nothing is truncated
+	// -o pid=,command=: no header
+	const options = {
+		maxBuffer: 64 * 1024 * 1024,
+		timeout: EXEC_TIMEOUT_MS,
+		signal,
+	};
+	if (pids.length > PS_WHOLE_TABLE_THRESHOLD) {
+		const wanted = new Set(pids);
+		const output = await runTolerant(
+			"ps",
+			["-Eww", "-axo", "pid=,command="],
+			options,
+		);
+		const values = new Map<number, string | null>();
+		for (const [pid, value] of parsePsEnvOutput(output)) {
+			if (wanted.has(pid)) values.set(pid, value);
+		}
+		return values;
+	}
+
+	const values = new Map<number, string | null>();
+	for (let i = 0; i < pids.length; i += PS_PID_BATCH) {
+		const batch = pids.slice(i, i + PS_PID_BATCH);
+		const output = await runTolerant(
+			"ps",
+			["-Eww", "-o", "pid=,command=", "-p", batch.join(",")],
+			options,
+		);
+		for (const [pid, value] of parsePsEnvOutput(output)) {
+			values.set(pid, value);
+		}
+	}
+	return values;
+}
+
+/**
+ * Parse `ps -Eww -o pid=,command=` output into pid → terminal id. The command
+ * column is argv followed by `KEY=value` environment entries, all
+ * space-separated; the ids are UUIDs, so scanning whitespace-split tokens for
+ * the keys is unambiguous. Exported for tests.
+ */
+export function parsePsEnvOutput(output: string): Map<number, string | null> {
+	const values = new Map<number, string | null>();
+	for (const line of output.split("\n")) {
+		const match = line.match(/^\s*(\d+)\s+(.*)$/);
+		if (!match) continue;
+		const pidStr = match[1];
+		const rest = match[2];
+		if (pidStr === undefined || rest === undefined) continue;
+		const pid = Number.parseInt(pidStr, 10);
+		values.set(pid, pickEnvValue(rest.split(/\s+/), TERMINAL_ID_ENV_KEYS));
+	}
+	return values;
+}

--- a/packages/port-scanner/src/terminal-env.ts
+++ b/packages/port-scanner/src/terminal-env.ts
@@ -16,9 +16,8 @@ export const TERMINAL_ID_ENV_KEYS = [
 const PS_PID_BATCH = 200;
 
 /**
- * Above this many pids, one whole-table `ps -ax` is cheaper than `-p` lookups
- * (a scan on a busy machine is ~1500 pids: ~80ms for the table, ~400ms
- * via -p batches).
+ * Above this many pids, whole-table `ps -ax` reads avoid spawning a separate
+ * command/environment pair for each batch on busy machines.
  */
 const PS_WHOLE_TABLE_THRESHOLD = PS_PID_BATCH;
 
@@ -45,18 +44,21 @@ export async function readTerminalIdsFromEnv(
 	if (pids.length === 0) return values;
 
 	const platform = os.platform();
+	// A failed snapshot is not evidence that every detached server exited.
+	// Let the manager preserve its last successful result and retry the scan.
 	let read: Map<number, string | null>;
 	try {
-		if (platform === "linux") {
-			read = await readEnvValuesLinuxProcfs(pids, TERMINAL_ID_ENV_KEYS, signal);
-		} else if (platform === "darwin") {
-			read = await readTerminalIdsDarwin(pids, signal);
-		} else {
-			read = new Map();
-		}
-	} catch (err) {
-		if (signal?.aborted) throw err;
-		read = new Map();
+		read =
+			platform === "linux"
+				? await readEnvValuesLinuxProcfs(pids, TERMINAL_ID_ENV_KEYS, signal)
+				: platform === "darwin"
+					? await readTerminalIdsDarwin(pids, signal)
+					: new Map<number, string | null>();
+	} catch {
+		// execFile errors can carry stdout containing complete environments.
+		// Never let those values reach the manager's error logger.
+		signal?.throwIfAborted();
+		throw new Error("Process environment inspection failed");
 	}
 
 	for (const pid of pids) values.set(pid, read.get(pid) ?? null);
@@ -77,13 +79,18 @@ async function readTerminalIdsDarwin(
 	};
 	if (pids.length > PS_WHOLE_TABLE_THRESHOLD) {
 		const wanted = new Set(pids);
+		const commands = await runTolerant(
+			"ps",
+			["-ww", "-axo", "pid=,command="],
+			options,
+		);
 		const output = await runTolerant(
 			"ps",
 			["-Eww", "-axo", "pid=,command="],
 			options,
 		);
 		const values = new Map<number, string | null>();
-		for (const [pid, value] of parsePsEnvOutput(output)) {
+		for (const [pid, value] of parsePsEnvOutput(output, commands)) {
 			if (wanted.has(pid)) values.set(pid, value);
 		}
 		return values;
@@ -92,12 +99,17 @@ async function readTerminalIdsDarwin(
 	const values = new Map<number, string | null>();
 	for (let i = 0; i < pids.length; i += PS_PID_BATCH) {
 		const batch = pids.slice(i, i + PS_PID_BATCH);
+		const commands = await runTolerant(
+			"ps",
+			["-ww", "-o", "pid=,command=", "-p", batch.join(",")],
+			options,
+		);
 		const output = await runTolerant(
 			"ps",
 			["-Eww", "-o", "pid=,command=", "-p", batch.join(",")],
 			options,
 		);
-		for (const [pid, value] of parsePsEnvOutput(output)) {
+		for (const [pid, value] of parsePsEnvOutput(output, commands)) {
 			values.set(pid, value);
 		}
 	}
@@ -105,12 +117,20 @@ async function readTerminalIdsDarwin(
 }
 
 /**
- * Parse `ps -Eww -o pid=,command=` output into pid → terminal id. The command
- * column is argv followed by `KEY=value` environment entries, all
- * space-separated; the ids are UUIDs, so scanning whitespace-split tokens for
- * the keys is unambiguous. Exported for tests.
+ * Strip the separately observed argv before inspecting `ps -Eww`'s appended
+ * environment. Arguments can mention terminal IDs without owning a terminal.
+ * If the observed argv prefix does not match, fail closed for that PID. This is a best-effort
+ * attribution hint, not a security boundary: ps does not escape environment values.
  */
-export function parsePsEnvOutput(output: string): Map<number, string | null> {
+export function parsePsEnvOutput(
+	output: string,
+	commandOutput: string,
+): Map<number, string | null> {
+	const commands = new Map<number, string>();
+	for (const line of commandOutput.split("\n")) {
+		const match = line.match(/^\s*(\d+)\s+(.*)$/);
+		if (match?.[1] && match[2]) commands.set(Number(match[1]), match[2]);
+	}
 	const values = new Map<number, string | null>();
 	for (const line of output.split("\n")) {
 		const match = line.match(/^\s*(\d+)\s+(.*)$/);
@@ -119,7 +139,15 @@ export function parsePsEnvOutput(output: string): Map<number, string | null> {
 		const rest = match[2];
 		if (pidStr === undefined || rest === undefined) continue;
 		const pid = Number.parseInt(pidStr, 10);
-		values.set(pid, pickEnvValue(rest.split(/\s+/), TERMINAL_ID_ENV_KEYS));
+		const command = commands.get(pid);
+		const environment =
+			command && rest.startsWith(`${command} `)
+				? rest.slice(command.length + 1)
+				: "";
+		values.set(
+			pid,
+			pickEnvValue(environment.split(/\s+/), TERMINAL_ID_ENV_KEYS),
+		);
 	}
 	return values;
 }


### PR DESCRIPTION
## What & why

Detect dev servers that Claude/Codex launch in detached subprocesses. Once a wrapper exits, these processes can be reparented to PID 1 with no controlling TTY, so walking descendants of the terminal shell misses their listening ports.

- Read the process table once per scan and retain existing tree-based attribution.
- Resolve remaining processes through inherited `SUPERSET_TERMINAL_ID` / `SUPERSET_PANE_ID`, propagating ownership from readable ancestors.
- Read environments via `ps -Eww` on macOS and procfs on Linux; re-read each scan because PID/parent alone cannot safely identify a process instance. Windows remains tree-only.
- Cover detached attribution, environment parsing, PID reuse, cancellation, and PortManager integration with regression tests.

- Revalidate current process ownership and the listening socket before killing a tracked port; do not rely on a possibly coalesced force-scan.
- Strip observed command arguments from macOS environment output before looking for terminal IDs.
- Reject results from replaced terminal sessions and preserve prior state when the environment snapshot fails. Inspection errors are sanitized so command stdout cannot leak environments into logs.

Scope: the owning terminal must remain registered. Workspace-level attribution after that terminal closes is not included.

## How I tested it

- `bun run lint`: passed.
- `bun run typecheck`: passed (38 tasks).
- Port-scanner tests: macOS 110 passed; Linux 109 passed, 1 macOS-only skip.
- `bun run check:plugins`: passed.
- `git diff --check`: passed.
- `bun run test`: incomplete; stopped in `@superset/trpc` with `Invalid environment variables` during module loading (required service credentials/configuration were undefined).

### Additional safety and edge-case verification

- Regression tests cover stale close requests after ownership changes, stopped listeners, terminal replacement during scanning/kill validation, failed inspection/recovery, and closing sibling ports on a shared process.
- Argument-only terminal IDs are rejected in parser tests, real targeted/whole-table macOS reads, and a real PPID-1 listener with cleared environment variables.
- Synthetic before/after checks against the previous commit: a stale entry invoked the mock kill function before (1 call), but not after (0 calls); an argv-only ID was accepted before and rejected after. No OS signal was sent by the mock-kill reproduction.
- Stress coverage: 10,002 synthetic process entries across three scans without mixing two terminal owners. Paired command/environment reads took 148–205 ms across 1,599 real macOS processes (10 samples, not a sustained battery/CPU soak).
- **Claude UI check:** a real Claude invocation in the matched app terminal launched the controlled double-fork/setsid listener (PPID 1, no TTY, port 18732). The sidebar showed one port; expanding showed localhost:18732, and the UI close confirmation stopped it. Screenshots were captured locally.
- **Codex partial check:** workspace-write initially blocked socket binding; enabling network access for the test invocation allowed the controlled listener to start. Its inherited terminal ID, PPID 1, socket and resolver attribution were verified. A code-triggered app restart returned the dev profile to onboarding, so this is **not** a Codex sidebar or app-restart restoration pass.
- Both agents ran a controlled self-detaching script, not the actual sprout-casquette dev-server/hot-reload journey. Test listeners and the dev stack started for verification were stopped.
- Final checks: macOS/Bun 1.3.11 tests 110 pass; Linux ARM64/Bun 1.3.14 tests 109 pass, 1 macOS-only skip; lint, typecheck and plugin validation pass. Root tests still stop at the previously documented missing tRPC environment variables.

**Remaining boundaries:** revalidation is not atomic with PID signalling or later process-tree escalation; no kernel process handle/start-time identity was added. macOS ps output remains a best-effort hint (unescaped environment values, non-atomic reads), not a security boundary. An unreadable orphan with no readable ancestor cannot be attributed. Windows runtime, sustained load/battery usage, and real dev-server hot reload through app restart remain unverified.

### Review follow-up (`bdca4d9317`)

- Removed the cross-scan environment cache to prevent stale ownership when a PID is reused with the same parent. Added resolver and PortManager regressions, including removal from the old terminal's kill controls after rescanning.
- `runTolerant` only tolerates numeric child exit codes; maxBuffer overflow and spawn failures now propagate. Real subprocess regression tests cover both.
- Linux environment reads receive the AbortSignal and propagate cancellation while preserving null results for ordinary read failures. Mocked filesystem tests cover this path on macOS.
- Environment reads measured 86–94 ms per scan across 1,427 processes on this Mac (five runs). This replaces near-zero cached steady-state work; batching and existing scan cadence/idle decay are unchanged.
- The checks above were rerun for this follow-up; the CDP screenshots below were captured for the original commit, not rerun for the review-only hardening.

### Before/after desktop verification

Used the authenticated dev Electron renderer from this worktree (`localhost:7145`, CDP `9555`, API `localhost:7141`). Through real CDP keyboard/mouse input, opened a workspace terminal and launched a controlled listener that double-forks and calls `setsid`. Both runs produced a listener on port 18732 with PPID 1, no controlling TTY, and an inherited terminal ID.

| Observation | Before fix | After fix |
| --- | --- | --- |
| Detached listener exists | Yes | Yes |
| Sidebar active-port badge | Absent | 1 active port |
| Expanded port details | No detected port | `localhost:18732` |
| Close port through UI | Not available | Listener killed; badge removed |

The app restarted between versions, so the same launch was repeated in a fresh terminal after the fix. Screenshots and numeric CDP measurements were captured locally in `.superset/cdp-evidence/` (not attached to this PR). The authenticated host-service query also confirmed the expected listener PID, terminal, and workspace.

This is end-to-end UI verification with a controlled detached-process launcher, not an actual Claude/Codex launch in the reported sprout-casquette workspace. The earlier scanner-level check against that workspace is separate evidence.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs — not applicable (same-repository branch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes port detection for dev servers that Claude Code and Codex launch as detached background processes, so their listening ports now show up in the owning terminal's sidebar.

- These processes are reparented to PID 1 when the wrapper shell exits, so walking the terminal's process tree never saw them.
- Each scan reads the process table once and attributes remaining processes through inherited `SUPERSET_TERMINAL_ID` or `SUPERSET_PANE_ID`, propagating ownership from the nearest readable ancestor and leaving unreadable roots unattributed.
- Environment is re-read every scan instead of cached — a reused PID could otherwise be misattributed. Killed, aborted, or truncated inspections throw so partial output is never treated as a valid scan; on failure, previous state is preserved.
- Kill requests re-read the process table and re-check ownership and the listening socket before signalling, failing closed on any error or stale observation; macOS reads strip observed argv so arguments can't be mistaken for environment.
- Scope: the owning terminal must stay registered; attribution after it closes is not covered.

<sup>Written for commit 6ee0f6845e7390af0aec2a43ee4e0dc0e930d381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Port scanning now detects detached background processes and associates them with the correct terminal on Linux and macOS.
  * Process-scanning APIs support reusable process-table snapshots.
  * Terminal-owned servers can be safely stopped after current process and port ownership is verified.

* **Bug Fixes**
  * Improved handling of exited, inaccessible, or reused processes.
  * Prevented stale port ownership and controls after process replacement.
  * Added cancellation and timeout handling for process inspections.

* **Tests**
  * Expanded coverage for detached attribution, environment detection, filtering, cancellation, and stale-process scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

