### PR TITLE
chore(desktop): bump version to 1.27.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.26.0",
+	"version": "1.27.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -839,7 +839,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/agent-setup": "workspace:*",
@@ -938,7 +938,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.26.0",
+	"version": "1.27.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.26.0",
+	"version": "1.27.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Automated by scripts/release/desktop.ts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the desktop app, `@superset/cli`, and `@superset/host-service` versions from 1.26.0 to 1.27.0 for the upcoming desktop release. No behavior changes; this is a version-only update.

<sup>Written for commit a32cd9091928efe75cf9c1fbaeb4e87df60a91c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated application and package version numbers for the 1.27.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->