### PR TITLE
fix(host-service): bound transcript line reads so one corrupt file cannot kill the usage worker

### DIFF
--- a/packages/host-service/src/trpc/router/usage/history/agy.ts
+++ b/packages/host-service/src/trpc/router/usage/history/agy.ts
@@ -1,11 +1,9 @@
 /** Antigravity CLI transcript usage (`~/.gemini/antigravity-cli/brain`). */
-import { createReadStream } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { createInterface } from "node:readline";
 import type { UsageLogEntry } from "./parse";
-import { toSessionLabel } from "./parse";
+import { forEachLine, toSessionLabel } from "./parse";
 
 type JsonObject = Record<string, unknown>;
 
@@ -135,39 +133,28 @@ export async function collectAgyEntries(
 		} catch {
 			continue;
 		}
-		let stream: ReturnType<typeof createReadStream>;
-		try {
-			stream = createReadStream(path, { encoding: "utf8" });
-		} catch {
-			continue;
-		}
 		scanned += 1;
-		const lines = createInterface({ input: stream, crlfDelay: Infinity });
 		let cwd: string | null = null;
-		try {
-			for await (const line of lines) {
-				let envelope: JsonObject | null = null;
-				try {
-					envelope = object(JSON.parse(line));
-				} catch {
-					continue;
-				}
-				if (!cwd) {
-					const workspace = object(envelope?.workspace);
-					const candidate =
-						envelope?.cwd ?? workspace?.current_dir ?? workspace?.project_dir;
-					if (typeof candidate === "string") cwd = candidate;
-				}
-				if (!sessionLabels.has(sessionId) && envelope?.type === "USER_INPUT") {
-					const label = toSessionLabel(envelope.content);
-					if (label) sessionLabels.set(sessionId, label);
-				}
-				const entry = parseAgyTranscriptLine(line, sessionId, cwd);
-				if (entry && entry.timestampMs >= cutoffMs) out.push(entry);
+		await forEachLine(path, (line) => {
+			let envelope: JsonObject | null = null;
+			try {
+				envelope = object(JSON.parse(line));
+			} catch {
+				return;
 			}
-		} catch {
-			// A concurrently written or removed transcript contributes what was read.
-		}
+			if (!cwd) {
+				const workspace = object(envelope?.workspace);
+				const candidate =
+					envelope?.cwd ?? workspace?.current_dir ?? workspace?.project_dir;
+				if (typeof candidate === "string") cwd = candidate;
+			}
+			if (!sessionLabels.has(sessionId) && envelope?.type === "USER_INPUT") {
+				const label = toSessionLabel(envelope.content);
+				if (label) sessionLabels.set(sessionId, label);
+			}
+			const entry = parseAgyTranscriptLine(line, sessionId, cwd);
+			if (entry && entry.timestampMs >= cutoffMs) out.push(entry);
+		});
 	}
 	return scanned;
 }

