### PR TITLE
fix(desktop): stop the stale 'Host unreachable' flash and soften the host gate

### DIFF
--- a/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-ws-transport.test.ts
@@ -1,4 +1,5 @@
 import {
+	afterAll,
 	afterEach,
 	beforeEach,
 	describe,
@@ -105,17 +106,23 @@ class FakeRelaySocket {
 	}
 }
 
-// bun's mock.module is process-global and leaks to every later test file in the
-// whole desktop run, so a partial stub breaks unrelated tests that import the
-// module's other named exports. Preserve the real exports and override only
-// createRelaySocket. (auth-client / posthog are deliberately NOT mocked: with a
+// mock.module affects later suites too. Snapshot the real exports before the
+// mock rewrites their live bindings, then restore them when this suite ends.
+// (auth-client / posthog are deliberately NOT mocked: with a
 // faked socket getToken/ensureFreshJwt never runs, and posthog.capture before
 // init is a harmless no-op — the real modules load fine, as the prior test did.)
+const realRelaySocketModule = { ...relaySocketModule };
 mock.module("@superset/workspace-client/relay-socket", () => ({
-	...relaySocketModule,
+	...realRelaySocketModule,
 	createRelaySocket: (options: Record<string, unknown>) =>
 		new FakeRelaySocket(options),
 }));
