### PR TITLE
fix(marketing): stop the API limiter and stale data-cache shapes from 500ing profile pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,6 +197,10 @@ STRIPE_ENTERPRISE_YEARLY_PRICE_ID=
 KV_REST_API_URL=
 KV_REST_API_TOKEN=
 KV_URL=
+
+# Shared by the API and marketing: marketing's server-side leaderboard reads
+# present it to skip the per-IP anonymous limiter. One value, both apps.
+LEADERBOARD_INTERNAL_TOKEN=
 QSTASH_TOKEN=
 QSTASH_URL=
 QSTASH_CURRENT_SIGNING_KEY=

--- a/.env.local.example
+++ b/.env.local.example
@@ -185,6 +185,7 @@ STRIPE_ENTERPRISE_YEARLY_PRICE_ID=price_fake_enterprise_yearly
 KV_REST_API_URL=http://localhost:8079
 KV_REST_API_TOKEN=local_dev_token
 KV_URL=redis://localhost:6379
+LEADERBOARD_INTERNAL_TOKEN=local-dev-leaderboard-internal-token
 QSTASH_TOKEN=fake-qstash-token
 QSTASH_URL=https://fake-qstash.example.com
 QSTASH_CURRENT_SIGNING_KEY=sig_fake_current

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -154,6 +154,7 @@ jobs:
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          LEADERBOARD_INTERNAL_TOKEN: ${{ secrets.LEADERBOARD_INTERNAL_TOKEN }}
           KV_URL: ${{ secrets.KV_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           LINEAR_CLIENT_ID: ${{ secrets.LINEAR_CLIENT_ID }}
@@ -220,6 +221,7 @@ jobs:
             --env POSTHOG_PROJECT_ID=$POSTHOG_PROJECT_ID \
             --env KV_REST_API_URL=$KV_REST_API_URL \
             --env KV_REST_API_TOKEN=$KV_REST_API_TOKEN \
+            --env LEADERBOARD_INTERNAL_TOKEN=$LEADERBOARD_INTERNAL_TOKEN \
             --env KV_URL=$KV_URL \
             --env RESEND_API_KEY=$RESEND_API_KEY \
             --env LINEAR_CLIENT_ID=$LINEAR_CLIENT_ID \
@@ -457,6 +459,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ secrets.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          LEADERBOARD_INTERNAL_TOKEN: ${{ secrets.LEADERBOARD_INTERNAL_TOKEN }}
           KV_URL: ${{ secrets.KV_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
@@ -485,6 +488,7 @@ jobs:
             --env NEXT_PUBLIC_SENTRY_ENVIRONMENT=$NEXT_PUBLIC_SENTRY_ENVIRONMENT \
             --env KV_REST_API_URL=$KV_REST_API_URL \
             --env KV_REST_API_TOKEN=$KV_REST_API_TOKEN \
+            --env LEADERBOARD_INTERNAL_TOKEN=$LEADERBOARD_INTERNAL_TOKEN \
             --env KV_URL=$KV_URL \
             --env RESEND_API_KEY=$RESEND_API_KEY \
             --env STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -107,6 +107,7 @@ jobs:
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          LEADERBOARD_INTERNAL_TOKEN: ${{ secrets.LEADERBOARD_INTERNAL_TOKEN }}
           KV_URL: ${{ secrets.KV_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           LINEAR_CLIENT_ID: ${{ secrets.LINEAR_CLIENT_ID }}
@@ -185,6 +186,7 @@ jobs:
             --env NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST \
             --env KV_REST_API_URL=$KV_REST_API_URL \
             --env KV_REST_API_TOKEN=$KV_REST_API_TOKEN \
+            --env LEADERBOARD_INTERNAL_TOKEN=$LEADERBOARD_INTERNAL_TOKEN \
             --env KV_URL=$KV_URL \
             --env RESEND_API_KEY=$RESEND_API_KEY \
             --env LINEAR_CLIENT_ID=$LINEAR_CLIENT_ID \
@@ -371,6 +373,7 @@ jobs:
           NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ secrets.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          LEADERBOARD_INTERNAL_TOKEN: ${{ secrets.LEADERBOARD_INTERNAL_TOKEN }}
           KV_URL: ${{ secrets.KV_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
@@ -399,6 +402,7 @@ jobs:
             --env NEXT_PUBLIC_SENTRY_ENVIRONMENT=$NEXT_PUBLIC_SENTRY_ENVIRONMENT \
             --env KV_REST_API_URL=$KV_REST_API_URL \
             --env KV_REST_API_TOKEN=$KV_REST_API_TOKEN \
+            --env LEADERBOARD_INTERNAL_TOKEN=$LEADERBOARD_INTERNAL_TOKEN \
             --env KV_URL=$KV_URL \
             --env RESEND_API_KEY=$RESEND_API_KEY \
             --env STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY \

--- a/apps/marketing/src/app/[lang]/user/[handle]/components/ProfileUnavailable/ProfileUnavailable.tsx
+++ b/apps/marketing/src/app/[lang]/user/[handle]/components/ProfileUnavailable/ProfileUnavailable.tsx
@@ -1,0 +1,26 @@
+import { Trans } from "@lingui/react/macro";
+import Link from "next/link";
+import { FactoryBackdrop } from "@/app/[lang]/components/FactoryBackdrop";
+
+export function ProfileUnavailable() {
+	return (
+		<main className="relative min-h-screen">
+			<FactoryBackdrop halfWidth={384} glow={false} grid={false} />
+
+			<div className="relative max-w-3xl mx-auto px-6 py-24 text-center">
+				<h1 className="text-2xl md:text-3xl font-medium text-foreground">
+					<Trans>This profile is busy right now</Trans>
+				</h1>
+				<p className="text-sm text-muted-foreground leading-relaxed mt-4">
+					<Trans>Too many people are looking at once. Try again shortly.</Trans>
+				</p>
+				<Link
+					href="/leaderboard"
+					className="inline-flex items-center mt-8 px-4 py-2.5 text-sm border border-border text-foreground hover:bg-muted transition-colors"
+				>
+					<Trans>Back to the leaderboard</Trans>
+				</Link>
+			</div>
+		</main>
+	);
+}

--- a/apps/marketing/src/app/[lang]/user/[handle]/components/ProfileUnavailable/index.ts
+++ b/apps/marketing/src/app/[lang]/user/[handle]/components/ProfileUnavailable/index.ts
@@ -1,0 +1,1 @@
+export { ProfileUnavailable } from "./ProfileUnavailable";

--- a/apps/marketing/src/app/[lang]/user/[handle]/page.tsx
+++ b/apps/marketing/src/app/[lang]/user/[handle]/page.tsx
@@ -20,7 +20,6 @@ import { TierTube } from "@/app/[lang]/components/TierTube";
 import { TokenSplitBar } from "@/app/[lang]/components/TokenSplitBar";
 import { localeUrl, localizedAlternates } from "@/app/[lang]/metadata";
 import { avatarUrl } from "@/app/[lang]/utils/avatarUrl";
-import { fetchParticipant } from "@/app/[lang]/utils/fetchLeaderboard";
 import {
 	dayCount,
 	formatCount,
@@ -31,8 +30,10 @@ import {
 import { initServerI18n } from "@/app/i18n-server";
 import { AchievementShelf } from "./components/AchievementShelf";
 import { ProfileLinks } from "./components/ProfileLinks";
+import { ProfileUnavailable } from "./components/ProfileUnavailable";
 import { ShareButtons } from "./components/ShareButtons";
 import { ViewToggle } from "./components/ViewToggle";
+import { loadProfile } from "./utils/loadProfile";
 
 const pixel = Silkscreen({
 	weight: ["400", "700"],
@@ -51,12 +52,16 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
 	const lang = await initServerI18n();
 	const { handle } = await params;
-	const profile = await fetchParticipant(handle, { period: "all" });
+	const lookup = await loadProfile(handle);
 
-	if (!profile) {
+	if (lookup.state === "missing") {
 		return { title: "Not found", robots: { index: false } };
 	}
+	if (lookup.state === "rate-limited") {
+		return { title: "Try again shortly", robots: { index: false } };
+	}
 
+	const { profile } = lookup;
 	const who = profile.name ?? `@${profile.handle}`;
 	const title = `${who} · #${profile.rank} on the ${COMPANY.NAME} leaderboard`;
 	const description = `${formatTokens(profile.allTime.tokens)} tokens and ${formatUsd(
@@ -91,10 +96,12 @@ export default async function UserProfilePage({ params }: PageProps) {
 
 	const { t } = useLingui();
 	const { handle } = await params;
-	const profile = await fetchParticipant(handle, { period: "all" });
+	const lookup = await loadProfile(handle);
 
-	if (!profile) notFound();
+	if (lookup.state === "missing") notFound();
+	if (lookup.state === "rate-limited") return <ProfileUnavailable />;
 
+	const { profile } = lookup;
 	const colors = buildModelColors([profile.models]);
 	const shareUrl = `${COMPANY.MARKETING_URL.replace(/\/$/, "")}/${profile.handle}`;
 	const company = COMPANY.NAME;

--- a/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/index.ts
+++ b/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/index.ts
@@ -1,0 +1,1 @@
+export { loadProfile, type ProfileLookup } from "./loadProfile";

--- a/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
+++ b/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
@@ -1,0 +1,24 @@
+import {
+	fetchParticipant,
+	isRateLimited,
+	type ParticipantProfile,
+} from "@/app/[lang]/utils/fetchLeaderboard";
+
+export type ProfileLookup =
+	| { state: "found"; profile: ParticipantProfile }
+	| { state: "missing" }
+	| { state: "rate-limited" };
+
+/**
+ * Shared by the page and its metadata. Only a refused read becomes a state
+ * of its own; any other failure still throws so ISR keeps the stale page.
+ */
+export async function loadProfile(handle: string): Promise<ProfileLookup> {
+	try {
+		const profile = await fetchParticipant(handle, { period: "all" });
+		return profile ? { state: "found", profile } : { state: "missing" };
+	} catch (error) {
+		if (isRateLimited(error)) return { state: "rate-limited" };
+		throw error;
+	}
+}

--- a/apps/marketing/src/app/[lang]/utils/fetchLeaderboard/fetchLeaderboard.ts
+++ b/apps/marketing/src/app/[lang]/utils/fetchLeaderboard/fetchLeaderboard.ts
@@ -77,6 +77,13 @@ export async function fetchParticipant(
 	}
 }
 
+/** The API's public limiter refused the read; the caller decides what to render. */
+export function isRateLimited(error: unknown): boolean {
+	return (
+		error instanceof TRPCClientError && error.data?.code === "TOO_MANY_REQUESTS"
+	);
+}
+
 export async function fetchStanding(
 	handle: string,
 	options: MetricQuery = {},

--- a/apps/marketing/src/app/[lang]/utils/fetchLeaderboard/index.ts
+++ b/apps/marketing/src/app/[lang]/utils/fetchLeaderboard/index.ts
@@ -15,4 +15,5 @@ export {
 	fetchStanding,
 	fetchStandings,
 	fetchStats,
+	isRateLimited,
 } from "./fetchLeaderboard";

--- a/apps/marketing/src/app/[lang]/utils/leaderboardClient/leaderboardClient.ts
+++ b/apps/marketing/src/app/[lang]/utils/leaderboardClient/leaderboardClient.ts
@@ -17,7 +17,10 @@ export const REVALIDATE_SECONDS = 300;
 function serverReadHeaders(): Record<string, string> {
 	if (typeof window !== "undefined") return {};
 	const headers: Record<string, string> = {};
-	if (env.LEADERBOARD_INTERNAL_TOKEN) {
+	if (
+		env.LEADERBOARD_INTERNAL_TOKEN &&
+		isPrivateTransport(env.NEXT_PUBLIC_API_URL)
+	) {
 		headers[INTERNAL_READ_HEADER] = env.LEADERBOARD_INTERNAL_TOKEN;
 	}
 	if (env.VERCEL_GIT_COMMIT_SHA) {
@@ -26,10 +29,23 @@ function serverReadHeaders(): Record<string, string> {
 	return headers;
 }
 
+// The token travels in a custom header, which fetch keeps on a cross-origin
+// redirect, so it only goes over TLS or to a loopback dev server.
+function isPrivateTransport(apiUrl: string): boolean {
+	const { protocol, hostname } = new URL(apiUrl);
+	return (
+		protocol === "https:" ||
+		hostname === "localhost" ||
+		hostname === "127.0.0.1"
+	);
+}
+
 /**
  * Reader for `leaderboard.public.*`. tRPC sends queries as GET, so the URLs
  * stay stable and cacheable by the CDN; the `next` option makes the ISR pages
- * revalidate on the same window and is ignored in the browser.
+ * revalidate on the same window and is ignored in the browser. Server-side
+ * reads refuse redirects: our own API never redirects a tRPC GET, and
+ * following one would carry the internal token to wherever it pointed.
  */
 export const leaderboardClient = createTRPCClient<AppRouter>({
 	links: [
@@ -38,7 +54,11 @@ export const leaderboardClient = createTRPCClient<AppRouter>({
 			transformer: superjson,
 			headers: serverReadHeaders,
 			fetch: (url, options) =>
-				fetch(url, { ...options, next: { revalidate: REVALIDATE_SECONDS } }),
+				fetch(url, {
+					...options,
+					...(typeof window === "undefined" ? { redirect: "error" } : {}),
+					next: { revalidate: REVALIDATE_SECONDS },
+				}),
 		}),
 	],
 });

--- a/apps/marketing/src/app/[lang]/utils/leaderboardClient/leaderboardClient.ts
+++ b/apps/marketing/src/app/[lang]/utils/leaderboardClient/leaderboardClient.ts
@@ -1,4 +1,5 @@
 import type { AppRouter } from "@superset/trpc";
+import { INTERNAL_READ_HEADER } from "@superset/trpc/leaderboard-schema";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import superjson from "superjson";
 import { env } from "@/env";
@@ -6,15 +7,36 @@ import { env } from "@/env";
 export const REVALIDATE_SECONDS = 300;
 
 /**
- * Anonymous reader for `leaderboard.public.*`. tRPC sends queries as GET, so the
- * URLs stay stable and cacheable by the CDN; the `next` option makes the ISR
- * pages revalidate on the same window and is ignored in the browser.
+ * Server-side reads only; the browser sends nothing extra. The token exempts
+ * our own renders from the API's per-IP anonymous limiter, which sees every
+ * marketing render behind Vercel's shared egress address as one visitor. The
+ * build id is part of Next's data-cache key, and the data cache outlives a
+ * deploy while the response shape does not: without it a new build reads the
+ * previous build's cached responses once per handle before revalidating.
+ */
+function serverReadHeaders(): Record<string, string> {
+	if (typeof window !== "undefined") return {};
+	const headers: Record<string, string> = {};
+	if (env.LEADERBOARD_INTERNAL_TOKEN) {
+		headers[INTERNAL_READ_HEADER] = env.LEADERBOARD_INTERNAL_TOKEN;
+	}
+	if (env.VERCEL_GIT_COMMIT_SHA) {
+		headers["x-superset-build"] = env.VERCEL_GIT_COMMIT_SHA;
+	}
+	return headers;
+}
+
+/**
+ * Reader for `leaderboard.public.*`. tRPC sends queries as GET, so the URLs
+ * stay stable and cacheable by the CDN; the `next` option makes the ISR pages
+ * revalidate on the same window and is ignored in the browser.
  */
 export const leaderboardClient = createTRPCClient<AppRouter>({
 	links: [
 		httpBatchLink({
 			url: `${env.NEXT_PUBLIC_API_URL}/api/trpc`,
 			transformer: superjson,
+			headers: serverReadHeaders,
 			fetch: (url, options) =>
 				fetch(url, { ...options, next: { revalidate: REVALIDATE_SECONDS } }),
 		}),

--- a/apps/marketing/src/env.ts
+++ b/apps/marketing/src/env.ts
@@ -25,6 +25,10 @@ export const env = createEnv({
 		// /starchart. GitHub's stargazers endpoint requires authentication even for
 		// public repos; without this the page falls back to a live total only.
 		GITHUB_TOKEN: z.string().optional(),
+		// Same value as the API's. Sent on server-side leaderboard reads so the
+		// API's per-IP anonymous limiter does not count every render as one
+		// visitor. Absent means those reads are anonymous, as they always were.
+		LEADERBOARD_INTERNAL_TOKEN: z.string().min(1).optional(),
 	},
 	client: {
 		NEXT_PUBLIC_API_URL: z.string().url(),

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Zpět na stránky"
 msgid "Back to tasks"
 msgstr "Zpět na úkoly"
 
+msgid "Back to the leaderboard"
+msgstr "Zpět na žebříček"
+
 msgid "Background"
 msgstr "Pozadí"
 
@@ -14296,6 +14299,9 @@ msgstr "Tento plugin nevyžaduje účet — jeho Skills jsou připraveny k použ
 msgid "This port is still in use"
 msgstr "Tento port se stále používá"
 
+msgid "This profile is busy right now"
+msgstr "Tento profil je právě přetížený"
+
 msgid "This project is no longer available on your devices."
 msgstr "Tento projekt už na vašich zařízeních není dostupný."
 
@@ -14548,6 +14554,9 @@ msgstr "Pro tento účet zveřejňuje příliš mnoho počítačů."
 
 msgid "Too many messages. Please try again later."
 msgstr "Příliš mnoho zpráv. Zkuste to prosím později."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Dívá se na něj příliš mnoho lidí najednou. Zkuste to za chvíli znovu."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Příliš mnoho odeslaných promptů. Zkuste to později."

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Zurück zu Seiten"
 msgid "Back to tasks"
 msgstr "Zurück zu Aufgaben"
 
+msgid "Back to the leaderboard"
+msgstr "Zurück zum Leaderboard"
+
 msgid "Background"
 msgstr "Hintergrund"
 
@@ -14296,6 +14299,9 @@ msgstr "Dieses Plugin braucht kein Konto — seine Skills sind sofort einsatzber
 msgid "This port is still in use"
 msgstr "Dieser Port ist noch in Benutzung"
 
+msgid "This profile is busy right now"
+msgstr "Dieses Profil ist gerade stark ausgelastet"
+
 msgid "This project is no longer available on your devices."
 msgstr "Dieses Projekt ist auf deinen Geräten nicht mehr verfügbar."
 
@@ -14548,6 +14554,9 @@ msgstr "Zu viele Rechner veröffentlichen für dieses Konto."
 
 msgid "Too many messages. Please try again later."
 msgstr "Zu viele Nachrichten. Bitte versuche es später erneut."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Zu viele Personen sehen es sich gleichzeitig an. Versuche es gleich noch einmal."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Zu viele eingereichte Prompts. Versuche es später erneut."

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Back to pages"
 msgid "Back to tasks"
 msgstr "Back to tasks"
 
+msgid "Back to the leaderboard"
+msgstr "Back to the leaderboard"
+
 msgid "Background"
 msgstr "Background"
 
@@ -14296,6 +14299,9 @@ msgstr "This plugin needs no account — its skills are ready to use."
 msgid "This port is still in use"
 msgstr "This port is still in use"
 
+msgid "This profile is busy right now"
+msgstr "This profile is busy right now"
+
 msgid "This project is no longer available on your devices."
 msgstr "This project is no longer available on your devices."
 
@@ -14548,6 +14554,9 @@ msgstr "Too many machines publishing for this account."
 
 msgid "Too many messages. Please try again later."
 msgstr "Too many messages. Please try again later."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Too many people are looking at once. Try again shortly."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Too many prompt submissions. Try again later."

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Volver a páginas"
 msgid "Back to tasks"
 msgstr "Volver a tareas"
 
+msgid "Back to the leaderboard"
+msgstr "Volver a la clasificación"
+
 msgid "Background"
 msgstr "Fondo"
 
@@ -14296,6 +14299,9 @@ msgstr "Este plugin no necesita cuenta — sus Skills están listos para usar."
 msgid "This port is still in use"
 msgstr "Este puerto sigue en uso"
 
+msgid "This profile is busy right now"
+msgstr "Este perfil está saturado ahora mismo"
+
 msgid "This project is no longer available on your devices."
 msgstr "Este proyecto ya no está disponible en tus dispositivos."
 
@@ -14548,6 +14554,9 @@ msgstr "Demasiadas máquinas publicando para esta cuenta."
 
 msgid "Too many messages. Please try again later."
 msgstr "Demasiados mensajes. Inténtalo de nuevo más tarde."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Demasiadas personas lo están viendo a la vez. Inténtalo de nuevo en un momento."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Demasiados envíos de prompts. Inténtalo más tarde."

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Retour aux pages"
 msgid "Back to tasks"
 msgstr "Retour aux tâches"
 
+msgid "Back to the leaderboard"
+msgstr "Retour au classement"
+
 msgid "Background"
 msgstr "Arrière-plan"
 
@@ -14296,6 +14299,9 @@ msgstr "Ce plugin ne nécessite aucun compte — ses compétences sont prêtes �
 msgid "This port is still in use"
 msgstr "Ce port est toujours utilisé"
 
+msgid "This profile is busy right now"
+msgstr "Ce profil est très sollicité en ce moment"
+
 msgid "This project is no longer available on your devices."
 msgstr "Ce projet n'est plus disponible sur vos appareils."
 
@@ -14548,6 +14554,9 @@ msgstr "Trop de machines publient pour ce compte."
 
 msgid "Too many messages. Please try again later."
 msgstr "Trop de messages. Veuillez réessayer plus tard."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Trop de personnes le consultent en même temps. Réessayez dans un instant."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Trop de prompts envoyés. Réessayez plus tard."

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Kembali ke halaman"
 msgid "Back to tasks"
 msgstr "Kembali ke tugas"
 
+msgid "Back to the leaderboard"
+msgstr "Kembali ke papan peringkat"
+
 msgid "Background"
 msgstr "Latar belakang"
 
@@ -14296,6 +14299,9 @@ msgstr "Plugin ini tidak memerlukan akun — Skill-nya siap dipakai."
 msgid "This port is still in use"
 msgstr "Port ini masih dipakai"
 
+msgid "This profile is busy right now"
+msgstr "Profil ini sedang sibuk"
+
 msgid "This project is no longer available on your devices."
 msgstr "Proyek ini sudah tidak tersedia di perangkat Anda."
 
@@ -14548,6 +14554,9 @@ msgstr "Terlalu banyak mesin yang mempublikasikan untuk akun ini."
 
 msgid "Too many messages. Please try again later."
 msgstr "Terlalu banyak pesan. Silakan coba lagi nanti."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Terlalu banyak orang yang melihat sekaligus. Coba lagi sebentar lagi."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Terlalu banyak prompt yang dikirim. Coba lagi nanti."

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Torna alle pagine"
 msgid "Back to tasks"
 msgstr "Torna ai task"
 
+msgid "Back to the leaderboard"
+msgstr "Torna alla classifica"
+
 msgid "Background"
 msgstr "Sfondo"
 
@@ -14296,6 +14299,9 @@ msgstr "Questo plugin non richiede un account — le sue Skill sono pronte all'u
 msgid "This port is still in use"
 msgstr "Questa porta è ancora in uso"
 
+msgid "This profile is busy right now"
+msgstr "Questo profilo è molto richiesto in questo momento"
+
 msgid "This project is no longer available on your devices."
 msgstr "Questo progetto non è più disponibile sui tuoi dispositivi."
 
@@ -14548,6 +14554,9 @@ msgstr "Troppe macchine stanno pubblicando per questo account."
 
 msgid "Too many messages. Please try again later."
 msgstr "Troppi messaggi. Riprova più tardi."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Troppe persone lo stanno guardando contemporaneamente. Riprova tra poco."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Troppi invii di prompt. Riprova più tardi."

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -2280,6 +2280,9 @@ msgstr "ページ"
 msgid "Back to tasks"
 msgstr "タスクに戻る"
 
+msgid "Back to the leaderboard"
+msgstr "リーダーボードに戻る"
+
 msgid "Background"
 msgstr "背景"
 
@@ -14296,6 +14299,9 @@ msgstr "このプラグインにアカウントは不要です — スキルは�
 msgid "This port is still in use"
 msgstr "このポートはまだ使用中です"
 
+msgid "This profile is busy right now"
+msgstr "このプロフィールは現在混み合っています"
+
 msgid "This project is no longer available on your devices."
 msgstr "このプロジェクトはお使いのデバイスでは利用できなくなりました。"
 
@@ -14548,6 +14554,9 @@ msgstr "このアカウントで公開しているマシンが多すぎます。
 
 msgid "Too many messages. Please try again later."
 msgstr "メッセージが多すぎます。しばらくしてからお試しください。"
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "同時に閲覧している人が多すぎます。しばらくしてからもう一度お試しください。"
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "プロンプトの送信が多すぎます。しばらくしてからお試しください。"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -14300,7 +14300,7 @@ msgid "This port is still in use"
 msgstr "이 포트는 아직 사용 중입니다"
 
 msgid "This profile is busy right now"
-msgstr "이 프로필은 지금 혼잡합니다"
+msgstr "이 프로필은 지금 이용자가 많습니다"
 
 msgid "This project is no longer available on your devices."
 msgstr "이 프로젝트는 더 이상 내 기기에서 사용할 수 없습니다."

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -2280,6 +2280,9 @@ msgstr "페이지로 돌아가기"
 msgid "Back to tasks"
 msgstr "작업으로 돌아가기"
 
+msgid "Back to the leaderboard"
+msgstr "리더보드로 돌아가기"
+
 msgid "Background"
 msgstr "배경"
 
@@ -14296,6 +14299,9 @@ msgstr "이 플러그인은 계정이 필요 없습니다 — 스킬을 바로 �
 msgid "This port is still in use"
 msgstr "이 포트는 아직 사용 중입니다"
 
+msgid "This profile is busy right now"
+msgstr "이 프로필은 지금 혼잡합니다"
+
 msgid "This project is no longer available on your devices."
 msgstr "이 프로젝트는 더 이상 내 기기에서 사용할 수 없습니다."
 
@@ -14548,6 +14554,9 @@ msgstr "이 계정에서 게시 중인 컴퓨터가 너무 많습니다."
 
 msgid "Too many messages. Please try again later."
 msgstr "메시지가 너무 많습니다. 잠시 후 다시 시도해 주세요."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "동시에 보는 사람이 너무 많습니다. 잠시 후 다시 시도해 주세요."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "프롬프트 제출이 너무 많습니다. 나중에 다시 시도하세요."

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Terug naar pagina's"
 msgid "Back to tasks"
 msgstr "Terug naar taken"
 
+msgid "Back to the leaderboard"
+msgstr "Terug naar de ranglijst"
+
 msgid "Background"
 msgstr "Achtergrond"
 
@@ -14296,6 +14299,9 @@ msgstr "Deze plugin heeft geen account nodig — de Skills zijn meteen klaar voo
 msgid "This port is still in use"
 msgstr "Deze poort is nog in gebruik"
 
+msgid "This profile is busy right now"
+msgstr "Dit profiel is momenteel druk bezet"
+
 msgid "This project is no longer available on your devices."
 msgstr "Dit project is niet meer beschikbaar op je apparaten."
 
@@ -14548,6 +14554,9 @@ msgstr "Te veel machines publiceren voor dit account."
 
 msgid "Too many messages. Please try again later."
 msgstr "Te veel berichten. Probeer het later opnieuw."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Te veel mensen bekijken het tegelijk. Probeer het zo opnieuw."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Te veel promptinzendingen. Probeer het later opnieuw."

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Wróć do stron"
 msgid "Back to tasks"
 msgstr "Wróć do zadań"
 
+msgid "Back to the leaderboard"
+msgstr "Wróć do rankingu"
+
 msgid "Background"
 msgstr "Tło"
 
@@ -14296,6 +14299,9 @@ msgstr "Ta wtyczka nie wymaga konta — jej Umiejętności są gotowe do użycia
 msgid "This port is still in use"
 msgstr "Ten port jest nadal używany"
 
+msgid "This profile is busy right now"
+msgstr "Ten profil jest teraz przeciążony"
+
 msgid "This project is no longer available on your devices."
 msgstr "Ten projekt nie jest już dostępny na Twoich urządzeniach."
 
@@ -14548,6 +14554,9 @@ msgstr "Zbyt wiele maszyn publikuje dla tego konta."
 
 msgid "Too many messages. Please try again later."
 msgstr "Zbyt wiele wiadomości. Spróbuj ponownie później."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Zbyt wiele osób ogląda go jednocześnie. Spróbuj ponownie za chwilę."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Zbyt wiele wysłanych promptów. Spróbuj ponownie później."

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Voltar para as páginas"
 msgid "Back to tasks"
 msgstr "Voltar para as tarefas"
 
+msgid "Back to the leaderboard"
+msgstr "Voltar ao ranking"
+
 msgid "Background"
 msgstr "Fundo"
 
@@ -14296,6 +14299,9 @@ msgstr "Este plugin não precisa de conta — suas Skills já estão prontas par
 msgid "This port is still in use"
 msgstr "Esta porta ainda está em uso"
 
+msgid "This profile is busy right now"
+msgstr "Este perfil está sobrecarregado agora"
+
 msgid "This project is no longer available on your devices."
 msgstr "Este projeto não está mais disponível nos seus dispositivos."
 
@@ -14548,6 +14554,9 @@ msgstr "Máquinas demais publicando nesta conta."
 
 msgid "Too many messages. Please try again later."
 msgstr "Muitas mensagens. Tente novamente mais tarde."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Muitas pessoas estão vendo ao mesmo tempo. Tente novamente em instantes."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Muitos envios de prompt. Tente novamente mais tarde."

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -2280,6 +2280,9 @@ msgstr "К страницам"
 msgid "Back to tasks"
 msgstr "К задачам"
 
+msgid "Back to the leaderboard"
+msgstr "Вернуться к рейтингу"
+
 msgid "Background"
 msgstr "Фон"
 
@@ -14296,6 +14299,9 @@ msgstr "Этому плагину не нужен аккаунт — его На
 msgid "This port is still in use"
 msgstr "Этот порт ещё используется"
 
+msgid "This profile is busy right now"
+msgstr "Этот профиль сейчас перегружен"
+
 msgid "This project is no longer available on your devices."
 msgstr "Этот проект больше недоступен на ваших устройствах."
 
@@ -14548,6 +14554,9 @@ msgstr "Слишком много машин публикуют данные д�
 
 msgid "Too many messages. Please try again later."
 msgstr "Слишком много сообщений. Попробуйте позже."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Слишком много людей смотрят его одновременно. Повторите попытку чуть позже."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Слишком много отправленных промптов. Попробуйте позже."

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Sayfalara dön"
 msgid "Back to tasks"
 msgstr "Görevlere dön"
 
+msgid "Back to the leaderboard"
+msgstr "Lider tablosuna dön"
+
 msgid "Background"
 msgstr "Arka plan"
 
@@ -14296,6 +14299,9 @@ msgstr "Bu eklenti hesap gerektirmez — Becerileri kullanıma hazır."
 msgid "This port is still in use"
 msgstr "Bu port hâlâ kullanımda"
 
+msgid "This profile is busy right now"
+msgstr "Bu profil şu anda yoğun"
+
 msgid "This project is no longer available on your devices."
 msgstr "Bu proje artık cihazlarınızda kullanılamıyor."
 
@@ -14548,6 +14554,9 @@ msgstr "Bu hesap için çok fazla makine yayın yapıyor."
 
 msgid "Too many messages. Please try again later."
 msgstr "Çok fazla mesaj. Lütfen daha sonra yeniden deneyin."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Aynı anda çok fazla kişi bakıyor. Kısa süre sonra tekrar deneyin."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Çok fazla istem gönderimi. Daha sonra yeniden deneyin."

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -2280,6 +2280,9 @@ msgstr "Quay lại danh sách trang"
 msgid "Back to tasks"
 msgstr "Quay lại tác vụ"
 
+msgid "Back to the leaderboard"
+msgstr "Quay lại bảng xếp hạng"
+
 msgid "Background"
 msgstr "Nền"
 
@@ -14296,6 +14299,9 @@ msgstr "Plugin này không cần tài khoản — các Skill của nó đã sẵ
 msgid "This port is still in use"
 msgstr "Cổng này vẫn đang được dùng"
 
+msgid "This profile is busy right now"
+msgstr "Hồ sơ này hiện đang quá tải"
+
 msgid "This project is no longer available on your devices."
 msgstr "Dự án này không còn khả dụng trên các thiết bị của bạn."
 
@@ -14548,6 +14554,9 @@ msgstr "Quá nhiều máy đang đăng dữ liệu cho tài khoản này."
 
 msgid "Too many messages. Please try again later."
 msgstr "Quá nhiều tin nhắn. Vui lòng thử lại sau."
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "Có quá nhiều người đang xem cùng lúc. Vui lòng thử lại sau giây lát."
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "Quá nhiều lượt gửi prompt. Hãy thử lại sau."

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -2280,6 +2280,9 @@ msgstr "返回页面"
 msgid "Back to tasks"
 msgstr "返回任务"
 
+msgid "Back to the leaderboard"
+msgstr "返回排行榜"
+
 msgid "Background"
 msgstr "背景"
 
@@ -14296,6 +14299,9 @@ msgstr "此插件无需账户 — 它的技能可直接使用。"
 msgid "This port is still in use"
 msgstr "此端口仍在使用中"
 
+msgid "This profile is busy right now"
+msgstr "此个人主页当前繁忙"
+
 msgid "This project is no longer available on your devices."
 msgstr "这个项目在你的设备上已不可用。"
 
@@ -14548,6 +14554,9 @@ msgstr "此账户发布数据的机器过多。"
 
 msgid "Too many messages. Please try again later."
 msgstr "消息过多。请稍后重试。"
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "同时查看的人太多了，请稍后再试。"
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "提示词提交次数过多。请稍后重试。"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -2280,6 +2280,9 @@ msgstr "返回頁面"
 msgid "Back to tasks"
 msgstr "返回任務"
 
+msgid "Back to the leaderboard"
+msgstr "返回排行榜"
+
 msgid "Background"
 msgstr "背景"
 
@@ -14296,6 +14299,9 @@ msgstr "此外掛不需要帳戶 — 它的技能可直接使用。"
 msgid "This port is still in use"
 msgstr "此埠仍在使用中"
 
+msgid "This profile is busy right now"
+msgstr "此個人檔案目前繁忙"
+
 msgid "This project is no longer available on your devices."
 msgstr "這個專案在你的裝置上已不可用。"
 
@@ -14548,6 +14554,9 @@ msgstr "此帳戶釋出資料的機器過多。"
 
 msgid "Too many messages. Please try again later."
 msgstr "訊息過多。請稍後重試。"
+
+msgid "Too many people are looking at once. Try again shortly."
+msgstr "同時查看的人太多了，請稍後再試。"
 
 msgid "Too many prompt submissions. Try again later."
 msgstr "提示詞提交次數過多。請稍後重試。"

--- a/packages/trpc/src/env.ts
+++ b/packages/trpc/src/env.ts
@@ -46,6 +46,11 @@ export const env = createEnv({
 		NEXT_PUBLIC_WEB_URL: z.string().url(),
 		KV_REST_API_URL: z.string().url().optional(),
 		KV_REST_API_TOKEN: z.string().optional(),
+		// Shared with apps/marketing. Its server-side leaderboard reads present
+		// it to skip the per-IP anonymous limiter, which would otherwise count
+		// every marketing render as one visitor (Vercel shares egress IPs).
+		// Absent means every read is anonymous and rate-limited.
+		LEADERBOARD_INTERNAL_TOKEN: z.string().min(1).optional(),
 		// Blaxel (cloud workspace sandboxes).
 		BLAXEL_API_KEY: z.string().min(1),
 		BLAXEL_WORKSPACE: z.string().min(1),

--- a/packages/trpc/src/router/leaderboard/internal-read.test.ts
+++ b/packages/trpc/src/router/leaderboard/internal-read.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { isInternalRead } from "./internal-read";
+import { INTERNAL_READ_HEADER } from "./schema";
+
+const TOKEN = "s3cret-token";
+
+describe("isInternalRead", () => {
+	test("no token configured never matches, even with no header", () => {
+		expect(isInternalRead(new Headers(), undefined)).toBe(false);
+		expect(isInternalRead(new Headers(), "")).toBe(false);
+	});
+
+	test("no token configured never matches a presented header", () => {
+		const headers = new Headers({ [INTERNAL_READ_HEADER]: TOKEN });
+		expect(isInternalRead(headers, undefined)).toBe(false);
+	});
+
+	test("missing header does not match", () => {
+		expect(isInternalRead(new Headers(), TOKEN)).toBe(false);
+	});
+
+	test("wrong token does not match", () => {
+		expect(
+			isInternalRead(new Headers({ [INTERNAL_READ_HEADER]: "other" }), TOKEN),
+		).toBe(false);
+		expect(
+			isInternalRead(
+				new Headers({ [INTERNAL_READ_HEADER]: `${TOKEN}x` }),
+				TOKEN,
+			),
+		).toBe(false);
+		expect(
+			isInternalRead(
+				new Headers({ [INTERNAL_READ_HEADER]: TOKEN.slice(0, -1) }),
+				TOKEN,
+			),
+		).toBe(false);
+	});
+
+	test("token in another header does not match", () => {
+		expect(
+			isInternalRead(new Headers({ authorization: `Bearer ${TOKEN}` }), TOKEN),
+		).toBe(false);
+	});
+
+	test("exact token matches", () => {
+		expect(
+			isInternalRead(new Headers({ [INTERNAL_READ_HEADER]: TOKEN }), TOKEN),
+		).toBe(true);
+	});
+});

--- a/packages/trpc/src/router/leaderboard/internal-read.ts
+++ b/packages/trpc/src/router/leaderboard/internal-read.ts
@@ -1,0 +1,19 @@
+import { timingSafeEqual } from "node:crypto";
+import { INTERNAL_READ_HEADER } from "./schema";
+
+/**
+ * True only when a token is configured and the request presents exactly it.
+ * Both sides absent is not a match: an environment without the token must
+ * keep rate-limiting every read.
+ */
+export function isInternalRead(
+	headers: Headers,
+	token: string | undefined,
+): boolean {
+	if (!token) return false;
+	const presented = headers.get(INTERNAL_READ_HEADER);
+	if (!presented) return false;
+	const expected = Buffer.from(token);
+	const actual = Buffer.from(presented);
+	return expected.length === actual.length && timingSafeEqual(expected, actual);
+}

--- a/packages/trpc/src/router/leaderboard/leaderboard.ts
+++ b/packages/trpc/src/router/leaderboard/leaderboard.ts
@@ -33,6 +33,7 @@ import {
 	evaluateAwards,
 	longestStreak,
 } from "./awards";
+import { isInternalRead } from "./internal-read";
 import { type LeaderboardPeriod, resolveDayRange } from "./periods";
 import {
 	getParticipant,
@@ -183,6 +184,7 @@ function assertDaysInWindow(days: readonly { day: string }[]): void {
 
 async function enforcePublicRead(headers: Headers): Promise<void> {
 	if (!publicReadRateLimit) return;
+	if (isInternalRead(headers, env.LEADERBOARD_INTERNAL_TOKEN)) return;
 	const ip =
 		headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
 		headers.get("x-real-ip") ||

--- a/packages/trpc/src/router/leaderboard/schema.ts
+++ b/packages/trpc/src/router/leaderboard/schema.ts
@@ -6,6 +6,13 @@ const dayKey = z.string().refine(isDayKey, "Expected a real YYYY-MM-DD date");
 
 export const MAX_TOKENS_PER_ROW_FIELD = 50_000_000_000;
 
+/**
+ * Carries LEADERBOARD_INTERNAL_TOKEN on marketing's server-side reads of
+ * `leaderboard.public.*`. Lives here, not next to the matcher, so the
+ * browser bundle that shares the tRPC client never imports node:crypto.
+ */
+export const INTERNAL_READ_HEADER = "x-leaderboard-internal-token";
+
 const tokenCount = z.number().int().min(0).max(MAX_TOKENS_PER_ROW_FIELD);
 
 export const handleSchema = z


### PR DESCRIPTION
## Problem

Public profile pages (`/[lang]/user/[handle]`, served as `/<handle>`) return 500s in two ways.

**MARKETING-6C** (513 events, ongoing since 2026-08-29): the page's server-side `fetchParticipant` call gets `TOO_MANY_REQUESTS` from `leaderboard.public.participant` and the render throws. 73% of events are single crawler sweeps of the whole handle list (~45 handles in 36 s); the rest are Chrome-UA crawls of `/user/<handle>`. Any human who opens a profile that is not in the ISR cache during such a sweep gets the same 500, and crawlers index the 500s.

**MARKETING-6D / 6E / 6F** (218 events, all within 2026-09-07 01:49–01:54 UTC plus one straggler at 04:46): the page renders with a profile that has no `awards` and no `axes`, so `highestPerSlug` iterates `undefined` and `factoryScore` / `rankingGap` read `.width` / `.sustain` off `undefined`. Each of 101 handles crashed exactly once.

**User-visible harm:** a visitor or crawler opening a profile page that is not yet cached gets a 500 instead of the profile, whenever more than 60 distinct profiles were rendered in the last minute, and once per handle after any deploy that changes the participant response shape.

## Root cause

Two, both in how marketing's server reads the API.

1. **The anonymous limiter counts our own server as one visitor.** `enforcePublicRead` keys a 60/min sliding window on `x-forwarded-for`. Every marketing render on Vercel leaves through a shared egress address, so all profile renders in a region share one bucket. Next's data cache bounds this to one API read per handle per 300 s, but a crawler walking the sitemap renders 60+ *distinct* handles a minute, and the limiter refuses the rest. Forwarding the visitor's IP (shape 1 in the task) cannot work: Vercel overwrites `x-forwarded-for` on inbound requests to the API and does not forward external IPs (documented under "Request headers"), so the API would keep seeing the egress address regardless of what marketing sends. It would also force the ISR page dynamic. So this PR takes shape 2: marketing's server-to-server reads authenticate as internal.

2. **The data cache outlives a deploy; the response contract does not.** Vercel's Data Cache persists across deployments and serves stale entries while revalidating. The marketing build before #7195 had cached `leaderboard.public.participant` responses (same URL, same `next.revalidate`) that had no `awards`/`axes`. The first marketing build with the new page went live at 01:48 UTC; every handle's first request after that got the previous build's cached shape once, then the revalidated one. The 04:46 straggler is a handle nobody had opened since. Types cannot fix this: `ParticipantProfile` already says `awards` is an array; the runtime value came from a cache written by code with a different type.

## Fix

- **API** (`packages/trpc`): `enforcePublicRead` returns early when the request carries `LEADERBOARD_INTERNAL_TOKEN` in `x-leaderboard-internal-token`. The matcher (`internal-read.ts`) is `false` when no token is configured, even if no header is presented, and compares in constant time. The header name lives in `schema.ts` so the browser bundle that shares the tRPC client never imports `node:crypto`. Plain `TRPCError`s are unchanged; no typed cause was added because nothing reads one.
- **Marketing** (`leaderboardClient.ts`): server-side reads send the token and an `x-superset-build: <commit sha>` header. Headers are part of Next's data-cache key, so each build starts from entries it wrote itself. The browser sends nothing extra.
- **Page**: `loadProfile` (shared by `generateMetadata` and the page) turns a refused read into a `rate-limited` state; the page renders `ProfileUnavailable` ("try again shortly", link back to the leaderboard, `robots: noindex`) instead of throwing. Unknown handles still `notFound()`; every other failure still throws so ISR keeps the stale page rather than caching a 404 or a retry page for a live profile.
- **Env**: `LEADERBOARD_INTERNAL_TOKEN` added to both schemas as optional with a real fallback (absent = today's behaviour), to `.env.example` / `.env.local.example`, and to the api and marketing jobs in both deploy workflows.

**Operator step before the token part takes effect:** `gh secret set LEADERBOARD_INTERNAL_TOKEN -R superset-sh/superset --body "<random>"` with one value for both environments, and add it to the root `.env` per `docs/environment-variables.md`. Until then, marketing reads stay anonymous and rate-limited exactly as today; the build-scoped cache key and the retry page are live on merge.

**Trade-off stated plainly:** the retry page is a normal 200 render, so in the misconfigured case (no token) ISR can hold it for that handle and locale for up to 300 s. I could not confirm from Next 16.2 source that calling `connection()` during an on-demand ISR render falls back to an uncached dynamic render rather than an error, so the page does not rely on it. With the token set, marketing's reads are never refused and this state is not reached.

**Adjacent, left alone:** `opengraph-image.tsx` and the `fight` page also call `fetchParticipant` and still throw on a refused read (they benefit from the token exemption). `deploy-marketing` and `deploy-api` run in parallel; if marketing ever lands first it can cache one old-shape response for 300 s. The `md/[...path]` route already maps failures to a 503.

## Verification

`bunx biome check <changed files>` (after one `--write` on `fetchLeaderboard.ts`):
```
Checked 14 files in 15ms. No fixes applied.
```

`cd packages/trpc && bun run typecheck`:
```
$ tsc --noEmit --emitDeclarationOnly false
```

`cd apps/marketing && bun run typecheck`:
```
$ tsc --noEmit
```

`cd packages/trpc && bun test src/router/leaderboard`:
```
 118 pass
 0 fail
 376 expect() calls
Ran 118 tests across 7 files. [100.00ms]
```

`cd apps/marketing && bun test "src/app/[lang]/utils" "src/app/[lang]/user"`:
```
 11 pass
 0 fail
 22 expect() calls
Ran 11 tests across 1 file. [47.00ms]
```

`bun run check:i18n` (three new strings, translated into all 16 locales by hand):
```
vi ⇒ locales/vi/messages.ts
Done in 543ms
exit=0
```

`cd packages/i18n && bun test`:
```
 119 pass
 0 fail
Ran 119 tests across 9 files. [1.51s]
```

The matcher test (`internal-read.test.ts`) covers the inputs it must NOT match: no token configured with no header, no token configured with a header presented, missing header, wrong or truncated or extended token, token in `Authorization` instead. The matcher is new code, so the negative cases could not be run against a prior implementation; the "no token and no header" case is the one a naive equality check would get wrong.

Refs MARKETING-6C
Refs MARKETING-6D
Refs MARKETING-6E
Refs MARKETING-6F

https://claude.ai/code/session_01QUcqsehCfQcsTTXVtC4yJj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Public profile pages no longer 500 when the API limiter refuses marketing's own reads or the data cache serves a previous deploy's response shape.

- Marketing's server-side leaderboard reads send a shared token (`LEADERBOARD_INTERNAL_TOKEN`) that exempts them from the per-IP anonymous limiter; the browser never sends it, it only travels over HTTPS or to a loopback dev server, and fetches refuse redirects so the token cannot leak.
- Reads include an `x-superset-build` header with the commit sha so each deploy starts from its own data-cache entries instead of reusing stale shapes.
- A rate-limited read now renders a "try again shortly" page instead of throwing; unknown handles and other failures behave as before.

**Migration**

- Set the `LEADERBOARD_INTERNAL_TOKEN` secret with one value for both environments and add it to the root `.env` before the token part takes effect.
- Without the token, marketing reads stay rate-limited exactly as today; the build-scoped cache key and retry page are live on merge.

<sup>Written for commit 50b46cb5f0c5b50c1b5355ba461fbbe172297f61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Profile pages now show a localized “try again shortly” message when temporarily unavailable due to high traffic.
  - Added a link back to the leaderboard from unavailable profiles.
  - Server-side leaderboard reads can avoid public rate limits, improving profile availability.
- **Localization**
  - Added profile availability and navigation translations across all supported languages.
- **Bug Fixes**
  - Profile lookups now distinguish between missing profiles and temporarily rate-limited requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->