--- a/packages/host-service/src/trpc/router/usage/history/parse.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/parse.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { forEachLine, MAX_LINE_LENGTH } from "./parse";
+
+const root = mkdtempSync(join(tmpdir(), "usage-parse-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+async function linesOf(path: string): Promise<string[]> {
+	const lines: string[] = [];
+	await forEachLine(path, (line) => lines.push(line));
+	return lines;
+}
+
+describe("forEachLine", () => {
+	test("splits on \\n, strips \\r, keeps blank lines, delivers an unterminated last line", async () => {
+		const path = join(root, "plain.jsonl");
+		writeFileSync(path, "a\r\nb\n\nc");
+		expect(await linesOf(path)).toEqual(["a", "b", "", "c"]);
+	});
+
+	test("reassembles a line that spans read chunks, including a split multibyte character", async () => {
+		// Chunks are 64 KiB; a 3-byte character never divides that evenly, so
+		// some boundary lands mid-character.
+		const path = join(root, "spanning.jsonl");
+		const line = "€".repeat(100_000);
+		writeFileSync(path, `${line}\n${line}\n`);
+		expect(await linesOf(path)).toEqual([line, line]);
+	});
+
+	test("skips a line past MAX_LINE_LENGTH and keeps reading after it", async () => {
+		const path = join(root, "oversized.jsonl");
+		writeFileSync(
+			path,
+			`first\n${"y".repeat(MAX_LINE_LENGTH)}\n${"x".repeat(MAX_LINE_LENGTH + 1)}\nlast\n`,
+		);
+		const lines = await linesOf(path);
+		expect(lines.map((line) => line.length)).toEqual([
+			"first".length,
+			MAX_LINE_LENGTH,
+			"last".length,
+		]);
+	});
+
+	test("finishes a file whose newline-free tail is past MAX_LINE_LENGTH", async () => {
+		const path = join(root, "unterminated.jsonl");
+		writeFileSync(path, `first\n${"x".repeat(MAX_LINE_LENGTH + 1)}`);
+		expect(await linesOf(path)).toEqual(["first"]);
+	});
+
+	test("skips an unreadable file without throwing", async () => {
+		expect(await linesOf(join(root, "missing.jsonl"))).toEqual([]);
+	});
+});

--- a/packages/host-service/src/trpc/router/usage/history/parse.test.ts
+++ b/packages/host-service/src/trpc/router/usage/history/parse.test.ts
@@ -43,6 +43,16 @@ describe("forEachLine", () => {
 		]);
 	});
 
