### PR TITLE
fix(host-service): classify a hollow nested-repository .git and a broken Xcode git shim as environmental

### DIFF
--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
@@ -358,4 +358,93 @@ describe("rethrowEnvironmentalGitError", () => {
 			),
 		).toBeNull();
 	});
+
+	test("nested repository with a hollow .git → PRECONDITION_FAILED / GIT_REPO_DAMAGED", () => {
+		// Shape from the Sentry group, reproduced by replacing a gitlink's
+		// `.git` with an empty directory: git opens every gitlink before it
+		// reports status or a diff and dies at the first one it cannot read.
+		const message =
+			"fatal: 'packages/vendored-tool/.git' not recognized as a git repository\n";
+		const thrown = capture(new Error(message));
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_REPO_DAMAGED");
+		expect(thrown?.message).toBe(message);
+	});
+
+	test("keeps git's not-a-repository wording on the NOT_GIT_REPO branch", () => {
+		// A gitfile or GIT_DIR that points nowhere says "not a git repository:"
+		// with the path after the colon. Different condition, different fix;
+		// the nested-repository branch must not take it.
+		const thrown = capture(
+			new Error("fatal: not a git repository: 'packages/vendored-tool/.git'\n"),
+		);
+		expect(thrown?.code).toBe("BAD_REQUEST");
+		expect(causeKind(thrown)).toBe("NOT_GIT_REPO");
+	});
+
+	test("Xcode installed but its git shim cannot run → PRECONDITION_FAILED / GIT_ENVIRONMENT", () => {
+		// Verbatim from the Sentry group, library identifiers shortened. Xcode
+		// is present, but xcodebuild cannot load its own libraries, so the
+		// /usr/bin/git stub never reaches a git binary and ends every attempt
+		// with the same refusal sentence it prints when no tools exist.
+		const message =
+			"Error loading required libraries. If there is an ongoing installation please wait for it to complete. Otherwise reinstall. (dlopen(@rpath/libxcodebuildLoader.dylib, 0x0001): Symbol not found: _XPCTypeBool\n" +
+			"  Referenced from: <UUID> /Library/Developer/PrivateFrameworks/CoreDevice.framework/Versions/A/CoreDevice\n" +
+			"  Expected in:     <UUID> /Library/Apple/System/Library/PrivateFrameworks/Mercury.framework/Versions/A/Mercury)\n" +
+			"git: error: sh -c '/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -find git 2> /dev/null' failed with exit code 65280: (null) (errno=Invalid argument)\n" +
+			"xcode-select: Failed to locate 'git', requesting installation of command line developer tools.\n";
+		const thrown = capture(new Error(message));
+		expect(thrown?.code).toBe("PRECONDITION_FAILED");
+		expect(causeKind(thrown)).toBe("GIT_ENVIRONMENT");
+		expect(thrown?.message).toBe(message);
+	});
+
+	test("does not claim the shim's refusal for a tool other than git", () => {
+		// A hook that runs some other tool through the same stub prints the
+		// same sentence naming that tool; git itself ran fine and the hook
+		// failure must keep reporting. The sentence without the stub's prefix
+		// at the start of a line is likewise the hook's, not git's.
+		expect(
+			capture(
+				new Error(
+					"xcode-select: Failed to locate 'swift', requesting installation of command line developer tools.\n" +
+						"fatal: cannot run .git/hooks/pre-commit: No such file or directory\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"pre-commit: Failed to locate 'git', requesting installation of command line developer tools.\n" +
+						"fatal: cannot run .git/hooks/pre-commit: No such file or directory\n",
+				),
+			),
+		).toBeNull();
+	});
+
+	test("genuine failures naming a .git path, a conflict or the network keep reporting", () => {
+		expect(capture(new Error("fatal: bad object HEAD\n"))).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"CONFLICT (content): Merge conflict in src/index.ts\n" +
+						"Automatic merge failed; fix conflicts and then commit the result.\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"fatal: unable to access 'https://example.invalid/repo.git/': Could not resolve host: example.invalid\n",
+				),
+			),
+		).toBeNull();
+		expect(
+			capture(
+				new Error(
+					"fatal: pathspec 'packages/vendored-tool/.git' did not match any files known to git\n",
+				),
+			),
+		).toBeNull();
+	});
 });

--- a/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
+++ b/packages/host-service/src/trpc/router/git/utils/classify-git-error.ts
@@ -30,6 +30,14 @@ const SIMPLE_GIT_BASE_DIR_MISSING_PATTERN =
 // ordinary failures all the time.
 const XCODE_SELECT_NO_TOOLS_PATTERN =
 	/^xcode-select: .*no developer tools were found/im;
