### PR TITLE
fix(agent-setup): isolate disabled-hooks SUPERSET_HOME_DIR

### DIFF
--- a/packages/agent-setup/src/disabled-agent-hooks.test.ts
+++ b/packages/agent-setup/src/disabled-agent-hooks.test.ts
@@ -9,13 +9,28 @@ import {
 	writeSharedDisabledAgentIds,
 } from "./disabled-agent-hooks";
 
-const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "superset-hooks-"));
 const ORIGINAL_HOME_DIR = process.env.SUPERSET_HOME_DIR;
 const ORIGINAL_DISABLED = process.env.SUPERSET_DISABLED_AGENT_HOOKS;
 
+let testHome: string;
+
 beforeEach(() => {
-	process.env.SUPERSET_HOME_DIR = TEST_HOME;
+	// A fresh directory per test (rather than wiping/reusing one shared dir)
+	// so this file has no directory-reuse race with anything else in the suite.
+	testHome = fs.mkdtempSync(path.join(os.tmpdir(), "superset-hooks-"));
+	process.env.SUPERSET_HOME_DIR = testHome;
 	delete process.env.SUPERSET_DISABLED_AGENT_HOOKS;
+	// agent-wrappers.test.ts mock.module()s "./paths" for the whole process
+	// without restoring it, and bun runs a package's test files in one process
+	// in no guaranteed order. So when that file loads first,
+	// resolveSupersetHomeDir() here ignores SUPERSET_HOME_DIR and lands in that
+	// file's root: every test below shares one state file, and the root itself
+	// may already be deleted by that file's afterEach. Work from the path these
+	// tests actually read — clear the state file so an earlier test's write
+	// can't leak in, and create its directory so the writes here can't fail.
+	const stateFile = getAgentHooksStateFilePath();
+	fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+	fs.rmSync(stateFile, { force: true });
 });
 
 afterEach(() => {
@@ -24,8 +39,7 @@ afterEach(() => {
 	if (ORIGINAL_DISABLED === undefined)
 		delete process.env.SUPERSET_DISABLED_AGENT_HOOKS;
 	else process.env.SUPERSET_DISABLED_AGENT_HOOKS = ORIGINAL_DISABLED;
-	fs.rmSync(TEST_HOME, { recursive: true, force: true });
-	fs.mkdirSync(TEST_HOME, { recursive: true });
+	fs.rmSync(testHome, { recursive: true, force: true });
 });
 
 describe("shared disabled-agent-hooks state", () => {


### PR DESCRIPTION
## What & why

I kept seeing agent-setup Test go red for no real reason. Same tip: sometimes green, sometimes `disabled-agent-hooks` expects `[]` and gets leftover `["claude", "codex"]` because bun shared a hooks state file across tests.

That blocked honest green on stacked hooks/MCP work (#7274), and anyone reading CI couldn't tell flake from a break. If you run `packages/agent-setup` tests, you can hit it.

This is test-only isolation (per-test home + clear at `getAgentHooksStateFilePath()`, same shape as `disabled-skills`) so that Test means what it says. No product change.

## How I tested it

Tip: `2f484bc27d2af5782ebcbc4a3a69f8188f8f4a26`

Race = unrestored `mock.module("./paths", …)` in `agent-wrappers.test.ts` + shared process file order. Fix = per-test `mkdtemp` home + `beforeEach` unlink/mkdir at `getAgentHooksStateFilePath()` (same shape as `disabled-skills.test.ts`).

Forced-order local probe (preload installs the same `./paths` mock agent-wrappers leaves behind):

```
bun test --preload <paths-mock> src/disabled-agent-hooks.test.ts
# pre-fix HEAD~1: 3 pass, 1 fail (received leftover ["claude","codex"])
# post-fix tip: 4 pass, 0 fail (same preload)
```

- Full package: `bun test` in `packages/agent-setup` → 279 pass / 0 fail
- `bun run typecheck` clean; `bunx biome check` clean
- Owned fork CI @ exact tip, Test SUCCESS: https://github.com/owieschon/superset/actions/runs/34176864239

## Checklist

- [x] Test-only change; no product behaviour touched
- [x] Owned CI green at tip `2f484bc27`
- [x] Failure reproduced before the fix, confirmed gone after
- [x] Typecheck and lint clean
