### PR TITLE
fix(api): acknowledge Linear webhooks before fanning them out

### DIFF
--- a/apps/api/src/app/api/integrations/linear/jobs/process-delivery/partitionDay.test.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/process-delivery/partitionDay.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { partitionDay } from "./partitionDay";
+
+describe("partitionDay", () => {
+	test("a timestamp truncated to milliseconds keeps its day", () => {
+		// What the round trip actually does: the row holds microseconds, the
+		// Date that comes back holds milliseconds.
+		const stored = "2026-09-08T03:25:01.812344Z";
+
+		expect(new Date(stored).toISOString()).toBe("2026-09-08T03:25:01.812Z");
+		expect(partitionDay(new Date(stored))).toBe("2026-09-08");
+	});
+
+	test("the last microseconds of a day do not fall into the next one", () => {
+		expect(partitionDay(new Date("2026-09-08T23:59:59.999999Z"))).toBe(
+			"2026-09-08",
+		);
+	});
+
+	test("the first microseconds of a day do not fall into the previous one", () => {
+		expect(partitionDay(new Date("2026-09-08T00:00:00.000999Z"))).toBe(
+			"2026-09-08",
+		);
+	});
+
+	test("is the UTC day, not the day where this happens to run", () => {
+		expect(partitionDay(new Date("2026-09-08T00:30:00.000Z"))).toBe(
+			"2026-09-08",
+		);
+		expect(partitionDay(new Date("2026-09-08T23:30:00.000Z"))).toBe(
+			"2026-09-08",
+		);
+	});
+});

--- a/apps/api/src/app/api/integrations/linear/jobs/process-delivery/partitionDay.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/process-delivery/partitionDay.ts
@@ -1,0 +1,16 @@
+/**
+ * The day partition of `ingest.webhook_payloads` a delivery's body is in.
+ *
+ * Deliberately a day and not the timestamp itself. `received_at` is a Postgres
+ * timestamp, which keeps microseconds, and it reaches this route through a
+ * JSON round trip as a JavaScript Date, which keeps milliseconds — so the
+ * value here is `2026-09-08 03:25:01.812` where the row holds
+ * `2026-09-08 03:25:01.812344`, and matching on it would find nothing. The day
+ * survives that truncation intact, because dropping sub-millisecond digits only
+ * ever moves a timestamp earlier within the same day, so it is safe to prune a
+ * partition with. Exactness comes from matching the event row's own
+ * `received_at` instead.
+ */
+export function partitionDay(receivedAt: Date): string {
+	return receivedAt.toISOString().slice(0, 10);
+}

--- a/apps/api/src/app/api/integrations/linear/jobs/process-delivery/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/process-delivery/route.ts
@@ -6,6 +6,7 @@ import { eq, sql } from "drizzle-orm";
 import { verifyQstashRequest } from "@/lib/verifyQstash";
 import { processDelivery } from "../../webhook/processDelivery";
 import { linearDeliveryWorkSchema, PROCESS_PATH } from "../../webhook/queue";
+import { partitionDay } from "./partitionDay";
 
 export const dynamic = "force-dynamic";
 
@@ -105,23 +106,27 @@ interface AcceptedDelivery {
  * The delivery's current state and the body recorded with it, in one round
  * trip.
  *
- * `received_at` is webhook_payloads' partition key, so passing it as a
- * constant makes the body a primary-key lookup inside a single day's
- * partition. It is cast through timestamptz rather than bound as a date: the
- * column is a timestamp without a zone holding UTC wall time, and this is what
- * makes the match independent of whatever timezone the driver would otherwise
- * serialize a Date in.
+ * Two conditions on `received_at`, and they do different jobs. `p.received_at
+ * = e.received_at` is what makes the match exact, at the full microsecond
+ * precision both columns hold. The day bounds are constants, which is what
+ * lets the planner prune `webhook_payloads` to the single partition the body
+ * is in — the partitions run midnight to midnight, so the bounds land on
+ * exactly one. Matching the queued timestamp directly would find nothing:
+ * see `partitionDay`.
  */
 async function loadAcceptedDelivery(
 	webhookEventId: string,
 	receivedAt: Date,
 ): Promise<AcceptedDelivery | null> {
+	const day = partitionDay(receivedAt);
 	const result = await db.execute<{ status: string; payload: unknown }>(sql`
 		SELECT e.status, p.payload
 		FROM ingest.webhook_events e
 		LEFT JOIN ingest.webhook_payloads p
 			ON p.webhook_event_id = e.id
-			AND p.received_at = ${receivedAt.toISOString()}::timestamptz AT TIME ZONE 'UTC'
+			AND p.received_at = e.received_at
+			AND p.received_at >= ${day}::timestamp
+			AND p.received_at < ${day}::timestamp + interval '1 day'
 		WHERE e.id = ${webhookEventId}
 	`);
 

--- a/apps/api/src/app/api/integrations/linear/jobs/process-delivery/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/process-delivery/route.ts
@@ -1,0 +1,167 @@
+import type { LinearWebhookPayload } from "@linear/sdk/webhooks";
+import { db } from "@superset/db/client";
+import { webhookEvents } from "@superset/db/schema";
+import { eq, sql } from "drizzle-orm";
+
+import { verifyQstashRequest } from "@/lib/verifyQstash";
+import { processDelivery } from "../../webhook/processDelivery";
+import { linearDeliveryWorkSchema, PROCESS_PATH } from "../../webhook/queue";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * The fan-out walks every connected organization one at a time and each one
+ * can cost a Linear API call, so this is nowhere near the platform default.
+ * Matches the other job routes; QStash retries anything the platform kills.
+ */
+export const maxDuration = 300;
+
+/**
+ * The half of a Linear delivery that does the work, run by QStash after the
+ * webhook route recorded the delivery and answered Linear.
+ *
+ * A non-2xx makes QStash retry, which is what a database or Linear hiccup
+ * deserves — and a retry is cheap, because the per-connection rows mean only
+ * the organizations that have not finished do any work the second time.
+ * Anything that will never succeed answers 200 with a reason instead, so it is
+ * not retried into the ground.
+ */
+export async function POST(request: Request): Promise<Response> {
+	const body = await request.text();
+	const rejected = await verifyQstashRequest(request, body, PROCESS_PATH);
+	if (rejected) return rejected;
+
+	let parsedBody: unknown;
+	try {
+		parsedBody = JSON.parse(body);
+	} catch {
+		return Response.json({ error: "Malformed work item" }, { status: 400 });
+	}
+	const parsed = linearDeliveryWorkSchema.safeParse(parsedBody);
+	if (!parsed.success) {
+		return Response.json({ error: "Unrecognised work item" }, { status: 400 });
+	}
+	const work = parsed.data;
+
+	const accepted = await loadAcceptedDelivery(
+		work.webhookEventId,
+		work.receivedAt,
+	);
+
+	if (!accepted) {
+		// The row is gone: retention removed it, or it never landed. Retrying
+		// cannot bring it back.
+		console.error(
+			"[linear/process-delivery] no webhook event:",
+			work.webhookEventId,
+		);
+		return Response.json({ skipped: "event missing" });
+	}
+
+	// A QStash redelivery of work that already finished, or a Linear retry that
+	// got past both dedup windows.
+	if (accepted.status === "processed" || accepted.status === "skipped") {
+		return Response.json({ skipped: `already ${accepted.status}` });
+	}
+
+	if (!isLinearPayload(accepted.payload)) {
+		// The body outlives the event row by seven days at most — its partition
+		// is dropped well before retention touches the row that points at it.
+		// Nothing to process and nothing a retry would recover.
+		const error =
+			accepted.payload === null ? "payload missing" : "payload unusable";
+		console.error(`[linear/process-delivery] ${error}:`, work.webhookEventId);
+		await markDelivery(work.webhookEventId, "failed", error);
+		return Response.json({ skipped: error });
+	}
+
+	const { status, results } = await processDelivery({
+		payload: accepted.payload,
+		deliveryId: work.deliveryId,
+	});
+
+	if (status === "failed") {
+		const error = results
+			.filter((result) => result.outcome === "failed")
+			.map((result) => `${result.connectionId}: ${result.error}`)
+			.join("; ");
+		await markDelivery(work.webhookEventId, "failed", error);
+		return Response.json({ status, results }, { status: 500 });
+	}
+
+	await markDelivery(
+		work.webhookEventId,
+		status === "no_subscribers" ? "skipped" : "processed",
+	);
+	return Response.json({ status, results });
+}
+
+interface AcceptedDelivery {
+	status: string;
+	payload: unknown;
+}
+
+/**
+ * The delivery's current state and the body recorded with it, in one round
+ * trip.
+ *
+ * `received_at` is webhook_payloads' partition key, so passing it as a
+ * constant makes the body a primary-key lookup inside a single day's
+ * partition. It is cast through timestamptz rather than bound as a date: the
+ * column is a timestamp without a zone holding UTC wall time, and this is what
+ * makes the match independent of whatever timezone the driver would otherwise
+ * serialize a Date in.
+ */
+async function loadAcceptedDelivery(
+	webhookEventId: string,
+	receivedAt: Date,
+): Promise<AcceptedDelivery | null> {
+	const result = await db.execute<{ status: string; payload: unknown }>(sql`
+		SELECT e.status, p.payload
+		FROM ingest.webhook_events e
+		LEFT JOIN ingest.webhook_payloads p
+			ON p.webhook_event_id = e.id
+			AND p.received_at = ${receivedAt.toISOString()}::timestamptz AT TIME ZONE 'UTC'
+		WHERE e.id = ${webhookEventId}
+	`);
+
+	const row = result.rows[0];
+	return row ? { status: row.status, payload: row.payload ?? null } : null;
+}
+
+async function markDelivery(
+	webhookEventId: string,
+	status: "processed" | "skipped" | "failed",
+	error?: string,
+): Promise<void> {
+	await db
+		.update(webhookEvents)
+		.set(
+			status === "failed"
+				? {
+						status,
+						error,
+						retryCount: sql`${webhookEvents.retryCount} + 1`,
+					}
+				: { status, processedAt: new Date(), error: null },
+		)
+		.where(eq(webhookEvents.id, webhookEventId));
+}
+
+/**
+ * The stored body, which is the payload with null characters stripped — the
+ * form Postgres can actually hold, and so the safer of the two to mirror into
+ * task rows.
+ */
+function isLinearPayload(value: unknown): value is LinearWebhookPayload {
+	const payload = value as {
+		organizationId?: unknown;
+		type?: unknown;
+		action?: unknown;
+	} | null;
+	return (
+		typeof payload?.organizationId === "string" &&
+		typeof payload.type === "string" &&
+		typeof payload.action === "string"
+	);
+}

--- a/apps/api/src/app/api/integrations/linear/jobs/process-delivery/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/process-delivery/route.ts
@@ -60,8 +60,14 @@ export async function POST(request: Request): Promise<Response> {
 	}
 
 	// A QStash redelivery of work that already finished, or a Linear retry that
-	// got past both dedup windows.
-	if (accepted.status === "processed" || accepted.status === "skipped") {
+	// got past both dedup windows. `abandoned` is the sweep's give-up state: a
+	// message still arriving for one is a straggler from before it was written
+	// off, and running it would undo the giving up.
+	if (
+		accepted.status === "processed" ||
+		accepted.status === "skipped" ||
+		accepted.status === "abandoned"
+	) {
 		return Response.json({ skipped: `already ${accepted.status}` });
 	}
 

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.test.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.test.ts
@@ -102,3 +102,23 @@ describe("planSweep", () => {
 		);
 	});
 });
