### PR TITLE
fix(desktop): decide a missing path ourselves before opening it externally

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
 	getAppCommand,
+	pathIsMissing,
 	RelativePathWithoutCwdError,
 	resolvePath,
 	stripPathWrappers,
@@ -745,5 +747,54 @@ describe("resolvePath guards against process.cwd() fallback", () => {
 		expect(resolvePath("src/index.ts", "/workspace")).toBe(
 			"/workspace/src/index.ts",
 		);
+	});
+});
+
+describe("pathIsMissing", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "external-helpers-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test("an absent path is missing", async () => {
+		expect(await pathIsMissing(path.join(tmpDir, "gone.ts"))).toBe(true);
+	});
+
+	test("an existing file is not missing", async () => {
+		const file = path.join(tmpDir, "present.ts");
+		await fs.writeFile(file, "");
+		expect(await pathIsMissing(file)).toBe(false);
+	});
+
+	test("an existing directory is not missing", async () => {
+		// openInApp opens workspace worktrees, not just files.
+		expect(await pathIsMissing(tmpDir)).toBe(false);
+	});
+
+	test("a path below a file is missing (ENOTDIR)", async () => {
+		const file = path.join(tmpDir, "present.ts");
+		await fs.writeFile(file, "");
+		expect(await pathIsMissing(path.join(file, "child.ts"))).toBe(true);
+	});
+
+	test("a symlink to a deleted target is missing", async () => {
+		const target = path.join(tmpDir, "target.ts");
+		const link = path.join(tmpDir, "link.ts");
+		await fs.writeFile(target, "");
+		await fs.symlink(target, link);
+		await fs.rm(target);
+		// The editor cannot open it either — `open` reports it as nonexistent.
+		expect(await pathIsMissing(link)).toBe(true);
+	});
+
+	test("a stat failure that is not absence does not count as missing", async () => {
+		// ENAMETOOLONG: we cannot tell whether the path is there, so the app
+		// still gets to try and its failure still reports.
+		expect(await pathIsMissing(`/${"a".repeat(5000)}`)).toBe(false);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
 import nodePath from "node:path";
 import type { ExternalApp } from "@superset/local-db";
 import { TRPCError } from "@trpc/server";
@@ -366,6 +367,26 @@ export function resolvePath(filePath: string, cwd?: string): string {
 	}
 
 	return resolved;
+}
+
+/**
+ * Whether `filePath` has no directory entry for an app to open.
+ *
+ * Only absence answers the question: ENOENT (nothing there) and ENOTDIR (a
+ * parent component is a file). Every other stat failure — EACCES on a parent
+ * directory, EIO on a stalled network mount, ENAMETOOLONG on a garbled path —
+ * leaves existence unknown, so we report it as present and let the app try,
+ * keeping its failure visible.
+ */
+export async function pathIsMissing(filePath: string): Promise<boolean> {
+	try {
+		// stat, not lstat: a symlink whose target is gone is equally unopenable.
+		await fs.stat(filePath);
+		return false;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		return code === "ENOENT" || code === "ENOTDIR";
+	}
 }
 
 /**

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -18,6 +18,7 @@ import { getWorkspacePath } from "../workspaces/utils/worktree";
 import {
 	type ExternalApp,
 	getAppCommand,
+	pathIsMissing,
 	RelativePathWithoutCwdError,
 	resolvePath,
 	spawnAsync,
@@ -79,6 +80,19 @@ async function openPathInApp(
 	filePath: string,
 	app: ExternalApp,
 ): Promise<void> {
+	// Paths reach here from terminal links, diff rows and workspace rows, any
+	// of which can name something an agent has since deleted or a worktree that
+	// has been removed. Whether it is still there is ours to answer, so answer
+	// it before handing the path to another program: otherwise the miss comes
+	// back as an opaque non-zero exit (macOS `open` writes "The file <path>
+	// does not exist"), which we can only report as a 500 (DESKTOP-15).
+	if (await pathIsMissing(filePath)) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "This file no longer exists.",
+		});
+	}
+
 	if (app === "finder") {
 		shell.showItemInFolder(filePath);
 		return;


### PR DESCRIPTION
## Problem

Clicking a file link, a diff row, or a workspace's "Open in editor" for something
that is no longer on disk (an agent deleted the file, the worktree was removed)
fails with no useful answer. `openInApp` / `openFileInEditor` hand the path
straight to the editor launcher; the launcher exits non-zero, `spawnAsync` turns
its stderr into a plain `Error`, and the router reports `INTERNAL_SERVER_ERROR`.

What the user gets:
- most call sites: a toast quoting a raw LaunchServices sentence, containing
  their own absolute path;
- the terminal link fallback handler: nothing at all, just a `console.error`;
- on Linux the CLI editors mostly open an empty buffer instead, so there is no
  signal either way.

And because a 500 is what the Sentry middleware reports, each one becomes an
event whose *title* is the user's absolute path.

**Will this reach the reported failure?** Yes. The events come from the shipped
desktop app (1.22.0–1.26.0, latest sample 1.24.2) on this exact code path, which
is unchanged on `main`; the fix ships in the next desktop release and reaches
users through the normal auto-update.

**Why code, not an archive or a filter?** A Sentry-side suppression is barred by
the repo contract, and archiving leaves the dead-end click in place. The renderer
cannot pre-empt it either: terminal links *are* stat-validated when they are
drawn, so the file can only be found missing at open time — the main process is
the sole place that can answer. The deleted-file path is not going away.

## Root cause

We asked another program a question we could answer ourselves, then had no way to
read its answer. Editor launchers phrase absence differently per app and per
platform, so a non-zero exit is indistinguishable from any other launch failure
by the time it reaches us — everything collapses into one 500.

## Fix

`pathIsMissing()` in `external/helpers.ts` (electron-free, so it is unit
testable), called at the top of `openPathInApp` — the single point where both
procedures hand a path to an external program. A missing path is now
`NOT_FOUND` with a message the existing toasts already render, and no absolute
path in it, since every call site already knows which file it asked for.

Deliberately narrow:

- Only `ENOENT` and `ENOTDIR` count as missing. Any other `stat` failure
  (`EACCES` on a parent directory, `EIO` on a stalled mount, `ENAMETOOLONG` on a
  garbled path) leaves existence unknown, so the app still gets to try and its
  failure still reports as it does today. There is a test asserting exactly that.
- **No stderr parsing.** The launcher's wording is never read.
- **Everything else still reports**: app not installed, LaunchServices timeouts
  (`-1712`), `'phpstorm' exited with code 16`, and so on all keep their current
  `INTERNAL_SERVER_ERROR`. This fix covers 132 of the issue's 510 events in 90d;
  the issue will stay open and should — see "Not fixed here".
- **Plain `NOT_FOUND`, no typed `cause`.** Nothing branches on a `kind`: the
  renderers already show the message, so a `kind` here would be code maintained
  for nothing.
- One intended behaviour change beyond the reported failure: revealing a missing
  path with the Finder app now errors instead of silently doing nothing, because
  the check sits ahead of that branch too.

## Not fixed here (adjacent, named and left)

- **"Unable to find application named 'X'" / `LSCopyApplicationURLsForBundleIdentifier` failed** —
  ~276 of the 510 events, the real bulk of DESKTOP-15. The existing
  `APP_NOT_INSTALLED` classification keys on spawn `ENOENT`, which only fires on
  Linux; on macOS the spawned binary is `/usr/bin/open`, which always exists, so
  "editor not installed" still lands as a 500. Classifying it needs a
  pre-flight installed-app lookup (`open -Ra`, or LaunchServices) — its own
  change and its own decision, not a stderr match.
- `openFileInEditor`'s "no editor configured yet" branch calls `shell.openPath`
  directly, bypassing `openPathInApp`; its error string is discarded, so a
  missing path there is still a silent no-op. It produces no Sentry events and is
  left alone.
- Desktop tRPC error messages are uniformly untranslated (0 of 120 `TRPCError`
  messages use Lingui); this one matches its neighbours rather than starting a
  half-conversion.

## Verification

Negative test written first and confirmed failing before the implementation:

```
$ bun test src/lib/trpc/routers/external
SyntaxError: Export named 'pathIsMissing' not found in module '.../external/helpers.ts'
 0 pass
 1 fail
```

After:

```
$ bun test src/lib/trpc/routers/external
 119 pass
 0 fail
 126 expect() calls
Ran 119 tests across 1 file. [82.00ms]

$ bun test src/lib/trpc/routers/external -t "pathIsMissing"
 6 pass
 113 filtered out
 0 fail

$ bunx biome check apps/desktop/src/lib/trpc/routers/external/{helpers.ts,helpers.test.ts,index.ts}
Checked 3 files in 23ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ tsc --noEmit      # clean, no output
```

`no-main-process-blocking.test.ts` was not run: no git-client code is touched.

Refs DESKTOP-15

https://claude.ai/code/session_01HAZsZGbBKyQwvT6VuRGdJy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop app's handling of file links, diff rows, and 'Open in editor' when the target no longer exists on disk. Instead of surfacing a 500 with a raw system error containing the user's absolute path, the app now reports `NOT_FOUND` with a clean "This file no longer exists" message. Addresses DESKTOP-15.

- Adds `pathIsMissing()`, which treats only `ENOENT` and `ENOTDIR` as missing; other stat failures (`EACCES`, `EIO`, garbled paths) keep existing failure reporting.
- The check runs before any external launcher spawn, so revealing a missing path with Finder now errors instead of silently doing nothing.
- Symlinks to deleted targets count as missing via `stat` rather than `lstat`.

**Not covered here**
- App-not-installed errors on macOS still report as 500 (~276 of 510 related events) because `/usr/bin/open` always exists; classifying them needs a separate pre-flight installed-app lookup.
- The 'no editor configured yet' branch in `openFileInEditor` bypasses this check and still silently ignores missing paths.
- Error messages remain untranslated, consistent with the rest of the desktop tRPC code.

<sup>Written for commit f76488ba058d5596f337f2ce80d8652ec10a8bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when opening files or folders that no longer exist.
  - Displays a clear “not found” error instead of attempting to open missing paths.
  - Correctly handles broken links and invalid paths while preserving other file-system errors.
- **Tests**
  - Added coverage for missing paths, existing files and folders, broken links, and other path errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->