### PR TITLE
fix(host-service): stop the login-shell env probe from leaking pipe descriptors

### DIFF
--- a/packages/host-service/src/terminal/clean-shell-env.test.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+	existsSync,
 	mkdtempSync,
 	readdirSync,
 	readFileSync,
@@ -132,7 +133,14 @@ describe("parseEnvOutput", () => {
 // shell's stdout/stderr and outlives it. Resolution must complete when the
 // shell exits, not when that daemon lets go of the pipes, and must not leave
 // the pipe read ends in this process's descriptor table (HOST-SERVICE-4E).
-describe.skipIf(process.platform === "win32")(
+// Needs the real zsh and perl binaries; a CI image without them (Linux
+// runners ship no zsh) cannot exercise the pipe-holding daemon at all.
+const canRunRealShell =
+	process.platform !== "win32" &&
+	existsSync("/bin/zsh") &&
+	existsSync("/usr/bin/perl");
+
+describe.skipIf(!canRunRealShell)(
 	"getStrictShellEnvironment with an rc-spawned daemon holding the pipes",
 	() => {
 		let home: string;

--- a/packages/host-service/src/terminal/clean-shell-env.test.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.test.ts
@@ -1,9 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
 	augmentPathForMacOS,
 	buildMinimalEnv,
+	clearStrictShellEnvCache,
+	getStrictShellEnvironment,
 	parseEnvOutput,
 } from "./clean-shell-env.ts";
+import { __setAccountShellForTesting } from "./user-shell.ts";
 
 describe("buildMinimalEnv", () => {
 	const trackedKeys = [
@@ -115,3 +127,54 @@ describe("parseEnvOutput", () => {
 		expect(() => parseEnvOutput(withDelimiters(""))).toThrow("returned empty");
 	});
 });
+
+// Real shell, real pipes: a daemon started from the rc file inherits the
+// shell's stdout/stderr and outlives it. Resolution must complete when the
+// shell exits, not when that daemon lets go of the pipes, and must not leave
+// the pipe read ends in this process's descriptor table (HOST-SERVICE-4E).
+describe.skipIf(process.platform === "win32")(
+	"getStrictShellEnvironment with an rc-spawned daemon holding the pipes",
+	() => {
+		let home: string;
+		let originalHome: string | undefined;
+		const openDescriptors = () =>
+			readdirSync(process.platform === "linux" ? "/proc/self/fd" : "/dev/fd")
+				.length;
+
+		beforeEach(() => {
+			home = mkdtempSync(join(tmpdir(), "clean-shell-env-"));
+			// New session so the timeout's tree kill cannot reach it, like a
+			// daemon that detached itself would be.
+			writeFileSync(
+				join(home, ".zshrc"),
+				`/usr/bin/perl -e 'use POSIX; POSIX::setsid(); sleep 30' &\necho $! > "${home}/holder.pid"\n`,
+			);
+			originalHome = process.env.HOME;
+			process.env.HOME = home;
+			__setAccountShellForTesting("/bin/zsh");
+			clearStrictShellEnvCache();
+		});
+
+		afterEach(() => {
+			__setAccountShellForTesting(undefined);
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			try {
+				process.kill(Number(readFileSync(join(home, "holder.pid"), "utf8")));
+			} catch {}
+			rmSync(home, { recursive: true, force: true });
+			clearStrictShellEnvCache();
+		});
+
+		test("resolves on shell exit and releases both pipe descriptors", async () => {
+			const before = openDescriptors();
+			const startedAt = Date.now();
+			const env = await getStrictShellEnvironment();
+			expect(env.HOME).toBe(home);
+			expect(Date.now() - startedAt).toBeLessThan(5_000);
+			// The holder is still alive with the write ends; ours are gone.
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			expect(openDescriptors()).toBe(before);
+		}, 15_000);
+	},
+);

--- a/packages/host-service/src/terminal/clean-shell-env.ts
+++ b/packages/host-service/src/terminal/clean-shell-env.ts
@@ -157,7 +157,43 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 		const stdoutBuffers: Buffer[] = [];
 		const stderrBuffers: Buffer[] = [];
 
-		child.stdout?.on("data", (data: Buffer) => stdoutBuffers.push(data));
+		// Settling releases this process's read ends of the two pipes. The
+		// shell's rc files run whatever the user put there, and a daemon they
+		// start inherits the shell's stdout/stderr: it keeps the write ends open
+		// after the shell exits, so `close` never fires on its own and, without
+		// this, the two descriptors stay in this process's table until that
+		// daemon dies. Every timed-out resolution then leaked two more (nothing
+		// is cached on failure, and the credential path resolves the env on
+		// every status poll), until the table filled and git could not be
+		// spawned at all — see HOST-SERVICE-4E.
+		let settled = false;
+		const settle = (outcome: () => void) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			child.stdout?.destroy();
+			child.stderr?.destroy();
+			outcome();
+		};
+
+		// Completion is the shell exiting with its output fully read: the shell
+		// prints the closing delimiter itself, immediately before `exit`, so
+		// once both have happened nothing that arrives later can matter. `exit`
+		// can fire before the pipe has been drained, so both orderings are
+		// handled; `close` still covers a shell that exited without ever
+		// printing the delimiter.
+		let exit: { code: number | null; signal: NodeJS.Signals | null } | null =
+			null;
+		const finishIfOutputComplete = () => {
+			if (!exit) return;
+			const stdout = Buffer.concat(stdoutBuffers).toString("utf8");
+			if (stdout.split(DELIMITER).length > 2) finish(exit.code, exit.signal);
+		};
+
+		child.stdout?.on("data", (data: Buffer) => {
+			stdoutBuffers.push(data);
+			finishIfOutputComplete();
+		});
 		child.stderr?.on("data", (data: Buffer) => stderrBuffers.push(data));
 
 		const timeout = setTimeout(() => {
@@ -171,51 +207,61 @@ function spawnCleanShellEnv(): Promise<Record<string, string>> {
 				}
 			}
 
-			reject(
-				new Error(
-					`Shell env resolution timed out after ${SHELL_ENV_TIMEOUT_MS}ms`,
+			settle(() =>
+				reject(
+					new Error(
+						`Shell env resolution timed out after ${SHELL_ENV_TIMEOUT_MS}ms`,
+					),
 				),
 			);
 		}, SHELL_ENV_TIMEOUT_MS);
 
 		child.on("error", (error) => {
-			clearTimeout(timeout);
-			reject(new Error(`Shell process error for ${shell}: ${error.message}`));
+			settle(() =>
+				reject(new Error(`Shell process error for ${shell}: ${error.message}`)),
+			);
 		});
 
-		child.on("close", (code, signal) => {
-			clearTimeout(timeout);
-
-			const stdout = Buffer.concat(stdoutBuffers).toString("utf8");
-			const stderr = Buffer.concat(stderrBuffers).toString("utf8").trim();
-			if (stderr) {
-				console.debug("[terminal-clean-shell-env] stderr:", stderr);
-			}
-
-			if (code !== 0 && code !== null) {
-				return reject(
-					new Error(
-						`Shell ${shell} exited with code ${code}${signal ? `, signal ${signal}` : ""}` +
-							(stderr ? ` stderr=${truncateForDiagnostics(stderr)}` : "") +
-							(stdout ? ` stdout=${truncateForDiagnostics(stdout)}` : ""),
-					),
-				);
-			}
-
-			try {
-				resolve(parseEnvOutput(stdout));
-			} catch (error) {
-				const detail = error instanceof Error ? error.message : String(error);
-				reject(
-					new Error(
-						`${detail} (shell=${shell}` +
-							` stdout=${truncateForDiagnostics(stdout)}` +
-							(stderr ? ` stderr=${truncateForDiagnostics(stderr)}` : "") +
-							")",
-					),
-				);
-			}
+		child.on("exit", (code, signal) => {
+			exit = { code, signal };
+			finishIfOutputComplete();
 		});
+
+		child.on("close", finish);
+
+		function finish(code: number | null, signal: NodeJS.Signals | null) {
+			settle(() => {
+				const stdout = Buffer.concat(stdoutBuffers).toString("utf8");
+				const stderr = Buffer.concat(stderrBuffers).toString("utf8").trim();
+				if (stderr) {
+					console.debug("[terminal-clean-shell-env] stderr:", stderr);
+				}
+
+				if (code !== 0 && code !== null) {
+					return reject(
+						new Error(
+							`Shell ${shell} exited with code ${code}${signal ? `, signal ${signal}` : ""}` +
+								(stderr ? ` stderr=${truncateForDiagnostics(stderr)}` : "") +
+								(stdout ? ` stdout=${truncateForDiagnostics(stdout)}` : ""),
+						),
+					);
+				}
+
+				try {
+					resolve(parseEnvOutput(stdout));
+				} catch (error) {
+					const detail = error instanceof Error ? error.message : String(error);
+					reject(
+						new Error(
+							`${detail} (shell=${shell}` +
+								` stdout=${truncateForDiagnostics(stdout)}` +
+								(stderr ? ` stderr=${truncateForDiagnostics(stderr)}` : "") +
+								")",
+						),
+					);
+				}
+			});
+		}
 
 		child.unref();
 	});

--- a/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.ts
+++ b/packages/host-service/src/trpc/router/git/utils/spawn-failure-diagnostics.ts
@@ -101,15 +101,16 @@ if (process.platform === "darwin") {
  *
  * These failures report with no first-party frame — the captured stack is
  * entirely simple-git's executor — and nothing in the event says why the
- * spawn was refused. The count against the enforced ceiling separates the two
- * candidates: at the ceiling is exhaustion, and the leak is ours to find;
- * nowhere near it is a descriptor that went bad while we still held it.
- *
- * Read the errno before the count, because it already settles which question
- * to ask: running out of descriptors is EMFILE, so an EBADF is a descriptor
- * that went bad and no count will explain it. See HOST-SERVICE-4E and
- * HOST-SERVICE-1R, where a machine enters this state and every subsequent
- * poll fails the same way for hours.
+ * spawn was refused. The count is what says it: on macOS a table that has
+ * grown past 10,240 entries cannot spawn anything, whatever the rlimit
+ * reads. libuv spawns through posix_spawn and hands the child's pipe ends
+ * to posix_spawn_file_actions_adddup2/addclose, and Apple's libsyscall
+ * rejects any descriptor number at or above OPEN_MAX (10,240) with EBADF
+ * before the kernel is involved. Once the low numbers are all taken, every
+ * fresh pipe lands above that line, so exhaustion surfaces as `spawn
+ * EBADF`, not EMFILE, and every event of HOST-SERVICE-4E / HOST-SERVICE-1R
+ * carried a count just above 10,240. A count nowhere near it would be the
+ * other case: a descriptor that went bad while we still held it.
  *
  * No-op for anything else, and no-op on the error itself: the message,
  * classification and 500 are exactly what they were.


### PR DESCRIPTION
## Problem

A host-service that has been running for a day or more starts failing every git command with `spawn EBADF`. The desktop's status poller retries `git.getStatus` every few seconds, so one machine in this state produces tens of thousands of identical events for hours while its Changes pane and branch state stay frozen. Five machines in the last week, releases 1.20.0 through 1.26.0. Every event's `open_file_descriptors` reads just above 10,240 (10,254 / 10,278 / 10,282 on three different machines with uptimes from 3 to 10 days).

**User-visible harm:** on an affected machine, git status, diffs and every other git-backed surface stop working until the user quits and relaunches the app.

**Reach:** the fix is in `packages/host-service`, which ships bundled with the desktop; it lands in the next desktop release and reaches every machine on it. Nothing else on main touches this code path.

**Why code:** this is a real resource leak in our own process. Archiving or filtering the issue would leave users with a dead Changes pane; the probe cannot be deleted (terminals, `gh`, and git credentials all need the login-shell environment); and the leaking site is ours.

## Root cause

Two halves, both established rather than guessed.

**Why EBADF and why the plateau at ~10,250.** libuv spawns through `posix_spawn` on macOS and registers the child's pipe ends with `posix_spawn_file_actions_adddup2` / `addclose`. Apple's libsyscall implementation range-checks every descriptor against `OPEN_MAX` (10,240) and returns `EBADF` for anything at or above it, before the kernel is involved. Once the low numbers are all occupied, every fresh pipe lands above 10,240, so table exhaustion surfaces as `spawn EBADF` rather than `EMFILE`, regardless of the 1,048,575 rlimit or the 245,760 `kern.maxfilesperproc` ceiling the diagnostics were comparing against. The existing docstring said the opposite ("an EBADF is a descriptor that went bad and no count will explain it"); it is corrected in this PR.

**What fills the table.** `spawnCleanShellEnv` (`packages/host-service/src/terminal/clean-shell-env.ts`) runs the user's interactive login shell with piped stdout/stderr to capture its environment, and only settled on the child's `close` event. `close` waits for both pipes to reach EOF. Anything the user's rc files start in the background that outlives the shell (a helper daemon that inherits the shell's stdout/stderr) keeps the write ends open, so:

1. `close` never fires; the 8 s timeout rejects instead.
2. The timeout's tree kill cannot reach a helper that detached into its own session.
3. The rejection is never cached, and `getToolEnvironment` swallows it and falls back to `process.env`, so nothing visible breaks.
4. The two read ends stay in our descriptor table for as long as that helper lives.

The git credential provider calls this resolver on every `git.getStatus`, so every poll on such a machine leaked two more descriptors. That matches the shape of the events: counts climb to ~10,240 over a day or more of polling, then stop growing once spawns fail (a failed spawn closes its own pipes), which is why the counts across machines agree so closely.

Reproduced locally with a temp `$HOME` whose `.zshrc` starts `perl -e 'POSIX::setsid(); sleep 40' &` (a detached holder of the inherited pipes), calling the real resolver three times:

```
before:
call 1: rejected: Shell env resolution timed out after 8000ms after 8374ms; fds before=5 after=8
call 2: rejected: Shell env resolution timed out after 8000ms after 8366ms; fds before=8 after=10
call 3: rejected: Shell env resolution timed out after 8000ms after 8367ms; fds before=10 after=12
surviving holders: 3 × /usr/bin/perl … (ppid 1, own process group)

after:
call 1: resolved (18 keys) after 321ms; fds before=5 after=5
call 2: resolved (18 keys) after 325ms; fds before=5 after=5
call 3: resolved (18 keys) after 336ms; fds before=5 after=5
surviving holders: 3 × /usr/bin/perl … (still alive; our read ends are gone)
```

A plain rc file resolves in ~320 ms with no growth both before and after.

## Fix

- The probe completes when the shell has exited **and** its closing delimiter has been read (the shell prints the delimiter itself, immediately before `exit`, so nothing arriving later can matter). `exit` can fire before the pipe is drained, so both orderings are handled; `close` still covers a shell that exited without printing the delimiter, with the same exit-code and parse-error messages as before.
- Every settle path (success, timeout, spawn error) destroys the pipe read ends, so a stranger holding the write ends can no longer keep them in our table.
- Docstring of `attachSpawnFailureDiagnostics` now records the `OPEN_MAX` mechanism so the next reader of an EBADF event knows it is exhaustion.

No typed cause was added: nothing reads one. The error path, message, classification and 500 are unchanged.

## Verification

`bunx biome check` on the three changed files (after `--write` on two formatting diffs):

```
Checked 3 files in 6ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`:

```
$ tsc --noEmit --emitDeclarationOnly false
typecheck exit=0
```

New regression test, run against the original source first (fails on the leak) and then against the fix:

```
=== BEFORE FIX (original source) ===
error: Shell env resolution timed out after 8000ms
(fail) getStrictShellEnvironment with an rc-spawned daemon holding the pipes > resolves on shell exit and releases both pipe descriptors [8091.24ms]
 9 pass
 1 fail

=== AFTER FIX ===
 10 pass
 0 fail
Ran 10 tests across 1 file. [276.00ms]
```

`bun test src/terminal src/trpc/router/git/utils`:

```
 804 pass
 0 fail
 1660 expect() calls
Ran 804 tests across 28 files. [18.03s]
```

## Out of scope, noted for the maintainer

- The credential provider still spawns a login shell on every status poll when the probe fails (the 60 s cache only fills on success, and concurrent polls each spawn their own shell). With this fix that costs a short-lived process per poll rather than descriptors, but a failure-side cache or an in-flight dedupe would remove the churn. Left alone here.
- `ai-workspace-names.ts` has the same "kill on timeout without destroying stdio" shape, but runs once per workspace creation, so it cannot reach 10,000.

Refs HOST-SERVICE-4E
Refs HOST-SERVICE-1R

https://claude.ai/code/session_016xRWNcYDdkDwvJyJwaL4ds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the login-shell environment probe leaking two pipe descriptors on every failed resolution, which over time filled the descriptor table and made every git command fail with `spawn EBADF` on macOS (HOST-SERVICE-4E, HOST-SERVICE-1R).

- The probe only settled on the child's `close` event, which waits for both pipes to reach EOF; a daemon started from the user's rc file that inherits the shell's stdout/stderr keeps them open, so each timeout rejected with nothing cached and left the two read ends in our table.
- It now resolves when the shell exits and its closing delimiter has been read, and every settle path (success, timeout, spawn error) destroys the pipe read ends.
- Exhaustion surfaces as `spawn EBADF` rather than `EMFILE` because Apple's libsyscall rejects any descriptor at or above `OPEN_MAX` (10,240); the diagnostics docstring now records this.
- Failed resolutions still spawn a short-lived shell per status poll, but no longer leak descriptors.
- The regression test for the pipe-holding daemon runs only where zsh and perl exist, so Linux CI doesn't fail before exercising the leak.

<sup>Written for commit 76dd49aff282b4b0cc30ded63f2db44b9ad96336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell environment loading so it completes promptly when the shell exits, even if a background process inherits its output streams.
  - Prevented lingering shell output handles from remaining open, reducing resource leaks and improving reliability during terminal and environment initialization.
  - Improved handling of shell startup errors, timeouts, and completion events to ensure environment loading settles reliably.

- **Documentation**
  - Clarified diagnostics for macOS process-launch failures caused by excessive open file descriptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->