### PR TITLE
fix(desktop): classify authorization, launchd, cache-path, 5xx and staging updater failures as environmental

### DIFF
--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -25,6 +25,32 @@ const MISSING_CHANNEL = "Cannot find channel “latest-mac.yml” update info";
 const NO_FILES = "No files provided in update info";
 const NO_CHECKSUM =
 	"Update info doesn't contain nor sha256 neither sha512 checksum";
+// Squirrel.Mac's own signature check on the staged bundle. These are ours by
+// policy and must keep reporting whatever else the machine looks like.
+const STAGED_SIGNATURE_REJECTED =
+	"Code signature at URL file:///Users/<user>/Library/Caches/com.superset.desktop.ShipIt/update.aBcDeF1/Superset.app/ did not pass validation: code failed to satisfy specified code requirement(s)";
+const STAGED_UNSIGNED =
+	"Code signature at URL file:///Users/<user>/Library/Caches/com.superset.desktop.ShipIt/update.aBcDeF1/Superset.app/ did not pass validation: code object is not signed at all";
+
+// Squirrel needs an admin authorization to replace a bundle the user cannot
+// write to. Foundation localises the prose around the OSStatus number.
+const AUTHORIZATION_CANCELLED_EN =
+	"The operation couldn’t be completed. (OSStatus error -60006.)";
+const AUTHORIZATION_DENIED_EN =
+	"The operation couldn’t be completed. (OSStatus error -60005.)";
+const AUTHORIZATION_DENIED_DE =
+	"Der Vorgang konnte nicht abgeschlossen werden. (OSStatus-Fehler -60005.)";
+const LAUNCHD_JOB_DISABLED = "The command is disabled and cannot be executed";
+const CACHE_PATH_IS_A_FILE =
+	"ENOTDIR: not a directory, mkdir '/Users/<user>/Library/Caches/@supersetdesktop-updater/pending'";
+const DOWNLOAD_GATEWAY_TIMEOUT =
+	'Cannot download "https://github.com/superset-sh/superset/releases/latest/download/Superset-1.26.0-arm64-mac.zip", status 504: ';
+const DOWNLOAD_BAD_GATEWAY =
+	'Cannot download "https://github.com/superset-sh/superset/releases/latest/download/Superset-1.26.0-arm64-mac.zip", status 502: Bad Gateway';
+const DOWNLOAD_NOT_FOUND =
+	'Cannot download "https://github.com/superset-sh/superset/releases/latest/download/Superset-1.26.0-arm64-mac.zip", status 404: Not Found';
+const DITTO_STAGING_FILE_MISSING =
+	"ditto: /Users/<user>/Library/Caches/com.superset.desktop.ShipIt/update.aBcDeF1/Superset.app/Contents/Resources/app.asar: No such file or directory";
 
 describe("isEnvironmentUpdateError", () => {
 	test("classifies a full staging volume without reading the message", () => {
@@ -93,6 +119,99 @@ describe("isEnvironmentUpdateError", () => {
 		expect(
 			isEnvironmentUpdateError(
 				"ENOENT: no such file or directory",
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+	});
+
+	test("classifies a refused or cancelled admin authorization by OSStatus number", () => {
+		for (const message of [
+			AUTHORIZATION_CANCELLED_EN,
+			AUTHORIZATION_DENIED_EN,
+			AUTHORIZATION_DENIED_DE,
+		]) {
+			expect(isEnvironmentUpdateError(message, ROOMY_VOLUME)).toBe(true);
+			expect(isEnvironmentUpdateError(message, null)).toBe(true);
+		}
+	});
+
+	test("does not extend the authorization match to other OSStatus codes", () => {
+		// errSecCSSignatureFailed: a signature problem wearing the same prose.
+		expect(
+			isEnvironmentUpdateError(
+				"The operation couldn’t be completed. (OSStatus error -67062.)",
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+		expect(
+			isEnvironmentUpdateError(
+				"The operation couldn’t be completed. (OSStatus error -600051.)",
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+	});
+
+	test("still reports a signature failure that also carries an authorization code", () => {
+		expect(
+			isEnvironmentUpdateError(
+				`${STAGED_SIGNATURE_REJECTED} ${AUTHORIZATION_CANCELLED_EN}`,
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+		expect(
+			isEnvironmentUpdateError(
+				`${STAGED_SIGNATURE_REJECTED} ${AUTHORIZATION_CANCELLED_EN}`,
+				FULL_VOLUME,
+			),
+		).toBe(false);
+	});
+
+	test("keeps reporting Squirrel's staged-bundle signature rejections", () => {
+		for (const message of [STAGED_SIGNATURE_REJECTED, STAGED_UNSIGNED]) {
+			expect(isEnvironmentUpdateError(message, ROOMY_VOLUME)).toBe(false);
+			expect(isEnvironmentUpdateError(message, FULL_VOLUME)).toBe(false);
+		}
+	});
+
+	test("classifies launchd refusing a disabled ShipIt job", () => {
+		expect(isEnvironmentUpdateError(LAUNCHD_JOB_DISABLED, ROOMY_VOLUME)).toBe(
+			true,
+		);
+	});
+
+	test("classifies a file sitting where the updater cache must be", () => {
+		expect(isEnvironmentUpdateError(CACHE_PATH_IS_A_FILE, ROOMY_VOLUME)).toBe(
+			true,
+		);
+		// The same errno off the updater paths is not the updater's business.
+		expect(
+			isEnvironmentUpdateError(
+				"ENOTDIR: not a directory, open '/Applications/Superset.app/Contents/Resources/app.asar'",
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+	});
+
+	test("classifies a server error on the release download, not a missing asset", () => {
+		expect(
+			isEnvironmentUpdateError(DOWNLOAD_GATEWAY_TIMEOUT, ROOMY_VOLUME),
+		).toBe(true);
+		expect(isEnvironmentUpdateError(DOWNLOAD_BAD_GATEWAY, ROOMY_VOLUME)).toBe(
+			true,
+		);
+		expect(isEnvironmentUpdateError(DOWNLOAD_NOT_FOUND, ROOMY_VOLUME)).toBe(
+			false,
+		);
+	});
+
+	test("classifies a staged copy that lost a file under ShipIt's directory", () => {
+		expect(
+			isEnvironmentUpdateError(DITTO_STAGING_FILE_MISSING, ROOMY_VOLUME),
+		).toBe(true);
+		// ditto complaining about the installed bundle is not a staging failure.
+		expect(
+			isEnvironmentUpdateError(
+				"ditto: /Applications/Superset.app/Contents/Resources/app.asar: No such file or directory",
 				ROOMY_VOLUME,
 			),
 		).toBe(false);

--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -204,6 +204,24 @@ describe("isEnvironmentUpdateError", () => {
 		);
 	});
 
+	test("keeps reporting a server error while fetching the feed itself", () => {
+		expect(
+			isEnvironmentUpdateError(
+				'Cannot download "https://github.com/superset-sh/superset/releases/latest/download/latest-mac.yml", status 502: Bad Gateway',
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+	});
+
+	test("does not take the ShipIt name alone as proof of a staging failure", () => {
+		expect(
+			isEnvironmentUpdateError(
+				"ditto: /Applications/ShipIt Tools/Superset.app/Contents/Resources/app.asar: No such file or directory",
+				ROOMY_VOLUME,
+			),
+		).toBe(false);
+	});
+
 	test("classifies a staged copy that lost a file under ShipIt's directory", () => {
 		expect(
 			isEnvironmentUpdateError(DITTO_STAGING_FILE_MISSING, ROOMY_VOLUME),

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -41,9 +41,16 @@ const AUTHORIZATION_OSSTATUS = /OSStatus\D*-6000[56](?!\d)/;
 // disabled it. Nothing but this sentence reaches us for it.
 const LAUNCHD_JOB_DISABLED = "the command is disabled and cannot be executed";
 
-// A server error from the release download is the CDN, not the artifact. A
-// 4xx stays reported: an asset that is not there is ours to publish.
-const DOWNLOAD_SERVER_ERROR = /^Cannot download ".*", status 5\d\d(?!\d)/;
+// A server error from the release-artifact download is the CDN, not the
+// artifact. A 4xx stays reported: an asset that is not there is ours to
+// publish. Only the packaged app counts; a 5xx while fetching the feed
+// (latest-mac.yml) is a different failure and keeps reporting.
+const DOWNLOAD_SERVER_ERROR =
+	/^Cannot download ".*\.(?:zip|dmg|exe|AppImage|deb|rpm)", status 5\d\d(?!\d)/;
+
+// Squirrel.Mac stages every update under this cache directory, one
+// `update.<id>` directory per attempt.
+const SHIPIT_STAGING_PATH = /\/com\.superset\.desktop\.shipit\/update\.[^/]+\//;
 
 // Update failures owned by the user's machine, not by us. A full volume is the
 // common one, and neither staging tool gives us a code to match: `ditto` prints
@@ -83,7 +90,7 @@ export function isEnvironmentUpdateError(
 	// and the download it was unpacked from is cleared on error.
 	if (
 		lowerMessage.startsWith("ditto:") &&
-		lowerMessage.includes("shipit") &&
+		SHIPIT_STAGING_PATH.test(lowerMessage) &&
 		lowerMessage.includes("no such file or directory")
 	) {
 		return true;

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -1,5 +1,6 @@
 const ENVIRONMENT_ERRNO_CODES = [
 	"ENOENT",
+	"ENOTDIR",
 	"EACCES",
 	"EPERM",
 	"EBUSY",
@@ -29,6 +30,21 @@ const UPDATER_DEFECT_PATTERNS = [
 	"no files provided",
 ];
 
+// Replacing a bundle the user cannot write to needs an admin authorization,
+// and Squirrel.Mac reports the prompt being cancelled (-60006) or refused
+// (-60005) as an NSOSStatusErrorDomain error. Foundation localises the prose
+// around it, so match the domain's name and the number, never the words. Any
+// other OSStatus keeps reporting: a signing failure wears the same sentence.
+const AUTHORIZATION_OSSTATUS = /OSStatus\D*-6000[56](?!\d)/;
+
+// launchd refusing to start the ShipIt job because the user or their MDM
+// disabled it. Nothing but this sentence reaches us for it.
+const LAUNCHD_JOB_DISABLED = "the command is disabled and cannot be executed";
+
+// A server error from the release download is the CDN, not the artifact. A
+// 4xx stays reported: an asset that is not there is ours to publish.
+const DOWNLOAD_SERVER_ERROR = /^Cannot download ".*", status 5\d\d(?!\d)/;
+
 // Update failures owned by the user's machine, not by us. A full volume is the
 // common one, and neither staging tool gives us a code to match: `ditto` prints
 // an errno-free line and Squirrel forwards NSError text localised to the user's
@@ -54,7 +70,21 @@ export function isEnvironmentUpdateError(
 	}
 	if (
 		lowerMessage.includes("read-only volume") ||
-		lowerMessage.includes("the request timed out")
+		lowerMessage.includes("the request timed out") ||
+		lowerMessage.includes(LAUNCHD_JOB_DISABLED) ||
+		AUTHORIZATION_OSSTATUS.test(message) ||
+		DOWNLOAD_SERVER_ERROR.test(message)
+	) {
+		return true;
+	}
+	// ditto naming a file it could not find under ShipIt's staging directory is
+	// a staged copy that lost its parent mid-unpack. It prints no errno, and
+	// nothing reuses it: Squirrel stages every attempt into a fresh directory
+	// and the download it was unpacked from is cleared on error.
+	if (
+		lowerMessage.startsWith("ditto:") &&
+		lowerMessage.includes("shipit") &&
+		lowerMessage.includes("no such file or directory")
 	) {
 		return true;
 	}


### PR DESCRIPTION
## Problem

Six updater failures that happen on the user's machine reach `Sentry.captureException` from the `autoUpdater.on("error")` handler because `isEnvironmentUpdateError` does not recognise them. Together they are the largest source of desktop events: DESKTOP-7N alone is ~4,400 events (2,700 of them `-60006`, 1,500 `-60005`) and refires every 4-hour check on each affected machine.

**Reality check**

1. **User-visible harm:** none that code here can remove. The user sees the updates pill in its error state with the raw message and a retry. What these events cost is us: quota on the uncapped desktop DSN, and real updater defects (the signature failures in DESKTOP-14Y / DESKTOP-15M) buried under thousands of non-actionable entries.
2. **Reach:** the events come from stable 1.21.0–1.26.0, all through `apps/desktop/src/main/lib/auto-updater.ts` → `isEnvironmentUpdateError`. This ships in the next desktop release and stops the capture on every machine that adopts it; machines stuck on an older build (some of these users cannot install updates at all) keep reporting until they do.
3. **Why code:** archiving does not stop ingestion or quota, and a Sentry-side filter is forbidden by the PR #6164 contract (classify at the capture site only). The classifier module exists precisely for this. No in-flight work restructures this path; #7273 (merged 2026-09-08) only touched the `net::ERR_` branch and is not retouched.

## Root cause

None of the six is a defect in the artifact or feed, and we do not own any of the producers:

- **-60006 / -60005 (DESKTOP-7N, DESKTOP-FZ):** Squirrel.Mac launches ShipIt privileged when the app bundle or its parent is not writable by the user, and `AuthorizationCreate` fails with `errAuthorizationCanceled` (user dismissed the admin prompt) or `errAuthorizationDenied`. Foundation localises the sentence; the `OSStatus` domain name and number do not change.
- **"The command is disabled and cannot be executed" (DESKTOP-8Z):** launchd refusing to start the ShipIt job because the user or an MDM disabled it. Only the sentence reaches the message.
- **ENOTDIR on the updater cache path (DESKTOP-159):** a file sits where electron-updater's cache directory must be.
- **`Cannot download …, status 504` (DESKTOP-45):** a server error from the release CDN.
- **`ditto: … app.asar: No such file or directory` under ShipIt (DESKTOP-14Z):** a staged copy lost its parent mid-unpack. I checked whether the error path already discards it: `clearCachedUpdate` runs on every non-network error (`auto-updater.ts:405`) and empties electron-updater's pending download, and Squirrel stages each attempt into a fresh `update.<id>` directory, so nothing reuses the half-staged copy. Classification alone is the correct fix here; no cache-clearing change was needed.

## Fix

`apps/desktop/src/main/lib/update-error-classification.ts`, matched on the most structural signal each failure offers, in the order the task set:

- `/OSStatus\D*-6000[56](?!\d)/` — the domain's name and the number token, never the English or German prose. Any other OSStatus keeps reporting (a signing failure, `-67062`, wears the same sentence; `-60008` `errAuthorizationInternal`, 18 events, also still reports).
- `ENOTDIR` added to `ENVIRONMENT_ERRNO_CODES`, behind the existing `-updater` / `shipit` path-marker guard.
- `/^Cannot download ".*", status 5\d\d(?!\d)/` — 5xx on the release download only; 404 stays reported because a missing asset is ours.
- `ditto:` + `shipit` + `no such file or directory` — ditto prints no errno; Darwin's strerror is not localised.
- `"the command is disabled and cannot be executed"` — wording, because no code is available in the message.

The defect-first ordering is untouched: `UPDATER_DEFECT_PATTERNS` still short-circuits before any of these, so a code-signature failure whose message also carries `-60006` still reports (pinned by a test). Electron does attach `code`/`domain` from the NSError to the error object, but our Sentry SDK does not serialise those properties, so they cannot be verified against production; the message token was verified against every event message in DESKTOP-7N and DESKTOP-FZ.

**What still reports after this change:** every `UPDATER_DEFECT_PATTERNS` entry (checksum, code signature, codesign, cannot parse update info, cannot find channel, no files provided), including DESKTOP-14Y / DESKTOP-15M; any other OSStatus code; 4xx on the download; errno failures off updater paths; ditto failures other than a missing file under ShipIt; `HttpError` 5xx on the feed yml fetch (DESKTOP-QX, not in scope, noted below).

No typed cause added: nothing reads one here, the handler only branches on the boolean.

## Verification

Tests were written first. Against the unchanged classifier the five positive cases fail and every negative case passes:

```
 9 pass
 5 fail
 39 expect() calls
Ran 14 tests across 1 file. [117.00ms]
```

After the change:

```
$ bunx biome check apps/desktop/src/main/lib/update-error-classification.ts apps/desktop/src/main/lib/update-error-classification.test.ts
Checked 2 files in 6ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ tsc --noEmit
(clean)

$ cd apps/desktop && bun test src/main/lib/update-error-classification.test.ts
 14 pass
 0 fail
 48 expect() calls
Ran 14 tests across 1 file. [113.00ms]

$ cd apps/desktop && bun test src/main/lib
 664 pass
 0 fail
 1337 expect() calls
Ran 664 tests across 46 files. [1.90s]
```

No desktop git code touched, so the main-thread git ratchet test was not in the affected set.

## Adjacent, left alone

- One native Squirrel failure is emitted twice on our `autoUpdater`: `MacUpdater` forwards the native `error` event directly and also rejects the download promise, whose `errorHandler` calls `dispatchError` on the same object. Every Squirrel-side failure (including DESKTOP-14Y) is captured twice. Upstream behaviour, not changed here.
- The affected machines re-download the archive and re-prompt for an admin password every 4 hours because `clearCachedUpdate` runs on the authorization failure too. Stopping that is a product decision (prompt once, or stop auto-download when the install target is not writable), not a classification change.
- DESKTOP-QX: `HttpError` 5xx/618 from the feed yml fetch, ~20 events in 90 days. Same class, different message shape and carries `statusCode`; not in this task's issue list.
- The comment in `update-error-redaction.ts` saying Sentry serialises non-standard error properties is not what the raw events show (`extra` is null); nothing depends on it.

Refs DESKTOP-7N
Refs DESKTOP-FZ
Refs DESKTOP-8Z
Refs DESKTOP-159
Refs DESKTOP-45
Refs DESKTOP-14Z

https://claude.ai/code/session_016FJrpE7y2akoSBfbnGXxZc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies six user-machine updater failures as environmental so they stop reaching Sentry, cutting the largest source of desktop error events.

- The failures are a cancelled or refused admin authorization (-60006/-60005), launchd disabling the ShipIt job, ENOTDIR on the updater cache path, a 5xx release download, and ditto losing a file during ShipIt staging.
- DESKTOP-7N alone accounts for ~4,400 events, refiring every 4 hours on each affected machine.
- Signature failures, 404s, feed-fetch 5xxs, and other OSStatus codes still report because the defect-first ordering is unchanged.

<sup>Written for commit 9d5a9f62e056c2ad2334bcd52d555a002f1cc76d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop update error handling for authorization cancellations, disabled updater services, unavailable download servers, missing staged files, and invalid updater paths.
  - More accurately distinguishes environment-related update failures from updater defects, reducing incorrect error classifications.
  - Added coverage for signature validation failures, authorization status codes, and file-system conditions to ensure consistent update diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->