### PR TITLE
feat(mcp): agents_presets add/edit/remove

### DIFF
--- a/packages/agent-setup/src/disabled-agent-hooks.test.ts
+++ b/packages/agent-setup/src/disabled-agent-hooks.test.ts
@@ -9,13 +9,28 @@ import {
 	writeSharedDisabledAgentIds,
 } from "./disabled-agent-hooks";
 
-const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "superset-hooks-"));
 const ORIGINAL_HOME_DIR = process.env.SUPERSET_HOME_DIR;
 const ORIGINAL_DISABLED = process.env.SUPERSET_DISABLED_AGENT_HOOKS;
 
+let testHome: string;
+
 beforeEach(() => {
-	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	// A fresh directory per test (rather than wiping/reusing one shared dir)
+	// so this file has no directory-reuse race with anything else in the suite.
+	testHome = fs.mkdtempSync(path.join(os.tmpdir(), "superset-hooks-"));
+	process.env.SUPERSET_HOME_DIR = testHome;
 	delete process.env.SUPERSET_DISABLED_AGENT_HOOKS;
+	// agent-wrappers.test.ts mock.module()s "./paths" for the whole process
+	// without restoring it, and bun runs a package's test files in one process
+	// in no guaranteed order. So when that file loads first,
+	// resolveSupersetHomeDir() here ignores SUPERSET_HOME_DIR and lands in that
+	// file's root: every test below shares one state file, and the root itself
+	// may already be deleted by that file's afterEach. Work from the path these
+	// tests actually read — clear the state file so an earlier test's write
+	// can't leak in, and create its directory so the writes here can't fail.
+	const stateFile = getAgentHooksStateFilePath();
+	fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+	fs.rmSync(stateFile, { force: true });
 });
 
 afterEach(() => {
@@ -24,8 +39,7 @@ afterEach(() => {
 	if (ORIGINAL_DISABLED === undefined)
 		delete process.env.SUPERSET_DISABLED_AGENT_HOOKS;
 	else process.env.SUPERSET_DISABLED_AGENT_HOOKS = ORIGINAL_DISABLED;
-	fs.rmSync(TEST_HOME, { recursive: true, force: true });
-	fs.mkdirSync(TEST_HOME, { recursive: true });
+	fs.rmSync(testHome, { recursive: true, force: true });
 });
 
 describe("shared disabled-agent-hooks state", () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -18,7 +18,8 @@
 		}
 	},
 	"scripts": {
-		"typecheck": "tsc --noEmit --emitDeclarationOnly false"
+		"typecheck": "tsc --noEmit --emitDeclarationOnly false",
+		"test": "bun test"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "1.30.0",

--- a/packages/mcp/src/tools/agents/presets/add.test.ts
+++ b/packages/mcp/src/tools/agents/presets/add.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHarness } from "./test-harness";
+
+const harness = createHarness();
+
+mock.module("../../../define-tool", () => ({
+	defineTool: harness.defineTool,
+}));
+mock.module("../../../host-service-client", () => ({
+	hostServiceCall: harness.hostServiceCall,
+}));
+
+const mod = await import("./add");
+const tool = harness.register(mod);
+
+beforeEach(() => {
+	harness.calls.length = 0;
+	harness.setResponse({});
+});
+
+describe("agents_presets_add", () => {
+	test("is a non-destructive tool named for preset CRUD", () => {
+		expect(tool.name).toBe("agents_presets_add");
+		expect(tool.annotations).toEqual({ destructiveHint: false });
+	});
+
+	test("sends a structured command with the host's defaults filled in", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			label: "Claude",
+			command: "claude",
+			args: ["--dangerously-skip-permissions"],
+		});
+
+		expect(harness.calls).toEqual([
+			{
+				hostId: "host-1",
+				procedure: "settings.agentConfigs.add",
+				method: "mutation",
+				input: {
+					label: "Claude",
+					command: "claude",
+					args: ["--dangerously-skip-permissions"],
+					promptTransport: "argv",
+					promptArgs: [],
+					env: {},
+					presetId: undefined,
+				},
+			},
+		]);
+	});
+
+	test("splits launchCommand into binary and args", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			label: "Codex",
+			launchCommand: "codex  --full-auto --sandbox danger",
+			promptTransport: "stdin",
+			promptArgs: ["-p"],
+			env: { CODEX_HOME: "/tmp/codex" },
+			presetId: "codex",
+		});
+
+		expect(harness.calls[0]?.input).toEqual({
+			label: "Codex",
+			command: "codex",
+			args: ["--full-auto", "--sandbox", "danger"],
+			promptTransport: "stdin",
+			promptArgs: ["-p"],
+			env: { CODEX_HOME: "/tmp/codex" },
+			presetId: "codex",
+		});
+	});
+
+	test("rejects a call that gives both launch shapes", async () => {
+		await expect(
+			harness.invoke(tool, {
+				hostId: "host-1",
+				label: "Claude",
+				command: "claude",
+				launchCommand: "claude --resume",
+			}),
+		).rejects.toThrow(
+			"Pass either command (with optional args) or launchCommand, not both.",
+		);
+		expect(harness.calls).toEqual([]);
+	});
+
+	test("rejects a launchCommand that tokenizes to nothing", async () => {
+		await expect(
+			harness.invoke(tool, {
+				hostId: "host-1",
+				label: "Claude",
+				launchCommand: "   ",
+			}),
+		).rejects.toThrow("launchCommand is empty");
+		expect(harness.calls).toEqual([]);
+	});
+
+	test("rejects a call that gives no command at all", async () => {
+		await expect(
+			harness.invoke(tool, { hostId: "host-1", label: "Claude" }),
+		).rejects.toThrow("Provide command");
+		expect(harness.calls).toEqual([]);
+	});
+
+	test("rejects args without a command to attach them to", async () => {
+		await expect(
+			harness.invoke(tool, {
+				hostId: "host-1",
+				label: "Claude",
+				args: ["--resume"],
+			}),
+		).rejects.toThrow("args must be passed together with command.");
+		expect(harness.calls).toEqual([]);
+	});
+
+	test("returns the created config from the host", async () => {
+		harness.setResponse({ id: "config-1", label: "Claude" });
+
+		expect(
+			await harness.invoke(tool, {
+				hostId: "host-1",
+				label: "Claude",
+				command: "claude",
+			}),
+		).toEqual({ id: "config-1", label: "Claude" });
+	});
+});

