### PR TITLE
fix(desktop): pass shell hotkeys and pointer gestures through page panes

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -3,9 +3,9 @@ import { session } from "electron";
 import {
 	type BrowserOpenRequest,
 	browserManager,
-	type ForwardedKey,
 } from "main/lib/browser/browser-manager";
 import { screenshotManager } from "main/lib/browser/screenshot-manager";
+import type { ForwardedKey } from "shared/hotkey-chord";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 
@@ -247,6 +247,24 @@ export const createBrowserRouter = () => {
 					};
 				});
 			}),
+
+		// Keystrokes intercepted while one of the calling window's own iframes
+		// had focus (a page pane, the PDF viewer). Scoped to that window: a
+		// replay must land in the renderer whose frame swallowed the key.
+		onHostKeyForward: publicProcedure.subscription(({ ctx }) => {
+			return observable<ForwardedKey>((emit) => {
+				const wc = ctx.senderWindow?.webContents;
+				if (!wc) return () => {};
+				const channel = `host-key-forward:${wc.id}`;
+				const handler = (key: ForwardedKey) => {
+					emit.next(key);
+				};
+				browserManager.on(channel, handler);
+				return () => {
+					browserManager.off(channel, handler);
+				};
+			});
+		}),
 
 		// External open requests (CLI/agents via the browser bridge). A global
 		// renderer hook consumes these and routes them through the same

--- a/apps/desktop/src/main/lib/browser/browser-manager.test.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.test.ts
@@ -374,6 +374,68 @@ describe("forced CDP detach", () => {
 	});
 });
 
