### PR TITLE
fix(marketing): resolve search indexing and localized rendering issues

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -37,6 +37,11 @@ const config = {
 			},
 			// Old top-level entry points from the previous docs structure (were 404ing).
 			{
+				source: "/guides/workspace-management",
+				destination: "/workspaces",
+				permanent: true,
+			},
+			{
 				source: "/getting-started",
 				destination: "/overview",
 				permanent: true,

--- a/apps/docs/src/app/robots.ts
+++ b/apps/docs/src/app/robots.ts
@@ -7,7 +7,9 @@ export default function robots(): MetadataRoute.Robots {
 			{
 				userAgent: "*",
 				allow: "/",
-				disallow: ["/api/", "/_next/", "/llms.mdx/", "/llms-full.txt"],
+				// Rendering assets must be crawlable. Raw markdown routes carry
+				// noindex headers, which crawlers need to fetch to observe.
+				disallow: ["/api/"],
 			},
 		],
 		sitemap: `${COMPANY.DOCS_URL}/sitemap.xml`,

--- a/apps/marketing/next.config.ts
+++ b/apps/marketing/next.config.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { SUPPORTED_LOCALES } from "@superset/i18n/locales";
 import { config as dotenvConfig } from "dotenv";
 import type { NextConfig } from "next";
 
@@ -131,6 +132,18 @@ const config: NextConfig = {
 		const docsUrl =
 			process.env.NEXT_PUBLIC_DOCS_URL || "https://docs.superset.sh";
 		return [
+			// These URLs were advertised before discovery files were excluded
+			// from locale expansion. Keep existing inbound links working.
+			{
+				source: `/:lang(${SUPPORTED_LOCALES.join("|")})/llms.txt`,
+				destination: "/llms.txt",
+				permanent: true,
+			},
+			{
+				source: "/opengraph-image",
+				destination: "/og-image.png",
+				permanent: true,
+			},
 			{
 				source: "/about",
 				destination: "/team",

--- a/apps/marketing/src/app/[lang]/agent-orchestration/page.tsx
+++ b/apps/marketing/src/app/[lang]/agent-orchestration/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
 	const url = localeUrl(lang, `/${SLUG}`);
 
 	return {
-		title: `${page.title} | ${COMPANY.NAME}`,
+		title: page.title,
 		description: page.description,
 		...(page.keywords.length > 0 && { keywords: page.keywords }),
 		alternates: localizedAlternates(lang, `/${SLUG}`),

--- a/apps/marketing/src/app/[lang]/blog/page.tsx
+++ b/apps/marketing/src/app/[lang]/blog/page.tsx
@@ -35,13 +35,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | Superset`,
 			description: description,
 			url: localeUrl(lang, "/blog"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | Superset`,
 			description: description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/changelog/page.tsx
+++ b/apps/marketing/src/app/[lang]/changelog/page.tsx
@@ -38,13 +38,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | Superset`,
 			description: description,
 			url: localeUrl(lang, "/changelog"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | Superset`,
 			description: description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/compare/[slug]/page.tsx
+++ b/apps/marketing/src/app/[lang]/compare/[slug]/page.tsx
@@ -101,7 +101,7 @@ export async function generateMetadata({
 	const url = localeUrl(lang, `/compare/${slug}`);
 
 	return {
-		title: `${page.title} | ${COMPANY.NAME}`,
+		title: page.title,
 		description: page.description,
 		...(page.keywords.length > 0 && { keywords: page.keywords }),
 		alternates: localizedAlternates(lang, `/compare/${slug}`),

--- a/apps/marketing/src/app/[lang]/compare/page.tsx
+++ b/apps/marketing/src/app/[lang]/compare/page.tsx
@@ -34,13 +34,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | Superset`,
 			description: description,
 			url: localeUrl(lang, "/compare"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | Superset`,
 			description: description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/components/AchievementMedal/AchievementMedal.tsx
+++ b/apps/marketing/src/app/[lang]/components/AchievementMedal/AchievementMedal.tsx
@@ -23,7 +23,7 @@ export function AchievementMedal({
 	tier,
 	awardedOn,
 }: AchievementMedalProps) {
-	const { t } = useLingui();
+	const { t, i18n } = useLingui();
 	const def = CATALOG_BY_SLUG[slug];
 	const copy = ACHIEVEMENT_COPY[slug];
 	if (!def?.art || !copy) return null;
@@ -78,12 +78,16 @@ export function AchievementMedal({
 				<p className="font-mono text-[0.56rem] uppercase tracking-[0.09em] text-muted-foreground/60 mt-2.5 border-t border-border pt-2">
 					<Trans>
 						Earned{" "}
-						{formatDate(new Date(`${awardedOn}T00:00:00Z`), {
-							day: "numeric",
-							month: "short",
-							year: "numeric",
-							timeZone: "UTC",
-						})}
+						{formatDate(
+							new Date(`${awardedOn}T00:00:00Z`),
+							{
+								day: "numeric",
+								month: "short",
+								year: "numeric",
+								timeZone: "UTC",
+							},
+							i18n.locale,
+						)}
 					</Trans>
 				</p>
 			</HoverCardContent>

--- a/apps/marketing/src/app/[lang]/components/ContributionGraph/ContributionGraph.tsx
+++ b/apps/marketing/src/app/[lang]/components/ContributionGraph/ContributionGraph.tsx
@@ -17,16 +17,24 @@ const LEVEL_ALPHA = [0.06, 0.28, 0.5, 0.72, 1];
 
 const WEEKDAY_SAMPLES = ["2024-01-01", "2024-01-03", "2024-01-05"] as const;
 
-const weekdayRows = () =>
+const weekdayRows = (locale: string) =>
 	WEEKDAY_SAMPLES.map((day) => ({
-		label: formatDate(new Date(`${day}T00:00:00Z`), {
-			weekday: "short",
-			timeZone: "UTC",
-		}),
+		label: formatDate(
+			new Date(`${day}T00:00:00Z`),
+			{
+				weekday: "short",
+				timeZone: "UTC",
+			},
+			locale,
+		),
 		offset: CELL + GAP,
 	}));
 
-function monthLabel(weeks: CalendarCell[][], index: number): string {
+function monthLabel(
+	weeks: CalendarCell[][],
+	index: number,
+	locale: string,
+): string {
 	const first = weeks[index]?.[0];
 	if (!first) return "";
 
@@ -34,10 +42,14 @@ function monthLabel(weeks: CalendarCell[][], index: number): string {
 	const previous = weeks[index - 1]?.[0]?.day.slice(0, 7);
 	if (month === previous) return "";
 
-	return formatDate(new Date(`${first.day}T00:00:00Z`), {
-		month: "short",
-		timeZone: "UTC",
-	});
+	return formatDate(
+		new Date(`${first.day}T00:00:00Z`),
+		{
+			month: "short",
+			timeZone: "UTC",
+		},
+		locale,
+	);
 }
 
 interface ContributionGraphProps {
@@ -51,7 +63,7 @@ export function ContributionGraph({
 	endDay,
 	rgb,
 }: ContributionGraphProps) {
-	const { t } = useLingui();
+	const { t, i18n } = useLingui();
 	const [active, setActive] = useState<CalendarCell | null>(null);
 	const calendar = buildCalendar(daily, endDay);
 
@@ -87,7 +99,7 @@ export function ContributionGraph({
 						className="flex flex-col shrink-0 pr-1"
 						style={{ gap: GAP, marginTop: CELL + GAP }}
 					>
-						{weekdayRows().map((row) => (
+						{weekdayRows(i18n.locale).map((row) => (
 							<span
 								key={row.label}
 								className="font-mono text-[0.55rem] uppercase tracking-[0.08em] text-muted-foreground/50 leading-none"
@@ -109,7 +121,7 @@ export function ContributionGraph({
 									className="font-mono text-[0.55rem] uppercase tracking-[0.08em] text-muted-foreground/50 leading-none whitespace-nowrap"
 									style={{ height: CELL }}
 								>
-									{monthLabel(calendar.weeks, index)}
+									{monthLabel(calendar.weeks, index, i18n.locale)}
 								</span>
 								{week.map((cell) =>
 									cell.inRange ? (
@@ -153,6 +165,7 @@ export function ContributionGraph({
 								year: "numeric",
 								timeZone: "UTC",
 							},
+							i18n.locale,
 						)}`
 					) : (
 						<Trans>

--- a/apps/marketing/src/app/[lang]/components/TierObjectives/TierObjectives.tsx
+++ b/apps/marketing/src/app/[lang]/components/TierObjectives/TierObjectives.tsx
@@ -21,7 +21,7 @@ interface TierObjectivesProps {
 }
 
 export function TierObjectives({ tier, axes }: TierObjectivesProps) {
-	const { t } = useLingui();
+	const { t, i18n } = useLingui();
 	const unranked = tier <= 0;
 	const gaps = unranked ? [rankingGap(axes)] : scoredGaps(axes, tier as Tier);
 	const atTop = tier >= 4;
@@ -32,6 +32,8 @@ export function TierObjectives({ tier, axes }: TierObjectivesProps) {
 
 	const laggingLabels = formatList(
 		laggingGaps(gaps, 2).map((gap) => t(AXIS_LABELS[gap.axis]).toLowerCase()),
+		undefined,
+		i18n.locale,
 	);
 
 	return (

--- a/apps/marketing/src/app/[lang]/download/components/DownloadInterstitial/DownloadInterstitial.tsx
+++ b/apps/marketing/src/app/[lang]/download/components/DownloadInterstitial/DownloadInterstitial.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { formatNumber } from "@superset/i18n/format";
 import { DOWNLOAD_URL_MAC_X64 } from "@superset/shared/constants";
 import { useEffect, useRef } from "react";
@@ -47,6 +47,7 @@ interface DownloadInterstitialProps {
 export function DownloadInterstitial({
 	latestRelease,
 }: DownloadInterstitialProps) {
+	const { i18n } = useLingui();
 	const { platform, archSource } = usePlatform();
 	const firedRef = useRef(false);
 
@@ -177,9 +178,13 @@ export function DownloadInterstitial({
 							<Trans>Size</Trans>
 						</dt>
 						<dd className="text-foreground">
-							{formatNumber(asset.sizeBytes / BYTES_PER_MB, {
-								maximumFractionDigits: 0,
-							})}
+							{formatNumber(
+								asset.sizeBytes / BYTES_PER_MB,
+								{
+									maximumFractionDigits: 0,
+								},
+								i18n.locale,
+							)}
 							{" MB"}
 						</dd>
 					</div>
@@ -188,7 +193,7 @@ export function DownloadInterstitial({
 							<Trans>Published</Trans>
 						</dt>
 						<dd className="text-foreground">
-							{formatReleaseDate(latestRelease.publishedAt)}
+							{formatReleaseDate(latestRelease.publishedAt, i18n.locale)}
 						</dd>
 					</div>
 				</dl>

--- a/apps/marketing/src/app/[lang]/download/components/ReleaseList/ReleaseList.tsx
+++ b/apps/marketing/src/app/[lang]/download/components/ReleaseList/ReleaseList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { formatNumber } from "@superset/i18n/format";
 import { COMPANY } from "@superset/shared/constants";
 import { FaApple, FaLinux, FaWindows } from "react-icons/fa";
@@ -33,9 +33,9 @@ const PLATFORM_GRID_CLASS: Record<number, string> = {
 	3: "md:grid-cols-3",
 };
 
-function formatSize(sizeBytes: number): string {
+function formatSize(sizeBytes: number, locale: string): string {
 	// Unit symbol is not translated; the number is
-	return `${formatNumber(sizeBytes / BYTES_PER_MB, { maximumFractionDigits: 0 })} MB`;
+	return `${formatNumber(sizeBytes / BYTES_PER_MB, { maximumFractionDigits: 0 }, locale)} MB`;
 }
 
 interface ReleaseListProps {
@@ -43,6 +43,7 @@ interface ReleaseListProps {
 }
 
 export function ReleaseList({ releases }: ReleaseListProps) {
+	const { i18n } = useLingui();
 	if (releases.length === 0) {
 		// The catalog is best-effort: if GitHub is unreachable the page still has
 		// the platform-aware button above, so point at the source instead of
@@ -86,7 +87,7 @@ export function ReleaseList({ releases }: ReleaseListProps) {
 									</span>
 								) : null}
 								<span className="font-mono text-muted-foreground text-xs">
-									{formatReleaseDate(release.publishedAt)}
+									{formatReleaseDate(release.publishedAt, i18n.locale)}
 								</span>
 							</span>
 							<HiMiniChevronDown className="size-5 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
@@ -126,7 +127,7 @@ export function ReleaseList({ releases }: ReleaseListProps) {
 															<span>{asset.label}</span>
 															<span className="flex shrink-0 items-center gap-2">
 																<span className="font-mono text-muted-foreground text-xs">
-																	{formatSize(asset.sizeBytes)}
+																	{formatSize(asset.sizeBytes, i18n.locale)}
 																</span>
 																<HiMiniArrowDownTray className="size-4 transition-colors group-hover/asset:text-brand" />
 															</span>

--- a/apps/marketing/src/app/[lang]/download/utils/formatReleaseDate/formatReleaseDate.ts
+++ b/apps/marketing/src/app/[lang]/download/utils/formatReleaseDate/formatReleaseDate.ts
@@ -5,11 +5,18 @@ import { formatDate } from "@superset/i18n/format";
 // not: a release published at 05:13Z is "Aug 31" on the server and "Aug 30" in
 // US-Pacific, which React reports as a hydration mismatch. Same reason the
 // production-run page pins UTC.
-export function formatReleaseDate(publishedAt: string): string {
-	return formatDate(new Date(publishedAt), {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-		timeZone: "UTC",
-	});
+export function formatReleaseDate(
+	publishedAt: string,
+	locale?: string,
+): string {
+	return formatDate(
+		new Date(publishedAt),
+		{
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+			timeZone: "UTC",
+		},
+		locale,
+	);
 }

--- a/apps/marketing/src/app/[lang]/factory-2026/page.tsx
+++ b/apps/marketing/src/app/[lang]/factory-2026/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			),
 			description,
 			url: localeUrl(lang, "/factory-2026"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
@@ -51,7 +51,7 @@ export async function generateMetadata(): Promise<Metadata> {
 				}),
 			),
 			description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/join-us/page.tsx
+++ b/apps/marketing/src/app/[lang]/join-us/page.tsx
@@ -42,7 +42,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			),
 			description,
 			url: localeUrl(lang, "/join-us"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
@@ -52,7 +52,7 @@ export async function generateMetadata(): Promise<Metadata> {
 				}),
 			),
 			description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/layout.tsx
+++ b/apps/marketing/src/app/[lang]/layout.tsx
@@ -1,4 +1,4 @@
-import { SUPPORTED_LOCALES } from "@superset/i18n";
+import { getLocaleMessages, SUPPORTED_LOCALES } from "@superset/i18n";
 import { COMPANY } from "@superset/shared/constants";
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Inter } from "next/font/google";
@@ -117,6 +117,7 @@ export default async function RootLayout({
 	children: React.ReactNode;
 }>) {
 	const locale = await initServerI18n();
+	const messages = await getLocaleMessages(locale);
 
 	return (
 		<html
@@ -151,7 +152,7 @@ export default async function RootLayout({
 				</Script>
 			</head>
 			<body className="overscroll-none font-sans">
-				<Providers locale={locale}>
+				<Providers locale={locale} messages={messages}>
 					<Header
 						ctaButtons={<CTAButtons />}
 						starCounter={<GitHubStarCounter />}

--- a/apps/marketing/src/app/[lang]/leaderboard/page.tsx
+++ b/apps/marketing/src/app/[lang]/leaderboard/page.tsx
@@ -48,13 +48,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | ${COMPANY.NAME}`,
 			description,
 			url: localeUrl(lang, "/leaderboard"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | ${COMPANY.NAME}`,
 			description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/metadata.test.ts
+++ b/apps/marketing/src/app/[lang]/metadata.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { SUPPORTED_LOCALES } from "@superset/i18n";
+import { COMPANY } from "@superset/shared/constants";
+import { hasLocalizedContent, localizedAlternates } from "./metadata";
+
+describe("indexable locale variants", () => {
+	test.each([
+		"/blog/parallel-coding-agents-guide",
+		"/changelog/2026-03-09-codemirror-workspace",
+		"/compare/superset-vs-warp",
+		"/parallel-coding-agents",
+		"/agent-orchestration",
+		"/privacy",
+		"/security",
+		"/subprocessors",
+		"/terms",
+		"/the-production-run",
+	])("consolidates untranslated content at %s", (path) => {
+		for (const locale of SUPPORTED_LOCALES) {
+			expect(localizedAlternates(locale, path)).toEqual({
+				canonical: `${COMPANY.MARKETING_URL}${path}`,
+			});
+		}
+		expect(hasLocalizedContent(path)).toBe(false);
+	});
+
+	test.each([
+		"/",
+		"/pricing",
+		"/factory-2026",
+		"/blog",
+		"/compare",
+		"/team",
+	])("preserves translated pages at %s", (path) => {
+		const alternates = localizedAlternates("fr", path);
+		expect(alternates.canonical).toBe(
+			`${COMPANY.MARKETING_URL}/fr${path === "/" ? "" : path}`,
+		);
+		expect(Object.keys(alternates.languages ?? {})).toHaveLength(
+			SUPPORTED_LOCALES.length + 1,
+		);
+		expect(hasLocalizedContent(path)).toBe(true);
+	});
+});

--- a/apps/marketing/src/app/[lang]/metadata.ts
+++ b/apps/marketing/src/app/[lang]/metadata.ts
@@ -11,15 +11,34 @@ export function localeUrl(lang: SupportedLocale, path: string): string {
 		: `${COMPANY.MARKETING_URL}/${lang}${suffix}`;
 }
 
+/** The MDX bodies and production-run essay currently exist only in English. */
+export function hasLocalizedContent(path: string): boolean {
+	return !(
+		/^\/(blog|changelog|compare)\/[^/]+$/.test(path) ||
+		[
+			"/agent-orchestration",
+			"/parallel-coding-agents",
+			"/privacy",
+			"/security",
+			"/subprocessors",
+			"/terms",
+			"/the-production-run",
+		].includes(path)
+	);
+}
+
 /**
- * Canonical + hreflang alternates for one page. Every locale URL names all
- * of its siblings, and x-default points at the bare English URL, which is
- * what tells search engines the set are translations of one page.
+ * Translated pages name their locale siblings. An English-only article keeps
+ * its English canonical even when rendered inside translated navigation.
  */
 export function localizedAlternates(
 	lang: SupportedLocale,
 	path: string,
 ): NonNullable<Metadata["alternates"]> {
+	if (!hasLocalizedContent(path)) {
+		return { canonical: localeUrl("en", path) };
+	}
+
 	const languages: Record<string, string> = {
 		"x-default": localeUrl("en", path),
 	};

--- a/apps/marketing/src/app/[lang]/parallel-coding-agents/page.tsx
+++ b/apps/marketing/src/app/[lang]/parallel-coding-agents/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
 	const url = localeUrl(lang, `/${SLUG}`);
 
 	return {
-		title: `${page.title} | ${COMPANY.NAME}`,
+		title: page.title,
 		description: page.description,
 		...(page.keywords.length > 0 && { keywords: page.keywords }),
 		alternates: localizedAlternates(lang, `/${SLUG}`),

--- a/apps/marketing/src/app/[lang]/roadmap/page.tsx
+++ b/apps/marketing/src/app/[lang]/roadmap/page.tsx
@@ -32,13 +32,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | Superset`,
 			description: description,
 			url: localeUrl(lang, "/roadmap"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | Superset`,
 			description: description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/starchart/page.tsx
+++ b/apps/marketing/src/app/[lang]/starchart/page.tsx
@@ -38,13 +38,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | ${COMPANY.NAME}`,
 			description,
 			url: localeUrl(lang, "/starchart"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | ${COMPANY.NAME}`,
 			description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/stats/page.tsx
+++ b/apps/marketing/src/app/[lang]/stats/page.tsx
@@ -40,13 +40,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | ${COMPANY.NAME}`,
 			description,
 			url: localeUrl(lang, "/stats"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | ${COMPANY.NAME}`,
 			description,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/team/page.tsx
+++ b/apps/marketing/src/app/[lang]/team/page.tsx
@@ -46,13 +46,13 @@ export async function generateMetadata(): Promise<Metadata> {
 			title: `${title} | Superset`,
 			description: ogDescription,
 			url: localeUrl(lang, "/team"),
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 		twitter: {
 			card: "summary_large_image",
 			title: `${title} | Superset`,
 			description: ogDescription,
-			images: ["/opengraph-image"],
+			images: ["/og-image.png"],
 		},
 	};
 }

--- a/apps/marketing/src/app/[lang]/the-production-run/components/RunSimulator/RunSimulator.tsx
+++ b/apps/marketing/src/app/[lang]/the-production-run/components/RunSimulator/RunSimulator.tsx
@@ -25,7 +25,7 @@ function formatTokens(value: number): string {
 }
 
 export function RunSimulator() {
-	const { t } = useLingui();
+	const { t, i18n } = useLingui();
 	const [months, setMonths] = useState(0);
 	const [playing, setPlaying] = useState(false);
 	const frame = useRef<number | null>(null);
@@ -81,7 +81,7 @@ export function RunSimulator() {
 				<div className="p-5 md:p-6 border-b md:border-b-0 md:border-r border-border">
 					<div className="flex items-baseline justify-between gap-3">
 						<span className="text-sm font-mono text-foreground">
-							{monthLabel(state.months)}
+							{monthLabel(state.months, i18n.locale)}
 						</span>
 						<span className="text-[11px] font-mono text-muted-foreground">
 							{state.months <= RUN_MONTHS

--- a/apps/marketing/src/app/[lang]/the-production-run/constants.ts
+++ b/apps/marketing/src/app/[lang]/the-production-run/constants.ts
@@ -298,14 +298,18 @@ export function runStateAt(months: number): RunState {
 	};
 }
 
-export function monthLabel(months: number): string {
+export function monthLabel(months: number, locale?: string): string {
 	const date = new Date(Date.UTC(2026, 7, 1));
 	date.setUTCMonth(date.getUTCMonth() + Math.round(months));
-	return formatDate(date, {
-		month: "short",
-		year: "numeric",
-		timeZone: "UTC",
-	});
+	return formatDate(
+		date,
+		{
+			month: "short",
+			year: "numeric",
+			timeZone: "UTC",
+		},
+		locale,
+	);
 }
 
 export interface RunTarget {

--- a/apps/marketing/src/app/[lang]/the-production-run/page.tsx
+++ b/apps/marketing/src/app/[lang]/the-production-run/page.tsx
@@ -33,13 +33,13 @@ export const metadata: Metadata = {
 		title: "The Production Run | Superset",
 		description: DESCRIPTION,
 		url: "/the-production-run",
-		images: ["/opengraph-image"],
+		images: ["/og-image.png"],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "The Production Run | Superset",
 		description: DESCRIPTION,
-		images: ["/opengraph-image"],
+		images: ["/og-image.png"],
 	},
 };
 

--- a/apps/marketing/src/app/providers.test.tsx
+++ b/apps/marketing/src/app/providers.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { Trans } from "@lingui/react";
+import { i18n, initI18n } from "@superset/i18n";
+import { I18nProvider } from "@superset/i18n/react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+describe("server-resolved client translations", () => {
+	test("renders the requested language before effects without changing another request's locale", () => {
+		initI18n("en");
+		const french = renderToStaticMarkup(
+			<I18nProvider locale="fr" initialMessages={{ greeting: "Bonjour" }}>
+				<Trans id="greeting" />
+			</I18nProvider>,
+		);
+		const german = renderToStaticMarkup(
+			<I18nProvider locale="de" initialMessages={{ greeting: "Hallo" }}>
+				<Trans id="greeting" />
+			</I18nProvider>,
+		);
+
+		expect(french).toBe("Bonjour");
+		expect(german).toBe("Hallo");
+		expect(i18n.locale).toBe("en");
+	});
+});

--- a/apps/marketing/src/app/providers.test.tsx
+++ b/apps/marketing/src/app/providers.test.tsx
@@ -1,10 +1,45 @@
 import { describe, expect, test } from "bun:test";
-import { Trans } from "@lingui/react";
+import { Trans, useLingui } from "@lingui/react";
 import { i18n, initI18n } from "@superset/i18n";
+import { formatDate, formatList, formatNumber } from "@superset/i18n/format";
 import { I18nProvider } from "@superset/i18n/react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server";
+
+function FormattedGreeting() {
+	const { i18n: requestI18n } = useLingui();
+	const locale = requestI18n.locale;
+	return (
+		<>
+			<Trans id="greeting" />|{formatNumber(1234.5, undefined, locale)}|
+			{formatDate(
+				new Date("2026-09-01T00:00:00Z"),
+				{ month: "long", timeZone: "UTC" },
+				locale,
+			)}
+			|{formatList(["A", "B"], undefined, locale)}
+		</>
+	);
+}
 
 describe("server-resolved client translations", () => {
+	test("keeps formatted values with their request's language across concurrent renders", async () => {
+		initI18n("en");
+		const render = async (locale: "fr" | "de", greeting: string) => {
+			const stream = await renderToReadableStream(
+				<I18nProvider locale={locale} initialMessages={{ greeting }}>
+					<FormattedGreeting />
+				</I18nProvider>,
+			);
+			return (await new Response(stream).text()).replaceAll("<!-- -->", "");
+		};
+		const [french, german] = await Promise.all([
+			render("fr", "Bonjour"),
+			render("de", "Hallo"),
+		]);
+		expect(french).toBe("Bonjour|1\u202f234,5|septembre|A et B");
+		expect(german).toBe("Hallo|1.234,5|September|A und B");
+		expect(i18n.locale).toBe("en");
+	});
 	test("renders the requested language before effects without changing another request's locale", () => {
 		initI18n("en");
 		const french = renderToStaticMarkup(

--- a/apps/marketing/src/app/providers.tsx
+++ b/apps/marketing/src/app/providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Messages } from "@lingui/core";
 import type { SupportedLocale } from "@superset/i18n";
 import { I18nProvider } from "@superset/i18n/react";
 import { THEME_STORAGE_KEY } from "@superset/shared/constants";
@@ -14,14 +15,16 @@ const loadMotionFeatures = () =>
 export function Providers({
 	children,
 	locale,
+	messages,
 }: {
 	children: React.ReactNode;
 	// Server-resolved locale, so client components render the same language
 	// the server did instead of re-inferring from the browser.
 	locale?: SupportedLocale;
+	messages?: Messages;
 }) {
 	return (
-		<I18nProvider locale={locale}>
+		<I18nProvider locale={locale} initialMessages={messages}>
 			<LazyMotion features={loadMotionFeatures}>
 				<ThemeProvider
 					attribute="class"

--- a/apps/marketing/src/app/robots.txt/route.ts
+++ b/apps/marketing/src/app/robots.txt/route.ts
@@ -26,7 +26,6 @@ User-Agent: *
 Allow: /
 Allow: /api/llms.txt
 Disallow: /api/
-Disallow: /_next/
 
 # AI assistants and AI search crawlers: explicitly welcome
 ${WELCOME_AI_AGENTS.map((agent) => `User-Agent: ${agent}\nAllow: /`).join("\n\n")}
@@ -42,16 +41,18 @@ Disallow: /
 Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 Sitemap: ${baseUrl}/sitemap.xml
-
-# Agent discovery
-Agentmap: ${baseUrl}/.well-known/ai-catalog.json
-schemamap: ${baseUrl}/schemamap.xml
 `;
 
 	return new Response(content, {
 		headers: {
 			"Content-Type": "text/plain; charset=utf-8",
 			"Cache-Control": "public, max-age=3600, s-maxage=3600",
+			// Discovery links are HTTP metadata, not robots.txt directives.
+			// Google reports custom Agentmap/schemamap lines as syntax errors.
+			Link: [
+				`<${baseUrl}/.well-known/ai-catalog.json>; rel="describedby"; type="application/json"`,
+				`<${baseUrl}/schemamap.xml>; rel="describedby"; type="application/xml"`,
+			].join(", "),
 		},
 	});
 }

--- a/apps/marketing/src/app/sitemap.test.ts
+++ b/apps/marketing/src/app/sitemap.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, mock, test } from "bun:test";
+import { COMPANY } from "@superset/shared/constants";
+
+// Exercise the real content inventory without calling the production API.
+mock.module("@/app/[lang]/utils/fetchLeaderboard", () => ({
+	fetchPublicHandles: async () => [
+		{ handle: "example-engineer", lastPublishedAt: new Date("2026-09-01") },
+	],
+}));
+
+const { default: sitemap } = await import("./sitemap");
+
+describe("marketing sitemap", () => {
+	test("lists canonical articles and profiles once and omits nonexistent discovery variants", async () => {
+		const entries = await sitemap();
+		const urls = entries.map((entry) => entry.url);
+
+		expect(urls.some((url) => url.endsWith("/llms.txt"))).toBe(false);
+		expect(
+			urls.filter((url) => url.includes("/compare/superset-vs-warp")),
+		).toEqual([`${COMPANY.MARKETING_URL}/compare/superset-vs-warp`]);
+		expect(urls.filter((url) => url.endsWith("/example-engineer"))).toEqual([
+			`${COMPANY.MARKETING_URL}/example-engineer`,
+		]);
+		expect(urls).toContain(`${COMPANY.MARKETING_URL}/fr`);
+		expect(urls).toContain(`${COMPANY.MARKETING_URL}/fr/pricing`);
+		expect(new Set(urls).size).toBe(urls.length);
+	});
+});

--- a/apps/marketing/src/app/sitemap.ts
+++ b/apps/marketing/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES } from "@superset/i18n";
 import { COMPANY } from "@superset/shared/constants";
 import type { MetadataRoute } from "next";
-import { localeUrl } from "@/app/[lang]/metadata";
+import { hasLocalizedContent, localeUrl } from "@/app/[lang]/metadata";
 import { fetchPublicHandles } from "@/app/[lang]/utils/fetchLeaderboard";
 import { getBlogPosts } from "@/lib/blog";
 import { getCategoryPages } from "@/lib/category";
@@ -80,12 +80,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			lastModified: new Date(),
 			changeFrequency: "monthly",
 			priority: 0.5,
-		},
-		{
-			url: `${baseUrl}/llms.txt`,
-			lastModified: new Date(),
-			changeFrequency: "weekly",
-			priority: 0.3,
 		},
 		{
 			url: `${baseUrl}/enterprise`,
@@ -209,11 +203,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		...themePages,
 	];
 
-	// Every page exists once per locale (English at the bare URL, others under
-	// /{locale}), and every entry names its siblings via hreflang alternates —
-	// this is what makes the localized tree discoverable to search engines.
+	// Only translated content has independently indexable locale variants.
+	// English-only articles remain accessible with translated navigation, but
+	// their canonical URL is the bare English path.
 	const expand = (entry: MetadataRoute.Sitemap[number]) => {
 		const path = entry.url === baseUrl ? "/" : entry.url.slice(baseUrl.length);
+		if (!hasLocalizedContent(path)) return [entry];
 		const languages: Record<string, string> = {
 			"x-default": localeUrl("en", path),
 		};

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,9 +1,14 @@
 import { auth } from "@superset/auth/server";
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import Image from "next/image";
 import { redirect } from "next/navigation";
 
 import { env } from "@/env";
+
+export const metadata: Metadata = {
+	robots: { index: false, follow: true },
+};
 
 export default async function AuthLayout({
 	children,

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Zač. 2027"
 msgid "Early 2028"
 msgstr "Zač. 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Získáno {0}"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Anfang 2027"
 msgid "Early 2028"
 msgstr "Anfang 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Erhalten am {0}"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Early 2027"
 msgid "Early 2028"
 msgstr "Early 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Earned {0}"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Principios de 2027"
 msgid "Early 2028"
 msgstr "Principios de 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Conseguido el {0}"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Début 2027"
 msgid "Early 2028"
 msgstr "Début 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Obtenu le {0}"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Awal 2027"
 msgid "Early 2028"
 msgstr "Awal 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Diraih pada {0}"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Inizio 2027"
 msgid "Early 2028"
 msgstr "Inizio 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Ottenuto il {0}"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -5205,7 +5205,7 @@ msgstr "2027年前半"
 msgid "Early 2028"
 msgstr "2028年前半"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "獲得日: {0}"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -5205,7 +5205,7 @@ msgstr "2027년 초"
 msgid "Early 2028"
 msgstr "2028년 초"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "{0}에 획득"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Begin 2027"
 msgid "Early 2028"
 msgstr "Begin 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Behaald op {0}"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Początek 2027"
 msgid "Early 2028"
 msgstr "Początek 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Zdobyto {0}"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Início de 2027"
 msgid "Early 2028"
 msgstr "Início de 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Conquistado em {0}"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Начало 2027"
 msgid "Early 2028"
 msgstr "Начало 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Получено {0}"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -5205,7 +5205,7 @@ msgstr "2027 başı"
 msgid "Early 2028"
 msgstr "2028 başı"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "{0} tarihinde kazanıldı"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -5205,7 +5205,7 @@ msgstr "Đầu 2027"
 msgid "Early 2028"
 msgstr "Đầu 2028"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "Đạt vào {0}"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -5205,7 +5205,7 @@ msgstr "2027年初"
 msgid "Early 2028"
 msgstr "2028年初"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "获得于 {0}"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -5205,7 +5205,7 @@ msgstr "2027年初"
 msgid "Early 2028"
 msgstr "2028年初"
 
-#. placeholder {0}: formatDate(new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", })
+#. placeholder {0}: formatDate( new Date(`${awardedOn}T00:00:00Z`), { day: "numeric", month: "short", year: "numeric", timeZone: "UTC", }, i18n.locale, )
 msgid "Earned {0}"
 msgstr "獲得於 {0}"
 

--- a/packages/i18n/src/format/index.ts
+++ b/packages/i18n/src/format/index.ts
@@ -3,7 +3,8 @@ import { DEFAULT_LOCALE } from "../locales";
 
 // Locale-aware wrappers around Intl.*. Every user-facing number, currency,
 // and date goes through these instead of hardcoding a locale — the active
-// locale comes from the shared i18n instance, and I18nProvider remounts its
+// locale defaults to the shared instance. SSR callers can pass their request's
+// locale explicitly. I18nProvider remounts its
 // subtree on locale change so formatted output re-renders everywhere.
 //
 // Constructing an Intl formatter per call costs single-digit microseconds
@@ -17,8 +18,9 @@ export function getActiveLocale(): string {
 export function formatNumber(
 	value: number,
 	options?: Intl.NumberFormatOptions,
+	locale = getActiveLocale(),
 ): string {
-	return new Intl.NumberFormat(getActiveLocale(), options).format(value);
+	return new Intl.NumberFormat(locale, options).format(value);
 }
 
 // 0.123 -> "12.3%"
@@ -36,8 +38,9 @@ export function formatPercent(
 export function formatList(
 	values: string[],
 	options?: Intl.ListFormatOptions,
+	locale = getActiveLocale(),
 ): string {
-	return new Intl.ListFormat(getActiveLocale(), {
+	return new Intl.ListFormat(locale, {
 		style: "long",
 		type: "conjunction",
 		...options,
@@ -77,8 +80,9 @@ export function formatDate(
 		month: "short",
 		day: "numeric",
 	},
+	locale = getActiveLocale(),
 ): string {
-	return new Intl.DateTimeFormat(getActiveLocale(), options).format(date);
+	return new Intl.DateTimeFormat(locale, options).format(date);
 }
 
 export function formatDateTime(

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -85,12 +85,16 @@ export function inferLocaleWithSource(): {
 	return { locale: DEFAULT_LOCALE, source: "system" };
 }
 
+/** Returns a request's catalog without changing the active global locale. */
+export async function getLocaleMessages(locale: SupportedLocale) {
+	const load = CATALOGS[locale];
+	return load ? (await load()).messages : enMessages;
+}
+
 /** Loads a catalog without activating it. Resolves immediately if cached. */
 export async function loadLocale(locale: SupportedLocale): Promise<void> {
 	if (loaded.has(locale)) return;
-	const load = CATALOGS[locale];
-	if (!load) return;
-	const { messages } = await load();
+	const messages = await getLocaleMessages(locale);
 	i18n.load(locale, messages);
 	loaded.add(locale);
 }

--- a/packages/i18n/src/react.tsx
+++ b/packages/i18n/src/react.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { type Messages, setupI18n } from "@lingui/core";
 import { I18nProvider as LinguiI18nProvider } from "@lingui/react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { i18n, inferLocale, initI18n } from "./index";
 import {
 	LOCALE_COOKIE,
@@ -16,20 +17,30 @@ import {
 // English, which threw a hydration mismatch on every translated client
 // string for every non-English user ("Search docs..." vs "Tìm trong tài
 // liệu..."). The provider switches to the inferred or chosen locale after
-// mount instead; the brief default-language flash on client chrome is the
-// price of hydration correctness, and server-component content (marketing
-// pages) is localized in the HTML itself and never hydrates.
+// mount instead unless the server supplies a locale and its catalog. That
+// snapshot translates the initial HTML and hydration with a request-local
+// instance, without activating a shared singleton during concurrent SSR.
 initI18n();
 
 export function I18nProvider({
 	children,
 	locale,
+	initialMessages,
 }: {
 	children: ReactNode;
 	// Explicit locale (persisted setting, device locale). Omitted: the
 	// module-scope inference above stands.
 	locale?: SupportedLocale;
+	/** Server-resolved catalog for translated SSR and matching hydration. */
+	initialMessages?: Messages;
 }) {
+	const renderI18n = useMemo(
+		() =>
+			locale && initialMessages
+				? setupI18n({ locale, messages: { [locale]: initialMessages } })
+				: i18n,
+		[locale, initialMessages],
+	);
 	// Remount the subtree when the locale changes: Trans/useLingui consumers
 	// re-render via Lingui's own subscription, but plain formatter calls
 	// (@superset/i18n/format) read the locale imperatively and only refresh on
@@ -54,7 +65,7 @@ export function I18nProvider({
 		}
 	}, [locale]);
 	return (
-		<LinguiI18nProvider key={activeLocale} i18n={i18n}>
+		<LinguiI18nProvider key={activeLocale} i18n={renderI18n}>
 			{children}
 		</LinguiI18nProvider>
 	);


### PR DESCRIPTION
## What & why

Search Console reported localized duplicate pages, missing discovery URLs, blocked rendering assets, and robots.txt syntax errors. Localized client components also served English in the initial HTML, leaving crawlers with duplicate content until hydration.

- Render marketing client translations from a request-specific Lingui catalog on the server and during hydration, without changing the shared locale during SSR. Pass the same request locale to marketing number/date/list formatters, including download details, calendars, and run simulator dates.
- Give untranslated articles an English canonical and include only canonical articles in the sitemap. Keep hreflang and locale variants for translated pages.
- Redirect old localized llms.txt URLs, the missing Open Graph image route, and the remaining legacy docs workspace guide. Point social metadata at the existing image.
- Allow crawlers to fetch rendering assets and read docs' existing noindex headers. Move unsupported Agentmap/schemamap robots directives into HTTP Link metadata and exclude authentication pages from indexing.
- Remove repeated brand suffixes from comparison and category page titles.

The broader Search Console audit found no security/manual-action, HTTPS, or breadcrumb issues. The existing docs sitemap was also submitted separately and Google accepted all 49 URLs. Desktop homepage CLS remains a monitoring item: the field report is 0.14, while the live browser probe measured approximately 0.027; this PR does not claim to resolve it.

## How I tested it

- `bun run lint`, full monorepo `bun run typecheck`, and `bun run check:plugins` pass.
- 292 affected tests pass across marketing, web, and i18n, including regressions for canonical/hreflang behavior, sitemap entries, and initial translated HTML without shared-locale mutation, and concurrent French/German renders with matching formatted values.
- Marketing production build passes with the workspace environment loaded; `bun run check:i18n` passes strict compilation with complete catalogs.
- Verified production-build responses for translated French/German HTML, canonical URLs, redirects, sitemap, robots body/Link header, and single brand suffixes.
- Verified French rendering and hydration in Comet over CDP with no console errors. Audited 180 live marketing URLs and all 49 docs sitemap URLs successfully.
- Full local tests reach an unrelated desktop suite failure: `useSidebarDnd.test.ts` imports a mocked React missing `createContext`. The same file passes all 8 tests in isolation; affected suites pass. Local Bun is 1.3.11; CI uses the pinned 1.3.14.

The initial commit also passed the complete hosted CI suite and all preview deployments.

Indexing reports require deployment and subsequent Google recrawling to reflect these changes.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (same-repository branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added locale-aware server-rendered translations and formatting for dates, numbers, and lists.
  - Added redirects for updated documentation, localized LLM resources, and social image URLs.
  - Exposed agent discovery links through standard HTTP metadata.

- **Bug Fixes**
  - Updated social sharing images to use the correct static image.
  - Prevented authenticated pages from being indexed.
  - Corrected sitemap entries and removed unsupported localized variants.

- **Documentation**
  - Crawlers can now access rendering assets and supported markdown resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->