--- a/packages/mcp/src/tools/agents/presets/add.ts
+++ b/packages/mcp/src/tools/agents/presets/add.ts
@@ -1,0 +1,97 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { defineTool } from "../../../define-tool";
+import { hostServiceCall } from "../../../host-service-client";
+import { resolveLaunch } from "./launch-input";
+import type { HostAgentConfig } from "./types";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "agents_presets_add",
+		annotations: { destructiveHint: false },
+		description:
+			"Add a terminal-agent preset to a host — a new row in Settings → Agents on that machine, launchable afterwards by `agents_create` or `workspaces_create`. Describe the launch either structurally (`command` plus `args`) or as a single `launchCommand` line; passing both is an error. Returns the created config, including the instance id to pass to `agents_presets_edit` or `agents_presets_remove`.",
+		inputSchema: {
+			hostId: z
+				.string()
+				.min(1)
+				.describe(
+					"Host machineId to add the preset on. See `hosts_list` to enumerate accessible hosts.",
+				),
+			label: z
+				.string()
+				.min(1)
+				.describe("Display name shown in Settings → Agents and agent pickers."),
+			command: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Binary to run, without arguments (e.g. `claude`). Pair with `args`. Mutually exclusive with `launchCommand`; one of the two is required.",
+				),
+			args: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"Arguments always passed to the binary, before any prompt args. Only valid alongside `command`; defaults to none.",
+				),
+			launchCommand: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Full launch line split on whitespace into binary and args (e.g. `codex --full-auto`). There is no quoting — an argument containing a space has to go through `command` + `args`. Mutually exclusive with `command`/`args`.",
+				),
+			promptTransport: z
+				.enum(["argv", "stdin"])
+				.default("argv")
+				.describe(
+					"How the prompt reaches the agent: `argv` appends it as a final argument, `stdin` pipes it.",
+				),
+			promptArgs: z
+				.array(z.string())
+				.default([])
+				.describe(
+					'Extra arguments spliced in when a prompt is present (e.g. `["-p"]`).',
+				),
+			env: z
+				.record(z.string(), z.string())
+				.default({})
+				.describe("Environment variables set for the agent process."),
+			presetId: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"Metadata tag identifying which built-in preset this row came from, used for the description and icon fallback. Defaults to `custom`. Duplicates are allowed — every row gets its own id.",
+				),
+		},
+		handler: async (input, ctx) => {
+			const launch = resolveLaunch(input);
+			if (!launch) {
+				throw new Error(
+					"Provide command (the binary, with optional args) or launchCommand (a full launch line).",
+				);
+			}
+			return hostServiceCall<HostAgentConfig>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: input.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"settings.agentConfigs.add",
+				"mutation",
+				{
+					label: input.label,
+					command: launch.command,
+					args: launch.args,
+					promptTransport: input.promptTransport,
+					promptArgs: input.promptArgs,
+					env: input.env,
+					presetId: input.presetId,
+				},
+			);
+		},
+	});
+}

