### PR TITLE
fix(agent-setup): preserve agent identity and enable OpenCode session resume

### DIFF
--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -24,7 +24,7 @@ import { getOpenCodeConfigDir, getOpenCodePluginDir } from "./paths";
 export const OPENCODE_PLUGIN_FILE = "superset-notify.js";
 
 const OPENCODE_PLUGIN_SIGNATURE = "// Superset opencode plugin";
-const OPENCODE_PLUGIN_VERSION = "v9";
+const OPENCODE_PLUGIN_VERSION = "v10";
 export const OPENCODE_PLUGIN_MARKER = `${OPENCODE_PLUGIN_SIGNATURE} ${OPENCODE_PLUGIN_VERSION}`;
 
 /**

--- a/packages/agent-setup/src/agent-wrappers-common.ts
+++ b/packages/agent-setup/src/agent-wrappers-common.ts
@@ -4,7 +4,7 @@ import { SUPERSET_MANAGED_BINARIES } from "./agent-setup-targets";
 import { NOTIFY_SCRIPT_NAME } from "./notify-hook";
 import { getBinDir } from "./paths";
 
-export const WRAPPER_MARKER = "# Superset agent-wrapper v4";
+export const WRAPPER_MARKER = "# Superset agent-wrapper v5";
 export { SUPERSET_MANAGED_BINARIES };
 
 /** Path (under SUPERSET_HOME_DIR) of the runtime notify hook script. */
@@ -21,12 +21,17 @@ export const DYNAMIC_NOTIFY_PATH_MARKER = `$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_R
 /**
  * Shell command written into an agent's global hook config. The notify path is
  * resolved at runtime from SUPERSET_HOME_DIR so one shared config works for both
- * dev and prod installs, and `SUPERSET_AGENT_ID` is inlined so the v2 hook
- * payload carries wrapper-level identity even when the agent is launched outside
- * the Superset wrapper (system PATH resolves the real binary directly).
+ * dev and prod installs. `SUPERSET_HOOK_HARNESS` names the harness whose config
+ * this command lives in; it is the identity fallback when the agent was
+ * launched outside the Superset wrapper (system PATH resolved the real binary,
+ * so no `SUPERSET_AGENT_ID` was exported). It must never override the wrapper's
+ * export: one harness can run another's hook config — cursor-agent replays
+ * `~/.claude/settings.json`, and an agent's tool call can launch a second CLI
+ * whose config fires under the terminal's agent — and the notify script uses
+ * the disagreement to drop those events instead of relabeling the terminal.
  */
 export function getManagedNotifyHookCommand(agentId: string): string {
-	return `[ -n "$SUPERSET_HOME_DIR" ] && [ -x "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" ] && SUPERSET_AGENT_ID=${agentId} "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" || true`;
+	return `[ -n "$SUPERSET_HOME_DIR" ] && [ -x "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" ] && SUPERSET_HOOK_HARNESS=${agentId} "$SUPERSET_HOME_DIR/${MANAGED_NOTIFY_RELATIVE_PATH}" || true`;
 }
 
 // Dev setup (.superset/lib/setup/steps.sh) points SUPERSET_HOME_DIR at
@@ -159,6 +164,13 @@ export interface BuildWrapperScriptOptions {
 	 * set, the wrapper exports `SUPERSET_AGENT_ID` so the agent process and
 	 * any hook subprocess it spawns inherit the wrapper-level identity. The
 	 * notify-hook script forwards this into the v2 hook payload.
+	 *
+	 * The export is first-wins: `SUPERSET_AGENT_ID` already being set means a
+	 * wrapper ran earlier in this terminal and this launch is nested under
+	 * its agent (a tool call running another CLI). The terminal's agent is
+	 * the outer one, so the wrapper keeps that identity and skips the launch
+	 * report. The host strips `SUPERSET_*` from every PTY env, so the
+	 * variable can only arrive from a wrapper in the same terminal.
 	 */
 	agentId?: string;
 }
@@ -205,10 +217,15 @@ export function buildWrapperScript(
 	execLine: string,
 	options: BuildWrapperScriptOptions = {},
 ): string {
-	const exportAgentId = options.agentId
-		? `export SUPERSET_AGENT_ID="${options.agentId}"\n\n`
+	// See BuildWrapperScriptOptions.agentId for why the export is first-wins.
+	const identity = options.agentId
+		? `if [ -z "$SUPERSET_AGENT_ID" ]; then
+export SUPERSET_AGENT_ID="${options.agentId}"
+
+${buildLaunchReportBlock()}fi
+
+`
 		: "";
-	const launchReport = options.agentId ? buildLaunchReportBlock() : "";
 	return `#!/bin/bash
 ${WRAPPER_MARKER}
 # Superset wrapper for ${binaryName}
@@ -220,7 +237,7 @@ if [ -z "$REAL_BIN" ]; then
   exit 127
 fi
 
