### PR TITLE
feat(desktop): remember the new-session host per project

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -126,6 +126,9 @@ export function PromptGroup({
 	const setLastHostId = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.setLastHostId,
 	);
+	const setHostIdForProject = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setHostIdForProject,
+	);
 	const handleGoToSetup = useCallback(() => {
 		if (!selectedProject?.id) return;
 		const targetProjectId = selectedProject.id;
@@ -784,6 +787,11 @@ export function PromptGroup({
 						hostId={hostId}
 						onSelectHostId={(next) => {
 							setLastHostId(next);
+							// A session has no project to hang the choice on, so it
+							// only moves the global default.
+							if (projectId && !isSessionSelected) {
+								setHostIdForProject(projectId, next);
+							}
 							updateDraft({ hostId: next });
 						}}
 					/>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/DashboardNewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/DashboardNewWorkspaceModalContent.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { resolveProjectIconUrl } from "renderer/hooks/host-projects/resolveProjectIconUrl";
 import { useHostProjects } from "renderer/hooks/host-projects/useHostProjects";
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useDashboardNewWorkspaceDraft } from "../../DashboardNewWorkspaceDraftContext";
+import { useProjectHostDefault } from "../../hooks/useProjectHostDefault";
 import { PromptGroup } from "../DashboardNewWorkspaceForm/PromptGroup";
 import { useSelectedHostProjectIds } from "./hooks/useSelectedHostProjectIds";
 
@@ -134,6 +135,17 @@ export function DashboardNewWorkspaceModalContent({
 		selectSession,
 		updateDraft,
 	]);
+
+	const applyHostId = useCallback(
+		(hostId: string) => updateDraft({ hostId }),
+		[updateDraft],
+	);
+	useProjectHostDefault({
+		isOpen,
+		projectId: draft.selectedProjectId,
+		isSession: draft.isSession,
+		onSelectHostId: applyHostId,
+	});
 
 	const selectedProject = recentProjects.find(
 		(project) => project.id === draft.selectedProjectId,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -66,6 +66,7 @@ import {
 	type PromptCardsVariant,
 	useNewWorkspacePromptCardsVariant,
 } from "../../hooks/useNewWorkspacePromptCardsVariant";
+import { useProjectHostDefault } from "../../hooks/useProjectHostDefault";
 import { DevicePicker } from "../DashboardNewWorkspaceForm/components/DevicePicker";
 import { CLOUD_HOST_ID } from "../DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker";
 import { useWorkspaceHostOptions } from "../DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions";
@@ -163,6 +164,9 @@ export function NewWorkspaceScreen({
 	);
 	const setLastHostId = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.setLastHostId,
+	);
+	const setHostIdForProject = useV2WorkspaceCreateDefaultsStore(
+		(state) => state.setHostIdForProject,
 	);
 	const samplePromptsDismissed = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.samplePromptsDismissed,
@@ -378,6 +382,16 @@ export function NewWorkspaceScreen({
 			updateDraft({ hostId: persistedHostId });
 		}
 	}, [isOpen, updateDraft]);
+	const applyHostId = useCallback(
+		(hostId: string) => updateDraft({ hostId }),
+		[updateDraft],
+	);
+	useProjectHostDefault({
+		isOpen,
+		projectId,
+		isSession: draft.isSession,
+		onSelectHostId: applyHostId,
+	});
 
 	// Reset baseBranch on project or host change, defaulting to the user's
 	// last selected branch for that project — the draft store is global, so a
@@ -1024,6 +1038,11 @@ export function NewWorkspaceScreen({
 								hostId={draft.hostId}
 								onSelectHostId={(next) => {
 									setLastHostId(next);
+									// A session has no project to hang the choice on, so
+									// it only moves the global default.
+									if (projectId && !draft.isSession) {
+										setHostIdForProject(projectId, next);
+									}
 									updateDraft({ hostId: next });
 								}}
 							/>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useProjectHostDefault/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useProjectHostDefault/index.ts
@@ -1,0 +1,1 @@
+export { useProjectHostDefault } from "./useProjectHostDefault";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useProjectHostDefault/useProjectHostDefault.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/hooks/useProjectHostDefault/useProjectHostDefault.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
+
+interface UseProjectHostDefaultOptions {
+	/** Create surface is showing. Closing it re-arms the seeding. */
+	isOpen: boolean;
+	projectId: string | null;
+	/** Explicit "No project" choice — sessions keep the global default. */
+	isSession: boolean;
+	onSelectHostId: (hostId: string) => void;
+}
+
+/**
+ * Points the create surface at the host a project was last created on.
+ *
+ * The host picker remembers one global choice, so someone alternating between
+ * a project that lives on a remote host and one they build locally kept
+ * finding the picker on the other project's machine. A project that has been
+ * created on a host before now re-selects it whenever that project is picked.
+ *
+ * Projects with no remembered host — and project-less sessions — are left
+ * alone on the global `lastHostId` the surface already seeded.
+ */
+export function useProjectHostDefault({
+	isOpen,
+	projectId,
+	isSession,
+	onSelectHostId,
+}: UseProjectHostDefaultOptions) {
+	const rememberedHostId = useV2WorkspaceCreateDefaultsStore((state) =>
+		projectId ? (state.hostIdsByProjectId[projectId] ?? null) : null,
+	);
+	// The project the remembered host has already been applied for. Re-picking
+	// the same project must not undo a host the user changed by hand since.
+	const appliedForProjectRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) {
+			appliedForProjectRef.current = null;
+			return;
+		}
+		if (isSession || !projectId) return;
+		if (appliedForProjectRef.current === projectId) return;
+		appliedForProjectRef.current = projectId;
+		if (!rememberedHostId) return;
+		onSelectHostId(rememberedHostId);
+	}, [isOpen, isSession, onSelectHostId, projectId, rememberedHostId]);
+}

--- a/apps/desktop/src/renderer/stores/v2-workspace-create-defaults.test.ts
+++ b/apps/desktop/src/renderer/stores/v2-workspace-create-defaults.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { useV2WorkspaceCreateDefaultsStore } from "./v2-workspace-create-defaults";
+
+describe("useV2WorkspaceCreateDefaultsStore host defaults", () => {
+	beforeEach(() => {
+		useV2WorkspaceCreateDefaultsStore.setState({
+			lastHostId: null,
+			hostIdsByProjectId: {},
+		});
+	});
+
+	it("remembers a host per project without disturbing the others", () => {
+		const { setHostIdForProject } =
+			useV2WorkspaceCreateDefaultsStore.getState();
+		setHostIdForProject("project-a", "host-1");
+		setHostIdForProject("project-b", "host-2");
+
+		expect(
+			useV2WorkspaceCreateDefaultsStore.getState().hostIdsByProjectId,
+		).toEqual({ "project-a": "host-1", "project-b": "host-2" });
+	});
+
+	it("overwrites the remembered host when a project moves machines", () => {
+		const { setHostIdForProject } =
+			useV2WorkspaceCreateDefaultsStore.getState();
+		setHostIdForProject("project-a", "host-1");
+		setHostIdForProject("project-a", "host-2");
+
+		expect(
+			useV2WorkspaceCreateDefaultsStore.getState().hostIdsByProjectId[
+				"project-a"
+			],
+		).toBe("host-2");
+	});
+
+	it("drops the entry for a null host so the project falls back to the global default", () => {
+		const { setHostIdForProject } =
+			useV2WorkspaceCreateDefaultsStore.getState();
+		setHostIdForProject("project-a", "host-1");
+		setHostIdForProject("project-a", null);
+
+		expect(
+			useV2WorkspaceCreateDefaultsStore.getState().hostIdsByProjectId,
+		).toEqual({});
+	});
+
+	it("leaves state untouched when clearing a project that was never remembered", () => {
+		const before =
+			useV2WorkspaceCreateDefaultsStore.getState().hostIdsByProjectId;
+		useV2WorkspaceCreateDefaultsStore
+			.getState()
+			.setHostIdForProject("project-a", null);
+
+		expect(
+			useV2WorkspaceCreateDefaultsStore.getState().hostIdsByProjectId,
+		).toBe(before);
+	});
+
+	it("keeps lastHostId independent of the per-project map", () => {
+		const { setHostIdForProject, setLastHostId } =
+			useV2WorkspaceCreateDefaultsStore.getState();
+		setLastHostId("host-1");
+		setHostIdForProject("project-a", "host-2");
+
+		expect(useV2WorkspaceCreateDefaultsStore.getState().lastHostId).toBe(
+			"host-1",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/stores/v2-workspace-create-defaults.ts
+++ b/apps/desktop/src/renderer/stores/v2-workspace-create-defaults.ts
@@ -12,6 +12,11 @@ interface V2WorkspaceCreateDefaultsState {
 	lastProjectId: string | null;
 	baseBranchesByProjectId: Record<string, V2WorkspaceCreateBaseBranchDefault>;
 	lastHostId: string | null;
+	/**
+	 * Host each project was last created on. `lastHostId` stays the fallback
+	 * for projects that have no entry yet and for project-less sessions.
+	 */
+	hostIdsByProjectId: Record<string, string>;
 	/** User closed the sample-prompt suggestions on the create surface. */
 	samplePromptsDismissed: boolean;
 
@@ -23,6 +28,7 @@ interface V2WorkspaceCreateDefaultsState {
 	) => void;
 	clearBaseBranchDefault: (projectId: string) => void;
 	setLastHostId: (hostId: string | null) => void;
+	setHostIdForProject: (projectId: string, hostId: string | null) => void;
 	setSamplePromptsDismissed: (dismissed: boolean) => void;
 }
 
@@ -34,6 +40,7 @@ export const useV2WorkspaceCreateDefaultsStore =
 					lastProjectId: null,
 					baseBranchesByProjectId: {},
 					lastHostId: null,
+					hostIdsByProjectId: {},
 					samplePromptsDismissed: false,
 
 					setLastProjectId: (projectId) => set({ lastProjectId: projectId }),
@@ -58,6 +65,25 @@ export const useV2WorkspaceCreateDefaultsStore =
 						}),
 
 					setLastHostId: (hostId) => set({ lastHostId: hostId }),
+
+					// A null host means "local device" on a machine whose id
+					// hasn't resolved — too ambiguous to remember, so it drops
+					// the project back to the global default.
+					setHostIdForProject: (projectId, hostId) =>
+						set((state) => {
+							if (hostId === null) {
+								if (!(projectId in state.hostIdsByProjectId)) return state;
+								const next = { ...state.hostIdsByProjectId };
+								delete next[projectId];
+								return { hostIdsByProjectId: next };
+							}
+							return {
+								hostIdsByProjectId: {
+									...state.hostIdsByProjectId,
+									[projectId]: hostId,
+								},
+							};
+						}),
 
 					setSamplePromptsDismissed: (dismissed) =>
 						set({ samplePromptsDismissed: dismissed }),


### PR DESCRIPTION
## What & why

The host picker on the create surface keeps a single global `lastHostId`. If you
alternate between a project that lives on a remote host and one you build
locally, the picker is always on the *other* project's machine, and it is easy
to start a create on the wrong one.

Each project now remembers the host it was last created on. This sits next to
`baseBranchesByProjectId` in the same store, which already keeps a per-project
default for exactly the same reason.

`lastHostId` stays the fallback, so nothing changes until you have explicitly
picked a host while a project was selected:

- project with a remembered host → picker moves to it when you select the project
- project without one → left on the global default, as today
- project-less session → left on the global default, as today
- re-picking the same project → never overrides a host you just changed by hand

Scoped to the main new-session surface (`NewWorkspaceScreen` and the dashboard
modal). The Tasks "run in workspace" popovers still use the global default —
happy to extend it there in a follow-up if you want the same behaviour.

## How I tested it

**End-to-end, in the dev desktop app over CDP** (`RENDERER_REMOTE_DEBUG_PORT`,
renderer on this workspace's `DESKTOP_VITE_PORT`), driving the real pickers with
dispatched mouse input. Two local projects, `orbit-api` and `pixel-web`. The same
scripted journey ran twice — once with the change reverted, once with it applied
— starting from a cleared `v2-workspace-create-defaults` key each time:

1. select `orbit-api` → set host to `build-box`
2. select `pixel-web` → set host to Local Device
3. select `orbit-api` again

Step 3 is the one that matters:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/eliotsagents/superset/pr-host-picker-screenshots/img/before-3-back-to-orbit.png) | ![after](https://raw.githubusercontent.com/eliotsagents/superset/pr-host-picker-screenshots/img/after-3-back-to-orbit.png) |
| falls back to the global last host | returns to `build-box` |

Steps 1 and 2 of the "after" run:

![step 1](https://raw.githubusercontent.com/eliotsagents/superset/pr-host-picker-screenshots/img/after-1-orbit-on-build-box.png)
![step 2](https://raw.githubusercontent.com/eliotsagents/superset/pr-host-picker-screenshots/img/after-2-pixel-on-local.png)

Persisted state read out of `localStorage` at the end of the "after" run agrees
with the screenshots — `lastHostId` is the local machine while `orbit-api` still
maps to `build-box`:

```json
{
  "lastHostId": "<local-machine-id>",
  "hostIdsByProjectId": {
    "<orbit-api-id>": "build-box-machine-id",
    "<pixel-web-id>": "<local-machine-id>"
  }
}
```

Full-window shot of the final state: [after-3-back-to-orbit-full.png](https://raw.githubusercontent.com/eliotsagents/superset/pr-host-picker-screenshots/img/after-3-back-to-orbit-full.png)

<details>
<summary>One disclosed fixture</summary>

My dev environment signs in local-first and registers no remote hosts, so the
picker only offered "Local Device" and there was nothing to switch to. For the
screenshots I temporarily added two entries to `otherHosts` in
`useWorkspaceHostOptions`; that edit is reverted and is not in this diff. Every
other step is real UI input against the real components, and the code under test
is untouched by it.

</details>

**Unit tests**: `apps/desktop/src/renderer/stores/v2-workspace-create-defaults.test.ts`
covers per-project isolation, overwrite, the null-host clear, the no-op clear,
and `lastHostId` independence. 5 pass.

**Checks**: `bun run lint` clean, `bun run typecheck` clean (38/38),
`bun run check:i18n` regenerates nothing. `apps/desktop` tests: 3598 pass, 1 fail
— `useSidebarDnd.test.ts` (`React.createContext is not a function` from
`@dnd-kit/core`), which fails identically on a pristine `main` in my checkout
(3593 pass, 1 fail) and passes in isolation on both. `packages/trpc` has 4
env-dependent failures locally (growth/sitemap, growth/search-console,
growth/github, plugins/oauth — "Invalid environment variables"), also unrelated.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the host picker remember the host each project was last created on, so switching between projects no longer leaves the picker pointing at the other project's machine. The global `lastHostId` stays the fallback for projects with no remembered host and for project-less sessions.

**Notes**
- Per-project hosts are stored in the same create-defaults store as the existing per-project base branches.
- Re-selecting a project won't override a host you changed by hand since.
- Applies to the new-workspace screen and dashboard modal; the Tasks "run in workspace" popovers still use the global default.

<sup>Written for commit 5bbac88872075b4e5729c34b5314f0a32c02decb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace creation now remembers the last selected host for each project.
  * Reopening a project’s workspace creation flow automatically selects its remembered host.
  * Session workspaces continue using the global default host.
* **Tests**
  * Added coverage for project-specific host assignments, updates, clearing, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->