### PR TITLE
fix(desktop): preserve cursor position in terminal rich input

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalRichInput/TerminalRichInput.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalRichInput/TerminalRichInput.tsx
@@ -198,12 +198,13 @@ function TerminalRichInputInner({
 	// editor exists (it is created asynchronously — immediatelyRender: false),
 	// so retry across frames until focus is actually inside the overlay.
 	const rootRef = useRef<HTMLDivElement | null>(null);
+	const focusInput = controller.textInput.focus;
 	useEffect(() => {
 		if (!isOpen) return;
 		let cancelled = false;
 		const attempt = (triesLeft: number) => {
 			if (cancelled || triesLeft <= 0) return;
-			controller.textInput.focus();
+			focusInput();
 			requestAnimationFrame(() => {
 				if (cancelled) return;
 				const root = rootRef.current;
@@ -215,7 +216,7 @@ function TerminalRichInputInner({
 		return () => {
 			cancelled = true;
 		};
-	}, [isOpen, controller]);
+	}, [isOpen, focusInput]);
 
 	return (
 		// Docked below the terminal rather than floating over it: opening adds


### PR DESCRIPTION
## What & why

Fixes [SUPER-2159](https://linear.app/superset-sh/issue/SUPER-2159/cursor-jumps-back-to-the-end-of-sentence-when-i-edit-text-on-input-ui). Editing in the middle of the terminal rich input reran autofocus on every keystroke because its effect depended on the changing input controller. Depend on the stable focus callback so the cursor stays at the insertion point.

## How I tested it

Verified before and after in this worktree's signed-in desktop app over CDP (`localhost:4145`, CDP port `9339`) using real keyboard input:

- Before: inserting `new ` at offset 14 jumped the cursor to the end (37), and the next word was appended there.
- After: the same insertions kept the cursor at offsets 18 and 23, producing `Please update new text the input behavior.`
- Repeated successfully after closing and reopening the input; draft preservation and autofocus worked. Cleared the test text afterward.
- Captured and inspected before/after screenshots locally.
- Targeted Biome check, `git diff --check`, and `bun run check:plugins` passed. Full monorepo lint/typecheck were not run.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — same-repository PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the terminal rich input cursor jumping to the end of the sentence when editing in the middle, resolving [SUPER-2159](https://linear.app/superset-sh/issue/SUPER-2159). The autofocus effect now depends on the stable focus callback instead of the changing input controller, so focus re-applies only when the input opens and the cursor stays at the insertion point while typing.

<sup>Written for commit a82c3a080e7e2982431c480e9e1981954c3755a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input autofocus reliability by preventing unnecessary focus retries when the underlying controller reference changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->