### PR TITLE
fix(cli): fail loud when ws create --agent launch fails

### DIFF
--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -742,6 +742,10 @@ runs a one-off shell command in the worktree and is independent of
 `--agent`/`--prompt`. Pass either or both. `--model` and `--effort` require
 `--agent`; see the [agent effort levels](#agent-effort-levels) below.
 
+When `--agent` is set and the agent fails to launch, the command exits
+non-zero and prints the host's error, even though the workspace itself was
+created — scripts can gate on the exit status instead of parsing `--json`.
+
 Omitting `--project` creates a **session**: a project-less workspace backed
 by a managed folder under `~/.superset/sessions`, initialized as its own git
 repo. Sessions have no branch semantics, so `--branch`, `--pr`, `--task`,

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 let createInput: Record<string, unknown> | undefined;
+/** Per-launch outcomes the mocked host returns in `agents[]`. */
+let agentsResult: { ok: boolean; error?: string }[] | undefined;
 
 mock.module("../../../lib/host-target", () => ({
 	requireHostTarget: () => "host-1",
@@ -12,8 +14,18 @@ mock.module("../../../lib/host-target", () => ({
 					mutate: async (input: Record<string, unknown>) => {
 						createInput = input;
 						return {
-							workspace: { name: "agent-effort" },
+							workspace: { id: "ws-1", name: "agent-effort" },
+							agents: agentsResult,
 							alreadyExists: false,
+						};
+					},
+				},
+				createSession: {
+					mutate: async (input: Record<string, unknown>) => {
+						createInput = input;
+						return {
+							workspace: { id: "ws-1", name: "agent-effort" },
+							agents: agentsResult,
 						};
 					},
 				},
@@ -58,6 +70,7 @@ function invoke(
 
 afterEach(() => {
 	createInput = undefined;
+	agentsResult = undefined;
 });
 
 describe("workspaces create", () => {
@@ -126,5 +139,70 @@ describe("workspaces create", () => {
 			/--model requires --agent/,
 		);
 		expect(createInput).toBeUndefined();
+	});
+
+	test("fails when the requested agent never launched (#5767)", async () => {
+		agentsResult = [{ ok: false, error: "no agent config for `claude`" }];
+
+		await expect(
+			invoke({ agent: "claude", prompt: "Implement the feature" }),
+		).rejects.toThrow(/Agent launch failed: no agent config for `claude`/);
+		expect(createInput).toMatchObject({ agents: [{ agent: "claude" }] });
+	});
+
+	test("names the surviving workspace so the caller can retry or clean up", async () => {
+		agentsResult = [{ ok: false, error: "spawn failed" }];
+
+		const error = await invoke({
+			agent: "claude",
+			prompt: "Implement the feature",
+		}).catch((err: Error & { suggestion?: string }) => err);
+
+		expect((error as { suggestion?: string }).suggestion).toContain("ws-1");
+	});
+
+	test("reports every failed launch, not just the first", async () => {
+		agentsResult = [
+			{ ok: false, error: "first failure" },
+			{ ok: false, error: "second failure" },
+		];
+
+		await expect(
+			invoke({ agent: "claude", prompt: "Implement the feature" }),
+		).rejects.toThrow(/first failure; second failure/);
+	});
+
+	test("fails a project-less session the same way", async () => {
+		agentsResult = [{ ok: false, error: "spawn failed" }];
+
+		await expect(
+			invoke({
+				project: undefined,
+				branch: undefined,
+				agent: "claude",
+				prompt: "Implement the feature",
+			}),
+		).rejects.toThrow(/Agent launch failed: spawn failed/);
+	});
+
+	test("succeeds when the agent launched", async () => {
+		agentsResult = [{ ok: true }];
+
+		const result = await invoke({
+			agent: "claude",
+			prompt: "Implement the feature",
+		});
+
+		expect(result).toMatchObject({
+			message: expect.stringContaining("Created workspace"),
+		});
+	});
+
+	test("succeeds when no agent was requested", async () => {
+		const result = await invoke();
+
+		expect(result).toMatchObject({
+			message: expect.stringContaining("Created workspace"),
+		});
 	});
 });

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -169,7 +169,9 @@ describe("workspaces create", () => {
 			prompt: "Implement the feature",
 		}).catch((err: Error & { suggestion?: string }) => err);
 
-		expect((error as { suggestion?: string }).suggestion).toContain("--host host-1");
+		expect((error as { suggestion?: string }).suggestion).toContain(
+			"--host host-1",
+		);
 	});
 
 	test("reports every failed launch, not just the first", async () => {

--- a/packages/cli/src/commands/workspaces/create/command.test.ts
+++ b/packages/cli/src/commands/workspaces/create/command.test.ts
@@ -161,6 +161,17 @@ describe("workspaces create", () => {
 		expect((error as { suggestion?: string }).suggestion).toContain("ws-1");
 	});
 
+	test("retry hint includes --host so remote creates stay retryable", async () => {
+		agentsResult = [{ ok: false, error: "spawn failed" }];
+
+		const error = await invoke({
+			agent: "claude",
+			prompt: "Implement the feature",
+		}).catch((err: Error & { suggestion?: string }) => err);
+
+		expect((error as { suggestion?: string }).suggestion).toContain("--host host-1");
+	});
+
 	test("reports every failed launch, not just the first", async () => {
 		agentsResult = [
 			{ ok: false, error: "first failure" },

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -213,7 +213,12 @@ export default command({
 		});
 
 		if (options.agent) {
-			requireAgentsLaunched(result.agents, result.workspace.id, options.agent, target.hostId);
+			requireAgentsLaunched(
+				result.agents,
+				result.workspace.id,
+				options.agent,
+				target.hostId,
+			);
 		}
 
 		return {

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -3,6 +3,29 @@ import { command } from "../../../lib/command";
 import { requireHostTarget, resolveHostTarget } from "../../../lib/host-target";
 import { uploadAttachments } from "../../../lib/upload-attachments";
 
+/**
+ * The host keeps the workspace when a requested agent fails to spawn: the
+ * launch outcome comes back per entry in `agents[]` instead of throwing. A
+ * caller that passed --agent asked for work to start, so a spawn failure is
+ * a failed create — exit non-zero instead of printing "Created workspace …"
+ * over an empty worktree (#5767).
+ */
+function requireAgentsLaunched(
+	agents: readonly { ok: boolean; error?: string }[] | undefined,
+	workspaceId: string,
+	agentId: string,
+): void {
+	const errors = (agents ?? [])
+		.filter((agent) => !agent.ok)
+		.map((agent) => agent.error ?? "unknown error");
+	if (errors.length === 0) return;
+
+	throw new CLIError(
+		`Agent launch failed: ${errors.join("; ")}`,
+		`Workspace ${workspaceId} exists without the agent. Retry with: superset agents create --workspace ${workspaceId} --agent ${agentId} --prompt "…"`,
+	);
+}
+
 export default command({
 	description: "Create a workspace on a host",
 	options: {
@@ -158,6 +181,13 @@ export default command({
 				agents,
 				command: options.command ?? undefined,
 			});
+			if (options.agent) {
+				requireAgentsLaunched(
+					result.agents,
+					result.workspace.id,
+					options.agent,
+				);
+			}
 			return {
 				data: result,
 				message: `Created session "${result.workspace.name}" on host ${target.hostId}`,
@@ -179,6 +209,10 @@ export default command({
 			command: options.command ?? undefined,
 			...(options.tag?.length ? { tags: options.tag } : {}),
 		});
+
+		if (options.agent) {
+			requireAgentsLaunched(result.agents, result.workspace.id, options.agent);
+		}
 
 		return {
 			data: result,

--- a/packages/cli/src/commands/workspaces/create/command.ts
+++ b/packages/cli/src/commands/workspaces/create/command.ts
@@ -14,6 +14,7 @@ function requireAgentsLaunched(
 	agents: readonly { ok: boolean; error?: string }[] | undefined,
 	workspaceId: string,
 	agentId: string,
+	hostId: string,
 ): void {
 	const errors = (agents ?? [])
 		.filter((agent) => !agent.ok)
@@ -22,7 +23,7 @@ function requireAgentsLaunched(
 
 	throw new CLIError(
 		`Agent launch failed: ${errors.join("; ")}`,
-		`Workspace ${workspaceId} exists without the agent. Retry with: superset agents create --workspace ${workspaceId} --agent ${agentId} --prompt "…"`,
+		`Workspace ${workspaceId} exists without the agent. Retry with: superset agents create --workspace ${workspaceId} --host ${hostId} --agent ${agentId} --prompt "…"`,
 	);
 }
 
@@ -186,6 +187,7 @@ export default command({
 					result.agents,
 					result.workspace.id,
 					options.agent,
+					target.hostId,
 				);
 			}
 			return {
@@ -211,7 +213,7 @@ export default command({
 		});
 
 		if (options.agent) {
-			requireAgentsLaunched(result.agents, result.workspace.id, options.agent);
+			requireAgentsLaunched(result.agents, result.workspace.id, options.agent, target.hostId);
 		}
 
 		return {


### PR DESCRIPTION
## What & why

`ws create --agent` used to exit 0 when the host returned `agents[].ok === false`, so a failed launch looked done. Fail loud: non-zero exit, host error on stderr, and a retry hint that names the surviving workspace **and** `--host <hostId>` so remote creates stay retryable (`agents create` resolves host via `options.host ?? getHostId()`).

Closes #5767. Does not revive #5784.

## How I tested it

After `workspaces.create` / `createSession`, CLI inspects host `agents[]`. Any `ok: false` while `--agent` was set → non-zero exit + stderr host error + hint: `superset agents create --workspace <id> --host <hostId> --agent … --prompt "…"`.

- Tip: `e31de594e09e657167a98989bd2898e3033a7248`
- Units: `bun test packages/cli/src/commands/workspaces/create/command.test.ts` → 14 pass / 0 fail (includes `--host host-1`)
- Live host `447e38a10a4884d2d4c34ce99141d850`: bad agent → exit 1; hint includes that `--host`; workspace cleaned after
- Fork tip-match CI: https://github.com/owieschon/superset/actions/runs/34224145956 (owned SUCCESS; Neon allowlisted)

## Checklist

- [x] Thin scope (cli create + test + cli-reference only)
- [x] Based on upstream `main`
- [x] Tip-native proof cited; fork CI URL present