+afterAll(() => {
+	mock.module(
+		"@superset/workspace-client/relay-socket",
+		() => realRelaySocketModule,
+	);
+});
 
 const { connect, createTransport, disconnect, park, reconnect } = await import(
 	"./terminal-ws-transport"

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostUnreachableState/WorkspaceHostUnreachableState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostUnreachableState/WorkspaceHostUnreachableState.tsx
@@ -53,14 +53,10 @@ export function WorkspaceHostUnreachableState({
 
 				<div className="flex flex-col gap-1.5">
 					<h1 className="text-[15px] font-medium tracking-tight text-foreground">
-						<Trans>Host unreachable</Trans>
+						<Trans>Can't connect right now</Trans>
 					</h1>
 					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground">
-						<Trans>
-							This workspace lives on a device Superset can't reach right now.
-							Terminals, files, and agents stay put — they come back as soon as
-							the connection does.
-						</Trans>
+						<Trans>We'll bring you back as soon as we reconnect.</Trans>
 					</p>
 					<p className="select-text cursor-text text-[13px] leading-relaxed text-muted-foreground/80">
 						{detail}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.test.ts
@@ -2,9 +2,17 @@ import { afterAll, afterEach, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 const NativeWebSocket = globalThis.WebSocket;
+const NativeEvent = globalThis.Event;
+const NativeMessageEvent = globalThis.MessageEvent;
+const NativeEventTarget = globalThis.EventTarget;
 const alreadyRegistered = GlobalRegistrator.isRegistered;
 if (!alreadyRegistered) GlobalRegistrator.register();
 globalThis.WebSocket = NativeWebSocket;
+// partysocket may already be loaded by another suite and extends the native
+// EventTarget. Its dynamically created events must stay in that same realm.
+globalThis.Event = NativeEvent;
+globalThis.MessageEvent = NativeMessageEvent;
+globalThis.EventTarget = NativeEventTarget;
 (
 	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+const NativeWebSocket = globalThis.WebSocket;
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+globalThis.WebSocket = NativeWebSocket;
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, cleanup, renderHook } = await import("@testing-library/react");
+const { setHostServiceSecret, removeHostServiceSecret } = await import(
+	"renderer/lib/host-service-auth"
+);
+const { useHostReachability } = await import("./useHostReachability");
+
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+test("a slow handshake completes while the degraded notice is showing", async () => {
+	let attempts = 0;
+	const server = Bun.serve({
+		port: 0,
+		async fetch(request, instance) {
+			attempts++;
+			// Longer than the old gate's first forced retry (2s + 5s),
+			// but within the relay's supported handshake budget.
+			await Bun.sleep(8_000);
+			if (instance.upgrade(request)) return;
+			return new Response("Upgrade cancelled", { status: 400 });
+		},
+		websocket: { message() {} },
+	});
+	const hostUrl = `http://127.0.0.1:${server.port}`;
+	setHostServiceSecret(hostUrl, "test-token");
+	try {
+		const { result, unmount } = renderHook(() => useHostReachability(hostUrl));
+		let sawDegraded = false;
+		const deadline = Date.now() + 10_000;
+		while (!result.current.hasConnected && Date.now() < deadline) {
+			// Flush each transition so the real grace timer and its effects
+			// run during the handshake, rather than after a single long act.
+			await act(async () => {
+				await Bun.sleep(25);
+			});
+			sawDegraded ||= result.current.isDegraded;
+		}
+		expect(sawDegraded).toBe(true);
+		expect(result.current.hasConnected).toBe(true);
+		expect(result.current.isDegraded).toBe(false);
+		expect(result.current.isUnreachable).toBe(false);
+		expect(attempts).toBe(1);
+		unmount();
+	} finally {
+		cleanup();
+		removeHostServiceSecret(hostUrl);
+		await server.stop(true);
+	}
+}, 20_000);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
@@ -1,9 +1,22 @@
 import { msg } from "@lingui/core/macro";
 import { i18n } from "@superset/i18n";
 import type { HostConnectionStatus } from "@superset/workspace-client";
-import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+	useSyncExternalStore,
+} from "react";
 import { useDelayElapsed } from "renderer/hooks/useDelayElapsed";
 import { getHostEventBus } from "renderer/lib/host-event-bus";
+
+/**
+ * How long the host has to stay down before the workspace says anything at
+ * all. Under this a dropped socket is indistinguishable from an ordinary
+ * redial, and announcing it would flicker a notice on every relay blip.
+ */
+const DEGRADED_GRACE_MS = 2_000;
 
 /**
  * How long the host has to stay unreachable before the workspace hands over to
@@ -15,19 +28,39 @@ import { getHostEventBus } from "renderer/lib/host-event-bus";
 const UNREACHABLE_GRACE_MS = 10_000;
 
 /**
- * While the screen is up, dial on this cadence instead of riding the socket's
+ * While the host is down, dial on this cadence instead of riding the socket's
  * own backoff. That backoff grows to 30s, so a host that came back could sit
  * behind "Reconnecting…" for half a minute — measured at 20.7s — which reads
  * as broken next to copy promising the workspace returns with the connection.
- * Only runs while the takeover is visible, so it can't hammer a healthy host.
+ * Only runs while the host is down, so it can't hammer a healthy host.
  */
 const REDIAL_INTERVAL_MS = 5_000;
 
+export interface HostReachabilityOptions {
+	/**
+	 * How long the host may stay down before `isUnreachable`. Callers that know
+	 * the outage is expected and self-healing (the local host service mid-
+	 * restart) hold the takeover longer; `isDegraded` keeps the user informed
+	 * in the meantime.
+	 */
+	unreachableAfterMs?: number;
+}
+
 export interface HostReachability {
+	/**
+	 * Down long enough to say so, not long enough to take the screen over.
+	 * Panes stay usable; show a non-blocking notice.
+	 */
+	isDegraded: boolean;
 	/** Sustained loss of the host connection — safe to take the screen over. */
 	isUnreachable: boolean;
 	/** A dial is in flight right now (auto-backoff or a manual retry). */
 	isReconnecting: boolean;
+	/**
+	 * The socket has opened at least once for this caller, so a drop is a
+	 * reconnect rather than a first connection that hasn't landed yet.
+	 */
+	hasConnected: boolean;
 	/** What the relay preflight says is wrong. Only read while unreachable. */
 	detail: string;
 	/** Dial now instead of waiting out the backoff. */
@@ -103,7 +136,10 @@ function describeFailure(
  * so it reflects what the UI can actually do rather than the cloud's `isOnline`
  * flag (which drifts through relay redeploys and API blips).
  */
-export function useHostReachability(hostUrl: string): HostReachability {
+export function useHostReachability(
+	hostUrl: string,
+	{ unreachableAfterMs = UNREACHABLE_GRACE_MS }: HostReachabilityOptions = {},
+): HostReachability {
 	const bus = useMemo(() => getHostEventBus(hostUrl), [hostUrl]);
 	// Hold the connection open for as long as this screen is mounted: the
 	// panes that normally keep the bus alive are gone once we take over, and a
@@ -116,18 +152,31 @@ export function useHostReachability(hostUrl: string): HostReachability {
 	);
 
 	const isDown = status.state !== "open";
-	const isUnreachable = useDelayElapsed(isDown, UNREACHABLE_GRACE_MS);
+	const [hasConnected, setHasConnected] = useState(false);
+	useEffect(() => {
+		if (!isDown) setHasConnected(true);
+	}, [isDown]);
+
+	const isDegraded = useDelayElapsed(isDown, DEGRADED_GRACE_MS);
+	const graceElapsed = useDelayElapsed(isDown, unreachableAfterMs);
+	// A 403 preflight is definitive — the relay only 403s a verified token, so
+	// no amount of redialling changes the answer. Waiting out the grace there
+	// only delays telling the user they lack access.
+	const isUnreachable =
+		graceElapsed || (isDown && status.probe?.status === 403);
 	const isRelayHost = /\/hosts\/[^/]+/.test(hostUrl);
 
 	useEffect(() => {
-		if (!isUnreachable) return;
+		if (!isDegraded) return;
 		const timer = window.setInterval(() => bus.reconnect(), REDIAL_INTERVAL_MS);
 		return () => window.clearInterval(timer);
-	}, [isUnreachable, bus]);
+	}, [isDegraded, bus]);
 
 	return {
+		isDegraded,
 		isUnreachable,
 		isReconnecting: isDown && status.state !== "closed",
+		hasConnected,
 		detail: describeFailure(status, isRelayHost),
 		retry: () => bus.reconnect(),
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
@@ -27,15 +27,6 @@ const DEGRADED_GRACE_MS = 2_000;
  */
 const UNREACHABLE_GRACE_MS = 10_000;
 
-/**
- * While the host is down, dial on this cadence instead of riding the socket's
- * own backoff. That backoff grows to 30s, so a host that came back could sit
- * behind "Reconnecting…" for half a minute — measured at 20.7s — which reads
- * as broken next to copy promising the workspace returns with the connection.
- * Only runs while the host is down, so it can't hammer a healthy host.
- */
-const REDIAL_INTERVAL_MS = 5_000;
-
 export interface HostReachabilityOptions {
 	/**
 	 * How long the host may stay down before `isUnreachable`. Callers that know
@@ -159,12 +150,6 @@ export function useHostReachability(
 	const isUnreachable =
 		graceElapsed || (isDown && status.probe?.status === 403);
 	const isRelayHost = /\/hosts\/[^/]+/.test(hostUrl);
-
-	useEffect(() => {
-		if (!isDegraded) return;
-		const timer = window.setInterval(() => bus.reconnect(), REDIAL_INTERVAL_MS);
-		return () => window.clearInterval(timer);
-	}, [isDegraded, bus]);
 
 	return {
 		isDegraded,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
@@ -75,7 +75,7 @@ function describeFailure(
 		return i18n._(
 			msg({
 				message:
-					"The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart.",
+					"Try again, or restart the host service from the Superset tray menu.",
 			}),
 		);
 	}
@@ -84,47 +84,41 @@ function describeFailure(
 	if (!probe) {
 		return i18n._(
 			msg({
-				message:
-					"Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine.",
+				message: "Please check your internet connection and try again.",
 			}),
 		);
 	}
 	if (probe.status === 503) {
 		return i18n._(
 			msg({
-				message:
-					"That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is.",
+				message: "Make sure the device is awake, online, and running Superset.",
 			}),
 		);
 	}
 	if (probe.status === 401 || probe.status === 403) {
 		return i18n._(
 			msg({
-				message:
-					"You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security.",
+				message: "Check your access under Settings > Security on that device.",
 			}),
 		);
 	}
 	if (probe.status === 502 || probe.status === 504) {
 		return i18n._(
 			msg({
-				message:
-					"The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works.",
+				message: "We couldn't reach the device. Please try again in a moment.",
 			}),
 		);
 	}
 	if (probe.status === 200) {
 		return i18n._(
 			msg({
-				message:
-					"That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device.",
+				message: "Please try again, or restart Superset on that device.",
 			}),
 		);
 	}
 	return i18n._({
 		...msg({
-			message:
-				"The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device.",
+			message: "Couldn't connect (error {status}). Please try again.",
 		}),
 		values: { status: probe.status },
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
@@ -9,11 +9,21 @@ import { StateScreenShell } from "../../../../components/StateScreenShell";
 import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceHostUnreachableState";
 import { useHostReachability } from "../../../../hooks/useHostReachability";
 import { LOCAL_HOST_SERVICE_DETAIL } from "../../utils/localHostServiceDetail";
+import { HostConnectionStrip } from "./components/HostConnectionStrip";
 
 const HOST_LIST_STALE_MS = 30_000;
 
 /**
- * Covers the workspace with the unreachable screen while its host is down.
+ * A local host-service restart is back in a few seconds and the strip covers
+ * it. Only a restart that runs this long deserves the takeover — and by then
+ * "restart it from the tray" is advice worth giving.
+ */
+const LOCAL_RESTART_TAKEOVER_MS = 30_000;
+
+/**
+ * Tells the workspace what its host connection is doing, in two steps. A host
+ * that has been down for a couple of seconds gets a non-blocking strip over
+ * live, usable panes; one that stays down gets the unreachable takeover.
  * Overlays rather than replaces: panes keep their live state (terminal
  * scrollback, unsaved editor documents, in-flight agent sessions) so a dropped
  * connection costs nothing once the host is back.
@@ -27,8 +37,6 @@ export function WorkspaceHostGate({
 }) {
 	const { t } = useLingui();
 	const hostUrl = useWorkspaceHostUrl();
-	const { isUnreachable, isReconnecting, detail, retry } =
-		useHostReachability(hostUrl);
 	const { machineId, hostServiceStatus } = useLocalHostService();
 
 	// A local host that dropped because the coordinator is mid-restart is not
@@ -38,6 +46,18 @@ export function WorkspaceHostGate({
 	// and for that the default advice stands.
 	const isLocalRestartInFlight =
 		workspace.hostId === machineId && hostServiceStatus === "starting";
+	const {
+		isDegraded,
+		isUnreachable,
+		isReconnecting,
+		hasConnected,
+		detail,
+		retry,
+	} = useHostReachability(hostUrl, {
+		unreachableAfterMs: isLocalRestartInFlight
+			? LOCAL_RESTART_TAKEOVER_MS
+			: undefined,
+	});
 	const { data: hostRows = [] } = cloudTrpc.v2Host.list.useQuery(undefined, {
 		staleTime: HOST_LIST_STALE_MS,
 	});
@@ -66,8 +86,19 @@ export function WorkspaceHostGate({
 			<div className="flex min-h-0 min-w-0 flex-1" inert={isUnreachable}>
 				{children}
 			</div>
+			{isDegraded && !isUnreachable ? (
+				<HostConnectionStrip
+					hostName={hostName}
+					isReconnecting={isReconnecting}
+					hasConnected={hasConnected}
+					isLocalRestartInFlight={isLocalRestartInFlight}
+					onRetry={retry}
+				/>
+			) : null}
+			{/* Translucent on purpose: the panes are still there, and letting them
+			    show through says so better than the copy can. */}
 			{isUnreachable ? (
-				<div className="absolute inset-0 z-50 bg-background">
+				<div className="absolute inset-0 z-50 bg-background/80 backdrop-blur-sm">
 					<StateScreenShell>
 						<WorkspaceHostUnreachableState
 							hostId={workspace.hostId}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/HostConnectionStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/HostConnectionStrip.tsx
@@ -1,0 +1,65 @@
+import { useLingui } from "@lingui/react/macro";
+import { cn } from "@superset/ui/utils";
+
+interface HostConnectionStripProps {
+	hostName: string;
+	/** A dial is in flight (the socket's own backoff or a forced redial). */
+	isReconnecting: boolean;
+	/** The socket has opened before, so this is a drop rather than a first dial. */
+	hasConnected: boolean;
+	/** The coordinator is restarting the local host service right now. */
+	isLocalRestartInFlight: boolean;
+	onRetry: () => void;
+}
+
+/**
+ * Non-blocking notice for a host that has been down for a few seconds. Panes
+ * stay visible and usable underneath while the socket redials; escalating to
+ * the full takeover is WorkspaceHostGate's call.
+ */
+export function HostConnectionStrip({
+	hostName,
+	isReconnecting,
+	hasConnected,
+	isLocalRestartInFlight,
+	onRetry,
+}: HostConnectionStripProps) {
+	const { t } = useLingui();
+	const isDialing = isReconnecting || isLocalRestartInFlight;
+	const label = isLocalRestartInFlight
+		? t({ message: "Host service is restarting…" })
+		: !isReconnecting
+			? t({ message: `Disconnected from ${hostName}` })
+			: hasConnected
+				? t({ message: `Reconnecting to ${hostName}…` })
+				: t({ message: `Connecting to ${hostName}…` });
+
+	return (
+		<div
+			aria-live="polite"
+			className="pointer-events-none absolute inset-x-0 top-2 z-40 flex justify-center"
+		>
+			<div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border/60 bg-background/95 py-1.5 pl-3 pr-1.5 text-[12px] text-muted-foreground shadow-sm backdrop-blur-sm">
+				<span
+					aria-hidden="true"
+					className={cn(
+						"size-1.5 shrink-0 rounded-full",
+						isDialing
+							? "animate-pulse bg-yellow-500"
+							: "bg-muted-foreground/40",
+					)}
+				/>
+				<span className="min-w-0 truncate" title={hostName}>
+					{label}
+				</span>
+				<button
+					type="button"
+					onClick={onRetry}
+					className="rounded-full px-1.5 py-0.5 font-medium text-foreground hover:bg-muted/60"
+				>
+					{t({ message: "Retry" })}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/HostConnectionStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/HostConnectionStrip.tsx
@@ -27,12 +27,12 @@ export function HostConnectionStrip({
 	const { t } = useLingui();
 	const isDialing = isReconnecting || isLocalRestartInFlight;
 	const label = isLocalRestartInFlight
-		? t({ message: "Host service is restarting…" })
+		? t({ message: "Restarting…" })
 		: !isReconnecting
-			? t({ message: `Disconnected from ${hostName}` })
+			? t({ message: "Disconnected" })
 			: hasConnected
-				? t({ message: `Reconnecting to ${hostName}…` })
-				: t({ message: `Connecting to ${hostName}…` });
+				? t({ message: "Reconnecting…" })
+				: t({ message: "Connecting…" });
 
 	return (
 		<div

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/index.ts
@@ -1,0 +1,1 @@
+export { HostConnectionStrip } from "./HostConnectionStrip";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/utils/localHostServiceDetail/localHostServiceDetail.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/utils/localHostServiceDetail/localHostServiceDetail.ts
@@ -13,8 +13,7 @@ export const LOCAL_HOST_SERVICE_DETAIL: Record<
 	MessageDescriptor
 > = {
 	starting: msg({
-		message:
-			"The local host service is still starting up. It should be ready in a few seconds.",
+		message: "Starting up. This should only take a moment.",
 	}),
 	stopped: msg({
 		message:

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Připojeno. Přihlášení bylo zrušeno, takže spouštěče „Já“ 
 msgid "Connecting"
 msgstr "Připojuji"
 
+msgid "Connecting to {hostName}…"
+msgstr "Připojování k {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Připojování k ploše…"
 
@@ -4936,6 +4939,9 @@ msgstr "Odpojit Slack?"
 
 msgid "Disconnected"
 msgstr "Odpojeno"
+
+msgid "Disconnected from {hostName}"
+msgstr "Odpojeno od {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Odpojuji..."
@@ -6820,6 +6826,9 @@ msgstr "Host service spadla"
 
 msgid "Host service is not running"
 msgstr "Služba hosta neběží"
+
+msgid "Host service is restarting…"
+msgstr "Host service se restartuje…"
 
 msgid "Host service is starting…"
 msgstr "Host service se spouští…"
@@ -11073,6 +11082,9 @@ msgstr "Nutné znovu připojit"
 
 msgid "Reconnecting"
 msgstr "Připojuji znovu"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Opětovné připojování k {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Připojuji znovu…"

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Můžu použít vlastní API klíče?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Můžeš sjednotit tooltipy napříč aplikací?"
 
+msgid "Can't connect right now"
+msgstr "Teď se nelze připojit"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Cesty vzdáleného pracovního prostoru nejde otevřít v externím editoru"
 
@@ -2842,6 +2845,9 @@ msgstr "Zkontrolovat prostředky"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Před uložením zkontrolujte vykreslený prompt a výstup spuštění"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Zkontrolujte svůj přístup v Nastavení > Zabezpečení na daném zařízení."
 
 msgid "Check your connection and try again"
 msgstr "Zkontrolujte připojení a zkuste to znovu"
@@ -3562,9 +3568,6 @@ msgstr "Připojeno. Přihlášení bylo zrušeno, takže spouštěče „Já“ 
 msgid "Connecting"
 msgstr "Připojuji"
 
-msgid "Connecting to {hostName}…"
-msgstr "Připojování k {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Připojování k ploše…"
 
@@ -4033,6 +4036,9 @@ msgstr "Tuto stránku se nepodařilo sledovat"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Nepodařilo se ověřit stav hvězdy — zkontrolujte, že je nainstalované GitHub CLI (`gh`), že jste přihlášeni a že máte připojení k síti"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Připojení se nezdařilo (chyba {status}). Zkuste to znovu."
+
 msgid "Couldn't copy branch name"
 msgstr "Název větve se nepodařilo zkopírovat"
 
@@ -4096,9 +4102,6 @@ msgstr "Nepodařilo se odeslat odpověď"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Nepodařilo se spojit s cloudem pro {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Na službu relay se nepodařilo dosáhnout. Zkontrolujte síťové připojení tohoto počítače — druhé zařízení je nejspíš v pořádku."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Kontext tohoto terminálu se nepodařilo načíst."
@@ -4939,9 +4942,6 @@ msgstr "Odpojit Slack?"
 
 msgid "Disconnected"
 msgstr "Odpojeno"
-
-msgid "Disconnected from {hostName}"
-msgstr "Odpojeno od {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Odpojuji..."
@@ -6827,9 +6827,6 @@ msgstr "Host service spadla"
 msgid "Host service is not running"
 msgstr "Služba hosta neběží"
 
-msgid "Host service is restarting…"
-msgstr "Host service se restartuje…"
-
 msgid "Host service is starting…"
 msgstr "Host service se spouští…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host není dostupný"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host není dostupný: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host je nedostupný"
 
 msgid "Hosted in the cloud"
 msgstr "Hostováno v cloudu"
@@ -8015,6 +8009,9 @@ msgstr "Nastavit jako výchozí"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Nastavit jako výchozí — nové terminály a agenty spouštět na tomto účtu."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Ujistěte se, že je zařízení probuzené, online a běží na něm Superset."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Udělat ze stylu čipu výchozí TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Přehrát {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Přehrát zvuk po dokončení úkolů"
 
+msgid "Please check your internet connection and try again."
+msgstr "Zkontrolujte připojení k internetu a zkuste to znovu."
+
 msgid "Please enter a project name"
 msgstr "Zadejte prosím název projektu"
 
@@ -10418,6 +10418,9 @@ msgstr "Vyberte prosím umístění projektu"
 
 msgid "Please select an organization"
 msgstr "Vyberte prosím organizaci"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Zkuste to znovu nebo na daném zařízení restartujte Superset."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Zkuste se prosím znovu přihlásit z desktopové aplikace."
@@ -11083,9 +11086,6 @@ msgstr "Nutné znovu připojit"
 msgid "Reconnecting"
 msgstr "Připojuji znovu"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Opětovné připojování k {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Připojuji znovu…"
 
@@ -11562,6 +11562,9 @@ msgstr "Restartuji agenty na {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Restartuji služby hosta…"
+
+msgid "Restarting…"
+msgstr "Restartuje se…"
 
 msgid "Restore"
 msgstr "Obnovit"
@@ -13199,6 +13202,9 @@ msgstr "Spouštím {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Spouštím cloudový pracovní prostor"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Spouští se. Mělo by to trvat jen chvilku."
+
 msgid "Starting workspace"
 msgstr "Spouštím pracovní prostor"
 
@@ -13850,12 +13856,6 @@ msgstr "Textové pole"
 msgid "Thanks for reaching out"
 msgstr "Díky, že jste se ozvali"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "To zařízení je online, ale spojení se nepodařilo navázat — obvykle jde o směrování relay, ne o zařízení samotné. Zkuste to znovu, a pokud potíže přetrvávají, restartujte na něm Superset."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "To zařízení není připojené k relay. Ověřte, že je vzhůru, online a běží na něm Superset — jakmile bude, připojí se samo."
-
 msgid "That handle is taken."
 msgstr "Tato přezdívka je obsazená."
 
@@ -13891,9 +13891,6 @@ msgstr "Nejlepší agent se změní.<0/>Vaše workflow ne."
 
 msgid "The Codex sign-in"
 msgstr "Přihlášení do Codexu"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Spojení selhalo (stav relay {status}). Zkuste to znovu, a pokud potíže přetrvávají, restartujte na tom zařízení Superset."
 
 msgid "The connection timed out"
 msgstr "Vypršel časový limit spojení"
@@ -13997,9 +13994,6 @@ msgstr "Odkaz může být špatný, stránka mohla být smazána, nebo k ní nem
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Propojený agent chybí nebo je vypnutý. Zobrazuje se snímek."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Místní host service se pořád spouští. Za pár vteřin by měla být připravená."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Místní host service není dostupná pro {organization} na {device}. Stav: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Místní host service neběží, takže pracovní prostor nemá na tomto
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Místní host service právě naběhla. Připojuji se k ní."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Místní host service přestala odpovídat. Nejdřív to zkuste znovu; pokud to nepomůže, restartujte ji v nabídce Superset v liště > Host Service > Restart."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Většina sloučených PR od agentů potřebuje jen revizi, bez jediné lidské úpravy."
@@ -14053,9 +14044,6 @@ msgstr "Lidé za Supersetem."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Lhůta pro obnovení skončila. Napište na support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Relay na to zařízení právě teď nedosáhne. Obvykle je to dočasné — za chvíli to zkuste znovu."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Vzdálená větev se rozešla. Před pokračováním udělejte pull."
@@ -14413,9 +14401,6 @@ msgstr "Tímto se ukončí relace i její proces."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Tímto zrušíte přípravu a vrátíte všechny připravené změny. Připravené nové soubory budou smazány. Tuto akci nelze vrátit zpět."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Tento pracovní prostor je na zařízení, na které Superset právě nedosáhne. Terminály, soubory i agenti zůstávají, kde jsou — vrátí se, jakmile se obnoví spojení."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Tento pracovní prostor mohl být odstraněn, nebo k němu už nemáte přístup."
 
@@ -14664,6 +14649,9 @@ msgstr "Zkuste jiný hledaný výraz nebo jiné zařízení."
 
 msgid "Try again"
 msgstr "Zkusit znovu"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Zkuste to znovu nebo restartujte službu hostitele z nabídky Superset v systémové liště."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Zkuste to znovu. Pokud potíže přetrvávají, načtěte Superset znovu."
@@ -15301,6 +15289,9 @@ msgstr "Nepodařilo se strhnout platbu z vašeho způsobu platby. Aktualizujte h
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Nepodařilo se rozpoznat správce balíčků ani konfiguraci prostředí."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "K zařízení se nepodařilo připojit. Zkuste to za chvíli znovu."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Neslibujeme plnou autonomii v roce 2026 ani 2027. Poctivé neznámé: zda obstojí revize agentem proti nepřátelské složitosti, zda specifikace ve velkém nahradí čtení kódu jako kotvu důvěry a zda ekonomika výpočtů udrží noční směnu levnější než lidi, které doplňuje. F5 je položka v rubrice, abychom ji poznali, až ji uvidíme — ne slib."
 
@@ -15312,6 +15303,9 @@ msgstr "Odkaz ke stažení jsme poslali na {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Brzy se vám ozveme."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Jakmile se spojení obnoví, vrátíme vás zpět."
 
 msgid "We'll get back to you shortly."
 msgstr "Brzy se vám ozveme."
@@ -15764,9 +15758,6 @@ msgstr "Tuto akci nelze vrátit zpět. Panely terminálu zobrazí „Proces skon
 
 msgid "You don't have access to this host"
 msgstr "K tomuto hostu nemáte přístup"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "K tomuto hostu nemáte přístup. Pokud je to vaše zařízení, zapněte na něm přístup přes relay v Nastavení > Zabezpečení."
 
 msgid "You don't have access to this terminal."
 msgstr "K tomuto terminálu nemáte přístup."

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Kann ich meine eigenen API-Schlüssel nutzen?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Kannst du die Tooltips in der ganzen App vereinheitlichen?"
 
+msgid "Can't connect right now"
+msgstr "Verbindung gerade nicht möglich"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Pfade aus Remote-Arbeitsbereichen lassen sich nicht im externen Editor öffnen"
 
@@ -2842,6 +2845,9 @@ msgstr "Ressourcen prüfen"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Prüfe den gerenderten Prompt und die Startausgabe vor dem Speichern"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Prüfe deinen Zugriff auf dem Gerät unter Einstellungen > Sicherheit."
 
 msgid "Check your connection and try again"
 msgstr "Prüfe deine Verbindung und versuche es erneut"
@@ -3562,9 +3568,6 @@ msgstr "Verbunden. Die Anmeldung wurde abgebrochen, daher passen Trigger mit \"I
 msgid "Connecting"
 msgstr "Verbindet"
 
-msgid "Connecting to {hostName}…"
-msgstr "Verbindung zu {hostName} wird hergestellt…"
-
 msgid "Connecting to the desktop…"
 msgstr "Verbindung zum Desktop wird hergestellt …"
 
@@ -4033,6 +4036,9 @@ msgstr "Seite ließ sich nicht beobachten"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Der Star-Status ließ sich nicht bestätigen — prüfe, ob die GitHub-CLI (`gh`) installiert und angemeldet ist und ob du eine Netzwerkverbindung hast"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Verbindung fehlgeschlagen (Fehler {status}). Bitte versuche es erneut."
+
 msgid "Couldn't copy branch name"
 msgstr "Branch-Name konnte nicht kopiert werden"
 
@@ -4096,9 +4102,6 @@ msgstr "Antwort konnte nicht gesendet werden"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Cloud für {0} nicht erreichbar: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Der Relay-Dienst war nicht erreichbar. Prüfe die Netzwerkverbindung dieses Rechners — das andere Gerät ist wahrscheinlich in Ordnung."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Der Kontext dieses Terminals konnte nicht gelesen werden."
@@ -4939,9 +4942,6 @@ msgstr "Slack trennen?"
 
 msgid "Disconnected"
 msgstr "Getrennt"
-
-msgid "Disconnected from {hostName}"
-msgstr "Verbindung zu {hostName} getrennt"
 
 msgid "Disconnecting..."
 msgstr "Wird getrennt..."
@@ -6827,9 +6827,6 @@ msgstr "Host-Dienst abgestürzt"
 msgid "Host service is not running"
 msgstr "Host-Dienst läuft nicht"
 
-msgid "Host service is restarting…"
-msgstr "Der Host-Dienst wird neu gestartet…"
-
 msgid "Host service is starting…"
 msgstr "Der Host-Dienst startet…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host nicht verfügbar"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host nicht verfügbar: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host nicht erreichbar"
 
 msgid "Hosted in the cloud"
 msgstr "In der Cloud gehostet"
@@ -8015,6 +8009,9 @@ msgstr "Als Standard festlegen"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Als Standard festlegen — neue Terminals und Agenten mit diesem Konto starten."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Stelle sicher, dass das Gerät wach und online ist und Superset darauf läuft."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Den Chip-Stil zum TooltipContent-Standard machen"
@@ -10407,6 +10404,9 @@ msgstr "{label} abspielen"
 msgid "Play a sound when tasks complete"
 msgstr "Einen Ton abspielen, wenn Aufgaben fertig sind"
 
+msgid "Please check your internet connection and try again."
+msgstr "Bitte prüfe deine Internetverbindung und versuche es erneut."
+
 msgid "Please enter a project name"
 msgstr "Bitte gib einen Projektnamen ein"
 
@@ -10418,6 +10418,9 @@ msgstr "Bitte wähle einen Projektort"
 
 msgid "Please select an organization"
 msgstr "Bitte wähle eine Organisation"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Bitte versuche es erneut oder starte Superset auf dem Gerät neu."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Bitte melde dich erneut aus der Desktop-App an."
@@ -11083,9 +11086,6 @@ msgstr "Neu verbinden erforderlich"
 msgid "Reconnecting"
 msgstr "Verbindet neu"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Verbindung zu {hostName} wird wiederhergestellt…"
-
 msgid "Reconnecting…"
 msgstr "Verbindung wird wiederhergestellt…"
 
@@ -11562,6 +11562,9 @@ msgstr "Agenten werden auf {accountLabel} neu gestartet."
 
 msgid "Restarting host services…"
 msgstr "Host-Dienste werden neu gestartet…"
+
+msgid "Restarting…"
+msgstr "Wird neu gestartet…"
 
 msgid "Restore"
 msgstr "Wiederherstellen"
@@ -13199,6 +13202,9 @@ msgstr "{agentLabel} wird gestartet"
 msgid "Starting cloud workspace"
 msgstr "Cloud-Arbeitsbereich wird gestartet"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Wird gestartet. Das dauert nur einen Moment."
+
 msgid "Starting workspace"
 msgstr "Arbeitsbereich wird gestartet"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Danke für deine Nachricht"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Dieses Gerät ist online, aber die Verbindung kam nicht zustande — meist liegt es am Relay-Routing, nicht am Gerät selbst. Versuche es erneut; bleibt es dabei, starte Superset auf diesem Gerät neu."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Dieses Gerät ist nicht mit dem Relay verbunden. Prüfe, ob es wach und online ist und Superset läuft — dann verbindet es sich von selbst wieder."
-
 msgid "That handle is taken."
 msgstr "Dieses Handle ist bereits vergeben."
 
@@ -13891,9 +13891,6 @@ msgstr "Der beste Agent wird wechseln.<0/>Dein Workflow nicht."
 
 msgid "The Codex sign-in"
 msgstr "Die Codex-Anmeldung"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Die Verbindung ist fehlgeschlagen (Relay-Status {status}). Versuche es erneut; bleibt es dabei, starte Superset auf diesem Gerät neu."
 
 msgid "The connection timed out"
 msgstr "Zeitüberschreitung bei der Verbindung"
@@ -13997,9 +13994,6 @@ msgstr "Der Link ist womöglich falsch, die Seite wurde gelöscht, oder du hast 
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Der verknüpfte Agent fehlt oder ist deaktiviert. Angezeigt wird der Snapshot."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Der lokale Host-Dienst startet noch. In ein paar Sekunden sollte er bereit sein."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Der lokale Host-Dienst ist für {organization} auf {device} nicht verfügbar. Status: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Der lokale Host-Dienst läuft nicht, daher kann nichts auf diesem Gerät
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Der lokale Host-Dienst ist gerade hochgekommen. Die Verbindung wird jetzt hergestellt."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Der lokale Host-Dienst antwortet nicht mehr. Versuche es zuerst erneut; hilft das nicht, starte ihn über das Superset-Menü in der Menüleiste > Host Service > Restart neu."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Die Mehrheit der gemergten Agenten-PRs braucht nur Review, ohne menschliche Bearbeitung."
@@ -14053,9 +14044,6 @@ msgstr "Die Menschen hinter Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Die Wiederherstellungsfrist ist abgelaufen. Wende dich an support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Der Relay konnte dieses Gerät gerade nicht erreichen. Das ist meist vorübergehend — ein erneuter Versuch klappt normalerweise."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Der Remote-Branch ist auseinandergelaufen. Pull erst, bevor du weitermachst."
@@ -14413,9 +14401,6 @@ msgstr "Damit werden die Sitzung und ihr zugrunde liegender Prozess beendet."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Damit werden alle gestageden Änderungen aus dem Index genommen und zurückgesetzt. Gestagede neue Dateien werden gelöscht. Das lässt sich nicht rückgängig machen."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Dieser Arbeitsbereich liegt auf einem Gerät, das Superset gerade nicht erreicht. Terminals, Dateien und Agenten bleiben, wo sie sind — sie kommen zurück, sobald die Verbindung wieder steht."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Dieser Arbeitsbereich wurde möglicherweise entfernt, oder du hast keinen Zugriff mehr darauf."
 
@@ -14664,6 +14649,9 @@ msgstr "Versuche einen anderen Suchbegriff oder ein anderes Gerät."
 
 msgid "Try again"
 msgstr "Erneut versuchen"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Versuche es erneut oder starte den Host-Dienst über das Superset-Menü in der Taskleiste neu."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Versuche es erneut. Wenn das Problem bleibt, lade Superset neu."
@@ -15301,6 +15289,9 @@ msgstr "Wir konnten deine Zahlungsmethode nicht belasten. Aktualisiere sie, um d
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Wir konnten keinen Paketmanager und keine Umgebungskonfiguration erkennen."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Wir konnten das Gerät nicht erreichen. Bitte versuche es gleich noch einmal."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Wir prognostizieren für 2026 oder 2027 kein vollständig autonomes Fahren. Die ehrlichen Unbekannten: ob Agenten-Review gegen bösartige Komplexität standhält, ob Spezifikation das Lesen von Code als Vertrauensanker im großen Maßstab ersetzen kann und ob die Rechenökonomie die Nachtschicht billiger hält als die Menschen, die sie ergänzt. F5 ist ein Rubrikeintrag, damit wir es erkennen, wenn wir es sehen — kein Versprechen."
 
@@ -15312,6 +15303,9 @@ msgstr "Wir haben den Download-Link an {submittedEmail} geschickt."
 
 msgid "We'll be in touch shortly."
 msgstr "Wir melden uns in Kürze."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Sobald die Verbindung wieder steht, geht es hier weiter."
 
 msgid "We'll get back to you shortly."
 msgstr "Wir melden uns in Kürze bei dir."
@@ -15764,9 +15758,6 @@ msgstr "Das lässt sich nicht rückgängig machen. Terminal-Bereiche zeigen dann
 
 msgid "You don't have access to this host"
 msgstr "Du hast keinen Zugriff auf diesen Host"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Du hast keinen Zugriff auf diesen Host. Wenn es dein eigenes Gerät ist, aktiviere dort den Relay-Zugriff unter Einstellungen > Sicherheit."
 
 msgid "You don't have access to this terminal."
 msgstr "Du hast keinen Zugriff auf dieses Terminal."

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Verbunden. Die Anmeldung wurde abgebrochen, daher passen Trigger mit \"I
 msgid "Connecting"
 msgstr "Verbindet"
 
+msgid "Connecting to {hostName}…"
+msgstr "Verbindung zu {hostName} wird hergestellt…"
+
 msgid "Connecting to the desktop…"
 msgstr "Verbindung zum Desktop wird hergestellt …"
 
@@ -4936,6 +4939,9 @@ msgstr "Slack trennen?"
 
 msgid "Disconnected"
 msgstr "Getrennt"
+
+msgid "Disconnected from {hostName}"
+msgstr "Verbindung zu {hostName} getrennt"
 
 msgid "Disconnecting..."
 msgstr "Wird getrennt..."
@@ -6820,6 +6826,9 @@ msgstr "Host-Dienst abgestürzt"
 
 msgid "Host service is not running"
 msgstr "Host-Dienst läuft nicht"
+
+msgid "Host service is restarting…"
+msgstr "Der Host-Dienst wird neu gestartet…"
 
 msgid "Host service is starting…"
 msgstr "Der Host-Dienst startet…"
@@ -11073,6 +11082,9 @@ msgstr "Neu verbinden erforderlich"
 
 msgid "Reconnecting"
 msgstr "Verbindet neu"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Verbindung zu {hostName} wird wiederhergestellt…"
 
 msgid "Reconnecting…"
 msgstr "Verbindung wird wiederhergestellt…"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Can I use my own API keys?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Can you standardize the tooltips across the app?"
 
+msgid "Can't connect right now"
+msgstr "Can't connect right now"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Can't open remote workspace paths in an external editor"
 
@@ -2842,6 +2845,9 @@ msgstr "Check Resources"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Check the rendered prompt and launch output before saving"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Check your access under Settings > Security on that device."
 
 msgid "Check your connection and try again"
 msgstr "Check your connection and try again"
@@ -3562,9 +3568,6 @@ msgstr "Connected. Sign-in was cancelled, so triggers by \"Me\" will not match y
 msgid "Connecting"
 msgstr "Connecting"
 
-msgid "Connecting to {hostName}…"
-msgstr "Connecting to {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Connecting to the desktop…"
 
@@ -4033,6 +4036,9 @@ msgstr "Could not watch this page"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Couldn't connect (error {status}). Please try again."
+
 msgid "Couldn't copy branch name"
 msgstr "Couldn't copy branch name"
 
@@ -4096,9 +4102,6 @@ msgstr "Couldn't post reply"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Couldn't reach cloud for {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Couldn't read this terminal's context."
@@ -4939,9 +4942,6 @@ msgstr "Disconnect Slack?"
 
 msgid "Disconnected"
 msgstr "Disconnected"
-
-msgid "Disconnected from {hostName}"
-msgstr "Disconnected from {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Disconnecting..."
@@ -6827,9 +6827,6 @@ msgstr "Host service crashed"
 msgid "Host service is not running"
 msgstr "Host service is not running"
 
-msgid "Host service is restarting…"
-msgstr "Host service is restarting…"
-
 msgid "Host service is starting…"
 msgstr "Host service is starting…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host unavailable"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host unavailable: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host unreachable"
 
 msgid "Hosted in the cloud"
 msgstr "Hosted in the cloud"
@@ -8015,6 +8009,9 @@ msgstr "Make default"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Make default — launch new terminals and agents on this account."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Make sure the device is awake, online, and running Superset."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Make the chip style the TooltipContent default"
@@ -10407,6 +10404,9 @@ msgstr "Play {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Play a sound when tasks complete"
 
+msgid "Please check your internet connection and try again."
+msgstr "Please check your internet connection and try again."
+
 msgid "Please enter a project name"
 msgstr "Please enter a project name"
 
@@ -10418,6 +10418,9 @@ msgstr "Please select a project location"
 
 msgid "Please select an organization"
 msgstr "Please select an organization"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Please try again, or restart Superset on that device."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Please try signing in again from the desktop app."
@@ -11083,9 +11086,6 @@ msgstr "Reconnect required"
 msgid "Reconnecting"
 msgstr "Reconnecting"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Reconnecting to {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Reconnecting…"
 
@@ -11562,6 +11562,9 @@ msgstr "Restarting agents on {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Restarting host services…"
+
+msgid "Restarting…"
+msgstr "Restarting…"
 
 msgid "Restore"
 msgstr "Restore"
@@ -13199,6 +13202,9 @@ msgstr "Starting {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Starting cloud workspace"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Starting up. This should only take a moment."
+
 msgid "Starting workspace"
 msgstr "Starting workspace"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Thanks for reaching out"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-
 msgid "That handle is taken."
 msgstr "That handle is taken."
 
@@ -13891,9 +13891,6 @@ msgstr "The best agent will change.<0/>Your workflow shouldn't."
 
 msgid "The Codex sign-in"
 msgstr "The Codex sign-in"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
 
 msgid "The connection timed out"
 msgstr "The connection timed out"
@@ -13997,9 +13994,6 @@ msgstr "The link may be wrong, the page may have been deleted, or you may not ha
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "The linked agent is missing or disabled. Showing the snapshot."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "The local host service is still starting up. It should be ready in a few seconds."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "The local host service isn't running, so nothing on this device can serv
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "The local host service just came up. Reconnecting to it now."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "The majority of merged agent PRs need review only, with zero human edits."
@@ -14053,9 +14044,6 @@ msgstr "The people behind Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "The recovery period has ended. Contact support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "The remote branch has diverged. Pull before continuing."
@@ -14413,9 +14401,6 @@ msgstr "This will terminate the session and its underlying process."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "This workspace may have been removed, or you no longer have access to it."
 
@@ -14664,6 +14649,9 @@ msgstr "Try a different search term or another device."
 
 msgid "Try again"
 msgstr "Try again"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Try again, or restart the host service from the Superset tray menu."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Try again. If the problem continues, reload Superset."
@@ -15301,6 +15289,9 @@ msgstr "We couldn't charge your payment method. Update it to keep this plan."
 msgid "We couldn't detect a package manager or environment config."
 msgstr "We couldn't detect a package manager or environment config."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "We couldn't reach the device. Please try again in a moment."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 
@@ -15312,6 +15303,9 @@ msgstr "We sent the download link to {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "We'll be in touch shortly."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "We'll bring you back as soon as we reconnect."
 
 msgid "We'll get back to you shortly."
 msgstr "We'll get back to you shortly."
@@ -15764,9 +15758,6 @@ msgstr "You can't undo this action. Terminal panes will show \"Process exited\" 
 
 msgid "You don't have access to this host"
 msgstr "You don't have access to this host"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
 
 msgid "You don't have access to this terminal."
 msgstr "You don't have access to this terminal."

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Connected. Sign-in was cancelled, so triggers by \"Me\" will not match y
 msgid "Connecting"
 msgstr "Connecting"
 
+msgid "Connecting to {hostName}…"
+msgstr "Connecting to {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Connecting to the desktop…"
 
@@ -4936,6 +4939,9 @@ msgstr "Disconnect Slack?"
 
 msgid "Disconnected"
 msgstr "Disconnected"
+
+msgid "Disconnected from {hostName}"
+msgstr "Disconnected from {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Disconnecting..."
@@ -6820,6 +6826,9 @@ msgstr "Host service crashed"
 
 msgid "Host service is not running"
 msgstr "Host service is not running"
+
+msgid "Host service is restarting…"
+msgstr "Host service is restarting…"
 
 msgid "Host service is starting…"
 msgstr "Host service is starting…"
@@ -11073,6 +11082,9 @@ msgstr "Reconnect required"
 
 msgid "Reconnecting"
 msgstr "Reconnecting"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Reconnecting to {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Reconnecting…"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Conectado. Se canceló el inicio de sesión, así que los disparadores p
 msgid "Connecting"
 msgstr "Conectando"
 
+msgid "Connecting to {hostName}…"
+msgstr "Conectando a {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Conectando con el escritorio…"
 
@@ -4936,6 +4939,9 @@ msgstr "¿Desconectar Slack?"
 
 msgid "Disconnected"
 msgstr "Desconectado"
+
+msgid "Disconnected from {hostName}"
+msgstr "Desconectado de {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Desconectando..."
@@ -6820,6 +6826,9 @@ msgstr "El servicio del host falló"
 
 msgid "Host service is not running"
 msgstr "El servicio del host no está en ejecución"
+
+msgid "Host service is restarting…"
+msgstr "El servicio de host se está reiniciando…"
 
 msgid "Host service is starting…"
 msgstr "El servicio del host está iniciándose…"
@@ -11073,6 +11082,9 @@ msgstr "Hay que volver a conectar"
 
 msgid "Reconnecting"
 msgstr "Reconectando"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Reconectando a {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Reconectando…"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -2649,6 +2649,9 @@ msgstr "¿Puedo usar mis propias claves de API?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "¿Puedes unificar los tooltips de toda la app?"
 
+msgid "Can't connect right now"
+msgstr "No podemos conectar ahora"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "No se pueden abrir rutas de espacios de trabajo remotos en un editor externo"
 
@@ -2842,6 +2845,9 @@ msgstr "Ver recursos"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Comprueba el prompt renderizado y la salida de lanzamiento antes de guardar"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Revisa tu acceso en Ajustes > Seguridad en ese dispositivo."
 
 msgid "Check your connection and try again"
 msgstr "Comprobar la conexión e intentarlo de nuevo"
@@ -3562,9 +3568,6 @@ msgstr "Conectado. Se canceló el inicio de sesión, así que los disparadores p
 msgid "Connecting"
 msgstr "Conectando"
 
-msgid "Connecting to {hostName}…"
-msgstr "Conectando a {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Conectando con el escritorio…"
 
@@ -4033,6 +4036,9 @@ msgstr "No se pudo observar esta página"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "No se pudo confirmar el estado de la estrella — comprueba que el CLI de GitHub (`gh`) esté instalado, con la sesión iniciada, y que tengas conexión de red"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "No se pudo conectar (error {status}). Inténtalo de nuevo."
+
 msgid "Couldn't copy branch name"
 msgstr "No se pudo copiar el nombre de la rama"
 
@@ -4096,9 +4102,6 @@ msgstr "No se pudo publicar la respuesta"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "No se pudo contactar con la nube para {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "No se pudo contactar con el servicio de relay. Revisa la conexión de red de esta máquina; el otro dispositivo probablemente esté bien."
 
 msgid "Couldn't read this terminal's context."
 msgstr "No se pudo leer el contexto de este terminal."
@@ -4939,9 +4942,6 @@ msgstr "¿Desconectar Slack?"
 
 msgid "Disconnected"
 msgstr "Desconectado"
-
-msgid "Disconnected from {hostName}"
-msgstr "Desconectado de {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Desconectando..."
@@ -6827,9 +6827,6 @@ msgstr "El servicio del host falló"
 msgid "Host service is not running"
 msgstr "El servicio del host no está en ejecución"
 
-msgid "Host service is restarting…"
-msgstr "El servicio de host se está reiniciando…"
-
 msgid "Host service is starting…"
 msgstr "El servicio del host está iniciándose…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host no disponible"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host no disponible: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host inaccesible"
 
 msgid "Hosted in the cloud"
 msgstr "Alojado en la nube"
@@ -8015,6 +8009,9 @@ msgstr "Usar como predeterminada"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Usar como predeterminada: las terminales y los agentes nuevos se lanzan con esta cuenta."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Asegúrate de que el dispositivo esté activo, conectado y con Superset en ejecución."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Hacer que el estilo de chip sea el predeterminado de TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Reproducir {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Reproducir un sonido cuando terminen las tareas"
 
+msgid "Please check your internet connection and try again."
+msgstr "Comprueba tu conexión a internet e inténtalo de nuevo."
+
 msgid "Please enter a project name"
 msgstr "Introduce un nombre de proyecto"
 
@@ -10418,6 +10418,9 @@ msgstr "Selecciona una ubicación para el proyecto"
 
 msgid "Please select an organization"
 msgstr "Selecciona una organización"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Inténtalo de nuevo o reinicia Superset en ese dispositivo."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Vuelve a iniciar sesión desde la app de escritorio."
@@ -11083,9 +11086,6 @@ msgstr "Hay que volver a conectar"
 msgid "Reconnecting"
 msgstr "Reconectando"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Reconectando a {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Reconectando…"
 
@@ -11562,6 +11562,9 @@ msgstr "Reiniciando agentes en {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Reiniciando los servicios de host…"
+
+msgid "Restarting…"
+msgstr "Reiniciando…"
 
 msgid "Restore"
 msgstr "Restaurar"
@@ -13199,6 +13202,9 @@ msgstr "Iniciando {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Iniciando el espacio de trabajo en la nube"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Iniciando. Solo debería tardar un momento."
+
 msgid "Starting workspace"
 msgstr "Iniciando el espacio de trabajo"
 
@@ -13850,12 +13856,6 @@ msgstr "Área de texto"
 msgid "Thanks for reaching out"
 msgstr "Gracias por escribirnos"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Ese dispositivo está en línea, pero no se pudo establecer la conexión: suele ser cosa del enrutado del relay, no del dispositivo. Reinténtalo y, si persiste, reinicia Superset en ese dispositivo."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Ese dispositivo no está conectado al relay. Comprueba que esté despierto, en línea y con Superset abierto: se reconecta solo en cuanto lo esté."
-
 msgid "That handle is taken."
 msgstr "Ese nombre de usuario ya está en uso."
 
@@ -13891,9 +13891,6 @@ msgstr "El mejor agente cambiará.<0/>Tu flujo de trabajo, no."
 
 msgid "The Codex sign-in"
 msgstr "La sesión de Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "La conexión falló (estado del relay {status}). Reinténtalo y, si persiste, reinicia Superset en ese dispositivo."
 
 msgid "The connection timed out"
 msgstr "Se agotó el tiempo de conexión"
@@ -13997,9 +13994,6 @@ msgstr "Puede que el enlace esté mal, que la página se haya eliminado o que no
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "El agente enlazado falta o está desactivado. Se muestra la instantánea."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "El servicio de host local todavía está arrancando. Debería estar listo en unos segundos."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "El servicio de host local no está disponible para {organization} en {device}. Estado: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "El servicio de host local no está en marcha, así que nada de este disp
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "El servicio de host local acaba de arrancar. Conectando con él ahora."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "El servicio de host local dejó de responder. Reinténtalo primero; si no funciona, reinícialo desde el menú de la bandeja de Superset > Servicio de host > Reiniciar."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "La mayoría de las pull requests de agentes fusionadas solo necesitan revisión, sin ninguna edición humana."
@@ -14053,9 +14044,6 @@ msgstr "Las personas detrás de Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "El periodo de recuperación ha terminado. Escribe a support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "El relay no pudo llegar a ese dispositivo ahora mismo. Suele ser temporal: normalmente basta con reintentarlo en un momento."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "La rama remota ha divergido. Haz pull antes de continuar."
@@ -14413,9 +14401,6 @@ msgstr "Esto terminará la sesión y su proceso subyacente."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Esto quitará de preparados y revertirá todos los cambios preparados. Los archivos nuevos preparados se eliminarán. Esto no se puede deshacer."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Este espacio de trabajo vive en un dispositivo con el que Superset no puede contactar ahora mismo. Las terminales, los archivos y los agentes siguen donde están: vuelven en cuanto lo haga la conexión."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Puede que este espacio de trabajo se haya eliminado o que ya no tengas acceso a él."
 
@@ -14664,6 +14649,9 @@ msgstr "Prueba con otro término de búsqueda u otro dispositivo."
 
 msgid "Try again"
 msgstr "Intentar de nuevo"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Inténtalo de nuevo o reinicia el servicio del host desde el menú de Superset en la bandeja del sistema."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Inténtalo de nuevo. Si el problema continúa, recarga Superset."
@@ -15301,6 +15289,9 @@ msgstr "No pudimos cobrar a tu método de pago. Actualízalo para conservar este
 msgid "We couldn't detect a package manager or environment config."
 msgstr "No se pudo detectar un gestor de paquetes ni una configuración de entorno."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "No pudimos conectar con el dispositivo. Inténtalo de nuevo en un momento."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "No pronosticamos autonomía total en 2026 ni en 2027. Las incógnitas honestas: si la revisión por agentes aguanta frente a una complejidad adversaria, si la especificación puede sustituir a la lectura de código como ancla de confianza a gran escala, y si la economía del cómputo mantiene el turno de noche más barato que las personas a las que asiste. F5 es una entrada de la rúbrica para reconocerlo cuando lo veamos, no una promesa."
 
@@ -15312,6 +15303,9 @@ msgstr "Enviamos el enlace de descarga a {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Nos pondremos en contacto en breve."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Volverás a tu espacio en cuanto se restablezca la conexión."
 
 msgid "We'll get back to you shortly."
 msgstr "Te responderemos en breve."
@@ -15764,9 +15758,6 @@ msgstr "Esta acción no se puede deshacer. Los paneles de terminal mostrarán \"
 
 msgid "You don't have access to this host"
 msgstr "No tienes acceso a este host"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "No tienes acceso a este host. Si es tu propio dispositivo, activa allí el acceso por relay en Configuración > Seguridad."
 
 msgid "You don't have access to this terminal."
 msgstr "No tienes acceso a este terminal."

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Puis-je utiliser mes propres clés d'API ?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Peux-tu uniformiser les tooltips dans toute l'application ?"
 
+msgid "Can't connect right now"
+msgstr "Connexion impossible pour le moment"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Impossible d'ouvrir les chemins d'un espace de travail distant dans un éditeur externe"
 
@@ -2842,6 +2845,9 @@ msgstr "Vérifier les ressources"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Vérifiez le prompt rendu et la sortie de lancement avant d'enregistrer"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Vérifiez votre accès dans Paramètres > Sécurité sur cet appareil."
 
 msgid "Check your connection and try again"
 msgstr "Vérifiez votre connexion et réessayez"
@@ -3562,9 +3568,6 @@ msgstr "Connecté. La connexion ayant été annulée, les déclencheurs « Moi �
 msgid "Connecting"
 msgstr "Connexion"
 
-msgid "Connecting to {hostName}…"
-msgstr "Connexion à {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Connexion au bureau…"
 
@@ -4033,6 +4036,9 @@ msgstr "Impossible de surveiller cette page"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Impossible de confirmer l'état de l'étoile — vérifiez que la CLI GitHub (`gh`) est installée, que vous y êtes connecté et que vous disposez d'une connexion réseau"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Connexion impossible (erreur {status}). Réessayez."
+
 msgid "Couldn't copy branch name"
 msgstr "Impossible de copier le nom de la branche"
 
@@ -4096,9 +4102,6 @@ msgstr "Impossible de publier la réponse"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Impossible de joindre le cloud pour {0} : {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Impossible de joindre le service de relais. Vérifiez la connexion réseau de cette machine — l'autre appareil n'est probablement pas en cause."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Impossible de lire le contexte de ce terminal."
@@ -4939,9 +4942,6 @@ msgstr "Déconnecter Slack ?"
 
 msgid "Disconnected"
 msgstr "Déconnecté"
-
-msgid "Disconnected from {hostName}"
-msgstr "Déconnecté de {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Déconnexion..."
@@ -6827,9 +6827,6 @@ msgstr "Le service hôte a planté"
 msgid "Host service is not running"
 msgstr "Le service de l'hôte n'est pas en cours d'exécution"
 
-msgid "Host service is restarting…"
-msgstr "Le service hôte redémarre…"
-
 msgid "Host service is starting…"
 msgstr "Le service hôte démarre…"
 
@@ -6844,9 +6841,6 @@ msgstr "Hôte indisponible"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Hôte indisponible : {hostName}"
-
-msgid "Host unreachable"
-msgstr "Hôte injoignable"
 
 msgid "Hosted in the cloud"
 msgstr "Hébergé dans le cloud"
@@ -8015,6 +8009,9 @@ msgstr "Définir par défaut"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Définir par défaut — lancer les nouveaux terminaux et agents sur ce compte."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Assurez-vous que l’appareil est actif, en ligne et que Superset y est lancé."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Faire du style chip la valeur par défaut de TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Lire {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Jouer un son à la fin des tâches"
 
+msgid "Please check your internet connection and try again."
+msgstr "Vérifiez votre connexion internet et réessayez."
+
 msgid "Please enter a project name"
 msgstr "Veuillez saisir un nom de projet"
 
@@ -10418,6 +10418,9 @@ msgstr "Veuillez sélectionner un emplacement de projet"
 
 msgid "Please select an organization"
 msgstr "Veuillez sélectionner une organisation"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Réessayez ou redémarrez Superset sur cet appareil."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Veuillez réessayer de vous connecter depuis l'application de bureau."
@@ -11083,9 +11086,6 @@ msgstr "Reconnexion requise"
 msgid "Reconnecting"
 msgstr "Reconnexion"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Reconnexion à {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Reconnexion…"
 
@@ -11562,6 +11562,9 @@ msgstr "Redémarrage des agents sur {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Redémarrage des services de l'hôte…"
+
+msgid "Restarting…"
+msgstr "Redémarrage…"
 
 msgid "Restore"
 msgstr "Restaurer"
@@ -13199,6 +13202,9 @@ msgstr "Démarrage de {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Démarrage de l'espace de travail cloud"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Démarrage en cours. Cela ne devrait prendre qu’un instant."
+
 msgid "Starting workspace"
 msgstr "Démarrage de l'espace de travail"
 
@@ -13850,12 +13856,6 @@ msgstr "Zone de texte"
 msgid "Thanks for reaching out"
 msgstr "Merci de nous avoir écrit"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Cet appareil est en ligne, mais la connexion n'a pas pu être établie — il s'agit généralement du routage du relais plutôt que de l'appareil lui-même. Réessayez, et si le problème persiste, redémarrez Superset sur cet appareil."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Cet appareil n'est pas connecté au relais. Vérifiez qu'il est allumé, en ligne et que Superset y est lancé — il se reconnecte tout seul une fois que c'est le cas."
-
 msgid "That handle is taken."
 msgstr "Ce pseudo est déjà pris."
 
@@ -13891,9 +13891,6 @@ msgstr "Le meilleur agent changera.<0/>Pas votre façon de travailler."
 
 msgid "The Codex sign-in"
 msgstr "La connexion Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "La connexion a échoué (statut du relais {status}). Réessayez, et si le problème persiste, redémarrez Superset sur cet appareil."
 
 msgid "The connection timed out"
 msgstr "Le délai de connexion a été dépassé"
@@ -13997,9 +13994,6 @@ msgstr "Le lien est peut-être erroné, la page a peut-être été supprimée, o
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "L'agent lié est absent ou désactivé. Affichage de l'instantané."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Le service hôte local est encore en train de démarrer. Il devrait être prêt dans quelques secondes."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Le service hôte local est indisponible pour {organization} sur {device}. Statut : {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Le service hôte local n'est pas en cours d'exécution, donc rien sur ce
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Le service hôte local vient de démarrer. Reconnexion en cours."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Le service hôte local ne répond plus. Réessayez d'abord ; si cela ne suffit pas, redémarrez-le depuis le menu de la barre d'état Superset > Service hôte > Redémarrer."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "La majorité des PR d'agents fusionnées ne demandent qu'une revue, sans aucune retouche humaine."
@@ -14053,9 +14044,6 @@ msgstr "Les personnes derrière Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "La période de récupération est terminée. Contactez support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Le relais n'a pas pu joindre cet appareil pour le moment. C'est généralement temporaire — réessayer dans un instant fonctionne habituellement."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "La branche distante a divergé. Faites un pull avant de continuer."
@@ -14413,9 +14401,6 @@ msgstr "Cette action arrêtera la session et son processus sous-jacent."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Cette action désindexera et annulera toutes les modifications indexées. Les nouveaux fichiers indexés seront supprimés. Cette action est irréversible."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Cet espace de travail se trouve sur un appareil que Superset ne peut pas joindre pour le moment. Les terminaux, les fichiers et les agents restent en place — ils reviennent dès que la connexion revient."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Cet espace de travail a peut-être été supprimé, ou vous n'y avez plus accès."
 
@@ -14664,6 +14649,9 @@ msgstr "Essayez un autre terme de recherche ou un autre appareil."
 
 msgid "Try again"
 msgstr "Réessayer"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Réessayez ou redémarrez le service hôte depuis le menu Superset dans la zone de notification."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Réessayez. Si le problème persiste, rechargez Superset."
@@ -15301,6 +15289,9 @@ msgstr "Nous n'avons pas pu débiter votre moyen de paiement. Mettez-le à jour 
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Nous n'avons pas pu détecter de gestionnaire de paquets ni de configuration d'environnement."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Impossible de joindre l’appareil. Réessayez dans un instant."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Nous ne prévoyons pas d'autonomie complète en 2026 ni en 2027. Les vraies inconnues : la revue par agents tiendra-t-elle face à une complexité adverse, la spécification pourra-t-elle remplacer la lecture du code comme ancrage de confiance à grande échelle, et l'économie du calcul gardera-t-elle l'équipe de nuit moins chère que les humains qu'elle épaule. F5 est une entrée de grille pour le reconnaître le jour venu, pas une promesse."
 
@@ -15312,6 +15303,9 @@ msgstr "Nous avons envoyé le lien de téléchargement à {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Nous vous recontacterons rapidement."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Vous retrouverez votre espace dès la connexion rétablie."
 
 msgid "We'll get back to you shortly."
 msgstr "Nous vous répondrons rapidement."
@@ -15764,9 +15758,6 @@ msgstr "Cette action est irréversible. Les volets de terminal afficheront « Pr
 
 msgid "You don't have access to this host"
 msgstr "Vous n'avez pas accès à cet hôte"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Vous n'avez pas accès à cet hôte. S'il s'agit de votre propre appareil, activez-y l'accès au relais dans Paramètres > Sécurité."
 
 msgid "You don't have access to this terminal."
 msgstr "Vous n'avez pas accès à ce terminal."

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Connecté. La connexion ayant été annulée, les déclencheurs « Moi �
 msgid "Connecting"
 msgstr "Connexion"
 
+msgid "Connecting to {hostName}…"
+msgstr "Connexion à {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Connexion au bureau…"
 
@@ -4936,6 +4939,9 @@ msgstr "Déconnecter Slack ?"
 
 msgid "Disconnected"
 msgstr "Déconnecté"
+
+msgid "Disconnected from {hostName}"
+msgstr "Déconnecté de {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Déconnexion..."
@@ -6820,6 +6826,9 @@ msgstr "Le service hôte a planté"
 
 msgid "Host service is not running"
 msgstr "Le service de l'hôte n'est pas en cours d'exécution"
+
+msgid "Host service is restarting…"
+msgstr "Le service hôte redémarre…"
 
 msgid "Host service is starting…"
 msgstr "Le service hôte démarre…"
@@ -11073,6 +11082,9 @@ msgstr "Reconnexion requise"
 
 msgid "Reconnecting"
 msgstr "Reconnexion"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Reconnexion à {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Reconnexion…"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Terhubung. Proses masuk dibatalkan, jadi pemicu oleh \"Saya\" tidak akan
 msgid "Connecting"
 msgstr "Menghubungkan"
 
+msgid "Connecting to {hostName}…"
+msgstr "Menghubungkan ke {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Menghubungkan ke desktop…"
 
@@ -4936,6 +4939,9 @@ msgstr "Putuskan Slack?"
 
 msgid "Disconnected"
 msgstr "Terputus"
+
+msgid "Disconnected from {hostName}"
+msgstr "Terputus dari {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Memutuskan..."
@@ -6820,6 +6826,9 @@ msgstr "Layanan host crash"
 
 msgid "Host service is not running"
 msgstr "Layanan host tidak berjalan"
+
+msgid "Host service is restarting…"
+msgstr "Layanan host sedang dimulai ulang…"
 
 msgid "Host service is starting…"
 msgstr "Layanan host sedang dimulai…"
@@ -11073,6 +11082,9 @@ msgstr "Perlu dihubungkan ulang"
 
 msgid "Reconnecting"
 msgstr "Menyambungkan ulang"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Menyambungkan ulang ke {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Menyambungkan ulang…"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Bisakah saya memakai kunci API saya sendiri?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Bisakah kamu menyeragamkan tooltip di seluruh aplikasi?"
 
+msgid "Can't connect right now"
+msgstr "Belum bisa terhubung"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Tidak bisa membuka path workspace jarak jauh di editor eksternal"
 
@@ -2842,6 +2845,9 @@ msgstr "Periksa Sumber Daya"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Periksa prompt yang dirender dan output peluncuran sebelum menyimpan"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Periksa akses Anda di Pengaturan > Keamanan pada perangkat tersebut."
 
 msgid "Check your connection and try again"
 msgstr "Periksa koneksi Anda dan coba lagi"
@@ -3562,9 +3568,6 @@ msgstr "Terhubung. Proses masuk dibatalkan, jadi pemicu oleh \"Saya\" tidak akan
 msgid "Connecting"
 msgstr "Menghubungkan"
 
-msgid "Connecting to {hostName}…"
-msgstr "Menghubungkan ke {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Menghubungkan ke desktop…"
 
@@ -4033,6 +4036,9 @@ msgstr "Tidak bisa memantau halaman ini"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Tidak bisa memastikan status star — pastikan GitHub CLI (`gh`) terpasang, sudah masuk, dan Anda punya koneksi jaringan"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Tidak dapat terhubung (kesalahan {status}). Coba lagi."
+
 msgid "Couldn't copy branch name"
 msgstr "Tidak bisa menyalin nama branch"
 
@@ -4096,9 +4102,6 @@ msgstr "Tidak bisa mengirim balasan"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Tidak bisa menjangkau cloud untuk {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Tidak bisa menjangkau layanan relay. Periksa koneksi jaringan mesin ini — perangkat yang satunya kemungkinan baik-baik saja."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Konteks terminal ini tidak bisa dibaca."
@@ -4939,9 +4942,6 @@ msgstr "Putuskan Slack?"
 
 msgid "Disconnected"
 msgstr "Terputus"
-
-msgid "Disconnected from {hostName}"
-msgstr "Terputus dari {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Memutuskan..."
@@ -6827,9 +6827,6 @@ msgstr "Layanan host crash"
 msgid "Host service is not running"
 msgstr "Layanan host tidak berjalan"
 
-msgid "Host service is restarting…"
-msgstr "Layanan host sedang dimulai ulang…"
-
 msgid "Host service is starting…"
 msgstr "Layanan host sedang dimulai…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host tidak tersedia"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host tidak tersedia: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host tidak terjangkau"
 
 msgid "Hosted in the cloud"
 msgstr "Dihosting di cloud"
@@ -8015,6 +8009,9 @@ msgstr "Jadikan bawaan"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Jadikan bawaan — jalankan terminal dan agen baru dengan akun ini."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Pastikan perangkat aktif, terhubung ke internet, dan menjalankan Superset."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Jadikan gaya chip sebagai bawaan TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Putar {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Bunyikan suara saat tugas selesai"
 
+msgid "Please check your internet connection and try again."
+msgstr "Periksa koneksi internet Anda dan coba lagi."
+
 msgid "Please enter a project name"
 msgstr "Silakan masukkan nama proyek"
 
@@ -10418,6 +10418,9 @@ msgstr "Silakan pilih lokasi proyek"
 
 msgid "Please select an organization"
 msgstr "Silakan pilih sebuah organisasi"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Coba lagi, atau mulai ulang Superset di perangkat tersebut."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Silakan coba masuk lagi dari aplikasi desktop."
@@ -11083,9 +11086,6 @@ msgstr "Perlu dihubungkan ulang"
 msgid "Reconnecting"
 msgstr "Menyambungkan ulang"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Menyambungkan ulang ke {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Menyambungkan ulang…"
 
@@ -11562,6 +11562,9 @@ msgstr "Menjalankan ulang agen di {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Memulai ulang layanan host…"
+
+msgid "Restarting…"
+msgstr "Memulai ulang…"
 
 msgid "Restore"
 msgstr "Pulihkan"
@@ -13199,6 +13202,9 @@ msgstr "Memulai {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Memulai workspace cloud"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Sedang memulai. Ini hanya perlu sebentar."
+
 msgid "Starting workspace"
 msgstr "Memulai workspace"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Terima kasih sudah menghubungi"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Perangkat itu online tapi koneksinya tidak bisa dibangun — biasanya soal perutean relay, bukan perangkatnya. Coba lagi, dan kalau terus terjadi mulai ulang Superset di perangkat itu."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Perangkat itu tidak terhubung ke relay. Pastikan perangkatnya menyala, online, dan menjalankan Superset — perangkat akan tersambung sendiri setelah itu."
-
 msgid "That handle is taken."
 msgstr "Handle itu sudah dipakai."
 
@@ -13891,9 +13891,6 @@ msgstr "Agen terbaik akan berganti.<0/>Alur kerja Anda tidak perlu."
 
 msgid "The Codex sign-in"
 msgstr "Sesi masuk Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Koneksinya gagal (status relay {status}). Coba lagi, dan kalau terus terjadi mulai ulang Superset di perangkat itu."
 
 msgid "The connection timed out"
 msgstr "Koneksinya kehabisan waktu"
@@ -13997,9 +13994,6 @@ msgstr "Tautannya mungkin salah, halamannya mungkin sudah dihapus, atau Anda mun
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Agen yang ditautkan hilang atau nonaktif. Menampilkan snapshot."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Layanan host lokal masih dimulai. Seharusnya siap dalam beberapa detik."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Layanan host lokal tidak tersedia untuk {organization} di {device}. Status: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Layanan host lokal tidak berjalan, jadi tidak ada yang bisa melayani wor
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Layanan host lokal baru saja aktif. Menyambungkan kembali sekarang."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Layanan host lokal berhenti merespons. Coba lagi dulu; kalau tidak berhasil, mulai ulang dari menu tray Superset > Host Service > Restart."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Mayoritas PR agen yang di-merge hanya perlu direview, tanpa suntingan manusia."
@@ -14053,9 +14044,6 @@ msgstr "Orang-orang di balik Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Masa pemulihan sudah berakhir. Hubungi support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Relay tidak bisa menjangkau perangkat itu saat ini. Ini biasanya sementara — coba lagi sebentar lagi biasanya berhasil."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Branch remote sudah menyimpang. Lakukan pull sebelum melanjutkan."
@@ -14413,9 +14401,6 @@ msgstr "Ini akan menghentikan sesi beserta proses di baliknya."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Ini akan meng-unstage dan mengembalikan semua perubahan yang di-stage. File baru yang di-stage akan dihapus. Ini tidak bisa dibatalkan."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Workspace ini ada di perangkat yang tidak bisa dijangkau Superset saat ini. Terminal, file, dan agen tetap di tempatnya — semuanya kembali begitu koneksinya pulih."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Workspace ini mungkin sudah dihapus, atau Anda sudah tidak punya akses ke sana."
 
@@ -14664,6 +14649,9 @@ msgstr "Coba kata kunci lain atau perangkat lain."
 
 msgid "Try again"
 msgstr "Coba lagi"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Coba lagi, atau mulai ulang layanan host dari menu Superset di baki sistem."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Coba lagi. Kalau masih bermasalah, muat ulang Superset."
@@ -15301,6 +15289,9 @@ msgstr "Kami tidak bisa menagih metode pembayaran Anda. Perbarui untuk mempertah
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Kami tidak menemukan package manager atau konfigurasi environment."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Perangkat tidak dapat dijangkau. Coba lagi sebentar lagi."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Kami tidak memperkirakan full self-driving pada 2026 atau 2027. Yang jujur belum diketahui: apakah review oleh agen bertahan menghadapi kompleksitas yang bermusuhan, apakah spesifikasi bisa menggantikan pembacaan kode sebagai jangkar kepercayaan dalam skala besar, dan apakah ekonomi komputasi menjaga shift malam tetap lebih murah daripada manusia yang dibantunya. F5 adalah entri rubrik supaya kami mengenalinya saat melihatnya, bukan sebuah janji."
 
@@ -15312,6 +15303,9 @@ msgstr "Kami mengirim tautan unduhan ke {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Kami akan segera menghubungi Anda."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Anda akan kembali begitu koneksi tersambung lagi."
 
 msgid "We'll get back to you shortly."
 msgstr "Kami akan segera menghubungi Anda kembali."
@@ -15764,9 +15758,6 @@ msgstr "Tindakan ini tidak bisa dibatalkan. Panel terminal akan menampilkan \"Pr
 
 msgid "You don't have access to this host"
 msgstr "Anda tidak punya akses ke host ini"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Anda tidak punya akses ke host ini. Kalau ini perangkat Anda sendiri, aktifkan akses relay di sana lewat Pengaturan > Keamanan."
 
 msgid "You don't have access to this terminal."
 msgstr "Anda tidak punya akses ke terminal ini."

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Posso usare le mie chiavi API?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Puoi standardizzare i tooltip in tutta l'app?"
 
+msgid "Can't connect right now"
+msgstr "Impossibile connettersi al momento"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Impossibile aprire i percorsi di un workspace remoto in un editor esterno"
 
@@ -2842,6 +2845,9 @@ msgstr "Controlla le risorse"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Controlla il prompt generato e l'output di avvio prima di salvare"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Controlla il tuo accesso in Impostazioni > Sicurezza su quel dispositivo."
 
 msgid "Check your connection and try again"
 msgstr "Controlla la connessione e riprova"
@@ -3562,9 +3568,6 @@ msgstr "Collegato. L'accesso è stato annullato, quindi i trigger su \"Io\" non 
 msgid "Connecting"
 msgstr "Connessione"
 
-msgid "Connecting to {hostName}…"
-msgstr "Connessione a {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Connessione al desktop…"
 
@@ -4033,6 +4036,9 @@ msgstr "Impossibile osservare questa pagina"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Impossibile confermare lo stato della star — controlla che la CLI di GitHub (`gh`) sia installata, che tu abbia effettuato l'accesso e che ci sia connessione di rete"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Connessione non riuscita (errore {status}). Riprova."
+
 msgid "Couldn't copy branch name"
 msgstr "Impossibile copiare il nome del branch"
 
@@ -4096,9 +4102,6 @@ msgstr "Impossibile pubblicare la risposta"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Impossibile raggiungere il cloud per {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Impossibile raggiungere il servizio relay. Controlla la connessione di rete di questa macchina — l'altro dispositivo probabilmente sta bene."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Impossibile leggere il contesto di questo terminale."
@@ -4939,9 +4942,6 @@ msgstr "Scollegare Slack?"
 
 msgid "Disconnected"
 msgstr "Disconnesso"
-
-msgid "Disconnected from {hostName}"
-msgstr "Disconnesso da {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Disconnessione..."
@@ -6827,9 +6827,6 @@ msgstr "Il servizio host è andato in crash"
 msgid "Host service is not running"
 msgstr "Il servizio host non è in esecuzione"
 
-msgid "Host service is restarting…"
-msgstr "Il servizio host si sta riavviando…"
-
 msgid "Host service is starting…"
 msgstr "Il servizio host si sta avviando…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host non disponibile"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host non disponibile: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host irraggiungibile"
 
 msgid "Hosted in the cloud"
 msgstr "Ospitato nel cloud"
@@ -8015,6 +8009,9 @@ msgstr "Imposta come predefinito"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Imposta come predefinito — avvia i nuovi terminali e agenti su questo account."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Assicurati che il dispositivo sia attivo, online e che Superset sia in esecuzione."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Rendi lo stile chip il predefinito di TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Riproduci {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Riproduci un suono al completamento dei task"
 
+msgid "Please check your internet connection and try again."
+msgstr "Controlla la connessione a internet e riprova."
+
 msgid "Please enter a project name"
 msgstr "Inserisci un nome per il progetto"
 
@@ -10418,6 +10418,9 @@ msgstr "Seleziona una posizione per il progetto"
 
 msgid "Please select an organization"
 msgstr "Seleziona un'organizzazione"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Riprova o riavvia Superset su quel dispositivo."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Prova ad accedere di nuovo dall'app desktop."
@@ -11083,9 +11086,6 @@ msgstr "È necessario ricollegarsi"
 msgid "Reconnecting"
 msgstr "Riconnessione"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Riconnessione a {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Riconnessione…"
 
@@ -11562,6 +11562,9 @@ msgstr "Riavvio degli agenti su {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Riavvio dei servizi host…"
+
+msgid "Restarting…"
+msgstr "Riavvio…"
 
 msgid "Restore"
 msgstr "Ripristina"
@@ -13199,6 +13202,9 @@ msgstr "Avvio di {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Avvio del workspace cloud"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Avvio in corso. Dovrebbe volerci solo un momento."
+
 msgid "Starting workspace"
 msgstr "Avvio del workspace"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Grazie per averci scritto"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Quel dispositivo è online ma non è stato possibile stabilire la connessione — di solito è l'instradamento del relay, non il dispositivo stesso. Riprova e, se persiste, riavvia Superset su quel dispositivo."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Quel dispositivo non è connesso al relay. Controlla che sia acceso, online e che stia eseguendo Superset — si riconnette da solo appena lo è."
-
 msgid "That handle is taken."
 msgstr "Questo handle è già in uso."
 
@@ -13891,9 +13891,6 @@ msgstr "Il miglior agente cambierà.<0/>Il tuo flusso di lavoro no."
 
 msgid "The Codex sign-in"
 msgstr "L'accesso Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "La connessione non è riuscita (stato del relay {status}). Riprova e, se persiste, riavvia Superset su quel dispositivo."
 
 msgid "The connection timed out"
 msgstr "La connessione è scaduta"
@@ -13997,9 +13994,6 @@ msgstr "Il link potrebbe essere sbagliato, la pagina potrebbe essere stata elimi
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "L'agente collegato manca o è disattivato. Viene mostrata l'istantanea."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Il servizio host locale è ancora in avvio. Dovrebbe essere pronto tra qualche secondo."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Il servizio host locale non è disponibile per {organization} su {device}. Stato: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Il servizio host locale non è in esecuzione, quindi niente su questo di
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Il servizio host locale è appena partito. Riconnessione in corso."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Il servizio host locale ha smesso di rispondere. Riprova prima; se non basta, riavvialo dal menu della barra di stato di Superset > Servizio host > Riavvia."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "La maggior parte delle PR degli agenti unite richiede solo revisione, senza modifiche umane."
@@ -14053,9 +14044,6 @@ msgstr "Le persone dietro Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Il periodo di recupero è terminato. Contatta support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Il relay non è riuscito a raggiungere quel dispositivo in questo momento. Di solito è temporaneo — riprovare tra poco di solito funziona."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Il branch remoto è divergente. Fai pull prima di continuare."
@@ -14413,9 +14401,6 @@ msgstr "Questo terminerà la sessione e il suo processo sottostante."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Questo toglierà dallo stage e annullerà tutte le modifiche in stage. I nuovi file in stage verranno eliminati. L'operazione non può essere annullata."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Questo workspace si trova su un dispositivo che Superset non riesce a raggiungere ora. Terminali, file e agenti restano dove sono — tornano appena torna la connessione."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Questo workspace potrebbe essere stato rimosso oppure non hai più accesso."
 
@@ -14664,6 +14649,9 @@ msgstr "Prova con un altro termine di ricerca o un altro dispositivo."
 
 msgid "Try again"
 msgstr "Riprova"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Riprova o riavvia il servizio host dal menu di Superset nell’area di notifica."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Riprova. Se il problema persiste, ricarica Superset."
@@ -15301,6 +15289,9 @@ msgstr "Non siamo riusciti ad addebitare il tuo metodo di pagamento. Aggiornalo 
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Non abbiamo rilevato un gestore di pacchetti o una configurazione dell'ambiente."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Non siamo riusciti a raggiungere il dispositivo. Riprova tra poco."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Non prevediamo la guida completamente autonoma nel 2026 o nel 2027. Le incognite oneste: se la revisione fatta dagli agenti regga di fronte a una complessità avversa, se la specifica possa sostituire la lettura del codice come ancora della fiducia su larga scala, e se l'economia del calcolo mantenga il turno di notte più economico delle persone che potenzia. F5 è una voce della griglia per riconoscerlo quando lo vedremo, non una promessa."
 
@@ -15312,6 +15303,9 @@ msgstr "Abbiamo inviato il link di download a {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Ti contatteremo a breve."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Tornerai al tuo spazio appena la connessione sarà ristabilita."
 
 msgid "We'll get back to you shortly."
 msgstr "Ti risponderemo a breve."
@@ -15764,9 +15758,6 @@ msgstr "Non puoi annullare questa azione. I pannelli del terminale mostreranno \
 
 msgid "You don't have access to this host"
 msgstr "Non hai accesso a questo host"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Non hai accesso a questo host. Se è un tuo dispositivo, attiva lì l'accesso relay in Impostazioni > Sicurezza."
 
 msgid "You don't have access to this terminal."
 msgstr "Non hai accesso a questo terminale."

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Collegato. L'accesso è stato annullato, quindi i trigger su \"Io\" non 
 msgid "Connecting"
 msgstr "Connessione"
 
+msgid "Connecting to {hostName}…"
+msgstr "Connessione a {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Connessione al desktop…"
 
@@ -4936,6 +4939,9 @@ msgstr "Scollegare Slack?"
 
 msgid "Disconnected"
 msgstr "Disconnesso"
+
+msgid "Disconnected from {hostName}"
+msgstr "Disconnesso da {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Disconnessione..."
@@ -6820,6 +6826,9 @@ msgstr "Il servizio host è andato in crash"
 
 msgid "Host service is not running"
 msgstr "Il servizio host non è in esecuzione"
+
+msgid "Host service is restarting…"
+msgstr "Il servizio host si sta riavviando…"
 
 msgid "Host service is starting…"
 msgstr "Il servizio host si sta avviando…"
@@ -11073,6 +11082,9 @@ msgstr "È necessario ricollegarsi"
 
 msgid "Reconnecting"
 msgstr "Riconnessione"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Riconnessione a {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Riconnessione…"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -2649,6 +2649,9 @@ msgstr "自分のAPIキーを使えますか?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "アプリ全体のtooltipを統一できますか?"
 
+msgid "Can't connect right now"
+msgstr "現在接続できません"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "リモートワークスペースのパスは外部エディタで開けません"
 
@@ -2842,6 +2845,9 @@ msgstr "リソースを確認"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "保存前にレンダリングされたプロンプトと起動出力を確認"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "そのデバイスの「設定」>「セキュリティ」でアクセス権を確認してください。"
 
 msgid "Check your connection and try again"
 msgstr "接続を確認してもう一度お試しください"
@@ -3562,9 +3568,6 @@ msgstr "接続しました。サインインがキャンセルされたため、
 msgid "Connecting"
 msgstr "接続中"
 
-msgid "Connecting to {hostName}…"
-msgstr "{hostName}に接続中…"
-
 msgid "Connecting to the desktop…"
 msgstr "デスクトップに接続しています…"
 
@@ -4033,6 +4036,9 @@ msgstr "このページを監視できませんでした"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "スター状態を確認できませんでした — GitHub CLI (`gh`) がインストール・サインイン済みで、ネットワーク接続があることを確認してください"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "接続できませんでした（エラー {status}）。もう一度お試しください。"
+
 msgid "Couldn't copy branch name"
 msgstr "ブランチ名をコピーできませんでした"
 
@@ -4096,9 +4102,6 @@ msgstr "返信を投稿できませんでした"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "{0}のクラウドに接続できませんでした: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "リレーサービスに到達できませんでした。このマシンのネットワーク接続を確認してください — 相手のデバイスはおそらく問題ありません。"
 
 msgid "Couldn't read this terminal's context."
 msgstr "このターミナルのコンテキストを読み取れませんでした。"
@@ -4939,9 +4942,6 @@ msgstr "Slackの接続を解除しますか?"
 
 msgid "Disconnected"
 msgstr "切断されました"
-
-msgid "Disconnected from {hostName}"
-msgstr "{hostName}から切断されました"
 
 msgid "Disconnecting..."
 msgstr "接続を解除中..."
@@ -6827,9 +6827,6 @@ msgstr "ホストサービスがクラッシュしました"
 msgid "Host service is not running"
 msgstr "ホストサービスが実行されていません"
 
-msgid "Host service is restarting…"
-msgstr "ホストサービスを再起動中…"
-
 msgid "Host service is starting…"
 msgstr "ホストサービスを起動中…"
 
@@ -6844,9 +6841,6 @@ msgstr "ホストが利用できません"
 
 msgid "Host unavailable: {hostName}"
 msgstr "ホストが利用できません: {hostName}"
-
-msgid "Host unreachable"
-msgstr "ホストに接続できません"
 
 msgid "Hosted in the cloud"
 msgstr "クラウドでホスト"
@@ -8015,6 +8009,9 @@ msgstr "デフォルトにする"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "デフォルトにする — 新しいターミナルとエージェントをこのアカウントで起動します。"
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "デバイスがスリープ状態ではなく、オンラインで Superset が起動していることを確認してください。"
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "チップスタイルをTooltipContentのデフォルトにする"
@@ -10407,6 +10404,9 @@ msgstr "{label}を再生"
 msgid "Play a sound when tasks complete"
 msgstr "タスク完了時にサウンドを再生"
 
+msgid "Please check your internet connection and try again."
+msgstr "インターネット接続を確認して、もう一度お試しください。"
+
 msgid "Please enter a project name"
 msgstr "プロジェクト名を入力してください"
 
@@ -10418,6 +10418,9 @@ msgstr "プロジェクトの場所を選択してください"
 
 msgid "Please select an organization"
 msgstr "組織を選択してください"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "もう一度試すか、そのデバイスで Superset を再起動してください。"
 
 msgid "Please try signing in again from the desktop app."
 msgstr "デスクトップアプリからもう一度サインインしてください。"
@@ -11083,9 +11086,6 @@ msgstr "再接続が必要です"
 msgid "Reconnecting"
 msgstr "再接続中"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "{hostName}に再接続中…"
-
 msgid "Reconnecting…"
 msgstr "再接続中…"
 
@@ -11562,6 +11562,9 @@ msgstr "{accountLabel}でエージェントを再起動しています。"
 
 msgid "Restarting host services…"
 msgstr "ホストサービスを再起動中…"
+
+msgid "Restarting…"
+msgstr "再起動中…"
 
 msgid "Restore"
 msgstr "復元"
@@ -13199,6 +13202,9 @@ msgstr "{agentLabel}を起動中"
 msgid "Starting cloud workspace"
 msgstr "クラウドワークスペースを開始中"
 
+msgid "Starting up. This should only take a moment."
+msgstr "起動中です。まもなく準備が整います。"
+
 msgid "Starting workspace"
 msgstr "ワークスペースを開始中"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "お問い合わせありがとうございます"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "そのデバイスはオンラインですが、接続を確立できませんでした — 通常はデバイス自体ではなくリレーのルーティングが原因です。再試行し、解消しない場合はそのデバイスでSupersetを再起動してください。"
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "そのデバイスはリレーに接続されていません。スリープしていないか、オンラインか、Supersetが動作しているかを確認してください — 条件が整えば自動的に再接続します。"
-
 msgid "That handle is taken."
 msgstr "そのハンドルは使用済みです。"
 
@@ -13891,9 +13891,6 @@ msgstr "最良のエージェントは変わります。<0/>ワークフロー�
 
 msgid "The Codex sign-in"
 msgstr "Codexのサインイン"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "接続に失敗しました(リレーのステータス{status})。再試行し、解消しない場合はそのデバイスでSupersetを再起動してください。"
 
 msgid "The connection timed out"
 msgstr "接続がタイムアウトしました"
@@ -13997,9 +13994,6 @@ msgstr "リンクが間違っているか、ページが削除されたか、ア
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "リンクされたエージェントが見つからないか無効です。スナップショットを表示しています。"
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "ローカルのホストサービスはまだ起動中です。数秒で準備できます。"
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "{device}の{organization}でローカルのホストサービスが利用できません。ステータス: {status}。{recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "ローカルのホストサービスが実行されていないため、
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "ローカルのホストサービスが起動しました。今すぐ再接続します。"
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "ローカルのホストサービスが応答しなくなりました。まず再試行し、解消しない場合はSupersetのトレイメニュー > ホストサービス > 再起動から再起動してください。"
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "マージされたエージェントのPRの過半数が、レビューのみで済み、人間の編集がゼロである。"
@@ -14053,9 +14044,6 @@ msgstr "Supersetを作っている人たち。"
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "復元期間は終了しました。support@superset.shまでご連絡ください。"
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "リレーは現在そのデバイスに到達できませんでした。通常は一時的なもので、少し待って再試行すれば解消します。"
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "リモートブランチが分岐しています。続ける前にpullしてください。"
@@ -14413,9 +14401,6 @@ msgstr "セッションとその基盤プロセスを終了します。"
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "ステージ済みの変更をすべてステージ解除して元に戻します。ステージ済みの新規ファイルは削除されます。元に戻せません。"
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "このワークスペースは、Supersetが現在接続できないデバイス上にあります。ターミナル、ファイル、エージェントはそのまま残り、接続が回復し次第戻ります。"
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "このワークスペースは削除されたか、アクセス権がなくなった可能性があります。"
 
@@ -14664,6 +14649,9 @@ msgstr "別の検索語や別のデバイスを試してください。"
 
 msgid "Try again"
 msgstr "再試行"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "もう一度試すか、Superset のトレイメニューからホストサービスを再起動してください。"
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "もう一度お試しください。問題が続く場合はSupersetを再読み込みしてください。"
@@ -15301,6 +15289,9 @@ msgstr "お客様の支払い方法に請求できませんでした。このプ
 msgid "We couldn't detect a package manager or environment config."
 msgstr "パッケージマネージャーや環境設定を検出できませんでした。"
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "デバイスに接続できませんでした。少し待ってからもう一度お試しください。"
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "2026年や2027年に完全自動運転が実現するとは予測していません。正直なところ未知数なのは、エージェントによるレビューが敵対的な複雑さに耐えられるか、仕様が大規模な場面でコードを読むことに代わる信頼の拠り所になれるか、そして計算コストの経済性が夜間シフトを人間より安く保てるかです。F5はルーブリック上の項目であり、実現したときにそれと分かるようにしてあるだけで、約束ではありません。"
 
@@ -15312,6 +15303,9 @@ msgstr "{submittedEmail}にダウンロードリンクを送信しました。"
 
 msgid "We'll be in touch shortly."
 msgstr "折り返しご連絡します。"
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "再接続でき次第、元の画面に戻ります。"
 
 msgid "We'll get back to you shortly."
 msgstr "折り返しご連絡します。"
@@ -15764,9 +15758,6 @@ msgstr "この操作は元に戻せません。ターミナルペインに「Pro
 
 msgid "You don't have access to this host"
 msgstr "このホストへのアクセス権がありません"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "このホストへのアクセス権がありません。自分のデバイスであれば、そのデバイスの設定 > セキュリティでリレーアクセスを有効にしてください。"
 
 msgid "You don't have access to this terminal."
 msgstr "このターミナルへのアクセス権がありません。"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -3562,6 +3562,9 @@ msgstr "接続しました。サインインがキャンセルされたため、
 msgid "Connecting"
 msgstr "接続中"
 
+msgid "Connecting to {hostName}…"
+msgstr "{hostName}に接続中…"
+
 msgid "Connecting to the desktop…"
 msgstr "デスクトップに接続しています…"
 
@@ -4936,6 +4939,9 @@ msgstr "Slackの接続を解除しますか?"
 
 msgid "Disconnected"
 msgstr "切断されました"
+
+msgid "Disconnected from {hostName}"
+msgstr "{hostName}から切断されました"
 
 msgid "Disconnecting..."
 msgstr "接続を解除中..."
@@ -6820,6 +6826,9 @@ msgstr "ホストサービスがクラッシュしました"
 
 msgid "Host service is not running"
 msgstr "ホストサービスが実行されていません"
+
+msgid "Host service is restarting…"
+msgstr "ホストサービスを再起動中…"
 
 msgid "Host service is starting…"
 msgstr "ホストサービスを起動中…"
@@ -11073,6 +11082,9 @@ msgstr "再接続が必要です"
 
 msgid "Reconnecting"
 msgstr "再接続中"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "{hostName}に再接続中…"
 
 msgid "Reconnecting…"
 msgstr "再接続中…"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -2649,6 +2649,9 @@ msgstr "제 API 키를 사용할 수 있나요?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "앱 전반의 툴팁을 표준화해 줄 수 있나요?"
 
+msgid "Can't connect right now"
+msgstr "지금은 연결할 수 없어요"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "원격 워크스페이스 경로는 외부 에디터에서 열 수 없습니다"
 
@@ -2842,6 +2845,9 @@ msgstr "리소스 확인"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "저장하기 전에 렌더링된 프롬프트와 실행 결과를 확인하세요"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "해당 기기의 설정 > 보안에서 접근 권한을 확인해 주세요."
 
 msgid "Check your connection and try again"
 msgstr "연결 상태를 확인하고 다시 시도하세요"
@@ -3562,9 +3568,6 @@ msgstr "연결되었습니다. 로그인이 취소되어, 다시 연결하기 �
 msgid "Connecting"
 msgstr "연결 중"
 
-msgid "Connecting to {hostName}…"
-msgstr "{hostName}에 연결하는 중…"
-
 msgid "Connecting to the desktop…"
 msgstr "데스크톱에 연결하는 중…"
 
@@ -4033,6 +4036,9 @@ msgstr "이 페이지를 감시할 수 없습니다"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "스타 상태를 확인하지 못했습니다 — GitHub CLI(`gh`)가 설치되어 로그인되어 있는지, 네트워크에 연결되어 있는지 확인하세요"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "연결하지 못했어요(오류 {status}). 다시 시도해 주세요."
+
 msgid "Couldn't copy branch name"
 msgstr "브랜치 이름을 복사하지 못했습니다"
 
@@ -4096,9 +4102,6 @@ msgstr "답글을 게시하지 못했습니다"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "{0}에 대해 클라우드에 연결할 수 없습니다: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "릴레이 서비스에 연결하지 못했습니다. 이 컴퓨터의 네트워크 연결을 확인하세요. 상대 기기는 아마 문제가 없을 것입니다."
 
 msgid "Couldn't read this terminal's context."
 msgstr "이 터미널의 컨텍스트를 읽을 수 없습니다."
@@ -4939,9 +4942,6 @@ msgstr "Slack 연결을 해제할까요?"
 
 msgid "Disconnected"
 msgstr "연결 끊김"
-
-msgid "Disconnected from {hostName}"
-msgstr "{hostName}과의 연결이 끊어졌습니다"
 
 msgid "Disconnecting..."
 msgstr "연결 해제 중..."
@@ -6827,9 +6827,6 @@ msgstr "호스트 서비스 충돌"
 msgid "Host service is not running"
 msgstr "호스트 서비스가 실행 중이 아닙니다"
 
-msgid "Host service is restarting…"
-msgstr "호스트 서비스를 다시 시작하는 중…"
-
 msgid "Host service is starting…"
 msgstr "호스트 서비스를 시작하는 중…"
 
@@ -6844,9 +6841,6 @@ msgstr "호스트를 사용할 수 없음"
 
 msgid "Host unavailable: {hostName}"
 msgstr "호스트를 사용할 수 없음: {hostName}"
-
-msgid "Host unreachable"
-msgstr "호스트에 연결할 수 없음"
 
 msgid "Hosted in the cloud"
 msgstr "클라우드에서 호스팅됨"
@@ -8015,6 +8009,9 @@ msgstr "기본값으로 설정"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "기본값으로 설정 — 새 터미널과 에이전트를 이 계정으로 실행합니다."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "기기가 절전 모드가 아니고 온라인 상태이며 Superset이 실행 중인지 확인해 주세요."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "칩 스타일을 TooltipContent 기본값으로 만들기"
@@ -10407,6 +10404,9 @@ msgstr "{label} 재생"
 msgid "Play a sound when tasks complete"
 msgstr "작업이 완료되면 소리를 재생합니다"
 
+msgid "Please check your internet connection and try again."
+msgstr "인터넷 연결을 확인하고 다시 시도해 주세요."
+
 msgid "Please enter a project name"
 msgstr "프로젝트 이름을 입력하세요"
 
@@ -10418,6 +10418,9 @@ msgstr "프로젝트 위치를 선택하세요"
 
 msgid "Please select an organization"
 msgstr "조직을 선택해 주세요"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "다시 시도하거나 해당 기기에서 Superset을 다시 시작해 주세요."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "데스크톱 앱에서 다시 로그인해 주세요."
@@ -11083,9 +11086,6 @@ msgstr "다시 연결 필요"
 msgid "Reconnecting"
 msgstr "다시 연결하는 중"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "{hostName}에 다시 연결하는 중…"
-
 msgid "Reconnecting…"
 msgstr "다시 연결하는 중…"
 
@@ -11562,6 +11562,9 @@ msgstr "{accountLabel}에서 에이전트를 다시 시작하는 중입니다."
 
 msgid "Restarting host services…"
 msgstr "호스트 서비스를 재시작하는 중…"
+
+msgid "Restarting…"
+msgstr "다시 시작 중…"
 
 msgid "Restore"
 msgstr "복원"
@@ -13199,6 +13202,9 @@ msgstr "{agentLabel} 시작 중"
 msgid "Starting cloud workspace"
 msgstr "클라우드 워크스페이스 시작 중"
 
+msgid "Starting up. This should only take a moment."
+msgstr "시작 중이에요. 잠시만 기다려 주세요."
+
 msgid "Starting workspace"
 msgstr "워크스페이스 시작 중"
 
@@ -13850,12 +13856,6 @@ msgstr "텍스트 영역"
 msgid "Thanks for reaching out"
 msgstr "연락해 주셔서 감사합니다"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "해당 기기는 온라인이지만 연결을 맺지 못했습니다. 보통 기기 자체보다는 릴레이 라우팅 문제입니다. 다시 시도하고, 계속되면 해당 기기에서 Superset을 다시 시작하세요."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "해당 기기가 릴레이에 연결되어 있지 않습니다. 기기가 깨어 있고 온라인이며 Superset이 실행 중인지 확인하세요. 조건이 갖춰지면 스스로 다시 연결됩니다."
-
 msgid "That handle is taken."
 msgstr "이미 사용 중인 핸들입니다."
 
@@ -13891,9 +13891,6 @@ msgstr "최고의 에이전트는 바뀝니다.<0/>워크플로는 그럴 필요
 
 msgid "The Codex sign-in"
 msgstr "Codex 로그인"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "연결에 실패했습니다(릴레이 상태 {status}). 다시 시도하고, 계속되면 해당 기기에서 Superset을 다시 시작하세요."
 
 msgid "The connection timed out"
 msgstr "연결 시간이 초과되었습니다"
@@ -13997,9 +13994,6 @@ msgstr "링크가 잘못되었거나, 페이지가 삭제되었거나, 접근 �
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "연결된 에이전트가 없거나 비활성화되어 있습니다. 스냅샷을 표시합니다."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "로컬 호스트 서비스가 아직 시작하는 중입니다. 몇 초 안에 준비될 것입니다."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "{device}의 {organization}에 대해 로컬 호스트 서비스를 사용할 수 없습니다. 상태: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "로컬 호스트 서비스가 실행 중이 아니어서 이 기기에�
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "로컬 호스트 서비스가 방금 올라왔습니다. 지금 다시 연결하는 중입니다."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "로컬 호스트 서비스가 응답을 멈췄습니다. 먼저 다시 시도하고, 해결되지 않으면 Superset 트레이 메뉴 > Host Service > Restart에서 다시 시작하세요."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "머지된 에이전트 PR의 대부분이 사람의 수정 없이 리뷰만으로 끝납니다."
@@ -14053,9 +14044,6 @@ msgstr "Superset을 만드는 사람들."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "복구 기간이 끝났습니다. support@superset.sh로 문의하세요."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "릴레이가 지금 해당 기기에 연결하지 못했습니다. 보통 일시적인 문제이며, 잠시 후 다시 시도하면 대개 해결됩니다."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "원격 브랜치가 갈라졌습니다. 계속하기 전에 pull하세요."
@@ -14413,9 +14401,6 @@ msgstr "이 세션과 그 하위 프로세스를 종료합니다."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "스테이징된 변경 사항을 모두 스테이징 해제하고 되돌립니다. 스테이징된 새 파일은 삭제됩니다. 되돌릴 수 없습니다."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "이 워크스페이스는 Superset이 지금 연결할 수 없는 기기에 있습니다. 터미널, 파일, 에이전트는 그대로 남아 있으며 연결이 복구되면 바로 돌아옵니다."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "이 워크스페이스가 제거되었거나 더 이상 접근 권한이 없을 수 있습니다."
 
@@ -14664,6 +14649,9 @@ msgstr "다른 검색어를 쓰거나 다른 기기를 선택해 보세요."
 
 msgid "Try again"
 msgstr "다시 시도"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "다시 시도하거나 Superset 트레이 메뉴에서 호스트 서비스를 다시 시작해 주세요."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "다시 시도하세요. 문제가 계속되면 Superset을 다시 불러오세요."
@@ -15301,6 +15289,9 @@ msgstr "결제 수단으로 청구하지 못했습니다. 이 플랜을 유지�
 msgid "We couldn't detect a package manager or environment config."
 msgstr "패키지 매니저나 환경 설정을 감지하지 못했습니다."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "기기에 연결하지 못했어요. 잠시 후 다시 시도해 주세요."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "2026년이나 2027년에 완전 자율 주행이 실현되리라고 예측하지는 않습니다. 솔직히 알 수 없는 부분이 있습니다. 에이전트 리뷰가 적대적인 복잡도를 견뎌 낼지, 대규모에서 명세가 코드 읽기를 대신해 신뢰의 기준이 될 수 있을지, 그리고 연산 비용이 야간 근무를 그것이 보완하는 사람보다 계속 저렴하게 유지할지입니다. F5는 약속이 아니라, 실제로 도달했을 때 알아보기 위한 평가 항목입니다."
 
@@ -15312,6 +15303,9 @@ msgstr "{submittedEmail}으로 다운로드 링크를 보냈습니다."
 
 msgid "We'll be in touch shortly."
 msgstr "곧 연락드리겠습니다."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "다시 연결되면 원래 화면으로 돌아갈게요."
 
 msgid "We'll get back to you shortly."
 msgstr "곧 회신드리겠습니다."
@@ -15764,9 +15758,6 @@ msgstr "이 작업은 되돌릴 수 없습니다. 터미널 패널에 \"Process 
 
 msgid "You don't have access to this host"
 msgstr "이 호스트에 접근할 권한이 없습니다"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "이 호스트에 접근할 권한이 없습니다. 본인 기기라면 해당 기기의 설정 > 보안에서 릴레이 접근을 켜세요."
 
 msgid "You don't have access to this terminal."
 msgstr "이 터미널에 접근할 권한이 없습니다."

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -3562,6 +3562,9 @@ msgstr "연결되었습니다. 로그인이 취소되어, 다시 연결하기 �
 msgid "Connecting"
 msgstr "연결 중"
 
+msgid "Connecting to {hostName}…"
+msgstr "{hostName}에 연결하는 중…"
+
 msgid "Connecting to the desktop…"
 msgstr "데스크톱에 연결하는 중…"
 
@@ -4936,6 +4939,9 @@ msgstr "Slack 연결을 해제할까요?"
 
 msgid "Disconnected"
 msgstr "연결 끊김"
+
+msgid "Disconnected from {hostName}"
+msgstr "{hostName}과의 연결이 끊어졌습니다"
 
 msgid "Disconnecting..."
 msgstr "연결 해제 중..."
@@ -6820,6 +6826,9 @@ msgstr "호스트 서비스 충돌"
 
 msgid "Host service is not running"
 msgstr "호스트 서비스가 실행 중이 아닙니다"
+
+msgid "Host service is restarting…"
+msgstr "호스트 서비스를 다시 시작하는 중…"
 
 msgid "Host service is starting…"
 msgstr "호스트 서비스를 시작하는 중…"
@@ -11073,6 +11082,9 @@ msgstr "다시 연결 필요"
 
 msgid "Reconnecting"
 msgstr "다시 연결하는 중"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "{hostName}에 다시 연결하는 중…"
 
 msgid "Reconnecting…"
 msgstr "다시 연결하는 중…"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Kan ik mijn eigen API-sleutels gebruiken?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Kun je de tooltips in de hele app standaardiseren?"
 
+msgid "Can't connect right now"
+msgstr "Verbinden lukt nu even niet"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Paden van externe werkruimtes kunnen niet in een externe editor worden geopend"
 
@@ -2842,6 +2845,9 @@ msgstr "Resources controleren"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Bekijk de gerenderde prompt en startuitvoer voordat je opslaat"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Controleer je toegang onder Instellingen > Beveiliging op dat apparaat."
 
 msgid "Check your connection and try again"
 msgstr "Controleer je verbinding en probeer het opnieuw"
@@ -3562,9 +3568,6 @@ msgstr "Verbonden. Het inloggen is geannuleerd, dus triggers met \"Ik\" komen ni
 msgid "Connecting"
 msgstr "Verbinden"
 
-msgid "Connecting to {hostName}…"
-msgstr "Verbinden met {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Verbinden met het bureaublad…"
 
@@ -4033,6 +4036,9 @@ msgstr "Kon deze pagina niet volgen"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Kan de sterstatus niet bevestigen — controleer of de GitHub-CLI (`gh`) is geïnstalleerd, of je bent ingelogd en of je een netwerkverbinding hebt"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Verbinden mislukt (fout {status}). Probeer het opnieuw."
+
 msgid "Couldn't copy branch name"
 msgstr "Kan branchnaam niet kopiëren"
 
@@ -4096,9 +4102,6 @@ msgstr "Kan antwoord niet plaatsen"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Kan de cloud niet bereiken voor {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Kan de relayservice niet bereiken. Controleer de netwerkverbinding van deze machine — met het andere apparaat is waarschijnlijk niets mis."
 
 msgid "Couldn't read this terminal's context."
 msgstr "De context van deze terminal kon niet worden gelezen."
@@ -4939,9 +4942,6 @@ msgstr "Slack loskoppelen?"
 
 msgid "Disconnected"
 msgstr "Verbinding verbroken"
-
-msgid "Disconnected from {hostName}"
-msgstr "Verbinding met {hostName} verbroken"
 
 msgid "Disconnecting..."
 msgstr "Verbinding verbreken..."
@@ -6827,9 +6827,6 @@ msgstr "Hostservice gecrasht"
 msgid "Host service is not running"
 msgstr "De hostservice draait niet"
 
-msgid "Host service is restarting…"
-msgstr "Hostservice wordt opnieuw gestart…"
-
 msgid "Host service is starting…"
 msgstr "De hostservice start op…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host niet beschikbaar"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host niet beschikbaar: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host onbereikbaar"
 
 msgid "Hosted in the cloud"
 msgstr "Gehost in de cloud"
@@ -8015,6 +8009,9 @@ msgstr "Standaard maken"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Standaard maken — start nieuwe terminals en agents op dit account."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Zorg dat het apparaat wakker en online is en dat Superset erop draait."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Maak de chipstijl de standaard voor TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "{label} afspelen"
 msgid "Play a sound when tasks complete"
 msgstr "Speel een geluid af wanneer taken klaar zijn"
 
+msgid "Please check your internet connection and try again."
+msgstr "Controleer je internetverbinding en probeer het opnieuw."
+
 msgid "Please enter a project name"
 msgstr "Voer een projectnaam in"
 
@@ -10418,6 +10418,9 @@ msgstr "Kies een projectlocatie"
 
 msgid "Please select an organization"
 msgstr "Kies een organisatie"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Probeer het opnieuw of herstart Superset op dat apparaat."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Probeer opnieuw in te loggen vanuit de desktop-app."
@@ -11083,9 +11086,6 @@ msgstr "Opnieuw verbinden vereist"
 msgid "Reconnecting"
 msgstr "Opnieuw verbinden"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Opnieuw verbinden met {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Opnieuw verbinden…"
 
@@ -11562,6 +11562,9 @@ msgstr "Agents worden herstart op {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Hostservices herstarten…"
+
+msgid "Restarting…"
+msgstr "Bezig met herstarten…"
 
 msgid "Restore"
 msgstr "Herstellen"
@@ -13199,6 +13202,9 @@ msgstr "{agentLabel} starten"
 msgid "Starting cloud workspace"
 msgstr "Cloudwerkruimte starten"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Bezig met starten. Dit duurt maar even."
+
 msgid "Starting workspace"
 msgstr "Werkruimte starten"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Bedankt voor je bericht"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Dat apparaat is online, maar de verbinding kon niet tot stand komen — meestal ligt dat aan de relayrouting en niet aan het apparaat zelf. Probeer het opnieuw; blijft het misgaan, herstart Superset dan op dat apparaat."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Dat apparaat is niet met de relay verbonden. Controleer of het wakker en online is en of Superset draait — daarna verbindt het vanzelf opnieuw."
-
 msgid "That handle is taken."
 msgstr "Die handle is al bezet."
 
@@ -13891,9 +13891,6 @@ msgstr "De beste agent verandert.<0/>Jouw workflow niet."
 
 msgid "The Codex sign-in"
 msgstr "De Codex-login"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "De verbinding is mislukt (relaystatus {status}). Probeer het opnieuw; blijft het misgaan, herstart Superset dan op dat apparaat."
 
 msgid "The connection timed out"
 msgstr "De verbinding is verlopen"
@@ -13997,9 +13994,6 @@ msgstr "De link klopt mogelijk niet, de pagina is verwijderd, of je hebt er geen
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "De gekoppelde agent ontbreekt of staat uit. De snapshot wordt getoond."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "De lokale hostservice start nog op. Over een paar seconden zou hij klaar moeten zijn."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "De lokale hostservice is niet beschikbaar voor {organization} op {device}. Status: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "De lokale hostservice draait niet, dus niets op dit apparaat kan de werk
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "De lokale hostservice is net gestart. Er wordt nu opnieuw verbinding mee gemaakt."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "De lokale hostservice reageert niet meer. Probeer het eerst opnieuw; helpt dat niet, herstart hem dan via het Superset-menu in de menubalk > Hostservice > Opnieuw starten."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "De meeste gemergede agent-PR's hoeven alleen gereviewd te worden, zonder menselijke bewerkingen."
@@ -14053,9 +14044,6 @@ msgstr "De mensen achter Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "De herstelperiode is voorbij. Neem contact op via support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "De relay kon dat apparaat nu niet bereiken. Dat is meestal tijdelijk — zo meteen opnieuw proberen werkt vaak."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "De remote branch is uiteengelopen. Pull voordat je verdergaat."
@@ -14413,9 +14401,6 @@ msgstr "Hiermee worden de sessie en het onderliggende proces beëindigd."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Hiermee worden alle gestagede wijzigingen ge-unstaged en teruggedraaid. Gestagede nieuwe bestanden worden verwijderd. Dit kan niet ongedaan worden gemaakt."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Deze werkruimte staat op een apparaat dat Superset nu niet kan bereiken. Terminals, bestanden en agents blijven staan — ze komen terug zodra de verbinding er weer is."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Deze werkruimte is mogelijk verwijderd, of je hebt er geen toegang meer toe."
 
@@ -14664,6 +14649,9 @@ msgstr "Probeer een andere zoekterm of een ander apparaat."
 
 msgid "Try again"
 msgstr "Opnieuw proberen"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Probeer het opnieuw of herstart de hostservice via het Superset-menu in het systeemvak."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Probeer het opnieuw. Blijft het misgaan, herlaad dan Superset."
@@ -15301,6 +15289,9 @@ msgstr "We konden je betaalmethode niet belasten. Werk die bij om dit plan te be
 msgid "We couldn't detect a package manager or environment config."
 msgstr "We konden geen package manager of omgevingsconfiguratie detecteren."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "We konden het apparaat niet bereiken. Probeer het zo nog eens."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "We voorspellen geen volledige zelfsturing in 2026 of 2027. De eerlijke onbekenden: of agentreview standhoudt tegen vijandige complexiteit, of specificatie op schaal het lezen van code kan vervangen als vertrouwensanker, en of de rekeneconomie de nachtploeg goedkoper houdt dan de mensen die zij aanvult. F5 staat in de rubric zodat we het herkennen als we het zien, niet als belofte."
 
@@ -15312,6 +15303,9 @@ msgstr "We hebben de downloadlink naar {submittedEmail} gestuurd."
 
 msgid "We'll be in touch shortly."
 msgstr "We nemen snel contact op."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Zodra de verbinding terug is, kun je hier verder."
 
 msgid "We'll get back to you shortly."
 msgstr "We nemen snel contact met je op."
@@ -15764,9 +15758,6 @@ msgstr "Dit kun je niet ongedaan maken. Terminalpanelen tonen \"Process exited\"
 
 msgid "You don't have access to this host"
 msgstr "Je hebt geen toegang tot deze host"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Je hebt geen toegang tot deze host. Is het je eigen apparaat, zet daar dan relaytoegang aan bij Instellingen > Beveiliging."
 
 msgid "You don't have access to this terminal."
 msgstr "Je hebt geen toegang tot deze terminal."

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Verbonden. Het inloggen is geannuleerd, dus triggers met \"Ik\" komen ni
 msgid "Connecting"
 msgstr "Verbinden"
 
+msgid "Connecting to {hostName}…"
+msgstr "Verbinden met {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Verbinden met het bureaublad…"
 
@@ -4936,6 +4939,9 @@ msgstr "Slack loskoppelen?"
 
 msgid "Disconnected"
 msgstr "Verbinding verbroken"
+
+msgid "Disconnected from {hostName}"
+msgstr "Verbinding met {hostName} verbroken"
 
 msgid "Disconnecting..."
 msgstr "Verbinding verbreken..."
@@ -6820,6 +6826,9 @@ msgstr "Hostservice gecrasht"
 
 msgid "Host service is not running"
 msgstr "De hostservice draait niet"
+
+msgid "Host service is restarting…"
+msgstr "Hostservice wordt opnieuw gestart…"
 
 msgid "Host service is starting…"
 msgstr "De hostservice start op…"
@@ -11073,6 +11082,9 @@ msgstr "Opnieuw verbinden vereist"
 
 msgid "Reconnecting"
 msgstr "Opnieuw verbinden"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Opnieuw verbinden met {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Opnieuw verbinden…"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Połączono. Logowanie zostało anulowane, więc wyzwalacze „Ja” nie
 msgid "Connecting"
 msgstr "Łączenie"
 
+msgid "Connecting to {hostName}…"
+msgstr "Łączenie z {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Łączenie z pulpitem…"
 
@@ -4936,6 +4939,9 @@ msgstr "Rozłączyć Slack?"
 
 msgid "Disconnected"
 msgstr "Rozłączono"
+
+msgid "Disconnected from {hostName}"
+msgstr "Rozłączono z {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Rozłączanie..."
@@ -6820,6 +6826,9 @@ msgstr "Awaria usługi hosta"
 
 msgid "Host service is not running"
 msgstr "Usługa hosta nie działa"
+
+msgid "Host service is restarting…"
+msgstr "Usługa hosta uruchamia się ponownie…"
 
 msgid "Host service is starting…"
 msgstr "Usługa hosta się uruchamia…"
@@ -11073,6 +11082,9 @@ msgstr "Wymagane ponowne połączenie"
 
 msgid "Reconnecting"
 msgstr "Ponowne łączenie"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Ponowne łączenie z {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Ponowne łączenie…"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Czy mogę używać własnych kluczy API?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Czy możesz ujednolicić tooltipy w całej aplikacji?"
 
+msgid "Can't connect right now"
+msgstr "Nie można teraz się połączyć"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Nie można otwierać ścieżek zdalnego obszaru roboczego w zewnętrznym edytorze"
 
@@ -2842,6 +2845,9 @@ msgstr "Sprawdź zasoby"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Sprawdź wyrenderowany prompt i wynik uruchomienia przed zapisaniem"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Sprawdź swój dostęp w Ustawienia > Bezpieczeństwo na tym urządzeniu."
 
 msgid "Check your connection and try again"
 msgstr "Sprawdź połączenie i spróbuj ponownie"
@@ -3562,9 +3568,6 @@ msgstr "Połączono. Logowanie zostało anulowane, więc wyzwalacze „Ja” nie
 msgid "Connecting"
 msgstr "Łączenie"
 
-msgid "Connecting to {hostName}…"
-msgstr "Łączenie z {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Łączenie z pulpitem…"
 
@@ -4033,6 +4036,9 @@ msgstr "Nie udało się obserwować tej strony"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Nie udało się potwierdzić statusu gwiazdki — sprawdź, czy GitHub CLI (`gh`) jest zainstalowane, zalogowane i czy masz połączenie z siecią"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Nie udało się połączyć (błąd {status}). Spróbuj ponownie."
+
 msgid "Couldn't copy branch name"
 msgstr "Nie udało się skopiować nazwy gałęzi"
 
@@ -4096,9 +4102,6 @@ msgstr "Nie udało się opublikować odpowiedzi"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Nie udało się połączyć z chmurą dla {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Nie udało się połączyć z usługą przekaźnika. Sprawdź połączenie sieciowe tej maszyny — z drugim urządzeniem prawdopodobnie wszystko w porządku."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Nie udało się odczytać kontekstu tego terminala."
@@ -4939,9 +4942,6 @@ msgstr "Rozłączyć Slack?"
 
 msgid "Disconnected"
 msgstr "Rozłączono"
-
-msgid "Disconnected from {hostName}"
-msgstr "Rozłączono z {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Rozłączanie..."
@@ -6827,9 +6827,6 @@ msgstr "Awaria usługi hosta"
 msgid "Host service is not running"
 msgstr "Usługa hosta nie działa"
 
-msgid "Host service is restarting…"
-msgstr "Usługa hosta uruchamia się ponownie…"
-
 msgid "Host service is starting…"
 msgstr "Usługa hosta się uruchamia…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host niedostępny"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host niedostępny: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host nieosiągalny"
 
 msgid "Hosted in the cloud"
 msgstr "Hostowany w chmurze"
@@ -8015,6 +8009,9 @@ msgstr "Ustaw jako domyślne"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Ustaw jako domyślne — uruchamiaj nowe terminale i agentów na tym koncie."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Upewnij się, że urządzenie jest wybudzone, ma dostęp do internetu i działa na nim Superset."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Ustaw styl chipa jako domyślny dla TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Odtwórz {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Odtwarzaj dźwięk po zakończeniu zadań"
 
+msgid "Please check your internet connection and try again."
+msgstr "Sprawdź połączenie z internetem i spróbuj ponownie."
+
 msgid "Please enter a project name"
 msgstr "Podaj nazwę projektu"
 
@@ -10418,6 +10418,9 @@ msgstr "Wybierz lokalizację projektu"
 
 msgid "Please select an organization"
 msgstr "Wybierz organizację"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Spróbuj ponownie lub uruchom ponownie Superset na tym urządzeniu."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Spróbuj zalogować się ponownie z aplikacji desktopowej."
@@ -11083,9 +11086,6 @@ msgstr "Wymagane ponowne połączenie"
 msgid "Reconnecting"
 msgstr "Ponowne łączenie"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Ponowne łączenie z {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Ponowne łączenie…"
 
@@ -11562,6 +11562,9 @@ msgstr "Ponowne uruchamianie agentów na {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Restartowanie usług hosta…"
+
+msgid "Restarting…"
+msgstr "Ponowne uruchamianie…"
 
 msgid "Restore"
 msgstr "Przywróć"
@@ -13199,6 +13202,9 @@ msgstr "Uruchamianie {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Uruchamianie obszaru roboczego w chmurze"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Uruchamianie. To powinno zająć tylko chwilę."
+
 msgid "Starting workspace"
 msgstr "Uruchamianie obszaru roboczego"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Dziękujemy za kontakt"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "To urządzenie jest online, ale nie udało się nawiązać połączenia — zwykle to kwestia routingu przekaźnika, a nie samego urządzenia. Ponów, a jeśli problem się utrzymuje, uruchom ponownie Superset na tamtym urządzeniu."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "To urządzenie nie jest połączone z przekaźnikiem. Sprawdź, czy jest wybudzone, online i czy działa na nim Superset — połączy się samo, gdy tak będzie."
-
 msgid "That handle is taken."
 msgstr "Ten pseudonim jest zajęty."
 
@@ -13891,9 +13891,6 @@ msgstr "Najlepszy agent się zmieni.<0/>Twój workflow nie musi."
 
 msgid "The Codex sign-in"
 msgstr "Logowanie Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Połączenie nie powiodło się (status przekaźnika {status}). Ponów, a jeśli problem się utrzymuje, uruchom ponownie Superset na tamtym urządzeniu."
 
 msgid "The connection timed out"
 msgstr "Przekroczono czas połączenia"
@@ -13997,9 +13994,6 @@ msgstr "Link może być błędny, strona mogła zostać usunięta albo nie masz 
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Powiązany agent nie istnieje lub jest wyłączony. Pokazywana jest migawka."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Lokalna usługa hosta wciąż się uruchamia. Powinna być gotowa za kilka sekund."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Lokalna usługa hosta jest niedostępna dla {organization} na {device}. Status: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Lokalna usługa hosta nie działa, więc nic na tym urządzeniu nie obs�
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Lokalna usługa hosta właśnie wstała. Trwa ponowne łączenie."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Lokalna usługa hosta przestała odpowiadać. Najpierw ponów; jeśli to nie pomoże, zrestartuj ją z menu zasobnika Superset > Usługa hosta > Uruchom ponownie."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Większość scalonych PR-ów od agentów wymaga tylko przeglądu, bez żadnych poprawek człowieka."
@@ -14053,9 +14044,6 @@ msgstr "Ludzie stojący za Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Okres odzyskiwania dobiegł końca. Napisz na support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Przekaźnik nie mógł teraz dosięgnąć tego urządzenia. Zwykle jest to chwilowe — ponowna próba za moment zazwyczaj pomaga."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Zdalna gałąź się rozjechała. Pobierz zmiany przed kontynuowaniem."
@@ -14413,9 +14401,6 @@ msgstr "Zakończy to sesję i jej proces bazowy."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Usunie to z indeksu i cofnie wszystkie zaindeksowane zmiany. Zaindeksowane nowe pliki zostaną usunięte. Tej operacji nie można cofnąć."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Ten obszar roboczy żyje na urządzeniu, którego Superset teraz nie dosięga. Terminale, pliki i agenci pozostają na miejscu — wrócą, gdy tylko wróci połączenie."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Ten obszar roboczy mógł zostać usunięty albo nie masz już do niego dostępu."
 
@@ -14664,6 +14649,9 @@ msgstr "Spróbuj innego wyszukiwania lub innego urządzenia."
 
 msgid "Try again"
 msgstr "Spróbuj ponownie"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Spróbuj ponownie lub uruchom ponownie usługę hosta z menu Superset w zasobniku systemowym."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Spróbuj ponownie. Jeśli problem się powtarza, przeładuj Superset."
@@ -15301,6 +15289,9 @@ msgstr "Nie udało się obciążyć Twojej metody płatności. Zaktualizuj ją, 
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Nie wykryto menedżera pakietów ani konfiguracji środowiska."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Nie udało się połączyć z urządzeniem. Spróbuj ponownie za chwilę."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Nie prognozujemy pełnej autonomii w 2026 ani 2027 roku. Uczciwe niewiadome: czy przegląd wykonywany przez agenta wytrzyma zderzenie ze złośliwą złożonością, czy specyfikacja może zastąpić czytanie kodu jako kotwica zaufania w skali i czy ekonomia mocy obliczeniowej utrzyma nocną zmianę taniej niż ludzie, których wspiera. F5 to pozycja w rubryce, byśmy rozpoznali go, gdy nadejdzie, a nie obietnica."
 
@@ -15312,6 +15303,9 @@ msgstr "Wysłaliśmy link do pobrania na {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Wkrótce się odezwiemy."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Wrócisz do pracy, gdy tylko odzyskamy połączenie."
 
 msgid "We'll get back to you shortly."
 msgstr "Odezwiemy się wkrótce."
@@ -15764,9 +15758,6 @@ msgstr "Tej operacji nie można cofnąć. Panele terminala pokażą „Proces za
 
 msgid "You don't have access to this host"
 msgstr "Nie masz dostępu do tego hosta"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Nie masz dostępu do tego hosta. Jeśli to Twoje urządzenie, włącz tam dostęp przez przekaźnik w Ustawienia > Bezpieczeństwo."
 
 msgid "You don't have access to this terminal."
 msgstr "Nie masz dostępu do tego terminala."

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Conectado. O login foi cancelado, então gatilhos de \"Eu\" não vão co
 msgid "Connecting"
 msgstr "Conectando"
 
+msgid "Connecting to {hostName}…"
+msgstr "Conectando a {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Conectando à área de trabalho…"
 
@@ -4936,6 +4939,9 @@ msgstr "Desconectar o Slack?"
 
 msgid "Disconnected"
 msgstr "Desconectado"
+
+msgid "Disconnected from {hostName}"
+msgstr "Desconectado de {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Desconectando..."
@@ -6820,6 +6826,9 @@ msgstr "O serviço do host travou"
 
 msgid "Host service is not running"
 msgstr "O serviço do host não está em execução"
+
+msgid "Host service is restarting…"
+msgstr "O serviço do host está reiniciando…"
 
 msgid "Host service is starting…"
 msgstr "O serviço do host está iniciando…"
@@ -11073,6 +11082,9 @@ msgstr "Precisa reconectar"
 
 msgid "Reconnecting"
 msgstr "Reconectando"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Reconectando a {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Reconectando…"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Posso usar minhas próprias chaves de API?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Dá para padronizar os tooltips do app inteiro?"
 
+msgid "Can't connect right now"
+msgstr "Não foi possível conectar agora"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Não dá para abrir caminhos de áreas de trabalho remotas em um editor externo"
 
@@ -2842,6 +2845,9 @@ msgstr "Verificar recursos"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Confira o prompt renderizado e a saída de execução antes de salvar"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Confira seu acesso em Configurações > Segurança nesse dispositivo."
 
 msgid "Check your connection and try again"
 msgstr "Verifique sua conexão e tente novamente"
@@ -3562,9 +3568,6 @@ msgstr "Conectado. O login foi cancelado, então gatilhos de \"Eu\" não vão co
 msgid "Connecting"
 msgstr "Conectando"
 
-msgid "Connecting to {hostName}…"
-msgstr "Conectando a {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Conectando à área de trabalho…"
 
@@ -4033,6 +4036,9 @@ msgstr "Não foi possível observar esta página"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Não foi possível confirmar o status da estrela — verifique se a CLI do GitHub (`gh`) está instalada, com login feito, e se você tem conexão"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Não foi possível conectar (erro {status}). Tente novamente."
+
 msgid "Couldn't copy branch name"
 msgstr "Não foi possível copiar o nome da branch"
 
@@ -4096,9 +4102,6 @@ msgstr "Não foi possível publicar a resposta"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Não foi possível acessar a nuvem para {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Não foi possível acessar o serviço de relay. Verifique a conexão de rede desta máquina — o outro dispositivo provavelmente está bem."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Não foi possível ler o contexto deste terminal."
@@ -4939,9 +4942,6 @@ msgstr "Desconectar o Slack?"
 
 msgid "Disconnected"
 msgstr "Desconectado"
-
-msgid "Disconnected from {hostName}"
-msgstr "Desconectado de {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Desconectando..."
@@ -6827,9 +6827,6 @@ msgstr "O serviço do host travou"
 msgid "Host service is not running"
 msgstr "O serviço do host não está em execução"
 
-msgid "Host service is restarting…"
-msgstr "O serviço do host está reiniciando…"
-
 msgid "Host service is starting…"
 msgstr "O serviço do host está iniciando…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host indisponível"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host indisponível: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host inacessível"
 
 msgid "Hosted in the cloud"
 msgstr "Hospedada na nuvem"
@@ -8015,6 +8009,9 @@ msgstr "Tornar padrão"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Tornar padrão — abre novos terminais e agentes nesta conta."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Confira se o dispositivo está ativo, online e com o Superset em execução."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Tornar o estilo de chip o padrão do TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Reproduzir {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Toca um som quando as tarefas terminam"
 
+msgid "Please check your internet connection and try again."
+msgstr "Confira sua conexão com a internet e tente novamente."
+
 msgid "Please enter a project name"
 msgstr "Digite um nome de projeto"
 
@@ -10418,6 +10418,9 @@ msgstr "Selecione um local para o projeto"
 
 msgid "Please select an organization"
 msgstr "Selecione uma organização"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Tente novamente ou reinicie o Superset nesse dispositivo."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Tente entrar de novo pelo app de desktop."
@@ -11083,9 +11086,6 @@ msgstr "Precisa reconectar"
 msgid "Reconnecting"
 msgstr "Reconectando"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Reconectando a {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Reconectando…"
 
@@ -11562,6 +11562,9 @@ msgstr "Reiniciando agentes em {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Reiniciando os serviços do host…"
+
+msgid "Restarting…"
+msgstr "Reiniciando…"
 
 msgid "Restore"
 msgstr "Restaurar"
@@ -13199,6 +13202,9 @@ msgstr "Iniciando {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Iniciando a área de trabalho na nuvem"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Iniciando. Deve levar só um instante."
+
 msgid "Starting workspace"
 msgstr "Iniciando a área de trabalho"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Obrigado pelo contato"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Esse dispositivo está online, mas não foi possível estabelecer a conexão — normalmente é roteamento do relay, não o dispositivo. Tente de novo e, se persistir, reinicie o Superset nesse dispositivo."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Esse dispositivo não está conectado ao relay. Confira se ele está ligado, online e com o Superset rodando — ele reconecta sozinho."
-
 msgid "That handle is taken."
 msgstr "Esse apelido já está em uso."
 
@@ -13891,9 +13891,6 @@ msgstr "O melhor agente vai mudar.<0/>Seu fluxo de trabalho, não."
 
 msgid "The Codex sign-in"
 msgstr "O login do Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "A conexão falhou (status do relay {status}). Tente de novo e, se persistir, reinicie o Superset nesse dispositivo."
 
 msgid "The connection timed out"
 msgstr "O tempo de conexão esgotou"
@@ -13997,9 +13994,6 @@ msgstr "O link pode estar errado, a página pode ter sido excluída ou você pod
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "O agente vinculado está ausente ou desativado. Exibindo o snapshot."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "O serviço do host local ainda está iniciando. Deve ficar pronto em alguns segundos."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "O serviço do host local está indisponível para {organization} em {device}. Status: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "O serviço do host local não está rodando, então nada neste dispositi
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "O serviço do host local acabou de subir. Reconectando a ele agora."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "O serviço do host local parou de responder. Tente de novo primeiro; se não resolver, reinicie pelo menu da bandeja do Superset > Serviço do host > Reiniciar."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "A maioria dos PRs de agentes mesclados precisa só de revisão, sem nenhuma edição humana."
@@ -14053,9 +14044,6 @@ msgstr "As pessoas por trás do Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "O período de recuperação terminou. Escreva para support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "O relay não conseguiu alcançar esse dispositivo agora. Normalmente é temporário — tentar de novo em instantes costuma funcionar."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "A branch remota divergiu. Faça pull antes de continuar."
@@ -14413,9 +14401,6 @@ msgstr "Isso encerra a sessão e o processo por trás dela."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Isso remove do stage e reverte todas as alterações no stage. Arquivos novos no stage serão excluídos. Não dá para desfazer."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Esta área de trabalho está em um dispositivo que o Superset não consegue alcançar agora. Terminais, arquivos e agentes continuam no lugar — eles voltam assim que a conexão voltar."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Esta área de trabalho pode ter sido removida ou você não tem mais acesso a ela."
 
@@ -14664,6 +14649,9 @@ msgstr "Tente outro termo de busca ou outro dispositivo."
 
 msgid "Try again"
 msgstr "Tentar novamente"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Tente novamente ou reinicie o serviço do host pelo menu do Superset na bandeja do sistema."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Tente novamente. Se o problema continuar, recarregue o Superset."
@@ -15301,6 +15289,9 @@ msgstr "Não conseguimos cobrar sua forma de pagamento. Atualize-a para manter e
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Não detectamos um gerenciador de pacotes nem configuração de ambiente."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Não conseguimos alcançar o dispositivo. Tente novamente em instantes."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Não prevemos direção totalmente autônoma em 2026 nem em 2027. As incógnitas honestas: se a revisão feita por agentes aguenta complexidade adversarial, se a especificação pode substituir a leitura de código como âncora de confiança em escala e se a economia de computação mantém o turno da noite mais barato que as pessoas que ele complementa. O F5 é um item da régua para reconhecermos quando acontecer, não uma promessa."
 
@@ -15312,6 +15303,9 @@ msgstr "Enviamos o link de download para {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Entramos em contato em breve."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Você voltará ao seu espaço assim que a conexão for restabelecida."
 
 msgid "We'll get back to you shortly."
 msgstr "Retornamos em breve."
@@ -15764,9 +15758,6 @@ msgstr "Não dá para desfazer. Os painéis de terminal vão mostrar \"Processo 
 
 msgid "You don't have access to this host"
 msgstr "Você não tem acesso a este host"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Você não tem acesso a este host. Se for seu próprio dispositivo, ligue o acesso ao relay nele em Configurações > Segurança."
 
 msgid "You don't have access to this terminal."
 msgstr "Você não tem acesso a este terminal."

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Можно использовать свои ключи API?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Можешь стандартизировать подсказки во всём приложении?"
 
+msgid "Can't connect right now"
+msgstr "Сейчас не удаётся подключиться"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Пути удалённых рабочих областей нельзя открыть во внешнем редакторе"
 
@@ -2842,6 +2845,9 @@ msgstr "Проверить ресурсы"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Проверьте отрендеренный промпт и вывод запуска перед сохранением"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Проверьте свой доступ в разделе «Настройки» > «Безопасность» на этом устройстве."
 
 msgid "Check your connection and try again"
 msgstr "Проверьте соединение и повторите"
@@ -3562,9 +3568,6 @@ msgstr "Подключено. Вход был отменён, поэтому т�
 msgid "Connecting"
 msgstr "Подключение"
 
-msgid "Connecting to {hostName}…"
-msgstr "Подключение к {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Подключение к рабочему столу…"
 
@@ -4033,6 +4036,9 @@ msgstr "Не удалось начать отслеживание этой ст�
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Не удалось проверить статус звезды — убедитесь, что GitHub CLI (`gh`) установлен, выполнен вход и есть подключение к сети"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Не удалось подключиться (ошибка {status}). Попробуйте ещё раз."
+
 msgid "Couldn't copy branch name"
 msgstr "Не удалось скопировать имя ветки"
 
@@ -4096,9 +4102,6 @@ msgstr "Не удалось отправить ответ"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Не удалось связаться с облаком для {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Не удалось связаться со службой реле. Проверьте сетевое подключение этой машины — с другим устройством, скорее всего, всё в порядке."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Не удалось прочитать контекст этого терминала."
@@ -4939,9 +4942,6 @@ msgstr "Отключить Slack?"
 
 msgid "Disconnected"
 msgstr "Отключено"
-
-msgid "Disconnected from {hostName}"
-msgstr "Соединение с {hostName} разорвано"
 
 msgid "Disconnecting..."
 msgstr "Отключение..."
@@ -6827,9 +6827,6 @@ msgstr "Служба хоста аварийно завершилась"
 msgid "Host service is not running"
 msgstr "Служба хоста не запущена"
 
-msgid "Host service is restarting…"
-msgstr "Служба хоста перезапускается…"
-
 msgid "Host service is starting…"
 msgstr "Служба хоста запускается…"
 
@@ -6844,9 +6841,6 @@ msgstr "Хост недоступен"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Хост недоступен: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Хост недоступен"
 
 msgid "Hosted in the cloud"
 msgstr "Размещена в облаке"
@@ -8015,6 +8009,9 @@ msgstr "Сделать основным"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Сделать основным — запускать новые терминалы и агентов на этом аккаунте."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Убедитесь, что устройство не в спящем режиме, подключено к интернету и на нём запущен Superset."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Сделать стиль чипа значением по умолчанию для TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Воспроизвести {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Проигрывать звук по завершении задач"
 
+msgid "Please check your internet connection and try again."
+msgstr "Проверьте подключение к интернету и попробуйте ещё раз."
+
 msgid "Please enter a project name"
 msgstr "Введите название проекта"
 
@@ -10418,6 +10418,9 @@ msgstr "Выберите расположение проекта"
 
 msgid "Please select an organization"
 msgstr "Выберите организацию"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Попробуйте ещё раз или перезапустите Superset на этом устройстве."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Попробуйте войти ещё раз из десктопного приложения."
@@ -11083,9 +11086,6 @@ msgstr "Требуется переподключение"
 msgid "Reconnecting"
 msgstr "Переподключение"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Переподключение к {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Переподключение…"
 
@@ -11562,6 +11562,9 @@ msgstr "Перезапускаем агентов на {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Перезапуск служб хоста…"
+
+msgid "Restarting…"
+msgstr "Перезапуск…"
 
 msgid "Restore"
 msgstr "Восстановить"
@@ -13199,6 +13202,9 @@ msgstr "Запуск {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Запуск облачной рабочей области"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Запускается. Это займёт всего несколько мгновений."
+
 msgid "Starting workspace"
 msgstr "Запуск рабочей области"
 
@@ -13850,12 +13856,6 @@ msgstr "Текстовое поле"
 msgid "Thanks for reaching out"
 msgstr "Спасибо, что написали"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Это устройство в сети, но соединение установить не удалось — обычно дело в маршрутизации реле, а не в самом устройстве. Повторите, а если не помогает — перезапустите Superset на том устройстве."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Это устройство не подключено к реле. Проверьте, что оно включено, в сети и на нём запущен Superset — оно переподключится само."
-
 msgid "That handle is taken."
 msgstr "Этот ник занят."
 
@@ -13891,9 +13891,6 @@ msgstr "Лучший агент будет меняться.<0/>Ваш проц�
 
 msgid "The Codex sign-in"
 msgstr "Вход в Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Соединение не удалось (статус реле {status}). Повторите, а если не помогает — перезапустите Superset на том устройстве."
 
 msgid "The connection timed out"
 msgstr "Истекло время ожидания соединения"
@@ -13997,9 +13994,6 @@ msgstr "Возможно, ссылка неверна, страница удал
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Связанный агент отсутствует или отключён. Показан снимок."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Локальная служба хоста ещё запускается. Через несколько секунд она должна быть готова."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Локальная служба хоста недоступна для {organization} на {device}. Статус: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Локальная служба хоста не запущена, поэ
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Локальная служба хоста только что поднялась. Подключаемся к ней."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Локальная служба хоста перестала отвечать. Сначала повторите; если не поможет, перезапустите её через меню Superset в трее > Host Service > Restart."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Большинству объединённых агентских PR нужно только ревью, без правок человека."
@@ -14053,9 +14044,6 @@ msgstr "Люди, которые делают Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Период восстановления истёк. Напишите на support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Реле сейчас не смогло достучаться до этого устройства. Обычно это временно — повтор через мгновение обычно помогает."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Удалённая ветка разошлась. Получите изменения, прежде чем продолжать."
@@ -14413,9 +14401,6 @@ msgstr "Это завершит сессию и связанный с ней п�
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Это снимет индексацию и откатит все проиндексированные изменения. Проиндексированные новые файлы будут удалены. Отменить нельзя."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Эта рабочая область находится на устройстве, до которого Superset сейчас не может достучаться. Терминалы, файлы и агенты остаются на месте — они вернутся, как только вернётся соединение."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Возможно, эта рабочая область удалена или у вас больше нет к ней доступа."
 
@@ -14664,6 +14649,9 @@ msgstr "Попробуйте другой запрос или другое ус�
 
 msgid "Try again"
 msgstr "Повторить"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Попробуйте ещё раз или перезапустите службу хоста через меню Superset в системном трее."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Повторите. Если проблема сохраняется, перезагрузите Superset."
@@ -15301,6 +15289,9 @@ msgstr "Не удалось списать средства с вашего сп
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Не удалось определить пакетный менеджер или конфигурацию окружения."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Не удалось связаться с устройством. Попробуйте ещё раз через минуту."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Мы не прогнозируем полную автономность в 2026 или 2027 году. Честные неизвестные: выдержит ли ревью агентами враждебную сложность, сможет ли спецификация заменить чтение кода как якорь доверия в масштабе и останется ли ночная смена по экономике вычислений дешевле людей, которых она усиливает. F5 — пункт рубрики, чтобы мы узнали его, когда увидим, а не обещание."
 
@@ -15312,6 +15303,9 @@ msgstr "Мы отправили ссылку на скачивание на {sub
 
 msgid "We'll be in touch shortly."
 msgstr "Скоро свяжемся."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Вы вернётесь к работе, как только связь восстановится."
 
 msgid "We'll get back to you shortly."
 msgstr "Скоро ответим."
@@ -15764,9 +15758,6 @@ msgstr "Это действие нельзя отменить. В панелях
 
 msgid "You don't have access to this host"
 msgstr "У вас нет доступа к этому хосту"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "У вас нет доступа к этому хосту. Если это ваше устройство, включите на нём доступ через реле в Настройки > Безопасность."
 
 msgid "You don't have access to this terminal."
 msgstr "У вас нет доступа к этому терминалу."

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Подключено. Вход был отменён, поэтому т�
 msgid "Connecting"
 msgstr "Подключение"
 
+msgid "Connecting to {hostName}…"
+msgstr "Подключение к {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Подключение к рабочему столу…"
 
@@ -4936,6 +4939,9 @@ msgstr "Отключить Slack?"
 
 msgid "Disconnected"
 msgstr "Отключено"
+
+msgid "Disconnected from {hostName}"
+msgstr "Соединение с {hostName} разорвано"
 
 msgid "Disconnecting..."
 msgstr "Отключение..."
@@ -6820,6 +6826,9 @@ msgstr "Служба хоста аварийно завершилась"
 
 msgid "Host service is not running"
 msgstr "Служба хоста не запущена"
+
+msgid "Host service is restarting…"
+msgstr "Служба хоста перезапускается…"
 
 msgid "Host service is starting…"
 msgstr "Служба хоста запускается…"
@@ -11073,6 +11082,9 @@ msgstr "Требуется переподключение"
 
 msgid "Reconnecting"
 msgstr "Переподключение"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Переподключение к {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Переподключение…"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Bağlandı. Oturum açma iptal edildiği için \"Ben\" tetikleyicileri, 
 msgid "Connecting"
 msgstr "Bağlanılıyor"
 
+msgid "Connecting to {hostName}…"
+msgstr "{hostName} bağlantısı kuruluyor…"
+
 msgid "Connecting to the desktop…"
 msgstr "Masaüstüne bağlanılıyor…"
 
@@ -4936,6 +4939,9 @@ msgstr "Slack bağlantısı kesilsin mi?"
 
 msgid "Disconnected"
 msgstr "Bağlantı kesildi"
+
+msgid "Disconnected from {hostName}"
+msgstr "{hostName} bağlantısı kesildi"
 
 msgid "Disconnecting..."
 msgstr "Bağlantı kesiliyor..."
@@ -6820,6 +6826,9 @@ msgstr "Host hizmeti çöktü"
 
 msgid "Host service is not running"
 msgstr "Host hizmeti çalışmıyor"
+
+msgid "Host service is restarting…"
+msgstr "Host hizmeti yeniden başlatılıyor…"
 
 msgid "Host service is starting…"
 msgstr "Host hizmeti başlatılıyor…"
@@ -11073,6 +11082,9 @@ msgstr "Yeniden bağlanmak gerekiyor"
 
 msgid "Reconnecting"
 msgstr "Yeniden bağlanılıyor"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "{hostName} bağlantısı yeniden kuruluyor…"
 
 msgid "Reconnecting…"
 msgstr "Yeniden bağlanılıyor…"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Kendi API anahtarlarımı kullanabilir miyim?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Uygulama genelindeki tooltip'leri standartlaştırabilir misin?"
 
+msgid "Can't connect right now"
+msgstr "Şu anda bağlanamıyoruz"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Uzak çalışma alanı yolları harici düzenleyicide açılamaz"
 
@@ -2842,6 +2845,9 @@ msgstr "Kaynakları denetle"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Kaydetmeden önce oluşturulan istemi ve başlatma çıktısını kontrol edin"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "O cihazda Ayarlar > Güvenlik bölümünden erişiminizi kontrol edin."
 
 msgid "Check your connection and try again"
 msgstr "Bağlantınızı kontrol edip yeniden deneyin"
@@ -3562,9 +3568,6 @@ msgstr "Bağlandı. Oturum açma iptal edildiği için \"Ben\" tetikleyicileri, 
 msgid "Connecting"
 msgstr "Bağlanılıyor"
 
-msgid "Connecting to {hostName}…"
-msgstr "{hostName} bağlantısı kuruluyor…"
-
 msgid "Connecting to the desktop…"
 msgstr "Masaüstüne bağlanılıyor…"
 
@@ -4033,6 +4036,9 @@ msgstr "Bu sayfa izlenemedi"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Yıldız durumu doğrulanamadı — GitHub CLI'nin (`gh`) kurulu ve oturum açmış olduğunu ve ağ bağlantınızın bulunduğunu kontrol edin"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Bağlanılamadı (hata {status}). Lütfen tekrar deneyin."
+
 msgid "Couldn't copy branch name"
 msgstr "Dal adı kopyalanamadı"
 
@@ -4096,9 +4102,6 @@ msgstr "Yanıt gönderilemedi"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "{0} için buluta erişilemedi: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Röle hizmetine erişilemedi. Bu makinenin ağ bağlantısını kontrol edin — diğer cihazda büyük olasılıkla sorun yok."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Bu terminalin bağlamı okunamadı."
@@ -4939,9 +4942,6 @@ msgstr "Slack bağlantısı kesilsin mi?"
 
 msgid "Disconnected"
 msgstr "Bağlantı kesildi"
-
-msgid "Disconnected from {hostName}"
-msgstr "{hostName} bağlantısı kesildi"
 
 msgid "Disconnecting..."
 msgstr "Bağlantı kesiliyor..."
@@ -6827,9 +6827,6 @@ msgstr "Host hizmeti çöktü"
 msgid "Host service is not running"
 msgstr "Host hizmeti çalışmıyor"
 
-msgid "Host service is restarting…"
-msgstr "Host hizmeti yeniden başlatılıyor…"
-
 msgid "Host service is starting…"
 msgstr "Host hizmeti başlatılıyor…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host kullanılamıyor"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host kullanılamıyor: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Host'a erişilemiyor"
 
 msgid "Hosted in the cloud"
 msgstr "Bulutta barındırılıyor"
@@ -8015,6 +8009,9 @@ msgstr "Varsayılan yap"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Varsayılan yap — yeni terminalleri ve ajanları bu hesapta başlat."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Cihazın uyanık, çevrimiçi ve Superset’in çalışır durumda olduğundan emin olun."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Çip stilini TooltipContent varsayılanı yap"
@@ -10407,6 +10404,9 @@ msgstr "Oynat: {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Görevler tamamlandığında bir ses çal"
 
+msgid "Please check your internet connection and try again."
+msgstr "Lütfen internet bağlantınızı kontrol edip tekrar deneyin."
+
 msgid "Please enter a project name"
 msgstr "Lütfen bir proje adı girin"
 
@@ -10418,6 +10418,9 @@ msgstr "Lütfen bir proje konumu seçin"
 
 msgid "Please select an organization"
 msgstr "Lütfen bir kuruluş seçin"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Lütfen tekrar deneyin veya o cihazda Superset’i yeniden başlatın."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Lütfen masaüstü uygulamasından yeniden oturum açmayı deneyin."
@@ -11083,9 +11086,6 @@ msgstr "Yeniden bağlanmak gerekiyor"
 msgid "Reconnecting"
 msgstr "Yeniden bağlanılıyor"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "{hostName} bağlantısı yeniden kuruluyor…"
-
 msgid "Reconnecting…"
 msgstr "Yeniden bağlanılıyor…"
 
@@ -11562,6 +11562,9 @@ msgstr "Ajanlar {accountLabel} üzerinde yeniden başlatılıyor."
 
 msgid "Restarting host services…"
 msgstr "Host hizmetleri yeniden başlatılıyor…"
+
+msgid "Restarting…"
+msgstr "Yeniden başlatılıyor…"
 
 msgid "Restore"
 msgstr "Geri yükle"
@@ -13199,6 +13202,9 @@ msgstr "{agentLabel} başlatılıyor"
 msgid "Starting cloud workspace"
 msgstr "Bulut çalışma alanı başlatılıyor"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Başlatılıyor. Yalnızca kısa bir süre alacaktır."
+
 msgid "Starting workspace"
 msgstr "Çalışma alanı başlatılıyor"
 
@@ -13850,12 +13856,6 @@ msgstr "Metin alanı"
 msgid "Thanks for reaching out"
 msgstr "Bize ulaştığınız için teşekkürler"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "O cihaz çevrimiçi ancak bağlantı kurulamadı — bu genellikle cihazdan değil, röle yönlendirmesinden kaynaklanır. Yeniden deneyin; sorun sürerse o cihazda Superset'i yeniden başlatın."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "O cihaz röleye bağlı değil. Uyanık, çevrimiçi ve Superset çalışır durumda olduğunu kontrol edin — olduğunda kendiliğinden yeniden bağlanır."
-
 msgid "That handle is taken."
 msgstr "Bu kullanıcı adı alınmış."
 
@@ -13891,9 +13891,6 @@ msgstr "En iyi ajan değişecek.<0/>İş akışınız değişmemeli."
 
 msgid "The Codex sign-in"
 msgstr "Codex oturumu"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Bağlantı başarısız oldu (röle durumu {status}). Yeniden deneyin; sorun sürerse o cihazda Superset'i yeniden başlatın."
 
 msgid "The connection timed out"
 msgstr "Bağlantı zaman aşımına uğradı"
@@ -13997,9 +13994,6 @@ msgstr "Bağlantı yanlış olabilir, sayfa silinmiş olabilir ya da erişiminiz
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Bağlı ajan eksik veya devre dışı. Anlık görüntü gösteriliyor."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Yerel host hizmeti hâlâ başlatılıyor. Birkaç saniye içinde hazır olmalı."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "{device} üzerinde {organization} için yerel host hizmeti kullanılamıyor. Durum: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Yerel host hizmeti çalışmıyor, bu yüzden bu cihazda hiçbir şey ç
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Yerel host hizmeti yeni açıldı. Şimdi ona yeniden bağlanılıyor."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Yerel host hizmeti yanıt vermeyi bıraktı. Önce yeniden deneyin; işe yaramazsa Superset tepsi menüsünde Host hizmeti > Yeniden başlat yolundan yeniden başlatın."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Birleştirilen ajan PR'larının çoğu yalnızca inceleme gerektirir, hiç insan düzenlemesi olmaz."
@@ -14053,9 +14044,6 @@ msgstr "Superset'in arkasındaki insanlar."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Kurtarma süresi sona erdi. support@superset.sh adresine yazın."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Röle şu anda o cihaza ulaşamadı. Bu genellikle geçicidir — birazdan yeniden denemek çoğunlukla işe yarar."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Uzak dal ayrıştı. Devam etmeden önce pull yapın."
@@ -14413,9 +14401,6 @@ msgstr "Bu işlem oturumu ve altındaki süreci sonlandırır."
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Bu işlem, hazırlanmış tüm değişiklikleri hazırlıktan çıkarır ve geri alır. Hazırlanmış yeni dosyalar silinir. Bu geri alınamaz."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Bu çalışma alanı, Superset'in şu anda erişemediği bir cihazda bulunuyor. Terminaller, dosyalar ve ajanlar yerinde kalır — bağlantı geri geldiğinde onlar da geri gelir."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Bu çalışma alanı kaldırılmış olabilir ya da artık erişiminiz olmayabilir."
 
@@ -14664,6 +14649,9 @@ msgstr "Farklı bir arama terimi veya başka bir cihaz deneyin."
 
 msgid "Try again"
 msgstr "Yeniden dene"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Tekrar deneyin veya sistem tepsisindeki Superset menüsünden ana makine hizmetini yeniden başlatın."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Yeniden deneyin. Sorun sürerse Superset'i yeniden yükleyin."
@@ -15301,6 +15289,9 @@ msgstr "Ödeme yönteminizden tahsilat yapamadık. Bu planı sürdürmek için g
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Bir paket yöneticisi veya ortam yapılandırması bulamadık."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Cihaza ulaşamadık. Lütfen birazdan tekrar deneyin."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "2026 veya 2027'de tam otonomi öngörmüyoruz. Dürüst bilinmezler şunlar: ajan incelemesinin düşmanca karmaşıklık karşısında dayanıp dayanmayacağı, spesifikasyonun ölçekte kod okumanın yerini güven çıpası olarak alıp alamayacağı ve işlem ekonomisinin gece vardiyasını desteklediği insanlardan ucuz tutup tutmayacağı. F5, gördüğümüzde tanıyabilelim diye bir değerlendirme maddesidir, bir vaat değil."
 
@@ -15312,6 +15303,9 @@ msgstr "İndirme bağlantısını {submittedEmail} adresine gönderdik."
 
 msgid "We'll be in touch shortly."
 msgstr "Kısa süre içinde sizinle iletişime geçeceğiz."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Bağlantı yeniden kurulur kurulmaz kaldığınız yere döneceksiniz."
 
 msgid "We'll get back to you shortly."
 msgstr "Kısa süre içinde size döneceğiz."
@@ -15764,9 +15758,6 @@ msgstr "Bu işlemi geri alamazsınız. Terminal bölmelerinde \"Process exited\"
 
 msgid "You don't have access to this host"
 msgstr "Bu host'a erişiminiz yok"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Bu host'a erişiminiz yok. Kendi cihazınızsa orada Ayarlar > Güvenlik bölümünden röle erişimini açın."
 
 msgid "You don't have access to this terminal."
 msgstr "Bu terminale erişiminiz yok."

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -3562,6 +3562,9 @@ msgstr "Đã kết nối. Việc đăng nhập bị hủy nên các trigger theo
 msgid "Connecting"
 msgstr "Đang kết nối"
 
+msgid "Connecting to {hostName}…"
+msgstr "Đang kết nối tới {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "Đang kết nối tới màn hình nền…"
 
@@ -4936,6 +4939,9 @@ msgstr "Ngắt kết nối Slack?"
 
 msgid "Disconnected"
 msgstr "Đã ngắt kết nối"
+
+msgid "Disconnected from {hostName}"
+msgstr "Đã ngắt kết nối khỏi {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Đang ngắt kết nối..."
@@ -6820,6 +6826,9 @@ msgstr "Dịch vụ host đã crash"
 
 msgid "Host service is not running"
 msgstr "Dịch vụ host không chạy"
+
+msgid "Host service is restarting…"
+msgstr "Dịch vụ host đang khởi động lại…"
 
 msgid "Host service is starting…"
 msgstr "Dịch vụ host đang khởi động…"
@@ -11073,6 +11082,9 @@ msgstr "Cần kết nối lại"
 
 msgid "Reconnecting"
 msgstr "Đang kết nối lại"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "Đang kết nối lại tới {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "Đang kết nối lại…"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -2649,6 +2649,9 @@ msgstr "Tôi có thể dùng khóa API của mình không?"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "Bạn chuẩn hóa tooltip trên toàn ứng dụng được không?"
 
+msgid "Can't connect right now"
+msgstr "Chưa thể kết nối lúc này"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "Không thể mở đường dẫn workspace từ xa trong trình soạn thảo ngoài"
 
@@ -2842,6 +2845,9 @@ msgstr "Kiểm tra tài nguyên"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "Kiểm tra prompt đã dựng và kết quả khởi chạy trước khi lưu"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "Kiểm tra quyền truy cập của bạn trong Cài đặt > Bảo mật trên thiết bị đó."
 
 msgid "Check your connection and try again"
 msgstr "Kiểm tra kết nối và thử lại"
@@ -3562,9 +3568,6 @@ msgstr "Đã kết nối. Việc đăng nhập bị hủy nên các trigger theo
 msgid "Connecting"
 msgstr "Đang kết nối"
 
-msgid "Connecting to {hostName}…"
-msgstr "Đang kết nối tới {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "Đang kết nối tới màn hình nền…"
 
@@ -4033,6 +4036,9 @@ msgstr "Không thể theo dõi trang này"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "Không xác nhận được trạng thái sao — hãy kiểm tra GitHub CLI (`gh`) đã cài, đã đăng nhập và bạn có kết nối mạng"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "Không thể kết nối (lỗi {status}). Vui lòng thử lại."
+
 msgid "Couldn't copy branch name"
 msgstr "Không thể sao chép tên nhánh"
 
@@ -4096,9 +4102,6 @@ msgstr "Không thể đăng trả lời"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "Không kết nối được tới cloud cho {0}: {1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "Không kết nối được tới dịch vụ relay. Hãy kiểm tra kết nối mạng của máy này — thiết bị kia có lẽ vẫn ổn."
 
 msgid "Couldn't read this terminal's context."
 msgstr "Không đọc được ngữ cảnh của terminal này."
@@ -4939,9 +4942,6 @@ msgstr "Ngắt kết nối Slack?"
 
 msgid "Disconnected"
 msgstr "Đã ngắt kết nối"
-
-msgid "Disconnected from {hostName}"
-msgstr "Đã ngắt kết nối khỏi {hostName}"
 
 msgid "Disconnecting..."
 msgstr "Đang ngắt kết nối..."
@@ -6827,9 +6827,6 @@ msgstr "Dịch vụ host đã crash"
 msgid "Host service is not running"
 msgstr "Dịch vụ host không chạy"
 
-msgid "Host service is restarting…"
-msgstr "Dịch vụ host đang khởi động lại…"
-
 msgid "Host service is starting…"
 msgstr "Dịch vụ host đang khởi động…"
 
@@ -6844,9 +6841,6 @@ msgstr "Host không khả dụng"
 
 msgid "Host unavailable: {hostName}"
 msgstr "Host không khả dụng: {hostName}"
-
-msgid "Host unreachable"
-msgstr "Không kết nối được host"
 
 msgid "Hosted in the cloud"
 msgstr "Chạy trên cloud"
@@ -8015,6 +8009,9 @@ msgstr "Đặt làm mặc định"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "Đặt làm mặc định — mở terminal và agent mới trên tài khoản này."
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "Đảm bảo thiết bị không ở chế độ ngủ, có kết nối mạng và đang chạy Superset."
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "Đặt kiểu chip làm mặc định cho TooltipContent"
@@ -10407,6 +10404,9 @@ msgstr "Phát {label}"
 msgid "Play a sound when tasks complete"
 msgstr "Phát âm thanh khi tác vụ hoàn tất"
 
+msgid "Please check your internet connection and try again."
+msgstr "Vui lòng kiểm tra kết nối internet rồi thử lại."
+
 msgid "Please enter a project name"
 msgstr "Vui lòng nhập tên dự án"
 
@@ -10418,6 +10418,9 @@ msgstr "Vui lòng chọn vị trí dự án"
 
 msgid "Please select an organization"
 msgstr "Vui lòng chọn một tổ chức"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "Vui lòng thử lại hoặc khởi động lại Superset trên thiết bị đó."
 
 msgid "Please try signing in again from the desktop app."
 msgstr "Vui lòng thử đăng nhập lại từ ứng dụng máy tính."
@@ -11083,9 +11086,6 @@ msgstr "Cần kết nối lại"
 msgid "Reconnecting"
 msgstr "Đang kết nối lại"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "Đang kết nối lại tới {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "Đang kết nối lại…"
 
@@ -11562,6 +11562,9 @@ msgstr "Đang khởi động lại các agent trên {accountLabel}."
 
 msgid "Restarting host services…"
 msgstr "Đang khởi động lại dịch vụ host…"
+
+msgid "Restarting…"
+msgstr "Đang khởi động lại…"
 
 msgid "Restore"
 msgstr "Khôi phục"
@@ -13199,6 +13202,9 @@ msgstr "Đang khởi động {agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "Đang khởi động workspace trên cloud"
 
+msgid "Starting up. This should only take a moment."
+msgstr "Đang khởi động. Sẽ chỉ mất một lát."
+
 msgid "Starting workspace"
 msgstr "Đang khởi động workspace"
 
@@ -13850,12 +13856,6 @@ msgstr "Textarea"
 msgid "Thanks for reaching out"
 msgstr "Cảm ơn bạn đã liên hệ"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "Thiết bị đó đang trực tuyến nhưng không thiết lập được kết nối — thường là do định tuyến relay chứ không phải bản thân thiết bị. Hãy thử lại, và nếu vẫn vậy thì khởi động lại Superset trên thiết bị đó."
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "Thiết bị đó chưa kết nối tới relay. Hãy kiểm tra máy đã bật, có mạng và đang chạy Superset — nó sẽ tự kết nối lại khi sẵn sàng."
-
 msgid "That handle is taken."
 msgstr "Tên định danh đó đã có người dùng."
 
@@ -13891,9 +13891,6 @@ msgstr "Agent tốt nhất sẽ thay đổi.<0/>Quy trình của bạn thì khô
 
 msgid "The Codex sign-in"
 msgstr "Lần đăng nhập Codex"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "Kết nối thất bại (trạng thái relay {status}). Hãy thử lại, và nếu vẫn vậy thì khởi động lại Superset trên thiết bị đó."
 
 msgid "The connection timed out"
 msgstr "Kết nối đã quá thời gian"
@@ -13997,9 +13994,6 @@ msgstr "Liên kết có thể sai, trang có thể đã bị xóa, hoặc bạn 
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "Agent được liên kết không còn hoặc đã bị tắt. Đang hiện bản lưu tạm."
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "Dịch vụ host cục bộ vẫn đang khởi động. Sẽ sẵn sàng trong vài giây."
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "Dịch vụ host cục bộ không khả dụng cho {organization} trên {device}. Trạng thái: {status}. {recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "Dịch vụ host cục bộ không chạy nên không có gì trên thi�
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "Dịch vụ host cục bộ vừa khởi động. Đang kết nối lại tới nó."
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "Dịch vụ host cục bộ đã ngừng phản hồi. Hãy thử lại trước; nếu không được, khởi động lại từ menu khay Superset > Dịch vụ host > Khởi động lại."
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "Phần lớn PR của agent được merge chỉ cần review, không có chỉnh sửa của con người."
@@ -14053,9 +14044,6 @@ msgstr "Những người đứng sau Superset."
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "Thời hạn khôi phục đã kết thúc. Hãy liên hệ support@superset.sh."
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "Hiện relay không kết nối được tới thiết bị đó. Việc này thường chỉ tạm thời — thử lại sau giây lát là được."
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "Nhánh remote đã rẽ nhánh khác. Hãy pull trước khi tiếp tục."
@@ -14413,9 +14401,6 @@ msgstr "Thao tác này sẽ kết thúc phiên và tiến trình bên dưới n�
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "Thao tác này sẽ bỏ stage và hoàn nguyên toàn bộ thay đổi đã stage. Các tệp mới đã stage sẽ bị xóa. Không thể hoàn tác."
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "Workspace này nằm trên một thiết bị mà Superset hiện không kết nối được. Terminal, tệp và agent vẫn nguyên đó — chúng trở lại ngay khi có kết nối."
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "Workspace này có thể đã bị gỡ, hoặc bạn không còn quyền truy cập."
 
@@ -14664,6 +14649,9 @@ msgstr "Hãy thử từ khóa khác hoặc thiết bị khác."
 
 msgid "Try again"
 msgstr "Thử lại"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "Thử lại hoặc khởi động lại dịch vụ máy chủ từ menu Superset ở khay hệ thống."
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "Hãy thử lại. Nếu vẫn lỗi, tải lại Superset."
@@ -15301,6 +15289,9 @@ msgstr "Chúng tôi không thể trừ tiền từ phương thức thanh toán c
 msgid "We couldn't detect a package manager or environment config."
 msgstr "Chúng tôi không phát hiện được trình quản lý gói hay cấu hình môi trường."
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "Không thể kết nối với thiết bị. Vui lòng thử lại sau giây lát."
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "Chúng tôi không dự báo tự vận hành hoàn toàn vào năm 2026 hay 2027. Những ẩn số thành thật: liệu agent review có trụ được trước độ phức tạp đối kháng hay không, liệu đặc tả có thay được việc đọc code làm chỗ dựa niềm tin ở quy mô lớn hay không, và liệu kinh tế điện toán có giữ cho ca đêm rẻ hơn những con người mà nó hỗ trợ hay không. F5 là một mục trong thang chấm để ta nhận ra khi nó xảy ra, không phải một lời hứa."
 
@@ -15312,6 +15303,9 @@ msgstr "Chúng tôi đã gửi liên kết tải tới {submittedEmail}."
 
 msgid "We'll be in touch shortly."
 msgstr "Chúng tôi sẽ liên hệ sớm."
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "Bạn sẽ quay lại ngay khi kết nối được khôi phục."
 
 msgid "We'll get back to you shortly."
 msgstr "Chúng tôi sẽ phản hồi sớm."
@@ -15764,9 +15758,6 @@ msgstr "Không thể hoàn tác thao tác này. Các khung terminal sẽ hiện 
 
 msgid "You don't have access to this host"
 msgstr "Bạn không có quyền truy cập host này"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "Bạn không có quyền truy cập host này. Nếu đó là thiết bị của bạn, hãy bật truy cập relay ở đó trong Cài đặt > Bảo mật."
 
 msgid "You don't have access to this terminal."
 msgstr "Bạn không có quyền truy cập terminal này."

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -15305,7 +15305,7 @@ msgid "We'll be in touch shortly."
 msgstr "我们会尽快与你联系。"
 
 msgid "We'll bring you back as soon as we reconnect."
-msgstr "连接恢复后，你就能回到工作区。"
+msgstr "连接恢复后，我们会立即带你回到工作区。"
 
 msgid "We'll get back to you shortly."
 msgstr "我们会尽快回复你。"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -3562,6 +3562,9 @@ msgstr "已连接。登录被取消，因此在你重新连接之前，按“我
 msgid "Connecting"
 msgstr "连接中"
 
+msgid "Connecting to {hostName}…"
+msgstr "正在连接到 {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "正在连接桌面…"
 
@@ -4936,6 +4939,9 @@ msgstr "断开Slack连接？"
 
 msgid "Disconnected"
 msgstr "已断开"
+
+msgid "Disconnected from {hostName}"
+msgstr "已与 {hostName} 断开连接"
 
 msgid "Disconnecting..."
 msgstr "正在断开连接..."
@@ -6820,6 +6826,9 @@ msgstr "主机服务已崩溃"
 
 msgid "Host service is not running"
 msgstr "主机服务未运行"
+
+msgid "Host service is restarting…"
+msgstr "主机服务正在重启…"
 
 msgid "Host service is starting…"
 msgstr "主机服务正在启动…"
@@ -11073,6 +11082,9 @@ msgstr "需要重新连接"
 
 msgid "Reconnecting"
 msgstr "正在重新连接"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "正在重新连接到 {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "正在重新连接…"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -2649,6 +2649,9 @@ msgstr "我可以用自己的API密钥吗？"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "能把整个应用的tooltip样式统一一下吗？"
 
+msgid "Can't connect right now"
+msgstr "暂时无法连接"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "无法在外部编辑器中打开远程工作区路径"
 
@@ -2842,6 +2845,9 @@ msgstr "查看资源"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "保存前检查渲染后的提示词和启动输出"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "请在该设备的“设置 > 安全”中检查你的访问权限。"
 
 msgid "Check your connection and try again"
 msgstr "请检查网络连接后重试"
@@ -3562,9 +3568,6 @@ msgstr "已连接。登录被取消，因此在你重新连接之前，按“我
 msgid "Connecting"
 msgstr "连接中"
 
-msgid "Connecting to {hostName}…"
-msgstr "正在连接到 {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "正在连接桌面…"
 
@@ -4033,6 +4036,9 @@ msgstr "无法关注此页面"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "无法确认加星状态，请检查是否已安装并登录GitHub CLI（`gh`），以及网络是否连通"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "无法连接（错误 {status}）。请重试。"
+
 msgid "Couldn't copy branch name"
 msgstr "无法复制分支名"
 
@@ -4096,9 +4102,6 @@ msgstr "无法发布回复"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "无法为{0}连接云端：{1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "无法连接到中继服务。请检查本机的网络连接 — 另一台设备很可能没有问题。"
 
 msgid "Couldn't read this terminal's context."
 msgstr "无法读取该终端的上下文。"
@@ -4939,9 +4942,6 @@ msgstr "断开Slack连接？"
 
 msgid "Disconnected"
 msgstr "已断开"
-
-msgid "Disconnected from {hostName}"
-msgstr "已与 {hostName} 断开连接"
 
 msgid "Disconnecting..."
 msgstr "正在断开连接..."
@@ -6827,9 +6827,6 @@ msgstr "主机服务已崩溃"
 msgid "Host service is not running"
 msgstr "主机服务未运行"
 
-msgid "Host service is restarting…"
-msgstr "主机服务正在重启…"
-
 msgid "Host service is starting…"
 msgstr "主机服务正在启动…"
 
@@ -6844,9 +6841,6 @@ msgstr "主机不可用"
 
 msgid "Host unavailable: {hostName}"
 msgstr "主机不可用：{hostName}"
-
-msgid "Host unreachable"
-msgstr "主机无法连接"
 
 msgid "Hosted in the cloud"
 msgstr "托管在云端"
@@ -8015,6 +8009,9 @@ msgstr "设为默认"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "设为默认——新终端和智能体将使用此账户启动。"
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "请确认设备未休眠、已联网且正在运行 Superset。"
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "把chip样式设为TooltipContent的默认样式"
@@ -10407,6 +10404,9 @@ msgstr "播放{label}"
 msgid "Play a sound when tasks complete"
 msgstr "任务完成时播放声音"
 
+msgid "Please check your internet connection and try again."
+msgstr "请检查网络连接后重试。"
+
 msgid "Please enter a project name"
 msgstr "请输入项目名称"
 
@@ -10418,6 +10418,9 @@ msgstr "请选择项目位置"
 
 msgid "Please select an organization"
 msgstr "请选择一个组织"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "请重试，或在该设备上重启 Superset。"
 
 msgid "Please try signing in again from the desktop app."
 msgstr "请从桌面应用重新登录。"
@@ -11083,9 +11086,6 @@ msgstr "需要重新连接"
 msgid "Reconnecting"
 msgstr "正在重新连接"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "正在重新连接到 {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "正在重新连接…"
 
@@ -11562,6 +11562,9 @@ msgstr "正在{accountLabel}上重新启动智能体。"
 
 msgid "Restarting host services…"
 msgstr "正在重启主机服务…"
+
+msgid "Restarting…"
+msgstr "正在重启…"
 
 msgid "Restore"
 msgstr "恢复"
@@ -13199,6 +13202,9 @@ msgstr "正在启动{agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "正在启动云端工作区"
 
+msgid "Starting up. This should only take a moment."
+msgstr "正在启动，请稍等片刻。"
+
 msgid "Starting workspace"
 msgstr "正在启动工作区"
 
@@ -13850,12 +13856,6 @@ msgstr "多行文本框"
 msgid "Thanks for reaching out"
 msgstr "感谢联系"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "该设备在线，但无法建立连接 — 通常是中继路由问题，而非设备本身。请重试；若持续如此，请在该设备上重启Superset。"
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "该设备未连接到中继。请检查它是否已唤醒、联网并正在运行Superset — 一旦就绪它会自行重新连接。"
-
 msgid "That handle is taken."
 msgstr "该用户名已被占用。"
 
@@ -13891,9 +13891,6 @@ msgstr "最好的智能体会变。<0/>你的工作流不该变。"
 
 msgid "The Codex sign-in"
 msgstr "Codex登录"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "连接失败（中继状态{status}）。请重试；若持续如此，请在该设备上重启Superset。"
 
 msgid "The connection timed out"
 msgstr "连接已超时"
@@ -13997,9 +13994,6 @@ msgstr "链接可能有误、页面可能已被删除，或者你没有访问权
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "关联的智能体已丢失或被禁用。正在显示快照。"
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "本地主机服务仍在启动中。应该在几秒内就绪。"
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "{device}上{organization}的本地主机服务不可用。状态：{status}。{recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "本地主机服务未运行，因此此设备上没有任何服务能提
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "本地主机服务刚刚启动。正在重新连接。"
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "本地主机服务已停止响应。请先重试；若无效，请从Superset托盘菜单 > 主机服务 > 重启中重启它。"
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "多数已合并的智能体PR只需审查，无需任何人工修改。"
@@ -14053,9 +14044,6 @@ msgstr "Superset背后的团队。"
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "恢复期已结束。请联系support@superset.sh。"
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "中继此刻无法连上该设备。这通常是暂时的 — 稍后重试一般就能成功。"
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "远程分支已分叉。请先拉取再继续。"
@@ -14413,9 +14401,6 @@ msgstr "这将终止该会话及其底层进程。"
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "这将取消暂存并还原所有已暂存的更改。已暂存的新文件将被删除。此操作无法撤销。"
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "此工作区位于Superset当前无法连接的设备上。终端、文件和智能体都会保持原样 — 连接一恢复它们就会回来。"
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "此工作区可能已被移除，或者你不再拥有它的访问权限。"
 
@@ -14664,6 +14649,9 @@ msgstr "试试其他搜索词或其他设备。"
 
 msgid "Try again"
 msgstr "重试"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "请重试，或从 Superset 托盘菜单重启主机服务。"
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "请重试。如果问题持续，请重新加载Superset。"
@@ -15301,6 +15289,9 @@ msgstr "我们无法从你的支付方式扣款。请更新支付方式以保留
 msgid "We couldn't detect a package manager or environment config."
 msgstr "我们没有检测到包管理器或环境配置。"
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "暂时无法连接到设备，请稍后重试。"
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "我们不预测2026或2027年实现完全自动驾驶。诚实地讲，未知数有三个：智能体审查能否扛住对抗性的复杂度；规格说明能否在大规模场景下取代读代码，成为信任的锚点；以及算力成本能否让夜班始终比它所增强的人力更便宜。F5写进评分表，是为了在它出现时能认出来，而不是一个承诺。"
 
@@ -15312,6 +15303,9 @@ msgstr "下载链接已发送至{submittedEmail}。"
 
 msgid "We'll be in touch shortly."
 msgstr "我们会尽快与你联系。"
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "连接恢复后，你就能回到工作区。"
 
 msgid "We'll get back to you shortly."
 msgstr "我们会尽快回复你。"
@@ -15764,9 +15758,6 @@ msgstr "此操作无法撤销。终端窗格会显示“进程已退出”，之
 
 msgid "You don't have access to this host"
 msgstr "你没有此主机的访问权限"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "你没有此主机的访问权限。如果这是你自己的设备，请在该设备的设置 > 安全中开启中继访问。"
 
 msgid "You don't have access to this terminal."
 msgstr "你没有此终端的访问权限。"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -15305,7 +15305,7 @@ msgid "We'll be in touch shortly."
 msgstr "我們會盡快與你聯絡。"
 
 msgid "We'll bring you back as soon as we reconnect."
-msgstr "連線恢復後，你就能回到工作區。"
+msgstr "連線恢復後，我們會立即帶你回到工作區。"
 
 msgid "We'll get back to you shortly."
 msgstr "我們會盡快回復你。"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -2649,6 +2649,9 @@ msgstr "我可以用自己的API金鑰嗎？"
 msgid "Can you standardize the tooltips across the app?"
 msgstr "能把整個應用的tooltip樣式統一一下嗎？"
 
+msgid "Can't connect right now"
+msgstr "目前無法連線"
+
 msgid "Can't open remote workspace paths in an external editor"
 msgstr "無法在外部編輯器中開啟遠端工作區路徑"
 
@@ -2842,6 +2845,9 @@ msgstr "檢視資源"
 
 msgid "Check the rendered prompt and launch output before saving"
 msgstr "儲存前檢查渲染後的提示詞和啟動輸出"
+
+msgid "Check your access under Settings > Security on that device."
+msgstr "請在該裝置的「設定 > 安全性」中檢查你的存取權限。"
 
 msgid "Check your connection and try again"
 msgstr "請檢查網路連線後重試"
@@ -3562,9 +3568,6 @@ msgstr "已連線。登入被取消，因此在你重新連線之前，按「我
 msgid "Connecting"
 msgstr "連線中"
 
-msgid "Connecting to {hostName}…"
-msgstr "正在連線到 {hostName}…"
-
 msgid "Connecting to the desktop…"
 msgstr "正在連線至桌面…"
 
@@ -4033,6 +4036,9 @@ msgstr "無法關注此頁面"
 msgid "Couldn't confirm star status — check that the GitHub CLI (`gh`) is installed, signed in, and that you have a network connection"
 msgstr "無法確認加星狀態，請檢查是否已安裝並登入GitHub CLI（`gh`），以及網路是否連通"
 
+msgid "Couldn't connect (error {status}). Please try again."
+msgstr "無法連線（錯誤 {status}）。請重試。"
+
 msgid "Couldn't copy branch name"
 msgstr "無法複製分支名"
 
@@ -4096,9 +4102,6 @@ msgstr "無法釋出回覆"
 #. placeholder {1}: first.message
 msgid "Couldn't reach cloud for {0}: {1}"
 msgstr "無法為{0}連線雲端：{1}"
-
-msgid "Couldn't reach the relay service. Check this machine's network connection — the other device is probably fine."
-msgstr "無法連線到中繼服務。請檢查本機的網路連線 — 另一臺裝置很可能沒有問題。"
 
 msgid "Couldn't read this terminal's context."
 msgstr "無法讀取這個終端的上下文。"
@@ -4939,9 +4942,6 @@ msgstr "斷開Slack連線？"
 
 msgid "Disconnected"
 msgstr "已斷開"
-
-msgid "Disconnected from {hostName}"
-msgstr "已與 {hostName} 中斷連線"
 
 msgid "Disconnecting..."
 msgstr "正在斷開連線..."
@@ -6827,9 +6827,6 @@ msgstr "主機服務已崩潰"
 msgid "Host service is not running"
 msgstr "主機服務未執行"
 
-msgid "Host service is restarting…"
-msgstr "主機服務正在重新啟動…"
-
 msgid "Host service is starting…"
 msgstr "主機服務正在啟動…"
 
@@ -6844,9 +6841,6 @@ msgstr "主機不可用"
 
 msgid "Host unavailable: {hostName}"
 msgstr "主機不可用：{hostName}"
-
-msgid "Host unreachable"
-msgstr "主機無法連線"
 
 msgid "Hosted in the cloud"
 msgstr "託管在雲端"
@@ -8015,6 +8009,9 @@ msgstr "設為預設"
 
 msgid "Make default — launch new terminals and agents on this account."
 msgstr "設為預設——新終端和代理程式將使用此帳戶啟動。"
+
+msgid "Make sure the device is awake, online, and running Superset."
+msgstr "請確認裝置未進入睡眠模式、已連上網路且正在執行 Superset。"
 
 msgid "Make the chip style the TooltipContent default"
 msgstr "把chip樣式設為TooltipContent的預設樣式"
@@ -10407,6 +10404,9 @@ msgstr "播放{label}"
 msgid "Play a sound when tasks complete"
 msgstr "任務完成時播放聲音"
 
+msgid "Please check your internet connection and try again."
+msgstr "請檢查網路連線後重試。"
+
 msgid "Please enter a project name"
 msgstr "請輸入專案名稱"
 
@@ -10418,6 +10418,9 @@ msgstr "請選擇專案位置"
 
 msgid "Please select an organization"
 msgstr "請選擇一個組織"
+
+msgid "Please try again, or restart Superset on that device."
+msgstr "請重試，或在該裝置上重新啟動 Superset。"
 
 msgid "Please try signing in again from the desktop app."
 msgstr "請從桌面應用程式重新登入。"
@@ -11083,9 +11086,6 @@ msgstr "需要重新連線"
 msgid "Reconnecting"
 msgstr "正在重新連線"
 
-msgid "Reconnecting to {hostName}…"
-msgstr "正在重新連線到 {hostName}…"
-
 msgid "Reconnecting…"
 msgstr "正在重新連線…"
 
@@ -11562,6 +11562,9 @@ msgstr "正在{accountLabel}上重新啟動代理程式。"
 
 msgid "Restarting host services…"
 msgstr "正在重啟主機服務…"
+
+msgid "Restarting…"
+msgstr "正在重新啟動…"
 
 msgid "Restore"
 msgstr "恢復"
@@ -13199,6 +13202,9 @@ msgstr "正在啟動{agentLabel}"
 msgid "Starting cloud workspace"
 msgstr "正在啟動雲端工作區"
 
+msgid "Starting up. This should only take a moment."
+msgstr "正在啟動，請稍等片刻。"
+
 msgid "Starting workspace"
 msgstr "正在啟動工作區"
 
@@ -13850,12 +13856,6 @@ msgstr "多行文字框"
 msgid "Thanks for reaching out"
 msgstr "感謝聯絡"
 
-msgid "That device is online but the connection couldn't be established — usually relay routing rather than the device itself. Retry, and if it persists restart Superset on that device."
-msgstr "該裝置線上，但無法建立連線 — 通常是中繼路由問題，而非裝置本身。請重試；若持續如此，請在該裝置上重啟Superset。"
-
-msgid "That device isn't connected to the relay. Check it's awake, online, and running Superset — it reconnects on its own once it is."
-msgstr "該裝置未連線到中繼。請檢查它是否已喚醒、聯網並正在執行Superset — 一旦就緒它會自行重新連線。"
-
 msgid "That handle is taken."
 msgstr "該使用者名稱已被佔用。"
 
@@ -13891,9 +13891,6 @@ msgstr "最好的代理程式會變。<0/>你的工作流不該變。"
 
 msgid "The Codex sign-in"
 msgstr "Codex登入"
-
-msgid "The connection failed (relay status {status}). Retry, and if it persists restart Superset on that device."
-msgstr "連線失敗（中繼狀態{status}）。請重試；若持續如此，請在該裝置上重啟Superset。"
 
 msgid "The connection timed out"
 msgstr "連線已逾時"
@@ -13997,9 +13994,6 @@ msgstr "連結可能有誤、頁面可能已被刪除，或者你沒有存取權
 msgid "The linked agent is missing or disabled. Showing the snapshot."
 msgstr "關聯的代理程式已丟失或被停用。正在顯示快照。"
 
-msgid "The local host service is still starting up. It should be ready in a few seconds."
-msgstr "本地主機服務仍在啟動中。應該在幾秒內就緒。"
-
 msgid "The local host service is unavailable for {organization} on {device}. Status: {status}. {recovery}"
 msgstr "{device}上{organization}的本地主機服務不可用。狀態：{status}。{recovery}"
 
@@ -14011,9 +14005,6 @@ msgstr "本地主機服務未執行，因此此裝置上沒有任何服務能提
 
 msgid "The local host service just came up. Reconnecting to it now."
 msgstr "本地主機服務剛剛啟動。正在重新連線。"
-
-msgid "The local host service stopped answering. Retry first; if that doesn't take, restart it from the Superset tray menu > Host Service > Restart."
-msgstr "本地主機服務已停止響應。請先重試；若無效，請從Superset托盤選單 > 主機服務 > 重啟中重啟它。"
 
 msgid "The majority of merged agent PRs need review only, with zero human edits."
 msgstr "多數已合併的代理程式PR只需審查，無需任何人工修改。"
@@ -14053,9 +14044,6 @@ msgstr "Superset背後的團隊。"
 
 msgid "The recovery period has ended. Contact support@superset.sh."
 msgstr "恢復期已結束。請聯絡support@superset.sh。"
-
-msgid "The relay couldn't reach that device right now. This is usually temporary — retrying in a moment normally works."
-msgstr "中繼此刻無法連上該裝置。這通常是暫時的 — 稍後重試一般就能成功。"
 
 msgid "The remote branch has diverged. Pull before continuing."
 msgstr "遠端分支已分叉。請先拉取再繼續。"
@@ -14413,9 +14401,6 @@ msgstr "這將終止該會話及其底層處理程序。"
 msgid "This will unstage and revert all staged changes. Staged new files will be deleted. This cannot be undone."
 msgstr "這將取消暫存並還原所有已暫存的更改。已暫存的新檔案將被刪除。此操作無法復原。"
 
-msgid "This workspace lives on a device Superset can't reach right now. Terminals, files, and agents stay put — they come back as soon as the connection does."
-msgstr "此工作區位於Superset目前無法連線的裝置上。終端、檔案和代理程式都會保持原樣 — 連線一恢復它們就會回來。"
-
 msgid "This workspace may have been removed, or you no longer have access to it."
 msgstr "此工作區可能已被移除，或者你不再擁有它的存取權限。"
 
@@ -14664,6 +14649,9 @@ msgstr "試試其他搜尋詞或其他裝置。"
 
 msgid "Try again"
 msgstr "重試"
+
+msgid "Try again, or restart the host service from the Superset tray menu."
+msgstr "請重試，或從 Superset 系統匣選單重新啟動主機服務。"
 
 msgid "Try again. If the problem continues, reload Superset."
 msgstr "請重試。如果問題持續，請重新載入Superset。"
@@ -15301,6 +15289,9 @@ msgstr "我們無法從你的支付方式扣款。請更新支付方式以保留
 msgid "We couldn't detect a package manager or environment config."
 msgstr "我們沒有檢測到包管理器或環境配置。"
 
+msgid "We couldn't reach the device. Please try again in a moment."
+msgstr "暫時無法連上裝置，請稍後重試。"
+
 msgid "We do not forecast full self-driving in 2026 or 2027. The honest unknowns: whether agent review holds up against adversarial complexity, whether specification can replace code reading as the trust anchor at scale, and whether compute economics keep the overnight shift cheaper than the humans it augments. F5 is a rubric entry so we recognize it when we see it, not a promise."
 msgstr "我們不預測2026或2027年實現完全自動駕駛。誠實地講，未知數有三個：代理程式審查能否扛住對抗性的複雜度；規格說明能否在大規模場景下取代讀程式碼，成為信任的錨點；以及算力成本能否讓夜班始終比它所增強的人力更便宜。F5寫進評分表，是為了在它出現時能認出來，而不是一個承諾。"
 
@@ -15312,6 +15303,9 @@ msgstr "下載連結已傳送至{submittedEmail}。"
 
 msgid "We'll be in touch shortly."
 msgstr "我們會盡快與你聯絡。"
+
+msgid "We'll bring you back as soon as we reconnect."
+msgstr "連線恢復後，你就能回到工作區。"
 
 msgid "We'll get back to you shortly."
 msgstr "我們會盡快回復你。"
@@ -15764,9 +15758,6 @@ msgstr "此操作無法復原。終端窗格會顯示「處理程序已退出」
 
 msgid "You don't have access to this host"
 msgstr "你沒有此主機的存取權限"
-
-msgid "You don't have access to this host. If it's your own device, turn on relay access there under Settings > Security."
-msgstr "你沒有此主機的存取權限。如果這是你自己的裝置，請在該裝置的設定 > 安全中開啟中繼存取。"
 
 msgid "You don't have access to this terminal."
 msgstr "你沒有此終端的存取權限。"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -3562,6 +3562,9 @@ msgstr "已連線。登入被取消，因此在你重新連線之前，按「我
 msgid "Connecting"
 msgstr "連線中"
 
+msgid "Connecting to {hostName}…"
+msgstr "正在連線到 {hostName}…"
+
 msgid "Connecting to the desktop…"
 msgstr "正在連線至桌面…"
 
@@ -4936,6 +4939,9 @@ msgstr "斷開Slack連線？"
 
 msgid "Disconnected"
 msgstr "已斷開"
+
+msgid "Disconnected from {hostName}"
+msgstr "已與 {hostName} 中斷連線"
 
 msgid "Disconnecting..."
 msgstr "正在斷開連線..."
@@ -6820,6 +6826,9 @@ msgstr "主機服務已崩潰"
 
 msgid "Host service is not running"
 msgstr "主機服務未執行"
+
+msgid "Host service is restarting…"
+msgstr "主機服務正在重新啟動…"
 
 msgid "Host service is starting…"
 msgstr "主機服務正在啟動…"
@@ -11073,6 +11082,9 @@ msgstr "需要重新連線"
 
 msgid "Reconnecting"
 msgstr "正在重新連線"
+
+msgid "Reconnecting to {hostName}…"
+msgstr "正在重新連線到 {hostName}…"
 
 msgid "Reconnecting…"
 msgstr "正在重新連線…"

--- a/packages/workspace-client/src/lib/eventBus.test.ts
+++ b/packages/workspace-client/src/lib/eventBus.test.ts
@@ -250,6 +250,32 @@ describe("eventBus", () => {
 		expect(host.clientCount()).toBe(0);
 	});
 
+	it("a handle minted before its connection was torn down binds to the live connection, not the dead one", async () => {
+		const host = makeHostServer();
+		// Minted with no hold yet — a WorkspaceHostGate's useMemo during the
+		// render that switches workspaces, while the outgoing tree still holds
+		// the connection.
+		const early = getEventBus(host.hostUrl, () => "tok");
+		const outgoing = getEventBus(host.hostUrl, () => "tok");
+		const release = outgoing.on("git:changed", "*", () => {});
+		cleanups.push(() => host.server.stop(true));
+		await waitFor(() => host.clientCount() === 1);
+
+		// The outgoing tree's cleanup runs before the incoming tree's effects
+		// and is the last hold: the connection closes and leaves the registry.
+		release();
+		await waitFor(() => host.clientCount() === 0);
+
+		// The incoming gate now takes its hold through the early handle. Bound
+		// to the dead entry, it would sit on a socket that never dials again
+		// and report "closed" for as long as it stayed mounted.
+		cleanups.push(early.retain());
+		cleanups.push(early.subscribeConnectionStatus(() => {}));
+		await waitFor(() => early.getConnectionStatus().state === "open");
+		expect(host.clientCount()).toBe(1);
+		expect(host.upgrades.length).toBe(2);
+	});
+
 	it("a git:watch the host rejects for its cap is re-sent by the next watchGit", async () => {
 		const host = makeHostServer();
 		const bus = getEventBus(host.hostUrl, () => "tok");

--- a/packages/workspace-client/src/lib/eventBus.test.ts
+++ b/packages/workspace-client/src/lib/eventBus.test.ts
@@ -172,6 +172,34 @@ describe("eventBus", () => {
 		expect(bus.getConnectionStatus().state).toBe("open");
 	});
 
+	it("caps automatic retry backoff so a recovered host is reached promptly", async () => {
+		const attempts: number[] = [];
+		const server = Bun.serve({
+			port: 0,
+			fetch(request, instance) {
+				attempts.push(Date.now());
+				// Enough failures to grow past five seconds without the cap.
+				if (attempts.length < 9)
+					return new Response("offline", { status: 503 });
+				if (instance.upgrade(request)) return;
+				return new Response("no", { status: 400 });
+			},
+			websocket: { message() {} },
+		});
+		const bus = getEventBus(`http://127.0.0.1:${server.port}`, () => "tok");
+		cleanups.push(bus.retain());
+		cleanups.push(() => server.stop(true));
+		await waitFor(() => bus.getConnectionStatus().state === "open", 30_000);
+		expect(attempts).toHaveLength(9);
+		const previousAttempt = attempts[7];
+		const finalAttempt = attempts[8];
+		if (previousAttempt === undefined || finalAttempt === undefined) {
+			throw new Error("Expected nine connection attempts");
+		}
+		// Allow scheduler jitter, but reject the uncapped 6.27s ninth dial.
+		expect(finalAttempt - previousAttempt).toBeLessThan(5_750);
+	}, 35_000);
+
 	it("closes the connection when the last listener unsubscribes", async () => {
 		const host = makeHostServer();
 		const bus = getEventBus(host.hostUrl, () => "tok");

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -158,7 +158,10 @@ interface ListenerEntry {
 }
 
 const RECONNECT_BASE_MS = 1_000;
-const RECONNECT_MAX_MS = 30_000;
+// Keep recovery responsive without a second timer forcing reconnect(). A
+// forced retry can abort a healthy relay handshake, which may take up to
+// DIAL_TIMEOUT_MS. Backoff runs only after an attempt finishes or fails.
+const RECONNECT_MAX_MS = 5_000;
 // Definitive access denial (preflight 403): the relay will keep saying no, so
 // exponential 1-30s retries just hammer it. Poll slowly instead of stopping
 // outright so access granted later (host sharing) is picked up eventually.

--- a/packages/workspace-client/src/lib/eventBus.ts
+++ b/packages/workspace-client/src/lib/eventBus.ts
@@ -539,7 +539,17 @@ export function getEventBus(
 	 */
 	getUrlParams?: () => Record<string, string> | null,
 ): EventBusHandle {
-	const state = getOrCreateConnection(hostUrl, getWsToken, getUrlParams);
+	// Resolve the connection per call, never once at creation. A handle is
+	// typically minted during render (a useMemo) and only takes its hold in an
+	// effect; when the connection's last holder releases in between — the
+	// outgoing tree of a workspace switch cleaning up in the same commit — the
+	// entry minted against is closed and gone from the registry. A handle
+	// bound to it would pin its caller to a socket that never dials again and
+	// report "closed" for as long as it stayed mounted, behind a workspace
+	// whose other subscribers were already live on a fresh connection.
+	const live = () => getOrCreateConnection(hostUrl, getWsToken, getUrlParams);
+	// Release paths must not mint a connection nobody will ever hold.
+	const peek = () => connections.get(hostUrl);
 
 	return {
 		on<T extends EventType>(
@@ -552,6 +562,7 @@ export function getEventBus(
 				workspaceId,
 				callback: listener as (...args: unknown[]) => void,
 			};
+			const state = live();
 			state.listeners.add(entry);
 
 			return () => {
@@ -561,6 +572,7 @@ export function getEventBus(
 		},
 
 		watchFs(workspaceId: string): void {
+			const state = live();
 			const count = state.fsWatchedWorkspaces.get(workspaceId) ?? 0;
 			state.fsWatchedWorkspaces.set(workspaceId, count + 1);
 			if (count === 0) {
@@ -569,17 +581,13 @@ export function getEventBus(
 		},
 
 		unwatchFs(workspaceId: string): void {
+			const state = peek();
+			if (!state) return;
 			const count = state.fsWatchedWorkspaces.get(workspaceId) ?? 0;
 			if (count <= 1) {
 				state.fsWatchedWorkspaces.delete(workspaceId);
 				sendCommand(state, { type: "fs:unwatch", workspaceId });
-				// getEventBus() above always creates the connection if it didn't
-				// already exist — a caller that only ever intends to release
-				// interest (a cleanup effect running after this connection's
-				// last retainer already tore it down) would otherwise mint a
-				// fresh, unretained, unlistened-to connection here and leave it
-				// dangling forever, since nothing else will ever call this again
-				// for it. Mirrors on()'s and retain()'s cleanup.
+				// Mirrors on()'s and retain()'s cleanup: a watch is a hold too.
 				maybeCleanupConnection(hostUrl);
 			} else {
 				state.fsWatchedWorkspaces.set(workspaceId, count - 1);
@@ -587,6 +595,7 @@ export function getEventBus(
 		},
 
 		watchGit(workspaceId: string): void {
+			const state = live();
 			const count = state.gitWatchedWorkspaces.get(workspaceId) ?? 0;
 			state.gitWatchedWorkspaces.set(workspaceId, count + 1);
 			if (count === 0) {
@@ -595,12 +604,12 @@ export function getEventBus(
 		},
 
 		unwatchGit(workspaceId: string): void {
+			const state = peek();
+			if (!state) return;
 			const count = state.gitWatchedWorkspaces.get(workspaceId) ?? 0;
 			if (count <= 1) {
 				state.gitWatchedWorkspaces.delete(workspaceId);
 				sendCommand(state, { type: "git:unwatch", workspaceId });
-				// See unwatchFs's comment: a release-only call can otherwise mint
-				// and permanently strand a fresh, never-retained connection.
 				maybeCleanupConnection(hostUrl);
 			} else {
 				state.gitWatchedWorkspaces.set(workspaceId, count - 1);
@@ -608,6 +617,7 @@ export function getEventBus(
 		},
 
 		watchFsFile(workspaceId: string, absolutePath: string): void {
+			const state = live();
 			const key = fileWatchKey(workspaceId, absolutePath);
 			const count = state.fsWatchedFiles.get(key) ?? 0;
 			state.fsWatchedFiles.set(key, count + 1);
@@ -621,6 +631,8 @@ export function getEventBus(
 		},
 
 		unwatchFsFile(workspaceId: string, absolutePath: string): void {
+			const state = peek();
+			if (!state) return;
 			const key = fileWatchKey(workspaceId, absolutePath);
 			const count = state.fsWatchedFiles.get(key) ?? 0;
 			if (count <= 1) {
@@ -630,8 +642,6 @@ export function getEventBus(
 					workspaceId,
 					absolutePath,
 				});
-				// See unwatchFs's comment: a release-only call can otherwise mint
-				// and permanently strand a fresh, never-retained connection.
 				maybeCleanupConnection(hostUrl);
 			} else {
 				state.fsWatchedFiles.set(key, count - 1);
@@ -643,6 +653,7 @@ export function getEventBus(
 		 * Returns a release function.
 		 */
 		retain(): () => void {
+			const state = live();
 			state.refCount++;
 			return () => {
 				state.refCount = Math.max(0, state.refCount - 1);
@@ -651,10 +662,11 @@ export function getEventBus(
 		},
 
 		getConnectionStatus(): HostConnectionStatus {
-			return state.status;
+			return live().status;
 		},
 
 		subscribeConnectionStatus(listener: ConnectionStatusListener): () => void {
+			const state = live();
 			state.statusListeners.add(listener);
 			return () => {
 				state.statusListeners.delete(listener);
@@ -663,6 +675,7 @@ export function getEventBus(
 		},
 
 		reconnect(): void {
+			const state = live();
 			// The synthetic close partysocket dispatches lands first, so publish
 			// "connecting" after it — otherwise the retry reads as a fresh failure.
 			state.socket.reconnect(1000, "manual reconnect");


### PR DESCRIPTION
Host restarts could leave a “Host unreachable” screen over a workspace that was already connected. Event-bus handles now follow the live connection, so the screen clears when the host comes back.

Brief outages show a small status pill after 2 seconds. Longer outages show a translucent overlay after 10 seconds, or 30 seconds during a local restart; access-denied errors appear immediately. The overlay says “Can't connect right now” with a short reassurance and recovery step. All new copy is translated into the 16 supported non-English locales.

Automatic retries use the socket's own backoff, capped at 5 seconds. The gate no longer forces reconnects on a timer: that timer repeatedly cancelled slow but valid handshakes. Manual Retry and endpoint/credential refreshes still reconnect immediately, and access-denied polling keeps its existing slower cadence.

Validation: the new React hook regression connects through an 8-second handshake on its first attempt; it failed before the fix. A second regression verifies recovery after repeated failures with at most 5 seconds of backoff, and also failed before the fix. All 29 workspace-client tests, the hook regression, desktop and workspace-client typechecks, Biome, and the plugin check pass. Catalog compilation and all 119 i18n tests passed with the copy update. Earlier CDP checks covered short outages and sustained crashes; the retry fix also passed built-app checks described below.

Built-app verification: the production-compiled desktop recovered from a host restart in 2.50 seconds. With an injected 8-second WebSocket handshake delay, both restart and workspace-switch-during-restart completed the handshake without interruption; the status pill cleared 151–183 ms after socket open, with the terminal still mounted and no takeover or uncaught renderer exception recorded. This used an isolated Electron profile and local backend, not the deployed production relay. Timestamped socket/UI logs and screenshots are retained in this worktree under `.superset/verification/`.

The CI handshake-test failure was traced to a process-global fake relay socket left behind by another test. The follow-up restores that mock and preserves native event classes across DOM setup; the paired 31-test run now passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a non-blocking connection banner with host details, reconnecting/restarting states, and a Retry action.
  - Workspace panes remain usable during brief connection interruptions.
  - Added localized connection, recovery, retry, and restart guidance.

- **Bug Fixes**
  - Existing event subscriptions now recover after connections close.
  - Prevented stale connections during workspace operations.
  - Reconnection attempts recover within a shorter maximum retry interval.
  - Full-screen connection errors now appear only after sustained outages.
  - Shortened connection and host-service status messages for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->