### PR TITLE
revert(marketing): back out the unverified profile cache opt-out

### DIFF
--- a/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
+++ b/apps/marketing/src/app/[lang]/user/[handle]/utils/loadProfile/loadProfile.ts
@@ -1,4 +1,3 @@
-import { unstable_noStore } from "next/cache";
 import {
 	fetchParticipant,
 	isRateLimited,
@@ -19,14 +18,7 @@ export async function loadProfile(handle: string): Promise<ProfileLookup> {
 		const profile = await fetchParticipant(handle, { period: "all" });
 		return profile ? { state: "found", profile } : { state: "missing" };
 	} catch (error) {
-		if (isRateLimited(error)) {
-			// A refusal describes this moment, not this profile. The retry page
-			// renders as an ordinary 200, so without opting out here the route's
-			// revalidate window would serve it for every visitor to that handle
-			// until it expired.
-			unstable_noStore();
-			return { state: "rate-limited" };
-		}
+		if (isRateLimited(error)) return { state: "rate-limited" };
 		throw error;
 	}
 }


### PR DESCRIPTION
Reverts #7287, which I merged without meeting the bar.

I confirmed that `unstable_noStore` is exported by the installed Next. I never confirmed that it actually defeats `export const revalidate` for an ISR render, and I added no test for that behaviour. #7281's author had already written in their PR body that they could not confirm it from the Next 16.2 source; applying a reviewer suggestion on top of that, using an `unstable_*` API, was not a sound basis to ship on.

The underlying concern is real but narrow. With `LEADERBOARD_INTERNAL_TOKEN` set, marketing's server reads are exempt from the anonymous limiter and the `rate-limited` state is unreachable, so the only exposure is a window where the token goes missing and a "this profile is busy" page could be cached for a handle for up to the revalidate window.

If we want that closed, it needs someone to establish what Next 16.2 actually does for a dynamic opt-out inside an on-demand ISR render and pin it with a test. Not a one-line call on an assumption.

https://claude.ai/code/session_01Lympqm6njii4G2VqdfA4sg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the prior fix that added `unstable_noStore` to the profile loader to avoid caching rate-limited responses. That change used an unverified `unstable_*` API without confirming it actually bypasses `export const revalidate` in Next 16.2, and shipped without a test. Removing it restores the previous caching behavior. The underlying issue is real but narrow: a rate-limited page could be cached for up to the revalidate window only when the internal token is missing. This needs proper verification and a test before making another attempt.

<sup>Written for commit 2a353abe0dbb8f1d740ec055ea7ba4d52b16952c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

