### PR TITLE
fix(sentry): turn tracing off everywhere and stop reporting updater transport errors

### DIFF
--- a/apps/admin/sentry.edge.config.ts
+++ b/apps/admin/sentry.edge.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
-	tracesSampleRate: 0.05,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/admin/sentry.server.config.ts
+++ b/apps/admin/sentry.server.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
-	tracesSampleRate: 0.05,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/admin/src/instrumentation-client.ts
+++ b/apps/admin/src/instrumentation-client.ts
@@ -31,7 +31,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: !!env.NEXT_PUBLIC_SENTRY_DSN_ADMIN,
-	tracesSampleRate: 0.05,
 	replaysSessionSampleRate: 0,
 	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,

--- a/apps/api/sentry.edge.config.ts
+++ b/apps/api/sentry.edge.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_API,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampler: ({ name }) => (name.includes("/api/auth/") ? 0 : 0.05),
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/api/sentry.server.config.ts
+++ b/apps/api/sentry.server.config.ts
@@ -6,15 +6,11 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_API,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	// Per-route sampling. /api/auth/* is session/JWT polling from every
-	// client — 87% of api traffic (~600M req/30d) with no diagnostic value,
-	// and at 10% it alone blew the span quota 16x. Webhooks/jobs are low
-	// volume and each trace is useful; the rest gets a working sample.
-	tracesSampler: ({ name }) => {
-		if (name.includes("/api/auth/")) return 0;
-		if (name.includes("/webhook") || name.includes("/jobs/")) return 0.25;
-		return 0.05;
-	},
+	// No tracesSampleRate or tracesSampler on purpose: the SDK treats a rate of
+	// 0 as "tracing on, sample nothing" and still records every span whose
+	// parent was sampled, and a sampler here was storing a flat 5% of ~20M
+	// requests a day (~19M spans, 115x the org quota). Omitting both disables
+	// spans outright.
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -68,15 +68,13 @@ export type { AutoUpdateStatusEvent } from "shared/auto-update";
 
 export const autoUpdateEmitter = new EventEmitter();
 
