### PR TITLE
fix(desktop): cancel timed-out git tasks in the worker instead of terminating the thread

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
@@ -16,13 +16,26 @@ const execFileAsync = promisify(execFile);
 const SIMPLE_GIT_OPTIONS =
 	USER_GIT_ENV_SIMPLE_GIT_OPTIONS satisfies Partial<SimpleGitOptions>;
 
+// The git task worker sets this for the task it is running, so every git
+// process built on that thread meanwhile dies with the task when the runner
+// cancels it. The main thread never sets it.
+let taskAbortSignal: AbortSignal | undefined;
+
+export function setGitTaskAbortSignal(signal: AbortSignal | undefined): void {
+	taskAbortSignal = signal;
+}
+
 function createUserSimpleGit(
 	repoPath?: string,
 	overrides?: Partial<SimpleGitOptions>,
 ): SimpleGit {
-	const options = overrides
-		? { ...SIMPLE_GIT_OPTIONS, ...overrides }
-		: SIMPLE_GIT_OPTIONS;
+	const options: Partial<SimpleGitOptions> = {
+		...SIMPLE_GIT_OPTIONS,
+		...overrides,
+	};
+	if (taskAbortSignal && !options.abort) {
+		options.abort = taskAbortSignal;
+	}
 	try {
 		if (repoPath) {
 			return simpleGit(repoPath, options);
@@ -56,5 +69,6 @@ export async function execGitWithShellPath(
 		...options,
 		encoding: "utf8",
 		env,
+		signal: options?.signal ?? taskAbortSignal,
 	});
 }

--- a/apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.test.ts
+++ b/apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.test.ts
@@ -5,6 +5,10 @@ type WorkerBehavior =
 	| "boot-fail"
 	| "fail-on-task"
 	| "mismatched-only"
+	// Never answers its first task; answers a cancel for it, then works normally.
+	| "hang-once"
+	// Never answers anything, cancels included.
+	| "hang-deaf"
 	| "success";
 
 let behaviors: WorkerBehavior[] = [];
@@ -13,8 +17,10 @@ const workers: MockWorker[] = [];
 
 class MockWorker extends EventEmitter {
 	public readonly id: number;
+	public readonly cancelledTaskIds: string[] = [];
+	public terminated = false;
 	private readonly behavior: WorkerBehavior;
-	private terminated = false;
+	private hungTaskId: string | null = null;
 
 	constructor(_scriptPath: string) {
 		super();
@@ -40,6 +46,33 @@ class MockWorker extends EventEmitter {
 			typeof message.taskId === "string"
 				? message.taskId
 				: "unknown";
+		const kind =
+			typeof message === "object" && message !== null && "kind" in message
+				? message.kind
+				: undefined;
+
+		if (kind === "cancel") {
+			this.cancelledTaskIds.push(taskId);
+			if (this.behavior === "hang-once" && this.hungTaskId === taskId) {
+				queueMicrotask(() => {
+					if (this.terminated) return;
+					this.emit("message", {
+						kind: "result",
+						taskId,
+						ok: false,
+						error: { name: "GitPluginError", message: "Abort signal received" },
+					});
+				});
+			}
+			return;
+		}
+
+		if (this.behavior === "hang-deaf") return;
+
+		if (this.behavior === "hang-once" && this.hungTaskId === null) {
+			this.hungTaskId = taskId;
+			return;
+		}
 
 		if (this.behavior === "fail-on-task") {
 			queueMicrotask(() => {
@@ -182,5 +215,49 @@ describe("WorkerTaskRunner failure handling", () => {
 
 		await expect(firstSettled).resolves.toBe("rejected");
 		await expect(secondSettled).resolves.toBe("rejected");
+	});
+
+	test("a timed-out task is cancelled in place and the worker is reused", async () => {
+		behaviors = ["hang-once"];
+		const runner = new WorkerTaskRunner({
+			workerScriptPath: "/mock/worker.js",
+			concurrency: 1,
+			cancelGraceMs: 1_000,
+		});
+
+		const first = runner.runTask("status", { id: "first" }, { timeoutMs: 20 });
+		await expect(first).rejects.toThrow(/timed out after 20ms$/);
+
+		const worker = workers[0];
+		expect(worker?.cancelledTaskIds.length).toBe(1);
+		expect(worker?.terminated).toBe(false);
+
+		const second = runner.runTask<{ workerId: number }>("status", {
+			id: "second",
+		});
+		await expect(second).resolves.toEqual({ workerId: 1 });
+		expect(workers.length).toBe(1);
+		await runner.dispose();
+	});
+
+	test("a worker that never reports the cancelled task is terminated after the grace period", async () => {
+		behaviors = ["hang-deaf", "success"];
+		const runner = new WorkerTaskRunner({
+			workerScriptPath: "/mock/worker.js",
+			concurrency: 1,
+			cancelGraceMs: 20,
+		});
+
+		const first = runner.runTask("status", { id: "first" }, { timeoutMs: 20 });
+		await expect(first).rejects.toThrow(/timed out after 20ms$/);
+		expect(workers[0]?.cancelledTaskIds.length).toBe(1);
+		expect(workers[0]?.terminated).toBe(false);
+
+		const second = runner.runTask<{ workerId: number }>("status", {
+			id: "second",
+		});
+		await expect(second).resolves.toEqual({ workerId: 2 });
+		expect(workers[0]?.terminated).toBe(true);
+		await runner.dispose();
 	});
 });

--- a/apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts
+++ b/apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
 import type {
 	SerializedWorkerError,
+	WorkerTaskCancelMessage,
 	WorkerTaskRequestMessage,
 	WorkerTaskResponseMessage,
 } from "./worker-task-protocol";
@@ -44,12 +45,17 @@ interface WorkerTaskRunnerOptions {
 	concurrency: number;
 	name?: string;
 	debug?: boolean;
+	/** How long a worker gets to report a cancelled task before it is terminated. */
+	cancelGraceMs?: number;
 }
 
 interface WorkerSlot {
 	id: number;
 	worker: Worker;
 	activeTaskId: string | null;
+	/** Task the caller gave up on; the slot stays busy until the worker reports it. */
+	cancelledTaskId: string | null;
+	cancelTimeoutHandle?: NodeJS.Timeout;
 	terminating: boolean;
 }
 
@@ -70,12 +76,14 @@ interface QueuedTask {
 }
 
 const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_CANCEL_GRACE_MS = 10_000;
 
 export class WorkerTaskRunner {
 	private readonly workerScriptPath: string;
 	private readonly concurrency: number;
 	private readonly name: string;
 	private readonly debug: boolean;
+	private readonly cancelGraceMs: number;
 	private readonly workerSlots = new Map<number, WorkerSlot>();
 	private readonly queue: string[] = [];
 	private readonly tasks = new Map<string, QueuedTask>();
@@ -89,6 +97,7 @@ export class WorkerTaskRunner {
 		this.concurrency = Math.max(1, options.concurrency);
 		this.name = options.name ?? "worker-runner";
 		this.debug = options.debug ?? false;
+		this.cancelGraceMs = options.cancelGraceMs ?? DEFAULT_CANCEL_GRACE_MS;
 	}
 
 	runTask<TResult>(
@@ -185,6 +194,7 @@ export class WorkerTaskRunner {
 
 		for (const slot of this.workerSlots.values()) {
 			slot.terminating = true;
+			this.clearCancelTimeout(slot);
 			if (slot.activeTaskId) {
 				this.rejectTask(
 					slot.activeTaskId,
@@ -204,6 +214,7 @@ export class WorkerTaskRunner {
 			id: slotId,
 			worker,
 			activeTaskId: null,
+			cancelledTaskId: null,
 			terminating: false,
 		};
 
@@ -236,7 +247,9 @@ export class WorkerTaskRunner {
 		this.ensureWorkerCapacity();
 
 		for (const slot of this.workerSlots.values()) {
-			if (slot.activeTaskId || slot.terminating) continue;
+			if (slot.activeTaskId || slot.cancelledTaskId || slot.terminating) {
+				continue;
+			}
 			if (this.queue.length === 0) break;
 
 			const nextTaskId = this.queue.shift();
@@ -274,6 +287,14 @@ export class WorkerTaskRunner {
 		}
 		const response = message;
 
+		if (slot.cancelledTaskId === response.taskId) {
+			// The caller was already answered; this only frees the thread.
+			this.clearCancelTimeout(slot);
+			slot.cancelledTaskId = null;
+			this.drainQueue();
+			return;
+		}
+
 		if (slot.activeTaskId !== response.taskId) {
 			this.log(
 				`worker ${slot.id} sent unexpected task result ${response.taskId} (active: ${slot.activeTaskId ?? "none"})`,
@@ -286,10 +307,7 @@ export class WorkerTaskRunner {
 			this.log(
 				`worker ${slot.id} reported result for missing active task ${response.taskId}; recycling worker`,
 			);
-			if (!slot.terminating) {
-				slot.terminating = true;
-				void slot.worker.terminate();
-			}
+			this.terminateSlot(slot);
 			return;
 		}
 
@@ -349,42 +367,60 @@ export class WorkerTaskRunner {
 		const task = this.tasks.get(taskId);
 		if (!task) return;
 
-		this.rejectTask(
-			taskId,
+		this.cancelTask(
+			task,
 			new WorkerTaskError(
 				`[${this.name}] Task "${task.taskType}" timed out after ${task.timeoutMs}ms`,
 			),
 		);
-
-		if (task.slotId) {
-			const slot = this.workerSlots.get(task.slotId);
-			if (slot && !slot.terminating) {
-				slot.terminating = true;
-				void slot.worker.terminate();
-				if (this.hasOutstandingWork()) {
-					this.ensureWorkerCapacity();
-					this.drainQueue();
-				}
-			}
-		}
 	}
 
 	private abortTask(taskId: string): void {
 		const task = this.tasks.get(taskId);
 		if (!task) return;
 
-		this.rejectTask(taskId, new WorkerTaskAbortedError("cancelled"));
+		this.cancelTask(task, new WorkerTaskAbortedError("cancelled"));
+	}
 
-		if (task.slotId) {
-			const slot = this.workerSlots.get(task.slotId);
-			if (slot && !slot.terminating) {
-				slot.terminating = true;
-				void slot.worker.terminate();
-				if (this.hasOutstandingWork()) {
-					this.ensureWorkerCapacity();
-					this.drainQueue();
-				}
-			}
+	// Answer the caller, then let the worker kill what the task spawned and
+	// report back. Terminating the thread instead orphans its child processes:
+	// they run on, and once they exit nothing reaps them, so each one stays a
+	// zombie holding a slot in the user's process table until the app quits.
+	private cancelTask(task: QueuedTask, reason: unknown): void {
+		const slot =
+			task.slotId === undefined ? undefined : this.workerSlots.get(task.slotId);
+		this.rejectTask(task.taskId, reason);
+		if (!slot || slot.terminating) return;
+
+		slot.cancelledTaskId = task.taskId;
+		const cancel: WorkerTaskCancelMessage = {
+			kind: "cancel",
+			taskId: task.taskId,
+		};
+		slot.worker.postMessage(cancel);
+		slot.cancelTimeoutHandle = setTimeout(() => {
+			this.log(
+				`worker ${slot.id} did not report cancelled task ${task.taskId} within ${this.cancelGraceMs}ms; terminating`,
+			);
+			this.terminateSlot(slot);
+		}, this.cancelGraceMs);
+	}
+
+	private terminateSlot(slot: WorkerSlot): void {
+		if (slot.terminating) return;
+		slot.terminating = true;
+		this.clearCancelTimeout(slot);
+		void slot.worker.terminate();
+		if (this.hasOutstandingWork()) {
+			this.ensureWorkerCapacity();
+			this.drainQueue();
+		}
+	}
+
+	private clearCancelTimeout(slot: WorkerSlot): void {
+		if (slot.cancelTimeoutHandle) {
+			clearTimeout(slot.cancelTimeoutHandle);
+			slot.cancelTimeoutHandle = undefined;
 		}
 	}
 
@@ -393,6 +429,7 @@ export class WorkerTaskRunner {
 		if (!slot) return;
 
 		const activeTaskId = slot.activeTaskId;
+		this.clearCancelTimeout(slot);
 		this.workerSlots.delete(slot.id);
 
 		if (activeTaskId) {

--- a/apps/desktop/src/lib/trpc/workers/worker-task-protocol.ts
+++ b/apps/desktop/src/lib/trpc/workers/worker-task-protocol.ts
@@ -12,6 +12,16 @@ export interface WorkerTaskRequestMessage {
 	payload: unknown;
 }
 
+/**
+ * The caller has given up on the task (timeout, abort). The worker kills what
+ * the task spawned and still reports a result for it, which is how the runner
+ * knows the thread is free again.
+ */
+export interface WorkerTaskCancelMessage {
+	kind: "cancel";
+	taskId: string;
+}
+
 export type WorkerTaskResponseMessage =
 	| {
 			kind: "result";

--- a/apps/desktop/src/main/git-task-worker.ts
+++ b/apps/desktop/src/main/git-task-worker.ts
@@ -1,9 +1,11 @@
 import { parentPort } from "node:worker_threads";
 import { executeGitTask } from "../lib/trpc/routers/changes/workers/git-task-handlers";
 import type { GitTaskType } from "../lib/trpc/routers/changes/workers/git-task-types";
+import { setGitTaskAbortSignal } from "../lib/trpc/routers/workspaces/utils/git-client";
 import { classifyEnvironmentalGitError } from "../lib/trpc/routers/workspaces/utils/git-errors";
 import {
 	serializeWorkerError,
+	type WorkerTaskCancelMessage,
 	type WorkerTaskRequestMessage,
 } from "../lib/trpc/workers/worker-task-protocol";
 
@@ -25,9 +27,34 @@ function isWorkerTaskRequestMessage(
 	);
 }
 
+function isWorkerTaskCancelMessage(
+	message: unknown,
+): message is WorkerTaskCancelMessage {
+	if (!message || typeof message !== "object") {
+		return false;
+	}
+	const candidate = message as Partial<WorkerTaskCancelMessage>;
+	return candidate.kind === "cancel" && typeof candidate.taskId === "string";
+}
+
+// The runner hands this thread one task at a time. Aborting kills the git
+// processes the task spawned while this thread is still alive to reap them;
+// the runner used to terminate the thread instead, which left them running
+// and, once they exited, zombies for the life of the app.
+let activeTask: { taskId: string; abort: AbortController } | null = null;
+
 parentPort.on("message", async (message: unknown) => {
+	if (isWorkerTaskCancelMessage(message)) {
+		if (activeTask?.taskId === message.taskId) {
+			activeTask.abort.abort();
+		}
+		return;
+	}
 	if (!isWorkerTaskRequestMessage(message)) return;
 	const task = message;
+	const abort = new AbortController();
+	activeTask = { taskId: task.taskId, abort };
+	setGitTaskAbortSignal(abort.signal);
 
 	try {
 		const result = await executeGitTask(
@@ -47,6 +74,11 @@ parentPort.on("message", async (message: unknown) => {
 			ok: false,
 			error: serializeWorkerError(translateRawGitError(error)),
 		});
+	} finally {
+		if (activeTask?.taskId === task.taskId) {
+			activeTask = null;
+			setGitTaskAbortSignal(undefined);
+		}
 	}
 });
 


### PR DESCRIPTION
## Problem

`Error: spawn git EAGAIN` from the changes router: DESKTOP-73 (2,504 of its last 2,528 events are EAGAIN, the rest ENOENT) and its `changes.getStatus` twin DESKTOP-5X. EAGAIN from `posix_spawn` on macOS means the user's process table is full (`kern.maxprocperuid`), so every git call behind the Changes panel fails until something on the machine exits. On the affected installs that state recurred for weeks (one 1.24.2 install: Aug 24 → Sep 4).

Reality check:

1. **User-visible harm.** While a machine is at its process limit the Changes panel (branches, status, commit files) fails outright, and the desktop keeps making it worse: every timed-out git task leaves a process-table slot that is never given back until the app is quit.
2. **Reach.** Ships in the next desktop release. Events come from 1.14.3–1.25.1, all macOS; those installs pick it up when they update, and their existing zombies disappear on restart.
3. **Why code.** The desktop itself leaks process-table entries (below), reproduced locally in a real Electron main process. Archiving or filtering would hide a real defect; a diagnostics capture is not needed because the leak reproduces without it.

## Root cause

`WorkerTaskRunner` answered a task timeout (30 s for `getBranches`, 45 s for `getStatus`) and an abort with `worker.terminate()`. Terminating a worker thread does not kill the child processes its event loop spawned, and nothing reaps them afterwards: the git process runs to completion on its own, and once it exits it stays a `Z` zombie under the desktop main process for the life of the app. Each zombie holds one slot in the per-user process table. Reproduced with Node 26, with Electron 41.10.3 (the desktop's Electron) as a plain main process, and with the real `git-task-worker` below.

In the field the leak rides on slow-repo machines: the 1.18.3 install that produced the most `getStatus` EAGAINs (DESKTOP-5X) also produced 1,301 `getBranches` timeouts (DESKTOP-5V) in the same eight days, the first EAGAIN a minute after the first timeout, and the two interleave from then on. Sentry cannot show which process pushed a given machine over the line (most bursts last seconds and recover without a restart, so something else on those machines already sits near the limit); what the leak adds is one permanent process-table entry per timed-out task on exactly the machines where git is already slow, plus an orphaned git process burning CPU on top, until the user restarts the app.

## Fix

- **Runner:** on timeout or abort, reject the caller as before (same message, so `translateGitTaskFailure` and the `GitEnvironmentError` translation are unchanged), then post a `cancel` message to the worker and keep the slot busy until the worker reports that task. The thread is reused. A worker that does not report within a grace period (10 s, a thread stuck in synchronous work) is terminated as before; nothing in the main thread knows its pids.
- **Worker:** one task at a time; each task gets an `AbortController`; a cancel aborts it.
- **git-client:** while a worker task is active, every simple-git instance built on that thread carries the task's `abort` signal (simple-git's abort plugin sends SIGINT to in-flight git and refuses new spawns) and `execGitWithShellPath` passes it as execFile's `signal`. The main thread never sets it, so in-process git calls are untouched.

No typed cause added: nothing reads a new kind, and the timeout error keeps its message and its existing classification.

Adjacent, left alone on purpose:

- `getStatusNoLock` wraps every non-ENOENT failure, `spawn git EAGAIN` included, in `GitEnvironmentError` ("Git can't read this workspace"). That is why DESKTOP-5X went quiet after 1.19 while DESKTOP-73 kept reporting the same episodes through `getBranches`. An over-match, but a separate change.
- The ENOENT slice of DESKTOP-73 (under 1%; a PATH without `/usr/bin`).
- `dispose()` on app quit still terminates; orphans are re-parented to launchd when the process exits, so no zombie.

## Verification

Before/after with the real `git-task-worker` and `WorkerTaskRunner` under bun, against a scratch repo whose `core.fsmonitor` hook blocks on its second call so simple-git's `git diff --numstat` never returns; `ps` filtered to children of the harness process.

Before (what the runner did on timeout: `worker.terminate()`):

```
children at the 3s timeout (git diff blocked on the hook):
95946 95249 S       00:02 git
worker terminated, as the old runner did
children 5s later (hook finished, git exited):
95946 95249 Z       00:08 <defunct>
```

After (this change, task timeout 3 s):

```
children 1.5s into the task (git diff blocked on the hook):
96840 96429 S       00:01 git
getStatus rejected after 3002 ms: [e2e] Task "getStatus" timed out after 3000ms
children right after the timeout:
(none)
children 1.5s later:
(none)
slots: [ { id: 1, terminating: false, cancelledTaskId: null } ]
getBranches on the same runner: {"local":[{"branch":"main","lastCommitDate":1788834877000}],"currentBranch":"main"}
slots after: [ 1 ]
```

Zombie reproduction in a plain Electron 41.10.3 main process (worker spawns `sleep 3`, main terminates the worker):

```
t+0:      86556 86550 S    /bin/sleep
t+4.5s:   86556 86550 Z    <defunct>
t+6.5s:   86556 86550 Z    <defunct>
```

```
$ bunx biome check apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.test.ts apps/desktop/src/lib/trpc/workers/worker-task-protocol.ts apps/desktop/src/main/git-task-worker.ts apps/desktop/src/lib/trpc/routers/workspaces/utils/git-client.ts
Checked 5 files in 13ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ tsc --noEmit
(clean)

$ cd apps/desktop && bun test src/lib/trpc/workers src/lib/trpc/routers/changes/workers src/no-main-process-blocking.test.ts
 26 pass
 0 fail
 58 expect() calls
Ran 26 tests across 4 files. [53.11s]
```

The two new runner tests pin the behaviour: a timed-out task is cancelled in place and the same worker serves the next task; a worker that never reports the cancelled task is terminated after the grace period and a replacement takes the queue.

Refs DESKTOP-73

https://claude.ai/code/session_01Wp3ifTic6pbP5y56moqf2D


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop's `spawn git EAGAIN` failures (DESKTOP-73) by cancelling timed-out git tasks in the worker thread instead of terminating it, which previously orphaned git child processes into unreaped zombies that leaked process-table slots until the app quit. A timeout or abort now rejects the caller as before, sends a cancel to the worker, and reuses the thread once the task's git processes are killed and reaped; a worker that doesn't report within 10 seconds is terminated as a fallback.

**Notes**
- Only the worker thread sets the abort signal, so in-process git calls on the main thread are unaffected.
- No typed cause was added; the timeout error keeps its message and classification.
- `dispose()` on app quit still terminates the worker; orphans are re-parented to launchd and reaped.

<sup>Written for commit 0135260f941e7bc3adbe377ec04e4afeba79168a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation of timed-out or abandoned background tasks, reducing unnecessary worker restarts.
  * Added a grace period for tasks to stop cleanly before forced termination.
  * Git operations now respond more reliably when cancelled, helping prevent lingering work and unresponsive activity.
  * Improved handling of workers that fail to acknowledge cancellation, maintaining stability by terminating them when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->