### PR TITLE
fix(desktop): report why a terminal PTY exited before it was ready

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -7,6 +7,7 @@ import { localDb } from "main/lib/local-db";
 import { restartDaemon as restartDaemonShared } from "main/lib/terminal";
 import {
 	isTerminalAttachCanceledError,
+	isTerminalSpawnFailedError,
 	TERMINAL_ATTACH_CANCELED_MESSAGE,
 	TERMINAL_SESSION_KILLED_MESSAGE,
 	TerminalKilledError,
@@ -21,6 +22,7 @@ import { publicProcedure, router } from "../..";
 import { assertWorkspaceUsable } from "../workspaces/utils/usability";
 import { resolveTerminalThemeType } from "./theme-type";
 import { getWorkspaceTerminalContext, resolveCwd } from "./utils";
+import { toTerminalSpawnError } from "./utils/terminal-spawn-error";
 
 const DEBUG_TERMINAL = process.env.SUPERSET_TERMINAL_DEBUG === "1";
 const logger = console;
@@ -208,6 +210,9 @@ export const createTerminalRouter = () => {
 					}
 					if (error instanceof TerminalHostClientDisposedError) {
 						throw error;
+					}
+					if (isTerminalSpawnFailedError(error)) {
+						throw toTerminalSpawnError(error);
 					}
 					if (DEBUG_TERMINAL) {
 						console.warn("[Terminal Router] createOrAttach failed:", {

--- a/apps/desktop/src/lib/trpc/routers/terminal/utils/terminal-spawn-error.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/utils/terminal-spawn-error.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isTerminalSpawnFailedError,
+	TerminalSpawnFailedError,
+} from "main/lib/terminal/errors";
+import { toTerminalSpawnError } from "./terminal-spawn-error";
+
+describe("isTerminalSpawnFailedError", () => {
+	it("does not match the legacy plain-string spawn failure", () => {
+		expect(
+			isTerminalSpawnFailedError(
+				new Error(
+					"CREATE_ATTACH_FAILED: Session spawn failed: PTY process exited immediately",
+				),
+			),
+		).toBe(false);
+	});
+
+	it("does not match a request timeout or a daemon connection failure", () => {
+		expect(
+			isTerminalSpawnFailedError(new Error("Request timeout: createOrAttach")),
+		).toBe(false);
+		expect(isTerminalSpawnFailedError(new Error("Connection lost"))).toBe(
+			false,
+		);
+	});
+
+	it("matches by name so an instance that lost its prototype still counts", () => {
+		const error = new TerminalSpawnFailedError({
+			kind: "PTY_SPAWN_TIMEOUT",
+			shell: "/bin/zsh",
+		});
+		const detached = Object.assign(new Error(error.message), {
+			name: error.name,
+			cause: error.cause,
+		});
+		expect(isTerminalSpawnFailedError(detached)).toBe(true);
+	});
+});
+
+describe("toTerminalSpawnError", () => {
+	it("turns a shell that exited before it was ready into a non-500 that names the shell and its first line", () => {
+		const trpcError = toTerminalSpawnError(
+			new TerminalSpawnFailedError({
+				kind: "SHELL_EXITED",
+				shell: "/opt/homebrew/bin/fish",
+				args: ["-l"],
+				exitCode: 1,
+				outputHead: "\x1b[31mfish: Unknown command\x1b[0m\r\nmore\r\n",
+			}),
+		);
+		expect(trpcError.code).toBe("PRECONDITION_FAILED");
+		expect(trpcError.message).toBe(
+			"Your shell (/opt/homebrew/bin/fish) exited immediately with code 1: fish: Unknown command",
+		);
+		expect(trpcError.cause).toMatchObject({
+			kind: "SHELL_EXITED",
+			exitCode: 1,
+		});
+	});
+
+	it("keeps a PTY that could not be opened as a 500 that carries the helper's reason", () => {
+		const trpcError = toTerminalSpawnError(
+			new TerminalSpawnFailedError({
+				kind: "PTY_SPAWN_FAILED",
+				shell: "/bin/zsh",
+				exitCode: 1,
+				error: "Spawn failed: posix_spawn failed: EAGAIN",
+			}),
+		);
+		expect(trpcError.code).toBe("INTERNAL_SERVER_ERROR");
+		expect(trpcError.message).toBe(
+			"Could not open a PTY for /bin/zsh: Spawn failed: posix_spawn failed: EAGAIN",
+		);
+	});
+
+	it("keeps a PTY ready timeout as a 500", () => {
+		const trpcError = toTerminalSpawnError(
+			new TerminalSpawnFailedError({
+				kind: "PTY_SPAWN_TIMEOUT",
+				shell: "/bin/zsh",
+			}),
+		);
+		expect(trpcError.code).toBe("INTERNAL_SERVER_ERROR");
+		expect(trpcError.message).toBe("Timed out waiting for a PTY for /bin/zsh");
+	});
+});

--- a/apps/desktop/src/lib/trpc/routers/terminal/utils/terminal-spawn-error.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/utils/terminal-spawn-error.ts
@@ -1,0 +1,38 @@
+import { TRPCError } from "@trpc/server";
+import type { TerminalSpawnFailedError } from "main/lib/terminal/errors";
+
+/**
+ * Single tRPC mapping for a PTY that never became ready.
+ *
+ * The switch is exhaustive: adding a kind to `TerminalSpawnFailureCause`
+ * without deciding its code here is a type error. Only SHELL_EXITED is the
+ * user's environment (their shell ran and died); the other kinds mean the
+ * PTY helper itself failed, which stays a 500 so Sentry keeps reporting it.
+ */
+export function toTerminalSpawnError(
+	error: TerminalSpawnFailedError,
+): TRPCError {
+	const { cause } = error;
+	switch (cause.kind) {
+		case "SHELL_EXITED":
+			return new TRPCError({
+				code: "PRECONDITION_FAILED",
+				message: error.message,
+				cause,
+			});
+		case "PTY_SPAWN_FAILED":
+		case "PTY_SPAWN_TIMEOUT":
+			return new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: error.message,
+				cause: error,
+			});
+		default: {
+			const unhandled: never = cause;
+			return new TRPCError({
+				code: "INTERNAL_SERVER_ERROR",
+				message: `Unhandled terminal spawn failure kind: ${String(unhandled)}`,
+			});
+		}
+	}
+}

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -33,7 +33,10 @@ import {
 import { app } from "electron";
 import { SUPERSET_DIR_NAME } from "shared/constants";
 import { throwIfAborted } from "../terminal/abort";
-import { TerminalAttachCanceledError } from "../terminal/errors";
+import {
+	TerminalAttachCanceledError,
+	TerminalSpawnFailedError,
+} from "../terminal/errors";
 import {
 	type CancelCreateOrAttachRequest,
 	type ClearScrollbackRequest,
@@ -727,6 +730,8 @@ export class TerminalHostClient extends EventEmitter {
 
 				if (message.ok) {
 					pending.resolve(message.payload);
+				} else if (message.error.cause) {
+					pending.reject(new TerminalSpawnFailedError(message.error.cause));
 				} else {
 					pending.reject(
 						new Error(`${message.error.code}: ${message.error.message}`),

--- a/apps/desktop/src/main/lib/terminal-host/types.ts
+++ b/apps/desktop/src/main/lib/terminal-host/types.ts
@@ -305,7 +305,7 @@ export type TerminalSpawnFailureCause =
 			args: string[];
 			exitCode: number;
 			signal?: number;
-			/** First bytes the process wrote before exiting; shells print why they died here. */
+			/** First characters the process wrote before exiting; shells print why they died here. */
 			outputHead: string;
 	  }
 	| {

--- a/apps/desktop/src/main/lib/terminal-host/types.ts
+++ b/apps/desktop/src/main/lib/terminal-host/types.ts
@@ -291,12 +291,40 @@ export interface IpcSuccessResponse {
 /**
  * Error response format (daemon -> client)
  */
+/**
+ * Why createOrAttach could not bring a PTY up, as a value rather than prose.
+ *
+ * SHELL_EXITED: the PTY opened and the shell process ended before it was
+ * ready — the user's shell, rc files, or preset command. The other kinds
+ * mean the PTY helper subprocess itself failed and are the host's problem.
+ */
+export type TerminalSpawnFailureCause =
+	| {
+			kind: "SHELL_EXITED";
+			shell: string;
+			args: string[];
+			exitCode: number;
+			signal?: number;
+			/** First bytes the process wrote before exiting; shells print why they died here. */
+			outputHead: string;
+	  }
+	| {
+			kind: "PTY_SPAWN_FAILED";
+			shell: string;
+			/** Exit code of the helper subprocess, or null if it is still running. */
+			exitCode: number | null;
+			/** The helper's own report (pty.spawn threw, or the subprocess could not start). */
+			error?: string;
+	  }
+	| { kind: "PTY_SPAWN_TIMEOUT"; shell: string };
+
 export interface IpcErrorResponse {
 	id: string;
 	ok: false;
 	error: {
 		code: string;
 		message: string;
+		cause?: TerminalSpawnFailureCause;
 	};
 }
 

--- a/apps/desktop/src/main/lib/terminal/errors.ts
+++ b/apps/desktop/src/main/lib/terminal/errors.ts
@@ -1,3 +1,5 @@
+import type { TerminalSpawnFailureCause } from "../terminal-host/types";
+
 export const TERMINAL_SESSION_KILLED_MESSAGE = "TERMINAL_SESSION_KILLED";
 export const TERMINAL_ATTACH_CANCELED_MESSAGE = "TERMINAL_ATTACH_CANCELED";
 
@@ -21,4 +23,62 @@ export function isTerminalAttachCanceledError(error: unknown): boolean {
 		(error instanceof Error &&
 			error.message === TERMINAL_ATTACH_CANCELED_MESSAGE)
 	);
+}
+
+/**
+ * The terminal host could not bring a PTY up for createOrAttach. Thrown by
+ * the daemon, serialized as `error.cause` on the socket, and rebuilt by the
+ * client so the tRPC router can switch on `cause.kind`.
+ */
+export class TerminalSpawnFailedError extends Error {
+	override readonly cause: TerminalSpawnFailureCause;
+
+	constructor(cause: TerminalSpawnFailureCause) {
+		super(describeTerminalSpawnFailure(cause));
+		this.name = "TerminalSpawnFailedError";
+		this.cause = cause;
+	}
+}
+
+export function isTerminalSpawnFailedError(
+	error: unknown,
+): error is TerminalSpawnFailedError {
+	return (
+		error instanceof Error &&
+		error.name === "TerminalSpawnFailedError" &&
+		typeof (error.cause as { kind?: unknown } | undefined)?.kind === "string"
+	);
+}
+
+const FIRST_LINE_MAX_CHARS = 200;
+
+export function describeTerminalSpawnFailure(
+	cause: TerminalSpawnFailureCause,
+): string {
+	switch (cause.kind) {
+		case "SHELL_EXITED": {
+			const signal = cause.signal ? ` (signal ${cause.signal})` : "";
+			const firstLine = firstOutputLine(cause.outputHead);
+			return `Your shell (${cause.shell}) exited immediately with code ${cause.exitCode}${signal}${firstLine ? `: ${firstLine}` : ""}`;
+		}
+		case "PTY_SPAWN_FAILED":
+			return `Could not open a PTY for ${cause.shell}: ${cause.error ?? `PTY helper exited with code ${cause.exitCode}`}`;
+		case "PTY_SPAWN_TIMEOUT":
+			return `Timed out waiting for a PTY for ${cause.shell}`;
+	}
+}
+
+// CSI, OSC (BEL- or ST-terminated), other two-byte escapes, then remaining
+// control characters. Shell startup errors are plain text underneath.
+const TERMINAL_ESCAPES =
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping terminal control sequences
+	/\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-Z\\-_]|[\x00-\x08\x0b-\x1f\x7f]/g;
+
+function firstOutputLine(outputHead: string): string {
+	const line = outputHead
+		.replace(TERMINAL_ESCAPES, "")
+		.split(/\r?\n|\r/)
+		.map((part) => part.trim())
+		.find((part) => part.length > 0);
+	return line ? line.slice(0, FIRST_LINE_MAX_CHARS) : "";
 }

--- a/apps/desktop/src/main/terminal-host/index.ts
+++ b/apps/desktop/src/main/terminal-host/index.ts
@@ -25,6 +25,7 @@ import { createServer, type Server, Socket } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { SUPERSET_DIR_NAME } from "shared/constants";
+import { isTerminalSpawnFailedError } from "../lib/terminal/errors";
 import {
 	type CancelCreateOrAttachRequest,
 	type ClearScrollbackRequest,
@@ -44,6 +45,7 @@ import {
 	type SignalRequest,
 	type TerminalErrorEvent,
 	type TerminalExitEvent,
+	type TerminalSpawnFailureCause,
 	type WriteRequest,
 } from "../lib/terminal-host/types";
 import { setupTerminalHostSignalHandlers } from "./signal-handlers";
@@ -161,8 +163,14 @@ function sendSuccess(socket: Socket, id: string, payload: unknown) {
 	sendResponse(socket, { id, ok: true, payload });
 }
 
-function sendError(socket: Socket, id: string, code: string, message: string) {
-	sendResponse(socket, { id, ok: false, error: { code, message } });
+function sendError(
+	socket: Socket,
+	id: string,
+	code: string,
+	message: string,
+	cause?: TerminalSpawnFailureCause,
+) {
+	sendResponse(socket, { id, ok: false, error: { code, message, cause } });
 }
 
 // =============================================================================
@@ -334,7 +342,13 @@ const handlers: Record<string, RequestHandler> = {
 			);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
-			sendError(socket, id, "CREATE_ATTACH_FAILED", message);
+			sendError(
+				socket,
+				id,
+				"CREATE_ATTACH_FAILED",
+				message,
+				isTerminalSpawnFailedError(error) ? error.cause : undefined,
+			);
 			log("error", `Failed to create/attach session: ${message}`);
 		}
 	},

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -34,6 +34,7 @@ import type {
 	TerminalErrorEvent,
 	TerminalExitEvent,
 	TerminalSnapshot,
+	TerminalSpawnFailureCause,
 } from "../lib/terminal-host/types";
 import { treeKillAsync } from "../lib/tree-kill";
 import {
@@ -80,6 +81,12 @@ const EMULATOR_WRITE_QUEUE_LOW_WATERMARK_BYTES = 250_000;
  * buffered writes flush immediately (same behavior as before this feature).
  */
 const SHELL_READY_TIMEOUT_MS = 15_000;
+
+/**
+ * How much of the process's first output to keep for a spawn failure report.
+ * A shell that dies during init prints why in its first lines.
+ */
+const SPAWN_OUTPUT_HEAD_CHARS = 2048;
 
 /**
  * Shell readiness lifecycle:
@@ -154,6 +161,13 @@ export class Session {
 	private subprocessStdinDrainArmed = false;
 	private ptyPid: number | null = null;
 	private emulatorWriteBackpressured = false;
+
+	// Spawn failure diagnostics — see describeSpawnFailure()
+	private spawnArgs: string[] = [];
+	private outputHead = "";
+	private ptyExitSignal: number | undefined;
+	private ptyExitReported = false;
+	private ptySpawnError: string | null = null;
 
 	// Promise that resolves when PTY is ready to accept writes
 	private ptyReadyPromise: Promise<void>;
@@ -262,6 +276,7 @@ export class Session {
 		const shellArgs = this.command
 			? getCommandShellArgs(this.shell, this.command)
 			: getShellArgs(this.shell);
+		this.spawnArgs = shellArgs;
 		const subprocessPath = path.join(__dirname, "pty-subprocess.js");
 
 		// Spawn subprocess with filtered env to prevent leaking NODE_ENV etc.
@@ -299,6 +314,9 @@ export class Session {
 
 		this.subprocess.on("error", (error) => {
 			console.error(`[Session ${this.sessionId}] Subprocess error:`, error);
+			if (this.ptyPid === null) {
+				this.ptySpawnError ??= error.message;
+			}
 			this.handleSubprocessExit(-1);
 		});
 
@@ -387,6 +405,13 @@ export class Session {
 					bytes.byteLength,
 				).toString("utf8");
 
+				if (this.outputHead.length < SPAWN_OUTPUT_HEAD_CHARS) {
+					this.outputHead += data.slice(
+						0,
+						SPAWN_OUTPUT_HEAD_CHARS - this.outputHead.length,
+					);
+				}
+
 				this.enqueueEmulatorWrite(data);
 
 				this.broadcastEvent("data", {
@@ -400,6 +425,8 @@ export class Session {
 				const exitCode = payload.length >= 4 ? payload.readInt32LE(0) : 0;
 				const signal = payload.length >= 8 ? payload.readInt32LE(4) : 0;
 				this.exitCode = exitCode;
+				this.ptyExitSignal = signal !== 0 ? signal : undefined;
+				this.ptyExitReported = true;
 
 				this.broadcastEvent("exit", {
 					type: "exit",
@@ -425,6 +452,9 @@ export class Session {
 					`[Session ${this.sessionId}] Subprocess error:`,
 					errorMessage,
 				);
+				if (this.ptyPid === null) {
+					this.ptySpawnError ??= errorMessage;
+				}
 
 				this.broadcastEvent("error", {
 					type: "error",
@@ -783,6 +813,32 @@ export class Session {
 	 */
 	waitForReady(): Promise<void> {
 		return this.ptyReadyPromise;
+	}
+
+	/**
+	 * Why the PTY is not usable after waitForReady(). Only meaningful when
+	 * `!isAlive || pid === null`.
+	 */
+	describeSpawnFailure(): TerminalSpawnFailureCause {
+		if (this.ptyPid !== null && this.ptyExitReported) {
+			return {
+				kind: "SHELL_EXITED",
+				shell: this.shell,
+				args: this.spawnArgs,
+				exitCode: this.exitCode ?? -1,
+				signal: this.ptyExitSignal,
+				outputHead: this.outputHead,
+			};
+		}
+		if (this.exitCode !== null || this.ptySpawnError !== null) {
+			return {
+				kind: "PTY_SPAWN_FAILED",
+				shell: this.shell,
+				exitCode: this.exitCode,
+				error: this.ptySpawnError ?? undefined,
+			};
+		}
+		return { kind: "PTY_SPAWN_TIMEOUT", shell: this.shell };
 	}
 
 	/**

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -83,8 +83,10 @@ const EMULATOR_WRITE_QUEUE_LOW_WATERMARK_BYTES = 250_000;
 const SHELL_READY_TIMEOUT_MS = 15_000;
 
 /**
- * How much of the process's first output to keep for a spawn failure report.
- * A shell that dies during init prints why in its first lines.
+ * How much of the process's first output to keep for a spawn failure report,
+ * counted in characters of the decoded text, not bytes — non-ASCII output
+ * crosses the socket larger than this number suggests. A shell that dies
+ * during init prints why in its first lines.
  */
 const SPAWN_OUTPUT_HEAD_CHARS = 2048;
 
@@ -406,10 +408,15 @@ export class Session {
 				).toString("utf8");
 
 				if (this.outputHead.length < SPAWN_OUTPUT_HEAD_CHARS) {
-					this.outputHead += data.slice(
-						0,
-						SPAWN_OUTPUT_HEAD_CHARS - this.outputHead.length,
-					);
+					const head =
+						this.outputHead +
+						data.slice(0, SPAWN_OUTPUT_HEAD_CHARS - this.outputHead.length);
+					// The cap counts UTF-16 code units, so it can land between the
+					// halves of a surrogate pair. Drop the orphan rather than report
+					// a lone surrogate.
+					const lastUnit = head.charCodeAt(head.length - 1);
+					this.outputHead =
+						lastUnit >= 0xd800 && lastUnit <= 0xdbff ? head.slice(0, -1) : head;
 				}
 
 				this.enqueueEmulatorWrite(data);

--- a/apps/desktop/src/main/terminal-host/terminal-host.test.ts
+++ b/apps/desktop/src/main/terminal-host/terminal-host.test.ts
@@ -218,3 +218,137 @@ describe("TerminalHost — PTY spawn failure handling", () => {
 		await session.dispose();
 	});
 });
+
+function emitData(child: FakeChildProcess, text: string): void {
+	const payload = Buffer.from(text, "utf8");
+	const header = createFrameHeader(PtySubprocessIpcType.Data, payload.length);
+	child.stdout.emit("data", Buffer.concat([header, payload]));
+}
+
+function emitExit(child: FakeChildProcess, exitCode: number, signal = 0): void {
+	const payload = Buffer.allocUnsafe(8);
+	payload.writeInt32LE(exitCode, 0);
+	payload.writeInt32LE(signal, 4);
+	const header = createFrameHeader(PtySubprocessIpcType.Exit, 8);
+	child.stdout.emit("data", Buffer.concat([header, payload]));
+}
+
+describe("TerminalHost — spawn failure cause", () => {
+	let fakeChild: FakeChildProcess;
+
+	beforeEach(() => {
+		fakeChild = new FakeChildProcess();
+	});
+
+	function spawnSession(shell = "/bin/zsh") {
+		const session = new Session({
+			sessionId: "session-cause",
+			workspaceId: "workspace-1",
+			paneId: "pane-1",
+			tabId: "tab-1",
+			cols: 80,
+			rows: 24,
+			cwd: "/tmp",
+			shell,
+			spawnProcess: () => fakeChild as unknown as ChildProcess,
+		});
+		session.spawn({
+			cwd: "/tmp",
+			cols: 80,
+			rows: 24,
+			env: { PATH: "/usr/bin" },
+		});
+		return session;
+	}
+
+	it("reports SHELL_EXITED with exit code, signal, shell, args and output when the PTY opened and the shell died", async () => {
+		const session = spawnSession("/bin/zsh");
+		emitReadyAndSpawned(fakeChild, 555);
+		emitData(fakeChild, "/Users/me/.zshrc:3: parse error near `}'\r\n");
+		emitExit(fakeChild, 1);
+
+		expect(session.isAlive).toBe(false);
+		expect(session.describeSpawnFailure()).toEqual({
+			kind: "SHELL_EXITED",
+			shell: "/bin/zsh",
+			args: ["-l"],
+			exitCode: 1,
+			signal: undefined,
+			outputHead: "/Users/me/.zshrc:3: parse error near `}'\r\n",
+		});
+
+		await session.dispose();
+	});
+
+	it("keeps the signal when the shell was killed", async () => {
+		const session = spawnSession();
+		emitReadyAndSpawned(fakeChild, 555);
+		emitExit(fakeChild, 0, 9);
+
+		expect(session.describeSpawnFailure()).toMatchObject({
+			kind: "SHELL_EXITED",
+			exitCode: 0,
+			signal: 9,
+		});
+
+		await session.dispose();
+	});
+
+	it("caps the captured output head at 2 KB", async () => {
+		const session = spawnSession();
+		emitReadyAndSpawned(fakeChild, 555);
+		emitData(fakeChild, "x".repeat(5000));
+		emitExit(fakeChild, 1);
+
+		const failure = session.describeSpawnFailure();
+		expect(failure.kind).toBe("SHELL_EXITED");
+		if (failure.kind === "SHELL_EXITED") {
+			expect(failure.outputHead).toHaveLength(2048);
+		}
+
+		await session.dispose();
+	});
+
+	it("does NOT report SHELL_EXITED when the PTY helper failed before opening a PTY", async () => {
+		const session = spawnSession();
+		emitReadyThenError(fakeChild, "Spawn failed: posix_spawn failed: EAGAIN");
+		fakeChild.emit("exit", 1);
+
+		expect(session.describeSpawnFailure()).toEqual({
+			kind: "PTY_SPAWN_FAILED",
+			shell: "/bin/zsh",
+			exitCode: 1,
+			error: "Spawn failed: posix_spawn failed: EAGAIN",
+		});
+
+		await session.dispose();
+	});
+
+	it("does NOT report SHELL_EXITED when the helper process itself could not start", async () => {
+		const session = spawnSession();
+		fakeChild.emit("error", new Error("spawn EBADF"));
+
+		expect(session.describeSpawnFailure()).toEqual({
+			kind: "PTY_SPAWN_FAILED",
+			shell: "/bin/zsh",
+			exitCode: -1,
+			error: "spawn EBADF",
+		});
+
+		await session.dispose();
+	});
+
+	it("reports PTY_SPAWN_TIMEOUT when the helper is alive but never opened a PTY", async () => {
+		const session = spawnSession();
+		emitReadyOnly(fakeChild);
+
+		expect(session.isAlive).toBe(true);
+		expect(session.pid).toBeNull();
+		expect(session.describeSpawnFailure()).toEqual({
+			kind: "PTY_SPAWN_TIMEOUT",
+			shell: "/bin/zsh",
+		});
+
+		await session.dispose();
+	});
+});

--- a/apps/desktop/src/main/terminal-host/terminal-host.test.ts
+++ b/apps/desktop/src/main/terminal-host/terminal-host.test.ts
@@ -294,7 +294,7 @@ describe("TerminalHost — spawn failure cause", () => {
 		await session.dispose();
 	});
 
-	it("caps the captured output head at 2 KB", async () => {
+	it("caps the captured output head at 2048 characters", async () => {
 		const session = spawnSession();
 		emitReadyAndSpawned(fakeChild, 555);
 		emitData(fakeChild, "x".repeat(5000));
@@ -304,6 +304,28 @@ describe("TerminalHost — spawn failure cause", () => {
 		expect(failure.kind).toBe("SHELL_EXITED");
 		if (failure.kind === "SHELL_EXITED") {
 			expect(failure.outputHead).toHaveLength(2048);
+		}
+
+		await session.dispose();
+	});
+
+	it("counts multibyte output in characters and never splits a surrogate pair", async () => {
+		const session = spawnSession();
+		emitReadyAndSpawned(fakeChild, 555);
+		// "✗" is one character over 3 bytes and each emoji is a surrogate pair,
+		// so the 2048-code-unit cap lands mid-pair after that odd-length prefix.
+		emitData(fakeChild, `✗${"🔥".repeat(2000)}`);
+		emitExit(fakeChild, 1);
+
+		const failure = session.describeSpawnFailure();
+		expect(failure.kind).toBe("SHELL_EXITED");
+		if (failure.kind === "SHELL_EXITED") {
+			expect(failure.outputHead).toHaveLength(2047);
+			expect(failure.outputHead.startsWith("✗🔥")).toBe(true);
+			// A dangling half-pair would come back as U+FFFD once encoded.
+			expect(Buffer.from(failure.outputHead, "utf8").toString("utf8")).toBe(
+				failure.outputHead,
+			);
 		}
 
 		await session.dispose();

--- a/apps/desktop/src/main/terminal-host/terminal-host.ts
+++ b/apps/desktop/src/main/terminal-host/terminal-host.ts
@@ -1,5 +1,8 @@
 import type { Socket } from "node:net";
-import { TerminalAttachCanceledError } from "../lib/terminal/errors";
+import {
+	TerminalAttachCanceledError,
+	TerminalSpawnFailedError,
+} from "../lib/terminal/errors";
 import type {
 	CancelCreateOrAttachRequest,
 	ClearScrollbackRequest,
@@ -157,10 +160,9 @@ export class TerminalHost {
 				throwIfAborted(pendingAttach.abortController.signal);
 
 				if (!session.isAlive || session.pid === null) {
+					const cause = session.describeSpawnFailure();
 					void session.dispose();
-					throw new Error(
-						"Session spawn failed: PTY process exited immediately",
-					);
+					throw new TerminalSpawnFailedError(cause);
 				}
 
 				this.sessions.set(sessionId, session);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/Terminal.tsx
@@ -338,6 +338,7 @@ export const Terminal = memo(function Terminal({
 		pendingInitialStateRef,
 		maybeApplyInitialState,
 		flushPendingEvents,
+		pendingEventsRef,
 		resetModes,
 		isAlternateScreenRef,
 		setPaneNameRef,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.attach.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.attach.test.ts
@@ -1,0 +1,275 @@
+/**
+ * The pane's stream belongs to the first createOrAttach that succeeds.
+ *
+ * When the initial attach fails because the shell ran and died before it was
+ * ready (SHELL_EXITED), the pane shows the exit and waits for a key instead of
+ * looping through reconnects. The restart that key triggers is then the first
+ * success, so it — not the initial path — has to start the cache-owned stream.
+ * Skip that and the restarted shell has a session nobody is subscribed to: it
+ * runs, and its output never reaches the pane.
+ */
+import { afterAll, afterEach, describe, expect, it, spyOn } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { SearchAddon } from "@xterm/addon-search";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import type { MutableRefObject } from "react";
+import type {
+	CreateOrAttachCallbacks,
+	CreateOrAttachInput,
+	CreateOrAttachResult,
+	TerminalStreamEvent,
+} from "../types";
+import type { UseTerminalLifecycleOptions } from "./useTerminalLifecycle";
+
+// happy-dom over the preloaded plain-object document. Process-wide, so this
+// unregisters in afterAll to leave the other renderer suites their document.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, cleanup, renderHook } = await import("@testing-library/react");
+const { createParserIdleGate } = await import(
+	"renderer/lib/terminal/parser-idle-gate"
+);
+const { waitForTerminalSessionReady } = await import(
+	"renderer/lib/terminal/session-readiness"
+);
+const v1TerminalCache = await import("../v1-terminal-cache");
+const { useTabsStore } = await import("renderer/stores/tabs/store");
+const { useTerminalLifecycle } = await import("./useTerminalLifecycle");
+
+const spies: Array<{ mockRestore: () => void }> = [];
+
+afterEach(() => {
+	cleanup();
+	for (const spy of spies) spy.mockRestore();
+	spies.length = 0;
+});
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+/**
+ * xterm needs a canvas to open, which happy-dom has none of. The lifecycle
+ * effect only calls back into it for the members below.
+ */
+function createFakeXterm(): XTerm {
+	const disposable = { dispose: () => {} };
+	return {
+		cols: 80,
+		rows: 24,
+		element: undefined,
+		textarea: undefined,
+		write: () => {},
+		clear: () => {},
+		focus: () => {},
+		paste: () => {},
+		getSelection: () => "",
+		attachCustomKeyEventHandler: () => {},
+		onData: () => disposable,
+		onKey: () => disposable,
+		onTitleChange: () => disposable,
+		onRender: () => disposable,
+	} as unknown as XTerm;
+}
+
+/** What the terminal router rejects with when the shell exited before ready. */
+const SHELL_EXITED_ERROR = {
+	message: "Your shell (/bin/zsh) exited immediately with code 1",
+	data: {
+		code: "PRECONDITION_FAILED",
+		cause: {
+			kind: "SHELL_EXITED",
+			shell: "/bin/zsh",
+			args: ["-l"],
+			exitCode: 1,
+			outputHead: "zsh: command not found: nvm\r\n",
+		},
+	},
+};
+
+/** Holds the callbacks of the in-flight createOrAttach so a test can answer it. */
+function createAttachStub() {
+	let pending: CreateOrAttachCallbacks | undefined;
+	const inputs: CreateOrAttachInput[] = [];
+
+	const mutate = (
+		input: CreateOrAttachInput,
+		callbacks?: CreateOrAttachCallbacks,
+	) => {
+		inputs.push(input);
+		pending = callbacks;
+	};
+
+	const answer = (respond: (callbacks: CreateOrAttachCallbacks) => void) => {
+		const callbacks = pending;
+		if (!callbacks) throw new Error("no createOrAttach in flight");
+		pending = undefined;
+		respond(callbacks);
+		callbacks.onSettled?.();
+	};
+
+	return {
+		inputs,
+		mutate,
+		succeed: (result?: Partial<CreateOrAttachResult>) =>
+			answer((callbacks) =>
+				callbacks.onSuccess?.({
+					wasRecovered: false,
+					isNew: true,
+					scrollback: "",
+					...result,
+				}),
+			),
+		/** The router's PRECONDITION_FAILED for a shell that exited before ready. */
+		failWithShellExited: () =>
+			answer((callbacks) => callbacks.onError?.(SHELL_EXITED_ERROR)),
+	};
+}
+
+function ref<T>(current: T): MutableRefObject<T> {
+	return { current };
+}
+
+function renderLifecycle(paneId: string) {
+	const attach = createAttachStub();
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+
+	// A mounted pane exists in the store; unmount then parks the terminal
+	// instead of tearing the session down.
+	useTabsStore.setState((state) => ({
+		panes: {
+			...state.panes,
+			[paneId]: {
+				id: paneId,
+				tabId: "tab-1",
+				type: "terminal",
+				name: "terminal",
+			},
+		},
+	}));
+
+	const connectionErrors: Array<string | null> = [];
+	const pendingEventsRef = ref<TerminalStreamEvent[]>([]);
+	const xterm = createFakeXterm();
+
+	spies.push(
+		spyOn(v1TerminalCache, "get").mockReturnValue(undefined),
+		spyOn(v1TerminalCache, "getOrCreate").mockReturnValue({
+			xterm,
+			fitAddon: { fit: () => {} } as unknown as FitAddon,
+			searchAddon: {} as SearchAddon,
+			gate: createParserIdleGate(),
+		} as ReturnType<typeof v1TerminalCache.getOrCreate>),
+		spyOn(v1TerminalCache, "attachToContainer").mockImplementation(() => {}),
+		spyOn(v1TerminalCache, "detachFromContainer").mockImplementation(() => {}),
+		spyOn(v1TerminalCache, "dispose").mockImplementation(() => {}),
+		spyOn(v1TerminalCache, "startStream").mockImplementation(() => {}),
+		spyOn(v1TerminalCache, "setStreamReady").mockImplementation(() => {}),
+	);
+
+	// Stable identities: the mount effect re-runs on any of these changing, and
+	// in the app they come from useCallback/refs.
+	const options: UseTerminalLifecycleOptions = {
+		paneId,
+		tabIdRef: ref("tab-1"),
+		workspaceId: "workspace-1",
+		terminalRef: ref<HTMLDivElement | null>(container),
+		xtermRef: ref<XTerm | null>(null),
+		fitAddonRef: ref<FitAddon | null>(null),
+		searchAddonRef: ref<SearchAddon | null>(null),
+		isExitedRef: ref(false),
+		wasKilledByUserRef: ref(false),
+		commandBufferRef: ref(""),
+		isFocusedRef: ref(true),
+		isRestoredModeRef: ref(false),
+		connectionErrorRef: ref<string | null>(null),
+		initialThemeRef: ref(null),
+		handleFileLinkClickRef: ref(() => {}),
+		handleUrlClickRef: ref<((url: string) => void) | undefined>(undefined),
+		paneInitialCwdRef: ref<string | undefined>(undefined),
+		clearPaneInitialDataRef: ref(() => {}),
+		setConnectionError: (error) => connectionErrors.push(error),
+		setExitStatus: () => {},
+		setIsRestoredMode: () => {},
+		setRestoredCwd: () => {},
+		createOrAttachRef: ref(attach.mutate),
+		writeRef: ref(() => {}),
+		resizeRef: ref(() => {}),
+		cancelCreateOrAttachRef: ref(() => {}),
+		clearScrollbackRef: ref(() => {}),
+		isStreamReadyRef: ref(false),
+		didFirstRenderRef: ref(false),
+		pendingInitialStateRef: ref<CreateOrAttachResult | null>(null),
+		maybeApplyInitialState: () => {},
+		flushPendingEvents: () => {},
+		pendingEventsRef,
+		resetModes: () => {},
+		isAlternateScreenRef: ref(false),
+		setPaneNameRef: ref(() => {}),
+		renameUnnamedWorkspaceRef: ref(() => {}),
+		handleTerminalFocusRef: ref(() => {}),
+		registerClearCallbackRef: ref(() => {}),
+		unregisterClearCallbackRef: ref(() => {}),
+		registerScrollToBottomCallbackRef: ref(() => {}),
+		unregisterScrollToBottomCallbackRef: ref(() => {}),
+		registerGetSelectionCallbackRef: ref(() => {}),
+		unregisterGetSelectionCallbackRef: ref(() => {}),
+		registerPasteCallbackRef: ref(() => {}),
+		unregisterPasteCallbackRef: ref(() => {}),
+		defaultRestartCommandRef: ref<string | undefined>(undefined),
+	};
+
+	const { result } = renderHook(() => useTerminalLifecycle(options));
+
+	return { attach, connectionErrors, pendingEventsRef, result };
+}
+
+describe("useTerminalLifecycle attach", () => {
+	it("starts the stream when a restart succeeds after the initial shell exited", async () => {
+		const paneId = "pane-shell-exited";
+		const { attach, connectionErrors, pendingEventsRef, result } =
+			renderLifecycle(paneId);
+
+		act(() => attach.failWithShellExited());
+
+		// The pane shows the exit and waits for a key — no reconnect loop, and
+		// no stream, because there is no session to subscribe to yet.
+		expect(pendingEventsRef.current).toContainEqual({
+			type: "exit",
+			exitCode: 1,
+			signal: undefined,
+		});
+		expect(connectionErrors.filter(Boolean)).toEqual([]);
+		expect(v1TerminalCache.startStream).not.toHaveBeenCalled();
+
+		// The key press restarts the session: this is the first attach that
+		// succeeds, so it owns the stream setup.
+		await act(async () => {
+			const restarted = result.current.restartTerminal();
+			attach.succeed();
+			await restarted;
+		});
+
+		expect(v1TerminalCache.startStream).toHaveBeenCalledWith(paneId);
+		expect(v1TerminalCache.setStreamReady).toHaveBeenCalledWith(paneId);
+		await expect(waitForTerminalSessionReady(paneId)).resolves.toBeUndefined();
+		expect(attach.inputs).toHaveLength(2);
+	});
+
+	it("starts the stream on a successful initial attach", async () => {
+		const paneId = "pane-initial-attach";
+		const { attach, result } = renderLifecycle(paneId);
+
+		act(() => attach.succeed());
+
+		expect(v1TerminalCache.startStream).toHaveBeenCalledWith(paneId);
+		expect(v1TerminalCache.setStreamReady).toHaveBeenCalledWith(paneId);
+		await expect(waitForTerminalSessionReady(paneId)).resolves.toBeUndefined();
+		expect(result.current.xtermInstance).not.toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -26,6 +26,7 @@ import {
 	setupFocusListener,
 } from "../helpers";
 import { isPaneDestroyed } from "../pane-guards";
+import { getShellExitedFailure } from "../shell-exited-failure";
 import { coldRestoreState, pendingDetaches } from "../state";
 import type {
 	CreateOrAttachMutate,
@@ -33,6 +34,7 @@ import type {
 	TerminalCancelCreateOrAttachMutate,
 	TerminalClearScrollbackMutate,
 	TerminalResizeMutate,
+	TerminalStreamEvent,
 	TerminalWriteMutate,
 } from "../types";
 import { scrollToBottom } from "../utils";
@@ -127,6 +129,7 @@ export interface UseTerminalLifecycleOptions {
 	pendingInitialStateRef: MutableRefObject<CreateOrAttachResult | null>;
 	maybeApplyInitialState: () => void;
 	flushPendingEvents: () => void;
+	pendingEventsRef: MutableRefObject<TerminalStreamEvent[]>;
 	resetModes: () => void;
 	isAlternateScreenRef: MutableRefObject<boolean>;
 	setPaneNameRef: MutableRefObject<(paneId: string, name: string) => void>;
@@ -188,6 +191,7 @@ export function useTerminalLifecycle({
 	pendingInitialStateRef,
 	maybeApplyInitialState,
 	flushPendingEvents,
+	pendingEventsRef,
 	resetModes,
 	isAlternateScreenRef,
 	setPaneNameRef,
@@ -203,6 +207,23 @@ export function useTerminalLifecycle({
 	unregisterPasteCallbackRef,
 	defaultRestartCommandRef,
 }: UseTerminalLifecycleOptions): UseTerminalLifecycleReturn {
+	// The shell ran and died before it was ready. Show it exactly like a
+	// process that exits a moment after attaching: its output, then the exit
+	// line and restart prompt. Not a connection error, so no reconnect loop.
+	const showShellExitedFailure = (
+		failure: NonNullable<ReturnType<typeof getShellExitedFailure>>,
+	) => {
+		pendingEventsRef.current.push(
+			{
+				type: "data",
+				data: `${failure.outputHead}\r\n\x1b[90m[Terminal] ${failure.message}\x1b[0m`,
+			},
+			{ type: "exit", exitCode: failure.exitCode, signal: failure.signal },
+		);
+		isStreamReadyRef.current = true;
+		flushPendingEvents();
+	};
+
 	const [xtermInstance, setXtermInstance] = useState<XTerm | null>(null);
 	const restartTerminalRef = useRef<
 		(options?: { command?: string; forceRestart?: boolean }) => Promise<void>
@@ -425,6 +446,12 @@ export function useTerminalLifecycle({
 									return;
 								}
 								if (isTerminalAttachCanceledMessage(error.message)) {
+									resolve();
+									return;
+								}
+								const shellExited = getShellExitedFailure(error);
+								if (shellExited) {
+									showShellExitedFailure(shellExited);
 									resolve();
 									return;
 								}
@@ -684,6 +711,15 @@ export function useTerminalLifecycle({
 										isStreamReadyRef.current = false;
 										setExitStatus("killed");
 										setConnectionError(null);
+										return;
+									}
+									const shellExited = getShellExitedFailure(error);
+									if (shellExited) {
+										rejectTerminalSessionReady(
+											paneId,
+											new Error(shellExited.message),
+										);
+										showShellExitedFailure(shellExited);
 										return;
 									}
 									console.error("[Terminal] Failed to create/attach:", error);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -94,6 +94,23 @@ function waitForAttachClear(paneId: string, waiter: () => void): () => void {
 		}
 	};
 }
+
+/**
+ * A createOrAttach succeeded, so the pane has a backend session: start the
+ * cache-owned stream subscription and open the gate so events reach the
+ * component's registered handler.
+ *
+ * The first attach that succeeds owns this, whether that is the initial attach
+ * or a restart after the initial shell exited before it was ready — a restarted
+ * shell whose stream never started writes into nothing. Every step is
+ * idempotent, so the attaches after it re-run this for free.
+ */
+function openPaneStream(paneId: string): void {
+	v1TerminalCache.startStream(paneId);
+	v1TerminalCache.setStreamReady(paneId);
+	markTerminalSessionReady(paneId);
+}
+
 export interface UseTerminalLifecycleOptions {
 	paneId: string;
 	tabIdRef: MutableRefObject<string>;
@@ -413,6 +430,7 @@ export function useTerminalLifecycle({
 									return;
 								}
 								setConnectionError(null);
+								openPaneStream(paneId);
 								syncBackendDimensions();
 								pendingInitialStateRef.current = result;
 								maybeApplyInitialState();
@@ -626,12 +644,7 @@ export function useTerminalLifecycle({
 									setConnectionError(null);
 									clearPaneInitialDataRef.current(paneId);
 
-									// Start the cache-owned stream subscription now that the
-									// backend session exists, and mark it ready so events
-									// flow through the component's registered handler.
-									v1TerminalCache.startStream(paneId);
-									v1TerminalCache.setStreamReady(paneId);
-									markTerminalSessionReady(paneId);
+									openPaneStream(paneId);
 									syncBackendDimensions();
 
 									const storedColdRestore = coldRestoreState.get(paneId);

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/shell-exited-failure.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/shell-exited-failure.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { getShellExitedFailure } from "./shell-exited-failure";
+
+describe("getShellExitedFailure", () => {
+	it("returns the failure for a SHELL_EXITED cause", () => {
+		expect(
+			getShellExitedFailure({
+				message: "Your shell (/bin/zsh) exited immediately with code 1",
+				data: {
+					code: "PRECONDITION_FAILED",
+					cause: {
+						kind: "SHELL_EXITED",
+						shell: "/bin/zsh",
+						args: ["-l"],
+						exitCode: 1,
+						outputHead: "bad rc\r\n",
+					},
+				},
+			}),
+		).toEqual({
+			message: "Your shell (/bin/zsh) exited immediately with code 1",
+			exitCode: 1,
+			signal: undefined,
+			outputHead: "bad rc\r\n",
+		});
+	});
+
+	it("ignores errors without a cause, with another cause, or with a malformed one", () => {
+		expect(getShellExitedFailure(new Error("Connection lost"))).toBeNull();
+		expect(
+			getShellExitedFailure({
+				message: "disposed",
+				data: { cause: { kind: "TERMINAL_HOST_CLIENT_DISPOSED" } },
+			}),
+		).toBeNull();
+		expect(
+			getShellExitedFailure({
+				message: "x",
+				data: { cause: { kind: "SHELL_EXITED", exitCode: "1" } },
+			}),
+		).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/shell-exited-failure.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/shell-exited-failure.ts
@@ -1,0 +1,40 @@
+export interface ShellExitedFailure {
+	message: string;
+	exitCode: number;
+	signal?: number;
+	outputHead: string;
+}
+
+/**
+ * createOrAttach rejected because the shell process exited before it was
+ * ready (PRECONDITION_FAILED with a SHELL_EXITED cause from the terminal
+ * router). The pane shows it like any other process exit instead of
+ * treating it as a lost connection to retry.
+ */
+export function getShellExitedFailure(
+	error: unknown,
+): ShellExitedFailure | null {
+	if (!error || typeof error !== "object") return null;
+	const { message, data } = error as { message?: unknown; data?: unknown };
+	const cause = (data as { cause?: unknown } | undefined)?.cause;
+	if (!cause || typeof cause !== "object") return null;
+	const { kind, exitCode, signal, outputHead } = cause as {
+		kind?: unknown;
+		exitCode?: unknown;
+		signal?: unknown;
+		outputHead?: unknown;
+	};
+	if (
+		kind !== "SHELL_EXITED" ||
+		typeof exitCode !== "number" ||
+		typeof outputHead !== "string"
+	) {
+		return null;
+	}
+	return {
+		message: typeof message === "string" ? message : "",
+		exitCode,
+		signal: typeof signal === "number" ? signal : undefined,
+		outputHead,
+	};
+}


### PR DESCRIPTION
## Problem

`terminal.createOrAttach` rejects with the fixed text `CREATE_ATTACH_FAILED: Session spawn failed: PTY process exited immediately` whenever the session is dead or has no pid after the ready wait (DESKTOP-3H, 3,648 events, 925 in 14 days, every release 1.21.0–1.27.0, 100% macOS). The event carries nothing about why: no exit code, no signal, no shell path, no output.

**User-visible harm.** The pane never opens. The renderer never shows the error text either: it prints `[Connection lost. Reconnecting...]` into an empty pane and retries five times with backoff, each retry another createOrAttach failure and another Sentry event. That is why the events arrive in bursts of 2–6 per machine per minute; the real failure rate is roughly one in six of the event count. The user is left with a blank terminal and a message that blames the connection when nothing was ever connected.

**Will it reach the failure?** The producer is the v1 terminal-host daemon bundled with the desktop app (`apps/desktop/src/main/terminal-host/`), the same code on every affected release, and still what the current release runs. This ships in the next desktop release; the daemon is restarted with the app so both sides pick it up together. Builds already in the field keep emitting the old string until they update. Version skew is graceful: a new client with an old daemon sees no `cause` and falls back to the old generic error, an old client ignores the new field.

**Why code.** Archiving would keep the blank-pane-plus-reconnect-loop experience and leave the cause unknowable. Nothing in flight deletes or restructures this path (checked open PRs touching terminal-host/pty). There is no other layer that has the facts: only the daemon's Session sees the PTY exit frame, the helper's error frame, and the first bytes of output. So the fix is to keep those facts and carry them to the boundary.

## Root cause

One string for four different conditions, and a renderer that treated it as a lost connection. The check `!session.isAlive || session.pid === null` in `TerminalHost.createOrAttach` fires for:

- the PTY opened and the shell process exited before the ready check (uninstalled or non-executable configured shell: node-pty's spawn-helper `_exit(1)`s silently on `execvp` failure; a rc file that exits; a preset command that is not installed);
- the PTY helper subprocess reported that `pty.spawn` threw (that Error frame was only broadcast to attached clients, and nobody is attached yet, so the reason was dropped);
- the helper subprocess itself could not start or died before opening a PTY;
- the helper stayed alive but never sent `Spawned` within 5 s (reported as "exited immediately", which is false).

## Fix

- `Session` keeps the facts it already receives: the shell and args it spawned, the PTY exit code and signal from the Exit frame, the helper's error report (Error frame or `spawn` error, only while no PTY pid exists), and the first 2 KB of output. `describeSpawnFailure()` turns them into a `TerminalSpawnFailureCause`: `SHELL_EXITED` (PTY opened, its exit frame arrived), `PTY_SPAWN_FAILED` (helper exited or reported an error before opening a PTY), or `PTY_SPAWN_TIMEOUT` (helper alive, no `Spawned`).
- `TerminalHost` throws `TerminalSpawnFailedError` with that cause instead of the string. The daemon serializes it as `error.cause` on the socket error response; the client rebuilds the typed error; the tRPC router checks it by name and switches on the kind exhaustively (`utils/terminal-spawn-error.ts`, same shape as the host-service's `toTerminalSessionError`).
- `SHELL_EXITED` becomes `PRECONDITION_FAILED` with the message `Your shell (<path>) exited immediately with code N[: <first output line>]`, the `cause` forwarded through the existing `errorFormatter`. `PTY_SPAWN_FAILED` and `PTY_SPAWN_TIMEOUT` stay `INTERNAL_SERVER_ERROR` with the reason in the message (`Could not open a PTY for <shell>: <helper error | helper exited with code N>`, `Timed out waiting for a PTY for <shell>`), so the next Sentry event names the reason.
- The renderer reads the `SHELL_EXITED` cause and shows it the way a shell that exits a moment after attaching is already shown: its output, the reason line, `[Process exited with code N]`, `[Press any key to restart]`. No `connectionError`, so no reconnect loop. On the restart path the promise resolves after showing the exit, since nothing consumes a rejection there.

The `cause: { kind }` on the TRPCError is read: the renderer branches on it (`shell-exited-failure.ts`). The two 500 kinds carry the original error as `cause` so the Sentry middleware captures it with its message.

**What the classifier matches that it should not, and why that is acceptable here.** `SHELL_EXITED` names exactly "the PTY opened and the process reported an exit before the ready check". Three things inside that condition are arguably ours rather than the user's: a broken Superset-managed rc wrapper, a preset agent command that is not installed, and a workspace directory that vanished after `resolveCwd`'s existence cache said it was there (spawn-helper's `chdir` fails silently with exit 1). All three now render verbatim in the pane (output head, shell, exit code), and a wrapper regression would hit every user at once and be caught elsewhere; none is silent. They no longer reach Sentry, which is the trade this classification makes. Negative tests pin that a helper failure (`PTY_SPAWN_FAILED`) and a ready timeout are never classified as `SHELL_EXITED`, and that the legacy string, a request timeout and a connection loss are never matched as spawn failures.

Not done on purpose: no retry added (the renderer's existing reconnect loop is bypassed for `SHELL_EXITED` only), no `/bin/sh` fallback (product decision, in the session report), no pre-spawn `access(X_OK)` probe on the shell path (would give a sharper cause for the exec-failure case, but a bare shell name resolved through PATH would false-positive; left for a follow-up if the new events show exit 1 with empty output dominating).

## Adjacent, left alone

- DESKTOP-2C `Request timeout: createOrAttach` (client-side 30 s request timeout, `client.ts` `sendRequest`), DESKTOP-E4 `Daemon failed to start in time`, DESKTOP-8D `Connection failed while waiting`: daemon lifecycle, not PTY spawn.
- The renderer's `MAX_RETRIES = 5` reconnect loop still treats every other createOrAttach failure as a connection loss.

## Verification

`bunx biome check <changed files>` (after one `--write` pass that reordered imports):
```
Checked 14 files in 20ms. No fixes applied.
Checked 1 file in 14ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:
```
$ tsc --noEmit
```
(exit 0, no diagnostics)

`cd apps/desktop && bun test src/main/terminal-host src/main/lib/terminal-host src/main/lib/terminal src/lib/trpc/routers/terminal src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal`:
```
 297 pass
 0 fail
 1097 expect() calls
Ran 297 tests across 21 files. [1223.00ms]
```
Re-run after the restart-path change (Terminal, terminal-host, terminal router directories):
```
 139 pass
 0 fail
Ran 139 tests across 13 files. [723.00ms]
```

New tests were written first and failed before the change (`describeSpawnFailure is not a function`, missing modules): `terminal-host.test.ts` (SHELL_EXITED with exit code/signal/shell/args/output, 2 KB cap, helper failure and helper start failure are not SHELL_EXITED, ready timeout), `utils/terminal-spawn-error.test.ts` (kind→code mapping, first-line extraction through ANSI, legacy string / timeout / connection loss never match), `shell-exited-failure.test.ts` (renderer matcher ignores other causes and malformed ones).

No desktop git code touched, so `no-main-process-blocking.test.ts` was not run.

Refs DESKTOP-3H

https://claude.ai/code/session_011DYYKEitXtoxzc3DgFiNNM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`createOrAttach` now reports why a terminal PTY died before it was ready instead of the generic "PTY process exited immediately". The pane shows the shell's output, the exit reason, and the restart prompt instead of a "[Connection lost. Reconnecting...]" loop that retried five times and spammed Sentry.

- The daemon classifies the failure as `SHELL_EXITED`, `PTY_SPAWN_FAILED`, or `PTY_SPAWN_TIMEOUT` and forwards the cause over the socket.
- `SHELL_EXITED` becomes a `PRECONDITION_FAILED` with the shell path and first output line; the other two stay `INTERNAL_SERVER_ERROR` so Sentry still captures them.
- The pane stream now starts on the first attach that succeeds, whether that is the initial attach or a restart after a `SHELL_EXITED`; previously the restarted shell ran with no subscriber and its output never reached the pane.
- The captured output head is capped at 2048 characters without splitting a surrogate pair.
- Older daemons keep sending the old string; the new client falls back to the previous behavior until they update.

Refs DESKTOP-3H

<sup>Written for commit 8c7668d0d55718beab24418134bbf751ddaa43fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal startup error handling with clearer, more actionable failure messages.
  - Shell processes that exit immediately now display exit details and output instead of triggering unnecessary reconnect attempts.
  - Terminal failures preserve relevant information such as exit codes, signals, and initial output while sanitizing and limiting displayed content.
  - Restarted shells now reliably receive terminal stream events.
  - PTY startup failures and timeouts continue to be reported as internal errors where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->