### PR TITLE
fix(desktop): classify intentional git worker aborts as non-500s

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-runner.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-runner.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { TRPCError } from "@trpc/server";
+import {
+	WorkerTaskAbortedError,
+	WorkerTaskError,
+} from "../../../workers/WorkerTaskRunner";
+import { GitEnvironmentError } from "../../workspaces/utils/git-errors";
+import { translateGitTaskFailure } from "./git-task-runner";
+
+function capture(error: unknown): unknown {
+	try {
+		translateGitTaskFailure(error);
+	} catch (thrown) {
+		return thrown;
+	}
+	throw new Error("translateGitTaskFailure must throw");
+}
+
+describe("translateGitTaskFailure", () => {
+	test("a worker crash stays a raw WorkerTaskError so the boundary reports it", () => {
+		const crash = new WorkerTaskError("Worker exited with code 1");
+		expect(capture(crash)).toBe(crash);
+	});
+
+	test("a worker-thrown error that only shares the abort name stays raw", () => {
+		const impostor = new WorkerTaskError("boom", {
+			name: "WorkerTaskAbortedError",
+			message: "boom",
+		});
+		expect(capture(impostor)).toBe(impostor);
+	});
+
+	test("a timeout is still an environment error", () => {
+		const timeout = new WorkerTaskError(
+			'[changes-git] Task "getStatus" timed out after 45000ms',
+		);
+		expect(capture(timeout)).toBeInstanceOf(GitEnvironmentError);
+	});
+
+	test("an abort on quit is a non-500 with the original message", () => {
+		const thrown = capture(
+			new WorkerTaskAbortedError("disposed", "Worker runner disposed"),
+		);
+		expect(thrown).toBeInstanceOf(TRPCError);
+		expect((thrown as TRPCError).code).toBe("SERVICE_UNAVAILABLE");
+		expect((thrown as TRPCError).message).toBe("Worker runner disposed");
+	});
+
+	test("a superseded task is a client-closed request", () => {
+		const thrown = capture(
+			new WorkerTaskAbortedError(
+				"superseded",
+				"Task superseded by a newer request",
+			),
+		);
+		expect((thrown as TRPCError).code).toBe("CLIENT_CLOSED_REQUEST");
+	});
+
+	test("a caller-cancelled task is a client-closed request", () => {
+		const thrown = capture(new WorkerTaskAbortedError("cancelled"));
+		expect((thrown as TRPCError).code).toBe("CLIENT_CLOSED_REQUEST");
+		expect((thrown as TRPCError).message).toBe("Worker task aborted");
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-runner.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-runner.ts
@@ -1,6 +1,8 @@
 import { cpus } from "node:os";
 import { join } from "node:path";
+import { TRPCError } from "@trpc/server";
 import {
+	type WorkerTaskAbortedError,
 	WorkerTaskError,
 	type WorkerTaskOptions,
 	WorkerTaskRunner,
@@ -65,25 +67,55 @@ export function runGitTask<TTask extends GitTaskType>(
 ): Promise<GitTaskResultMap[TTask]> {
 	return getRunner()
 		.runTask<GitTaskResultMap[TTask]>(taskType, payload, options)
-		.catch((error) => {
-			// The worker boundary serializes errors down to {name, message, stack,
-			// code}; rebuild the domain classes here so callers can use instanceof.
-			// Runner timeouts are an environment condition (huge repos, cold
-			// network volumes), not a worker bug.
-			if (error instanceof WorkerTaskError) {
-				if (error.name === "NotGitRepoError") {
-					throw new NotGitRepoError(error.message);
-				}
-				if (error.name === "GitEnvironmentError") {
-					throw new GitEnvironmentError(error.message);
-				}
-				if (
-					error.name === "WorkerTaskError" &&
-					/ timed out after \d+ms$/.test(error.message)
-				) {
-					throw new GitEnvironmentError(error.message);
-				}
+		.catch(translateGitTaskFailure);
+}
+
+export function translateGitTaskFailure(error: unknown): never {
+	// The worker boundary serializes errors down to {name, message, stack,
+	// code}; rebuild the domain classes here so callers can use instanceof.
+	// Runner timeouts are an environment condition (huge repos, cold
+	// network volumes), not a worker bug.
+	if (error instanceof WorkerTaskError) {
+		if (error.name === "NotGitRepoError") {
+			throw new NotGitRepoError(error.message);
+		}
+		if (error.name === "GitEnvironmentError") {
+			throw new GitEnvironmentError(error.message);
+		}
+		if (
+			error.name === "WorkerTaskError" &&
+			/ timed out after \d+ms$/.test(error.message)
+		) {
+			throw new GitEnvironmentError(error.message);
+		}
+		throw error;
+	}
+
+	// The runner only aborts on purpose (app quit, a newer request for the
+	// same key, the caller's signal). Those are expected states, so they
+	// leave as non-500s; anything else is a real failure and stays reported.
+	if (error instanceof Error && error.name === "WorkerTaskAbortedError") {
+		const kind = (error as WorkerTaskAbortedError).kind;
+		switch (kind) {
+			case "disposed":
+				throw new TRPCError({
+					code: "SERVICE_UNAVAILABLE",
+					message: error.message,
+				});
+			case "superseded":
+			case "cancelled":
+				throw new TRPCError({
+					code: "CLIENT_CLOSED_REQUEST",
+					message: error.message,
+				});
+			default: {
+				const exhaustive: never = kind;
+				throw new Error(`Unhandled worker abort kind: ${exhaustive}`, {
+					cause: error,
+				});
 			}
-			throw error;
-		});
+		}
+	}
+
+	throw error;
 }

--- a/apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts
+++ b/apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts
@@ -17,10 +17,16 @@ export class WorkerTaskError extends Error {
 	}
 }
 
+/** Why the runner gave up on a task on purpose; none of these is a worker failure. */
+export type WorkerTaskAbortKind = "disposed" | "superseded" | "cancelled";
+
 export class WorkerTaskAbortedError extends Error {
-	constructor(message = "Worker task aborted") {
+	public readonly kind: WorkerTaskAbortKind;
+
+	constructor(kind: WorkerTaskAbortKind, message = "Worker task aborted") {
 		super(message);
 		this.name = "WorkerTaskAbortedError";
+		this.kind = kind;
 	}
 }
 
@@ -172,7 +178,7 @@ export class WorkerTaskRunner {
 		for (const taskId of [...this.queue]) {
 			this.rejectTask(
 				taskId,
-				new WorkerTaskAbortedError("Worker runner disposed"),
+				new WorkerTaskAbortedError("disposed", "Worker runner disposed"),
 			);
 		}
 		this.queue.length = 0;
@@ -182,7 +188,7 @@ export class WorkerTaskRunner {
 			if (slot.activeTaskId) {
 				this.rejectTask(
 					slot.activeTaskId,
-					new WorkerTaskAbortedError("Worker runner disposed"),
+					new WorkerTaskAbortedError("disposed", "Worker runner disposed"),
 				);
 			}
 			await slot.worker.terminate();
@@ -239,7 +245,7 @@ export class WorkerTaskRunner {
 			if (!task) continue;
 
 			if (task.abortSignal?.aborted) {
-				this.rejectTask(task.taskId, new WorkerTaskAbortedError());
+				this.rejectTask(task.taskId, new WorkerTaskAbortedError("cancelled"));
 				continue;
 			}
 
@@ -298,7 +304,10 @@ export class WorkerTaskRunner {
 			) {
 				this.rejectTask(
 					task.taskId,
-					new WorkerTaskAbortedError("Task superseded by a newer request"),
+					new WorkerTaskAbortedError(
+						"superseded",
+						"Task superseded by a newer request",
+					),
 				);
 			} else {
 				this.resolveTask(task.taskId, response.result);
@@ -364,7 +373,7 @@ export class WorkerTaskRunner {
 		const task = this.tasks.get(taskId);
 		if (!task) return;
 
-		this.rejectTask(taskId, new WorkerTaskAbortedError());
+		this.rejectTask(taskId, new WorkerTaskAbortedError("cancelled"));
 
 		if (task.slotId) {
 			const slot = this.workerSlots.get(task.slotId);
@@ -407,7 +416,10 @@ export class WorkerTaskRunner {
 			this.queue.splice(i, 1);
 			this.rejectTask(
 				queuedTask.taskId,
-				new WorkerTaskAbortedError("Task superseded by a newer request"),
+				new WorkerTaskAbortedError(
+					"superseded",
+					"Task superseded by a newer request",
+				),
 			);
 		}
 	}


### PR DESCRIPTION
## Problem

`WorkerTaskAbortedError: Worker runner disposed` is the desktop project's noisiest issue (DESKTOP-5Y, ~11k events since March; DESKTOP-6X and DESKTOP-7B are the same error surfacing through a different frame or procedure). Every event is a `changes.getBranches` / `changes.getStatus` query that was in flight when the user quit the app. No user is affected: the renderer is being torn down at the same moment. The cost is Sentry quota on the uncapped desktop DSN and a top-of-list issue that buries real desktop 500s.

## Root cause

The changes git worker pool is disposed on Electron `before-quit`. `WorkerTaskRunner.dispose()` rejects every queued and in-flight task with `WorkerTaskAbortedError`. The git task adapter (`runGitTask`) only translated `WorkerTaskError` subtypes, so the abort fell through untouched, tRPC wrapped it as `INTERNAL_SERVER_ERROR`, and the boundary middleware reported it. The abort is deliberate; the classification was missing.

Each abort site was checked for intent before being classified:

| kind | sites | fires when | intentional? |
|---|---|---|---|
| `disposed` | `dispose()` queue drain + active-slot rejection | the before-quit hook, the only caller of `dispose()` | yes: app quit |
| `superseded` | `latest-wins` generation check + `dropQueuedTasksByKey` | a newer request for the same dedupe key under the `latest-wins` strategy, which the caller opts into | yes: caller policy (no desktop caller uses `latest-wins` today) |
| `cancelled` | already-aborted signal at dequeue + `abortTask` | the caller's own `AbortSignal` fires | yes: explicit cancel (no desktop caller passes a signal today) |

No abort path fires for a non-intentional reason. Everything that is not an abort keeps reporting as a 500: worker crash (`error` event), non-zero exit, a worker-reported error, and `runTask()` after disposal (`WorkerTaskError("Runner has been disposed")`, which would indicate a use-after-dispose bug and stays a 500 on purpose). Timeouts were already mapped to `GitEnvironmentError` and are unchanged.

## Fix

- `WorkerTaskAbortedError` gains a required, discriminated `kind: "disposed" | "superseded" | "cancelled"`; every existing abort site passes its kind. Messages are unchanged.
- The catch in `runGitTask` becomes `translateGitTaskFailure`, the single adapter all six worker-running procedures pass through (`getBranches`, `getStatus`, `getCommitFiles`, `getGitFileContents`, `getGitOriginalContent`, `getAheadBehind`). It name-checks `error.name === "WorkerTaskAbortedError"` (never `instanceof`) and switches exhaustively on `kind`: `disposed` becomes `SERVICE_UNAVAILABLE` (the main process is shutting down), `superseded` and `cancelled` become `CLIENT_CLOSED_REQUEST` (the request was withdrawn). The default arm is a `never` assertion, so a new kind cannot be added without deciding how it reports.
- Plain `new TRPCError({ code, message })`, no typed `cause`: nothing in the renderer branches on an abort (the app is quitting, or the caller withdrew the request), and neither code is in the renderer's deterministic-failure backoff set, so polling behaviour is unchanged.
- `sentryMiddleware` untouched. No filter anywhere.

The adapter throws the `TRPCError` rather than each procedure because the two file-contents procedures have no catch of their own, and the four that do already rethrow anything they do not recognise, so a `TRPCError` passes through them unchanged.

## Verification

Negative test written first and confirmed failing before the change:

```
$ bun test src/lib/trpc/routers/changes/workers/git-task-runner.test.ts
SyntaxError: Export named 'translateGitTaskFailure' not found in module '.../git-task-runner.ts'.
 0 pass
 1 fail
```

After the change:

```
$ bunx biome check src/lib/trpc/workers/WorkerTaskRunner.ts src/lib/trpc/routers/changes/workers/git-task-runner.ts src/lib/trpc/routers/changes/workers/git-task-runner.test.ts
Checked 3 files in 9ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ tsc --noEmit
(clean)

$ bun test src/lib/trpc/workers src/lib/trpc/routers/changes src/no-main-process-blocking.test.ts
 106 pass
 0 fail
 236 expect() calls
Ran 106 tests across 11 files. [4.07s]
```

The new test covers what the classifier must not match: a worker crash stays a raw `WorkerTaskError`, a worker-thrown error that merely shares the name `WorkerTaskAbortedError` stays raw (it arrives as a `WorkerTaskError` and never reaches the abort switch), and a timeout still maps to `GitEnvironmentError`. `no-main-process-blocking.test.ts` ratchet counts unchanged.

Reach: the events come from 1.24.1 and 1.25.1; the runner code is unchanged on those builds, and this ships with desktop 1.27.0 (current `package.json` version) to every auto-updating user.

Adjacent, left alone: `packages/host-service/src/workers/WorkerTaskRunner.ts` is a sibling copy with the same message-only `WorkerTaskAbortedError`; host-service already treats aborts as an expected state in its cleanup preflight, and these issues are desktop-only.

Refs DESKTOP-5Y
Refs DESKTOP-6X
Refs DESKTOP-7B

https://claude.ai/code/session_01KrkwwfbpU4moGLo1ecv6Zs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop Sentry noise from intentional git worker aborts being reported as 500s. Aborts on quit (`disposed`) now map to `SERVICE_UNAVAILABLE`, and superseded/cancelled aborts to `CLIENT_CLOSED_REQUEST`, so they don't appear as errors (refs DESKTOP-5Y, -6X, -7B). Real worker failures (crashes, timeouts) still report as 500s.

<sup>Written for commit 424695d9c026b42026a95d61dfa93bb5458865c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for Git tasks that are disposed, superseded, cancelled, or timed out.
  - Git task failures now provide more accurate service-availability or request-cancellation errors instead of generic failures.
  - Unknown abort conditions and unexpected worker failures continue to be reported as failures.

- **Tests**
  - Added coverage for worker crashes, timeout handling, cancellation scenarios, and task replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->