-${exportAgentId}${launchReport}${execLine}
+${identity}${execLine}
 `;
 }
 

--- a/packages/agent-setup/src/agent-wrappers-copilot.ts
+++ b/packages/agent-setup/src/agent-wrappers-copilot.ts
@@ -11,7 +11,7 @@ import { getHooksDir } from "./paths";
 export const COPILOT_HOOK_SCRIPT_NAME = "copilot-hook.sh";
 
 const COPILOT_HOOK_SIGNATURE = "# Superset copilot hook";
-const COPILOT_HOOK_VERSION = "v5";
+const COPILOT_HOOK_VERSION = "v6";
 export const COPILOT_HOOK_MARKER = `${COPILOT_HOOK_SIGNATURE} ${COPILOT_HOOK_VERSION}`;
 
 export function getCopilotHookScriptPath(): string {

--- a/packages/agent-setup/src/agent-wrappers-cursor.ts
+++ b/packages/agent-setup/src/agent-wrappers-cursor.ts
@@ -19,7 +19,7 @@ import { getHooksDir } from "./paths";
 export const CURSOR_HOOK_SCRIPT_NAME = "cursor-hook.sh";
 
 const CURSOR_HOOK_SIGNATURE = "# Superset cursor hook";
-const CURSOR_HOOK_VERSION = "v7";
+const CURSOR_HOOK_VERSION = "v8";
 export const CURSOR_HOOK_MARKER = `${CURSOR_HOOK_SIGNATURE} ${CURSOR_HOOK_VERSION}`;
 
 interface CursorHookEntry {
@@ -55,7 +55,15 @@ const CURSOR_MANAGED_EVENT_ARGS: Record<string, string> = {
 	stop: "Stop",
 	beforeShellExecution: "PermissionRequest",
 	beforeMCPExecution: "PermissionRequest",
+	postToolUse: "Start",
+	postToolUseFailure: "Start",
 };
+
+// Only Shell and MCP calls have a before-hook above that parks the terminal
+// on PermissionRequest, so only their completions need to move it back to
+// Start. File tools stay out: a subagent's read would otherwise post its own
+// session id over the parent terminal's.
+const CURSOR_POST_TOOL_MATCHER = "^(Shell|MCP:.+)$";
 
 function cursorHooksSpec(
 	hookScriptPath: string,
@@ -68,7 +76,15 @@ function cursorHooksSpec(
 		desiredEntriesByEvent: Object.fromEntries(
 			Object.entries(CURSOR_MANAGED_EVENT_ARGS).map(([eventName, arg]) => [
 				eventName,
-				[{ command: `${hookScriptPath} ${arg}` }],
+				[
+					{
+						command: `${hookScriptPath} ${arg}`,
+						...(eventName === "postToolUse" ||
+						eventName === "postToolUseFailure"
+							? { matcher: CURSOR_POST_TOOL_MATCHER }
+							: {}),
+					},
+				],
 			]),
 		),
 		cleanEntry: (entry) =>

--- a/packages/agent-setup/src/agent-wrappers-gemini.ts
+++ b/packages/agent-setup/src/agent-wrappers-gemini.ts
@@ -19,7 +19,7 @@ import { getHooksDir } from "./paths";
 export const GEMINI_HOOK_SCRIPT_NAME = "gemini-hook.sh";
 
 const GEMINI_HOOK_SIGNATURE = "# Superset gemini hook";
-const GEMINI_HOOK_VERSION = "v6";
+const GEMINI_HOOK_VERSION = "v7";
 export const GEMINI_HOOK_MARKER = `${GEMINI_HOOK_SIGNATURE} ${GEMINI_HOOK_VERSION}`;
 
 interface GeminiHookDefinition {

--- a/packages/agent-setup/src/agent-wrappers-grok.ts
+++ b/packages/agent-setup/src/agent-wrappers-grok.ts
@@ -5,6 +5,7 @@ import {
 	buildWrapperScript,
 	createWrapper,
 	getManagedNotifyHookCommand,
+	MANAGED_NOTIFY_RELATIVE_PATH,
 	removeOwnedFileIfMarked,
 	writeFileIfChanged,
 } from "./agent-wrappers-common";
@@ -49,9 +50,10 @@ export const GROK_BLOCKING_NOTIFICATION_TYPES = [
 
 const GROK_MANAGED_HOOK_COMMAND = getManagedNotifyHookCommand("grok");
 
-// Vendor hook configs Superset also manages. Grok replays them in compat mode
-// with their inlined SUPERSET_AGENT_ID (claude/cursor-agent), which would
-// misattribute grok sessions; disable replay and register native hooks instead.
+// Vendor hook configs Superset also manages. Grok replays them in compat mode;
+// their events carry Claude's or Cursor's harness id, so the notify script
+// drops them as foreign (and, without the wrapper, would misattribute grok
+// sessions). Disable replay and register native hooks instead.
 const GROK_COMPAT_HOOK_VENDORS = ["claude", "cursor"] as const;
 
 function getGrokHomeDir(): string {
@@ -156,9 +158,10 @@ export function getGrokConfigTomlContent(existing: string): string {
  * marker-owned compat block in config.toml. No-op when neither exists.
  */
 export function removeGrokManagedHooks(): void {
+	// The notify path is in every version of the file Superset has written.
 	removeOwnedFileIfMarked(
 		getGrokHooksJsonPath(),
-		"SUPERSET_AGENT_ID=grok",
+		MANAGED_NOTIFY_RELATIVE_PATH,
 		"Grok hooks json",
 	);
 	removeManagedTomlBlock(GROK_TOML_SPEC);

--- a/packages/agent-setup/src/agent-wrappers-kimi.ts
+++ b/packages/agent-setup/src/agent-wrappers-kimi.ts
@@ -63,7 +63,13 @@ function isManagedOrPartialHookTable(lines: string[]): boolean {
 	}
 
 	const commandLine = lines.find((line) => /^\s*command\s*=/.test(line));
-	return !commandLine || commandLine.includes("SUPERSET_AGENT_ID=kimi");
+	// SUPERSET_AGENT_ID=kimi is the pre-v5 command shape; still recognized
+	// so an upgrade replaces those blocks instead of stacking a second one.
+	return (
+		!commandLine ||
+		commandLine.includes("SUPERSET_HOOK_HARNESS=kimi") ||
+		commandLine.includes("SUPERSET_AGENT_ID=kimi")
+	);
 }
 
 const KIMI_TOML_SPEC: ManagedTomlBlockSpec = {

--- a/packages/agent-setup/src/agent-wrappers-launch-report.test.ts
+++ b/packages/agent-setup/src/agent-wrappers-launch-report.test.ts
@@ -70,6 +70,10 @@ async function runWrapper(
 			PATH: `${path.dirname(scenario.wrapperPath)}:${path.join(scenario.root, "bin")}:${process.env.PATH ?? ""}`,
 			SUPERSET_TERMINAL_ID: "terminal-test",
 			SUPERSET_HOME_DIR: scenario.supersetHome,
+			// This test process may itself run under an agent wrapper (a Claude
+			// session running `bun test`), whose identity would make every
+			// launch look nested.
+			SUPERSET_AGENT_ID: "",
 			...envOverrides,
 		},
 		stdout: "ignore",
@@ -121,6 +125,21 @@ describe("wrapper launch report", () => {
 		expect(readNotifyLog(fastExit)).toBe("");
 		expect(readNotifyLog(helpFlag)).toBe("");
 		expect(readNotifyLog(outsideSuperset)).toBe("");
+	}, 15000);
+
+	it("keeps an outer agent's identity and stays silent when launched nested", async () => {
+		// Claude's Bash tool running `codex exec`: the terminal's agent is
+		// still Claude, so the inner wrapper must neither relabel the process
+		// tree nor report a second launch.
+		const nested = setupScenario(
+			`printf '%s' "$SUPERSET_AGENT_ID" > "$SUPERSET_HOME_DIR/identity"; sleep ${(REPORT_DELAY_MS + 1200) / 1000}`,
+		);
+		await runWrapper(nested, ["chat"], { SUPERSET_AGENT_ID: "claude" });
+
+		expect(
+			readFileSync(path.join(nested.supersetHome, "identity"), "utf-8"),
+		).toBe("claude");
+		expect(readNotifyLog(nested)).toBe("");
 	}, 15000);
 
 	it("only injects the launch report for wrappers with an agent identity", () => {

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -263,6 +263,44 @@ describe("agent-wrappers opencode", () => {
 		).toBe(true);
 	});
 
+	it("orders root replacement and legacy permissions behind an in-flight deletion", async () => {
+		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
+		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
+		const notifications: unknown[] = [];
+		const deleting = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const hooks = await SupersetNotifyPlugin({
+			$: async (
+				_parts: TemplateStringsArray,
+				_notifyPath: string,
+				payload: string,
+			) => {
+				const notification = JSON.parse(payload);
+				if (notification.hook_event_name === "SessionEnd") {
+					deleting.resolve();
+					await release.promise;
+				}
+				notifications.push(notification);
+			},
+		});
+		const event = (type: string, id: string) =>
+			hooks.event({ event: { type, properties: { info: { id } } } });
+		await event("session.created", "old");
+		notifications.length = 0;
+		const deletion = event("session.deleted", "old");
+		await deleting.promise;
+		const creation = event("session.created", "new");
+		const permission = hooks["permission.ask"]({}, { status: "ask" });
+		release.resolve();
+		await Promise.all([deletion, creation, permission]);
+
+		expect(notifications).toEqual([
+			{ hook_event_name: "SessionEnd", session_id: "old" },
+			{ hook_event_name: "SessionStart", session_id: "new" },
+			{ hook_event_name: "PermissionRequest", session_id: "new" },
+		]);
+	});
+
 	it("captures resumed and subsequent root sessions without a session.created event", async () => {
 		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
 		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -177,23 +177,29 @@ describe("agent-wrappers opencode", () => {
 		expect(notifications).toEqual(["PermissionRequest"]);
 	});
 
-	it("retains the legacy permission.ask notification hook", async () => {
+	it("retains legacy permission.ask using the tracked root when the input omits its ID", async () => {
 		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
 		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
-		const notifications: string[] = [];
+		const notifications: unknown[] = [];
 		const hooks = await SupersetNotifyPlugin({
 			$: (
 				_parts: TemplateStringsArray,
 				_notifyPath: string,
 				payload: string,
 			) => {
-				notifications.push(JSON.parse(payload).hook_event_name);
+				notifications.push(JSON.parse(payload));
 			},
 		});
 
+		await hooks.event({
+			event: { type: "session.created", properties: { info: { id: "root" } } },
+		});
+		notifications.length = 0;
 		await hooks["permission.ask"]({}, { status: "ask" });
 
-		expect(notifications).toEqual(["PermissionRequest"]);
+		expect(notifications).toEqual([
+			{ hook_event_name: "PermissionRequest", session_id: "root" },
+		]);
 	});
 
 	it("carries the root session through lifecycle events without accepting child or competing sessions", async () => {
@@ -220,6 +226,7 @@ describe("agent-wrappers opencode", () => {
 			hooks.event({ event: { type, properties } });
 
 		await event("session.created", { info: { id: "root" } });
+		await event("session.created", { info: { id: "other-before-busy" } });
 		await event("session.status", {
 			sessionID: "root",
 			status: { type: "busy" },
@@ -305,6 +312,7 @@ describe("agent-wrappers opencode", () => {
 			client: { session: { list: async () => ({ data: [] }) } },
 		});
 		await hooks.event({ event: { type: "session.created", properties: {} } });
+		await hooks["permission.ask"]({}, { status: "ask" });
 		await hooks.event({
 			event: {
 				type: "session.status",

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -236,6 +236,11 @@ describe("agent-wrappers opencode", () => {
 		await event("permission.asked", { sessionID: "root" });
 		await event("session.idle", { sessionID: "root" });
 		await event("session.idle", { sessionID: "root" });
+		// Idle is still the same resumable conversation. Unrelated session
+		// creation/deletion must not replace or end its host binding.
+		await event("session.created", { info: { id: "other-after-stop" } });
+		await event("permission.asked", { sessionID: "other-after-stop" });
+		await event("session.deleted", { info: { id: "other-after-stop" } });
 		await event("session.deleted", { info: { id: "child", parentID: "root" } });
 		await event("session.deleted", { info: { id: "root" } });
 

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -130,9 +130,9 @@ describe("agent-wrappers opencode", () => {
 	beforeEach(() => {
 		delete (
 			globalThis as typeof globalThis & {
-				__supersetOpencodeNotifyPluginV9?: boolean;
+				__supersetOpencodeNotifyPluginV10?: boolean;
 			}
-		).__supersetOpencodeNotifyPluginV9;
+		).__supersetOpencodeNotifyPluginV10;
 	});
 
 	afterEach(() => {
@@ -194,6 +194,125 @@ describe("agent-wrappers opencode", () => {
 		await hooks["permission.ask"]({}, { status: "ask" });
 
 		expect(notifications).toEqual(["PermissionRequest"]);
+	});
+
+	it("carries the root session through lifecycle events without accepting child or competing sessions", async () => {
+		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
+		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
+		const notifications: unknown[] = [];
+		const commands: string[] = [];
+		const hooks = await SupersetNotifyPlugin({
+			$: (
+				parts: TemplateStringsArray,
+				_notifyPath: string,
+				payload: string,
+			) => {
+				commands.push(parts.join(""));
+				notifications.push(JSON.parse(payload));
+			},
+			client: {
+				session: {
+					list: async () => ({ data: [{ id: "root" }, { id: "other" }] }),
+				},
+			},
+		});
+		const event = (type: string, properties: Record<string, unknown>) =>
+			hooks.event({ event: { type, properties } });
+
+		await event("session.created", { info: { id: "root" } });
+		await event("session.status", {
+			sessionID: "root",
+			status: { type: "busy" },
+		});
+		await event("session.created", { info: { id: "child", parentID: "root" } });
+		await event("session.status", {
+			sessionID: "child",
+			status: { type: "busy" },
+		});
+		await event("permission.asked", { sessionID: "child" });
+		await event("session.created", { info: { id: "other" } });
+		await event("permission.asked", { sessionID: "other" });
+		await event("session.deleted", { info: { id: "other" } });
+		await event("permission.asked", { sessionID: "root" });
+		await event("session.idle", { sessionID: "root" });
+		await event("session.idle", { sessionID: "root" });
+		await event("session.deleted", { info: { id: "child", parentID: "root" } });
+		await event("session.deleted", { info: { id: "root" } });
+
+		expect(notifications).toEqual(
+			["SessionStart", "Start", "PermissionRequest", "Stop", "SessionEnd"].map(
+				(hook_event_name) => ({ hook_event_name, session_id: "root" }),
+			),
+		);
+		expect(
+			commands.every((command) =>
+				command.includes("SUPERSET_HOOK_HARNESS=opencode"),
+			),
+		).toBe(true);
+	});
+
+	it("captures resumed and subsequent root sessions without a session.created event", async () => {
+		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
+		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
+		const notifications: unknown[] = [];
+		const hooks = await SupersetNotifyPlugin({
+			$: (
+				_parts: TemplateStringsArray,
+				_notifyPath: string,
+				payload: string,
+			) => {
+				notifications.push(JSON.parse(payload));
+			},
+			client: {
+				session: {
+					list: async () => ({ data: [{ id: "resumed" }, { id: "next" }] }),
+				},
+			},
+		});
+		for (const sessionID of ["resumed", "next"]) {
+			await hooks.event({
+				event: {
+					type: "session.status",
+					properties: { sessionID, status: { type: "busy" } },
+				},
+			});
+			await hooks["permission.ask"]({ sessionID }, { status: "ask" });
+			await hooks.event({
+				event: { type: "session.idle", properties: { sessionID } },
+			});
+		}
+		expect(notifications).toEqual(
+			["resumed", "next"].flatMap((session_id) =>
+				["Start", "PermissionRequest", "Stop"].map((hook_event_name) => ({
+					hook_event_name,
+					session_id,
+				})),
+			),
+		);
+	});
+
+	it("does not bind missing or unverified sessions", async () => {
+		process.env.SUPERSET_TERMINAL_ID = "terminal-1";
+		const { SupersetNotifyPlugin } = await loadOpenCodePlugin();
+		const notify = mock(() => {});
+		const hooks = await SupersetNotifyPlugin({
+			$: notify,
+			client: { session: { list: async () => ({ data: [] }) } },
+		});
+		await hooks.event({ event: { type: "session.created", properties: {} } });
+		await hooks.event({
+			event: {
+				type: "session.status",
+				properties: { sessionID: "unknown", status: { type: "busy" } },
+			},
+		});
+		await hooks.event({
+			event: {
+				type: "session.deleted",
+				properties: { info: { id: "unknown" } },
+			},
+		});
+		expect(notify).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -26,7 +26,7 @@ let mockedHomeDir = path.join(TEST_ROOT, "home");
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v14",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v15",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},
@@ -264,7 +264,7 @@ describe("agent-wrappers copilot", () => {
 		expect(wrapper).not.toContain("-c 'notify=");
 		expect(wrapper).toContain('export SUPERSET_AGENT_ID="codex"');
 
-		expect(wrapper).toContain("# Superset agent-wrapper v4");
+		expect(wrapper).toContain("# Superset agent-wrapper v5");
 
 		// Native hooks remain enabled, but the process-scoped TUI session log is
 		// the reliable Start signal for installed Codex TUI builds.
@@ -746,7 +746,7 @@ exit 0
 		expect(plugin).toContain('amp.on("agent.end"');
 		expect(plugin).toContain('notify("Stop", event)');
 		expect(plugin).toContain('import { spawn } from "node:child_process"');
-		expect(plugin).toContain('SUPERSET_AGENT_ID: "amp"');
+		expect(plugin).toContain('SUPERSET_HOOK_HARNESS: "amp"');
 		expect(plugin).toContain("[superset-amp-plugin]");
 		expect(plugin).toContain("SUPERSET_HOME_DIR");
 	});
@@ -792,7 +792,7 @@ exit 0
 		const content2 = requireContent(getCursorHooksJsonContent(currentHookPath));
 
 		const parsed = JSON.parse(content) as {
-			hooks: Record<string, Array<{ command: string }>>;
+			hooks: Record<string, Array<{ command: string; matcher?: string }>>;
 		};
 		const beforeSubmitPrompt = parsed.hooks.beforeSubmitPrompt;
 
@@ -822,6 +822,20 @@ exit 0
 		).toBe(true);
 		expect(Array.isArray(parsed.hooks.beforeShellExecution)).toBe(true);
 		expect(Array.isArray(parsed.hooks.beforeMCPExecution)).toBe(true);
+		for (const event of ["postToolUse", "postToolUseFailure"]) {
+			expect(parsed.hooks[event]).toEqual([
+				{ command: `${currentHookPath} Start`, matcher: "^(Shell|MCP:.+)$" },
+			]);
+			const matcher = new RegExp(
+				requireContent(parsed.hooks[event][0]?.matcher ?? null),
+			);
+			for (const tool of ["Shell", "MCP:audit_echo"]) {
+				expect(matcher.test(tool)).toBe(true);
+			}
+			for (const tool of ["Read", "Edit", "Task", "ShellOther", "OtherMCP:x"]) {
+				expect(matcher.test(tool)).toBe(false);
+			}
+		}
 		expect(JSON.parse(content2)).toEqual(JSON.parse(content));
 	});
 
@@ -951,9 +965,9 @@ exit 0
 	});
 
 	it("bumps hook script markers when hook semantics change", () => {
-		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v5");
-		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v7");
-		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v6");
+		expect(COPILOT_HOOK_MARKER).toBe("# Superset copilot hook v6");
+		expect(CURSOR_HOOK_MARKER).toBe("# Superset cursor hook v8");
+		expect(GEMINI_HOOK_MARKER).toBe("# Superset gemini hook v7");
 	});
 
 	it("replaces stale Mastra hook commands from old superset paths", () => {
@@ -1850,7 +1864,7 @@ describe("vibe hooks.toml", () => {
 		expect(out).toContain(VIBE_HOOKS_MARKER_END);
 		expect(out).toContain('type = "before_tool"');
 		expect(out).toContain('type = "post_agent_turn"');
-		expect(out).toContain("SUPERSET_AGENT_ID=vibe");
+		expect(out).toContain("SUPERSET_HOOK_HARNESS=vibe");
 	});
 	it("preserves user hooks and is idempotent", () => {
 		const user =
@@ -1950,7 +1964,7 @@ describe("kimi config.toml", () => {
 		]) {
 			expect(out).toContain(`event = "${event}"`);
 		}
-		expect(out).toContain("SUPERSET_AGENT_ID=kimi");
+		expect(out).toContain("SUPERSET_HOOK_HARNESS=kimi");
 	});
 
 	it("preserves user config and replaces the managed block idempotently", () => {
@@ -2030,7 +2044,9 @@ describe("grok hooks json", () => {
 				hooks: Array<{ type: string; command: string }>;
 			}>;
 			expect(definition.hooks[0].type).toBe("command");
-			expect(definition.hooks[0].command).toContain("SUPERSET_AGENT_ID=grok");
+			expect(definition.hooks[0].command).toContain(
+				"SUPERSET_HOOK_HARNESS=grok",
+			);
 		}
 		expect(parsed.hooks.Notification[0].matcher).toBe(
 			`^(${GROK_BLOCKING_NOTIFICATION_TYPES.join("|")})$`,
@@ -2425,7 +2441,7 @@ describe("agent-wrappers omp", () => {
 		);
 		expect(content).toContain("pi.on(eventName");
 		expect(content).toContain("fire(hookEventName)");
-		expect(content).toContain('SUPERSET_AGENT_ID: "omp"');
+		expect(content).toContain('SUPERSET_HOOK_HARNESS: "omp"');
 	});
 
 	it("installs the Oh My Pi extension into the global ~/.omp/agent/extensions directory", () => {

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -104,7 +104,7 @@ function writeHookManifest(home: string, orgId: string, endpoint: string) {
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v14");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v15");
 	});
 
 	it("forwards hooks fired inside a subagent (agent_id present) to the host roster only", async () => {
@@ -259,7 +259,7 @@ describe("getNotifyScriptContent", () => {
 			"HOOK_SESSION_ID=$(json_field session_id sessionId)",
 		);
 		expect(script).toContain(
-			'dispatch_to_host "{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$SUPERSET_AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$SESSION_ID")\\"}}}"',
+			'dispatch_to_host "{\\"json\\":{\\"terminalId\\":\\"$(json_escape "$SUPERSET_TERMINAL_ID")\\",\\"eventType\\":\\"$(json_escape "$EVENT_TYPE")\\",\\"agent\\":{\\"agentId\\":\\"$(json_escape "$AGENT_ID")\\",\\"sessionId\\":\\"$(json_escape "$SESSION_ID")\\"}}}"',
 		);
 		// One dispatcher serves both the agent and subagent payloads.
 		expect(script.split('dispatch_to_host "').length - 1).toBe(2);
@@ -268,7 +268,7 @@ describe("getNotifyScriptContent", () => {
 				.length - 1,
 		).toBe(1);
 		expect(script).toContain(
-			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID subagentId=$SUBAGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
+			"event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$AGENT_ID subagentId=$SUBAGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID",
 		);
 		expect(script).toContain('V1_EVENT_TYPE="$EVENT_TYPE"');
 		expect(script).toContain('V1_EVENT_TYPE="Stop"');
@@ -389,8 +389,8 @@ describe("per-agent hook scripts dispatch to v2", () => {
 
 	for (const [template, agentIdVar] of [
 		["cursor-hook.template.sh", "AGENT_ID"],
-		["copilot-hook.template.sh", "SUPERSET_AGENT_ID"],
-		["gemini-hook.template.sh", "SUPERSET_AGENT_ID"],
+		["copilot-hook.template.sh", "AGENT_ID"],
+		["gemini-hook.template.sh", "AGENT_ID"],
 	] as const) {
 		it(`${template} posts v2 first and falls back to v1`, () => {
 			const script = readFileSync(getTemplatePath(template), "utf-8");
@@ -479,5 +479,206 @@ describe("call-time endpoint resolution (frozen-port healing)", () => {
 			envHost.stop();
 			manifestHost.stop();
 		}
+	});
+});
+
+describe("agent identity precedence", () => {
+	const stop = { hook_event_name: "Stop", session_id: "s1" };
+
+	async function dispatched(
+		envOverrides: Record<string, string>,
+		input: Record<string, unknown> = stop,
+	) {
+		const host = fakeHostService(false);
+		try {
+			const result = await runNotifyHookAsync(input, {
+				SUPERSET_HOST_AGENT_HOOK_URL: `${host.url}/trpc/notifications.hook`,
+				SUPERSET_HOOK_HARNESS: "",
+				CURSOR_AGENT: "",
+				CURSOR_CLI: "",
+				CURSOR_VERSION: "",
+				...envOverrides,
+			});
+			expect(result.exitCode).toBe(0);
+			return host.requests.map((request) => request.json);
+		} finally {
+			host.stop();
+		}
+	}
+
+	it("reports the wrapper's identity when its own harness's hook config fires", async () => {
+		expect(
+			await dispatched({
+				SUPERSET_AGENT_ID: "codex",
+				SUPERSET_HOOK_HARNESS: "codex",
+			}),
+		).toEqual([
+			{
+				terminalId: "terminal-test",
+				eventType: "Stop",
+				agent: { agentId: "codex", sessionId: "s1" },
+			},
+		]);
+	});
+
+	it("reports the wrapper's identity for the wrapper's own launch report", async () => {
+		expect(
+			await dispatched(
+				{ SUPERSET_AGENT_ID: "opencode" },
+				{ hook_event_name: "SessionStart" },
+			),
+		).toEqual([
+			{
+				terminalId: "terminal-test",
+				eventType: "SessionStart",
+				agent: { agentId: "opencode", sessionId: "" },
+			},
+		]);
+	});
+
+	it("names the agent from the hook config when no wrapper exported an identity", async () => {
+		// The binary was resolved from the system PATH: the config that
+		// fired is the only identity there is.
+		expect(
+			await dispatched({
+				SUPERSET_AGENT_ID: "",
+				SUPERSET_HOOK_HARNESS: "claude",
+			}),
+		).toEqual([
+			{
+				terminalId: "terminal-test",
+				eventType: "Stop",
+				agent: { agentId: "claude", sessionId: "s1" },
+			},
+		]);
+	});
+
+	it("drops another harness's hook config firing under the terminal's agent", async () => {
+		// Claude's Bash tool running `codex exec`: Codex's config fires with
+		// the Claude wrapper's identity still exported. The Codex thread id
+		// must not become the Claude terminal's resumable session.
+		expect(
+			await dispatched({
+				SUPERSET_AGENT_ID: "claude",
+				SUPERSET_HOOK_HARNESS: "codex",
+			}),
+		).toEqual([]);
+		expect(
+			await dispatched(
+				{ SUPERSET_AGENT_ID: "claude", SUPERSET_HOOK_HARNESS: "codex" },
+				{
+					hook_event_name: "SubagentStart",
+					agent_id: "child-1",
+					session_id: "child-thread",
+				},
+			),
+		).toEqual([]);
+	});
+
+	it("drops Claude's hook config replayed by cursor-agent", async () => {
+		// cursor-agent loads ~/.claude/settings.json and fires Claude's hooks
+		// with its own event names; the Cursor session id and identity ride
+		// cursor-hook.sh instead. Verified on cursor-agent 2026.09.02.
+		const replay = { hook_event_name: "sessionStart", session_id: "cursor-1" };
+		expect(
+			await dispatched(
+				{
+					SUPERSET_AGENT_ID: "cursor-agent",
+					SUPERSET_HOOK_HARNESS: "claude",
+					CURSOR_AGENT: "1",
+					CURSOR_VERSION: "2026.09.02-c22c1a3",
+				},
+				replay,
+			),
+		).toEqual([]);
+		// Launched without the wrapper, Cursor's env is the only tell.
+		for (const tell of ["CURSOR_AGENT", "CURSOR_CLI", "CURSOR_VERSION"]) {
+			expect(
+				await dispatched(
+					{
+						SUPERSET_AGENT_ID: "",
+						SUPERSET_HOOK_HARNESS: "claude",
+						[tell]: "1",
+					},
+					replay,
+				),
+			).toEqual([]);
+		}
+	});
+});
+
+describe("cursor-hook.template.sh identity", () => {
+	function renderCursorHook(): string {
+		return readFileSync(getTemplatePath("cursor-hook.template.sh"), "utf-8")
+			.replaceAll("{{MARKER}}", "# test hook")
+			.replaceAll("{{DEFAULT_PORT}}", "48763");
+	}
+
+	async function runCursorHook(
+		eventArg: string,
+		envOverrides: Record<string, string>,
+	) {
+		const host = fakeHostService(false);
+		try {
+			const proc = Bun.spawn({
+				cmd: ["bash", "-c", renderCursorHook(), "cursor-hook.sh", eventArg],
+				env: hookEnv({
+					SUPERSET_HOST_AGENT_HOOK_URL: `${host.url}/trpc/notifications.hook`,
+					CURSOR_AGENT: "",
+					CURSOR_CLI: "",
+					...envOverrides,
+				}),
+				stdin: Buffer.from(JSON.stringify({ session_id: "cursor-1" })),
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			const [exitCode, stdout] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+			]);
+			expect(exitCode).toBe(0);
+			return { stdout, requests: host.requests.map((request) => request.json) };
+		} finally {
+			host.stop();
+		}
+	}
+
+	it("reports the wrapper's cursor-agent identity", async () => {
+		expect(
+			(await runCursorHook("Stop", { SUPERSET_AGENT_ID: "cursor-agent" }))
+				.requests,
+		).toEqual([
+			{
+				terminalId: "terminal-test",
+				eventType: "Stop",
+				agent: { agentId: "cursor-agent", sessionId: "cursor-1" },
+			},
+		]);
+	});
+
+	it("tells cursor-agent from the IDE Composer when launched without the wrapper", async () => {
+		const cli = await runCursorHook("Stop", {
+			SUPERSET_AGENT_ID: "",
+			CURSOR_AGENT: "1",
+		});
+		expect(cli.requests[0]?.agent).toEqual({
+			agentId: "cursor-agent",
+			sessionId: "cursor-1",
+		});
+		const composer = await runCursorHook("Stop", { SUPERSET_AGENT_ID: "" });
+		expect(composer.requests[0]?.agent).toEqual({
+			agentId: "cursor-composer",
+			sessionId: "cursor-1",
+		});
+	});
+
+	it("drops events from cursor-agent running under another agent, after auto-approving", async () => {
+		const nested = await runCursorHook("PermissionRequest", {
+			SUPERSET_AGENT_ID: "claude",
+			CURSOR_AGENT: "1",
+		});
+		// The approval must still reach cursor-agent or the tool call hangs.
+		expect(nested.stdout).toBe('{"continue":true}\n');
+		expect(nested.requests).toEqual([]);
 	});
 });

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -536,6 +536,39 @@ describe("agent identity precedence", () => {
 		]);
 	});
 
+	it.each([
+		"opencode",
+		"",
+	])("captures OpenCode's resumable session with wrapper identity %j", async (wrapperIdentity) => {
+		expect(
+			await dispatched(
+				{
+					SUPERSET_AGENT_ID: wrapperIdentity,
+					SUPERSET_HOOK_HARNESS: "opencode",
+				},
+				{ hook_event_name: "Stop", session_id: "ses_opencode" },
+			),
+		).toEqual([
+			{
+				terminalId: "terminal-test",
+				eventType: "Stop",
+				agent: { agentId: "opencode", sessionId: "ses_opencode" },
+			},
+		]);
+	});
+
+	it("drops a nested OpenCode plugin's lifecycle and session ID", async () => {
+		expect(
+			await dispatched(
+				{
+					SUPERSET_AGENT_ID: "claude",
+					SUPERSET_HOOK_HARNESS: "opencode",
+				},
+				{ hook_event_name: "Stop", session_id: "ses_child" },
+			),
+		).toEqual([]);
+	});
+
 	it("names the agent from the hook config when no wrapper exported an identity", async () => {
 		// The binary was resolved from the system PATH: the config that
 		// fired is the only identity there is.

--- a/packages/agent-setup/src/notify-hook.ts
+++ b/packages/agent-setup/src/notify-hook.ts
@@ -5,7 +5,7 @@ import { getHooksDir } from "./paths";
 import { writeFileIfChanged } from "./write-file-if-changed";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v14";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v15";
 
 export function getNotifyScriptPath(): string {
 	return path.join(getHooksDir(), NOTIFY_SCRIPT_NAME);

--- a/packages/agent-setup/templates/amp-plugin.template.ts
+++ b/packages/agent-setup/templates/amp-plugin.template.ts
@@ -108,7 +108,7 @@ export default function supersetAmpLifecyclePlugin(amp: AmpApi) {
 			const child = spawn(notifyPath, [], {
 				stdio: ["pipe", "ignore", "ignore"],
 				detached: true,
-				env: { ...env, SUPERSET_AGENT_ID: "amp" },
+				env: { ...env, SUPERSET_HOOK_HARNESS: "amp" },
 			});
 			child.on("error", (error) => {
 				debugLog("spawn failed event=" + hookEventName + " error=" + error.message);

--- a/packages/agent-setup/templates/copilot-hook.template.sh
+++ b/packages/agent-setup/templates/copilot-hook.template.sh
@@ -27,6 +27,12 @@ printf '{}\n'
 # SUPERSET_* vars.
 [ -n "$SUPERSET_TERMINAL_ID" ] || [ -n "$SUPERSET_TAB_ID" ] || exit 0
 
+# The wrapper's identity, or copilot when launched without one. Another
+# agent's identity means copilot is running under it (a tool call), which is
+# not this terminal's lifecycle.
+AGENT_ID="${SUPERSET_AGENT_ID:-copilot}"
+[ "$AGENT_ID" = "copilot" ] || exit 0
+
 V1_EVENT_TYPE="$EVENT_TYPE"
 case "$V1_EVENT_TYPE" in
   SessionStart) V1_EVENT_TYPE="Start" ;;
@@ -42,7 +48,7 @@ json_escape() {
 # port, while each org manifest is rewritten with the live endpoint on every
 # start. Only the host that owns this terminal answers "ignored":false.
 if [ -n "$SUPERSET_TERMINAL_ID" ]; then
-  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
 
   HOOK_CANDIDATE_URLS="$SUPERSET_HOST_AGENT_HOOK_URL"
   for MANIFEST_FILE in "${SUPERSET_HOME_DIR:-$HOME/.superset}"/host/*/manifest.json; do
@@ -89,7 +95,7 @@ curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
   --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
   --data-urlencode "eventType=$V1_EVENT_TYPE" \
   --data-urlencode "rawEventType=$EVENT_TYPE" \
-  --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
+  --data-urlencode "agentId=$AGENT_ID" \
   --data-urlencode "env=$SUPERSET_ENV" \
   --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
   > /dev/null 2>&1

--- a/packages/agent-setup/templates/cursor-hook.template.sh
+++ b/packages/agent-setup/templates/cursor-hook.template.sh
@@ -37,6 +37,8 @@ json_escape() {
 # This script only fires for Cursor sessions, so an unset SUPERSET_AGENT_ID
 # means Cursor ran outside a Superset wrapper: the cursor-agent CLI stamps
 # CURSOR_AGENT/CURSOR_CLI into its env; anything else is the IDE Composer.
+# Another agent's identity means cursor-agent is running under it (a tool
+# call), which is not this terminal's lifecycle.
 AGENT_ID="$SUPERSET_AGENT_ID"
 if [ -z "$AGENT_ID" ]; then
   if [ -n "$CURSOR_AGENT" ] || [ -n "$CURSOR_CLI" ]; then
@@ -44,6 +46,8 @@ if [ -z "$AGENT_ID" ]; then
   else
     AGENT_ID="cursor-composer"
   fi
+elif [ "$AGENT_ID" != "cursor-agent" ]; then
+  exit 0
 fi
 
 # Resolve the host-service endpoint at call time: the env URL is frozen at

--- a/packages/agent-setup/templates/gemini-hook.template.sh
+++ b/packages/agent-setup/templates/gemini-hook.template.sh
@@ -25,6 +25,12 @@ printf '{}\n'
 # outside Superset terminals; only those terminals set SUPERSET_* vars.
 [ -n "$SUPERSET_TERMINAL_ID" ] || [ -n "$SUPERSET_TAB_ID" ] || exit 0
 
+# The wrapper's identity, or gemini when launched without one. Another
+# agent's identity means gemini is running under it (a tool call), which is
+# not this terminal's lifecycle.
+AGENT_ID="${SUPERSET_AGENT_ID:-gemini}"
+[ "$AGENT_ID" = "gemini" ] || exit 0
+
 V1_EVENT_TYPE="$EVENT_TYPE"
 case "$V1_EVENT_TYPE" in
   SessionStart) V1_EVENT_TYPE="Start" ;;
@@ -40,7 +46,7 @@ json_escape() {
 # port, while each org manifest is rewritten with the live endpoint on every
 # start. Only the host that owns this terminal answers "ignored":false.
 if [ -n "$SUPERSET_TERMINAL_ID" ]; then
-  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
+  PAYLOAD="{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$AGENT_ID")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\"}}}"
 
   HOOK_CANDIDATE_URLS="$SUPERSET_HOST_AGENT_HOOK_URL"
   for MANIFEST_FILE in "${SUPERSET_HOME_DIR:-$HOME/.superset}"/host/*/manifest.json; do
@@ -89,7 +95,7 @@ curl -sG "http://127.0.0.1:${SUPERSET_PORT:-{{DEFAULT_PORT}}}/hook/complete" \
   --data-urlencode "hookSessionId=$HOOK_SESSION_ID" \
   --data-urlencode "eventType=$V1_EVENT_TYPE" \
   --data-urlencode "rawEventType=$EVENT_TYPE" \
-  --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
+  --data-urlencode "agentId=$AGENT_ID" \
   --data-urlencode "env=$SUPERSET_ENV" \
   --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
   > /dev/null 2>&1

--- a/packages/agent-setup/templates/notify-hook.template.sh
+++ b/packages/agent-setup/templates/notify-hook.template.sh
@@ -17,6 +17,31 @@ fi
 # payload alone must never dispatch.
 [ -n "$SUPERSET_TERMINAL_ID" ] || [ -n "$SUPERSET_TAB_ID" ] || exit 0
 
+# Which agent this event belongs to. A Superset wrapper exports
+# SUPERSET_AGENT_ID for the process it launches (first-wins, so a CLI an
+# agent runs from a tool call keeps the terminal's identity), and every
+# hook config Superset writes inlines SUPERSET_HOOK_HARNESS, the harness
+# whose config fired. The two can disagree: cursor-agent replays
+# ~/.claude/settings.json, so Claude's config fires inside a Cursor session;
+# and Claude's Bash tool running `codex exec` fires Codex's config under a
+# Claude terminal. Neither is this terminal's lifecycle — the replay is
+# covered by Cursor's own hooks and the nested run belongs to a child
+# process — so a foreign harness's event is dropped rather than allowed to
+# relabel the terminal (and hand its session id to the wrong agent's
+# resume). A config firing with no wrapper identity at all names the agent
+# itself: the binary was resolved from the system PATH.
+AGENT_ID="$SUPERSET_AGENT_ID"
+if [ -z "$AGENT_ID" ]; then
+  # cursor-agent stamps CURSOR_AGENT/CURSOR_CLI/CURSOR_VERSION into its env;
+  # without a wrapper that is the only sign Claude's config is being replayed.
+  if [ "$SUPERSET_HOOK_HARNESS" = "claude" ] && { [ -n "$CURSOR_AGENT" ] || [ -n "$CURSOR_CLI" ] || [ -n "$CURSOR_VERSION" ]; }; then
+    exit 0
+  fi
+  AGENT_ID="$SUPERSET_HOOK_HARNESS"
+elif [ -n "$SUPERSET_HOOK_HARNESS" ] && [ "$SUPERSET_HOOK_HARNESS" != "$AGENT_ID" ]; then
+  exit 0
+fi
+
 # Claude Code and Codex set agent_id only when the hook fires inside a
 # subagent (Task tool / spawn_agent). Subagent activity must not drive
 # terminal-level agent status, notifications, or the session id binding —
@@ -98,7 +123,7 @@ elif [ "$SUPERSET_ENV" = "development" ] || [ "$NODE_ENV" = "development" ]; the
 fi
 
 if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
-  echo "[notify-hook] event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID subagentId=$SUBAGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID" >&2
+  echo "[notify-hook] event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$AGENT_ID subagentId=$SUBAGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID paneId=$SUPERSET_PANE_ID tabId=$SUPERSET_TAB_ID workspaceId=$SUPERSET_WORKSPACE_ID" >&2
 fi
 
 debug_log() {
@@ -167,13 +192,13 @@ dispatch_to_host() {
 # terminal's resumable session), and the raw event name so the host can tell
 # a start from a stop.
 if [ -n "$SUBAGENT_ID" ]; then
-  debug_log "subagent event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID subagentId=$SUBAGENT_ID subagentType=$SUBAGENT_TYPE"
+  debug_log "subagent event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$AGENT_ID subagentId=$SUBAGENT_ID subagentType=$SUBAGENT_TYPE"
   [ -n "$SUPERSET_TERMINAL_ID" ] || exit 0
   dispatch_to_host "{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"subagent\":{\"id\":\"$(json_escape "$SUBAGENT_ID")\",\"type\":\"$(json_escape "$SUBAGENT_TYPE")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\",\"transcriptPath\":\"$(json_escape "$TRANSCRIPT_PATH")\",\"agentTranscriptPath\":\"$(json_escape "$AGENT_TRANSCRIPT_PATH")\"}}}"
   exit 0
 fi
 
-debug_log "event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$SUPERSET_AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID tabId=$SUPERSET_TAB_ID"
+debug_log "event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$AGENT_ID sessionId=$SESSION_ID hookSessionId=$HOOK_SESSION_ID resourceId=$RESOURCE_ID tabId=$SUPERSET_TAB_ID"
 
 V1_EVENT_TYPE="$EVENT_TYPE"
 case "$V1_EVENT_TYPE" in
@@ -186,7 +211,7 @@ case "$V1_EVENT_TYPE" in
 esac
 
 if [ -n "$SUPERSET_TERMINAL_ID" ]; then
-  dispatch_to_host "{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$SUPERSET_AGENT_ID")\",\"sessionId\":\"$(json_escape "$SESSION_ID")\"}}}"
+  dispatch_to_host "{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"agent\":{\"agentId\":\"$(json_escape "$AGENT_ID")\",\"sessionId\":\"$(json_escape "$SESSION_ID")\"}}}"
   [ "$HOOK_ACCEPTED" = "1" ] && exit 0
   # Delivered somewhere (2xx) but no host owned the terminal: keep the
   # pre-existing "any 2xx wins" behavior and skip the v1 fallback.
@@ -211,7 +236,7 @@ if [ "$DEBUG_HOOKS_ENABLED" = "1" ]; then
     --data-urlencode "resourceId=$RESOURCE_ID" \
     --data-urlencode "eventType=$V1_EVENT_TYPE" \
     --data-urlencode "rawEventType=$EVENT_TYPE" \
-    --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
+    --data-urlencode "agentId=$AGENT_ID" \
     --data-urlencode "env=$SUPERSET_ENV" \
     --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
     -o /dev/null -w "%{http_code}" 2>/dev/null)
@@ -230,7 +255,7 @@ else
     --data-urlencode "resourceId=$RESOURCE_ID" \
     --data-urlencode "eventType=$V1_EVENT_TYPE" \
     --data-urlencode "rawEventType=$EVENT_TYPE" \
-    --data-urlencode "agentId=$SUPERSET_AGENT_ID" \
+    --data-urlencode "agentId=$AGENT_ID" \
     --data-urlencode "env=$SUPERSET_ENV" \
     --data-urlencode "version=$SUPERSET_HOOK_VERSION" \
     > /dev/null 2>&1

--- a/packages/agent-setup/templates/omp-extension.template.ts
+++ b/packages/agent-setup/templates/omp-extension.template.ts
@@ -75,7 +75,7 @@ export default function (pi: OmpExtensionApi) {
 			const child = spawn(notifyScript, [], {
 				stdio: ["pipe", "ignore", "ignore"],
 				detached: true,
-				env: { ...process.env, SUPERSET_AGENT_ID: "omp" },
+				env: { ...process.env, SUPERSET_HOOK_HARNESS: "omp" },
 			});
 			child.on("error", () => {
 				/* swallow — never let hook failures affect OMP */

--- a/packages/agent-setup/templates/opencode-plugin.template.js
+++ b/packages/agent-setup/templates/opencode-plugin.template.js
@@ -34,7 +34,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
 
   // State tracking for deduplication and session-scoping
   let currentState = 'idle'; // 'idle' | 'busy'
-  let rootSessionID = null;  // The session we're tracking (first busy session)
+  let rootSessionID = null;  // Retained while idle for the host's resume binding
   let stopSent = false;      // Prevent duplicate Stop notifications
 
   const log = (...args) => {
@@ -106,8 +106,9 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
    * Only sends Start if transitioning from idle and session matches root.
    */
   const handleBusy = async (sessionID) => {
-    // If we don't have a root session yet, this becomes our root
-    if (!rootSessionID) {
+    // A new busy root after an idle turn is a conversation switch. Merely
+    // creating or deleting another session is not evidence of a switch.
+    if (!rootSessionID || currentState === 'idle') {
       rootSessionID = sessionID;
       log('Root session set:', rootSessionID);
     }
@@ -131,7 +132,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
   /**
    * Handles state transition to idle/stopped.
    * Only sends Stop once per busy period and only for root session.
-   * Resets rootSessionID after Stop so we can track new sessions.
+   * Retains rootSessionID while idle so unrelated events cannot steal resume.
    */
   const handleStop = async (sessionID, reason) => {
     // Only process events for our root session (if we have one)
@@ -146,9 +147,6 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
       stopSent = true;
       log('Stopping, reason:', reason);
       await notify('Stop', sessionID);
-      // Reset rootSessionID so we can track a new session if OpenCode starts another conversation
-      rootSessionID = null;
-      log('Reset rootSessionID for next session');
     } else {
       log('Skipping Stop - state:', currentState, 'stopSent:', stopSent, 'reason:', reason);
     }
@@ -173,6 +171,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
         // — by the time deletion fires the session is gone from list().
         if (sessionID) childSessionCache.set(sessionID, isChild);
         if (!isChild) {
+          if (!rootSessionID) rootSessionID = sessionID;
           await notify("SessionStart", sessionID);
         }
         return;
@@ -186,6 +185,11 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
             : await isChildSession(sessionID);
         if (!isChild) {
           await notify("SessionEnd", sessionID);
+          if (rootSessionID === sessionID) {
+            rootSessionID = null;
+            currentState = 'idle';
+            stopSent = true;
+          }
         }
         if (sessionID) childSessionCache.delete(sessionID);
         return;

--- a/packages/agent-setup/templates/opencode-plugin.template.js
+++ b/packages/agent-setup/templates/opencode-plugin.template.js
@@ -152,8 +152,19 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
     }
   };
 
+  // OpenCode can dispatch another hook while an earlier notification is in
+  // flight. Keep ownership transitions and their notifications in arrival
+  // order, including legacy permission callbacks that use the current root.
+  let pendingEvent = Promise.resolve();
+  const enqueue = (handle) => {
+    pendingEvent = pendingEvent.then(handle).catch((err) => {
+      log('Event handling failed:', err?.message || err);
+    });
+    return pendingEvent;
+  };
+
   return {
-    event: async ({ event }) => {
+    event: ({ event }) => enqueue(async () => {
       // session.created carries the new session info under `info`, not `sessionID`.
       const sessionID =
         event.properties?.sessionID ??
@@ -236,13 +247,13 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
       if (event.type === "session.error") {
         await handleStop(sessionID, 'session.error');
       }
-    },
-    "permission.ask": async (permission, output) => {
+    }),
+    "permission.ask": (permission, output) => enqueue(async () => {
       if (output.status === "ask") {
         const sessionID = permission?.sessionID ?? rootSessionID;
         if (!sessionID || await isChildSession(sessionID)) return;
         await notify("PermissionRequest", sessionID);
       }
-    },
+    }),
   };
 };

--- a/packages/agent-setup/templates/opencode-plugin.template.js
+++ b/packages/agent-setup/templates/opencode-plugin.template.js
@@ -76,12 +76,12 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
   const childSessionCache = new Map();
   const isChildSession = async (sessionID) => {
     if (!sessionID) return true; // No sessionID = can't verify, skip
-    if (!client?.session?.list) return true; // Can't check, skip
 
     // Check cache first
     if (childSessionCache.has(sessionID)) {
       return childSessionCache.get(sessionID);
     }
+    if (!client?.session?.list) return true; // Can't check, skip
 
     try {
       const sessions = await client.session.list();
@@ -240,7 +240,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
     "permission.ask": async (permission, output) => {
       if (output.status === "ask") {
         const sessionID = permission?.sessionID ?? rootSessionID;
-        if (sessionID && await isChildSession(sessionID)) return;
+        if (!sessionID || await isChildSession(sessionID)) return;
         await notify("PermissionRequest", sessionID);
       }
     },

--- a/packages/agent-setup/templates/opencode-plugin.template.js
+++ b/packages/agent-setup/templates/opencode-plugin.template.js
@@ -5,7 +5,7 @@
  * This plugin sends desktop notifications when OpenCode sessions need attention.
  * It hooks into session.status (busy/idle), session.idle, session.error, and permission.ask events.
  *
- * ROBUSTNESS FEATURES (v9):
+ * ROBUSTNESS FEATURES (v10):
  * - Session-scoped: Tracks root sessionID, ignores events from other sessions
  * - Deduplication: Only sends Start on idle→busy, Stop on busy→idle transitions
  * - Safe defaults: On error, assumes child session to avoid false positives
@@ -23,8 +23,8 @@
  * @see https://github.com/sst/opencode/blob/dev/packages/app/src/context/notification.tsx
  */
 export const SupersetNotifyPlugin = async ({ $, client }) => {
-  if (globalThis.__supersetOpencodeNotifyPluginV9) return {};
-  globalThis.__supersetOpencodeNotifyPluginV9 = true;
+  if (globalThis.__supersetOpencodeNotifyPluginV10) return {};
+  globalThis.__supersetOpencodeNotifyPluginV10 = true;
 
   // Only run inside a v2 Superset terminal session.
   if (!process?.env?.SUPERSET_TERMINAL_ID) return {};
@@ -45,14 +45,20 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
    * Sends a notification to Superset's notification server.
    * Best-effort only - failures are silently ignored to avoid breaking the agent.
    */
-  const notify = async (hookEventName) => {
-    const payload = JSON.stringify({ hook_event_name: hookEventName });
+  const notify = async (hookEventName, sessionID = rootSessionID) => {
+    // An event from a different root must not replace the active session's
+    // identity or end its binding (the host uses this ID for native resume).
+    if (rootSessionID && sessionID && sessionID !== rootSessionID) return;
+    const payload = JSON.stringify({
+      hook_event_name: hookEventName,
+      ...(sessionID ? { session_id: sessionID } : {}),
+    });
     log('Sending notification:', hookEventName);
     try {
-      // SUPERSET_AGENT_ID=opencode is exported by the opencode wrapper and
-      // inherited by every child of the opencode process, so the notify
-      // script reads the right id from env without any explicit forwarding.
-      await $`bash ${notifyPath} ${payload}`;
+      // Preserve the outer wrapper's identity. notify.sh drops this event
+      // when OpenCode runs under another harness, and uses this marker as
+      // its identity fallback when OpenCode bypasses the wrapper.
+      await $`SUPERSET_HOOK_HARNESS=opencode bash ${notifyPath} ${payload}`;
       log('Notification sent successfully');
     } catch (err) {
       log('Notification failed:', err?.message || err);
@@ -80,7 +86,10 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
     try {
       const sessions = await client.session.list();
       const session = sessions.data?.find((s) => s.id === sessionID);
-      const isChild = !!session?.parentID;
+      // A missing session is not proof of a root. Retry on a later event
+      // instead of caching a race with session creation as a root identity.
+      if (!session) return true;
+      const isChild = !!session.parentID;
       childSessionCache.set(sessionID, isChild);
       log('Session lookup:', sessionID, 'isChild:', isChild);
       return isChild;
@@ -113,7 +122,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
     if (currentState === 'idle') {
       currentState = 'busy';
       stopSent = false; // Reset stop flag for new busy period
-      await notify('Start');
+      await notify('Start', sessionID);
     } else {
       log('Already busy, skipping Start');
     }
@@ -136,7 +145,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
       currentState = 'idle';
       stopSent = true;
       log('Stopping, reason:', reason);
-      await notify('Stop');
+      await notify('Stop', sessionID);
       // Reset rootSessionID so we can track a new session if OpenCode starts another conversation
       rootSessionID = null;
       log('Reset rootSessionID for next session');
@@ -153,6 +162,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
         event.properties?.info?.id ??
         null;
       log('Event:', event.type, 'sessionID:', sessionID);
+      if (!sessionID) return;
 
       // SessionStart/SessionEnd give the host binding store its earliest/latest
       // signal — fired before any prompt arrives. Filter out child sessions so
@@ -163,7 +173,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
         // — by the time deletion fires the session is gone from list().
         if (sessionID) childSessionCache.set(sessionID, isChild);
         if (!isChild) {
-          await notify("SessionStart");
+          await notify("SessionStart", sessionID);
         }
         return;
       }
@@ -175,7 +185,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
             ? cachedIsChild
             : await isChildSession(sessionID);
         if (!isChild) {
-          await notify("SessionEnd");
+          await notify("SessionEnd", sessionID);
         }
         if (sessionID) childSessionCache.delete(sessionID);
         return;
@@ -194,7 +204,7 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
         event.type === "permission.asked" ||
         event.type === "question.asked"
       ) {
-        await notify("PermissionRequest");
+        await notify("PermissionRequest", sessionID);
         return;
       }
 
@@ -223,9 +233,11 @@ export const SupersetNotifyPlugin = async ({ $, client }) => {
         await handleStop(sessionID, 'session.error');
       }
     },
-    "permission.ask": async (_permission, output) => {
+    "permission.ask": async (permission, output) => {
       if (output.status === "ask") {
-        await notify("PermissionRequest");
+        const sessionID = permission?.sessionID ?? rootSessionID;
+        if (sessionID && await isChildSession(sessionID)) return;
+        await notify("PermissionRequest", sessionID);
       }
     },
   };

--- a/packages/agent-setup/templates/pi-extension.template.ts
+++ b/packages/agent-setup/templates/pi-extension.template.ts
@@ -41,7 +41,7 @@ export default function (pi: ExtensionAPI) {
 			const child = spawn(notifyScript, [], {
 				stdio: ["pipe", "ignore", "ignore"],
 				detached: true,
-				env: { ...process.env, SUPERSET_AGENT_ID: "pi" },
+				env: { ...process.env, SUPERSET_HOOK_HARNESS: "pi" },
 			});
 			child.on("error", () => {
 				/* swallow — never let hook failures affect pi */

--- a/plans/agent-session-ownership.md
+++ b/plans/agent-session-ownership.md
@@ -1,0 +1,170 @@
+# Terminal agent session ownership
+
+Status: proposed follow-up to [PR #7263](https://github.com/superset-sh/superset/pull/7263).
+This document does not introduce a new protocol or database migration.
+
+## Problem
+
+A terminal ID identifies where a hook should be delivered. It does not prove that
+the reporting process owns that terminal's top-level agent session. A child CLI
+inherits the terminal's environment, and may report a different provider or native
+session ID. The current host can then replace the parent binding or mark the
+parent finished. That binding also selects the executable and conversation used
+for automatic resume.
+
+PR #7263 separates the wrapper's agent identity from the hook configuration's
+harness, drops foreign-harness events, and supplies OpenCode's native session ID.
+It reproduces and fixes Cursor replaying Claude hooks and subsequently resuming
+with Claude. It does not establish ownership of a particular agent process.
+
+Remaining examples:
+
+- Claude launches a standalone Claude child. Both have harness `claude`, but the
+  child's ordinary hook can carry its own conversation ID without a native
+  subagent marker. Harness comparison cannot distinguish them.
+- A delayed hook from a completed launch arrives after another agent starts in
+  the same shell. Terminal identity is unchanged, but launch identity changed.
+- An unwrapped binary emits hooks without the launch metadata supplied by a
+  managed wrapper.
+
+Native subagents that carry explicit subagent identity already have a separate
+roster path. Preserve that behavior rather than treating every child as a new
+terminal agent.
+
+## Invariants
+
+1. Only the current, verified top-level launch can replace the terminal binding's
+   provider, native session ID, definition, or lifecycle state.
+2. Stop means the turn completed. It does not release ownership of the live agent
+   or its resumable conversation.
+3. A nested child's completion cannot finish its parent or replace its resume ID.
+4. A legitimate new top-level agent in the same shell can acquire ownership after
+   the previous owner exits. Do not make terminal identity permanently immutable.
+5. A late event from a previous launch cannot resurrect or end the current one.
+6. Validation happens before persistence, lifecycle broadcasts, notifications, or
+   other event-driven effects. Dropping only the store write is insufficient.
+7. Host-service restart must preserve ownership of surviving PTYs and agents.
+
+## Proposed model
+
+Keep these concepts separate:
+
+| Field | Meaning |
+| --- | --- |
+| Terminal ID | PTY destination; may outlive multiple agent launches |
+| Launch generation | Host-issued identifier for one accepted top-level launch |
+| Process identity | Runtime/host, PID, process start identity, and PTY association |
+| Provider / harness | Which CLI owns the native conversation and emits the hook |
+| Native session ID | Provider-specific conversation to resume |
+| Parent launch / subagent ID | Explicit relationship for child activity |
+
+Persist the accepted launch generation and process identity alongside the binding
+in the host's local database. Do not put entity-scoped ownership in renderer
+localStorage. Account/definition identity remains separate from the provider and
+is retained for command construction. Any schema change needs a generated local
+migration in the implementation PR.
+
+A launch generation inherited through the environment is correlation data, not
+proof. Children inherit it too. The host must corroborate the reporting process
+against the accepted owner, including ancestry and process-start identity to avoid
+PID reuse. A PID supplied by an HTTP caller is also only a claim.
+
+## Acceptance flow
+
+1. A wrapper requests launch registration before replacing itself with the CLI.
+   The host associates it with the real PTY and captures process-start identity.
+   Use the PTY daemon's process relationship as primary evidence. The wrapper's
+   PID surviving `exec` helps correlate the later CLI, but executable validation
+   must account for interpreter/shim launchers.
+2. If the existing owner is alive and the new launch descends from it, classify
+   the launch as nested. Keep the parent binding. A native child can join the
+   roster; an unsupported standalone child cannot mutate terminal lifecycle.
+3. If the former owner exited and the shell starts another CLI, register a new
+   generation. Ordinary progress hooks cannot perform this replacement.
+4. For each hook, resolve its reporting process through known transient hook
+   shells to its owning agent. Require the accepted generation, provider, and
+   process relationship before changing the binding or emitting lifecycle events.
+5. A native session ID may be learned after launch. Once bound, a different ID
+   requires an adapter-recognized conversation switch from the verified owner.
+   Changing conversations inside OpenCode or clearing a Claude conversation must
+   remain supported without granting a nested CLI the same authority.
+6. SessionEnd releases ownership only when it belongs to the accepted launch.
+   Terminal loss preserves the validated provider/session pair for resume. A new
+   terminal created by resume receives a new launch generation and an explicit
+   link to its predecessor.
+
+Implement a pure acceptance decision shared by the host's hook route and binding
+store. Return a classification such as accepted, nested, stale, or unverified;
+apply side effects only to accepted events. Keep classification independent of UI.
+
+## Compatibility and recovery
+
+- Introduce optional wire metadata first and deploy updated wrappers/adapters
+  before enforcing it. Version provisioning so existing installations update.
+- For legacy/unwrapped launches, attempt host-side process reconciliation. If
+  ownership cannot be proven, preserve an existing validated resume binding.
+  Do not silently replace it based on the latest arriving hook.
+- Decide separately how to display an unverified first launch; uncertainty must
+  not manufacture an automatically executable resume binding.
+- Surviving agents retain immutable environment variables across host restarts.
+  Reload accepted generations from host storage and reconcile them with daemon
+  state; do not invalidate every launch just because the receiver restarted.
+- Remote evidence must be gathered on the execution host, never from desktop-local
+  PIDs. Include the runtime/host identity and avoid comparing PIDs across hosts.
+- Keep bounded diagnostics for rejected events and their reason. Exclude prompts,
+  credentials, and complete process environments. Rate-limit repeated failures.
+- This protects against accidental attribution errors among cooperating local
+  processes. It is not a security boundary against arbitrary hostile code running
+  as the same OS user; stronger authentication is a separate design question.
+
+## Implementation boundaries
+
+Primary sites are `packages/host-service/src/trpc/router/notifications/notifications.ts`
+(accept before broadcasting), `packages/host-service/src/terminal-agents/store.ts`
+(binding and roster decisions), terminal/daemon process tracking, agent launch and
+resume paths, and `packages/agent-setup` wrappers and adapters.
+
+Before adding environment variables, follow `docs/environment-variables.md`.
+Process probes must be bounded and cached for the lifetime of a process identity;
+do not run an unbounded process-tree scan on every tool hook.
+
+Keep the missing built-in-agent configuration fallback separate: detection may
+work while resume is unsupported because no host configuration exists. Ownership
+validation must not silently invent account settings or user command arguments.
+
+## Verification matrix
+
+| Scenario | Required result |
+| --- | --- |
+| Cursor replays Claude hooks | Cursor identity and native session remain intact |
+| Claude launches Codex/OpenCode | Parent remains Claude; child cannot finish it |
+| Same-harness standalone child | Child session ID cannot replace parent's ID |
+| Native subagent start/stop | Roster updates; parent identity/lifecycle preserved |
+| Agent exits, user starts another in same shell | New launch becomes owner |
+| Delayed Stop/SessionEnd from old launch | No effect on current owner |
+| Same process starts a new native conversation | Verified adapter transition updates ID |
+| Missing wrapper / transient hook shell | Correct process reconciliation or explicit uncertainty |
+| PID reused / host-service restarted | No false match; surviving owners remain valid |
+| Remote host / multiple organizations | Ownership stays within execution host and terminal |
+| Kill terminal and remount | Correct CLI resumes the exact verified conversation |
+| Missing config / missing transcript | Explicit unsupported or recovery result |
+
+Use deterministic store tests with delayed/reordered event sequences, real script
+integration tests, and before/after CDP journeys on the actual app. Verify provider,
+root session ID, lifecycle state, and successful resume independently. A correct
+icon or Start/Stop sequence alone does not establish resumability.
+
+## Reference implementations
+
+These are implementation ideas, not proof that another application handles every
+case above:
+
+- [Orca's identity resolver](https://github.com/stablyai/orca/blob/61c7b51c8cc9e992dbdebc037562c208f84ac8cd/src/shared/agent-status-identity.ts)
+  retains a fresh active parent's provider against foreign hooks. Its state/time
+  heuristic does not establish same-harness session ownership.
+- [cmux process binding](https://github.com/manaflow-ai/cmux/blob/main/CLI/CMUXCLI%2BAgentHookProcessBinding.swift)
+  prefers live process/TTY evidence and can reject an ambient claim after a failed
+  live probe.
+- [ccmux's marker linker](https://github.com/epilande/ccmux/blob/main/src/daemon/adapters/link.ts)
+  re-evaluates native-session ownership and repairs incorrect links using pane/PID
+  evidence, with a process-start check when available.

--- a/plans/agent-session-ownership.md
+++ b/plans/agent-session-ownership.md
@@ -94,8 +94,14 @@ PID reuse. A PID supplied by an HTTP caller is also only a claim.
    link to its predecessor.
 
 Implement a pure acceptance decision shared by the host's hook route and binding
-store. Return a classification such as accepted, nested, stale, or unverified;
-apply side effects only to accepted events. Keep classification independent of UI.
+store. Execute that decision in a per-terminal transaction or compare-and-swap:
+validate the expected generation and process identity against current state, then
+commit the generation, process identity, ownership, and binding together. Retry
+or reject a decision if its expected state changed. Return a classification such
+as accepted, nested, stale, or unverified; rejected events have no lifecycle side
+effects. Broadcast lifecycle changes and notifications only after the accepted
+commit, preserving per-terminal commit order. Validation followed by an unrelated
+store write is insufficient. Keep classification independent of UI.
 
 ## Compatibility and recovery
 
@@ -104,6 +110,11 @@ apply side effects only to accepted events. Keep classification independent of U
 - For legacy/unwrapped launches, attempt host-side process reconciliation. If
   ownership cannot be proven, preserve an existing validated resume binding.
   Do not silently replace it based on the latest arriving hook.
+- Preserve OpenCode's legacy `permission.ask` fallback: when the callback omits
+  `permission.sessionID`, use the verified tracked `rootSessionID` for that owner.
+  If both identifiers are absent, classify the event as unverified and leave
+  ownership and permission state unchanged. This fallback does not bypass the
+  reporting process and launch-generation checks.
 - Decide separately how to display an unverified first launch; uncertainty must
   not manufacture an automatically executable resume binding.
 - Surviving agents retain immutable environment variables across host restarts.
@@ -142,6 +153,8 @@ validation must not silently invent account settings or user command arguments.
 | Native subagent start/stop | Roster updates; parent identity/lifecycle preserved |
 | Agent exits, user starts another in same shell | New launch becomes owner |
 | Delayed Stop/SessionEnd from old launch | No effect on current owner |
+| Concurrent replacement and old-owner hook | Atomic validation/commit rejects stale ownership; effects follow commit order |
+| OpenCode legacy permission without a session ID | Verified tracked root supplies the ID; absent root leaves ownership and permission state unchanged |
 | Same process starts a new native conversation | Verified adapter transition updates ID |
 | Missing wrapper / transient hook shell | Correct process reconciliation or explicit uncertainty |
 | PID reused / host-service restarted | No false match; surviving owners remain valid |


### PR DESCRIPTION
## What & why

Cursor Agent could acquire a Claude binding and then fail to resume: Cursor replays `~/.claude/settings.json`, whose managed hook command overwrote `SUPERSET_AGENT_ID` with `claude`. The host accepted that identity together with Cursor's session ID, so a later terminal restore ran `claude --resume <cursor-session-id>` and reported no conversation found.

This change preserves the terminal's agent identity across foreign hook activity and captures OpenCode's native session ID so OpenCode conversations can resume after terminal loss.

- Managed hook commands identify their source with `SUPERSET_HOOK_HARNESS` instead of overwriting the wrapper's `SUPERSET_AGENT_ID`. Wrappers preserve an existing identity and skip nested launch reports; hook adapters drop foreign-harness events. Wrapper-less Cursor replay is also filtered using Cursor's environment markers.
- Cursor's native `postToolUse` and `postToolUseFailure` hooks restore Start after a Shell/MCP permission event completes. This incorporates @owieschon's Cursor work from #7252 and supersedes that PR.
- OpenCode's plugin sends its native session ID and explicit harness marker, rejects missing or unverified session events, and prevents child or competing-root events from replacing the active root. It retains legacy permission-hook support and captures resumed sessions without requiring `session.created`. The root session stays bound while idle, so unrelated session creation/deletion cannot replace or end its resume binding; a new busy root can still switch conversations.
- Provisioning markers are bumped so existing installations receive the updated wrappers/hooks, including OpenCode plugin v10. Kimi's managed-block matcher still replaces the old command format.

## How I tested it

**Real desktop app, driven through CDP:** both Cursor runs used this worktree's renderer on port 6545, CDP 9226, the expected signed-in development organization, and real keyboard/paste/mouse input. Host SQLite bindings and hook logs were read as supporting evidence; no synthetic lifecycle events were injected into the live app.

| Journey | Before | After |
| --- | --- | --- |
| Cursor 2026.09.02: launch, prompt a shell command, approve, kill the terminal shell, switch tabs and return | On parent commit `4fff6157b2`, `postToolUse` relabeled the binding to Claude while preserving Cursor session `01753eba-…`. Remount ran `claude --resume` with that ID and failed with “No conversation found.” | Binding retained `cursor-agent` and session `43d60bf7-…`. Remount ran `cursor-agent --resume` with that ID and restored the original conversation. PermissionRequest → Start also retained identity. |
| OpenCode 1.18.29: launch from preset, submit a no-tools prompt, kill the terminal shell, switch tabs and return | The old plugin omitted the session ID; previously observed bindings had no resume ID. | Start → Stop recorded `ses_f8158c475ffegEXjg1Qm6p4cNM`. Remount created a new OpenCode terminal with the same session ID and displayed the original prompt and answer. |

Screenshots and binding records were captured for the failing Cursor resume and both successful restores. The Cursor continuation does not claim a clean observed Stop transition: additional tool requests were declined before terminal-loss testing. The original report of a top-level OpenCode terminal becoming Claude remains unconfirmed.

**Automated checks:**

- 74 tests pass in `agent-wrappers.test.ts`; 34 pass in `notify-hook.test.ts` (108 total), run separately.
- New OpenCode regressions failed before implementation and pass afterward: lifecycle session IDs, child/competing-root filtering, missing-session rejection, resumed/subsequent sessions, wrapper-less attribution, and nested OpenCode event rejection.
- Final review added an idle-root regression: unrelated creation, permission, and deletion events after Stop caused incorrect lifecycle notifications before the fix and are now ignored. All 74 wrapper tests pass with that additional case.
- Agent-setup typecheck and Biome checks for changed TypeScript files pass.
- `git diff --check` and `bun run check:plugins` pass.

## Review findings addressed

Final verification at `765c24e405`: all five review threads are resolved, CodeRabbit completed with no concrete current-head merge-blocking risk, and required Test/Lint/Typecheck/Build checks pass. GitHub still requires an approving review before merge.

- [Competing root creation before busy](https://github.com/superset-sh/superset/pull/7263#discussion_r3953785457): select the root before SessionStart dispatch and test two competing session.created events before busy. The root also stays bound after Stop so unrelated idle-time creation/deletion cannot corrupt resume.
- [Legacy permission without a session ID](https://github.com/superset-sh/superset/pull/7263#discussion_r3953785462): reject the notification when neither input nor tracked root supplies an ID. Verified-root fallback still works for older permission hooks.
- [Concurrent deletion and replacement](https://github.com/superset-sh/superset/pull/7263#discussion_r3953835923): serialize plugin events and legacy permission callbacks so a pending SessionEnd cannot discard the next root. A regression holds SessionEnd in flight while creating the replacement and requesting permission; it fails before the fix and passes afterward.
- Ownership design now requires atomic validation and commit before ordered lifecycle effects, and explicitly preserves the verified-root fallback for legacy OpenCode permissions.
- All 74 wrapper tests, package typecheck, changed-file Biome checks, plugin validation, and diff checks pass after the final fixes.

## Follow-ups outside this PR

Proposed design: [Terminal agent session ownership](https://github.com/superset-sh/superset/blob/fix-agent-identification/plans/agent-session-ownership.md). It specifies the host acceptance model, compatibility rollout, and verification matrix; implementation is deferred.

**Host ownership validation:** an inherited terminal ID identifies a destination, but does not prove that the reporting process owns its top-level agent session. The host currently accepts hook identity/session replacements. A future check should tie the binding to a host-owned launch generation and corroborating process evidence, and validate events before both lifecycle broadcast and persistence. It must distinguish nested child processes from legitimate sequential top-level launches in the same shell.

That distinction also covers **same-harness nesting**: a standalone child using the same harness may emit its own session ID without a native subagent marker. An isolated synthetic check confirms the generic script still accepts that shape; it is not a live nested-CLI reproduction. Native subagents carrying explicit subagent identity already use a separate path.

**Missing agent configuration:** a detected built-in agent with no saved host agent config still reports resume unsupported. The fallback is unchanged.

Source comparison informed these boundaries: Orca preserves active parent identity against foreign hooks; cmux validates hook delivery against live process evidence; ccmux rechecks and repairs session ownership. These comparisons were code reviews, not end-to-end tests of those applications.

## Checklist

- [x] PR title follows conventional commits
- [x] Package tests/typecheck, changed-file Biome checks, plugin validation, and diff checks pass
- [x] Repository-wide test, lint, typecheck, and build pass on `765c24e405`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent identity handling during nested launches, reducing duplicate or misattributed activity.
  * Prevented unrelated, replayed, or mismatched hook events from being processed.
  * Refined Cursor tool-event handling to focus on Shell and MCP activity.
  * Improved OpenCode session tracking and serialized lifecycle notifications and permission handling.
  * Enhanced compatibility when upgrading or replacing managed hook configurations.

* **Maintenance**
  * Updated integration hook definitions and markers across supported agents.

* **Documentation**
  * Clarified agent session ownership and hook-event handling requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