--- a/packages/mcp/src/tools/agents/presets/edit.test.ts
+++ b/packages/mcp/src/tools/agents/presets/edit.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHarness } from "./test-harness";
+
+const harness = createHarness();
+
+mock.module("../../../define-tool", () => ({
+	defineTool: harness.defineTool,
+}));
+mock.module("../../../host-service-client", () => ({
+	hostServiceCall: harness.hostServiceCall,
+}));
+
+const mod = await import("./edit");
+const tool = harness.register(mod);
+
+beforeEach(() => {
+	harness.calls.length = 0;
+	harness.setResponse({});
+});
+
+describe("agents_presets_edit", () => {
+	test("is a non-destructive, idempotent tool", () => {
+		expect(tool.name).toBe("agents_presets_edit");
+		expect(tool.annotations).toEqual({
+			destructiveHint: false,
+			idempotentHint: true,
+		});
+	});
+
+	test("patches only the fields the caller passed", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			id: "config-1",
+			label: "Claude (yolo)",
+			env: { ANTHROPIC_MODEL: "opus" },
+		});
+
+		expect(harness.calls).toEqual([
+			{
+				hostId: "host-1",
+				procedure: "settings.agentConfigs.update",
+				method: "mutation",
+				input: {
+					id: "config-1",
+					patch: {
+						label: "Claude (yolo)",
+						env: { ANTHROPIC_MODEL: "opus" },
+					},
+				},
+			},
+		]);
+	});
+
+	test("replaces command and args as a pair", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			id: "config-1",
+			command: "claude",
+			args: ["--permission-mode", "plan"],
+		});
+
+		expect(harness.calls[0]?.input).toEqual({
+			id: "config-1",
+			patch: { command: "claude", args: ["--permission-mode", "plan"] },
+		});
+	});
+
+	test("clears stored args when a command arrives without them", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			id: "config-1",
+			command: "claude",
+		});
+
+		expect(harness.calls[0]?.input).toEqual({
+			id: "config-1",
+			patch: { command: "claude", args: [] },
+		});
+	});
+
+	test("splits launchCommand into the command and args pair", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			id: "config-1",
+			launchCommand: "codex --full-auto",
+		});
+
+		expect(harness.calls[0]?.input).toEqual({
+			id: "config-1",
+			patch: { command: "codex", args: ["--full-auto"] },
+		});
+	});
+
+	test("rejects a patch that gives both launch shapes", async () => {
+		await expect(
+			harness.invoke(tool, {
+				hostId: "host-1",
+				id: "config-1",
+				command: "claude",
+				launchCommand: "codex --full-auto",
+			}),
+		).rejects.toThrow(
+			"Pass either command (with optional args) or launchCommand, not both.",
+		);
+		expect(harness.calls).toEqual([]);
+	});
+
+	test("refuses an empty patch without calling the host", async () => {
+		await expect(
+			harness.invoke(tool, { hostId: "host-1", id: "config-1" }),
+		).rejects.toThrow("Nothing to update");
+		expect(harness.calls).toEqual([]);
+	});
+
+	test("passes an emptied promptArgs and env through as a real change", async () => {
+		await harness.invoke(tool, {
+			hostId: "host-1",
+			id: "config-1",
+			promptArgs: [],
+			env: {},
+		});
+
+		expect(harness.calls[0]?.input).toEqual({
+			id: "config-1",
+			patch: { promptArgs: [], env: {} },
+		});
+	});
+
+	test("returns the updated config from the host", async () => {
+		harness.setResponse({ id: "config-1", label: "Claude (yolo)" });
+
+		expect(
+			await harness.invoke(tool, {
+				hostId: "host-1",
+				id: "config-1",
+				label: "Claude (yolo)",
+			}),
+		).toEqual({ id: "config-1", label: "Claude (yolo)" });
+	});
+});