+	test("a CRLF line of exactly MAX_LINE_LENGTH is kept: the CR does not count", async () => {
+		const path = join(root, "crlf-boundary.jsonl");
+		writeFileSync(path, `${"y".repeat(MAX_LINE_LENGTH)}\r\nlast\r\n`);
+		const lines = await linesOf(path);
+		expect(lines.map((line) => line.length)).toEqual([
+			MAX_LINE_LENGTH,
+			"last".length,
+		]);
+	});
+
 	test("finishes a file whose newline-free tail is past MAX_LINE_LENGTH", async () => {
 		const path = join(root, "unterminated.jsonl");
 		writeFileSync(path, `first\n${"x".repeat(MAX_LINE_LENGTH + 1)}`);

--- a/packages/host-service/src/trpc/router/usage/history/parse.ts
+++ b/packages/host-service/src/trpc/router/usage/history/parse.ts
@@ -16,7 +16,6 @@
 
 import { createReadStream } from "node:fs";
 import { basename } from "node:path";
-import { createInterface } from "node:readline";
 import type { UsageAgent } from "../types";
 import type { LogFile } from "./logs";
 
@@ -64,16 +63,56 @@ export function toSessionLabel(text: unknown): string | null {
 		: line;
 }
 
+/** Longest line handed to a parser. Real transcript lines top out in the
+ * single-digit MB (5.8 MB was the largest across 90 days of heavy Claude and
+ * Codex use), so anything past this is a corrupt or foreign file, not usage.
+ * The bound is what keeps a data file from killing the worker: V8 refuses
+ * strings past ~512 MB, and node:readline buffered a newline-free run
+ * without limit, throwing `RangeError: Invalid string length` from inside
+ * the stream's data callback — unreachable by any try/catch around the
+ * iteration, so it took the worker thread down and hung the inline retry. */
+export const MAX_LINE_LENGTH = 32 * 1024 * 1024;
+
+/** Calls `onLine` for every `\n`-terminated line of a UTF-8 file (a trailing
+ * `\r` is stripped). A line longer than MAX_LINE_LENGTH is skipped and the
+ * file continues at the next newline. */
 export async function forEachLine(
 	path: string,
 	onLine: (line: string) => void,
 ): Promise<void> {
+	let pending = "";
+	let skipping = false;
+	const emit = (line: string) => {
+		onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+	};
 	try {
-		const rl = createInterface({
-			input: createReadStream(path, { encoding: "utf-8" }),
-			crlfDelay: Number.POSITIVE_INFINITY,
-		});
-		for await (const line of rl) onLine(line);
+		const chunks = createReadStream(path, {
+			encoding: "utf-8",
+		}) as AsyncIterable<string>;
+		for await (const chunk of chunks) {
+			let start = 0;
+			for (
+				let end = chunk.indexOf("\n");
+				end !== -1;
+				end = chunk.indexOf("\n", start)
+			) {
+				if (skipping) {
+					skipping = false;
+				} else {
+					const line = pending + chunk.slice(start, end);
+					pending = "";
+					if (line.length <= MAX_LINE_LENGTH) emit(line);
+				}
+				start = end + 1;
+			}
+			if (skipping) continue;
+			pending += chunk.slice(start);
+			if (pending.length > MAX_LINE_LENGTH) {
+				pending = "";
+				skipping = true;
+			}
+		}
+		if (!skipping && pending) emit(pending);
 	} catch {
 		// Unreadable or vanished mid-scan — skip the file.
 	}

--- a/packages/host-service/src/trpc/router/usage/history/parse.ts
+++ b/packages/host-service/src/trpc/router/usage/history/parse.ts
@@ -82,8 +82,10 @@ export async function forEachLine(
 ): Promise<void> {
 	let pending = "";
 	let skipping = false;
-	const emit = (line: string) => {
-		onLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+	const emit = (raw: string) => {
+		// Strip the CR before measuring so LF and CRLF files share one bound.
+		const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+		if (line.length <= MAX_LINE_LENGTH) onLine(line);
 	};
 	try {
 		const chunks = createReadStream(path, {
@@ -101,7 +103,7 @@ export async function forEachLine(
 				} else {
 					const line = pending + chunk.slice(start, end);
 					pending = "";
-					if (line.length <= MAX_LINE_LENGTH) emit(line);
+					emit(line);
 				}
 				start = end + 1;
 			}


### PR DESCRIPTION
## Problem

For a user opted into the leaderboard, `usage.leaderboardPayload` fails on every auto-publish attempt (the desktop checks every 5 minutes), so their usage never publishes and each attempt costs a dead worker thread plus ~110 s of a hung inline retry on the host-service main thread. Both issues come from one machine on release 1.25.1, and the sample events share a single trace: HOST-SERVICE-55 is the worker dying, HOST-SERVICE-56 is the inline retry of that same request timing out.

Reality check:
1. **User-visible harm**: one opted-in user's leaderboard never updates, and their host-service burns a worker crash and a 110 s hung task every publish cycle.
2. **Reach**: the events are from release 1.25.1 host-service (the desktop-bundled one). This change is in `packages/host-service`, so it ships with the next desktop/host-service release and reaches that build's successor on update.
3. **Instrument**: code. Archiving leaves the user unpublishable and the 5-minute crash loop running. A Sentry-side filter is forbidden by repo law. There is no other layer: the reader is the only thing that touches the file.

## Root cause

`forEachLine` in `parse.ts` used `node:readline`, which buffers a line until it sees a newline with no bound. A `.jsonl` under the transcript roots with a newline-free stretch longer than V8's maximum string (~512 MB) makes readline throw `RangeError: Invalid string length` inside the stream's `data` callback. That throw is not a rejection of the `for await`, so the surrounding `try/catch` never sees it:

- In the host-worker thread it is an uncaught exception, so the worker dies (mechanism `auto.child_process.worker_thread`, HOST-SERVICE-55).
- The pool then retries the task inline. On the main thread `safety.ts` swallows the same uncaught exception to keep the process alive, but the readline iteration never settles, so the task hits the 110 s timeout (HOST-SERVICE-56, `(inline)` in the message). The inline throws are absent from Sentry because the repeat throttle fingerprints them identically to the worker ones.

Reproduced end to end with a 640 MB newline-free fixture, running `forEachLine` at HEAD:

```
--- worker thread (as the host-worker pool runs it)
worker 'error' event after 355 ms: RangeError Invalid string length
worker exit code 1
--- inline (pool's crash retry on the main thread, safety.ts keeps the process alive)
uncaughtException after 262 ms: RangeError Invalid string length — staying up
inline forEachLine: still pending after 20s → would hit the 110s task timeout lines seen: 1
```

The 56 events are not a "large history exceeds the budget" timeout: no other machine times out, and every 56 event follows a 55 from the same request. That is why this PR does not add an incremental per-file aggregate cache; see the notes below.

## Fix

- `forEachLine` splits read chunks on `\n` itself (stripping a trailing `\r`) and never buffers more than `MAX_LINE_LENGTH` (32 MB). A longer line is skipped and reading resumes at the next newline, so no data file can throw from inside the worker. The cap is calibrated against real data: the longest line across 90 days of heavy Claude and Codex transcripts on a developer machine was 5.8 MB, and it is 16× below V8's limit.
- The Antigravity collector (`agy.ts`) had its own `readline` over the same kind of file and now uses the shared reader, so the same walk has one bounded reader.
- No new throw site, so no typed `cause` was added: nothing reads one.

Same fixture with the new reader, in a worker thread: `{ lines: [158, 158], ms: 261 }`, exit code 0 (the two real entries around the 640 MB junk are delivered).

Negative test first: the new `parse.test.ts` case "skips a line past MAX_LINE_LENGTH" was run against the HEAD reader, which delivered the oversized line:

```
old readline reader → line lengths delivered: [ 5, 33554433, 4 ]
new bounded reader → line lengths delivered: [ 5, 4 ]
```

## Verification

`bunx biome check` on the three changed files:
```
Checked 3 files in 10ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:
```
$ tsc --noEmit --emitDeclarationOnly false
```
(no errors)

`bun test src/trpc/router/usage`:
```
 107 pass
 0 fail
 226 expect() calls
Ran 107 tests across 19 files. [282.00ms]
```

Full package suite, `cd packages/host-service && bun run test`, run twice. First run: 1647 pass, 8 todo, 1 fail (the failing test was not captured before the rerun). Second run:
```
 1648 pass
 8 todo
 0 fail
 3826 expect() calls
Ran 1656 tests across 159 files. [224.23s]
```

## Out of scope, left as is

- **Incremental per-file aggregates** (the task's part 2): not evidenced by these issues, and it needs an architecture decision because worker task handlers may not import the host DB (`no-native-worker-imports` ratchet), so persistence would have to be a separate file store or a `prepare`/result round-trip. Recommend a separate ticket if a real budget timeout ever shows up on a machine without a crash.
- Every other reader in the walk (`grok.ts`, `opencode.ts`, `cursor.ts` `readFile`) surfaces failures as rejections, which the existing catches and `allSettled` already handle.

Refs HOST-SERVICE-55
Refs HOST-SERVICE-56

https://claude.ai/code/session_01BnLYGiunj6h6fGV1qRgk5b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the unbounded `node:readline` line reader in `forEachLine` with a chunk-splitting reader that skips any line past 32 MB, so one corrupt transcript file can no longer crash the usage worker with a `RangeError: Invalid string length` and hang the 110 s inline retry. Fixes HOST-SERVICE-55 and HOST-SERVICE-56.

- The Antigravity collector now uses the same bounded reader instead of its own `readline`.
- The cap is measured after stripping a trailing `\r`, so LF and CRLF files share one bound.
- Added tests covering split multibyte characters, oversized lines, unterminated tails, CRLF boundaries, and unreadable files.
- Real transcript lines top out around 5.8 MB, so the 32 MB cap only affects corrupt or foreign files.

<sup>Written for commit 517d276131f91db16c8d1adc3f7bbd51e8849370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage history processing for transcript files with varied line endings, incomplete final lines, and multibyte characters.
  - Prevented unusually large transcript lines from interrupting processing, allowing subsequent entries to continue being read.
  - Improved resilience when transcript files are unavailable or updated during processing.

- **Tests**
  - Added coverage for line parsing, large entries, partial content, and unreadable files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->