### PR TITLE
fix(marketing): don't let a refused profile read get cached

### DIFF
--- a/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
+++ b/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
@@ -1,3 +1,4 @@
+import { unstable_noStore } from "next/cache";
 import {
 	fetchParticipant,
 	isRateLimited,
@@ -18,7 +19,14 @@ export async function loadProfile(handle: string): Promise<ProfileLookup> {
 		const profile = await fetchParticipant(handle, { period: "all" });
 		return profile ? { state: "found", profile } : { state: "missing" };
 	} catch (error) {
-		if (isRateLimited(error)) return { state: "rate-limited" };
+		if (isRateLimited(error)) {
+			// A refusal describes this moment, not this profile. The retry page
+			// renders as an ordinary 200, so without opting out here the route's
+			// revalidate window would serve it for every visitor to that handle
+			// until it expired.
+			unstable_noStore();
+			return { state: "rate-limited" };
+		}
 		throw error;
 	}
 }


### PR DESCRIPTION
Follow-up to #7281, which I merged before clearing this finding.

## Problem

`loadProfile` turns a refused leaderboard read into a `rate-limited` state and the page renders `ProfileUnavailable` for it. That render is an ordinary 200 on a route with `export const revalidate = 300`, so a single refusal could be cached and served to every visitor of that handle and locale for the rest of the window. On a public, crawled profile URL that is the wrong thing to hold onto.

The window is narrow in practice: with `LEADERBOARD_INTERNAL_TOKEN` set (it now is, in both environments) marketing's server reads are exempt from the anonymous limiter and this state is not reached. It becomes reachable again the moment the token is absent or rotated wrong, which is exactly when you least want the retry page pinned in front of real profiles.

## Fix

`unstable_noStore()` in the branch that produces the state, rather than at the call sites. Both consumers of `loadProfile` (the page and `generateMetadata`) are covered by the one call, and a third consumer cannot be added without it. Successful profiles and `notFound()` are untouched and still cache normally.

`opengraph-image.tsx` and the fight page call `fetchParticipant` directly and still throw on a refusal, so ISR keeps their stale output. Unchanged here.

## Verification

```
$ bunx biome check apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
Checked 1 file in 35ms. No fixes applied.

$ cd apps/marketing && bun run typecheck
$ tsc --noEmit
(clean)

$ cd apps/marketing && bun test "src/app/[lang]/utils" "src/app/[lang]/user"
 11 pass
 0 fail
Ran 11 tests across 1 file. [47.00ms]
```

Refs MARKETING-6C

https://claude.ai/code/session_01Lympqm6njii4G2VqdfA4sg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a refused leaderboard read from caching the "profile unavailable" page and serving it to every visitor of that handle for the 300s revalidate window. `loadProfile` now calls `unstable_noStore()` when it produces the `rate-limited` state, covering both the page and `generateMetadata`; successful profiles and `notFound()` still cache normally.

<sup>Written for commit 2275d5768742769a805b945e41257fb9f4648cbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