--- a/packages/mcp/src/tools/agents/presets/edit.ts
+++ b/packages/mcp/src/tools/agents/presets/edit.ts
@@ -1,0 +1,90 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { defineTool } from "../../../define-tool";
+import { hostServiceCall } from "../../../host-service-client";
+import { resolveLaunch } from "./launch-input";
+import type { HostAgentConfig } from "./types";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "agents_presets_edit",
+		annotations: { destructiveHint: false, idempotentHint: true },
+		description:
+			"Edit a terminal-agent preset on a host. Every field replaces rather than merges: `promptArgs` and `env` overwrite the stored set whole, and `command` and `args` always move together. Omitted fields are left alone, but at least one is required. `presetId` and display order are not editable. Returns the updated config.",
+		inputSchema: {
+			hostId: z.string().min(1).describe("Host machineId the preset lives on."),
+			id: z
+				.string()
+				.min(1)
+				.describe(
+					"Instance id of the preset to edit, as returned by `agents_list` or `agents_presets_add`.",
+				),
+			label: z.string().min(1).optional().describe("New display name."),
+			command: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"New binary, without arguments. Replaces `args` too — pass them together, or the stored args are cleared. Mutually exclusive with `launchCommand`.",
+				),
+			args: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"New argument list, replacing the stored one. Only valid alongside `command`.",
+				),
+			launchCommand: z
+				.string()
+				.min(1)
+				.optional()
+				.describe(
+					"New launch line, split on whitespace into binary and args. Mutually exclusive with `command`/`args`.",
+				),
+			promptTransport: z
+				.enum(["argv", "stdin"])
+				.optional()
+				.describe(
+					"How the prompt reaches the agent: `argv` appends it as a final argument, `stdin` pipes it.",
+				),
+			promptArgs: z
+				.array(z.string())
+				.optional()
+				.describe(
+					"New prompt arguments, replacing the stored set. Pass `[]` to clear.",
+				),
+			env: z
+				.record(z.string(), z.string())
+				.optional()
+				.describe(
+					"New environment map, replacing the stored one whole. Pass `{}` to clear.",
+				),
+		},
+		handler: async (input, ctx) => {
+			const launch = resolveLaunch(input);
+			const patch: Record<string, unknown> = {};
+			if (input.label !== undefined) patch.label = input.label;
+			if (launch) {
+				patch.command = launch.command;
+				patch.args = launch.args;
+			}
+			if (input.promptTransport !== undefined)
+				patch.promptTransport = input.promptTransport;
+			if (input.promptArgs !== undefined) patch.promptArgs = input.promptArgs;
+			if (input.env !== undefined) patch.env = input.env;
+			if (Object.keys(patch).length === 0) {
+				throw new Error("Nothing to update");
+			}
+			return hostServiceCall<HostAgentConfig>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: input.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"settings.agentConfigs.update",
+				"mutation",
+				{ id: input.id, patch },
+			);
+		},
+	});
+}

