### PR TITLE
fix(desktop): stop an orphaned dev Electron from spinning on EPIPE forever

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -342,19 +342,39 @@ process.on("unhandledRejection", (reason) => {
 
 // Without these handlers, Electron may not quit when electron-vite sends SIGTERM
 if (process.env.NODE_ENV === "development") {
+	const DEV_EXIT_DEADLINE_MS = 5_000;
 	let signalHandled = false;
 	const handleTerminationSignal = (signal: string) => {
 		if (signalHandled) return;
 		signalHandled = true;
+		isQuitting = true;
 		console.log(`[main] Received ${signal}, quitting...`);
+		// Teardown can hang on a dead daemon socket; never let that keep an
+		// orphaned dev Electron alive.
+		setTimeout(() => {
+			console.log("[main] Teardown deadline reached, exiting");
+			app.exit(0);
+		}, DEV_EXIT_DEADLINE_MS);
 		getHostServiceCoordinator().stopAll();
-		void Promise.allSettled([teardownTerminalHost()]).finally(() =>
-			app.exit(0),
-		);
+		void Promise.allSettled([teardownTerminalHost()]).finally(() => {
+			console.log("[main] Teardown complete, exiting");
+			app.exit(0);
+		});
 	};
 
 	process.on("SIGTERM", () => handleTerminationSignal("SIGTERM"));
 	process.on("SIGINT", () => handleTerminationSignal("SIGINT"));
+
+	// electron-vite (or turbo above it) owns our stdout/stderr pipes. When it
+	// dies without signalling us, the next write fails with EPIPE. Without a
+	// listener that surfaces as an uncaughtException, whose logging writes to
+	// the same dead pipe and throws again: an unbounded loop that pins a core
+	// until someone kills the process. Treat it as the dev runner going away.
+	const handleStdioError = (error: NodeJS.ErrnoException) => {
+		if (error.code === "EPIPE") handleTerminationSignal("stdio-closed");
+	};
+	process.stdout.on("error", handleStdioError);
+	process.stderr.on("error", handleStdioError);
 
 	// Fallback: electron-vite may exit without signaling the child Electron process
 	const parentPid = process.ppid;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,6 +35,7 @@ import { isUpdateReadyToInstall, setupAutoUpdater } from "./lib/auto-updater";
 import { startBrowserBridge } from "./lib/browser/browser-bridge";
 import { downloadManager } from "./lib/browser/download-manager";
 import { installBundledCliShim } from "./lib/bundled-cli";
+import { installDevRunnerExit } from "./lib/dev-runner-exit";
 import { resolveDevWorkspaceName } from "./lib/dev-workspace-name";
 import { setWorkspaceDockIcon } from "./lib/dock-icon";
 import { loadWebviewBrowserExtension } from "./lib/extensions";
@@ -340,61 +341,20 @@ process.on("unhandledRejection", (reason) => {
 	console.error("[main] Unhandled rejection:", reason);
 });
 
-// Without these handlers, Electron may not quit when electron-vite sends SIGTERM
 if (process.env.NODE_ENV === "development") {
-	const DEV_EXIT_DEADLINE_MS = 5_000;
-	let signalHandled = false;
-	const handleTerminationSignal = (signal: string) => {
-		if (signalHandled) return;
-		signalHandled = true;
-		isQuitting = true;
-		console.log(`[main] Received ${signal}, quitting...`);
-		// Teardown can hang on a dead daemon socket; never let that keep an
-		// orphaned dev Electron alive.
-		setTimeout(() => {
-			console.log("[main] Teardown deadline reached, exiting");
-			app.exit(0);
-		}, DEV_EXIT_DEADLINE_MS);
-		getHostServiceCoordinator().stopAll();
-		void Promise.allSettled([teardownTerminalHost()]).finally(() => {
-			console.log("[main] Teardown complete, exiting");
-			app.exit(0);
-		});
-	};
-
-	process.on("SIGTERM", () => handleTerminationSignal("SIGTERM"));
-	process.on("SIGINT", () => handleTerminationSignal("SIGINT"));
-
-	// electron-vite (or turbo above it) owns our stdout/stderr pipes. When it
-	// dies without signalling us, the next write fails with EPIPE. Without a
-	// listener that surfaces as an uncaughtException, whose logging writes to
-	// the same dead pipe and throws again: an unbounded loop that pins a core
-	// until someone kills the process. Treat it as the dev runner going away.
-	const handleStdioError = (error: NodeJS.ErrnoException) => {
-		if (error.code === "EPIPE") handleTerminationSignal("stdio-closed");
-	};
-	process.stdout.on("error", handleStdioError);
-	process.stderr.on("error", handleStdioError);
-
-	// Fallback: electron-vite may exit without signaling the child Electron process
-	const parentPid = process.ppid;
-	const isParentAlive = (): boolean => {
-		try {
-			process.kill(parentPid, 0);
-			return true;
-		} catch {
-			return false;
-		}
-	};
-
-	const parentCheckInterval = setInterval(() => {
-		if (!isParentAlive()) {
-			console.log("[main] Parent process exited, quitting...");
-			clearInterval(parentCheckInterval);
-			handleTerminationSignal("parent-exit");
-		}
-	}, 1000);
-	parentCheckInterval.unref();
+	installDevRunnerExit({
+		parentPid: process.ppid,
+		stdio: [process.stdout, process.stderr],
+		subscribeSignal: (signal, handler) => {
+			process.on(signal, handler);
+		},
+		markQuitting: () => {
+			isQuitting = true;
+		},
+		stopHostServices: () => getHostServiceCoordinator().stopAll(),
+		teardownTerminalHost,
+		exit: (code) => app.exit(code),
+	});
 }
 
 // Chromium refuses to cache any single entry larger than about an eighth

--- a/apps/desktop/src/main/lib/dev-runner-exit.test.ts
+++ b/apps/desktop/src/main/lib/dev-runner-exit.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	DEV_EXIT_DEADLINE_MS,
+	DEV_PARENT_POLL_MS,
+	installDevRunnerExit,
+} from "./dev-runner-exit";
+
+type Listener<T> = (arg: T) => void;
+
+function setup(overrides: { teardown?: () => Promise<void> } = {}) {
+	const signalHandlers = new Map<string, () => void>();
+	const stdioHandlers: Listener<NodeJS.ErrnoException>[] = [];
+	const timers: Array<{ callback: () => void; delayMs: number }> = [];
+	let poll: { callback: () => void; intervalMs: number } | null = null;
+	let pollStopped = false;
+	let parentAlive = true;
+
+	const deps = {
+		markQuitting: mock(() => {}),
+		stopHostServices: mock(() => {}),
+		exit: mock((_code: number) => {}),
+		log: mock((_message: string) => {}),
+	};
+
+	installDevRunnerExit({
+		parentPid: 4242,
+		stdio: [
+			{
+				on: (_event, listener) => {
+					stdioHandlers.push(listener);
+				},
+			},
+		],
+		subscribeSignal: (signal, handler) => {
+			signalHandlers.set(signal, handler);
+		},
+		teardownTerminalHost: overrides.teardown ?? (() => Promise.resolve()),
+		isProcessAlive: () => parentAlive,
+		scheduleTimer: (callback, delayMs) => {
+			timers.push({ callback, delayMs });
+		},
+		scheduleInterval: (callback, intervalMs) => {
+			poll = { callback, intervalMs };
+			return () => {
+				pollStopped = true;
+			};
+		},
+		...deps,
+	});
+
+	return {
+		...deps,
+		signal: (name: string) => signalHandlers.get(name)?.(),
+		stdioError: (code: string) => {
+			for (const handler of stdioHandlers) {
+				handler(Object.assign(new Error(`write ${code}`), { code }));
+			}
+		},
+		timers,
+		fireTimers: () => {
+			for (const timer of timers.splice(0)) timer.callback();
+		},
+		tickPoll: () => poll?.callback(),
+		pollIntervalMs: () => poll?.intervalMs,
+		isPollStopped: () => pollStopped,
+		killParent: () => {
+			parentAlive = false;
+		},
+	};
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("installDevRunnerExit", () => {
+	test("SIGTERM marks quitting, stops services, and exits once teardown finishes", async () => {
+		const h = setup();
+		h.signal("SIGTERM");
+		expect(h.markQuitting).toHaveBeenCalledTimes(1);
+		expect(h.stopHostServices).toHaveBeenCalledTimes(1);
+		expect(h.exit).not.toHaveBeenCalled();
+		await settle();
+		expect(h.exit).toHaveBeenCalledWith(0);
+		expect(h.exit).toHaveBeenCalledTimes(1);
+	});
+
+	test("exits at the deadline when teardown never resolves", () => {
+		const h = setup({ teardown: () => new Promise(() => {}) });
+		h.signal("SIGINT");
+		expect(h.exit).not.toHaveBeenCalled();
+		expect(h.timers).toEqual([
+			expect.objectContaining({ delayMs: DEV_EXIT_DEADLINE_MS }),
+		]);
+		h.fireTimers();
+		expect(h.exit).toHaveBeenCalledTimes(1);
+	});
+
+	test("exits only once even when the deadline fires after teardown", async () => {
+		const h = setup();
+		h.signal("SIGTERM");
+		await settle();
+		h.fireTimers();
+		expect(h.exit).toHaveBeenCalledTimes(1);
+	});
+
+	test("a second reason after the first is ignored", async () => {
+		const h = setup();
+		h.signal("SIGTERM");
+		h.signal("SIGINT");
+		h.stdioError("EPIPE");
+		await settle();
+		expect(h.markQuitting).toHaveBeenCalledTimes(1);
+		expect(h.stopHostServices).toHaveBeenCalledTimes(1);
+		expect(h.exit).toHaveBeenCalledTimes(1);
+	});
+
+	test("EPIPE on stdio quits as stdio-closed", () => {
+		const h = setup();
+		h.stdioError("EPIPE");
+		expect(h.markQuitting).toHaveBeenCalledTimes(1);
+		expect(h.log).toHaveBeenCalledWith(
+			"[main] Received stdio-closed, quitting...",
+		);
+	});
+
+	test("other stdio errors are swallowed without quitting", () => {
+		const h = setup();
+		h.stdioError("EAGAIN");
+		expect(h.markQuitting).not.toHaveBeenCalled();
+		expect(h.stopHostServices).not.toHaveBeenCalled();
+	});
+
+	test("polls the parent every second and quits when it is gone", () => {
+		const h = setup();
+		expect(h.pollIntervalMs()).toBe(DEV_PARENT_POLL_MS);
+		h.tickPoll();
+		expect(h.markQuitting).not.toHaveBeenCalled();
+		expect(h.isPollStopped()).toBe(false);
+		h.killParent();
+		h.tickPoll();
+		expect(h.isPollStopped()).toBe(true);
+		expect(h.log).toHaveBeenCalledWith(
+			"[main] Received parent-exit, quitting...",
+		);
+	});
+});

--- a/apps/desktop/src/main/lib/dev-runner-exit.ts
+++ b/apps/desktop/src/main/lib/dev-runner-exit.ts
@@ -1,0 +1,125 @@
+/**
+ * Dev-only exit handling for the main process under electron-vite.
+ *
+ * In development the process is a child of electron-vite (and of turbo above
+ * it), which owns its lifetime and its stdout/stderr pipes. Electron does not
+ * quit on its own when that runner goes away, so three signals are treated as
+ * "the runner is gone, exit now":
+ *
+ * - SIGTERM / SIGINT forwarded by the runner on a normal stop.
+ * - The parent pid disappearing, for runners that exit without signalling.
+ * - EPIPE on stdout/stderr: the pipe reader died. Without a listener that
+ *   error surfaces as an uncaughtException, whose logging writes to the same
+ *   dead pipe and throws again, an unbounded loop that pins a core until
+ *   someone kills the process.
+ *
+ * Extracted from `main/index.ts` so the sequencing can be tested without
+ * booting the main process.
+ */
+
+export const DEV_EXIT_DEADLINE_MS = 5_000;
+export const DEV_PARENT_POLL_MS = 1_000;
+
+export type DevExitReason =
+	| "SIGTERM"
+	| "SIGINT"
+	| "parent-exit"
+	| "stdio-closed";
+
+interface ErrorSource {
+	on(event: "error", listener: (error: NodeJS.ErrnoException) => void): unknown;
+}
+
+export interface DevRunnerExitDeps {
+	parentPid: number;
+	stdio: ErrorSource[];
+	subscribeSignal: (signal: "SIGTERM" | "SIGINT", handler: () => void) => void;
+	/** Flip the main-process quitting flag so exception handlers stop logging. */
+	markQuitting: () => void;
+	stopHostServices: () => void;
+	teardownTerminalHost: () => Promise<void>;
+	exit: (code: number) => void;
+	isProcessAlive?: (pid: number) => boolean;
+	scheduleTimer?: (callback: () => void, delayMs: number) => void;
+	/** Returns a function that stops the interval. */
+	scheduleInterval?: (callback: () => void, intervalMs: number) => () => void;
+	log?: (message: string) => void;
+}
+
+export function installDevRunnerExit(deps: DevRunnerExitDeps): void {
+	const {
+		parentPid,
+		stdio,
+		subscribeSignal,
+		markQuitting,
+		stopHostServices,
+		teardownTerminalHost,
+		exit,
+		isProcessAlive = defaultIsProcessAlive,
+		scheduleTimer = (callback, delayMs) => {
+			setTimeout(callback, delayMs);
+		},
+		scheduleInterval = defaultScheduleInterval,
+		log = (message) => console.log(message),
+	} = deps;
+
+	let quitting = false;
+	let exited = false;
+	const exitOnce = (message: string) => {
+		if (exited) return;
+		exited = true;
+		log(message);
+		exit(0);
+	};
+
+	const quit = (reason: DevExitReason) => {
+		if (quitting) return;
+		quitting = true;
+		markQuitting();
+		log(`[main] Received ${reason}, quitting...`);
+		// Teardown can hang on a dead daemon socket; never let that keep an
+		// orphaned dev Electron alive.
+		scheduleTimer(
+			() => exitOnce("[main] Teardown deadline reached, exiting"),
+			DEV_EXIT_DEADLINE_MS,
+		);
+		stopHostServices();
+		void Promise.allSettled([teardownTerminalHost()]).finally(() =>
+			exitOnce("[main] Teardown complete, exiting"),
+		);
+	};
+
+	subscribeSignal("SIGTERM", () => quit("SIGTERM"));
+	subscribeSignal("SIGINT", () => quit("SIGINT"));
+
+	for (const stream of stdio) {
+		stream.on("error", (error) => {
+			if (error.code === "EPIPE") quit("stdio-closed");
+		});
+	}
+
+	const stopPolling = scheduleInterval(() => {
+		if (isProcessAlive(parentPid)) return;
+		stopPolling();
+		log("[main] Parent process exited, quitting...");
+		quit("parent-exit");
+	}, DEV_PARENT_POLL_MS);
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function defaultScheduleInterval(
+	callback: () => void,
+	intervalMs: number,
+): () => void {
+	const interval = setInterval(callback, intervalMs);
+	interval.unref();
+	return () => clearInterval(interval);
+}


### PR DESCRIPTION
## Problem

When electron-vite (or turbo above it) dies without signalling the dev Electron, the main process is left holding stdout/stderr pipes with no reader. The next log write fails with `EPIPE`. That error has no listener, so it surfaces as an `uncaughtException`; our handler logs it to the same dead pipe, which throws again. The result is an unbounded loop that pins a core until someone kills the process. One such orphan ran at 100% CPU for two hours on my machine today, and `sample` showed the main thread doing nothing but `CheckImmediate → TriggerUncaughtException → console.error`.

The existing parent-exit fallback did fire and stopped the host-services, but the storm kept the process alive.

## Fix

The dev-only shutdown wiring now lives in `apps/desktop/src/main/lib/dev-runner-exit.ts` (same injected-deps shape as `quit-sequence.ts`), and `index.ts` just installs it. Three signals all mean "the runner is gone, exit now":

- SIGTERM / SIGINT forwarded by the runner, as before.
- The parent pid disappearing, as before.
- New: `error` on `process.stdout` / `process.stderr` with code `EPIPE`.

On any of them it marks `isQuitting` so the exception handlers stop logging, stops host-services, tears down the terminal host, and exits. A 5 s hard `app.exit(0)` deadline means a hung teardown can never keep an orphan alive. Exit happens exactly once.

Seven unit tests cover the sequencing (idempotent quit, deadline, exit-once, EPIPE vs other stdio errors, parent poll). Each of three mutations to the module (drop the exit-once guard, quit on any stdio error, keep polling after parent death) fails exactly one test.

## End-to-end verification

Ran the dev stack as `launch.sh 2>&1 | cat > log` and then `kill -9` the `cat` reader, the `bun scripts/dev.ts` launcher, and `electron-vite` together, which is what a dead turbo looks like to Electron.

| | before | after |
|---|---|---|
| orphan CPU | 120% | 0% |
| uncaught exceptions (main-process inspector) | ~25k/s `Error: write EPIPE` | 0 |
| exits on its own | no (still alive after 20 s; real orphan lived 2 h) | yes, in 1.0 to 1.2 s |

Note for anyone re-verifying: keep the Node inspector client detached when timing the exit. An attached `--inspect` client blocks the exit in `node::inspector::MainThreadInterface::WaitForFrontendEvent` until it disconnects, which looked like a minutes-long hang until I spotted it.

https://claude.ai/code/session_01LpE5Veo71wdWoQyTmYsFWS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development-mode shutdown behavior when the parent process exits, terminal output closes unexpectedly, or termination signals are received.
  - Prevented duplicate shutdown attempts and ensured the application exits reliably even when cleanup takes too long.
  - Improved handling of development-process cleanup to stop services and close terminal resources before exiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->