### PR TITLE
fix(desktop): close a browser pane whose page closes itself and search unparseable addresses

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
@@ -214,3 +214,137 @@ describe("browserRuntimeRegistry overlay layer", () => {
 		expect(browserRuntimeRegistry.getOverlayContainer("nope")).toBeNull();
 	});
 });
+
+describe("browserRuntimeRegistry guest lifecycle", () => {
+	interface LifecycleEntry {
+		webview: EventTarget & { getURL?: () => string; getTitle?: () => string };
+		state: {
+			currentUrl: string;
+			pageTitle: string;
+			isLoading: boolean;
+			error: { code: number } | null;
+		};
+		onPersist: ((state: { url: string }) => void) | null;
+		onClose: (() => void) | null;
+	}
+	const registryInternals = browserRuntimeRegistry as unknown as {
+		entries: Map<string, LifecycleEntry>;
+		createEntry: (
+			paneId: string,
+			initialUrl: string,
+			workspaceId: string,
+		) => LifecycleEntry;
+	};
+	const makeElement = () =>
+		Object.assign(new EventTarget(), {
+			style: {} as Record<string, string>,
+			setAttribute: () => {},
+			remove: () => {},
+			src: "",
+		});
+	const createEntry = (paneId: string) => {
+		const original = document.createElement;
+		document.createElement = makeElement as unknown as typeof original;
+		try {
+			const entry = registryInternals.createEntry(
+				paneId,
+				"http://localhost:3000",
+				"workspace-1",
+			);
+			registryInternals.entries.set(paneId, entry);
+			return entry;
+		} finally {
+			document.createElement = original;
+		}
+	};
+	const fire = (
+		target: EventTarget,
+		type: string,
+		props: Record<string, unknown> = {},
+	) => target.dispatchEvent(Object.assign(new Event(type), props));
+	// What every guest method throws once Electron has destroyed the guest.
+	const deadGuest = () => {
+		throw new Error("Invalid guestInstanceId: 7");
+	};
+
+	test("tracks the URL and title from events, not from the guest", () => {
+		const paneId = "lifecycle-events-pane";
+		const entry = createEntry(paneId);
+		entry.webview.getURL = deadGuest;
+		entry.webview.getTitle = deadGuest;
+		const persisted: string[] = [];
+		entry.onPersist = (state) => persisted.push(state.url);
+		try {
+			fire(entry.webview, "did-navigate", { url: "http://localhost:3000/app" });
+			fire(entry.webview, "page-title-updated", { title: "App" });
+			fire(entry.webview, "did-stop-loading");
+
+			const state = browserRuntimeRegistry.getState(paneId);
+			expect(state.currentUrl).toBe("http://localhost:3000/app");
+			expect(state.pageTitle).toBe("App");
+			expect(state.isLoading).toBe(false);
+			expect(persisted).toEqual(["http://localhost:3000/app"]);
+
+			fire(entry.webview, "did-navigate-in-page", {
+				url: "http://localhost:3000/app#tab",
+			});
+			expect(browserRuntimeRegistry.getState(paneId).currentUrl).toBe(
+				"http://localhost:3000/app#tab",
+			);
+		} finally {
+			registryInternals.entries.delete(paneId);
+		}
+	});
+
+	test("records the attempted URL of a failed main-frame load only", () => {
+		const paneId = "lifecycle-failed-load-pane";
+		const entry = createEntry(paneId);
+		try {
+			fire(entry.webview, "did-fail-load", {
+				errorCode: -102,
+				errorDescription: "ERR_CONNECTION_REFUSED",
+				validatedURL: "http://localhost:3000/",
+				isMainFrame: true,
+			});
+			let state = browserRuntimeRegistry.getState(paneId);
+			expect(state.currentUrl).toBe("http://localhost:3000/");
+			expect(state.error?.code).toBe(-102);
+
+			fire(entry.webview, "did-fail-load", {
+				errorCode: -105,
+				errorDescription: "ERR_NAME_NOT_RESOLVED",
+				validatedURL: "http://ads.example/",
+				isMainFrame: false,
+			});
+			state = browserRuntimeRegistry.getState(paneId);
+			expect(state.currentUrl).toBe("http://localhost:3000/");
+		} finally {
+			registryInternals.entries.delete(paneId);
+		}
+	});
+
+	test("drops the entry and closes the pane when the guest is destroyed", () => {
+		const paneId = "lifecycle-destroyed-pane";
+		const entry = createEntry(paneId);
+		const onClose = mock(() => {});
+		entry.onClose = onClose;
+		try {
+			fire(entry.webview, "destroyed");
+
+			expect(registryInternals.entries.has(paneId)).toBe(false);
+			expect(onClose).toHaveBeenCalledTimes(1);
+			expect(unregister).toHaveBeenCalledWith({ paneId });
+
+			// Late events from the dead guest reach no handler.
+			fire(entry.webview, "did-navigate", {
+				url: "http://localhost:3000/late",
+			});
+			expect(browserRuntimeRegistry.getState(paneId).currentUrl).toBe(
+				"about:blank",
+			);
+			browserRuntimeRegistry.reload(paneId);
+		} finally {
+			registryInternals.entries.delete(paneId);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -40,6 +40,8 @@ interface RegistryEntry {
 	overlay: HTMLDivElement;
 	state: BrowserRuntimeState;
 	onPersist: ((state: PersistableBrowserState) => void) | null;
+	/** Asks the pane to close itself; fired when the guest closes itself. */
+	onClose: (() => void) | null;
 	/** Owning workspace — sent on register so the main process scopes pane ops. */
 	workspaceId: string;
 	webContentsId: number | null;
@@ -300,6 +302,7 @@ class BrowserRuntimeRegistryImpl {
 			overlay,
 			state: { ...EMPTY_STATE, currentUrl: initialUrl },
 			onPersist: null,
+			onClose: null,
 			workspaceId,
 			webContentsId: null,
 			detachHandlers: () => {},
@@ -337,19 +340,23 @@ class BrowserRuntimeRegistryImpl {
 			});
 		};
 
+		// URL and title come from the events that carry them, never from
+		// `getURL()`/`getTitle()`: those are synchronous calls into the guest,
+		// and the guest can already be gone when a queued event is handled. A
+		// page that calls `window.close()` is destroyed by Electron the moment
+		// it asks, while the did-stop-loading it emitted first is still in
+		// flight, so a read in that handler throws "Invalid guestInstanceId".
+		// The title resets on each committed navigation and arrives through
+		// page-title-updated, so a page with no <title> shows the pane's URL
+		// fallback instead of Chromium's synthesized one.
 		const handleDidStopLoading = () => {
-			const url = webview.getURL() ?? "";
-			const title = webview.getTitle() ?? "";
-			this.setState(paneId, {
-				isLoading: false,
-				currentUrl: url,
-				pageTitle: title,
-			});
+			this.setState(paneId, { isLoading: false });
 			this.refreshNavState(paneId);
 			this.refreshZoomState(paneId);
-			if (url && url !== "about:blank") {
+			const { currentUrl, pageTitle, faviconUrl } = entry.state;
+			if (currentUrl && currentUrl !== "about:blank") {
 				electronTrpcClient.browserHistory.upsert
-					.mutate({ url, title, faviconUrl: entry.state.faviconUrl })
+					.mutate({ url: currentUrl, title: pageTitle, faviconUrl })
 					.catch((err) => {
 						console.error("[browserRuntimeRegistry] upsert history:", err);
 					});
@@ -358,11 +365,9 @@ class BrowserRuntimeRegistryImpl {
 		};
 
 		const handleDidNavigate = (e: Electron.DidNavigateEvent) => {
-			const url = e.url ?? "";
-			const title = webview.getTitle() ?? "";
 			this.setState(paneId, {
-				currentUrl: url,
-				pageTitle: title,
+				currentUrl: e.url ?? "",
+				pageTitle: "",
 				isLoading: false,
 			});
 			this.refreshNavState(paneId);
@@ -370,9 +375,7 @@ class BrowserRuntimeRegistryImpl {
 		};
 
 		const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
-			const url = e.url ?? "";
-			const title = webview.getTitle() ?? "";
-			this.setState(paneId, { currentUrl: url, pageTitle: title });
+			this.setState(paneId, { currentUrl: e.url ?? "" });
 			this.refreshNavState(paneId);
 		};
 
@@ -397,8 +400,13 @@ class BrowserRuntimeRegistryImpl {
 
 		const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
 			if (e.errorCode === -3) return; // ERR_ABORTED
+			// A failed main-frame load commits Chromium's error page without a
+			// did-navigate, so the address comes from the failure itself.
 			this.setState(paneId, {
 				isLoading: false,
+				...(e.isMainFrame
+					? { currentUrl: e.validatedURL ?? "", pageTitle: "" }
+					: {}),
 				error: {
 					code: e.errorCode ?? 0,
 					description: e.errorDescription ?? "",
@@ -409,6 +417,18 @@ class BrowserRuntimeRegistryImpl {
 
 		const handleFoundInPage = (e: Electron.FoundInPageEvent) => {
 			this.notifyFoundInPage(paneId, e.result);
+		};
+
+		// The guest webContents is gone: Electron destroys a guest whose page
+		// calls `window.close()` (a sign-in flow finishing, a page closing
+		// itself). The element cannot be revived — every guest method now throws
+		// "Invalid guestInstanceId" — so the entry goes with it and the pane
+		// closes, as a browser closes a tab whose page closed itself.
+		const handleDestroyed = () => {
+			if (this.entries.get(paneId) !== entry) return;
+			const onClose = entry.onClose;
+			this.destroy(paneId);
+			onClose?.();
 		};
 
 		webview.addEventListener("dom-ready", handleDomReady);
@@ -438,6 +458,7 @@ class BrowserRuntimeRegistryImpl {
 			"found-in-page",
 			handleFoundInPage as EventListener,
 		);
+		webview.addEventListener("destroyed", handleDestroyed);
 
 		entry.detachHandlers = () => {
 			webview.removeEventListener("dom-ready", handleDomReady);
@@ -467,6 +488,7 @@ class BrowserRuntimeRegistryImpl {
 				"found-in-page",
 				handleFoundInPage as EventListener,
 			);
+			webview.removeEventListener("destroyed", handleDestroyed);
 		};
 
 		return entry;
@@ -478,6 +500,7 @@ class BrowserRuntimeRegistryImpl {
 		initialUrl: string,
 		workspaceId: string,
 		onPersist: (state: PersistableBrowserState) => void,
+		onClose: () => void,
 	): void {
 		const root = this.ensureRootContainer();
 		let entry = this.entries.get(paneId);
@@ -510,6 +533,7 @@ class BrowserRuntimeRegistryImpl {
 			this.refreshNavState(paneId);
 		}
 		entry.onPersist = onPersist;
+		entry.onClose = onClose;
 		entry.placeholder = placeholder;
 		entry.visible = true;
 		entry.lastUsedAt = ++this.useSeq;
@@ -574,6 +598,7 @@ class BrowserRuntimeRegistryImpl {
 		const entry = this.entries.get(paneId);
 		if (!entry) return;
 		entry.onPersist = null;
+		entry.onClose = null;
 		entry.resizeObserver?.disconnect();
 		entry.detachHandlers();
 		entry.webview.remove();

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/hooks/usePersistentWebview/usePersistentWebview.ts
@@ -64,6 +64,9 @@ export function usePersistentWebview({
 					faviconUrl,
 				});
 			},
+			() => {
+				void ctxRef.current.actions.close();
+			},
 		);
 		setOverlayContainer(browserRuntimeRegistry.getOverlayContainer(paneId));
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/sanitizeUrl.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/sanitizeUrl.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeUrl } from "./sanitizeUrl";
+
+const SEARCH_PREFIX = "https://www.google.com/search?q=";
+
+describe("sanitizeUrl", () => {
+	test("keeps absolute http(s) and about: URLs as typed", () => {
+		for (const url of [
+			"http://localhost:3000/x?y=1#z",
+			"https://user:pw@example.com/",
+			"http://[::1]:3000",
+			"about:blank",
+			// Odd but parseable hosts are the page's problem, not ours.
+			"https://{host}/health",
+			"https://*.example.com/",
+		]) {
+			expect(sanitizeUrl(url)).toBe(url);
+		}
+	});
+
+	test("adds a scheme to hosts typed without one", () => {
+		expect(sanitizeUrl("localhost:3000")).toBe("http://localhost:3000");
+		expect(sanitizeUrl("127.0.0.1:8080/x")).toBe("http://127.0.0.1:8080/x");
+		expect(sanitizeUrl("example.com/path")).toBe("https://example.com/path");
+	});
+
+	test("searches text that is not a URL", () => {
+		expect(sanitizeUrl("hello world")).toBe(`${SEARCH_PREFIX}hello%20world`);
+		expect(sanitizeUrl("")).toBe(SEARCH_PREFIX);
+	});
+
+	// A webview's `src` is parsed with `new URL()` inside Electron's
+	// connectedCallback, so anything that gains a scheme but still cannot
+	// parse would throw from appendChild. These all did.
+	test("searches input that a scheme alone cannot make a URL", () => {
+		for (const input of [
+			"https://",
+			"http://",
+			"git@github.com:org/repo.git",
+			"example.com:abc",
+			"localhost:99999",
+			"http://foo bar.com",
+		]) {
+			expect(sanitizeUrl(input)).toBe(
+				`${SEARCH_PREFIX}${encodeURIComponent(input)}`,
+			);
+		}
+	});
+
+	test("always returns a parseable absolute URL", () => {
+		for (const input of [
+			"https://",
+			"git@github.com:org/repo.git",
+			"localhost:3000",
+			"example.com",
+			"hello world",
+			"",
+		]) {
+			expect(URL.canParse(sanitizeUrl(input))).toBe(true);
+		}
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/sanitizeUrl.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/sanitizeUrl.ts
@@ -1,5 +1,20 @@
+const SEARCH_URL = "https://www.google.com/search?q=";
+
+/**
+ * The one place address-bar text and persisted pane URLs become a webview
+ * URL. Always returns a parseable absolute URL: Electron parses a webview's
+ * `src` with `new URL()` inside the element's connectedCallback, so a value
+ * that merely gained a scheme (`git@github.com:org/repo.git` linkified in a
+ * terminal, `https://` on its own, a non-numeric port) would throw from
+ * `appendChild`. Such text is searched instead, like any other non-URL.
+ */
 export function sanitizeUrl(url: string): string {
 	const value = url.trim();
+	const candidate = withScheme(value);
+	return URL.canParse(candidate) ? candidate : searchUrl(value);
+}
+
+function withScheme(value: string): string {
 	if (/^https?:\/\//i.test(value) || value.startsWith("about:")) {
 		return value;
 	}
@@ -9,5 +24,9 @@ export function sanitizeUrl(url: string): string {
 	if (/^[^\s/]+\.[^\s]+(\/.*)?$/.test(value)) {
 		return `https://${value}`;
 	}
-	return `https://www.google.com/search?q=${encodeURIComponent(value)}`;
+	return searchUrl(value);
+}
+
+function searchUrl(value: string): string {
+	return `${SEARCH_URL}${encodeURIComponent(value)}`;
 }


### PR DESCRIPTION
## Reality check

1. **User-visible harm.** After a page inside a browser pane closes itself (a Google sign-in flow's closing page, an app calling `window.close()`), the pane goes blank and stays that way: reload does nothing, typing an address does nothing, and the user has to close the pane and open a new one. Breadcrumbs show the same users hitting this three or four times in a row. Separately, clicking some terminal links (a `git@github.com:org/repo.git` remote, an address with a non-numeric port) throws an uncaught renderer error instead of opening a pane.
2. **Reach.** Every affected event is from the v2 browser pane runtime (`browserRuntimeRegistry.ts`), releases 1.16 through 1.26.0, Electron 41.10.3. This change ships in the next desktop release and reaches every v2 user.
3. **Why code.** Archiving would leave the dead-pane behaviour in place. A Sentry filter is forbidden by the repo contract and would hide a real defect. No in-flight work touches these paths: #6928 (browser pane popups) changes `resolveWindowOpen` in the main process, not the renderer registry.

## Problem

Three Sentry issues, two root causes in this runtime. Both are read straight out of the Electron 41.10.3 source, not guessed.

## Root cause 1: a guest can die under the registry (DESKTOP-F8, DESKTOP-F7, DESKTOP-FP)

`WebContents::CloseContents` in Electron 41 emits `close` and then unconditionally calls `Destroy()`. So a page inside a `<webview>` that calls `window.close()` destroys its own guest webContents. The guest-view manager deletes the guest from its map, and every later `GUEST_VIEW_MANAGER_CALL` for that id throws `Invalid guestInstanceId: N`. Electron tells the element about it through the webview's `destroyed` event, which the registry never listened to.

Every F8, F7 and FP breadcrumb trail shows the same shape: `renderer.destroyed` for the guest's webContents id, then the throw with that same id. The F7 trails show the page was Google Identity Services' closing page; the FP trail shows a user's own app page destroyed the same way.

Two consequences:

- **Zombie pane (F7).** The element keeps its stale guest id, so `reload()` and every other method throw. The pane is blank and dead until the user closes it.
- **In-flight events (F8, FP).** Electron dispatches guest events over async IPC in order, but the guest-map deletion happens synchronously on the main side. A `did-stop-loading` or `did-navigate-in-page` emitted just before the page closed itself is handled after the guest is gone, and the handler's synchronous `getURL()` / `getTitle()` throws. No try/catch can fix the ordering; the handlers must not round-trip to the guest for data the events already carry.

## Root cause 2: `sanitizeUrl` guaranteed a scheme, not a URL (DESKTOP-E6, DESKTOP-AH)

Electron resolves a webview's `src` with `new URL(src, location.href)` inside `connectedCallback`, so the throw surfaces from `root.appendChild(entry.webview)` in `attach` (E6), and again a microtask later from the `src` attribute's MutationObserver (AH, same trace id, same timestamps). `sanitizeUrl` prefixed `https://` onto anything containing a dot and passed anything starting with `http(s)://` through untouched, so these all reached `src` unparseable:

- `git@github.com:org/repo.git` (a git remote in terminal output, which the terminal's link detector hands to the pane) → `https://git@github.com:org/repo.git`, port "org/repo.git"
- `example.com:abc`, `localhost:99999` (bad port)
- `https://` or `http://` alone, a host containing a space

The three most recent E6 trails all end with a terminal link click (`xterm-link-layer`) right before the throw.

## Fix

**Registry lifecycle** (`browserRuntimeRegistry.ts`)

- Listen for the webview's `destroyed` event. Drop the entry through the existing `destroy()` path (handlers removed, element removed, main-side `unregister`) and call a new `onClose` callback the pane supplies at `attach`. `usePersistentWebview` wires it to `ctx.actions.close()`, the same path the CLI's close-pane bridge already uses. The pane closes, as a browser closes a tab whose page closed itself.
- `did-stop-loading`, `did-navigate` and `did-navigate-in-page` no longer call `getURL()` / `getTitle()`. URL comes from the navigation events; title comes from `page-title-updated` and resets on each committed navigation. `did-fail-load` records the attempted URL for main-frame failures, because Chromium commits its error page without a `did-navigate` (also from the Electron source: `DidFinishNavigation` skips `did-navigate` for error pages).
- The only guest reads left in event handlers are `canGoBack` / `canGoForward` / `getZoomFactor`, which were already guarded; untouched.

One behaviour delta, deliberate: a page with no `<title>` previously showed Chromium's synthesized title (`host/path`) via `getTitle()`; it now shows the pane's existing fallback (`host`). Titled pages are unchanged.

**URL normalisation** (`sanitizeUrl.ts`)

`sanitizeUrl` is the single place address-bar text and persisted pane URLs become a webview URL (both `src` and `navigate()` go through it). It now validates its candidate with `URL.canParse` and searches anything that still cannot parse, the same fallback plain text already gets. Valid URLs, scheme-less hosts and `about:` values are returned exactly as before.

The negative tests were written first and failed before the change (2 fail / 3 pass), then passed after. Two inputs I initially listed as negatives, `https://{host}/health` and `https://*.example.com/`, parse under the WHATWG parser; they are asserted as kept-as-typed so the classifier's boundary is explicit and it matches nothing it should not.

No typed `cause` added: nothing reads one here.

## Not fixed here: DESKTOP-D9, DESKTOP-CV, DESKTOP-CK

These unhandled `loadURL` rejections (`ERR_ABORTED`, `ERR_NAME_NOT_RESOLVED`, `ERR_CONNECTION_REFUSED`) do not come from this runtime. Every trail is on the v1 workspace route (`#/workspace/…`), and the v1 pane has its own `sanitizeUrl` that produced the `https://users/…` shapes in the titles (a pasted `/Users/…` path gains `https://`). The v1 hook calls `webview.loadURL(...)` without observing the promise; the v2 registry has caught it since the port. The v1 pane already renders these failures in-pane through `did-fail-load`, so the only consequence is the Sentry entry. Recommend archiving them; the v1 pane is deprecated and opt-in. The alternative is a three-line `.catch` on the v1 hook's three `loadURL` calls, which is the maintainer's call, not a symptom fix I want to sneak into this PR.

## What still reports after this

- A guest that crashes (`render-process-gone`) is not handled by the registry; the webContents survives a crash, so nothing throws, but the pane shows a blank guest until reload. Adjacent, left alone.
- Failures from the main-process `BrowserManager` (CDP, screenshots) are unrelated to these issues.

## Verification

```
$ bunx biome check <5 changed files>
Checked 5 files in 12ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ tsr generate
$ tsc --noEmit
typecheck exit: 0

$ bun test ./src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane
 22 pass
 0 fail
 73 expect() calls
Ran 22 tests across 3 files. [45.00ms]

$ bun test ./src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry
 120 pass
 0 fail
 20243 expect() calls
Ran 120 tests across 21 files. [431.00ms]
```

Negative test run before the sanitizer change:

```
(fail) sanitizeUrl > searches input that a scheme alone cannot make a URL
(fail) sanitizeUrl > always returns a parseable absolute URL
 3 pass
 2 fail
```

No desktop git code touched, so `no-main-process-blocking.test.ts` was not run.

Refs DESKTOP-F8
Refs DESKTOP-F7
Refs DESKTOP-FP
Refs DESKTOP-E6
Refs DESKTOP-AH

https://claude.ai/code/session_01AwPSErt1JMRg7MeZFBufUe


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 browser pane runtime so a page that closes itself no longer leaves a blank, dead pane, and address text that can't become a valid URL is searched instead of throwing an uncaught error.

**Registry lifecycle**
- The registry now listens for the webview's `destroyed` event, drops the entry, and closes the pane (same path as the CLI's close-pane bridge).
- URL and title now come from navigation events, never from `getURL()`/`getTitle()`, which throw once Electron destroys a guest whose page calls `window.close()`.
- Side effect: pages without a `<title>` now show the pane's fallback (`host`) instead of Chromium's synthesized title.

**URL normalization**
- `sanitizeUrl` now validates with `URL.canParse` and searches anything that still fails to parse, so git remotes and bad ports go to a search instead of crashing.
- Valid URLs, scheme-less hosts, and `about:` values are unchanged.

Fixes DESKTOP-F8, DESKTOP-F7, DESKTOP-FP, DESKTOP-E6, DESKTOP-AH. Leaves DESKTOP-D9, DESKTOP-CV, and DESKTOP-CK alone (v1 runtime, unrelated paths).

<sup>Written for commit 5de9853ff18c630d7e308927a16765dfd487f9df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser panes now close automatically when a webpage requests to close itself.
  * Navigation and page titles continue updating reliably during browser guest failures or shutdowns.
  * Failed main-frame loads retain the attempted address for improved navigation state.

* **Bug Fixes**
  * Invalid or incomplete addresses are safely converted into Google searches instead of causing navigation errors.

* **Tests**
  * Added coverage for browser pane lifecycle events, navigation tracking, and address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->