+describe("host window key forwarding", () => {
+	type BeforeInput = (
+		event: { preventDefault: () => void },
+		input: Record<string, unknown>,
+	) => void;
+
+	function makeHostWindow(focusedFrame: { parent: object | null } | null) {
+		let handler: BeforeInput | null = null;
+		const wc = {
+			id: 4242,
+			focusedFrame,
+			on: (event: string, listener: BeforeInput) => {
+				if (event === "before-input-event") handler = listener;
+			},
+		};
+		browserManager.registerHostWindow(wc as unknown as Electron.WebContents);
+		const press = (input: Record<string, unknown>) => {
+			const event = { preventDefault: mock(() => {}) };
+			handler?.(event, { type: "keyDown", ...input });
+			return event.preventDefault.mock.calls.length > 0;
+		};
+		return { wc, press };
+	}
+
+	const cmdW = {
+		key: "w",
+		code: "KeyW",
+		meta: true,
+		control: false,
+		alt: false,
+		shift: false,
+	};
+
+	test("suppresses and forwards a forwardable chord while a subframe has focus", () => {
+		browserManager.setForwardableChords(["meta+w"]);
+		const { wc, press } = makeHostWindow({ parent: {} });
+		const forwarded: unknown[] = [];
+		const listener = (key: unknown) => forwarded.push(key);
+		browserManager.on(`host-key-forward:${wc.id}`, listener);
+		try {
+			expect(press(cmdW)).toBe(true);
+			expect(forwarded).toEqual([cmdW]);
+			// Not a forwardable chord: the page keeps it.
+			expect(press({ ...cmdW, key: "c", code: "KeyC" })).toBe(false);
+			expect(forwarded).toHaveLength(1);
+		} finally {
+			browserManager.off(`host-key-forward:${wc.id}`, listener);
+			browserManager.setForwardableChords([]);
+		}
+	});
+
+	test("leaves keystrokes alone while the top frame (or nothing) has focus", () => {
+		browserManager.setForwardableChords(["meta+w"]);
+		try {
+			expect(makeHostWindow({ parent: null }).press(cmdW)).toBe(false);
+			expect(makeHostWindow(null).press(cmdW)).toBe(false);
+		} finally {
+			browserManager.setForwardableChords([]);
+		}
+	});
+});
+
 describe("window.open handling", () => {
 	function openDetails(
 		overrides: Partial<Electron.HandlerDetails>,

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -8,7 +8,7 @@ import type {
 	DesignModeScreenshot,
 	DesignModeSelectionResult,
 } from "shared/browser-design-mode";
-import { chordFromInput } from "shared/hotkey-chord";
+import { chordFromInput, type ForwardedKey } from "shared/hotkey-chord";
 import {
 	forwardSessionFor,
 	handleTargetCommand,
@@ -50,15 +50,6 @@ export interface BrowserOpenRequest {
 export interface CdpSession {
 	send: (rawMessage: string) => void;
 	detach: () => void;
-}
-
-export interface ForwardedKey {
-	key: string;
-	code: string;
-	meta: boolean;
-	control: boolean;
-	alt: boolean;
-	shift: boolean;
 }
 
 const MAX_CONSOLE_ENTRIES = 500;
@@ -330,6 +321,24 @@ class BrowserManager extends EventEmitter {
 		} catch {
 			// webContents may be destroyed
 		}
+	}
+
+	/**
+	 * The host window's own subframes — a page pane's iframe, the PDF viewer —
+	 * swallow keystrokes the way a guest webview does: while one has focus the
+	 * host document's listeners never see them. Suppress the forwardable chords
+	 * there too and hand them to that window's renderer to replay. Focus in the
+	 * top frame is left alone so the renderer handles the real event.
+	 */
+	registerHostWindow(wc: Electron.WebContents): void {
+		wc.on("before-input-event", (event, input) => {
+			if (input.type !== "keyDown") return;
+			if (!wc.focusedFrame?.parent) return;
+			const key = this.forwardableKey(input);
+			if (!key) return;
+			event.preventDefault();
+			this.emit(`host-key-forward:${wc.id}`, key);
+		});
 	}
 
 	unregisterAll(): void {
@@ -1085,6 +1094,20 @@ class BrowserManager extends EventEmitter {
 		});
 	}
 
+	/** The keystroke as a forwardable chord, or null when it is not one. */
+	private forwardableKey(input: Electron.Input): ForwardedKey | null {
+		const chord = chordFromInput(input);
+		if (!chord || !this.forwardableChords.has(chord)) return null;
+		return {
+			key: input.key,
+			code: input.code,
+			meta: input.meta,
+			control: input.control,
+			alt: input.alt,
+			shift: input.shift,
+		};
+	}
+
 	// When a webview has focus, keystrokes route to the guest renderer — host
 	// `react-hotkeys-hook` listeners never see them and the menu's CmdOrCtrl+W
 	// accelerator closes the whole window. `before-input-event` fires in the
@@ -1109,17 +1132,10 @@ class BrowserManager extends EventEmitter {
 				}
 			}
 
-			const chord = chordFromInput(input);
-			if (!chord || !this.forwardableChords.has(chord)) return;
+			const key = this.forwardableKey(input);
+			if (!key) return;
 			event.preventDefault();
-			this.emit(`key-forward:${paneId}`, {
-				key: input.key,
-				code: input.code,
-				meta: input.meta,
-				control: input.control,
-				alt: input.alt,
-				shift: input.shift,
-			} satisfies ForwardedKey);
+			this.emit(`key-forward:${paneId}`, key);
 		};
 
 		wc.on("before-input-event", handler);

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -470,6 +470,7 @@ export async function createPlatformWindow({
 	}
 
 	ipcHandler?.attachWindow(window);
+	browserManager.registerHostWindow(window.webContents);
 
 	// macOS Sequoia+: occluded/minimized windows can lose compositor layers
 	if (PLATFORM.IS_MAC) {

--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -370,3 +370,9 @@
 		margin: 0;
 	}
 }
+
+/* Embedded documents hit-test ahead of the host; while a host gesture is in
+   flight they yield to it. See renderer/lib/pointer-passthrough.ts. */
+html[data-pointer-passthrough] iframe {
+	pointer-events: none;
+}

--- a/apps/desktop/src/renderer/hotkeys/index.ts
+++ b/apps/desktop/src/renderer/hotkeys/index.ts
@@ -33,3 +33,8 @@ export {
 	resolveHotkeyFromEvent,
 	serializeBinding,
 } from "./utils";
+export {
+	FORWARDED_HOTKEYS,
+	getForwardableChords,
+	replayForwardedKey,
+} from "./utils/forwardedHotkeys";

--- a/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.test.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { canonicalizeChord } from "shared/hotkey-chord";
+import { getDispatchChord } from "../hooks/useBinding/useBinding";
+import { PLATFORM } from "../registry";
+import { useHotkeyOverridesStore } from "../stores/hotkeyOverridesStore";
+
+const isMac = PLATFORM === "mac";
 
 class FakeKeyboardEvent {
 	type: string;
@@ -8,10 +14,24 @@ class FakeKeyboardEvent {
 		this.init = init;
 	}
 }
-(globalThis as unknown as Record<string, unknown>).KeyboardEvent =
-	FakeKeyboardEvent;
 const dispatchEvent = mock((_event: FakeKeyboardEvent) => true);
-(document as unknown as Record<string, unknown>).dispatchEvent = dispatchEvent;
+const originalKeyboardEvent = globalThis.KeyboardEvent;
+const originalDispatchEvent = document.dispatchEvent;
+const originalOverrides = useHotkeyOverridesStore.getState().overrides;
+
+beforeEach(() => {
+	(globalThis as unknown as Record<string, unknown>).KeyboardEvent =
+		FakeKeyboardEvent;
+	(document as unknown as Record<string, unknown>).dispatchEvent =
+		dispatchEvent;
+	dispatchEvent.mockClear();
+});
+
+afterEach(() => {
+	globalThis.KeyboardEvent = originalKeyboardEvent;
+	document.dispatchEvent = originalDispatchEvent;
+	useHotkeyOverridesStore.setState({ overrides: originalOverrides });
+});
 
 const { getForwardableChords, replayForwardedKey } = await import(
 	"./forwardedHotkeys"
@@ -20,19 +40,101 @@ const { getForwardableChords, replayForwardedKey } = await import(
 const key = (overrides: Partial<Parameters<typeof replayForwardedKey>[0]>) => ({
 	key: "w",
 	code: "KeyW",
-	meta: true,
-	control: false,
+	meta: isMac,
+	control: !isMac,
 	alt: false,
-	shift: false,
+	shift: !isMac,
 	...overrides,
 });
 
 describe("forwardedHotkeys", () => {
+	test.each([
+		"CLOSE_TAB",
+		"REOPEN_TAB",
+		"SPLIT_RIGHT",
+		"SPLIT_DOWN",
+		"SPLIT_AUTO",
+		"SPLIT_WITH_BROWSER",
+		"SPLIT_WITH_DESKTOP",
+		"EQUALIZE_PANE_SPLITS",
+		"TOGGLE_SIDEBAR",
+		"TOGGLE_WORKSPACE_SIDEBAR",
+		"NEW_GROUP",
+		"NEW_BROWSER",
+		"OPEN_DIFF_VIEWER",
+		"QUICK_OPEN",
+		"OPEN_COMMAND_PALETTE",
+		"CHECK_RESOURCES",
+		"NEW_WORKSPACE",
+	] as const)("forwards the resolved shell binding for %s", (id) => {
+		const chord = getDispatchChord(id);
+		expect(chord).not.toBeNull();
+		if (!chord) throw new Error(`Missing default binding for ${id}`);
+		expect(getForwardableChords()).toContain(canonicalizeChord(chord));
+	});
+
+	test("replays split-right from either embedded surface", () => {
+		expect(replayForwardedKey(key({ key: "d", code: "KeyD" }))).toBe(true);
+		expect(dispatchEvent.mock.calls.map(([event]) => event.type)).toEqual([
+			"keydown",
+			"keyup",
+		]);
+	});
+
+	test("honors remapped and explicitly unassigned shell shortcuts", () => {
+		useHotkeyOverridesStore.getState().setOverride("SPLIT_RIGHT", "alt+x");
+		expect(getForwardableChords()).toContain("alt+x");
+		expect(replayForwardedKey(key({ key: "d", code: "KeyD" }))).toBe(false);
+		expect(
+			replayForwardedKey(
+				key({
+					key: "x",
+					code: "KeyX",
+					meta: false,
+					control: false,
+					shift: false,
+					alt: true,
+				}),
+			),
+		).toBe(true);
+		useHotkeyOverridesStore.getState().setOverride("SPLIT_RIGHT", null);
+		expect(getForwardableChords()).not.toContain("alt+x");
+	});
+
+	test.each([
+		"FOCUS_PANE_LEFT",
+		"FOCUS_PANE_RIGHT",
+		"FOCUS_PANE_UP",
+		"FOCUS_PANE_DOWN",
+	] as const)("forwards %s when the user assigns it", (id) => {
+		useHotkeyOverridesStore.getState().setOverride(id, "alt+x");
+		expect(getForwardableChords()).toContain("alt+x");
+	});
+
+	test.each([
+		"a",
+		"c",
+		"v",
+		"x",
+		"z",
+		"f",
+		"r",
+	])("leaves document shortcut %s to the embedded document", (letter) => {
+		expect(
+			replayForwardedKey(
+				key({ key: letter, code: `Key${letter.toUpperCase()}`, shift: false }),
+			),
+		).toBe(false);
+		expect(dispatchEvent).not.toHaveBeenCalled();
+	});
+
 	test("the synced chord set covers closing the pane and tab switching", () => {
 		const chords = getForwardableChords();
-		expect(chords).toContain("meta+w");
-		expect(chords).toContain("alt+meta+arrowright");
-		expect(chords).not.toContain("meta+c");
+		expect(chords).toContain(isMac ? "meta+w" : "ctrl+shift+w");
+		expect(chords).toContain(
+			isMac ? "alt+meta+arrowright" : "alt+ctrl+shift+arrowright",
+		);
+		expect(chords).not.toContain(isMac ? "meta+c" : "ctrl+c");
 	});
 
 	test("replays a forwardable chord as a keydown/keyup pair on the document", () => {
@@ -43,8 +145,9 @@ describe("forwardedHotkeys", () => {
 		expect(dispatched[0]?.init).toMatchObject({
 			key: "w",
 			code: "KeyW",
-			metaKey: true,
-			ctrlKey: false,
+			metaKey: isMac,
+			ctrlKey: !isMac,
+			shiftKey: !isMac,
 			bubbles: true,
 		});
 	});

--- a/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.test.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, mock, test } from "bun:test";
+
+class FakeKeyboardEvent {
+	type: string;
+	init: KeyboardEventInit;
+	constructor(type: string, init: KeyboardEventInit) {
+		this.type = type;
+		this.init = init;
+	}
+}
+(globalThis as unknown as Record<string, unknown>).KeyboardEvent =
+	FakeKeyboardEvent;
+const dispatchEvent = mock((_event: FakeKeyboardEvent) => true);
+(document as unknown as Record<string, unknown>).dispatchEvent = dispatchEvent;
+
+const { getForwardableChords, replayForwardedKey } = await import(
+	"./forwardedHotkeys"
+);
+
+const key = (overrides: Partial<Parameters<typeof replayForwardedKey>[0]>) => ({
+	key: "w",
+	code: "KeyW",
+	meta: true,
+	control: false,
+	alt: false,
+	shift: false,
+	...overrides,
+});
+
+describe("forwardedHotkeys", () => {
+	test("the synced chord set covers closing the pane and tab switching", () => {
+		const chords = getForwardableChords();
+		expect(chords).toContain("meta+w");
+		expect(chords).toContain("alt+meta+arrowright");
+		expect(chords).not.toContain("meta+c");
+	});
+
+	test("replays a forwardable chord as a keydown/keyup pair on the document", () => {
+		dispatchEvent.mockClear();
+		expect(replayForwardedKey(key({}))).toBe(true);
+		const dispatched = dispatchEvent.mock.calls.map(([event]) => event);
+		expect(dispatched.map((event) => event.type)).toEqual(["keydown", "keyup"]);
+		expect(dispatched[0]?.init).toMatchObject({
+			key: "w",
+			code: "KeyW",
+			metaKey: true,
+			ctrlKey: false,
+			bubbles: true,
+		});
+	});
+
+	test("drops a chord outside the forwardable set", () => {
+		dispatchEvent.mockClear();
+		expect(replayForwardedKey(key({ key: "c", code: "KeyC" }))).toBe(false);
+		expect(dispatchEvent).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.ts
@@ -1,0 +1,70 @@
+import {
+	canonicalizeChord,
+	chordFromInput,
+	type ForwardedKey,
+} from "shared/hotkey-chord";
+import { getDispatchChord } from "../hooks/useBinding/useBinding";
+import type { HotkeyId } from "../registry";
+
+/**
+ * Hotkeys the host replays when an embedded document (a guest webview, a
+ * page pane's iframe) had focus for the keystroke. Scoped to tab switching,
+ * zoom and closing the pane: none has a registered menu accelerator (so a
+ * replay can't double-fire) and none is a page shortcut worth keeping. The
+ * main process is synced these chords so it suppresses and forwards only
+ * them; everything else stays in the page (copy, paste, find, …).
+ */
+export const FORWARDED_HOTKEYS: ReadonlySet<HotkeyId> = new Set<HotkeyId>([
+	"ZOOM_IN",
+	"ZOOM_OUT",
+	"ZOOM_RESET",
+	"PREV_TAB",
+	"NEXT_TAB",
+	"PREV_TAB_ALT",
+	"NEXT_TAB_ALT",
+	"JUMP_TO_TAB_1",
+	"JUMP_TO_TAB_2",
+	"JUMP_TO_TAB_3",
+	"JUMP_TO_TAB_4",
+	"JUMP_TO_TAB_5",
+	"JUMP_TO_TAB_6",
+	"JUMP_TO_TAB_7",
+	"JUMP_TO_TAB_8",
+	"JUMP_TO_TAB_9",
+	"CLOSE_PANE",
+]);
+
+/** Canonical chords of {@link FORWARDED_HOTKEYS} under the current bindings. */
+export function getForwardableChords(): string[] {
+	const chords: string[] = [];
+	for (const id of FORWARDED_HOTKEYS) {
+		const chord = getDispatchChord(id);
+		if (chord) chords.push(canonicalizeChord(chord));
+	}
+	return chords;
+}
+
+/**
+ * Replay a forwarded keystroke onto the host document so `react-hotkeys-hook`
+ * picks it up. Re-gated against the current bindings in case the main
+ * process's chord set lags a remap. Returns whether it was replayed.
+ */
+export function replayForwardedKey(key: ForwardedKey): boolean {
+	const chord = chordFromInput(key);
+	if (!chord || !getForwardableChords().includes(chord)) return false;
+	const init: KeyboardEventInit = {
+		key: key.key,
+		code: key.code,
+		metaKey: key.meta,
+		ctrlKey: key.control,
+		altKey: key.alt,
+		shiftKey: key.shift,
+		bubbles: true,
+		cancelable: true,
+	};
+	document.dispatchEvent(new KeyboardEvent("keydown", init));
+	// keyup balances react-hotkeys-hook's pressed-key set; without it the key
+	// stays stuck as "pressed".
+	document.dispatchEvent(new KeyboardEvent("keyup", init));
+	return true;
+}

--- a/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.ts
+++ b/apps/desktop/src/renderer/hotkeys/utils/forwardedHotkeys.ts
@@ -8,11 +8,11 @@ import type { HotkeyId } from "../registry";
 
 /**
  * Hotkeys the host replays when an embedded document (a guest webview, a
- * page pane's iframe) had focus for the keystroke. Scoped to tab switching,
- * zoom and closing the pane: none has a registered menu accelerator (so a
- * replay can't double-fire) and none is a page shortcut worth keeping. The
- * main process is synced these chords so it suppresses and forwards only
- * them; everything else stays in the page (copy, paste, find, …).
+ * page pane's iframe) had focus for the keystroke. Shell actions must work
+ * from embedded content just as they do from a pane header. Keep this list
+ * shared between both surfaces and resolve the user's current bindings.
+ * Native menu accelerators and document actions (copy, paste, find, undo,
+ * reload, …) keep their existing handling instead of being replayed here.
  */
 export const FORWARDED_HOTKEYS: ReadonlySet<HotkeyId> = new Set<HotkeyId>([
 	"ZOOM_IN",
@@ -32,6 +32,27 @@ export const FORWARDED_HOTKEYS: ReadonlySet<HotkeyId> = new Set<HotkeyId>([
 	"JUMP_TO_TAB_8",
 	"JUMP_TO_TAB_9",
 	"CLOSE_PANE",
+	"CLOSE_TAB",
+	"REOPEN_TAB",
+	"SPLIT_RIGHT",
+	"SPLIT_DOWN",
+	"SPLIT_AUTO",
+	"SPLIT_WITH_BROWSER",
+	"SPLIT_WITH_DESKTOP",
+	"EQUALIZE_PANE_SPLITS",
+	"FOCUS_PANE_LEFT",
+	"FOCUS_PANE_RIGHT",
+	"FOCUS_PANE_UP",
+	"FOCUS_PANE_DOWN",
+	"TOGGLE_SIDEBAR",
+	"TOGGLE_WORKSPACE_SIDEBAR",
+	"NEW_GROUP",
+	"NEW_BROWSER",
+	"OPEN_DIFF_VIEWER",
+	"QUICK_OPEN",
+	"OPEN_COMMAND_PALETTE",
+	"CHECK_RESOURCES",
+	"NEW_WORKSPACE",
 ]);
 
 /** Canonical chords of {@link FORWARDED_HOTKEYS} under the current bindings. */

--- a/apps/desktop/src/renderer/lib/pointer-passthrough.test.ts
+++ b/apps/desktop/src/renderer/lib/pointer-passthrough.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const toggleAttribute = mock((_name: string, _force?: boolean) => {});
+(
+	document.documentElement as unknown as Record<string, unknown>
+).toggleAttribute = toggleAttribute;
+
+const {
+	NATIVE_DRAG_SOURCE,
+	POINTER_PASSTHROUGH_ATTRIBUTE,
+	pointerPassthrough,
+} = await import("./pointer-passthrough");
+
+describe("pointerPassthrough", () => {
+	test("stays active until the last source releases, notifying on each edge", () => {
+		const seen: boolean[] = [];
+		const unsubscribe = pointerPassthrough.subscribe((active) =>
+			seen.push(active),
+		);
+		toggleAttribute.mockClear();
+		try {
+			pointerPassthrough.set("a", true);
+			pointerPassthrough.set("b", true);
+			expect(pointerPassthrough.active).toBe(true);
+			// One source releasing must not clear a gesture still in flight.
+			pointerPassthrough.set("b", false);
+			expect(pointerPassthrough.active).toBe(true);
+			pointerPassthrough.set("a", false);
+			expect(pointerPassthrough.active).toBe(false);
+
+			expect(seen).toEqual([true, false]);
+			expect(toggleAttribute.mock.calls).toEqual([
+				[POINTER_PASSTHROUGH_ATTRIBUTE, true],
+				[POINTER_PASSTHROUGH_ATTRIBUTE, false],
+			]);
+		} finally {
+			unsubscribe();
+			pointerPassthrough.set("a", false);
+			pointerPassthrough.set("b", false);
+		}
+	});
+
+	test("releasing a source that was never held is a no-op", () => {
+		const seen: boolean[] = [];
+		const unsubscribe = pointerPassthrough.subscribe((active) =>
+			seen.push(active),
+		);
+		try {
+			pointerPassthrough.set("never", false);
+			expect(seen).toEqual([]);
+			expect(pointerPassthrough.active).toBe(false);
+		} finally {
+			unsubscribe();
+		}
+	});
+
+	test("a native drag holds passthrough from dragstart to drop, dragend or blur", () => {
+		const handlers = new Map<string, () => void>();
+		const target = {
+			addEventListener: (type: string, handler: () => void) => {
+				handlers.set(type, handler);
+			},
+		} as unknown as Window;
+		// The module installs on the real window at import; a fresh target
+		// exercises the listener wiring itself.
+		const fresh = new (Object.getPrototypeOf(pointerPassthrough).constructor)();
+		fresh.installNativeDragListeners(target);
+		fresh.installNativeDragListeners(target);
+		expect([...handlers.keys()].sort()).toEqual([
+			"blur",
+			"dragend",
+			"dragstart",
+			"drop",
+		]);
+
+		for (const end of ["drop", "dragend", "blur"] as const) {
+			handlers.get("dragstart")?.();
+			expect(fresh.active).toBe(true);
+			handlers.get(end)?.();
+			expect(fresh.active).toBe(false);
+		}
+		expect(NATIVE_DRAG_SOURCE).toBe("native-drag");
+	});
+});

--- a/apps/desktop/src/renderer/lib/pointer-passthrough.ts
+++ b/apps/desktop/src/renderer/lib/pointer-passthrough.ts
@@ -1,0 +1,75 @@
+/**
+ * Embedded documents — a page pane's iframe, a hoisted browser webview —
+ * hit-test ahead of the host, so a host gesture that crosses one stalls at
+ * its edge: a pane drag never reaches the drop target underneath, a Radix
+ * popover never sees the click that should dismiss it. While such a gesture
+ * is in flight the host is marked `data-pointer-passthrough` and embeds let
+ * the pointer fall through — `globals.css` covers iframes, and the browser
+ * registry mirrors the state onto its webviews, which live outside the pane
+ * tree where a stylesheet rule can't reach them.
+ *
+ * Sources are ref-counted by name so one gesture ending can't clear another
+ * still in flight (two panes' popovers, a drag during a resize).
+ */
+export const POINTER_PASSTHROUGH_ATTRIBUTE = "data-pointer-passthrough";
+
+export const NATIVE_DRAG_SOURCE = "native-drag";
+
+class PointerPassthrough {
+	private sources = new Set<string>();
+	private listeners = new Set<(active: boolean) => void>();
+	private nativeDragListenersInstalled = false;
+
+	get active(): boolean {
+		return this.sources.size > 0;
+	}
+
+	set(source: string, active: boolean): void {
+		const wasActive = this.active;
+		if (active) this.sources.add(source);
+		else this.sources.delete(source);
+		if (this.active === wasActive) return;
+		document.documentElement.toggleAttribute(
+			POINTER_PASSTHROUGH_ATTRIBUTE,
+			this.active,
+		);
+		for (const listener of this.listeners) listener(this.active);
+	}
+
+	subscribe(listener: (active: boolean) => void): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	/**
+	 * A native drag (a pane or tab header, a sidebar row) is the one gesture
+	 * every embed must yield to; the others are opted into by their owners.
+	 * `drop` ends a drag that landed, `dragend` one that didn't, and a window
+	 * blur one the OS cancelled without either.
+	 */
+	installNativeDragListeners(target: Window): void {
+		if (this.nativeDragListenersInstalled) return;
+		this.nativeDragListenersInstalled = true;
+		const start = () => this.set(NATIVE_DRAG_SOURCE, true);
+		const end = () => this.set(NATIVE_DRAG_SOURCE, false);
+		target.addEventListener("dragstart", start, true);
+		target.addEventListener("dragend", end, true);
+		target.addEventListener("drop", end, true);
+		target.addEventListener("blur", end);
+	}
+}
+
+export const pointerPassthrough: PointerPassthrough =
+	(import.meta.hot?.data?.pointerPassthrough as
+		| PointerPassthrough
+		| undefined) ?? new PointerPassthrough();
+
+if (import.meta.hot) {
+	import.meta.hot.data.pointerPassthrough = pointerPassthrough;
+}
+
+if (typeof window !== "undefined") {
+	pointerPassthrough.installNativeDragListeners(window);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/PageViewer/PageViewer.tsx
@@ -27,6 +27,7 @@ interface PageViewerProps {
 	commentsEnabled: boolean;
 	onCommentsEnabledChange: (enabled: boolean) => void;
 	onResolved?: (page: ResolvedPage) => void;
+	onFramePointerDown?: () => void;
 }
 
 export function PageViewer({
@@ -36,6 +37,7 @@ export function PageViewer({
 	commentsEnabled,
 	onCommentsEnabledChange,
 	onResolved,
+	onFramePointerDown,
 }: PageViewerProps) {
 	const { t } = useLingui();
 	const { data: session } = authClient.useSession();
@@ -113,6 +115,7 @@ export function PageViewer({
 						title={resolvedTitle}
 						initialScrollY={scrollPositions.get(scrollKey) ?? 0}
 						onScrollYChange={(y) => scrollPositions.set(scrollKey, y)}
+						onFramePointerDown={onFramePointerDown}
 					/>
 				</div>
 				{commentsEnabled ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useBrowserShellInteractionPassthrough/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useBrowserShellInteractionPassthrough/index.ts
@@ -1,1 +1,0 @@
-export { useBrowserShellInteractionPassthrough } from "./useBrowserShellInteractionPassthrough";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
@@ -15,6 +15,11 @@ mock.module("renderer/lib/trpc-client", () => ({
 	},
 }));
 
+(
+	document.documentElement as unknown as Record<string, unknown>
+).toggleAttribute = mock(() => {});
+
+const { pointerPassthrough } = await import("renderer/lib/pointer-passthrough");
 const { browserRuntimeRegistry } = await import("./browserRuntimeRegistry");
 
 describe("browserRuntimeRegistry detached persistence", () => {
@@ -126,41 +131,32 @@ describe("browserRuntimeRegistry detached persistence", () => {
 	});
 });
 
-describe("browserRuntimeRegistry host popover passthrough", () => {
-	test("keeps webviews passed through until the last open popover closes", () => {
-		const makeEntry = () => ({
+describe("browserRuntimeRegistry pointer passthrough", () => {
+	test("mirrors the passthrough state onto visible webviews only", () => {
+		const makeEntry = (visible: boolean) => ({
 			webview: { style: { pointerEvents: "auto" } },
 			overlay: { style: {} },
-			visible: true,
+			visible,
 		});
-		const a = makeEntry();
-		const b = makeEntry();
+		const shown = makeEntry(true);
+		const parked = makeEntry(false);
 		const registryInternals = browserRuntimeRegistry as unknown as {
 			entries: Map<string, ReturnType<typeof makeEntry>>;
 		};
-		registryInternals.entries.set("popover-pane-a", a);
-		registryInternals.entries.set("popover-pane-b", b);
+		registryInternals.entries.set("passthrough-shown", shown);
+		registryInternals.entries.set("passthrough-parked", parked);
 
 		try {
-			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-a", true);
-			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-b", true);
-			expect(a.webview.style.pointerEvents).toBe("none");
-			expect(b.webview.style.pointerEvents).toBe("none");
+			pointerPassthrough.set("test-gesture", true);
+			expect(shown.webview.style.pointerEvents).toBe("none");
+			expect(parked.webview.style.pointerEvents).toBe("auto");
 
-			// One pane closing (or unmounting) must not restore pointer events
-			// while another pane's popover is still open.
-			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-b", false);
-			expect(a.webview.style.pointerEvents).toBe("none");
-			expect(b.webview.style.pointerEvents).toBe("none");
-
-			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-a", false);
-			expect(a.webview.style.pointerEvents).toBe("auto");
-			expect(b.webview.style.pointerEvents).toBe("auto");
+			pointerPassthrough.set("test-gesture", false);
+			expect(shown.webview.style.pointerEvents).toBe("auto");
 		} finally {
-			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-a", false);
-			browserRuntimeRegistry.setHostPopoverOpen("popover-pane-b", false);
-			registryInternals.entries.delete("popover-pane-a");
-			registryInternals.entries.delete("popover-pane-b");
+			pointerPassthrough.set("test-gesture", false);
+			registryInternals.entries.delete("passthrough-shown");
+			registryInternals.entries.delete("passthrough-parked");
 		}
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -1,3 +1,4 @@
+import { pointerPassthrough } from "renderer/lib/pointer-passthrough";
 import { selectRuntimesToEvict } from "renderer/lib/terminal/terminal-runtime-eviction";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type { BrowserLoadError } from "shared/tabs-types";
@@ -86,14 +87,6 @@ class BrowserRuntimeRegistryImpl {
 	private pendingEviction: ReturnType<typeof setTimeout> | null = null;
 	private rootContainer: HTMLDivElement | null = null;
 	private globalListenersInstalled = false;
-	private windowDragPassthrough = false;
-	private shellInteractionPassthrough = false;
-	// Panes whose host popover (the toolbar's overflow menu) is open. The
-	// webview swallows pointer events, so a click on the page would never
-	// reach the document listener Radix dismisses on; passing the click
-	// through to the host lets it dismiss the popover instead, as in a real
-	// browser. Keyed by pane so one pane closing can't drop another's.
-	private hostPopoverOpenPaneIds = new Set<string>();
 	// Panes an agent is driving (live CDP session or in-flight capture, fed
 	// by the main process). Parked presentable instead of hidden — a
 	// visibility-hidden webview gets no compositor frames, so CDP
@@ -138,26 +131,17 @@ class BrowserRuntimeRegistryImpl {
 		return root;
 	}
 
+	constructor() {
+		// Webviews are hoisted to <body>, out of reach of the stylesheet rule
+		// that handles iframes, so the passthrough state is mirrored onto them.
+		pointerPassthrough.subscribe((active) =>
+			this.applyPointerPassthrough(active),
+		);
+	}
+
 	private installGlobalListeners() {
 		if (this.globalListenersInstalled) return;
 		this.globalListenersInstalled = true;
-
-		window.addEventListener(
-			"dragstart",
-			() => this.setWindowDragPassthrough(true),
-			true,
-		);
-		window.addEventListener(
-			"dragend",
-			() => this.setWindowDragPassthrough(false),
-			true,
-		);
-		window.addEventListener(
-			"drop",
-			() => this.setWindowDragPassthrough(false),
-			true,
-		);
-		window.addEventListener("blur", () => this.setWindowDragPassthrough(false));
 
 		window.addEventListener("resize", () => {
 			for (const entry of this.entries.values()) {
@@ -198,40 +182,7 @@ class BrowserRuntimeRegistryImpl {
 		entry.overlay.style.visibility = "hidden";
 	}
 
-	private setWindowDragPassthrough(passthrough: boolean) {
-		const wasActive = this.isPointerPassthroughActive();
-		this.windowDragPassthrough = passthrough;
-		this.applyPointerPassthroughIfChanged(wasActive);
-	}
-
-	setShellInteractionPassthrough(passthrough: boolean): void {
-		const wasActive = this.isPointerPassthroughActive();
-		this.shellInteractionPassthrough = passthrough;
-		this.applyPointerPassthroughIfChanged(wasActive);
-	}
-
-	setHostPopoverOpen(paneId: string, open: boolean): void {
-		const wasActive = this.isPointerPassthroughActive();
-		if (open) this.hostPopoverOpenPaneIds.add(paneId);
-		else this.hostPopoverOpenPaneIds.delete(paneId);
-		this.applyPointerPassthroughIfChanged(wasActive);
-	}
-
-	private isPointerPassthroughActive() {
-		return (
-			this.windowDragPassthrough ||
-			this.shellInteractionPassthrough ||
-			this.hostPopoverOpenPaneIds.size > 0
-		);
-	}
-
-	private applyPointerPassthroughIfChanged(wasActive: boolean) {
-		const isActive = this.isPointerPassthroughActive();
-		if (wasActive !== isActive) this.applyPointerPassthrough();
-	}
-
-	private applyPointerPassthrough() {
-		const passthrough = this.isPointerPassthroughActive();
+	private applyPointerPassthrough(passthrough: boolean) {
 		for (const entry of this.entries.values()) {
 			if (!entry.visible) continue;
 			entry.webview.style.pointerEvents = passthrough ? "none" : "auto";
@@ -574,7 +525,7 @@ class BrowserRuntimeRegistryImpl {
 		entry.webview.style.visibility = "visible";
 		entry.webview.style.opacity = "";
 		entry.overlay.style.visibility = "visible";
-		this.applyPointerPassthrough();
+		this.applyPointerPassthrough(pointerPassthrough.active);
 	}
 
 	detach(paneId: string): void {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserOverflowMenu/BrowserOverflowMenu.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import { TbDots } from "react-icons/tb";
 import { ImportHistoryDialog } from "renderer/components/ImportHistoryDialog";
 import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { pointerPassthrough } from "renderer/lib/pointer-passthrough";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
 	BROWSER_ZOOM,
@@ -72,9 +73,14 @@ export function BrowserOverflowMenu({
 	const [isClearDataOpen, setIsClearDataOpen] = useState(false);
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 
+	// The webview swallows pointer events, so a click on the page would never
+	// reach the document listener Radix dismisses on; passing the click
+	// through to the host lets it dismiss the menu instead, as in a real
+	// browser. Keyed by pane so one pane closing can't drop another's.
 	useEffect(() => {
-		browserRuntimeRegistry.setHostPopoverOpen(paneId, isMenuOpen);
-		return () => browserRuntimeRegistry.setHostPopoverOpen(paneId, false);
+		const source = `host-popover:${paneId}`;
+		pointerPassthrough.set(source, isMenuOpen);
+		return () => pointerPassthrough.set(source, false);
 	}, [paneId, isMenuOpen]);
 
 	const handlePrint = () => browserRuntimeRegistry.print(paneId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -1,46 +1,14 @@
 import type { RendererContext } from "@superset/panes";
 import { useParams } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-	getDispatchChord,
-	type HotkeyId,
-	resolveHotkeyFromEvent,
-	useHotkeyOverridesStore,
-	useKeyboardPreferencesStore,
-} from "renderer/hotkeys";
-import { useKeyboardLayoutStore } from "renderer/hotkeys/stores/keyboardLayoutStore";
+import { replayForwardedKey } from "renderer/hotkeys";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import type {
 	BrowserPaneData,
 	PaneViewerData,
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
-import { canonicalizeChord } from "shared/hotkey-chord";
 import { browserRuntimeRegistry } from "../../browserRuntimeRegistry";
 import { DEFAULT_BROWSER_URL } from "../../constants";
-
-// Hotkeys the pane replays onto the host document when the guest forwards a
-// keystroke. Scoped to tab switching and zoom: no registered menu accelerator
-// (so replaying can't double-fire) and not page shortcuts. The main process is
-// synced these chords so it suppresses + forwards only them — see the
-// forwardable-chord sync below.
-const FORWARDABLE_HOTKEYS = new Set<HotkeyId>([
-	"ZOOM_IN",
-	"ZOOM_OUT",
-	"ZOOM_RESET",
-	"PREV_TAB",
-	"NEXT_TAB",
-	"PREV_TAB_ALT",
-	"NEXT_TAB_ALT",
-	"JUMP_TO_TAB_1",
-	"JUMP_TO_TAB_2",
-	"JUMP_TO_TAB_3",
-	"JUMP_TO_TAB_4",
-	"JUMP_TO_TAB_5",
-	"JUMP_TO_TAB_6",
-	"JUMP_TO_TAB_7",
-	"JUMP_TO_TAB_8",
-	"JUMP_TO_TAB_9",
-]);
 
 interface UsePersistentWebviewOptions {
 	paneId: string;
@@ -149,30 +117,11 @@ export function usePersistentWebview({
 				},
 			},
 		);
-		// Replay forwarded chords onto the host document so react-hotkeys-hook
-		// picks them up. Re-gated to tab-switch hotkeys in case the main set lags.
+		// Chords the main process suppressed in the focused guest, replayed
+		// onto the host document so react-hotkeys-hook picks them up.
 		const keyForwardSub = electronTrpcClient.browser.onKeyForward.subscribe(
 			{ paneId },
-			{
-				onData: (key) => {
-					const init: KeyboardEventInit = {
-						key: key.key,
-						code: key.code,
-						metaKey: key.meta,
-						ctrlKey: key.control,
-						altKey: key.alt,
-						shiftKey: key.shift,
-						bubbles: true,
-						cancelable: true,
-					};
-					const id = resolveHotkeyFromEvent(new KeyboardEvent("keydown", init));
-					if (!id || !FORWARDABLE_HOTKEYS.has(id)) return;
-					document.dispatchEvent(new KeyboardEvent("keydown", init));
-					// keyup balances react-hotkeys-hook's pressed-key set; without it
-					// the key stays stuck as "pressed".
-					document.dispatchEvent(new KeyboardEvent("keyup", init));
-				},
-			},
+			{ onData: replayForwardedKey },
 		);
 		return () => {
 			newWindowSub.unsubscribe();
@@ -182,34 +131,6 @@ export function usePersistentWebview({
 			keyForwardSub.unsubscribe();
 		};
 	}, [paneId]);
-
-	// Sync the main process's forwardable-chord set with the current bindings,
-	// recomputing on the same remap / layout / preference changes that rebuild
-	// `resolveHotkeyFromEvent`'s index.
-	useEffect(() => {
-		const push = () => {
-			const chords = [...FORWARDABLE_HOTKEYS]
-				.map((id) => getDispatchChord(id))
-				.filter((chord): chord is string => chord !== null)
-				.map(canonicalizeChord);
-			electronTrpcClient.browser.setForwardableChords
-				.mutate({ chords })
-				.catch((error) => {
-					// Stale main-process suppression means webview tab-switch hotkeys
-					// silently stop working — leave a trace.
-					console.warn("[browser] failed to sync forwardable chords", error);
-				});
-		};
-		push();
-		const unsubs = [
-			useHotkeyOverridesStore.subscribe(push),
-			useKeyboardLayoutStore.subscribe(push),
-			useKeyboardPreferencesStore.subscribe(push),
-		];
-		return () => {
-			for (const unsub of unsubs) unsub();
-		};
-	}, []);
 
 	const goBack = useCallback(() => {
 		browserRuntimeRegistry.goBack(paneId);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/PagePane/PagePane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/PagePane/PagePane.tsx
@@ -7,9 +7,20 @@ interface PagePaneProps {
 	data: PagePaneData;
 	paneId: string;
 	onDataChange: (data: PagePaneData) => void;
+	/**
+	 * Make this the active pane. Clicking anywhere in a pane activates it,
+	 * but a click inside the page's iframe never reaches the pane's own
+	 * handler, so the frame reports it and the pane activates itself.
+	 */
+	onFocus: () => void;
 }
 
-export function PagePane({ data, paneId, onDataChange }: PagePaneProps) {
+export function PagePane({
+	data,
+	paneId,
+	onDataChange,
+	onFocus,
+}: PagePaneProps) {
 	const { commentsEnabled, setCommentsEnabled } = usePagePaneUi(paneId);
 
 	const onDataChangeRef = useRef(onDataChange);
@@ -35,6 +46,7 @@ export function PagePane({ data, paneId, onDataChange }: PagePaneProps) {
 			commentsEnabled={commentsEnabled}
 			onCommentsEnabledChange={setCommentsEnabled}
 			onResolved={handleResolved}
+			onFramePointerDown={onFocus}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/usePaneRegistry.tsx
@@ -797,6 +797,7 @@ export function usePaneRegistry({
 									onDataChange={(data) =>
 										ctx.actions.updateData(data as PaneViewerData)
 									}
+									onFocus={ctx.actions.focus}
 								/>
 							),
 							contextMenuActions: (_ctx, defaults) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useShellInteractionPassthrough/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useShellInteractionPassthrough/index.ts
@@ -1,0 +1,1 @@
+export { useShellInteractionPassthrough } from "./useShellInteractionPassthrough";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useShellInteractionPassthrough/useShellInteractionPassthrough.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useShellInteractionPassthrough/useShellInteractionPassthrough.ts
@@ -1,19 +1,27 @@
 import type { WorkspaceInteractionState } from "@superset/panes";
 import { useCallback, useEffect, useRef } from "react";
-import { browserRuntimeRegistry } from "../usePaneRegistry/components/BrowserPane";
+import { pointerPassthrough } from "renderer/lib/pointer-passthrough";
 
-interface UseBrowserShellInteractionPassthroughArgs {
+const SOURCE = "shell-resize";
+
+interface UseShellInteractionPassthroughArgs {
 	sidebarOpen: boolean;
 }
 
-export function useBrowserShellInteractionPassthrough({
+/**
+ * A split or sidebar resize tracks the pointer on the host document; a
+ * hoisted webview under the pointer would swallow the moves and stall the
+ * drag, so embeds yield to the gesture for its duration.
+ */
+export function useShellInteractionPassthrough({
 	sidebarOpen,
-}: UseBrowserShellInteractionPassthroughArgs) {
+}: UseShellInteractionPassthroughArgs) {
 	const workspaceResizeActiveRef = useRef(false);
 	const sidebarResizeActiveRef = useRef(false);
 
 	const syncBrowserShellInteractionPassthrough = useCallback(() => {
-		browserRuntimeRegistry.setShellInteractionPassthrough(
+		pointerPassthrough.set(
+			SOURCE,
 			workspaceResizeActiveRef.current || sidebarResizeActiveRef.current,
 		);
 	}, []);
@@ -37,7 +45,7 @@ export function useBrowserShellInteractionPassthrough({
 	const clearBrowserShellInteractionPassthrough = useCallback(() => {
 		workspaceResizeActiveRef.current = false;
 		sidebarResizeActiveRef.current = false;
-		browserRuntimeRegistry.setShellInteractionPassthrough(false);
+		pointerPassthrough.set(SOURCE, false);
 	}, []);
 
 	useEffect(() => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -38,7 +38,6 @@ import { WorkspaceEmptyState } from "./components/WorkspaceEmptyState";
 import { WorkspaceMissingWorktreeState } from "./components/WorkspaceMissingWorktreeState";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { useAutoAdoptBackgroundSessions } from "./hooks/useAutoAdoptBackgroundSessions";
-import { useBrowserShellInteractionPassthrough } from "./hooks/useBrowserShellInteractionPassthrough";
 import { useClearActivePaneAttention } from "./hooks/useClearActivePaneAttention";
 import { useConsumeAutomationRunLink } from "./hooks/useConsumeAutomationRunLink";
 import { useConsumeOpenUrlRequest } from "./hooks/useConsumeOpenUrlRequest";
@@ -50,6 +49,7 @@ import { usePagePaneIntentOpener } from "./hooks/usePagePaneIntentOpener";
 import { usePaneRegistry } from "./hooks/usePaneRegistry";
 import { renderBrowserTabIcon } from "./hooks/usePaneRegistry/components/BrowserPane";
 import { useRunWorkspaceCreationPresets } from "./hooks/useRunWorkspaceCreationPresets";
+import { useShellInteractionPassthrough } from "./hooks/useShellInteractionPassthrough";
 import { useSlotElement } from "./hooks/useSlotElement";
 import { useTabCloseGuard } from "./hooks/useTabCloseGuard";
 import { useV2PresetExecution } from "./hooks/useV2PresetExecution";
@@ -272,7 +272,7 @@ function V2WorkspaceContent() {
 	const sidebarWidth = v2UserPreferences.rightSidebarWidth ?? 340;
 	const [isSidebarResizing, setIsSidebarResizing] = useState(false);
 	const { onSidebarResizeDragging, onWorkspaceInteractionStateChange } =
-		useBrowserShellInteractionPassthrough({ sidebarOpen });
+		useShellInteractionPassthrough({ sidebarOpen });
 	const handleSidebarResizingChange = useCallback(
 		(resizing: boolean) => {
 			setIsSidebarResizing(resizing);

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useForwardedHotkeys/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useForwardedHotkeys/index.ts
@@ -1,0 +1,1 @@
+export { useForwardedHotkeys } from "./useForwardedHotkeys";

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useForwardedHotkeys/useForwardedHotkeys.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useForwardedHotkeys/useForwardedHotkeys.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import {
+	getForwardableChords,
+	replayForwardedKey,
+	useHotkeyOverridesStore,
+	useKeyboardPreferencesStore,
+} from "renderer/hotkeys";
+import { useKeyboardLayoutStore } from "renderer/hotkeys/stores/keyboardLayoutStore";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+
+/**
+ * Keeps hotkeys working while an embedded document has keyboard focus.
+ *
+ * Syncs the main process's forwardable-chord set with the current bindings —
+ * it suppresses exactly those chords in focused guest webviews and host
+ * iframes and hands them back — and replays the ones intercepted in this
+ * window's own iframes (a page pane, the PDF viewer). Guest webviews replay
+ * theirs per pane, where the pane id is known.
+ */
+export function useForwardedHotkeys() {
+	// Recomputed on the same remap / layout / preference changes that rebuild
+	// the hotkey resolver's index.
+	useEffect(() => {
+		const push = () => {
+			electronTrpcClient.browser.setForwardableChords
+				.mutate({ chords: getForwardableChords() })
+				.catch((error) => {
+					// Stale main-process suppression means embedded-focus hotkeys
+					// silently stop working — leave a trace.
+					console.warn("[hotkeys] failed to sync forwardable chords", error);
+				});
+		};
+		push();
+		const unsubs = [
+			useHotkeyOverridesStore.subscribe(push),
+			useKeyboardLayoutStore.subscribe(push),
+			useKeyboardPreferencesStore.subscribe(push),
+		];
+		return () => {
+			for (const unsub of unsubs) unsub();
+		};
+	}, []);
+
+	useEffect(() => {
+		const sub = electronTrpcClient.browser.onHostKeyForward.subscribe(
+			undefined,
+			{ onData: replayForwardedKey },
+		);
+		return () => sub.unsubscribe();
+	}, []);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -41,6 +41,7 @@ import {
 	V2FlipWelcome,
 } from "renderer/routes/_authenticated/components/V1FlipNotice";
 import { V1ImportModal } from "renderer/routes/_authenticated/components/V1ImportModal";
+import { useForwardedHotkeys } from "renderer/routes/_authenticated/hooks/useForwardedHotkeys";
 import { useZoomHotkeys } from "renderer/routes/_authenticated/hooks/useZoomHotkeys";
 import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { useSettingsStore } from "renderer/stores/settings-state";
@@ -187,6 +188,7 @@ function AuthenticatedLayout() {
 	});
 
 	useZoomHotkeys();
+	useForwardedHotkeys();
 
 	// Menu navigation subscription
 	electronTrpc.menu.subscribe.useSubscription(undefined, {

--- a/apps/desktop/src/shared/hotkey-chord.ts
+++ b/apps/desktop/src/shared/hotkey-chord.ts
@@ -127,6 +127,15 @@ export interface KeyChordInput {
 }
 
 /**
+ * A keystroke an embedded document (a guest webview, a host iframe) had focus
+ * for. The main process suppresses it there and hands it to the renderer,
+ * which replays it onto the host document as a synthetic KeyboardEvent.
+ */
+export interface ForwardedKey extends KeyChordInput {
+	key: string;
+}
+
+/**
  * Electron key input → canonical chord for the main process. Shares
  * {@link assembleChord} with {@link eventToChord}, so a given key produces the
  * same chord in both processes. The DOM-only AltGr/IME guards are absent here

--- a/packages/ui/src/components/PageComments/components/PageCommentsView/PageCommentsView.tsx
+++ b/packages/ui/src/components/PageComments/components/PageCommentsView/PageCommentsView.tsx
@@ -24,6 +24,11 @@ interface PageCommentsViewProps {
 	title: string;
 	initialScrollY?: number;
 	onScrollYChange?: (y: number) => void;
+	/**
+	 * A press inside the frame. It never bubbles into the host document, so a
+	 * host that focuses on click (a pane) hears about it here instead.
+	 */
+	onFramePointerDown?: () => void;
 }
 
 export function PageCommentsView({
@@ -31,10 +36,13 @@ export function PageCommentsView({
 	title,
 	initialScrollY,
 	onScrollYChange,
+	onFramePointerDown,
 }: PageCommentsViewProps) {
 	const scrollYRef = useRef(initialScrollY ?? 0);
 	const onScrollYChangeRef = useRef(onScrollYChange);
 	onScrollYChangeRef.current = onScrollYChange;
+	const onFramePointerDownRef = useRef(onFramePointerDown);
+	onFramePointerDownRef.current = onFramePointerDown;
 	const frameRef = useRef<HTMLIFrameElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [container, setContainer] = useState({ width: 0, height: 0 });
@@ -147,6 +155,7 @@ export function PageCommentsView({
 			}
 			if (data.type === "hover") setHoverRect(data.rect);
 			if (data.type === "pointer-down") {
+				onFramePointerDownRef.current?.();
 				notifyFramePointerDown();
 				if (!submitting) {
 					discardDraft();


### PR DESCRIPTION
## What & why

Page iframes swallow shell keyboard and pointer input. Forward configured shell shortcuts from focused host subframes to their window's renderer, sharing chord synchronization and replay with browser webviews. Activate page panes on frame pointer presses and share pointer passthrough during pane drags, resizing, and browser popovers.

The verification follow-up also fixes the narrow forwarding allowlist for **both surfaces**: split/layout actions, sidebar toggles, new terminal/browser tabs, close-tab, Changes, Quick Open, command palette, Resources, and New Workspace. Equalize and assigned directional pane-focus bindings are included. Document editing/find/reload shortcuts retain their existing handling. Tests cover remaps, unassignment, and platform-specific bindings.

## How I tested it

- Real app, matched worktree: renderer `localhost:6825`, CDP `9568`; authenticated local session. Real CDP mouse input + native keyboard input, with focus, geometry, tab/pane counts, route, dialogs, console errors, and screenshots recorded.
- Before/after for all 13 missing shell actions: failed from embedded content before this follow-up; passed afterward with `IFRAME` or `WEBVIEW` focused. Page split-right changed 2 → 3 panes and width 549.5 → 272.25 px. Browser splits changed 1 → 2 panes. Sidebar toggles changed/restored geometry. Creation/search/resource actions produced the expected tabs, dialogs, or routes.
- Close-tab passed from both: browser 4 → 3 tabs; page 3 → 2, without closing the host window. Existing previous/next tab variants rechecked; earlier numbered-tab checks covered all nine targets.
- Earlier pointer checks passed native pane drop, reverse drop, cancel, split/sidebar resize, oscillation/dwell and induced stalls; pointer passthrough returned to inactive after the gestures.
- 65 focused tests pass / 150 assertions across BrowserManager, forwarding, pointer passthrough, and browser registry. Forwarding tests also pass with Linux and Windows platform detection (33 each; not native GUI certification).
- `bun run lint:fix`, `bun run lint`, `bun run typecheck --filter=@superset/desktop --filter=@superset/ui`, `bun run check:plugins`, and `git diff --check` pass. No user-facing strings changed.

### Remaining verification limits

- Full desktop suite: 3583 passed, with the existing sidebar DnD `React.createContext is not a function` test-loading error on both Bun 1.3.11 and pinned 1.3.14. The sidebar suite passes 8/8 in isolation. Full monorepo rerun reached 21 successful tasks but failed in desktop on that error and a git-test timeout. This is **not** a full-suite-green claim.
- Native zoom/edit E2E checks remain inconclusive; custom directional bindings/equalize/desktop split have unit coverage only. V2 has no reopen-tab handler; forwarding `REOPEN_TAB` supports the existing legacy handler, not a new v2 reopen feature.
- Screenshots and detailed matrix are saved locally in `.superset/reports/hotkey-verification.md` and `/tmp/pages-hotkey-pr.VGdA1K/`. Refused/stale-target test attempts were excluded from accepted results.

## Checklist

- [x] Conventional-commit title
- [x] Maintainers can edit this same-repository branch
- [x] Lint and changed-package typechecks pass
- [x] Before/after native keyboard verification for the repaired shell actions in both pane types
- [ ] Full test suite / CI green
- [ ] Complete native zoom/edit shortcut verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Keyboard shortcuts now continue working when focus is inside embedded pages, webviews, iframes, or PDF content.
  - Embedded page interactions can automatically focus the active pane.
  - Pointer interactions pass through embedded content during supported gestures, including resizing, menus, and native dragging.
  - More workspace, pane, sidebar, browser, and command shortcuts are supported within embedded content.

- **Bug Fixes**
  - Improved handling of forwarded keyboard shortcuts and pointer events across embedded content.
  - Prevented unsupported shortcuts from being unnecessarily intercepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->