+// The same stub when Xcode is installed but cannot run: it asks xcodebuild
+// where git is, xcodebuild fails to load its own libraries (a broken Xcode
+// after an OS upgrade), and the stub ends with this sentence instead of
+// running git. Every git command fails the same way until Xcode or the
+// Command Line Tools are reinstalled. Naming `git` in the sentence keeps this
+// off a hook that reaches some other tool through the same stub.
+const XCODE_SELECT_GIT_NOT_LOCATED_PATTERN =
+	/^xcode-select: Failed to locate 'git', requesting installation of command line developer tools\.$/im;
 // A content filter's helper program is not installed on this machine. Git runs
 // `filter.<name>.process`/`.clean` through the shell with the configured
 // command as the shell's $0, so an absent helper fails as
@@ -55,6 +63,17 @@ const FILTER_HELPER_MISSING_PATTERN =
 // failures, which name blobs, loose files and stdin rather than this damage.
 const UNREADABLE_TREE_OBJECT_PATTERN =
 	/unable to read tree \(?[0-9a-f]{7,64}\)?/i;
+// Git's text (is_submodule_modified, submodule.c) when a gitlink in the index
+// — a nested repository or submodule — has a `.git` that is a directory but
+// not a repository: HEAD, objects or refs are gone, which is what a cloud-sync
+// client leaves behind when it rewrites a nested `.git`. Git opens every
+// gitlink before it reports status or a diff and dies at the first bad one, so
+// status, diff and add all fail until the nested checkout is repaired or its
+// gitlink removed. The workspace itself resolved fine: git's wording for a
+// repository that cannot be found is "not a git repository", which
+// NOT_GIT_REPO_PATTERN keeps.
+const NESTED_REPO_GIT_DIR_INVALID_PATTERN =
+	/^fatal: '.*\/\.git' not recognized as a git repository$/im;
 
 /**
  * Rethrows environmental git failures as typed non-500 TRPCErrors — the same
@@ -99,7 +118,10 @@ export function rethrowEnvironmentalGitError(error: unknown): void {
 			cause: { kind: "GIT_ENVIRONMENT" },
 		});
 	}
-	if (XCODE_SELECT_NO_TOOLS_PATTERN.test(error.message)) {
+	if (
+		XCODE_SELECT_NO_TOOLS_PATTERN.test(error.message) ||
+		XCODE_SELECT_GIT_NOT_LOCATED_PATTERN.test(error.message)
+	) {
 		throw new TRPCError({
 			code: "PRECONDITION_FAILED",
 			message: error.message,
@@ -113,7 +135,10 @@ export function rethrowEnvironmentalGitError(error: unknown): void {
 			cause: { kind: "GIT_ENVIRONMENT" },
 		});
 	}
-	if (UNREADABLE_TREE_OBJECT_PATTERN.test(error.message)) {
+	if (
+		UNREADABLE_TREE_OBJECT_PATTERN.test(error.message) ||
+		NESTED_REPO_GIT_DIR_INVALID_PATTERN.test(error.message)
+	) {
 		throw new TRPCError({
 			code: "PRECONDITION_FAILED",
 			message: error.message,


### PR DESCRIPTION
## Problem

Two git failures that the host-service status adapter does not recognise, so `git.getStatus` returns a 500 and reports on every refresh. Both are the user's machine or repository, not our code:

- **HOST-SERVICE-57** (3,249 events, one host, 1.25.1): every status call fails with `fatal: '<path>/.git' not recognized as a git repository`. The user's Changes tab is unusable for that workspace, and status, diff and stage-all all fail the same way.
- **HOST-SERVICE-58** (80 events, one host, 1.26.0): every git call fails with a dyld error from xcodebuild followed by `xcode-select: Failed to locate 'git', requesting installation of command line developer tools.` No git command can run on that Mac until Xcode or the Command Line Tools are reinstalled.

Reality check:
1. **Harm:** the affected user has a dead Changes tab in every affected workspace, and on 1.25.1 the host reports every refresh (17 events in one 38-second burst, driven by `git:changed` and window focus, not an interval). Nothing in our code can make either git call succeed.
2. **Reach:** both events come from the host-service bundled in the desktop app (`app.asar`, `git.getStatus`). This change ships in the next desktop/host-service release and applies to the getStatus path both users hit. Machines on 1.25.1/1.26.0 keep reporting until they update, as with every host-service fix.
3. **Why code:** archiving is undone by the next machine; an inbound filter is forbidden by the #6164 contract; the existing adapter is exactly the place the repo classifies git's own text, and both wordings are unambiguous once traced to their source.

## Root cause

- The "not recognized" wording is emitted by exactly one place in git: `is_submodule_modified()` in `submodule.c`, when a gitlink in the index has a `.git` that is a directory but not a repository (HEAD, objects or refs are gone). That is what a cloud-sync client leaves behind when it rewrites a nested repository's `.git`. Git opens every gitlink before it reports status or a diff and dies at the first bad one. Reproduced locally by replacing a nested repository's `.git` with an empty directory: status, `diff`, and `add -A` all die with this exact line, `branch -m` succeeds, which matches the procedure split in the Sentry group. The workspace itself resolved fine, so this is not `NOT_GIT_REPO` (git says "not a git repository:" for that, and the existing branch keeps it). It is repository damage the user has to repair, so it joins the unreadable-tree-object case under `GIT_REPO_DAMAGED`.
- The Xcode wording is the `/usr/bin/git` stub: it asks `xcodebuild -find git`, xcodebuild fails to load its own libraries, and the stub prints this sentence instead of running git. Same condition as the existing no-developer-tools stub, worded for a broken Xcode install, so it joins that branch under `GIT_ENVIRONMENT`.

## Fix

Two anchored patterns in `classify-git-error.ts`, each on an existing branch:

- `^fatal: '.*\/\.git' not recognized as a git repository$` → `PRECONDITION_FAILED` / `GIT_REPO_DAMAGED`
- `^xcode-select: Failed to locate 'git', requesting installation of command line developer tools\.$` → `PRECONDITION_FAILED` / `GIT_ENVIRONMENT`

No new cause kind. No host-service consumer reads cause kinds today (the v2 renderer reads none; only the tests and the v1 desktop hook do), so a `GIT_UNAVAILABLE` kind here would be vocabulary nobody reads. The xcode-select case stays on the branch the existing xcode-select pattern already uses. Messages are preserved verbatim.

Negative cases written first and confirmed passing before the change: git's `not a git repository: '<path>/.git'` wording stays `NOT_GIT_REPO`; the stub naming another tool (`swift`) from a hook, the sentence without the stub prefix at line start, `fatal: bad object HEAD`, a merge conflict, a network failure, and a pathspec ending in `.git` all stay unclassified 500s. `spawn git EAGAIN` stays a 500 (existing test).

**Still reports as a 500 after this change:** every other git failure, including the same two conditions surfacing through procedures that do not run the classifier (`git.renameBranch`, `git.stageAll`, `project.create` each appear a handful of times in these groups). Those are adjacent throw sites left as they are.

**Not touched:** DESKTOP-73. That group is 2,671 `spawn git EAGAIN` events versus 25 `spawn git ENOENT` over 90 days, all macOS. EAGAIN is resource exhaustion and must keep reporting; the ENOENT slice is under 1% and on macOS means the PATH handed to git lacks `/usr/bin`, which is not "git isn't installed". Details in the session summary.

## Verification

```
$ bunx biome check packages/host-service/src/trpc/router/git/utils/classify-git-error.ts packages/host-service/src/trpc/router/git/utils/classify-git-error.test.ts
Checked 2 files in 11ms. No fixes applied.

$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false

$ cd packages/host-service && bun test src/trpc/router/git/utils
 102 pass
 0 fail
Ran 102 tests across 8 files. [16.86s]
```

Before the change, the same test file ran with exactly the two new positive cases failing and all negatives passing:

```
(fail) rethrowEnvironmentalGitError > nested repository with a hollow .git → PRECONDITION_FAILED / GIT_REPO_DAMAGED
(fail) rethrowEnvironmentalGitError > Xcode installed but its git shim cannot run → PRECONDITION_FAILED / GIT_ENVIRONMENT
 25 pass
 2 fail
```

The verbatim Sentry strings (run outside the repo so no user path lands in the tree) classify as 57 → `PRECONDITION_FAILED` / `GIT_REPO_DAMAGED`, 58 → `PRECONDITION_FAILED` / `GIT_ENVIRONMENT`; `spawn git EAGAIN` and `spawn git ENOENT` remain unclassified.

Refs HOST-SERVICE-57
Refs HOST-SERVICE-58

https://claude.ai/code/session_01RU6TRLQj25fDjQ8WiukBUj


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `git.getStatus` returning 500 on two environmental git failures: a nested repository with a hollow `.git` (cloud-sync damage) and a broken Xcode git shim. These are now classified as `PRECONDITION_FAILED` with `GIT_REPO_DAMAGED` and `GIT_ENVIRONMENT` cause kinds, so they stop appearing as server errors.

- Adds two anchored patterns to `classify-git-error.ts`, matching git's exact wording and preserving messages verbatim.
- Negative tests confirm unrelated failures (bad object, merge conflict, network, pathspec) and git's "not a git repository" wording remain unclassified.
- Resolves HOST-SERVICE-57 and HOST-SERVICE-58.

<sup>Written for commit fb29ee074c6a1e11a404ba1adfd9c2949b940397. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git error handling for damaged nested repositories and invalid `.git` directories.
  * Improved detection of macOS Git environment failures when Xcode cannot load required libraries.
  * Preserved correct handling for non-repository paths, conflicts, network issues, and unsupported Git tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->