--- a/packages/mcp/src/tools/agents/presets/launch-input.ts
+++ b/packages/mcp/src/tools/agents/presets/launch-input.ts
@@ -1,0 +1,53 @@
+import { tokenizeAgentCommand } from "@superset/shared/host-agent-presets";
+
+export interface LaunchInput {
+	command?: string;
+	args?: string[];
+	launchCommand?: string;
+}
+
+export interface ResolvedLaunch {
+	command: string;
+	args: string[];
+}
+
+/**
+ * Collapse the two ways a caller can describe how an agent launches into the
+ * single `command` + `args` pair the host stores.
+ *
+ * Structured `command` + `args` is the primary shape. `launchCommand` mirrors
+ * the CLI's `--command`: one whitespace-separated launch line, split into
+ * binary and args, for a caller that has a command line rather than an argv
+ * array. Both at once would make the winner arbitrary, so it is rejected.
+ *
+ * Returns undefined when the caller supplied neither — `edit` reads that as
+ * "leave the launch settings alone", `add` rejects it.
+ */
+export function resolveLaunch(input: LaunchInput): ResolvedLaunch | undefined {
+	const hasStructured = input.command !== undefined || input.args !== undefined;
+	if (input.launchCommand !== undefined && hasStructured) {
+		throw new Error(
+			"Pass either command (with optional args) or launchCommand, not both.",
+		);
+	}
+
+	if (input.launchCommand !== undefined) {
+		const [command, ...args] = tokenizeAgentCommand(input.launchCommand);
+		if (!command) throw new Error("launchCommand is empty");
+		return { command, args };
+	}
+
+	if (input.command === undefined) {
+		// `args` alone has no binary to attach to. Command and args always
+		// replace each other as a pair, so that the stored launch line can
+		// never be half of one caller's intent and half of an earlier one's.
+		if (input.args !== undefined) {
+			throw new Error("args must be passed together with command.");
+		}
+		return undefined;
+	}
+
+	const command = input.command.trim();
+	if (!command) throw new Error("command is empty");
+	return { command, args: input.args ?? [] };
+}

--- a/packages/mcp/src/tools/agents/presets/remove.test.ts
+++ b/packages/mcp/src/tools/agents/presets/remove.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHarness } from "./test-harness";
+
+const harness = createHarness();
+
+mock.module("../../../define-tool", () => ({
+	defineTool: harness.defineTool,
+}));
+mock.module("../../../host-service-client", () => ({
+	hostServiceCall: harness.hostServiceCall,
+}));
+
+const mod = await import("./remove");
+const tool = harness.register(mod);
+
+beforeEach(() => {
+	harness.calls.length = 0;
+	harness.setResponse({ success: true });
+});
+
+describe("agents_presets_remove", () => {
+	test("is flagged destructive", () => {
+		expect(tool.name).toBe("agents_presets_remove");
+		expect(tool.annotations).toEqual({ destructiveHint: true });
+	});
+
+	test("deletes the row and echoes the id back", async () => {
+		const result = await harness.invoke(tool, {
+			hostId: "host-1",
+			id: "config-1",
+		});
+
+		expect(harness.calls).toEqual([
+			{
+				hostId: "host-1",
+				procedure: "settings.agentConfigs.remove",
+				method: "mutation",
+				input: { id: "config-1" },
+			},
+		]);
+		expect(result).toEqual({ id: "config-1", success: true });
+	});
+
+	test("surfaces a host failure instead of reporting success", async () => {
+		harness.setFailure(new Error("Host agent config not found: config-9"));
+
+		await expect(
+			harness.invoke(tool, { hostId: "host-1", id: "config-9" }),
+		).rejects.toThrow("Host agent config not found: config-9");
+	});
+});

--- a/packages/mcp/src/tools/agents/presets/remove.ts
+++ b/packages/mcp/src/tools/agents/presets/remove.ts
@@ -1,0 +1,38 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { defineTool } from "../../../define-tool";
+import { hostServiceCall } from "../../../host-service-client";
+
+export function register(server: McpServer): void {
+	defineTool(server, {
+		name: "agents_presets_remove",
+		annotations: { destructiveHint: true },
+		description:
+			"Delete a terminal-agent preset from a host, removing the row from Settings → Agents. Sessions already running are untouched; the agent can no longer be launched by this id. Fails if the id does not exist.",
+		inputSchema: {
+			hostId: z.string().min(1).describe("Host machineId the preset lives on."),
+			id: z
+				.string()
+				.min(1)
+				.describe(
+					"Instance id of the preset to delete, as returned by `agents_list`.",
+				),
+		},
+		handler: async (input, ctx) => {
+			await hostServiceCall<{ success: true }>(
+				{
+					relayUrl: ctx.relayUrl,
+					organizationId: ctx.organizationId,
+					hostId: input.hostId,
+					jwt: ctx.bearerToken,
+				},
+				"settings.agentConfigs.remove",
+				"mutation",
+				{ id: input.id },
+			);
+			// The host answers with a bare `{ success: true }`; echoing the id back
+			// keeps the deleted row identifiable in the tool result.
+			return { id: input.id, success: true as const };
+		},
+	});
+}