-// Network errors that don't need to be shown to the user
-// These are transient/expected and will resolve on retry
+// Network errors that don't need to be shown to the user or reported: they are
+// transient and the next check retries. Chromium names every transport failure
+// net::ERR_* (timeouts, HTTP/2 resets, a laptop suspending mid-download, a
+// proxy's certificate), and none of them is a defect in the feed or artifact —
+// an enumerated list was reporting ~800 of the unlisted ones a day.
 const SILENT_ERROR_PATTERNS = [
-	"net::ERR_INTERNET_DISCONNECTED",
-	"net::ERR_NETWORK_CHANGED",
-	"net::ERR_CONNECTION_REFUSED",
-	"net::ERR_NAME_NOT_RESOLVED",
-	"net::ERR_CONNECTION_TIMED_OUT",
-	"net::ERR_CONNECTION_RESET",
+	"net::ERR_",
 	"ENOTFOUND",
 	"ETIMEDOUT",
 	"ECONNREFUSED",

--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -81,8 +81,11 @@ const SILENT_ERROR_PATTERNS = [
 	"ECONNRESET",
 ];
 
+// Certificate failures are the exception: a proxy that rewrites TLS is
+// permanent, so the user needs to see why updates never arrive.
 function isNetworkError(error: Error | string): boolean {
 	const message = typeof error === "string" ? error : error.message;
+	if (message.includes("net::ERR_CERT_")) return false;
 	return SILENT_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
 }
 

--- a/apps/desktop/src/main/lib/sentry.ts
+++ b/apps/desktop/src/main/lib/sentry.ts
@@ -21,7 +21,6 @@ export function initSentry(): void {
 		Sentry.init({
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
-			tracesSampleRate: 0,
 			sendDefaultPii: false,
 			// One machine repeating one failure should not crowd out everyone
 			// else's rare ones, nor spend the org's quota getting there.

--- a/apps/desktop/src/renderer/lib/sentry.ts
+++ b/apps/desktop/src/renderer/lib/sentry.ts
@@ -22,7 +22,6 @@ export async function initSentry(): Promise<void> {
 		Sentry.init({
 			dsn: env.SENTRY_DSN_DESKTOP,
 			environment: env.NODE_ENV,
-			tracesSampleRate: 0,
 			ignoreErrors: SENTRY_IGNORE_ERRORS,
 			// tRPC failures are reported by the main-process middleware with full
 			// server context; renderer copies (unhandled query/mutation promises)

--- a/apps/docs/sentry.edge.config.ts
+++ b/apps/docs/sentry.edge.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.01,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/docs/sentry.server.config.ts
+++ b/apps/docs/sentry.server.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.01,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -37,7 +37,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_DOCS,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.01,
 	replaysSessionSampleRate: 0,
 	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,

--- a/apps/marketing/sentry.edge.config.ts
+++ b/apps/marketing/sentry.edge.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.01,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/marketing/sentry.server.config.ts
+++ b/apps/marketing/sentry.server.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.01,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/marketing/src/instrumentation-client.ts
+++ b/apps/marketing/src/instrumentation-client.ts
@@ -63,7 +63,6 @@ async function initSentry() {
 		dsn: env.NEXT_PUBLIC_SENTRY_DSN_MARKETING,
 		environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 		enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-		tracesSampleRate: 0.01,
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 0,
 		sendDefaultPii: true,

--- a/apps/mobile/lib/sentry/sentry.ts
+++ b/apps/mobile/lib/sentry/sentry.ts
@@ -8,7 +8,6 @@ export function initSentry() {
 	Sentry.init({
 		dsn: env.EXPO_PUBLIC_SENTRY_DSN_MOBILE,
 		environment: env.EXPO_PUBLIC_SENTRY_ENVIRONMENT,
-		tracesSampleRate: 0,
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 0,
 		sendDefaultPii: false,

--- a/apps/relay/src/index.ts
+++ b/apps/relay/src/index.ts
@@ -307,9 +307,10 @@ function isPeerGone(message: string): boolean {
 
 // Exceptions only — console/breadcrumb capture stays off: retaining every log
 // line is a memory leak at relay volume. No-op until SENTRY_DSN is set.
+// No tracesSampleRate either: 0 keeps tracing enabled and inherits the caller's
+// sampling decision, which stored 165k /presence spans a day from api traces.
 const sentryOptions = (env: RelayEnv): Sentry.CloudflareOptions => ({
 	dsn: env.SENTRY_DSN,
-	tracesSampleRate: 0,
 	sendDefaultPii: false,
 	integrations: (defaults) =>
 		defaults.filter((integration) => integration.name !== "Console"),

--- a/apps/usercontent/src/index.ts
+++ b/apps/usercontent/src/index.ts
@@ -457,7 +457,6 @@ app.notFound(() => notFound());
 // Exceptions only; no-op until SENTRY_DSN is set.
 const sentryOptions = (env: UsercontentEnv): Sentry.CloudflareOptions => ({
 	dsn: env.SENTRY_DSN,
-	tracesSampleRate: 0,
 	sendDefaultPii: false,
 	integrations: (defaults) =>
 		defaults.filter((integration) => integration.name !== "Console"),

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.05,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -6,7 +6,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.05,
 	sendDefaultPii: true,
 	debug: false,
 });

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -29,7 +29,6 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_WEB,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	tracesSampleRate: 0.05,
 	replaysSessionSampleRate: 0,
 	replaysOnErrorSampleRate: 0,
 	sendDefaultPii: true,

--- a/packages/host-service/src/sentry.ts
+++ b/packages/host-service/src/sentry.ts
@@ -15,7 +15,6 @@ export function initSentry(options: { organizationId?: string }): void {
 		dsn,
 		release: process.env.HOST_SERVICE_SENTRY_RELEASE,
 		environment: process.env.HOST_SERVICE_SENTRY_ENVIRONMENT,
-		tracesSampleRate: 0,
 		// A host that fails once usually fails in a loop: git.getStatus alone
 		// sent 135k copies of one `spawn EBADF` from seven machines last month.
 		beforeSend: throttleRepeats,


### PR DESCRIPTION
## Why

The Sentry bill: **262M spans against a 5M quota (5251%)**, 98% from the `api` project, plus errors at 774%.

- The api's `tracesSampler` (from #6087) was storing a flat 5% of every route — auth and webhooks included, so its route rules never took effect. ~20M requests/day × ~18 spans × 5% ≈ 19M stored spans/day, 115x the monthly quota every day since at least Aug 8. Not a spike: the org rejected everything Sep 1–3, then ingestion resumed at the same rate and became billable.
- The relay, at `tracesSampleRate: 0`, was still storing 165k `/presence` spans/day. In `@sentry/core` 10.68 `hasSpansEnabled` is a `!= null` check, so 0 keeps tracing on, and `sampleSpan` lets a sampled parent override the local rate. The api calls the relay with sampled headers.

## What

- Remove `tracesSampleRate` / `tracesSampler` from every Sentry init in the repo (api, web, admin, docs, marketing — server, edge and client; relay, usercontent, host-service, desktop main + renderer, mobile). Omitting the key is the only setting the SDK treats as disabled. Nothing in the repo calls `startSpan`. Replay rates are untouched.
- `apps/desktop/src/main/lib/auto-updater.ts`: the silent network list matches any `net::ERR_` message instead of six named ones. The unlisted variants (`ERR_TIMED_OUT`, `ERR_HTTP2_PROTOCOL_ERROR`, `ERR_NETWORK_IO_SUSPENDED`, …) were DESKTOP-1E, 40% of desktop errors, 54k events since January. Chromium transport failures reaching the GitHub feed are not ours to fix and the next check retries.

When traces work is wanted later: a `tracesSampler` returning ~0.001 for the routes under investigation and 0 elsewhere, time-boxed — never a flat rate.

## Verification

- `biome check` clean on all changed files.
- `turbo typecheck` passes for api, relay, web, admin, docs, marketing, host-service, desktop, usercontent.

https://claude.ai/code/session_01Sjva1Y1dnaKt1Eew3YRPNS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables Sentry tracing across all apps to stop the 5251% span overage (262M spans against a 5M quota) and silences transient updater network errors in the desktop app.

**Sentry tracing**
- Removed `tracesSampler`/`tracesSampleRate` from every Sentry init (api, web, admin, docs, marketing, relay, usercontent, host-service, desktop, mobile) — omitting the key is the only setting the SDK treats as disabled.
- The api was storing a flat 5% of ~20M requests a day because its per-route rules never took effect, ~19M spans a day against the monthly quota.
- The relay stored 165k `/presence` spans a day because `tracesSampleRate: 0` still enables tracing and inherits an already-sampled parent.
- Nothing calls `startSpan`, and replay rates are untouched.

**Desktop updater**
- The silent list now matches any `net::ERR_*` message instead of six named variants, except `net::ERR_CERT_*`, which stays reported because a broken TLS proxy or certificate is permanent.
- The unlisted transient variants (timeouts, HTTP/2 resets, suspended machines) were ~800 a day, 40% of desktop error volume — the next check retries.

<sup>Written for commit b2b724b45b76d95f38f9d0ef374c863b0e26c3df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Desktop update checks now surface certificate-related connection failures as errors instead of silently retrying them.
  - Certificate-related update failures are cleared from cached update state and reported for monitoring.
- **Monitoring**
  - Sentry tracing now follows default or inherited sampling behavior across applications and services.
  - Removed explicit trace-sampling limits, including configurations that disabled tracing.
  - API traces no longer use route-specific sampling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->