### PR TITLE
feat(marketing): add a Content-Security-Policy header to superset.sh

### DIFF
--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -12,6 +12,82 @@ if (process.env.NODE_ENV !== "production") {
 	});
 }
 
+const isProduction = process.env.NODE_ENV === "production";
+// The leaderboard/fight/stats pages call the API from the browser
+// (leaderboardClient). Hard-coded prod fallback so the header stays correct
+// even if NEXT_PUBLIC_API_URL isn't in the build env.
+const apiOrigin = process.env.NEXT_PUBLIC_API_URL
+	? new URL(process.env.NEXT_PUBLIC_API_URL).origin
+	: isProduction
+		? "https://api.superset.sh"
+		: null;
+
+// Third parties this site actually loads (probed against production):
+// - Google Ads gtag + Reddit pixel, injected in [lang]/layout.tsx
+// - Cloudflare Web Analytics, injected at the edge by the Cloudflare proxy
+// - Work at a Startup job board (+ its hCaptcha) on /join-us
+// - PostHog goes through the same-origin /ingest rewrite; ui_host is listed
+//   so the toolbar can still connect.
+// - Sentry browser SDK reports to *.ingest.sentry.io
+const googleAdsScripts = [
+	"https://www.googletagmanager.com",
+	"https://www.googleadservices.com",
+	"https://googleads.g.doubleclick.net",
+	"https://www.google.com",
+];
+const hcaptcha = ["https://hcaptcha.com", "https://*.hcaptcha.com"];
+
+const contentSecurityPolicy = [
+	"default-src 'self'",
+	"base-uri 'self'",
+	[
+		"connect-src 'self'",
+		apiOrigin,
+		"https://*.ingest.sentry.io",
+		"https://*.sentry.io",
+		"https://us.posthog.com",
+		"https://cloudflareinsights.com",
+		"https://www.google.com",
+		"https://www.googleadservices.com",
+		"https://googleads.g.doubleclick.net",
+		"https://ad.doubleclick.net",
+		"https://alb.reddit.com",
+		"https://www.workatastartup.com",
+		...hcaptcha,
+		!isProduction && "ws:",
+		!isProduction && "wss:",
+	]
+		.filter(Boolean)
+		.join(" "),
+	"font-src 'self' data: https://fonts.gstatic.com https://www.workatastartup.com",
+	"form-action 'self'",
+	"frame-ancestors 'none'",
+	[
+		"frame-src",
+		"https://td.doubleclick.net",
+		"https://www.googletagmanager.com",
+		...hcaptcha,
+	].join(" "),
+	"img-src 'self' data: blob: https:",
+	"object-src 'none'",
+	[
+		"script-src 'self' 'unsafe-inline'",
+		...googleAdsScripts,
+		"https://www.redditstatic.com",
+		"https://static.cloudflareinsights.com",
+		"https://www.workatastartup.com",
+		...hcaptcha,
+		!isProduction && "'unsafe-eval'",
+	]
+		.filter(Boolean)
+		.join(" "),
+	[
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+		...hcaptcha,
+	].join(" "),
+	"worker-src 'self' blob:",
+].join("; ");
+
 const config: NextConfig = {
 	reactStrictMode: true,
 	reactCompiler: true,
@@ -98,6 +174,7 @@ const config: NextConfig = {
 			{
 				source: "/(.*)",
 				headers: [
+					{ key: "Content-Security-Policy", value: contentSecurityPolicy },
 					{ key: "X-Content-Type-Options", value: "nosniff" },
 					{ key: "X-Frame-Options", value: "DENY" },
 					{


### PR DESCRIPTION
## Why

superset.sh sends HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy and Permissions-Policy, but no Content-Security-Policy. It is the one header every scanner and vendor questionnaire flags, and it is what a cold "security observation" email to founders@ was about today.

## What

Adds a CSP to the marketing app, following the shape of the web app's policy. The allowlist comes from what production actually loads, probed over CDP across `/`, `/join-us`, `/leaderboard`, `/blog`, `/changelog`, `/community`, `/fight`, `/stats`:

- Google Ads gtag and the Reddit pixel from `[lang]/layout.tsx`
- Cloudflare Web Analytics, injected at the edge by the Cloudflare proxy
- Work at a Startup job board on `/join-us`, plus hCaptcha (per hCaptcha's CSP docs; the apply flow was not exercised)
- `api.superset.sh` for the leaderboard client, with a prod fallback when `NEXT_PUBLIC_API_URL` is missing from the build env
- PostHog through the same-origin `/ingest` rewrite; Sentry ingest
- `img-src https:` for avatars (unavatar, dicebear) and blog images; videos are same-origin
- `frame-ancestors 'none'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`

`'unsafe-inline'` stays in `script-src` because Next inlines its bootstrap and the gtag/pixel snippets are inline; a nonce-based policy is a follow-up.

## Verification

- Enforced on a local dev server: all eight pages above load with zero CSP violations in the console, and injecting a script from a disallowed origin is reported, so the probe can fail.
- Cloudflare Web Analytics only appears behind the Cloudflare proxy, so its allowance is verified by the production origin list, not enforcement.

https://claude.ai/code/session_01PtLQ1FQPbnYHFcThP3NWMy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Content-Security-Policy header to `superset.sh`, the one missing from the marketing site's security headers. The policy mirrors the web app's and is built from an allowlist of third-party resources probed across all production pages.

**Notes**
- `'unsafe-inline'` stays in `script-src` for Next's bootstrap; a nonce-based policy is a follow-up.
- Cloudflare Web Analytics allowance is from the production origin list, as it only appears behind the proxy.

<sup>Written for commit da1ed7589d1e5484f42549a053e675660a671375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added Content Security Policy headers across marketing site routes.
  * Configured trusted connections for required third-party services.
  * Applied stricter security directives in production while retaining development compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->