+
+describe("planSweep write-back fencing", () => {
+	test("carries the count the row was read at, so the write-back can fence on it", () => {
+		const plan = planSweep([row({ retry_count: 3 })], LIMITS);
+
+		expect(plan.requeue[0]?.observedRetryCount).toBe(3);
+	});
+
+	test("the queue message carries only what the consumer needs", () => {
+		const plan = planSweep([row()], LIMITS);
+		const { observedRetryCount, ...work } = plan.requeue[0] ?? {};
+
+		expect(observedRetryCount).toBe(0);
+		expect(Object.keys(work).sort()).toEqual([
+			"deliveryId",
+			"receivedAt",
+			"webhookEventId",
+		]);
+	});
+});

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.test.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import { type AbandonedRow, planSweep } from "./planSweep";
+
+const LIMITS = { maxAttempts: 5, maxRequeues: 50 };
+const HEADER = "b8c5d0aa-0000-4000-8000-000000000000";
+
+function row(overrides: Partial<AbandonedRow> = {}): AbandonedRow {
+	return {
+		id: "9f1c0a3e-0000-4000-8000-000000000001",
+		event_id: `delivery:h:${HEADER}`,
+		received_at: "2026-09-08 01:53:31.335643",
+		retry_count: 0,
+		...overrides,
+	};
+}
+
+describe("planSweep", () => {
+	test("never re-queues a per-connection row as if it were a delivery", () => {
+		const plan = planSweep(
+			[
+				row({
+					event_id: `11111111-1111-1111-1111-111111111111-${HEADER}`,
+				}),
+			],
+			LIMITS,
+		);
+
+		expect(plan.requeue).toHaveLength(0);
+		expect(plan.unrecognised).toHaveLength(1);
+	});
+
+	test("never re-queues a row recorded before this format existed", () => {
+		const plan = planSweep([row({ event_id: HEADER })], LIMITS);
+
+		expect(plan.requeue).toHaveLength(0);
+		expect(plan.unrecognised).toEqual([HEADER]);
+	});
+
+	test("gives up rather than looping once the attempts are spent", () => {
+		const plan = planSweep([row({ retry_count: 5 })], LIMITS);
+
+		expect(plan.requeue).toHaveLength(0);
+		expect(plan.exhausted).toEqual(["9f1c0a3e-0000-4000-8000-000000000001"]);
+	});
+
+	test("the attempt before the last is still re-queued", () => {
+		const plan = planSweep([row({ retry_count: 4 })], LIMITS);
+
+		expect(plan.requeue).toHaveLength(1);
+		expect(plan.exhausted).toHaveLength(0);
+	});
+
+	test("bounds one run, and the overflow is not silently given up on", () => {
+		const rows = Array.from({ length: 120 }, (_, index) =>
+			row({ id: `id-${index}` }),
+		);
+
+		const plan = planSweep(rows, LIMITS);
+
+		expect(plan.requeue).toHaveLength(50);
+		expect(plan.exhausted).toHaveLength(0);
+		expect(plan.unrecognised).toHaveLength(0);
+	});
+
+	test("the ceiling never crowds out giving up", () => {
+		// Exhausted rows must still be marked even when the re-queue ceiling is
+		// already full, or a poison delivery is never written off.
+		const rows = [
+			...Array.from({ length: 60 }, (_, index) => row({ id: `id-${index}` })),
+			row({ id: "poison", retry_count: 9 }),
+		];
+
+		const plan = planSweep(rows, LIMITS);
+
+		expect(plan.requeue).toHaveLength(50);
+		expect(plan.exhausted).toEqual(["poison"]);
+	});
+
+	test("carries the delivery header through unchanged", () => {
+		const plan = planSweep([row()], LIMITS);
+
+		expect(plan.requeue[0]?.deliveryId).toBe(HEADER);
+	});
+
+	test("a delivery that arrived without a header stays without one", () => {
+		const plan = planSweep(
+			[row({ event_id: "delivery:c:org-1-1757000000000-Issue-issue-1" })],
+			LIMITS,
+		);
+
+		expect(plan.requeue[0]?.deliveryId).toBeNull();
+	});
+
+	test("reads the timestamp back as the UTC instant it was stored as", () => {
+		const plan = planSweep([row()], LIMITS);
+
+		// Microseconds are lost to Date, which is exactly why the consumer matches
+		// the body on the event row rather than on this value.
+		expect(plan.requeue[0]?.receivedAt.toISOString()).toBe(
+			"2026-09-08T01:53:31.335Z",
+		);
+	});
+});

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.ts
@@ -1,0 +1,79 @@
+import { deliveryHeaderFromRow } from "../../webhook/deliveryIds";
+
+/**
+ * One row of the band, as the sweep's query returns it. A type alias rather
+ * than an interface so it carries the implicit index signature `execute`
+ * requires of a row shape.
+ */
+export type AbandonedRow = {
+	id: string;
+	event_id: string;
+	received_at: string | Date;
+	retry_count: number;
+};
+
+export interface SweepPlan {
+	/** Given up on: enough attempts have been spent to stop trying. */
+	exhausted: string[];
+	/** To hand back to QStash, already resolved to what the consumer needs. */
+	requeue: Array<{
+		webhookEventId: string;
+		receivedAt: Date;
+		deliveryId: string | null;
+	}>;
+	/** Rows the band turned up that are not deliveries, which is a bug if > 0. */
+	unrecognised: string[];
+}
+
+/**
+ * Decides what one sweep does with the rows it found: which deliveries are
+ * handed back to QStash, which have had enough and are given up on, and which
+ * are not deliveries at all.
+ *
+ * Separate from the route because this is the part with the rules in it — the
+ * give-up threshold, the per-run ceiling, and the refusal to treat a
+ * per-connection row as a whole delivery — and none of them need a database to
+ * be worth pinning down.
+ */
+export function planSweep(
+	rows: AbandonedRow[],
+	{ maxAttempts, maxRequeues }: { maxAttempts: number; maxRequeues: number },
+): SweepPlan {
+	const plan: SweepPlan = { exhausted: [], requeue: [], unrecognised: [] };
+
+	for (const row of rows) {
+		if (row.retry_count >= maxAttempts) {
+			plan.exhausted.push(row.id);
+			continue;
+		}
+		if (plan.requeue.length >= maxRequeues) continue;
+
+		// A per-connection row cannot reach here — only the row recorded per
+		// delivery carries the prefix the query matches on — but re-queueing one
+		// would fan out a fragment of a delivery, so this refuses rather than
+		// assumes. `undefined` is "not a delivery row"; `null` is the real and
+		// different answer "this delivery arrived without a header".
+		const deliveryId = deliveryHeaderFromRow(row.event_id);
+		if (deliveryId === undefined) {
+			plan.unrecognised.push(row.event_id);
+			continue;
+		}
+
+		plan.requeue.push({
+			webhookEventId: row.id,
+			receivedAt: toDate(row.received_at),
+			deliveryId,
+		});
+	}
+
+	return plan;
+}
+
+/**
+ * The driver hands timestamps back as strings holding UTC wall time, the same
+ * shape `recordWebhookDelivery` parses.
+ */
+function toDate(value: string | Date): Date {
+	if (value instanceof Date) return value;
+	return new Date(`${String(value).replace(" ", "T")}Z`);
+}

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/planSweep.ts
@@ -15,8 +15,15 @@ export type AbandonedRow = {
 export interface SweepPlan {
 	/** Given up on: enough attempts have been spent to stop trying. */
 	exhausted: string[];
-	/** To hand back to QStash, already resolved to what the consumer needs. */
+	/**
+	 * To hand back to QStash, already resolved to what the consumer needs, plus
+	 * the `retry_count` the row was read at. That count is carried so the
+	 * write-back can fence on it: the consumer increments the same column when
+	 * it fails, and an unfenced increment on top of the consumer's would spend
+	 * two of a delivery's attempts for one.
+	 */
 	requeue: Array<{
+		observedRetryCount: number;
 		webhookEventId: string;
 		receivedAt: Date;
 		deliveryId: string | null;
@@ -60,6 +67,7 @@ export function planSweep(
 		}
 
 		plan.requeue.push({
+			observedRetryCount: row.retry_count,
 			webhookEventId: row.id,
 			receivedAt: toDate(row.received_at),
 			deliveryId,

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
@@ -1,5 +1,5 @@
 import { webhookEvents } from "@superset/db/schema";
-import { inArray, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
 
 import { singleFlight } from "@/lib/singleFlight";
 import { verifyQstashRequest } from "@/lib/verifyQstash";
@@ -61,6 +61,18 @@ const MAX_REQUEUES = 50;
  * against `MAX_REQUEUES` so the give-up marking still sees rows past the cap.
  */
 const MAX_ROWS = 500;
+
+/**
+ * Publishes to give up on in a row before abandoning the run.
+ *
+ * Failures here are not row-specific — the message is a fixed-shape pointer, so
+ * a publish fails because QStash is unreachable or refusing, which the next row
+ * will discover too. Without this, an outage costs 50 doomed publishes at two
+ * attempts each, which can outrun `maxDuration` and kill the run before the
+ * write-back below commits — leaving deliveries that *were* published
+ * uncounted, to be published again next run.
+ */
+const MAX_CONSECUTIVE_PUBLISH_FAILURES = 3;
 
 /**
  * Re-queues Linear deliveries that were accepted but never carried through,
@@ -127,9 +139,14 @@ export async function POST(request: Request): Promise<Response> {
 			);
 		}
 
-		// Marked before anything is re-queued, and to a status the sweep does not
-		// select, so a delivery nothing can process stops being carried around the
-		// loop and stays visible as what it is.
+		// Fenced on the state the row was read in, not just its id. A consumer
+		// re-queued by an earlier run can still be mid-flight — it has up to
+		// `maxDuration` 300s — and commit `processed` between the select above and
+		// this update. Writing `abandoned` over that would record the opposite of
+		// what happened, and because `abandoned` is a state the consumer refuses,
+		// it would also buy a duplicate fan-out from the next redelivery. Under
+		// read-committed the predicate is re-checked against the newer row, so the
+		// update simply does not land.
 		if (plan.exhausted.length > 0) {
 			await tx
 				.update(webhookEvents)
@@ -137,33 +154,68 @@ export async function POST(request: Request): Promise<Response> {
 					status: "abandoned",
 					error: `Abandoned after ${MAX_ATTEMPTS} attempts`,
 				})
-				.where(inArray(webhookEvents.id, plan.exhausted));
+				.where(
+					and(
+						inArray(webhookEvents.id, plan.exhausted),
+						inArray(webhookEvents.status, ["pending", "failed"]),
+						gte(webhookEvents.retryCount, MAX_ATTEMPTS),
+					),
+				);
 		}
 
-		const requeued: string[] = [];
+		const requeued: typeof plan.requeue = [];
 		const failed: string[] = [];
-		for (const work of plan.requeue) {
+		let consecutiveFailures = 0;
+		for (const { observedRetryCount, ...work } of plan.requeue) {
 			try {
 				await enqueueLinearDelivery(work);
-				requeued.push(work.webhookEventId);
+				requeued.push({ observedRetryCount, ...work });
+				consecutiveFailures = 0;
 			} catch (error) {
 				// Left exactly as it was, so the next run tries it again. Publishing
 				// before counting the attempt is deliberate: a re-queue that never
 				// happened must not spend one of the delivery's five.
 				console.error("[linear/sweep-abandoned] re-queue failed:", error);
 				failed.push(work.webhookEventId);
+				consecutiveFailures += 1;
+				if (consecutiveFailures >= MAX_CONSECUTIVE_PUBLISH_FAILURES) {
+					console.error(
+						"[linear/sweep-abandoned] giving up this run after",
+						consecutiveFailures,
+						"consecutive publish failures",
+					);
+					break;
+				}
 			}
 		}
 
-		// Counted only for deliveries actually handed back to QStash. The consumer
-		// is idempotent, so the cost of a duplicate is one query per connection
-		// that already finished; the cost of losing count is a delivery that is
-		// retried forever.
-		if (requeued.length > 0) {
+		// Counted only for deliveries actually handed back to QStash, and only
+		// where the row still holds the count it was read at.
+		//
+		// The consumer increments this same column when it marks a delivery
+		// failed, and a consumer started by the first publish of this loop can
+		// finish before the last one returns. Without the fence both increments
+		// land and one re-queue spends two of the delivery's five attempts — so a
+		// delivery gives up early during exactly the incident the attempts exist
+		// for. Grouped by the observed count so this stays one statement per
+		// distinct value, of which there are at most `MAX_ATTEMPTS`.
+		const byObservedCount = new Map<number, string[]>();
+		for (const item of requeued) {
+			const ids = byObservedCount.get(item.observedRetryCount) ?? [];
+			ids.push(item.webhookEventId);
+			byObservedCount.set(item.observedRetryCount, ids);
+		}
+		for (const [observed, ids] of byObservedCount) {
 			await tx
 				.update(webhookEvents)
 				.set({ retryCount: sql`${webhookEvents.retryCount} + 1` })
-				.where(inArray(webhookEvents.id, requeued));
+				.where(
+					and(
+						inArray(webhookEvents.id, ids),
+						inArray(webhookEvents.status, ["pending", "failed"]),
+						eq(webhookEvents.retryCount, observed),
+					),
+				);
 		}
 
 		return {

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
@@ -1,0 +1,186 @@
+import { webhookEvents } from "@superset/db/schema";
+import { inArray, sql } from "drizzle-orm";
+
+import { singleFlight } from "@/lib/singleFlight";
+import { verifyQstashRequest } from "@/lib/verifyQstash";
+import { DELIVERY_PREFIX_LENGTH } from "../../webhook/deliveryIds";
+import { enqueueLinearDelivery } from "../../webhook/queue";
+import { type AbandonedRow, planSweep } from "./planSweep";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export const SWEEP_PATH =
+	"/api/integrations/linear/jobs/sweep-abandoned" as const;
+
+/**
+ * How long a delivery has to sit unfinished before it counts as abandoned
+ * rather than in flight.
+ *
+ * The consumer's own ceiling is `maxDuration = 300`, so five minutes is the
+ * longest a delivery can legitimately be mid-processing, and QStash's three
+ * retries are done well inside the hour. An hour is also where Linear's second
+ * redelivery lands, so its own retry gets first attempt at anything broken and
+ * this is the backstop behind it. Well inside the seven days that
+ * `webhook_payloads` keeps a body, so anything swept can still be read.
+ */
+const ABANDONED_AFTER_MINUTES = 60;
+
+/**
+ * How much of the timeline one run looks at: deliveries received between 75
+ * and 60 minutes ago.
+ *
+ * Fifteen minutes is a measured ceiling, not a guess. The band is the entire
+ * cost of this route, and on production-shaped data fifteen minutes of ingest
+ * is 22.7k rows, 539ms, and sorts in memory. An hour is 89.4k rows, 4.9s, and
+ * spills to disk — too much to run on a schedule for something that finds
+ * nothing almost every time.
+ *
+ * This is a rolling backstop, not a catch-up: a delivery is examined while it
+ * sits in the band and never again. So the band has to stay wider than the
+ * cadence — at every 5 minutes each delivery passes under three runs, and two
+ * can be missed entirely before anything goes unexamined. An outage longer
+ * than that leaves its deliveries to Linear's own redeliveries.
+ */
+const BAND_MINUTES = 15;
+
+/**
+ * Attempts a delivery gets before it is given up on. Counts every attempt the
+ * row has been through, not only this route's: the consumer increments it on
+ * failure and `recordWebhookDelivery` increments it when a Linear redelivery
+ * reopens a failed row. A poison delivery therefore stops being re-queued
+ * within a few sweeps rather than being carried around the loop forever.
+ */
+const MAX_ATTEMPTS = 5;
+
+/** Ceiling on re-queues per run, so one run cannot become the incident. */
+const MAX_REQUEUES = 50;
+
+/**
+ * Anything the band turns up beyond this is left for the next run. Generous
+ * against `MAX_REQUEUES` so the give-up marking still sees rows past the cap.
+ */
+const MAX_ROWS = 500;
+
+/**
+ * Re-queues Linear deliveries that were accepted but never carried through,
+ * and gives up on the ones that have had enough attempts.
+ *
+ * The gap this closes: the webhook route answers Linear the moment a delivery
+ * is durable, and everything after that is QStash's to retry. When QStash
+ * exhausts its retries the message goes to its dead-letter queue and the row
+ * stays `pending` or `failed` with nothing left to pick it up. Linear's own
+ * redeliveries stop after six hours. Without this the delivery is durable,
+ * queryable and permanently unprocessed.
+ *
+ * **Why it reads a time band rather than a status.** The obvious query — Linear
+ * rows that are `pending` or `failed` — measured at 48.7s on production-shaped
+ * data, walking 130k rows and dirtying 311k buffers, and it gets worse as the
+ * backlog grows: a job that costs more than its cadence is exactly what #7114
+ * had to stop happening. `webhook_events` is 137M rows and 101 GB, so the
+ * partial index that would make a status query cheap needs a lock the ingest
+ * path cannot afford. What the table does have is an index on `received_at`,
+ * and a band of it is a bounded amount of work whatever the backlog looks
+ * like: 22.7k rows and 539ms for fifteen minutes of ingest, and it stays that
+ * whether there are no abandoned deliveries or ten thousand.
+ *
+ * The band is read inside `AS MATERIALIZED` on purpose. Without the fence the
+ * planner has three ways to answer this and picks a different one depending on
+ * how the bounds are written and what the statistics look like that day — one
+ * of them being the 48.7s scan. The fence makes `received_at` the only usable
+ * predicate, so the cost is the band and nothing else, permanently.
+ */
+export async function POST(request: Request): Promise<Response> {
+	const body = await request.text();
+	const rejected = await verifyQstashRequest(request, body, SWEEP_PATH);
+	if (rejected) return rejected;
+
+	// One sweep at a time. Two runs overlapping would re-queue the same
+	// deliveries twice, and a run is held open across its QStash publishes, so
+	// the lock also bounds this route to a single connection.
+	const attempt = await singleFlight("linear.sweep-abandoned", async (tx) => {
+		const { rows } = await tx.execute<AbandonedRow>(sql`
+			WITH band AS MATERIALIZED (
+				SELECT id, provider, status, event_id, received_at, retry_count
+				FROM ingest.webhook_events
+				WHERE received_at >= now() - ${`${ABANDONED_AFTER_MINUTES + BAND_MINUTES} minutes`}::interval
+					AND received_at < now() - ${`${ABANDONED_AFTER_MINUTES} minutes`}::interval
+			)
+			SELECT id, event_id, received_at, retry_count
+			FROM band
+			WHERE provider = 'linear'
+				AND status IN ('pending', 'failed')
+				AND left(event_id, ${DELIVERY_PREFIX_LENGTH}) = 'delivery:'
+			ORDER BY received_at
+			LIMIT ${MAX_ROWS}
+		`);
+
+		const plan = planSweep(rows, {
+			maxAttempts: MAX_ATTEMPTS,
+			maxRequeues: MAX_REQUEUES,
+		});
+
+		if (plan.unrecognised.length > 0) {
+			console.error(
+				"[linear/sweep-abandoned] not delivery rows:",
+				plan.unrecognised,
+			);
+		}
+
+		// Marked before anything is re-queued, and to a status the sweep does not
+		// select, so a delivery nothing can process stops being carried around the
+		// loop and stays visible as what it is.
+		if (plan.exhausted.length > 0) {
+			await tx
+				.update(webhookEvents)
+				.set({
+					status: "abandoned",
+					error: `Abandoned after ${MAX_ATTEMPTS} attempts`,
+				})
+				.where(inArray(webhookEvents.id, plan.exhausted));
+		}
+
+		const requeued: string[] = [];
+		const failed: string[] = [];
+		for (const work of plan.requeue) {
+			try {
+				await enqueueLinearDelivery(work);
+				requeued.push(work.webhookEventId);
+			} catch (error) {
+				// Left exactly as it was, so the next run tries it again. Publishing
+				// before counting the attempt is deliberate: a re-queue that never
+				// happened must not spend one of the delivery's five.
+				console.error("[linear/sweep-abandoned] re-queue failed:", error);
+				failed.push(work.webhookEventId);
+			}
+		}
+
+		// Counted only for deliveries actually handed back to QStash. The consumer
+		// is idempotent, so the cost of a duplicate is one query per connection
+		// that already finished; the cost of losing count is a delivery that is
+		// retried forever.
+		if (requeued.length > 0) {
+			await tx
+				.update(webhookEvents)
+				.set({ retryCount: sql`${webhookEvents.retryCount} + 1` })
+				.where(inArray(webhookEvents.id, requeued));
+		}
+
+		return {
+			scanned: rows.length,
+			requeued: requeued.length,
+			abandoned: plan.exhausted.length,
+			failed: failed.length,
+			truncated: rows.length === MAX_ROWS,
+		};
+	});
+
+	// Another run holds the lock. Its band overlaps this one's, so nothing is
+	// skipped by standing down.
+	if (!attempt.ran) return Response.json({ skipped: "already running" });
+
+	if (attempt.result.requeued > 0 || attempt.result.abandoned > 0) {
+		console.log("[linear/sweep-abandoned]", attempt.result);
+	}
+	return Response.json(attempt.result);
+}

--- a/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.test.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	connectionEventId,
+	type DeliveryIdentity,
+	deliveryEventId,
+} from "./deliveryIds";
+
+const CONNECTION = "11111111-1111-1111-1111-111111111111";
+
+function delivery(overrides: Partial<DeliveryIdentity> = {}): DeliveryIdentity {
+	return {
+		organizationId: "org-1",
+		type: "Issue",
+		action: "update",
+		webhookTimestamp: 1_757_000_000_000,
+		data: { id: "issue-1" },
+		...overrides,
+	};
+}
+
+describe("deliveryEventId", () => {
+	test("an empty delivery header is not an id", () => {
+		expect(deliveryEventId(delivery(), "")).toBe(
+			"org-1-1757000000000-Issue-issue-1",
+		);
+	});
+
+	test("bulk edits in the same millisecond do not collide", () => {
+		const first = deliveryEventId(delivery({ data: { id: "issue-1" } }), null);
+		const second = deliveryEventId(delivery({ data: { id: "issue-2" } }), null);
+
+		expect(first).not.toBe(second);
+	});
+
+	test("falls back to the action when the payload names no entity", () => {
+		expect(deliveryEventId(delivery({ data: null }), null)).toBe(
+			"org-1-1757000000000-Issue-update",
+		);
+		expect(deliveryEventId(delivery({ data: {} }), null)).toBe(
+			"org-1-1757000000000-Issue-update",
+		);
+	});
+
+	test("the same delivery to two organizations is one id", () => {
+		const header = "b8c5d0aa-0000-4000-8000-000000000000";
+
+		expect(deliveryEventId(delivery(), header)).toBe(
+			deliveryEventId(delivery({ organizationId: "org-2" }), header),
+		);
+	});
+});
+
+describe("connectionEventId", () => {
+	test("keeps the format per-connection rows were recorded under", () => {
+		const header = "b8c5d0aa-0000-4000-8000-000000000000";
+
+		expect(
+			connectionEventId(CONNECTION, deliveryEventId(delivery(), header)),
+		).toBe(`${CONNECTION}-${header}`);
+		expect(
+			connectionEventId(CONNECTION, deliveryEventId(delivery(), null)),
+		).toBe(`${CONNECTION}-org-1-1757000000000-Issue-issue-1`);
+	});
+
+	test("two connections on one delivery get different rows", () => {
+		const id = deliveryEventId(delivery(), "delivery-1");
+
+		expect(connectionEventId(CONNECTION, id)).not.toBe(
+			connectionEventId("22222222-2222-2222-2222-222222222222", id),
+		);
+	});
+
+	test("a connection row never collides with the delivery row", () => {
+		const id = deliveryEventId(delivery(), "delivery-1");
+
+		expect(connectionEventId(CONNECTION, id)).not.toBe(id);
+	});
+});

--- a/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.test.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import {
 	connectionEventId,
+	DELIVERY_PREFIX_LENGTH,
 	type DeliveryIdentity,
 	deliveryEventId,
+	deliveryHeaderFromRow,
+	deliveryRowEventId,
 } from "./deliveryIds";
 
 const CONNECTION = "11111111-1111-1111-1111-111111111111";
@@ -75,5 +78,70 @@ describe("connectionEventId", () => {
 		const id = deliveryEventId(delivery(), "delivery-1");
 
 		expect(connectionEventId(CONNECTION, id)).not.toBe(id);
+	});
+});
+
+describe("deliveryHeaderFromRow", () => {
+	const header = "b8c5d0aa-0000-4000-8000-000000000000";
+
+	test("refuses a per-connection row, so the sweep cannot re-queue a fragment", () => {
+		const connectionRow = connectionEventId(
+			CONNECTION,
+			deliveryEventId(delivery(), header),
+		);
+
+		expect(deliveryHeaderFromRow(connectionRow)).toBeUndefined();
+	});
+
+	test("refuses a row recorded before this format existed", () => {
+		expect(deliveryHeaderFromRow(header)).toBeUndefined();
+		expect(
+			deliveryHeaderFromRow("org-1-1757000000000-Issue-issue-1"),
+		).toBeUndefined();
+	});
+
+	test("refuses a near miss rather than guessing", () => {
+		expect(deliveryHeaderFromRow("delivery:")).toBeUndefined();
+		expect(deliveryHeaderFromRow("delivery:x:whatever")).toBeUndefined();
+		expect(deliveryHeaderFromRow("Delivery:h:abc")).toBeUndefined();
+	});
+
+	test("round-trips a delivery that carried a header", () => {
+		expect(deliveryHeaderFromRow(deliveryRowEventId(delivery(), header))).toBe(
+			header,
+		);
+	});
+
+	test("round-trips a delivery that carried none, as null and not as a string", () => {
+		const row = deliveryRowEventId(delivery(), null);
+
+		// null and undefined mean different things here: null is "there was no
+		// header", undefined is "this is not a delivery row".
+		expect(deliveryHeaderFromRow(row)).toBeNull();
+	});
+
+	test("re-deriving the queued header reproduces the original ids exactly", () => {
+		for (const original of [header, null]) {
+			const row = deliveryRowEventId(delivery(), original);
+			const recovered = deliveryHeaderFromRow(row) ?? null;
+
+			expect(
+				connectionEventId(CONNECTION, deliveryEventId(delivery(), recovered)),
+			).toBe(
+				connectionEventId(CONNECTION, deliveryEventId(delivery(), original)),
+			);
+		}
+	});
+
+	test("the marker length the sweep matches on covers exactly the prefix", () => {
+		const row = deliveryRowEventId(delivery(), header);
+
+		expect(row.slice(0, DELIVERY_PREFIX_LENGTH)).toBe("delivery:");
+		expect(
+			connectionEventId(CONNECTION, deliveryEventId(delivery(), header)).slice(
+				0,
+				DELIVERY_PREFIX_LENGTH,
+			),
+		).not.toBe("delivery:");
 	});
 });

--- a/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.ts
@@ -1,0 +1,47 @@
+/**
+ * The identity a Linear delivery dedupes on, and the identity of that
+ * delivery's work on one connection.
+ *
+ * Linear's `linear-delivery` header is stable across its retries, which is
+ * what makes it a dedup key. The payload carries no delivery id of its own, so
+ * without the header the organization, send time, entity and action stand in
+ * for one — the timestamp alone collides for bulk edits landing in the same
+ * millisecond.
+ */
+export interface DeliveryIdentity {
+	organizationId: string;
+	type: string;
+	action: string;
+	webhookTimestamp: number;
+	data?: { id?: unknown } | null;
+}
+
+/**
+ * One id per delivery, connection-independent, so the row recorded before the
+ * webhook is acknowledged is the delivery itself rather than a delivery seen
+ * through one subscriber.
+ */
+export function deliveryEventId(
+	payload: DeliveryIdentity,
+	deliveryHeader: string | null,
+): string {
+	if (deliveryHeader) return deliveryHeader;
+	const entityId = payload.data?.id;
+	return `${payload.organizationId}-${payload.webhookTimestamp}-${payload.type}-${entityId ?? payload.action}`;
+}
+
+/**
+ * One row per (delivery × connection) so each subscriber's processing status
+ * is independently retryable: a redelivery re-runs only the connections that
+ * have not finished.
+ *
+ * Deliberately a prefix of `deliveryEventId`, which is the format these ids
+ * have always had — changing it would orphan every in-flight row and let a
+ * redelivery process twice.
+ */
+export function connectionEventId(
+	connectionId: string,
+	deliveryEventId: string,
+): string {
+	return `${connectionId}-${deliveryEventId}`;
+}

--- a/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/deliveryIds.ts
@@ -31,6 +31,52 @@ export function deliveryEventId(
 }
 
 /**
+ * Marks the one row per delivery, as opposed to the per-connection rows that
+ * share the table. The sweep needs to tell them apart — re-queueing a
+ * per-connection row would mean fanning out a fragment of a delivery — and
+ * this is the only thing in the row that distinguishes them.
+ *
+ * The letter after it records whether Linear sent a delivery header, which
+ * cannot be recovered from the id itself: `c` ids are the composite fallback,
+ * whose first field is an organization id, and nothing reliably tells that
+ * shape from a header. The consumer needs the difference, because a delivery
+ * with no header derives its automation-event dedup key differently.
+ */
+const DELIVERY_PREFIX = "delivery:";
+const WITH_HEADER = `${DELIVERY_PREFIX}h:`;
+const WITHOUT_HEADER = `${DELIVERY_PREFIX}c:`;
+
+/** Length of the marker the sweep matches on, kept in step with the prefix. */
+export const DELIVERY_PREFIX_LENGTH = DELIVERY_PREFIX.length;
+
+/** The `event_id` of the row recorded before a delivery is acknowledged. */
+export function deliveryRowEventId(
+	payload: DeliveryIdentity,
+	deliveryHeader: string | null,
+): string {
+	return deliveryHeader
+		? `${WITH_HEADER}${deliveryHeader}`
+		: `${WITHOUT_HEADER}${deliveryEventId(payload, null)}`;
+}
+
+/**
+ * The delivery header a row was recorded with, exactly as the webhook route
+ * had it — `null` where there was none, which is a value the consumer acts on
+ * rather than a failure to parse. Returns `undefined` for anything that is not
+ * a delivery row, so a per-connection row can never be re-queued as if it
+ * were a whole delivery.
+ */
+export function deliveryHeaderFromRow(
+	eventId: string,
+): string | null | undefined {
+	if (eventId.startsWith(WITH_HEADER)) {
+		return eventId.slice(WITH_HEADER.length);
+	}
+	if (eventId.startsWith(WITHOUT_HEADER)) return null;
+	return undefined;
+}
+
+/**
  * One row per (delivery × connection) so each subscriber's processing status
  * is independently retryable: a redelivery re-runs only the connections that
  * have not finished.

--- a/apps/api/src/app/api/integrations/linear/webhook/processDelivery.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/processDelivery.ts
@@ -1,0 +1,441 @@
+import type {
+	EntityWebhookPayloadWithIssueData,
+	LinearWebhookPayload,
+} from "@linear/sdk/webhooks";
+import { db } from "@superset/db/client";
+import type { SelectIntegrationConnection } from "@superset/db/schema";
+import {
+	integrationConnections,
+	members,
+	taskStatuses,
+	tasks,
+	users,
+	webhookEvents,
+} from "@superset/db/schema";
+import {
+	getLinearClient,
+	isLinearAuthError,
+	mapPriorityFromLinear,
+} from "@superset/trpc/integrations/linear";
+import { and, asc, eq, isNull, sql } from "drizzle-orm";
+
+import { ingestAutomationEvent } from "@/lib/automations/ingestAutomationEvent";
+import { recordWebhookDelivery } from "@/lib/ingest/recordWebhookDelivery";
+import { stripNullChars } from "@/lib/strip-null-chars";
+import { connectionEventId, deliveryEventId } from "./deliveryIds";
+import {
+	type LinearDelivery,
+	matchableFrom,
+	normalizeLinearDelivery,
+} from "./normalizeLinearDelivery";
+
+export interface ConnectionResult {
+	connectionId: string;
+	outcome: "processed" | "skipped" | "failed";
+	error?: string;
+}
+
+export interface DeliveryResult {
+	status: "processed" | "no_subscribers" | "failed";
+	results: ConnectionResult[];
+}
+
+/**
+ * Whether any Superset organization is still connected to this Linear
+ * organization.
+ *
+ * The accept path keeps this one indexed lookup so a delivery nobody
+ * subscribes to costs what it always did — a query and nothing else. 317 of
+ * the 1,661 Linear organizations on record have disconnected every one of
+ * their connections, and recording their deliveries instead would start
+ * writing rows and queueing work for traffic no measurement here can see.
+ */
+export async function hasActiveSubscriber(
+	externalOrgId: string,
+): Promise<boolean> {
+	const [subscriber] = await db
+		.select({ id: integrationConnections.id })
+		.from(integrationConnections)
+		.where(
+			and(
+				eq(integrationConnections.externalOrgId, externalOrgId),
+				eq(integrationConnections.provider, "linear"),
+				isNull(integrationConnections.disconnectedAt),
+			),
+		)
+		.limit(1);
+
+	return subscriber !== undefined;
+}
+
+/**
+ * Everything one Linear delivery owes every Superset organization connected to
+ * that Linear organization. Runs off the request path, after the webhook has
+ * been recorded and acknowledged.
+ *
+ * The connections are walked one at a time on purpose. neon-http opens a
+ * connection per query, and a `Promise.all` over 17 connections asked for 17 at
+ * the same instant, every one of them a miss against the proxy's idle pool and
+ * so a permit on the per-compute semaphore that only has 100 with a 10ms
+ * timeout. In sequence they reuse one pooled connection instead. Bounding it
+ * this way was never affordable while Linear was still holding the response
+ * open; it is the whole reason the delivery is acknowledged first.
+ */
+export async function processDelivery({
+	payload,
+	deliveryId,
+}: {
+	payload: LinearWebhookPayload;
+	deliveryId: string | null;
+}): Promise<DeliveryResult> {
+	const connections = await db.query.integrationConnections.findMany({
+		where: and(
+			eq(integrationConnections.externalOrgId, payload.organizationId),
+			eq(integrationConnections.provider, "linear"),
+			isNull(integrationConnections.disconnectedAt),
+		),
+		orderBy: [asc(integrationConnections.id)],
+	});
+
+	if (connections.length === 0) {
+		console.log(
+			"[linear/process-delivery] No active connections for Linear org:",
+			payload.organizationId,
+		);
+		return { status: "no_subscribers", results: [] };
+	}
+
+	// Caught per connection, and the loop runs to the end regardless: one
+	// organization's broken token or missing workflow state must not cost the
+	// other sixteen their delivery.
+	const results: ConnectionResult[] = [];
+	for (const connection of connections) {
+		results.push(
+			await processForConnection(payload, deliveryId, connection).catch(
+				(error) => ({
+					connectionId: connection.id,
+					outcome: "failed" as const,
+					error: errorMessage(error),
+				}),
+			),
+		);
+	}
+
+	const anyFailed = results.some((result) => result.outcome === "failed");
+	if (anyFailed) {
+		console.error("[linear/process-delivery] processing failures:", results);
+	}
+
+	return { status: anyFailed ? "failed" : "processed", results };
+}
+
+async function processForConnection(
+	payload: LinearWebhookPayload,
+	deliveryId: string | null,
+	connection: SelectIntegrationConnection,
+): Promise<ConnectionResult> {
+	// One webhookEvents row per (Linear event × Superset connection) so each
+	// tenant's processing status is independently retryable, and so a retried
+	// delivery only re-runs the connections that have not finished.
+	const eventId = connectionEventId(
+		connection.id,
+		deliveryEventId(payload, deliveryId),
+	);
+
+	const webhookEvent = await recordWebhookDelivery({
+		provider: "linear",
+		eventId,
+		eventType: `${payload.type}.${payload.action}`,
+		payload: stripNullChars(payload),
+	});
+
+	if (!webhookEvent) {
+		return {
+			connectionId: connection.id,
+			outcome: "failed",
+			error: "Failed to store event",
+		};
+	}
+
+	if (webhookEvent.status === "processed") {
+		return { connectionId: connection.id, outcome: "processed" };
+	}
+	if (webhookEvent.status !== "pending") {
+		return { connectionId: connection.id, outcome: "skipped" };
+	}
+
+	// The task mirror and the automation event run independently so a failure
+	// in one never suppresses the other. Either failing marks the row `failed`
+	// so a redelivery re-runs both: the task upsert is idempotent and the
+	// automation event dedupes on delivery id.
+	let outcome: "processed" | "skipped" = "processed";
+	const failures: string[] = [];
+
+	if (payload.type === "Issue") {
+		try {
+			outcome = await processIssueEvent(
+				payload as EntityWebhookPayloadWithIssueData,
+				connection,
+			);
+		} catch (error) {
+			console.error("[linear/process-delivery] task sync failed:", error);
+			failures.push(errorMessage(error));
+		}
+	}
+
+	if (isEntityDelivery(payload)) {
+		try {
+			await ingest(payload, deliveryId, connection, webhookEvent.id);
+		} catch (error) {
+			console.error(
+				"[linear/process-delivery] automation event failed:",
+				error,
+			);
+			failures.push(errorMessage(error));
+		}
+	}
+
+	if (failures.length > 0) {
+		const message = failures.join("; ");
+		await db
+			.update(webhookEvents)
+			.set({
+				status: "failed",
+				error: message,
+				retryCount: webhookEvent.retryCount + 1,
+			})
+			.where(eq(webhookEvents.id, webhookEvent.id));
+		return { connectionId: connection.id, outcome: "failed", error: message };
+	}
+
+	await db
+		.update(webhookEvents)
+		.set({ status: outcome, processedAt: new Date() })
+		.where(eq(webhookEvents.id, webhookEvent.id));
+
+	return { connectionId: connection.id, outcome };
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : "Unknown error";
+}
+
+/** Entity deliveries carry `data`; OAuth and notification payloads do not. */
+function isEntityDelivery(payload: unknown): payload is LinearDelivery {
+	const data = (payload as { data?: { id?: unknown } }).data;
+	return typeof data?.id === "string";
+}
+
+async function ingest(
+	delivery: LinearDelivery,
+	deliveryHeader: string | null,
+	connection: SelectIntegrationConnection,
+	webhookEventId: string,
+): Promise<void> {
+	const event = matchableFrom(delivery);
+	// Nothing in the product names this delivery, so there is nothing to record.
+	if (event.names.length === 0) return;
+
+	// Linear's per-delivery id is stable across its retries. The payload itself
+	// carries no such id, so without the header the entity and send time stand
+	// in for one.
+	const deliveryId =
+		deliveryHeader ??
+		`${delivery.type}:${delivery.data.id}:${delivery.webhookTimestamp}`;
+
+	await ingestAutomationEvent(
+		db,
+		normalizeLinearDelivery({
+			delivery,
+			event,
+			deliveryId,
+			connection,
+			webhookEventId,
+		}),
+	);
+}
+
+// `branchName` is derived by Linear from the identifier + title and is not
+// part of the webhook payload, so it needs its own fetch. Returns null when
+// there is no usable connection or value; transient request failures are
+// rethrown so the webhook-event retry path re-runs the sync instead of
+// recording a processed event with a stale branch.
+async function fetchIssueBranchName(
+	organizationId: string,
+	issueId: string,
+): Promise<string | null> {
+	const client = await getLinearClient(organizationId);
+	if (!client) return null;
+	try {
+		const response = await client.client.request<
+			{ issue: { branchName: string } | null },
+			{ id: string }
+		>(`query IssueBranchName($id: String!) { issue(id: $id) { branchName } }`, {
+			id: issueId,
+		});
+		return response.issue?.branchName || null;
+	} catch (error) {
+		// A broken connection won't heal on retry — sync the rest of the
+		// event without the branch rather than failing it forever.
+		if (isLinearAuthError(error)) {
+			console.warn(
+				`[linear/process-delivery] auth error fetching branchName for issue ${issueId}, skipping branch:`,
+				error,
+			);
+			return null;
+		}
+		throw error;
+	}
+}
+
+async function processIssueEvent(
+	payload: EntityWebhookPayloadWithIssueData,
+	connection: SelectIntegrationConnection,
+): Promise<"processed" | "skipped"> {
+	const issue = payload.data;
+
+	if (payload.action === "create" || payload.action === "update") {
+		const externalUpdatedAt = new Date(issue.updatedAt);
+
+		const [taskStatus, existing] = await Promise.all([
+			db.query.taskStatuses.findFirst({
+				where: and(
+					eq(taskStatuses.organizationId, connection.organizationId),
+					eq(taskStatuses.externalProvider, "linear"),
+					eq(taskStatuses.externalId, issue.state.id),
+				),
+			}),
+			db.query.tasks.findFirst({
+				where: and(
+					eq(tasks.organizationId, connection.organizationId),
+					eq(tasks.externalProvider, "linear"),
+					eq(tasks.externalId, issue.id),
+				),
+				columns: { externalUpdatedAt: true },
+			}),
+		]);
+
+		// Either our own write coming back through Linear, or a redelivery that
+		// a later edit has already overtaken. Applying it would revert whatever
+		// the newer write left behind. Checked here, ahead of the branchName
+		// fetch below, so an echo costs no Linear API call; the upsert's
+		// setWhere is what makes the decision atomic.
+		if (
+			existing?.externalUpdatedAt &&
+			existing.externalUpdatedAt >= externalUpdatedAt
+		) {
+			return "processed";
+		}
+
+		if (!taskStatus) {
+			// TODO(SUPER-237): Handle new workflow states in webhooks by triggering syncWorkflowStates
+			// Currently webhooks silently fail when Linear has new statuses that aren't synced yet.
+			// Should either: (1) trigger workflow state sync and retry, (2) queue for retry, or (3) keep periodic sync only
+			console.warn(
+				`[webhook] Status not found for state ${issue.state.id}, skipping update`,
+			);
+			return "skipped";
+		}
+
+		let assigneeId: string | null = null;
+		if (issue.assignee?.email) {
+			const matchedMember = await db
+				.select({ userId: users.id })
+				.from(users)
+				.innerJoin(members, eq(members.userId, users.id))
+				.where(
+					and(
+						eq(users.email, issue.assignee.email),
+						eq(members.organizationId, connection.organizationId),
+					),
+				)
+				.limit(1)
+				.then((rows) => rows[0]);
+			assigneeId = matchedMember?.userId ?? null;
+		}
+
+		let assigneeExternalId: string | null = null;
+		let assigneeDisplayName: string | null = null;
+		let assigneeAvatarUrl: string | null = null;
+
+		if (issue.assignee && !assigneeId) {
+			assigneeExternalId = issue.assignee.id;
+			assigneeDisplayName = issue.assignee.name ?? null;
+			assigneeAvatarUrl = issue.assignee.avatarUrl ?? null;
+		}
+
+		const branchName = await fetchIssueBranchName(
+			connection.organizationId,
+			issue.id,
+		);
+
+		const taskData = {
+			slug: issue.identifier,
+			title: issue.title,
+			description: issue.description ?? null,
+			statusId: taskStatus.id,
+			priority: mapPriorityFromLinear(issue.priority),
+			assigneeId,
+			assigneeExternalId,
+			assigneeDisplayName,
+			assigneeAvatarUrl,
+			estimate: issue.estimate ?? null,
+			dueDate: issue.dueDate ? new Date(issue.dueDate) : null,
+			labels: issue.labels.map((l) => l.name),
+			...(branchName ? { branch: branchName } : {}),
+			startedAt: issue.startedAt ? new Date(issue.startedAt) : null,
+			completedAt: issue.completedAt ? new Date(issue.completedAt) : null,
+			externalProvider: "linear" as const,
+			externalId: issue.id,
+			externalKey: issue.identifier,
+			externalUrl: issue.url,
+			...(issue.project !== undefined
+				? {
+						externalProjectId: issue.project?.id ?? null,
+						externalProjectName: issue.project?.name ?? null,
+					}
+				: {}),
+			...(issue.cycle !== undefined
+				? {
+						externalCycleId: issue.cycle?.id ?? null,
+						externalCycleName: issue.cycle?.name ?? null,
+					}
+				: {}),
+			externalUpdatedAt,
+			lastSyncedAt: new Date(),
+		};
+
+		await db
+			.insert(tasks)
+			.values({
+				...taskData,
+				organizationId: connection.organizationId,
+				creatorId: connection.connectedByUserId,
+				createdAt: new Date(issue.createdAt),
+			})
+			.onConflictDoUpdate({
+				target: [
+					tasks.organizationId,
+					tasks.externalProvider,
+					tasks.externalId,
+				],
+				set: { ...taskData, syncError: null },
+				// The read above can go stale before this runs, and two deliveries
+				// for one issue can race here.
+				setWhere: sql`${tasks.externalUpdatedAt} IS NULL OR ${tasks.externalUpdatedAt} < excluded.external_updated_at`,
+			});
+	} else if (payload.action === "remove") {
+		await db
+			.update(tasks)
+			.set({ deletedAt: new Date() })
+			.where(
+				and(
+					eq(tasks.organizationId, connection.organizationId),
+					eq(tasks.externalProvider, "linear"),
+					eq(tasks.externalId, issue.id),
+				),
+			);
+	}
+
+	return "processed";
+}

--- a/apps/api/src/app/api/integrations/linear/webhook/queue.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/queue.ts
@@ -1,0 +1,62 @@
+import { Client } from "@upstash/qstash";
+import { z } from "zod";
+
+import { env } from "@/env";
+
+/**
+ * Linear gives a webhook endpoint five seconds, then retries at 1 minute, 1
+ * hour and 6 hours and may disable the webhook outright. One Linear
+ * organization can be connected to many Superset organizations, and the route
+ * used to do every one of their task-mirror and automation writes inline: 17
+ * connections meant ~100 database queries per delivery, ~40 of them at once,
+ * which is what exhausts Neon's per-compute connect permits during a bulk
+ * edit (Sentry API-18) and what put p95 at 15.7s — past Linear's own timeout.
+ *
+ * So the route now does only what proves the delivery is Linear's, records it,
+ * and hands the fan-out to QStash; `jobs/process-delivery` does the rest with
+ * retries and no clock over its head.
+ */
+const qstash = new Client({ token: env.QSTASH_TOKEN, baseUrl: env.QSTASH_URL });
+
+export const PROCESS_PATH =
+	"/api/integrations/linear/jobs/process-delivery" as const;
+const PROCESS_URL = `${env.NEXT_PUBLIC_API_URL}${PROCESS_PATH}`;
+
+/**
+ * A pointer, not the body. The body is already in ingest.webhook_payloads by
+ * the time this is published, and keeping it out of the message means no
+ * delivery can outgrow QStash's message limit — a limit that would otherwise
+ * turn one oversized issue description into a webhook Linear disables.
+ *
+ * `receivedAt` travels with the id because it is the partition key: with it
+ * the consumer's read is a primary-key lookup in one day's partition.
+ */
+export const linearDeliveryWorkSchema = z.object({
+	webhookEventId: z.uuid(),
+	receivedAt: z.coerce.date(),
+	deliveryId: z.string().nullable(),
+});
+export type LinearDeliveryWork = z.infer<typeof linearDeliveryWorkSchema>;
+
+/**
+ * Throws if QStash will not take the message. The caller must not acknowledge
+ * a delivery it has failed to queue: the row is durable but nothing would ever
+ * pick it up, and a webhook lost in silence is worse than one Linear retries.
+ */
+export async function enqueueLinearDelivery(
+	work: LinearDeliveryWork,
+): Promise<void> {
+	// Deliberately no `deduplicationId`. It looks made for this — one id per
+	// delivery — but QStash keeps deduplication ids for 90 days, so once a
+	// message had exhausted its retries the same id would silently swallow
+	// Linear's 1-hour and 6-hour redeliveries of that event: accepted, not
+	// enqueued, 200. The delivery's own row dedupes instead, and it has the
+	// right lifetime — the route queues nothing whose row is already carried
+	// through, and `recordWebhookDelivery` reopens a failed one so a redelivery
+	// is queued again. A duplicate that does get through costs one query.
+	await qstash.publishJSON({
+		url: PROCESS_URL,
+		body: { ...work, receivedAt: work.receivedAt.toISOString() },
+		retries: 3,
+	});
+}

--- a/apps/api/src/app/api/integrations/linear/webhook/queue.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/queue.ts
@@ -16,7 +16,18 @@ import { env } from "@/env";
  * and hands the fan-out to QStash; `jobs/process-delivery` does the rest with
  * retries and no clock over its head.
  */
-const qstash = new Client({ token: env.QSTASH_TOKEN, baseUrl: env.QSTASH_URL });
+const qstash = new Client({
+	token: env.QSTASH_TOKEN,
+	baseUrl: env.QSTASH_URL,
+	// The publish is the one part of accepting a delivery that leaves the
+	// building, and it runs against Linear's five-second clock. The client's
+	// default is five retries backing off by `Math.exp(n) * 50` ms — about 4.3s
+	// of sleeping before it ever throws, which would spend the whole budget on
+	// the path whose only job is to answer quickly. Two attempts: if QStash is
+	// not there, a fast 500 is worth far more than a slow one, because the row
+	// is already durable and Linear's redelivery re-queues it.
+	retry: { retries: 1, backoff: () => 150 },
+});
 
 export const PROCESS_PATH =
 	"/api/integrations/linear/jobs/process-delivery" as const;

--- a/apps/api/src/app/api/integrations/linear/webhook/route.test.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/route.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/env", () => ({
+	env: { LINEAR_WEBHOOK_SECRET: "test-secret" },
+}));
+
+mock.module("@linear/sdk/webhooks", () => ({
+	LINEAR_WEBHOOK_SIGNATURE_HEADER: "linear-signature",
+	LinearWebhookClient: class {
+		parseData(body: Buffer) {
+			return JSON.parse(body.toString());
+		}
+	},
+}));
+
+// Verified as a Hookdeck delivery, which is the path that skips Linear's own
+// signature. What this file is about is what happens after verification.
+mock.module("@/lib/webhooks/hookdeck", () => ({
+	verifyHookdeckDelivery: () => "verified",
+}));
+
+let recorded: {
+	id: string;
+	status: string;
+	retryCount: number;
+	receivedAt: Date;
+} | null = null;
+let recordCalls = 0;
+let recordThrows: Error | null = null;
+mock.module("@/lib/ingest/recordWebhookDelivery", () => ({
+	recordWebhookDelivery: mock(async () => {
+		recordCalls += 1;
+		if (recordThrows) throw recordThrows;
+		return recorded;
+	}),
+}));
+
+let subscribed = true;
+mock.module("./processDelivery", () => ({
+	hasActiveSubscriber: mock(async () => subscribed),
+}));
+
+let enqueued: unknown[] = [];
+let enqueueThrows: Error | null = null;
+mock.module("./queue", () => ({
+	enqueueLinearDelivery: mock(async (work: unknown) => {
+		if (enqueueThrows) throw enqueueThrows;
+		enqueued.push(work);
+	}),
+}));
+
+const { POST } = await import("./route");
+
+const PAYLOAD = {
+	organizationId: "org-1",
+	type: "Issue",
+	action: "update",
+	webhookTimestamp: 1_757_000_000_000,
+	data: { id: "issue-1" },
+};
+
+const RECEIVED_AT = new Date("2026-09-07T10:00:00.123Z");
+
+function request(headers: Record<string, string> = {}): Request {
+	return new Request("http://localhost/api/integrations/linear/webhook", {
+		method: "POST",
+		headers: { "x-hookdeck-signature": "sig", ...headers },
+		body: JSON.stringify(PAYLOAD),
+	});
+}
+
+beforeEach(() => {
+	recorded = {
+		id: "9f1c0a3e-0000-4000-8000-000000000000",
+		status: "pending",
+		retryCount: 0,
+		receivedAt: RECEIVED_AT,
+	};
+	recordCalls = 0;
+	recordThrows = null;
+	subscribed = true;
+	enqueued = [];
+	enqueueThrows = null;
+});
+
+describe("linear webhook acceptance", () => {
+	test("does not acknowledge a delivery it could not record", async () => {
+		recorded = null;
+
+		const response = await POST(request());
+
+		expect(response.status).toBe(500);
+		expect(enqueued).toHaveLength(0);
+	});
+
+	test("does not acknowledge a delivery it could not queue", async () => {
+		enqueueThrows = new Error("qstash unavailable");
+
+		const response = await POST(request());
+
+		expect(response.status).toBe(500);
+		await expect(response.json()).resolves.toMatchObject({
+			error: "Failed to queue delivery",
+		});
+	});
+
+	test("records before queueing, and queues a pointer to the recorded row", async () => {
+		const response = await POST(request({ "linear-delivery": "delivery-1" }));
+
+		expect(response.status).toBe(200);
+		expect(recordCalls).toBe(1);
+		expect(enqueued).toEqual([
+			{
+				webhookEventId: "9f1c0a3e-0000-4000-8000-000000000000",
+				receivedAt: RECEIVED_AT,
+				deliveryId: "delivery-1",
+			},
+		]);
+	});
+
+	test("a delivery already carried through is not queued again", async () => {
+		recorded = {
+			id: "9f1c0a3e-0000-4000-8000-000000000000",
+			status: "processed",
+			retryCount: 0,
+			receivedAt: RECEIVED_AT,
+		};
+
+		const response = await POST(request({ "linear-delivery": "delivery-1" }));
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			status: "processed",
+		});
+		expect(enqueued).toHaveLength(0);
+	});
+
+	test("acknowledges without the delivery header, keyed on the payload", async () => {
+		const response = await POST(request());
+
+		expect(response.status).toBe(200);
+		expect(enqueued).toHaveLength(1);
+		expect(enqueued[0]).toMatchObject({ deliveryId: null });
+	});
+
+	test("a delivery nobody subscribes to is neither recorded nor queued", async () => {
+		subscribed = false;
+
+		const response = await POST(request({ "linear-delivery": "delivery-1" }));
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			status: "no_subscribers",
+		});
+		expect(recordCalls).toBe(0);
+		expect(enqueued).toHaveLength(0);
+	});
+
+	test("a malformed body is rejected before anything is recorded", async () => {
+		const response = await POST(
+			new Request("http://localhost/api/integrations/linear/webhook", {
+				method: "POST",
+				headers: { "x-hookdeck-signature": "sig" },
+				body: "{not json",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(recordCalls).toBe(0);
+		expect(enqueued).toHaveLength(0);
+	});
+});

--- a/apps/api/src/app/api/integrations/linear/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/route.ts
@@ -8,7 +8,7 @@ import { env } from "@/env";
 import { recordWebhookDelivery } from "@/lib/ingest/recordWebhookDelivery";
 import { stripNullChars } from "@/lib/strip-null-chars";
 import { verifyHookdeckDelivery } from "@/lib/webhooks/hookdeck";
-import { deliveryEventId } from "./deliveryIds";
+import { deliveryRowEventId } from "./deliveryIds";
 import { hasActiveSubscriber } from "./processDelivery";
 import { enqueueLinearDelivery } from "./queue";
 
@@ -77,7 +77,7 @@ export async function POST(request: Request) {
 	}
 
 	const deliveryId = request.headers.get("linear-delivery");
-	const eventId = deliveryEventId(payload, deliveryId);
+	const eventId = deliveryRowEventId(payload, deliveryId);
 
 	const accepted = await recordWebhookDelivery({
 		provider: "linear",

--- a/apps/api/src/app/api/integrations/linear/webhook/route.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/route.ts
@@ -1,40 +1,34 @@
-import type {
-	EntityWebhookPayloadWithIssueData,
-	LinearWebhookPayload,
-} from "@linear/sdk/webhooks";
+import type { LinearWebhookPayload } from "@linear/sdk/webhooks";
 import {
 	LINEAR_WEBHOOK_SIGNATURE_HEADER,
 	LinearWebhookClient,
 } from "@linear/sdk/webhooks";
-import { db } from "@superset/db/client";
-import type { SelectIntegrationConnection } from "@superset/db/schema";
-import {
-	integrationConnections,
-	members,
-	taskStatuses,
-	tasks,
-	users,
-	webhookEvents,
-} from "@superset/db/schema";
-import {
-	getLinearClient,
-	isLinearAuthError,
-	mapPriorityFromLinear,
-} from "@superset/trpc/integrations/linear";
-import { and, asc, eq, isNull, sql } from "drizzle-orm";
+
 import { env } from "@/env";
-import { ingestAutomationEvent } from "@/lib/automations/ingestAutomationEvent";
 import { recordWebhookDelivery } from "@/lib/ingest/recordWebhookDelivery";
 import { stripNullChars } from "@/lib/strip-null-chars";
 import { verifyHookdeckDelivery } from "@/lib/webhooks/hookdeck";
-import {
-	type LinearDelivery,
-	matchableFrom,
-	normalizeLinearDelivery,
-} from "./normalizeLinearDelivery";
+import { deliveryEventId } from "./deliveryIds";
+import { hasActiveSubscriber } from "./processDelivery";
+import { enqueueLinearDelivery } from "./queue";
 
 const webhookClient = new LinearWebhookClient(env.LINEAR_WEBHOOK_SECRET);
 
+/**
+ * Accepts a Linear delivery and does no work on it.
+ *
+ * The route proves the delivery is Linear's, checks somebody is still
+ * subscribed, writes it — identity and body, one round trip — and hands the
+ * fan-out to QStash. Everything a delivery owes the organizations connected to
+ * it happens in `jobs/process-delivery`. Two indexed queries and a publish,
+ * where this used to run every connected organization's task-mirror and
+ * automation writes inline.
+ *
+ * The order is the contract: nothing is acknowledged before it is durable, and
+ * nothing is acknowledged that has not been queued. A delivery recorded but not
+ * queued gets a 500 so Linear retries it, because a row nothing will ever pick
+ * up is a webhook lost in silence.
+ */
 export async function POST(request: Request) {
 	const body = await request.text();
 
@@ -70,18 +64,11 @@ export async function POST(request: Request) {
 			return Response.json({ error: "Invalid signature" }, { status: 401 });
 		}
 	}
-	const deliveryId = request.headers.get("linear-delivery");
 
-	const connections = await db.query.integrationConnections.findMany({
-		where: and(
-			eq(integrationConnections.externalOrgId, payload.organizationId),
-			eq(integrationConnections.provider, "linear"),
-			isNull(integrationConnections.disconnectedAt),
-		),
-		orderBy: [asc(integrationConnections.id)],
-	});
-
-	if (connections.length === 0) {
+	// Deliveries for a Linear organization that has disconnected are dropped
+	// here rather than recorded and queued, which is what the route has always
+	// done with them.
+	if (!(await hasActiveSubscriber(payload.organizationId))) {
 		console.log(
 			"[linear/webhook] No active connections for Linear org:",
 			payload.organizationId,
@@ -89,32 +76,43 @@ export async function POST(request: Request) {
 		return Response.json({ success: true, status: "no_subscribers" });
 	}
 
-	const results = await Promise.all(
-		connections.map((connection) =>
-			processForConnection(payload, deliveryId, connection).catch((error) => ({
-				connectionId: connection.id,
-				outcome: "failed" as const,
-				error: error instanceof Error ? error.message : "Unknown error",
-			})),
-		),
-	);
+	const deliveryId = request.headers.get("linear-delivery");
+	const eventId = deliveryEventId(payload, deliveryId);
 
-	const anyFailed = results.some((r) => r.outcome === "failed");
-	const allFailed = results.every((r) => r.outcome === "failed");
-	if (anyFailed) {
-		console.error("[linear/webhook] processing failures:", results);
+	const accepted = await recordWebhookDelivery({
+		provider: "linear",
+		eventId,
+		eventType: `${payload.type}.${payload.action}`,
+		payload: stripNullChars(payload),
+	});
+
+	if (!accepted) {
+		return Response.json({ error: "Failed to store event" }, { status: 500 });
 	}
-	return Response.json(
-		{
-			success: !allFailed,
-			status: allFailed
-				? "failed"
-				: anyFailed
-					? "partial_failure"
-					: "processed",
-		},
-		{ status: allFailed ? 500 : 200 },
-	);
+
+	// A delivery already carried through, or one deliberately not carried
+	// through. `recordWebhookDelivery` resets a failed row to pending, so a
+	// redelivery of something that broke is queued again rather than landing
+	// here.
+	if (accepted.status !== "pending") {
+		return Response.json({ success: true, status: accepted.status });
+	}
+
+	try {
+		await enqueueLinearDelivery({
+			webhookEventId: accepted.id,
+			receivedAt: accepted.receivedAt,
+			deliveryId,
+		});
+	} catch (error) {
+		console.error("[linear/webhook] failed to queue delivery:", error);
+		return Response.json(
+			{ error: "Failed to queue delivery" },
+			{ status: 500 },
+		);
+	}
+
+	return Response.json({ success: true, status: "accepted" });
 }
 
 // The SDK only enforces Linear's ±60s replay window when handed the
@@ -131,317 +129,4 @@ function parseVerifiedPayload(
 		signature,
 		typeof webhookTimestamp === "number" ? webhookTimestamp : undefined,
 	);
-}
-
-async function processForConnection(
-	payload: LinearWebhookPayload,
-	deliveryId: string | null,
-	connection: SelectIntegrationConnection,
-): Promise<{
-	connectionId: string;
-	outcome: "processed" | "skipped" | "failed";
-	error?: string;
-}> {
-	// One webhookEvents row per (Linear event × Superset connection) so each
-	// tenant's processing status is independently retryable. Linear's delivery
-	// id is stable across its retries; without the header, the timestamp alone
-	// collides for bulk edits landing in the same millisecond.
-	const entityId = (payload as { data?: { id?: unknown } }).data?.id;
-	const eventId = deliveryId
-		? `${connection.id}-${deliveryId}`
-		: `${connection.id}-${payload.organizationId}-${payload.webhookTimestamp}-${payload.type}-${entityId ?? payload.action}`;
-
-	const webhookEvent = await recordWebhookDelivery({
-		provider: "linear",
-		eventId,
-		eventType: `${payload.type}.${payload.action}`,
-		payload: stripNullChars(payload),
-	});
-
-	if (!webhookEvent) {
-		return {
-			connectionId: connection.id,
-			outcome: "failed",
-			error: "Failed to store event",
-		};
-	}
-
-	if (webhookEvent.status === "processed") {
-		return { connectionId: connection.id, outcome: "processed" };
-	}
-	if (webhookEvent.status !== "pending") {
-		return { connectionId: connection.id, outcome: "skipped" };
-	}
-
-	// The task mirror and the automation event run independently so a failure
-	// in one never suppresses the other. Either failing marks the row `failed`
-	// so a redelivery re-runs both: the task upsert is idempotent and the
-	// automation event dedupes on delivery id.
-	let outcome: "processed" | "skipped" = "processed";
-	const failures: string[] = [];
-
-	if (payload.type === "Issue") {
-		try {
-			outcome = await processIssueEvent(
-				payload as EntityWebhookPayloadWithIssueData,
-				connection,
-			);
-		} catch (error) {
-			console.error("[linear/webhook] task sync failed:", error);
-			failures.push(errorMessage(error));
-		}
-	}
-
-	if (isEntityDelivery(payload)) {
-		try {
-			await ingest(payload, deliveryId, connection, webhookEvent.id);
-		} catch (error) {
-			console.error("[linear/webhook] automation event failed:", error);
-			failures.push(errorMessage(error));
-		}
-	}
-
-	if (failures.length > 0) {
-		const message = failures.join("; ");
-		await db
-			.update(webhookEvents)
-			.set({
-				status: "failed",
-				error: message,
-				retryCount: webhookEvent.retryCount + 1,
-			})
-			.where(eq(webhookEvents.id, webhookEvent.id));
-		return { connectionId: connection.id, outcome: "failed", error: message };
-	}
-
-	await db
-		.update(webhookEvents)
-		.set({ status: outcome, processedAt: new Date() })
-		.where(eq(webhookEvents.id, webhookEvent.id));
-
-	return { connectionId: connection.id, outcome };
-}
-
-function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : "Unknown error";
-}
-
-/** Entity deliveries carry `data`; OAuth and notification payloads do not. */
-function isEntityDelivery(payload: unknown): payload is LinearDelivery {
-	const data = (payload as { data?: { id?: unknown } }).data;
-	return typeof data?.id === "string";
-}
-
-async function ingest(
-	delivery: LinearDelivery,
-	deliveryHeader: string | null,
-	connection: SelectIntegrationConnection,
-	webhookEventId: string,
-): Promise<void> {
-	const event = matchableFrom(delivery);
-	// Nothing in the product names this delivery, so there is nothing to record.
-	if (event.names.length === 0) return;
-
-	// Linear's per-delivery id is stable across its retries. The payload itself
-	// carries no such id, so without the header the entity and send time stand
-	// in for one.
-	const deliveryId =
-		deliveryHeader ??
-		`${delivery.type}:${delivery.data.id}:${delivery.webhookTimestamp}`;
-
-	await ingestAutomationEvent(
-		db,
-		normalizeLinearDelivery({
-			delivery,
-			event,
-			deliveryId,
-			connection,
-			webhookEventId,
-		}),
-	);
-}
-
-// `branchName` is derived by Linear from the identifier + title and is not
-// part of the webhook payload, so it needs its own fetch. Returns null when
-// there is no usable connection or value; transient request failures are
-// rethrown so the webhook-event retry path re-runs the sync instead of
-// recording a processed event with a stale branch.
-async function fetchIssueBranchName(
-	organizationId: string,
-	issueId: string,
-): Promise<string | null> {
-	const client = await getLinearClient(organizationId);
-	if (!client) return null;
-	try {
-		const response = await client.client.request<
-			{ issue: { branchName: string } | null },
-			{ id: string }
-		>(`query IssueBranchName($id: String!) { issue(id: $id) { branchName } }`, {
-			id: issueId,
-		});
-		return response.issue?.branchName || null;
-	} catch (error) {
-		// A broken connection won't heal on retry — sync the rest of the
-		// event without the branch rather than failing it forever.
-		if (isLinearAuthError(error)) {
-			console.warn(
-				`[linear/webhook] auth error fetching branchName for issue ${issueId}, skipping branch:`,
-				error,
-			);
-			return null;
-		}
-		throw error;
-	}
-}
-
-async function processIssueEvent(
-	payload: EntityWebhookPayloadWithIssueData,
-	connection: SelectIntegrationConnection,
-): Promise<"processed" | "skipped"> {
-	const issue = payload.data;
-
-	if (payload.action === "create" || payload.action === "update") {
-		const externalUpdatedAt = new Date(issue.updatedAt);
-
-		const [taskStatus, existing] = await Promise.all([
-			db.query.taskStatuses.findFirst({
-				where: and(
-					eq(taskStatuses.organizationId, connection.organizationId),
-					eq(taskStatuses.externalProvider, "linear"),
-					eq(taskStatuses.externalId, issue.state.id),
-				),
-			}),
-			db.query.tasks.findFirst({
-				where: and(
-					eq(tasks.organizationId, connection.organizationId),
-					eq(tasks.externalProvider, "linear"),
-					eq(tasks.externalId, issue.id),
-				),
-				columns: { externalUpdatedAt: true },
-			}),
-		]);
-
-		// Either our own write coming back through Linear, or a redelivery that
-		// a later edit has already overtaken. Applying it would revert whatever
-		// the newer write left behind. Checked here, ahead of the branchName
-		// fetch below, so an echo costs no Linear API call; the upsert's
-		// setWhere is what makes the decision atomic.
-		if (
-			existing?.externalUpdatedAt &&
-			existing.externalUpdatedAt >= externalUpdatedAt
-		) {
-			return "processed";
-		}
-
-		if (!taskStatus) {
-			// TODO(SUPER-237): Handle new workflow states in webhooks by triggering syncWorkflowStates
-			// Currently webhooks silently fail when Linear has new statuses that aren't synced yet.
-			// Should either: (1) trigger workflow state sync and retry, (2) queue for retry, or (3) keep periodic sync only
-			console.warn(
-				`[webhook] Status not found for state ${issue.state.id}, skipping update`,
-			);
-			return "skipped";
-		}
-
-		let assigneeId: string | null = null;
-		if (issue.assignee?.email) {
-			const matchedMember = await db
-				.select({ userId: users.id })
-				.from(users)
-				.innerJoin(members, eq(members.userId, users.id))
-				.where(
-					and(
-						eq(users.email, issue.assignee.email),
-						eq(members.organizationId, connection.organizationId),
-					),
-				)
-				.limit(1)
-				.then((rows) => rows[0]);
-			assigneeId = matchedMember?.userId ?? null;
-		}
-
-		let assigneeExternalId: string | null = null;
-		let assigneeDisplayName: string | null = null;
-		let assigneeAvatarUrl: string | null = null;
-
-		if (issue.assignee && !assigneeId) {
-			assigneeExternalId = issue.assignee.id;
-			assigneeDisplayName = issue.assignee.name ?? null;
-			assigneeAvatarUrl = issue.assignee.avatarUrl ?? null;
-		}
-
-		const branchName = await fetchIssueBranchName(
-			connection.organizationId,
-			issue.id,
-		);
-
-		const taskData = {
-			slug: issue.identifier,
-			title: issue.title,
-			description: issue.description ?? null,
-			statusId: taskStatus.id,
-			priority: mapPriorityFromLinear(issue.priority),
-			assigneeId,
-			assigneeExternalId,
-			assigneeDisplayName,
-			assigneeAvatarUrl,
-			estimate: issue.estimate ?? null,
-			dueDate: issue.dueDate ? new Date(issue.dueDate) : null,
-			labels: issue.labels.map((l) => l.name),
-			...(branchName ? { branch: branchName } : {}),
-			startedAt: issue.startedAt ? new Date(issue.startedAt) : null,
-			completedAt: issue.completedAt ? new Date(issue.completedAt) : null,
-			externalProvider: "linear" as const,
-			externalId: issue.id,
-			externalKey: issue.identifier,
-			externalUrl: issue.url,
-			...(issue.project !== undefined
-				? {
-						externalProjectId: issue.project?.id ?? null,
-						externalProjectName: issue.project?.name ?? null,
-					}
-				: {}),
-			...(issue.cycle !== undefined
-				? {
-						externalCycleId: issue.cycle?.id ?? null,
-						externalCycleName: issue.cycle?.name ?? null,
-					}
-				: {}),
-			externalUpdatedAt,
-			lastSyncedAt: new Date(),
-		};
-
-		await db
-			.insert(tasks)
-			.values({
-				...taskData,
-				organizationId: connection.organizationId,
-				creatorId: connection.connectedByUserId,
-				createdAt: new Date(issue.createdAt),
-			})
-			.onConflictDoUpdate({
-				target: [
-					tasks.organizationId,
-					tasks.externalProvider,
-					tasks.externalId,
-				],
-				set: { ...taskData, syncError: null },
-				// The read above can go stale before this runs, and two deliveries
-				// for one issue can race here.
-				setWhere: sql`${tasks.externalUpdatedAt} IS NULL OR ${tasks.externalUpdatedAt} < excluded.external_updated_at`,
-			});
-	} else if (payload.action === "remove") {
-		await db
-			.update(tasks)
-			.set({ deletedAt: new Date() })
-			.where(
-				and(
-					eq(tasks.organizationId, connection.organizationId),
-					eq(tasks.externalProvider, "linear"),
-					eq(tasks.externalId, issue.id),
-				),
-			);
-	}
-
-	return "processed";
 }

--- a/packages/db/src/schema/ingest.ts
+++ b/packages/db/src/schema/ingest.ts
@@ -35,7 +35,7 @@ export const webhookEvents = ingestSchema.table(
 		eventType: text("event_type"),
 
 		// Processing state
-		status: text().notNull().default("pending"), // pending | processed | failed | skipped
+		status: text().notNull().default("pending"), // pending | processed | failed | skipped | abandoned
 		processedAt: timestamp("processed_at"),
 		error: text(),
 		retryCount: integer("retry_count").notNull().default(0),


### PR DESCRIPTION
## Problem

Sentry API-18, `Failed to acquire permit to connect`, on the Linear webhook route. It survived #7114, which fixed the *scheduled* jobs stacking; this is the ingest path itself.

The route fanned out inline: `Promise.all` over every `integration_connection` for the delivering Linear organization, each one doing its own `recordWebhookDelivery`, task-status and task lookups, an assignee join, a Linear API call and a task upsert, plus an automation event.

Measured on a copy of production for this change:

- one Linear organization is connected to **17** Superset organizations (`max` over `integration_connections` grouped by `external_org_id`), so a single delivery issued ~100 neon-http queries, ~40 concurrently;
- **1,344** Linear organizations have at least one active connection; **317** have disconnected all of theirs.

From the earlier investigation on the same data: a bulk edit produced 3,501 deliveries in 8 minutes (~15k route invocations in 10 minutes), route p50 0.9s, **p95 15.7s, max 33s** — against Linear's **5 second** timeout, after which it retries at 1 minute / 1 hour / 6 hours and may disable the webhook outright.

## Root cause

Two things compounding, and only one of them is the fan-out being wide.

neon-http sends one HTTPS request per query. A query whose connection misses the proxy's idle pool has to open a compute connection, and that needs a permit from a per-compute semaphore — `permits=100`, `timeout=10ms`. `Promise.all` over 17 connections asks for 17 connections *at the same instant*, every one of them a pool miss. That is what exhausts the permits.

The obvious fix — bound the fan-out concurrency — was not available, because the route was holding Linear's response open the whole time and p95 was already three times Linear's timeout. Serializing would have traded 500s for dropped deliveries.

So the ordering had to change before the concurrency could.

## Fix

The route accepts and does not work.

**`webhook/route.ts`** verifies the delivery, checks somebody is still subscribed, records the delivery **once** — identity in `ingest.webhook_events`, body in `ingest.webhook_payloads`, one round trip — and publishes a pointer to QStash. Two indexed queries and a publish. This is the ack-then-process shape the api already runs for Slack events and Microsoft Teams notifications, both of which have the same kind of clock over them.

**`jobs/process-delivery/route.ts`** does the work QStash hands back, with no clock over it. It walks the connections **one at a time**, so they reuse one pooled connection rather than asking for seventeen at once. Each connection is caught individually and the loop runs to the end, so one organization's broken token cannot cost the other sixteen their delivery.

The queue message is a pointer (`webhookEventId`, `receivedAt`, `deliveryId`), not the body, so no oversized issue description can outgrow a QStash message limit and turn into a webhook Linear disables. The consumer reads the body back in the same round trip as the delivery's status: exactness comes from the event row's own `received_at`, and the *day* is passed as constant bounds so the planner prunes `webhook_payloads` to the single partition the body is in.

Per-connection `webhook_events` rows are unchanged, ids included (`deliveryIds.ts` reproduces the existing format exactly, so no in-flight row is orphaned). They are what makes a retry cheap: only the organizations that have not finished do any work the second time.

**The ordering is the contract.** Nothing is acknowledged before it is durable, and nothing is acknowledged that has not been queued — a delivery recorded but not queued answers 500 so Linear retries it, because a row nothing will ever pick up is a webhook lost in silence.

### What happens on a cold start

Nothing is lost, and this is the reason the work goes to QStash rather than `after()` / `waitUntil`. The handoff between accepting a delivery and processing it is a durable row plus a queued message, both outside the process. No in-memory queue, no timer, no post-response continuation. An instance that is recycled, killed or cold the moment after it answers Linear is carrying no state that mattered. A cold start is also now strictly cheaper on the request path than it was: module init, two indexed queries and a publish, where it used to be module init and the entire fan-out.

### What happens on a duplicate delivery

`recordWebhookDelivery` dedupes on `(provider, event_id)` as it always has, and the route queues nothing whose row is not `pending` — a redelivery of something already carried through is a single query and a 200.

There is deliberately **no** QStash `deduplicationId`, despite the shape fitting. QStash keeps deduplication ids for 90 days, so once a message had exhausted its retries the same id would silently swallow Linear's 1-hour and 6-hour redeliveries of that event: accepted, not enqueued, 200. The delivery's own row dedupes instead and has the right lifetime, since `recordWebhookDelivery` reopens a `failed` row so a redelivery *is* queued again. A duplicate that does get through costs one query in the consumer, which returns early on an already-processed row.

### What happens if the deferred work fails

- **A connection fails.** The other connections still run. The consumer marks the delivery `failed` and answers 500, so QStash retries; the per-connection rows mean only the unfinished organizations repeat any work.
- **QStash exhausts its 3 retries.** The message lands in QStash's DLQ and the row stays `failed` with the per-connection errors on it. Linear's own 1-hour and 6-hour redeliveries then reopen the row and queue it again — which works only because there is no deduplication id.
- **Both give up.** `jobs/sweep-abandoned` picks the delivery back up an hour after it arrived and hands it to QStash again — see below. After five attempts it is marked `abandoned` and left alone, durable and queryable with the reason on the row.
- **The body is gone** (its partition is dropped at 7 days, well before the row's 30): the consumer marks it `failed` and answers 200 rather than retrying something no retry can recover.

## Deliberately not in this change

- **No Cloudflare Queues.** This is the api-only step: the split between accepting a delivery and processing it, with an idempotent consumer, is the part the ratified plan needs either way. When the queue arrives it replaces `enqueueLinearDelivery` and calls the same `processDelivery`.
- **No new env vars** — `QSTASH_TOKEN`/`QSTASH_URL` are already required by the api's env schema and used by the other job routes. The sweep does need a QStash schedule created, which is the one thing outside the repo; see **Before this works on a schedule**.
- **No retry loop** anywhere around the failing query.
- **GitHub's route is untouched**, though it shows the same permit errors at lower volume. It already records once per delivery; it does not fan out per connection, so it is a different fix.
- **The per-connection rows still each store a copy of the body.** That predates this change (17 copies per delivery); the accepted delivery now adds an 18th. Storing it once is worth doing and belongs with the plan's "bodies stored once", not here.
- **Deliveries nobody subscribes to are still dropped without a record**, exactly as before — the one 200 that persists nothing, and it carries no work to lose. 317 Linear organizations have disconnected everything, and recording them would start writing rows and queueing work for traffic no measurement here can see.

## The sweep

`jobs/sweep-abandoned` re-queues deliveries that were accepted but never carried through, and gives up on the ones that have had enough.

**It reads a time band, not a status.** The obvious query — Linear rows that are `pending` or `failed` — I measured on production-shaped data before writing it:

| access path | cost | grows with |
| --- | --- | --- |
| `(provider, status)` | **48.7s**, 130k rows, 311k buffers dirtied | the pending/failed backlog |
| `(provider, event_id)` prefix | one entry per delivery in retention — millions | all deliveries ever |
| bitmap `AND` of both | 293ms, but walks 222k index entries | the backlog |
| **band of `received_at`** | **539ms, 22.7k rows, sorts in memory** | 15 minutes of ingest, nothing else |

A job that costs more than its cadence is precisely what #7114 had to stop happening, so the first one is not an option. The partial index that would make a status query cheap needs an `ACCESS EXCLUSIVE` lock on a 137M-row, 101 GB table on the hottest write path — the same index #7114 declined for the same reason — so this PR does not add one either. Only the band has a cost that does not move when the backlog does.

The band is read inside `AS MATERIALIZED` deliberately. Without the fence the planner has three ways to answer this and chooses between them on how the bounds are written and that day's statistics — one of the three being the 48.7s scan. The fence makes `received_at` the only usable predicate, so the cost is the band, permanently.

**Sixty minutes is the abandonment age.** Longer than the consumer's own `maxDuration = 300`, so nothing merely slow is swept; past QStash's three retries; and level with Linear's second redelivery, so Linear's own retry gets first attempt and this sits behind it. Far inside the seven days `webhook_payloads` keeps a body, so anything swept can still be read.

**Fifteen minutes is the band**, because that is what the measurement allows: an hour is 89.4k rows, 4.9s, and spills to disk. That makes this a rolling backstop rather than a catch-up — a delivery is examined while it sits in the band and never again — so the band has to stay wider than the cadence. At every 5 minutes each delivery passes under three runs and two can be missed before anything goes unexamined; a longer outage leaves its deliveries to Linear's redeliveries.

**Bounds.** `singleFlight` (the advisory lock from #7114) keeps one run at a time, and the run is held across its publishes so the route is one connection. At most 500 rows are read and 50 re-queued per run; the rest wait. A run also stops after three consecutive publish failures — a failure here is not row-specific, so 50 doomed publishes at two attempts each can outrun `maxDuration` and kill the run before the write-back commits, leaving deliveries that *were* published uncounted and published again next run.

**Both write-backs are fenced on the state the row was read in, not just its id.** A consumer re-queued by an earlier run can still be mid-flight — it has up to its own 300s ceiling — and commit while the sweep is working. So the abandonment update carries the status and attempt-count conditions it selected on: writing `abandoned` over a consumer's completed result would record the opposite of what happened, and since `abandoned` is a state the consumer refuses, it would also buy a duplicate fan-out from the next redelivery.

The attempt-count update needed more than that same status fence. The consumer increments `retry_count` when it marks a delivery failed, and a consumer started by the first publish of a run can finish before the last publish returns — `failed` is inside the status fence, so both increments would land and one re-queue would spend two of the delivery's five attempts. That makes the give-up fire early during exactly the incident the attempts exist for, which is a delivery-loss direction. It is therefore fenced on the count the row was read at as well, grouped by that value so it stays one statement per distinct count.

**Ordering: publish, then count.** A publish that failed does not spend one of the delivery's five. The opposite ordering is cheaper to write and loses deliveries, and a duplicate costs one query per already-finished connection.

That ordering has a cost, and it is worth naming rather than leaving implied. The band is read `ORDER BY received_at` with a ceiling of 50 re-queues, and a failed publish deliberately leaves the row untouched — so **a partial but persistent publish failure starves the tail of the band**: the same oldest rows sit at the head across all three runs a delivery gets, and rows behind them age out of the band unexamined. This is distinct from the outage case above, and it is not covered by "leaves its deliveries to Linear's own redeliveries" being about downtime.

It is accepted rather than fixed, for three reasons. The message is a fixed-shape pointer, so there is no row-specific reason for a publish to fail — 50 consecutive failures means QStash is unreachable, refusing or rate-limiting, and in that state no row can be re-queued whichever ones are picked, so the blocking loses nothing that was not already lost. The deliveries are not lost meanwhile: Linear's redeliveries at 1 minute, 1 hour and 6 hours reopen the row through `recordWebhookDelivery`, and the band sits at 60–75 minutes, so a starved delivery still has the 6-hour attempt ahead of it. And the obvious fix — a persisted recovery cursor — is worse in the case it is meant to help: the band's starvation is self-limiting at fifteen minutes, where a cursor parked on a row that keeps failing blocks everything behind it indefinitely unless it is aged, at which point it is the band again with durable state added to a route whose entire cost argument is that it holds none.

**What would change that:** a publish failure that is persistent *and* row-specific — a delivery id shape QStash rejects, a per-row quota. If one appears, this ordering is the first thing to revisit, and the cheap answer is to rotate the offset within the band rather than to persist a cursor.

**Giving up.** Five attempts — counting every attempt the row has had, including the consumer's own failures and reopenings by Linear redeliveries — and then the row is set to `abandoned`, a status neither the sweep's query nor the consumer will act on. A poison delivery stops within a few sweeps and stays visible with the reason on it, instead of being swept forever.

**Not re-queueing a fragment.** Delivery rows and per-connection rows share this table, and re-queueing a per-connection row would fan out part of a delivery. The delivery row's `event_id` now carries a `delivery:h:` / `delivery:c:` marker: the prefix is what the query matches on, and the letter records whether Linear sent a delivery header — which cannot be recovered from the id, and which the consumer needs, because a delivery with no header derives its automation-event dedup key differently. `planSweep` refuses anything that is not a delivery row rather than guessing, and per-connection ids are untouched.

## Before this works on a schedule

One thing outside the repo: **a QStash schedule has to be created for `POST /api/integrations/linear/jobs/sweep-abandoned`, every 5 minutes.** Schedules for this app live in the Upstash console, not in this repository — there is no `vercel.json` `crons` block and no schedule manifest to add to — which is why the earlier revision of this PR avoided adding a route that nothing would call.

Until that schedule exists the route is inert: it verifies QStash signatures like every other job route, so it cannot be triggered by anything else, and nothing else calls it. Everything else in this PR works without it; what is missing without it is only the backstop, and the failure it backstops needs QStash to have exhausted its retries *and* Linear to have exhausted its own.

## Immediate follow-up

Three findings from the bot review; each is answered in its thread.

**Fixed — the body lookup matched nothing (critical).** The consumer looked the body up by the timestamp carried through the queue. `received_at` is a Postgres timestamp keeping microseconds and arrives here as a JavaScript `Date`, which keeps milliseconds, so the lookup asked for `…01.812` where the row holds `…01.812344`. Every delivery would have been marked `failed` with "payload missing" and none of the fan-out would have run — the feature would have been broken outright, not degraded. Checked against a copy of production: the old condition matches **0** rows for a real delivery, the new one matches **1**. Exactness now comes from `p.received_at = e.received_at`; only the day is constant, and `EXPLAIN` confirms pruning to one partition is intact. `partitionDay` holds the reasoning and is tested at both midnight edges.

**Fixed — the publish was unbounded against Linear's clock.** The QStash client defaults to `retries: 5` with `backoff: (n) => Math.exp(n) * 50`, about 4.3s of sleeping before it throws, inside a five-second budget, on the path whose only job is to answer fast. The client now uses `retry: { retries: 1, backoff: () => 150 }`. There is no `signal` or publish timeout to pass — the SDK's `timeout` bounds QStash's call to the destination — and racing a timer would leave the publish running with an unknowable outcome, which is the one thing this path cannot have. A *fast* 500 is strictly better than a slow one: the row is already durable and Linear's redelivery re-queues it.

**Not taken — an atomic `pending → processing` claim per connection.** The race is real but pre-existing and unchanged here: the route already read a `pending` row and acted on it without claiming it, and this PR moves that code rather than widening the window. A lease would also need a reaper for rows abandoned by a killed function, and claim semantics belong in the queued-ingest consumer, decided once for every provider.

The decline rests entirely on the side effects being idempotent, so here is that claim in full rather than as an assertion — it is what a future reviewer needs to re-check, and it is exactly what stops holding if someone adds a fourth writer to this path.

`processForConnection` has three side effects, and each is idempotent for a different reason:

1. **The task mirror** (`processIssueEvent`, `tasks`). The upsert carries `setWhere: tasks.externalUpdatedAt IS NULL OR tasks.externalUpdatedAt < excluded.external_updated_at`. Two racing deliveries for one issue both write, and Postgres discards the one carrying the older `updatedAt` — the decision is made by the conditional write, not by the read above it, which is why the read going stale is harmless. Equal timestamps — the same delivery processed twice — also lose, so a duplicate is a no-op rather than a rewrite.
2. **The automation event** (`ingestAutomationEvent` → `recordAutomationEvent`). Deduped on `(integration_connection_id, provider, external_event_id)`, where `external_event_id` is the delivery id: Linear's `linear-delivery` header, which is stable across its retries, or `${type}:${data.id}:${webhookTimestamp}` when there is none. A second run inserts nothing and dispatches nothing.
3. **The branch-name fetch** (`fetchIssueBranchName`). A read against Linear's API. A duplicate costs one wasted API call.

So the worst a duplicate fan-out does is spend a Linear API call and two no-op writes. That is the whole basis of the decline, and it is also why the sweep can re-queue a delivery without knowing whether a consumer is still on it.

**What would break it.** Any new writer on this path that is not conditional on the delivery's own ordering or deduped on its id — an append rather than an upsert (a comment mirror, an audit row, an outbound notification), a counter increment, a write keyed on something other than the delivery. `retry_count` is already such a counter and is already approximate for this reason. Adding one of those makes the claim false and makes the lease necessary, and the give-away is that it will not have a `setWhere` or a unique index behind it.

## Verification

`bunx biome check apps/api/src/app/api/integrations/linear`

```
Checked 20 files in 13ms. No fixes applied.
```

`bunx tsc --noEmit` in `apps/api` — clean, no output.

`bun test src` in `apps/api` (whole app, not just the touched directory):

```
 69 pass
 0 fail
 124 expect() calls
Ran 69 tests across 9 files. [90.00ms]
```

`bun test` in `packages/db`, which this branch also touches:

```
 13 pass
 0 fail
 30 expect() calls
Ran 13 tests across 1 file. [45.00ms]
```

The sweep's rules are in `planSweep`, a pure function, so they are pinned without a database: it never re-queues a per-connection row or a row recorded before this format existed, it gives up at the fifth attempt but not the fourth, the per-run ceiling never crowds out marking a poison delivery abandoned, and a delivery that arrived without a header is re-queued as having none rather than as the string `"null"`. `deliveryIds` pins the marker itself — that a per-connection id can never be read as a delivery row, and that re-deriving the header from a swept row reproduces the original per-connection ids exactly.

The sweep's query was run against a copy of production with its real bind parameters, and the plan checked (`CTE Scan on band`, fence intact). The two fenced write-backs were run against Postgres on a temp table rather than argued — each is `UPDATE 1`, not 2:

```
 id |  status   | retry_count |           outcome
----+-----------+-------------+------------------------------
  1 | abandoned |           5 | ok: abandoned
  2 | processed |           5 | ok: consumer result survived
  3 | pending   |           5 | ok: counted once
  4 | failed    |           5 | ok: no double count
``` The new tests were written before the code. `deliveryIds.test.ts` pins the dedup keys — an empty delivery header is not an id, bulk edits in the same millisecond do not collide, the per-connection format is byte-identical to the one rows were already recorded under, and a connection row can never collide with the delivery row. `route.test.ts` pins the acceptance contract: no acknowledgement of a delivery it could not record, none of a delivery it could not queue, nothing recorded for a delivery nobody subscribes to, and nothing recorded for a malformed body.

The consumer's payload read was checked against a copy of production rather than reasoned about, for a real delivery — the condition this PR started with against the one it ships:

```
           stored           |      as_a_js_date       | old_exact_match_rows | fixed_match_rows
 2026-09-08 01:53:31.335643 | 2026-09-08 01:53:31.335 |                    0 |                1
```

and that the day bounds still prune to one partition:

```
 Nested Loop Left Join
   Join Filter: (p.received_at = e.received_at)
   ->  Index Scan using webhook_events_pkey on webhook_events e
   ->  Index Scan using webhook_payloads_20260908_pkey on webhook_payloads_20260908 p
         Index Cond: ((webhook_event_id = ...) AND (received_at >= '2026-09-08 00:00:00')
                      AND (received_at < '2026-09-09 00:00:00'))
```

The fan-out width and subscriber counts quoted above are from the same database, queried directly.

Not verified end to end against live Linear traffic: QStash cannot reach a local api, so the queued half needs either a QStash dev server via `QSTASH_URL` or the deploy. Worth watching API-18 and the route's p95 after it lands.

Refs API-18

https://claude.ai/code/session_01RSwhAUCDyim8EcDyyRW5Hn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linear webhook deliveries are processed asynchronously for more reliable handling.
  * Events are delivered to active connections, including issue updates and automation events.
  * Abandoned deliveries can be re-queued automatically, while exhausted attempts are marked accordingly.
  * Duplicate deliveries are detected and prevented from being processed multiple times.
  * Connection-specific results and processing statuses are tracked.

* **Bug Fixes**
  * Failed deliveries can be retried instead of being silently acknowledged.
  * Invalid requests are rejected, while completed deliveries are safely acknowledged.
  * Delivery payloads are matched reliably across timestamp precision and day boundaries.
  * Deliveries without active subscribers are acknowledged without unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->