### PR TITLE
fix(desktop): keep workspace picker searches open

### DIFF
--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.test.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.test.ts
@@ -14,9 +14,9 @@ import { join } from "node:path";
 // popover, wheel scrolling inside the project list reaches that scrollable
 // wrapper and the dropdown can't scroll past the first ~8 items.
 //
-// Every other picker in this file and in the dashboard variant uses the same
+// The sibling branch picker and the dashboard variant uses the same
 // `onWheel={(event) => event.stopPropagation()}` mitigation — see
-// CompareBaseBranchPickerInline below in the same file, and
+// components/CompareBaseBranchPickerInline, and
 // routes/_authenticated/components/DashboardNewWorkspaceModal/.../ProjectPickerPill.tsx.
 describe("ProjectPickerPill (PromptGroup)", () => {
 	const source = readFileSync(join(import.meta.dir, "PromptGroup.tsx"), "utf8");
@@ -86,10 +86,16 @@ describe("ProjectPickerPill (PromptGroup)", () => {
 		);
 	});
 
-	test("matches the pattern used by every other picker in this file", () => {
-		// Sanity-check: the sibling picker in the same file already has the fix.
+	test("matches the wheel handling of the sibling branch picker", () => {
+		// Sanity-check: the sibling picker already has the fix.
 		// If it ever loses it, this regression class will resurface.
-		const sibling = extractFunctionSource("CompareBaseBranchPickerInline");
+		const sibling = readFileSync(
+			join(
+				import.meta.dir,
+				"components/CompareBaseBranchPickerInline/CompareBaseBranchPickerInline.tsx",
+			),
+			"utf8",
+		);
 		const siblingPopover = extractPopoverContentProps(sibling);
 		expect(siblingPopover).toMatch(
 			/onWheel=\{[\s\S]*?\.stopPropagation\(\)[\s\S]*?\}/,

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/PromptGroup.tsx
@@ -20,7 +20,6 @@ import {
 	usePromptInputAttachments,
 	useProviderAttachments,
 } from "@superset/ui/ai-elements/prompt-input";
-import { Button } from "@superset/ui/button";
 import {
 	Command,
 	CommandEmpty,
@@ -38,19 +37,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { cn } from "@superset/ui/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import {
-	ArrowUpIcon,
-	ExternalLinkIcon,
-	PaperclipIcon,
-	PlusIcon,
-} from "lucide-react";
+import { ArrowUpIcon, PaperclipIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-	GoArrowUpRight,
-	GoGitBranch,
-	GoGlobe,
-	GoIssueOpened,
-} from "react-icons/go";
+import { GoIssueOpened } from "react-icons/go";
 import { HiCheck, HiChevronUpDown } from "react-icons/hi2";
 import { LuFolderGit, LuFolderOpen, LuGitPullRequest } from "react-icons/lu";
 import { AgentSelect } from "renderer/components/AgentSelect";
@@ -58,7 +47,6 @@ import { LinkedIssuePill } from "renderer/components/LinkedIssuePill";
 import { useAgentLaunchPreferences } from "renderer/hooks/useAgentLaunchPreferences";
 import { PLATFORM } from "renderer/hotkeys";
 import { electronTrpc } from "renderer/lib/electron-trpc";
-import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
 import { resolveEffectiveWorkspaceBaseBranch } from "renderer/lib/workspaceBaseBranch";
 import { navigateToWorkspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
 import { ProjectThumbnail } from "renderer/screens/main/components/WorkspaceSidebar/ProjectSection/ProjectThumbnail";
@@ -70,6 +58,7 @@ import {
 } from "renderer/stores/new-workspace-modal";
 import type { LinkedPR } from "../../NewWorkspaceModalDraftContext";
 import { useNewWorkspaceModalDraft } from "../../NewWorkspaceModalDraftContext";
+import { CompareBaseBranchPickerInline } from "./components/CompareBaseBranchPickerInline";
 import { GitHubIssueLinkCommand } from "./components/GitHubIssueLinkCommand";
 import { LinkedGitHubIssuePill } from "./components/LinkedGitHubIssuePill";
 import { LinkedPRPill } from "./components/LinkedPRPill";
@@ -270,274 +259,6 @@ function ProjectPickerPill({
 								<Trans>New project</Trans>
 							</CommandItem>
 						</CommandGroup>
-					</CommandList>
-				</Command>
-			</PopoverContent>
-		</Popover>
-	);
-}
-
-function CompareBaseBranchPickerInline({
-	effectiveCompareBaseBranch,
-	defaultBranch,
-	isBranchesLoading,
-	isBranchesError,
-	branches,
-	worktreeBranches,
-	openableWorktrees,
-	activeWorkspacesByBranch,
-	externalWorktreeBranches,
-	modKey,
-	onSelectCompareBaseBranch,
-	onOpenWorktree,
-	onOpenActiveWorkspace,
-}: {
-	effectiveCompareBaseBranch: string | null;
-	defaultBranch?: string;
-	isBranchesLoading: boolean;
-	isBranchesError: boolean;
-	branches: Array<{ name: string; lastCommitDate: number; isLocal: boolean }>;
-	worktreeBranches: Set<string>;
-	openableWorktrees: Map<string, OpenableWorktreeAction>;
-	activeWorkspacesByBranch: Map<string, string>;
-	externalWorktreeBranches: Set<string>;
-	modKey: string;
-	onSelectCompareBaseBranch: (branchName: string) => void;
-	onOpenWorktree: (action: OpenableWorktreeAction) => void;
-	onOpenActiveWorkspace: (workspaceId: string) => void;
-}) {
-	const { t } = useLingui();
-	const [open, setOpen] = useState(false);
-	const [branchSearch, setBranchSearch] = useState("");
-	const [filterMode, setFilterMode] = useState<"all" | "worktrees">("all");
-
-	const filteredBranches = useMemo(() => {
-		if (!branches.length) return [];
-		if (!branchSearch) return branches;
-		const searchLower = branchSearch.toLowerCase();
-		return branches.filter((branch) =>
-			branch.name.toLowerCase().includes(searchLower),
-		);
-	}, [branches, branchSearch]);
-
-	const displayBranches = useMemo(() => {
-		if (filterMode === "all") return filteredBranches;
-		return filteredBranches.filter((b) => worktreeBranches.has(b.name));
-	}, [filteredBranches, filterMode, worktreeBranches]);
-
-	if (isBranchesError) {
-		return (
-			<span className="text-xs text-destructive">
-				<Trans>Failed to load branches</Trans>
-			</span>
-		);
-	}
-
-	return (
-		<Popover
-			open={open}
-			onOpenChange={(v) => {
-				setOpen(v);
-				if (!v) {
-					setBranchSearch("");
-					setFilterMode("all");
-				}
-			}}
-		>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					disabled={isBranchesLoading}
-					className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 min-w-0 max-w-full"
-				>
-					<GoGitBranch className="size-3 shrink-0" />
-					{isBranchesLoading ? (
-						<span className="h-2.5 w-14 rounded-sm bg-muted-foreground/15 animate-pulse" />
-					) : (
-						<span className="font-mono truncate">
-							{effectiveCompareBaseBranch || "..."}
-						</span>
-					)}
-					<HiChevronUpDown className="size-3 shrink-0" />
-				</button>
-			</PopoverTrigger>
-			<PopoverContent
-				className="w-96 p-0"
-				align="start"
-				onWheel={(event) => event.stopPropagation()}
-			>
-				<Command shouldFilter={false}>
-					<div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5 mx-2 mt-2">
-						{(["all", "worktrees"] as const).map((value) => {
-							const count =
-								value === "all"
-									? branches.length
-									: branches.filter((b) => worktreeBranches.has(b.name)).length;
-							return (
-								<button
-									key={value}
-									type="button"
-									onClick={() => setFilterMode(value)}
-									className={cn(
-										"flex-1 rounded px-2 py-1 text-xs text-center transition-colors",
-										filterMode === value
-											? "bg-background text-foreground shadow-sm"
-											: "text-muted-foreground hover:text-foreground",
-									)}
-								>
-									{value === "all" ? (
-										<Trans>All</Trans>
-									) : (
-										<Trans>Worktrees</Trans>
-									)}
-									<span className="ml-1 text-foreground/40">{count}</span>
-								</button>
-							);
-						})}
-					</div>
-					<CommandInput
-						placeholder={t({
-							message: "Search branches...",
-						})}
-						value={branchSearch}
-						onValueChange={setBranchSearch}
-					/>
-					<CommandList className="max-h-[400px]">
-						<CommandEmpty>
-							<Trans>No branches found</Trans>
-						</CommandEmpty>
-						{displayBranches.map((branch) => {
-							const openAction = openableWorktrees.get(branch.name);
-							const activeWorkspaceId = activeWorkspacesByBranch.get(
-								branch.name,
-							);
-							const isExternal = externalWorktreeBranches.has(branch.name);
-							const hasExistingWorkspace = !!(activeWorkspaceId || openAction);
-
-							// Determine icon based on state - all same color
-							let icon: React.ReactNode;
-							if (activeWorkspaceId) {
-								icon = (
-									<GoArrowUpRight className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							} else if (openAction) {
-								icon = (
-									<ExternalLinkIcon className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							} else if (branch.isLocal) {
-								icon = (
-									<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							} else {
-								icon = (
-									<GoGlobe className="size-3.5 shrink-0 text-muted-foreground" />
-								);
-							}
-
-							return (
-								<CommandItem
-									key={branch.name}
-									value={branch.name}
-									onSelect={() => {
-										if (activeWorkspaceId) {
-											onOpenActiveWorkspace(activeWorkspaceId);
-										} else if (openAction) {
-											onOpenWorktree(openAction);
-										} else {
-											onSelectCompareBaseBranch(branch.name);
-										}
-										setOpen(false);
-									}}
-									className="group h-11 flex items-center justify-between gap-3 px-3"
-								>
-									<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
-										{icon}
-										<span className="truncate font-mono text-xs">
-											{branch.name}
-										</span>
-
-										{/* Inline badges */}
-										<span className="flex items-center gap-1.5 shrink-0">
-											{branch.name === defaultBranch && (
-												<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-													<Trans>default</Trans>
-												</span>
-											)}
-											{isExternal && !activeWorkspaceId && (
-												<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
-													<Trans>external</Trans>
-												</span>
-											)}
-										</span>
-									</span>
-
-									{/* Right side: time + buttons */}
-									<span className="flex items-center gap-2 shrink-0">
-										{branch.lastCommitDate > 0 && (
-											<span className="text-[11px] text-muted-foreground/70 group-data-[selected=true]:hidden">
-												{formatRelativeTime(branch.lastCommitDate)}
-											</span>
-										)}
-
-										{/* Show checkmark for selected base branch when not hovering */}
-										{!hasExistingWorkspace &&
-											effectiveCompareBaseBranch === branch.name && (
-												<HiCheck className="size-4 text-primary group-data-[selected=true]:hidden" />
-											)}
-
-										{/* Action buttons - show on hover/select */}
-										<span className="hidden group-data-[selected=true]:flex items-center gap-1.5">
-											{hasExistingWorkspace && (
-												<Button
-													size="sm"
-													variant="ghost"
-													className="h-7 px-2.5 text-xs font-medium hover:bg-accent/10 hover:text-accent-foreground"
-													onClick={(e) => {
-														e.stopPropagation();
-														if (activeWorkspaceId) {
-															onOpenActiveWorkspace(activeWorkspaceId);
-														} else if (openAction) {
-															onOpenWorktree(openAction);
-														}
-														setOpen(false);
-													}}
-												>
-													<GoArrowUpRight className="size-3.5 mr-1" />
-													<Trans>Open</Trans>
-													<span className="ml-1 text-[10px] opacity-60">↵</span>
-												</Button>
-											)}
-											<Button
-												size="sm"
-												className="h-7 px-2.5 text-xs font-medium"
-												onClick={(e) => {
-													e.stopPropagation();
-													onSelectCompareBaseBranch(branch.name);
-													setOpen(false);
-												}}
-											>
-												{hasExistingWorkspace ? (
-													<>
-														<PlusIcon className="size-3.5 mr-1" />
-														<Trans>Create</Trans>
-														<span className="ml-1 text-[10px] opacity-70">
-															{modKey}↵
-														</span>
-													</>
-												) : (
-													<>
-														<Trans>Create</Trans>
-														<span className="ml-1 text-[10px] opacity-70">
-															↵
-														</span>
-													</>
-												)}
-											</Button>
-										</span>
-									</span>
-								</CommandItem>
-							);
-						})}
 					</CommandList>
 				</Command>
 			</PopoverContent>

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/CompareBaseBranchPickerInline/CompareBaseBranchPickerInline.test.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/CompareBaseBranchPickerInline/CompareBaseBranchPickerInline.test.tsx
@@ -1,0 +1,86 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, cleanup, fireEvent, render, waitFor, within } = await import(
+	"@testing-library/react"
+);
+const { CompareBaseBranchPickerInline } = await import(
+	"./CompareBaseBranchPickerInline"
+);
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+describe("legacy branch picker", () => {
+	test.each([
+		"row",
+		"keyboard",
+		"open",
+		"create",
+		"escape",
+	] as const)("clears search and worktree filter after %s", async (action) => {
+		const onOpenActiveWorkspace = mock(() => {});
+		const onSelectCompareBaseBranch = mock(() => {});
+		render(
+			<CompareBaseBranchPickerInline
+				effectiveCompareBaseBranch="main"
+				defaultBranch="main"
+				isBranchesLoading={false}
+				isBranchesError={false}
+				branches={[
+					{ name: "main", lastCommitDate: 0, isLocal: true },
+					{ name: "feature", lastCommitDate: 0, isLocal: true },
+				]}
+				worktreeBranches={new Set(["feature"])}
+				openableWorktrees={new Map()}
+				activeWorkspacesByBranch={new Map([["feature", "workspace-id"]])}
+				externalWorktreeBranches={new Set()}
+				modKey="⌘"
+				onSelectCompareBaseBranch={onSelectCompareBaseBranch}
+				onOpenWorktree={() => {}}
+				onOpenActiveWorkspace={onOpenActiveWorkspace}
+			/>,
+		);
+		const page = within(document.body);
+		const trigger = page.getByRole("button", { name: "main" });
+		await act(async () => {
+			fireEvent.click(trigger);
+		});
+		const search = page.getByRole("combobox");
+		await act(async () => {
+			fireEvent.click(page.getByRole("button", { name: /Worktrees/ }));
+			fireEvent.change(search, { target: { value: "feat" } });
+		});
+		expect(page.getAllByRole("option")).toHaveLength(1);
+		await act(async () => {
+			if (action === "row") fireEvent.click(page.getByRole("option"));
+			else if (action === "keyboard")
+				fireEvent.keyDown(search, { key: "Enter", code: "Enter" });
+			else if (action === "escape")
+				fireEvent.keyDown(search, { key: "Escape", code: "Escape" });
+			else
+				fireEvent.click(
+					page.getByRole("button", {
+						name: action === "open" ? /Open/ : /Create/,
+					}),
+				);
+		});
+		await waitFor(() => expect(page.queryByRole("dialog")).toBeNull());
+		if (action === "create")
+			expect(onSelectCompareBaseBranch).toHaveBeenCalledWith("feature");
+		else if (action !== "escape")
+			expect(onOpenActiveWorkspace).toHaveBeenCalledWith("workspace-id");
+		await act(async () => {
+			fireEvent.click(trigger);
+		});
+		expect((page.getByRole("combobox") as HTMLInputElement).value).toBe("");
+		expect(page.getAllByRole("option")).toHaveLength(2);
+	});
+});

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/CompareBaseBranchPickerInline/CompareBaseBranchPickerInline.tsx
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/CompareBaseBranchPickerInline/CompareBaseBranchPickerInline.tsx
@@ -1,0 +1,284 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@superset/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
+import { cn } from "@superset/ui/utils";
+import { ExternalLinkIcon, PlusIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+import { GoArrowUpRight, GoGitBranch, GoGlobe } from "react-icons/go";
+import { HiCheck, HiChevronUpDown } from "react-icons/hi2";
+import { formatRelativeTime } from "renderer/lib/formatRelativeTime";
+import type { OpenableWorktreeAction } from "../../utils/resolveOpenableWorktrees";
+
+export function CompareBaseBranchPickerInline({
+	effectiveCompareBaseBranch,
+	defaultBranch,
+	isBranchesLoading,
+	isBranchesError,
+	branches,
+	worktreeBranches,
+	openableWorktrees,
+	activeWorkspacesByBranch,
+	externalWorktreeBranches,
+	modKey,
+	onSelectCompareBaseBranch,
+	onOpenWorktree,
+	onOpenActiveWorkspace,
+}: {
+	effectiveCompareBaseBranch: string | null;
+	defaultBranch?: string;
+	isBranchesLoading: boolean;
+	isBranchesError: boolean;
+	branches: Array<{ name: string; lastCommitDate: number; isLocal: boolean }>;
+	worktreeBranches: Set<string>;
+	openableWorktrees: Map<string, OpenableWorktreeAction>;
+	activeWorkspacesByBranch: Map<string, string>;
+	externalWorktreeBranches: Set<string>;
+	modKey: string;
+	onSelectCompareBaseBranch: (branchName: string) => void;
+	onOpenWorktree: (action: OpenableWorktreeAction) => void;
+	onOpenActiveWorkspace: (workspaceId: string) => void;
+}) {
+	const { t } = useLingui();
+	const [open, setOpen] = useState(false);
+	const [branchSearch, setBranchSearch] = useState("");
+	const [filterMode, setFilterMode] = useState<"all" | "worktrees">("all");
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) {
+			setBranchSearch("");
+			setFilterMode("all");
+		}
+	};
+
+	const filteredBranches = useMemo(() => {
+		if (!branches.length) return [];
+		if (!branchSearch) return branches;
+		const searchLower = branchSearch.toLowerCase();
+		return branches.filter((branch) =>
+			branch.name.toLowerCase().includes(searchLower),
+		);
+	}, [branches, branchSearch]);
+
+	const displayBranches = useMemo(() => {
+		if (filterMode === "all") return filteredBranches;
+		return filteredBranches.filter((b) => worktreeBranches.has(b.name));
+	}, [filteredBranches, filterMode, worktreeBranches]);
+
+	if (isBranchesError) {
+		return (
+			<span className="text-xs text-destructive">
+				<Trans>Failed to load branches</Trans>
+			</span>
+		);
+	}
+
+	return (
+		<Popover open={open} onOpenChange={handleOpenChange}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					disabled={isBranchesLoading}
+					className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 min-w-0 max-w-full"
+				>
+					<GoGitBranch className="size-3 shrink-0" />
+					{isBranchesLoading ? (
+						<span className="h-2.5 w-14 rounded-sm bg-muted-foreground/15 animate-pulse" />
+					) : (
+						<span className="font-mono truncate">
+							{effectiveCompareBaseBranch || "..."}
+						</span>
+					)}
+					<HiChevronUpDown className="size-3 shrink-0" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-96 p-0"
+				align="start"
+				onWheel={(event) => event.stopPropagation()}
+			>
+				<Command shouldFilter={false}>
+					<div className="flex items-center gap-0.5 rounded-md bg-muted/40 p-0.5 mx-2 mt-2">
+						{(["all", "worktrees"] as const).map((value) => {
+							const count =
+								value === "all"
+									? branches.length
+									: branches.filter((b) => worktreeBranches.has(b.name)).length;
+							return (
+								<button
+									key={value}
+									type="button"
+									onClick={() => setFilterMode(value)}
+									className={cn(
+										"flex-1 rounded px-2 py-1 text-xs text-center transition-colors",
+										filterMode === value
+											? "bg-background text-foreground shadow-sm"
+											: "text-muted-foreground hover:text-foreground",
+									)}
+								>
+									{value === "all" ? (
+										<Trans>All</Trans>
+									) : (
+										<Trans>Worktrees</Trans>
+									)}
+									<span className="ml-1 text-foreground/40">{count}</span>
+								</button>
+							);
+						})}
+					</div>
+					<CommandInput
+						placeholder={t({
+							message: "Search branches...",
+						})}
+						value={branchSearch}
+						onValueChange={setBranchSearch}
+					/>
+					<CommandList className="max-h-[400px]">
+						<CommandEmpty>
+							<Trans>No branches found</Trans>
+						</CommandEmpty>
+						{displayBranches.map((branch) => {
+							const openAction = openableWorktrees.get(branch.name);
+							const activeWorkspaceId = activeWorkspacesByBranch.get(
+								branch.name,
+							);
+							const isExternal = externalWorktreeBranches.has(branch.name);
+							const hasExistingWorkspace = !!(activeWorkspaceId || openAction);
+
+							// Determine icon based on state - all same color
+							let icon: React.ReactNode;
+							if (activeWorkspaceId) {
+								icon = (
+									<GoArrowUpRight className="size-3.5 shrink-0 text-muted-foreground" />
+								);
+							} else if (openAction) {
+								icon = (
+									<ExternalLinkIcon className="size-3.5 shrink-0 text-muted-foreground" />
+								);
+							} else if (branch.isLocal) {
+								icon = (
+									<GoGitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+								);
+							} else {
+								icon = (
+									<GoGlobe className="size-3.5 shrink-0 text-muted-foreground" />
+								);
+							}
+
+							return (
+								<CommandItem
+									key={branch.name}
+									value={branch.name}
+									onSelect={() => {
+										if (activeWorkspaceId) {
+											onOpenActiveWorkspace(activeWorkspaceId);
+										} else if (openAction) {
+											onOpenWorktree(openAction);
+										} else {
+											onSelectCompareBaseBranch(branch.name);
+										}
+										handleOpenChange(false);
+									}}
+									className="group h-11 flex items-center justify-between gap-3 px-3"
+								>
+									<span className="flex items-center gap-2.5 truncate flex-1 min-w-0">
+										{icon}
+										<span className="truncate font-mono text-xs">
+											{branch.name}
+										</span>
+
+										{/* Inline badges */}
+										<span className="flex items-center gap-1.5 shrink-0">
+											{branch.name === defaultBranch && (
+												<span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+													<Trans>default</Trans>
+												</span>
+											)}
+											{isExternal && !activeWorkspaceId && (
+												<span className="text-[10px] text-muted-foreground/60 bg-muted/60 px-1.5 py-0.5 rounded">
+													<Trans>external</Trans>
+												</span>
+											)}
+										</span>
+									</span>
+
+									{/* Right side: time + buttons */}
+									<span className="flex items-center gap-2 shrink-0">
+										{branch.lastCommitDate > 0 && (
+											<span className="text-[11px] text-muted-foreground/70 group-data-[selected=true]:hidden">
+												{formatRelativeTime(branch.lastCommitDate)}
+											</span>
+										)}
+
+										{/* Show checkmark for selected base branch when not hovering */}
+										{!hasExistingWorkspace &&
+											effectiveCompareBaseBranch === branch.name && (
+												<HiCheck className="size-4 text-primary group-data-[selected=true]:hidden" />
+											)}
+
+										{/* Action buttons - show on hover/select */}
+										<span className="hidden group-data-[selected=true]:flex items-center gap-1.5">
+											{hasExistingWorkspace && (
+												<Button
+													size="sm"
+													variant="ghost"
+													className="h-7 px-2.5 text-xs font-medium hover:bg-accent/10 hover:text-accent-foreground"
+													onClick={(e) => {
+														e.stopPropagation();
+														if (activeWorkspaceId) {
+															onOpenActiveWorkspace(activeWorkspaceId);
+														} else if (openAction) {
+															onOpenWorktree(openAction);
+														}
+														handleOpenChange(false);
+													}}
+												>
+													<GoArrowUpRight className="size-3.5 mr-1" />
+													<Trans>Open</Trans>
+													<span className="ml-1 text-[10px] opacity-60">↵</span>
+												</Button>
+											)}
+											<Button
+												size="sm"
+												className="h-7 px-2.5 text-xs font-medium"
+												onClick={(e) => {
+													e.stopPropagation();
+													onSelectCompareBaseBranch(branch.name);
+													handleOpenChange(false);
+												}}
+											>
+												{hasExistingWorkspace ? (
+													<>
+														<PlusIcon className="size-3.5 mr-1" />
+														<Trans>Create</Trans>
+														<span className="ml-1 text-[10px] opacity-70">
+															{modKey}↵
+														</span>
+													</>
+												) : (
+													<>
+														<Trans>Create</Trans>
+														<span className="ml-1 text-[10px] opacity-70">
+															↵
+														</span>
+													</>
+												)}
+											</Button>
+										</span>
+									</span>
+								</CommandItem>
+							);
+						})}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/CompareBaseBranchPickerInline/index.ts
+++ b/apps/desktop/src/renderer/components/NewWorkspaceModal/components/PromptGroup/components/CompareBaseBranchPickerInline/index.ts
@@ -1,0 +1,1 @@
+export { CompareBaseBranchPickerInline } from "./CompareBaseBranchPickerInline";

--- a/apps/desktop/src/renderer/lib/radix-layers/inputGroupPopover.test.tsx
+++ b/apps/desktop/src/renderer/lib/radix-layers/inputGroupPopover.test.tsx
@@ -24,10 +24,20 @@ afterAll(async () => {
 
 // Mirrors the workspace composer: Radix content is portaled out of the DOM
 // footer but its React click events still bubble through InputGroupAddon.
-function ComposerWithIssuePicker() {
+function ComposerWithIssuePicker({
+	control,
+}: {
+	control: "input" | "textarea" | "contenteditable";
+}) {
 	return (
 		<InputGroup>
-			<div contentEditable data-testid="composer" />
+			{control === "contenteditable" ? (
+				<div contentEditable data-testid="composer" />
+			) : control === "textarea" ? (
+				<textarea data-testid="composer" />
+			) : (
+				<input data-testid="composer" />
+			)}
 			<InputGroupAddon>
 				<span>Footer padding</span>
 				<Popover>
@@ -45,9 +55,13 @@ function ComposerWithIssuePicker() {
 	);
 }
 
-describe("input group popup interactions", () => {
+describe.each([
+	"input",
+	"textarea",
+	"contenteditable",
+] as const)("%s group popup interactions", (control) => {
 	test("clicking and typing in a portaled search keeps the popup focused and open", async () => {
-		render(<ComposerWithIssuePicker />);
+		render(<ComposerWithIssuePicker control={control} />);
 		const page = within(document.body);
 		await act(async () => {
 			fireEvent.click(page.getByRole("button", { name: "Link issue" }));
@@ -73,7 +87,7 @@ describe("input group popup interactions", () => {
 	});
 
 	test("ordinary addon clicks still focus the composer and buttons keep their action", async () => {
-		render(<ComposerWithIssuePicker />);
+		render(<ComposerWithIssuePicker control={control} />);
 		const page = within(document.body);
 		await act(async () => {
 			fireEvent.click(page.getByText("Footer padding"));

--- a/apps/desktop/src/renderer/lib/radix-layers/inputGroupPopover.test.tsx
+++ b/apps/desktop/src/renderer/lib/radix-layers/inputGroupPopover.test.tsx
@@ -1,0 +1,93 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, cleanup, fireEvent, render, waitFor, within } = await import(
+	"@testing-library/react"
+);
+const { InputGroup, InputGroupAddon } = await import(
+	"@superset/ui/input-group"
+);
+const { Popover, PopoverContent, PopoverTrigger } = await import(
+	"@superset/ui/popover"
+);
+
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+// Mirrors the workspace composer: Radix content is portaled out of the DOM
+// footer but its React click events still bubble through InputGroupAddon.
+function ComposerWithIssuePicker() {
+	return (
+		<InputGroup>
+			<div contentEditable data-testid="composer" />
+			<InputGroupAddon>
+				<span>Footer padding</span>
+				<Popover>
+					<PopoverTrigger asChild>
+						<button type="button">Link issue</button>
+					</PopoverTrigger>
+					<PopoverContent>
+						<input aria-label="Search issues" />
+						<label htmlFor="closed-issues">Show closed</label>
+						<input id="closed-issues" type="checkbox" />
+					</PopoverContent>
+				</Popover>
+			</InputGroupAddon>
+		</InputGroup>
+	);
+}
+
+describe("input group popup interactions", () => {
+	test("clicking and typing in a portaled search keeps the popup focused and open", async () => {
+		render(<ComposerWithIssuePicker />);
+		const page = within(document.body);
+		await act(async () => {
+			fireEvent.click(page.getByRole("button", { name: "Link issue" }));
+		});
+		const search = page.getByRole("textbox", { name: "Search issues" });
+		await waitFor(() => expect(document.activeElement).toBe(search));
+
+		await act(async () => {
+			fireEvent.click(search);
+			fireEvent.change(search, { target: { value: "popup" } });
+		});
+
+		expect(page.queryByRole("dialog")).not.toBeNull();
+		expect(document.activeElement).toBe(search);
+		expect((search as HTMLInputElement).value).toBe("popup");
+
+		await act(async () => {
+			fireEvent.click(page.getByText("Show closed"));
+		});
+		expect(page.queryByRole("dialog")).not.toBeNull();
+		expect((page.getByRole("checkbox") as HTMLInputElement).checked).toBe(true);
+		expect(document.activeElement).not.toBe(page.getByTestId("composer"));
+	});
+
+	test("ordinary addon clicks still focus the composer and buttons keep their action", async () => {
+		render(<ComposerWithIssuePicker />);
+		const page = within(document.body);
+		await act(async () => {
+			fireEvent.click(page.getByText("Footer padding"));
+		});
+		expect(document.activeElement).toBe(page.getByTestId("composer"));
+
+		await act(async () => {
+			fireEvent.click(page.getByRole("button", { name: "Link issue" }));
+		});
+		expect(page.queryByRole("dialog")).not.toBeNull();
+		await waitFor(() =>
+			expect(document.activeElement).toBe(
+				page.getByRole("textbox", { name: "Search issues" }),
+			),
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/components/CompareBaseBranchPicker/CompareBaseBranchPicker.tsx
@@ -67,6 +67,10 @@ export function CompareBaseBranchPicker({
 	// Mirror cmdk's selected row so Mod+Enter can resolve it without DOM lookup.
 	const [selectedValue, setSelectedValue] = useState("");
 	const sentinelRef = useRef<HTMLDivElement | null>(null);
+	const handleOpenChange = (nextOpen: boolean) => {
+		setOpen(nextOpen);
+		if (!nextOpen) onBranchSearchChange("");
+	};
 
 	useEffect(() => {
 		if (!open || !hasNextPage || isFetchingNextPage) return;
@@ -101,13 +105,7 @@ export function CompareBaseBranchPicker({
 	}
 
 	return (
-		<Popover
-			open={open}
-			onOpenChange={(v) => {
-				setOpen(v);
-				if (!v) onBranchSearchChange("");
-			}}
-		>
+		<Popover open={open} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild>
 				<FormPickerTrigger
 					disabled={isBranchesLoading && branches.length === 0}
@@ -148,7 +146,7 @@ export function CompareBaseBranchPicker({
 							e.preventDefault();
 							e.stopPropagation();
 							onOpenWorkspace(toOpenWorkspaceTarget(selectedBranch));
-							setOpen(false);
+							handleOpenChange(false);
 						}
 					}}
 				>
@@ -193,7 +191,7 @@ export function CompareBaseBranchPicker({
 											branch.name,
 											branch.isLocal ? "local" : "remote-tracking",
 										);
-										setOpen(false);
+										handleOpenChange(false);
 									}}
 									className="group items-start gap-3 rounded-md px-2.5 py-2"
 								>
@@ -247,7 +245,7 @@ export function CompareBaseBranchPicker({
 											onClick={(e) => {
 												e.stopPropagation();
 												onOpenWorkspace(toOpenWorkspaceTarget(branch));
-												setOpen(false);
+												handleOpenChange(false);
 											}}
 										>
 											<Trans>Open workspace</Trans>

--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -72,6 +72,11 @@ function InputGroupAddon({
 			data-align={align}
 			className={cn(inputGroupAddonVariants({ align }), className)}
 			onClick={(e) => {
+				// React portal clicks still bubble through the addon. Focusing the
+				// composer here would steal focus from (and dismiss) its popovers.
+				if (!e.currentTarget.contains(e.target as Node)) {
+					return;
+				}
 				if ((e.target as HTMLElement).closest("button")) {
 					return;
 				}

--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -83,6 +83,7 @@ function InputGroupAddon({
 				const parent = e.currentTarget.parentElement;
 				const focusTarget =
 					parent?.querySelector<HTMLElement>("input") ??
+					parent?.querySelector<HTMLElement>("textarea") ??
 					parent?.querySelector<HTMLElement>("[contenteditable]");
 				focusTarget?.focus();
 			}}


### PR DESCRIPTION
## What & why

Clicking the Linear, GitHub issue, or pull-request search input on New Workspace closed the picker and moved focus into the prompt editor. React portal clicks bubbled through `InputGroupAddon`, whose click handler refocused the composer. Ignore clicks originating outside the addon's DOM subtree so popups retain their own focus while ordinary addon clicks still focus the composer.

Clear branch search on every close path in both v2 and legacy pickers, including selection and opening a workspace. The legacy picker also resets its Worktrees filter. Previously, reopening after selecting a searched branch retained the old filters. Extract the legacy picker into its own component folder to test its real interactions.

The shared addon also now focuses textarea controls when clicking footer padding; tests ensure this preserves popup focus.

Audited all shared addon/header/footer consumers: the dashboard modal receives the same fix; the legacy modal, terminal rich input, web preview/design examples, and separate native mobile implementation were reviewed. [Full audit and coverage limits](https://github.com/superset-sh/superset/blob/623370d114e7daad355f2265b6f8bad23684afa0/audit.md). Both additional audit findings are fixed in this PR and covered by component integration tests.

## How I tested it

- Reproduced the original dismissal in this worktree's Electron app at `localhost:4245/#/new-workspace` via CDP, then repeated the same click after the fix: focus stays in the search input and the picker stays open.
- Exercised searches, checkbox labels, scrolling, selections, nested menus, Escape/outside clicks and reopen behavior across the page's available pickers; also checked create/clone dialogs, tooltips, native chooser opening/cancellation and image preview dismissal. Repeated the issue searches nine times after page navigation with zero captured console errors.
- Verified v2 branch search resets after both mouse and keyboard selection. Rechecked six Linear/GitHub/PR search interactions in the real app after the additional fixes.
- Verified both audit fixes in the actual legacy modal via CDP, with failing-before/passing-after screenshots: footer clicks now focus the textarea, and branch Create/reopen clears search and Worktrees filters (1 filtered result before, all 29 afterward). Also passed row/keyboard selection, Escape/outside dismissal, Open-existing-workspace then modal reopen, textarea typing and focus after remount, and GitHub/PR popup searches. Zero captured console errors or runtime exceptions in the lifecycle runs. Restored the original v2 setting afterward. Screenshots and detailed measurements are in the linked audit.
- Added a Radix integration regression test that fails without the portal guard and passes with it. Both Radix test files and legacy branch picker tests pass together: **12 tests, 60 assertions**. Legacy row/keyboard selection, Open, and Create reset tests and the textarea padding-focus test fail before their fixes and pass afterward; Escape reset also passes.
- `bun run lint:fix`, `bun run lint`, `bun run typecheck` (**38 tasks**), and `bun run check:plugins`: pass.
- `bun run test`: blocked by missing environment variables in `@superset/trpc`.
- Full desktop suite: **3,614 pass, 1 fail, 1 error** from an existing `React.createContext` mock failure in `useSidebarDnd.test.ts`. The earlier baseline run without the added regression tests produces the same failure (**3,603 pass**).
- Native file selection and populated prompt history were not verified end-to-end. Image preview setup used CDP file input. The dashboard modal and web/mobile consumers were source-audited; the legacy modal was also tested live as detailed above.

Before: clicking search dismisses the popup.

![Before: search click focuses composer and closes popup](https://raw.githubusercontent.com/superset-sh/superset/623370d114e7daad355f2265b6f8bad23684afa0/before.png)

After: the same click retains the search input and popup.

![After: search input remains focused and popup stays open](https://raw.githubusercontent.com/superset-sh/superset/623370d114e7daad355f2265b6f8bad23684afa0/after.png)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — same-repository branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an inline compare-base branch picker with branch search, All/Worktrees filters, status badges, and actions to select branches, open worktrees, or create workspaces.
  - Added loading and error states for branch information.

- **Bug Fixes**
  - Popovers now remain open and focused correctly when interacting with portaled search content.
  - Addon clicks correctly focus supported controls, including textareas.
  - Branch searches now clear consistently whenever the picker closes or an action is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