--- a/packages/mcp/src/tools/agents/presets/test-harness.ts
+++ b/packages/mcp/src/tools/agents/presets/test-harness.ts
@@ -1,0 +1,82 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { type ZodRawShape, z } from "zod";
+import type { McpContext } from "../../../auth";
+
+/**
+ * Test double for `defineTool` and `hostServiceCall`.
+ *
+ * The real `defineTool` reaches the database client through the MCP auth
+ * module, which needs credentials these tools never use. Mocking that seam
+ * keeps the tests to what the tool files themselves decide: the declared
+ * schema, the input the handler builds for the host, and the errors it raises
+ * before the host is called at all.
+ */
+export interface CapturedTool {
+	name: string;
+	annotations?: ToolAnnotations;
+	description: string;
+	inputSchema: ZodRawShape;
+	handler: (input: unknown, ctx: McpContext) => Promise<unknown>;
+}
+
+export interface CapturedCall {
+	procedure: string;
+	method: string;
+	input: unknown;
+	hostId: string;
+}
+
+const CTX = {
+	relayUrl: "https://relay.test",
+	organizationId: "org-1",
+	bearerToken: "bearer",
+} as McpContext;
+
+export function createHarness() {
+	const tools: CapturedTool[] = [];
+	const calls: CapturedCall[] = [];
+	let response: unknown = {};
+	let failure: Error | undefined;
+
+	return {
+		calls,
+		setResponse(next: unknown) {
+			response = next;
+			failure = undefined;
+		},
+		/** Make the next host call reject, the way an unreachable or
+		 * complaining host does. */
+		setFailure(next: Error) {
+			failure = next;
+		},
+		defineTool(_server: unknown, def: CapturedTool) {
+			tools.push(def);
+		},
+		hostServiceCall(
+			options: { hostId: string },
+			procedure: string,
+			method: string,
+			input: unknown,
+		) {
+			calls.push({ procedure, method, input, hostId: options.hostId });
+			return failure ? Promise.reject(failure) : Promise.resolve(response);
+		},
+		/** Register the module under test and hand back its single tool. */
+		register(mod: { register: (server: McpServer) => void }): CapturedTool {
+			tools.length = 0;
+			mod.register({} as McpServer);
+			const tool = tools[0];
+			if (!tool) throw new Error("register() defined no tool");
+			return tool;
+		},
+		/**
+		 * Call a tool the way the MCP server would: validate and default the
+		 * raw arguments against the declared schema first, so tests exercise
+		 * the defaults rather than restating them.
+		 */
+		invoke(tool: CapturedTool, input: Record<string, unknown>) {
+			return tool.handler(z.object(tool.inputSchema).parse(input), CTX);
+		},
+	};
+}

--- a/packages/mcp/src/tools/agents/presets/types.ts
+++ b/packages/mcp/src/tools/agents/presets/types.ts
@@ -1,0 +1,20 @@
+import type { PromptTransport } from "@superset/shared/agent-prompt-launch";
+
+/**
+ * A configured terminal-agent row on a host — one entry in Settings → Agents.
+ * Mirrors the output of `settings.agentConfigs.*` on the host tRPC router.
+ */
+export interface HostAgentConfig {
+	id: string;
+	presetId: string;
+	iconId: string | null;
+	label: string;
+	command: string;
+	args: string[];
+	promptTransport: PromptTransport;
+	promptArgs: string[];
+	resumeArgs: string[];
+	forkArgs: string[];
+	env: Record<string, string>;
+	order: number;
+}

--- a/packages/mcp/src/tools/register.ts
+++ b/packages/mcp/src/tools/register.ts
@@ -6,6 +6,9 @@ import {
 
 import * as agentsCreate from "./agents/create";
 import * as agentsList from "./agents/list";
+import * as agentsPresetsAdd from "./agents/presets/add";
+import * as agentsPresetsEdit from "./agents/presets/edit";
+import * as agentsPresetsRemove from "./agents/presets/remove";
 import * as automationsCreate from "./automations/create";
 import * as automationsDelete from "./automations/delete";
 import * as automationsGet from "./automations/get";
@@ -69,6 +72,9 @@ const REGISTRARS = [
 	workspacesDelete,
 	agentsCreate,
 	agentsList,
+	agentsPresetsAdd,
+	agentsPresetsEdit,
+	agentsPresetsRemove,
 	terminalsCreate,
 	terminalsList,
 	terminalsSend,

--- a/packages/shared/src/host-agent-presets.ts
+++ b/packages/shared/src/host-agent-presets.ts
@@ -14,7 +14,12 @@ export interface HostAgentPreset {
 	env: Record<string, string>;
 }
 
-function tokenize(commandString: string): string[] {
+/**
+ * Split a launch line into `[binary, ...args]`. Whitespace is the only
+ * separator — there is no quoting, so an arg containing a space has to be
+ * passed structurally rather than through a launch string.
+ */
+export function tokenizeAgentCommand(commandString: string): string[] {
 	return commandString.split(/\s+/).filter(Boolean);
 }
 
@@ -25,7 +30,7 @@ function deriveSuffixArgs(
 	variantCommand: string | undefined,
 ): string[] {
 	if (!variantCommand) return [];
-	return tokenize(variantCommand).slice(commandTokens.length);
+	return tokenizeAgentCommand(variantCommand).slice(commandTokens.length);
 }
 
 /**
@@ -47,7 +52,7 @@ function deriveSuffixArgs(
  */
 export const HOST_AGENT_PRESETS: readonly HostAgentPreset[] =
 	BUILTIN_TERMINAL_AGENTS.map((agent) => {
-		const commandTokens = tokenize(agent.command);
+		const commandTokens = tokenizeAgentCommand(agent.command);
 		const [bin = agent.id, ...args] = commandTokens;
 		return {
 			presetId: agent.id,


### PR DESCRIPTION
## What & why

I could list and launch host agent presets over MCP, but I couldn't author one — still Settings → Agents by hand. That gap hits anyone driving agents from MCP (and anyone stacking on #7269 CLI presets): you can run a preset you can't create remotely.

This closes it with `agents_presets_add|edit|remove` on the same `settings.agentConfigs.*` / `hostAgentConfigs` path as the CLI. `agents_create` stays launch; CRUD is `agents_presets_*`. Verb `edit` matches CLI (host procedure still `update`). Launch shape: structured `command`+`args` primary, or `launchCommand` (tokenized); dual-reject. `tokenizeAgentCommand` from `@superset/shared`. Out of scope: reorder/restoreDefault/iconId/resumeArgs/forkArgs/SDK.

Also carries the #7276 agent-setup Test isolation cherry-pick so owned Test means what it says on this tip.

## How I tested it

Tip: `19387b99c644d81d85864acca2a560b28d8ad1f9` (= `dfe48dbdf` + #7276 isolation cherry-pick).

- `bun test` in `packages/mcp`: 20/20 (mock `hostServiceCall` — structured/`launchCommand` add, dual-reject, empty binary/patch, pair replace, remove id echo). Typecheck (mcp + host-service), shared suite, biome, sherif.
- Tip-native live receipt PASS 12/12 @ tip above: real MCP Client → handlers → relay → host `447e38a1…`; add/edit/remove round-trip; dual-shape + empty-patch reject; cleaned after.
- Owned fork CI @ exact tip, Test SUCCESS: https://github.com/owieschon/superset/actions/runs/34178960314. Lint/Typecheck/Sherif/Build/Build CLI/Version Sync/Vale green. Neon/translations = secret allowlist.
- Upstream Actions rollup is thin (CodeRabbit) — environment fact, not claimed as green.

## Checklist

- [x] MCP-only (+ trivial `tokenizeAgentCommand` export in `@superset/shared`); no CLI / host-service / dock / SDK CRUD
- [x] Same host procedures; no second store
- [x] Unit tests + typecheck/lint/sherif
- [x] Tip-native live-host receipt PASS @ tip SHA above
- [x] Fork CI exact-commit observed

Approach issue: https://github.com/superset-sh/superset/issues/7370
