### PR TITLE
fix(desktop): apply local-db migrations by identity, not by timestamp watermark

### DIFF
--- a/apps/desktop/src/main/lib/local-db/index.ts
+++ b/apps/desktop/src/main/lib/local-db/index.ts
@@ -5,7 +5,6 @@ import * as schema from "@superset/local-db";
 
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { app } from "electron";
 import { validate as uuidValidate, version as uuidVersion } from "uuid";
 import { env } from "../../env.main";
@@ -14,6 +13,7 @@ import {
 	SUPERSET_HOME_DIR,
 	SUPERSET_SENSITIVE_FILE_MODE,
 } from "../app-environment";
+import { runMigrations } from "./runMigrations";
 
 const DB_PATH = join(SUPERSET_HOME_DIR, "local.db");
 
@@ -96,7 +96,7 @@ console.log(`[local-db] Running migrations from: ${migrationsFolder}`);
 export const localDb = drizzle(sqlite, { schema });
 
 try {
-	migrate(localDb, { migrationsFolder });
+	runMigrations(localDb, migrationsFolder);
 } catch (error) {
 	console.error("[local-db] Migration failed:", error);
 }

--- a/apps/desktop/src/main/lib/local-db/runMigrations/index.ts
+++ b/apps/desktop/src/main/lib/local-db/runMigrations/index.ts
@@ -1,0 +1,1 @@
+export { type MigrationDatabase, runMigrations } from "./runMigrations";

--- a/apps/desktop/src/main/lib/local-db/runMigrations/runMigrations.test.ts
+++ b/apps/desktop/src/main/lib/local-db/runMigrations/runMigrations.test.ts
@@ -1,0 +1,212 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { runMigrations } from "./runMigrations";
+
+/**
+ * The desktop runs migrations through better-sqlite3, which Bun cannot load.
+ * bun:sqlite drives the identical drizzle migrator code path (both are sync
+ * sessions on SQLiteSyncDialect), so these arms reproduce production
+ * semantics exactly.
+ */
+
+type Entry = { tag: string; when: number; sql: string };
+
+const REAL_JOURNAL = join(
+	import.meta.dir,
+	"../../../../../../../packages/local-db/drizzle/meta/_journal.json",
+);
+
+const CREATE_WORKTREES: Entry = {
+	tag: "0000_create_worktrees",
+	when: 1_000,
+	sql: "CREATE TABLE `worktrees` (`id` text PRIMARY KEY NOT NULL, `path` text NOT NULL);",
+};
+
+/** Generated before the branch migration below, but merged after it. */
+const ADD_CREATED_BY_SUPERSET: Entry = {
+	tag: "0001_add_created_by_superset_to_worktrees",
+	when: 2_000,
+	sql: "ALTER TABLE `worktrees` ADD `created_by_superset` integer DEFAULT true NOT NULL;",
+};
+
+/** Generated after, but shipped first — a branch or canary build. */
+const ADD_BRANCH_COLUMN: Entry = {
+	tag: "0002_add_branch_column",
+	when: 3_000,
+	sql: "ALTER TABLE `worktrees` ADD `branch` text;",
+};
+
+describe("runMigrations", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of tempDirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	function writeMigrations(entries: Entry[]): string {
+		const dir = mkdtempSync(join(tmpdir(), "local-db-migrations-"));
+		tempDirs.push(dir);
+		mkdirSync(join(dir, "meta"));
+		for (const entry of entries) {
+			writeFileSync(join(dir, `${entry.tag}.sql`), entry.sql);
+		}
+		writeFileSync(
+			join(dir, "meta/_journal.json"),
+			JSON.stringify({
+				version: "7",
+				dialect: "sqlite",
+				entries: entries.map((entry, idx) => ({
+					idx,
+					version: "6",
+					when: entry.when,
+					tag: entry.tag,
+					breakpoints: true,
+				})),
+			}),
+		);
+		return dir;
+	}
+
+	function columns(sqlite: Database, table: string): string[] {
+		return (
+			sqlite.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]
+		).map((row) => row.name);
+	}
+
+	function open(): Database {
+		const sqlite = new Database(":memory:");
+		sqlite.exec("PRAGMA foreign_keys = OFF");
+		return sqlite;
+	}
+
+	test("drizzle's migrator drops a migration whose `when` is below the watermark", () => {
+		const sqlite = open();
+		// A build that shipped the later-generated migration first.
+		migrate(drizzle(sqlite), {
+			migrationsFolder: writeMigrations([CREATE_WORKTREES, ADD_BRANCH_COLUMN]),
+		});
+		// Upgrading to the build that carries both.
+		migrate(drizzle(sqlite), {
+			migrationsFolder: writeMigrations([
+				CREATE_WORKTREES,
+				ADD_CREATED_BY_SUPERSET,
+				ADD_BRANCH_COLUMN,
+			]),
+		});
+
+		// Silently skipped, with no error raised — the defect this runner replaces.
+		expect(columns(sqlite, "worktrees")).not.toContain("created_by_superset");
+	});
+
+	test("applies a migration whose `when` is below the watermark", () => {
+		const sqlite = open();
+		runMigrations(
+			drizzle(sqlite),
+			writeMigrations([CREATE_WORKTREES, ADD_BRANCH_COLUMN]),
+		);
+		runMigrations(
+			drizzle(sqlite),
+			writeMigrations([
+				CREATE_WORKTREES,
+				ADD_CREATED_BY_SUPERSET,
+				ADD_BRANCH_COLUMN,
+			]),
+		);
+
+		expect(columns(sqlite, "worktrees")).toContain("created_by_superset");
+	});
+
+	test("heals a database drizzle's migrator already skipped a migration on", () => {
+		const sqlite = open();
+		migrate(drizzle(sqlite), {
+			migrationsFolder: writeMigrations([CREATE_WORKTREES, ADD_BRANCH_COLUMN]),
+		});
+		const current = writeMigrations([
+			CREATE_WORKTREES,
+			ADD_CREATED_BY_SUPERSET,
+			ADD_BRANCH_COLUMN,
+		]);
+		migrate(drizzle(sqlite), { migrationsFolder: current });
+		expect(columns(sqlite, "worktrees")).not.toContain("created_by_superset");
+
+		runMigrations(drizzle(sqlite), current);
+
+		expect(columns(sqlite, "worktrees")).toContain("created_by_superset");
+	});
+
+	test("does not re-run a migration that was edited after it shipped", () => {
+		const sqlite = open();
+		const folder = writeMigrations([
+			CREATE_WORKTREES,
+			ADD_CREATED_BY_SUPERSET,
+			ADD_BRANCH_COLUMN,
+		]);
+		runMigrations(drizzle(sqlite), folder);
+
+		// 0004-0008 and 0011 were all edited after shipping, so their recorded
+		// hashes no longer match the files. Re-running this one would raise
+		// "duplicate column name".
+		writeFileSync(
+			join(folder, `${ADD_CREATED_BY_SUPERSET.tag}.sql`),
+			`${ADD_CREATED_BY_SUPERSET.sql}\n-- edited after shipping\n`,
+		);
+
+		expect(() =>
+			runMigrations(drizzle(sqlite), folder),
+		).not.toThrow();
+	});
+
+	test("rolls the whole batch back when one migration fails", () => {
+		const sqlite = open();
+		const poison: Entry = {
+			tag: "0003_poison",
+			when: 4_000,
+			sql: "ALTER TABLE `missing_table` ADD `x` integer;",
+		};
+
+		expect(() =>
+			runMigrations(
+				drizzle(sqlite),
+				writeMigrations([
+					CREATE_WORKTREES,
+					ADD_CREATED_BY_SUPERSET,
+					ADD_BRANCH_COLUMN,
+					poison,
+				]),
+			),
+		).toThrow();
+
+		// Nothing landed, so the next launch retries the batch from the top
+		// rather than running against a half-applied schema.
+		const tables = (
+			sqlite
+				.prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+				.all() as { name: string }[]
+		).map((row) => row.name);
+		expect(tables).not.toContain("worktrees");
+	});
+
+	test("every shipped journal entry has a distinct `when`", () => {
+		// The runner identifies applied migrations by `when`. Two entries sharing
+		// one would let a real migration be mistaken for an applied one.
+		const journal = JSON.parse(readFileSync(REAL_JOURNAL, "utf8")) as {
+			entries: { when: number }[];
+		};
+		const whens = journal.entries.map((entry) => entry.when);
+
+		expect(new Set(whens).size).toBe(whens.length);
+	});
+});

--- a/apps/desktop/src/main/lib/local-db/runMigrations/runMigrations.test.ts
+++ b/apps/desktop/src/main/lib/local-db/runMigrations/runMigrations.test.ts
@@ -164,9 +164,7 @@ describe("runMigrations", () => {
 			`${ADD_CREATED_BY_SUPERSET.sql}\n-- edited after shipping\n`,
 		);
 
-		expect(() =>
-			runMigrations(drizzle(sqlite), folder),
-		).not.toThrow();
+		expect(() => runMigrations(drizzle(sqlite), folder)).not.toThrow();
 	});
 
 	test("rolls the whole batch back when one migration fails", () => {

--- a/apps/desktop/src/main/lib/local-db/runMigrations/runMigrations.ts
+++ b/apps/desktop/src/main/lib/local-db/runMigrations/runMigrations.ts
@@ -1,0 +1,80 @@
+import { type SQL, sql } from "drizzle-orm";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+
+/**
+ * The slice of a synchronous drizzle sqlite database this runner uses.
+ * Declaring it structurally keeps the runner off the native driver, so the
+ * tests can exercise this exact code on bun:sqlite — the only sqlite Bun can
+ * load.
+ */
+export type MigrationDatabase = {
+	run(query: SQL): unknown;
+	all<TRow = unknown>(query: SQL): TRow[];
+};
+
+const MIGRATIONS_TABLE = sql.identifier("__drizzle_migrations");
+
+/**
+ * Applies every migration this database has not recorded yet.
+ *
+ * Drizzle's own migrator picks what to run by comparing each migration's
+ * journal `when` against the single highest `created_at` in
+ * `__drizzle_migrations`. That is a watermark, not a set, and it only moves
+ * forward: a migration that arrives carrying a `when` below the watermark is
+ * skipped, and stays skipped through every later upgrade. `when` records when
+ * drizzle-kit generated the file, not the order files merged, so a machine
+ * takes on a too-high watermark by running any build whose migration was
+ * generated after — but shipped before — one still in flight elsewhere.
+ * Branch and canary builds do that routinely.
+ *
+ * Keying on the set of recorded `created_at` values closes the hole and heals
+ * databases that already lost a migration, whose `when` is simply absent from
+ * the set. `created_at` is that same journal `when`, which drizzle has always
+ * recorded, so this reads tables written by every previous version and writes
+ * rows those versions still understand.
+ *
+ * It keys on `created_at` rather than `hash` deliberately: migrations 0004
+ * through 0008 and 0011 were edited after they had already shipped, so the
+ * hashes those machines recorded no longer match the files on disk, and
+ * hashing would re-run migrations that are already applied.
+ */
+export function runMigrations(
+	db: MigrationDatabase,
+	migrationsFolder: string,
+): void {
+	const migrations = readMigrationFiles({ migrationsFolder });
+
+	db.run(
+		sql`CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+			id SERIAL PRIMARY KEY,
+			hash text NOT NULL,
+			created_at numeric
+		)`,
+	);
+
+	const recorded = db.all<{ created_at: number | string | null }>(
+		sql`SELECT created_at FROM ${MIGRATIONS_TABLE}`,
+	);
+	const applied = new Set(recorded.map((row) => Number(row.created_at)));
+
+	const pending = migrations.filter(
+		(migration) => !applied.has(migration.folderMillis),
+	);
+	if (pending.length === 0) return;
+
+	db.run(sql`BEGIN`);
+	try {
+		for (const migration of pending) {
+			for (const statement of migration.sql) {
+				db.run(sql.raw(statement));
+			}
+			db.run(
+				sql`INSERT INTO ${MIGRATIONS_TABLE} ("hash", "created_at") VALUES(${migration.hash}, ${migration.folderMillis})`,
+			);
+		}
+		db.run(sql`COMMIT`);
+	} catch (error) {
+		db.run(sql`ROLLBACK`);
+		throw error;
+	}
+}


### PR DESCRIPTION
## Problem

On one machine, every workspace list fails: `workspaces.getAllGrouped` selects
from the local SQLite `worktrees` table and sqlite answers
`no such column: "created_by_superset"`. That query backs the entire sidebar, so
the app's primary navigation is empty. It has been failing since 2026-08-16
across three upgrades the user took (1.22.0 → 1.24.2 → 1.26.0) and never heals.

The column comes from migration `0037_add_created_by_superset_to_worktrees`,
which shipped 2026-03-21. The app kept starting anyway.

## Root cause

Not a failed migration — a **skipped** one.

The Sentry evidence narrows this precisely: that machine reports *only*
`created_by_superset`. `getSettings` does `select().from(settings)` and works
fine there on 1.26.0, so every migration from 0038 through 0055 applied
normally. Exactly one migration in the middle of the sequence was missed. (The
`persist_terminal` and `active_organization_id` issues are unrelated machines on
older releases — the known #6450 downgrade incident.)

That is the signature of drizzle's migrator gate. `SQLiteSyncDialect.migrate`
reads a single row:

```js
SELECT id, hash, created_at FROM __drizzle_migrations ORDER BY created_at DESC LIMIT 1
...
if (!lastDbMigration || Number(lastDbMigration[2]) < migration.folderMillis) { apply }
```

That is a **watermark, not a set**, and it only moves forward. Any migration
arriving with a journal `when` below the watermark is skipped silently, and
stays skipped through every later upgrade — there is no error, and no retry
that can ever pick it up.

A machine takes on a too-high watermark because `when` records when
drizzle-kit *generated* a file, not the order files *merged*. `0037` was
generated 2026-03-18 and merged 2026-03-21. Any build carrying a migration
generated inside that window but shipped first — a branch build, or a canary,
which `scripts/release-canary.sh [commit]` builds from an arbitrary commit —
pushes the watermark past `0037` and masks it permanently. Migration order on
`main` is monotonic today, so `main`-only installs are not exposed; builds off
`main` are.

Two mechanisms the issue also proposed are ruled out:

- **Partial DDL with the journal advanced** cannot happen. Drizzle already runs
  the whole pending batch inside one `BEGIN`/`COMMIT` and rolls back on failure,
  so schema changes are all-or-nothing per launch. Atomicity is not the defect.
- **A migration failing on that machine** would have stalled everything from
  0037 onward, and `getSettings` would fail too. It does not.

## Fix

Select pending migrations from the **set** of recorded `created_at` values
rather than from `max(created_at)`. Affected databases heal on the next launch,
because the skipped migration's `when` is simply absent from the set.

`created_at` *is* the journal `when`, and drizzle has always recorded it, so
this reads tables written by every previous version and writes rows those
versions still understand — a downgrade after this change still behaves.

It keys on `created_at` rather than `hash` deliberately: migrations 0004–0008
and 0011 were edited after they had already shipped (`#822`, `#824`, `#826`,
and the Better Auth revert), so the hashes those machines recorded no longer
match the files on disk and hashing would re-run migrations that are already
applied. `0011`'s journal `when` was itself rewritten twice during that churn,
and it is the only entry ever rewritten — it is a no-op (`SELECT 1;`) today, so
re-running it is harmless. All 56 `when` values are distinct; a test ratchets
that, since two entries sharing one would let a real migration be mistaken for
an applied one.

Everything else is unchanged: same transaction and rollback semantics, same
`__drizzle_migrations` table shape, same statement execution path. The existing
`catch` around the call is untouched — see the note below.

No typed `cause` is added: nothing reads one. The failing query keeps throwing
the plain `TRPCError` it throws today.

### Deliberately not in scope

`apps/desktop/src/main/lib/local-db/index.ts:100` swallows migration failures —
the app boots and serves queries against whatever schema it has, and the real
error only reaches `console.error`. That is why this issue took 14 symptom
events across three releases to diagnose with zero events naming a cause. It did
not cause this bug (migrations did not fail here, one was skipped), and changing
it means deciding whether a failed migration should refuse to start the app —
a product call. Flagged for the maintainer rather than made here.

## Verification

`bunx biome check` on the four changed files:

```
Checked 4 files in 53ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`:

```
$ tsc --noEmit
(clean)
```

`bun test src/main/ src/no-main-process-blocking.test.ts`:

```
 714 pass
 0 fail
 1461 expect() calls
Ran 714 tests across 53 files. [2.70s]
```

Full `apps/desktop` suite, with the change:

```
 3634 pass
 1 fail
 2 snapshots, 59290 expect() calls
Ran 3635 tests across 394 files. [27.04s]
```

The one failure is pre-existing, not from this change. Same suite with the
change reverted:

```
 3628 pass
 1 fail
 2 snapshots, 59282 expect() calls
Ran 3629 tests across 393 files. [33.39s]
```

It is `useSidebarDnd.test.ts` hitting `React.createContext is not a function`
inside `@dnd-kit/core` — cross-file module-registry pollution. It passes in
isolation (`8 pass, 0 fail`) and has no reference to local-db.

### End-to-end, against the real 56-migration set

bun:sqlite cannot register the two custom sqlite functions `0032` needs, so
that one file's `uuid_v4()` / `uuid_is_valid_v4()` calls were stubbed
identically in both arms; nothing else was touched.

```
A) drizzle migrate() tables: 42
B) runMigrations()  tables: 42
A === B (full schema identical on the real 56-migration set): true

C) after upgrade via drizzle, worktrees has created_by_superset: false <- reproduces DESKTOP-YF
C) settings column count: 49 (later migrations DID apply, matching the Sentry evidence)
C) after runMigrations, created_by_superset: true <- repaired
C) schema now identical to a clean install: true
```

Arm C builds the exact reported state — a build shipped without `0037` sets the
watermark past it, the upgrade skips it silently, `worktrees` loses the column
while `settings` keeps all 49 — then repairs it to a clean-install schema.

The committed test covers the same ground on synthetic folders, including an arm
that pins drizzle's skip so a revert to `migrate()` fails loudly, an arm proving
a post-ship edit does not re-run a migration, and an arm proving a failing batch
still rolls back whole.

Refs DESKTOP-YF

https://claude.ai/code/session_01PyGdhAtqsxEKHPTFkMvwVJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop local-db migration runner so it applies migrations by identity (`created_at`) instead of Drizzle's timestamp watermark, and heals databases that already skipped one.

**Bug Fixes**
- Drizzle's watermark only moves forward, so a migration with a `when` below the highest recorded `created_at` is skipped silently forever.
- `when` records when drizzle-kit generated the file, not when it merged, so branch/canary builds can ship a later migration first and mask an earlier one.
- The new runner keys on `created_at` rather than `hash` because migrations 0004–0008 and 0011 were edited after shipping, so recorded hashes no longer match.
- Transaction, rollback, and the `__drizzle_migrations` table shape are unchanged; downgrades still work.
- The existing catch that swallows migration failures is untouched; whether to refuse startup on failure is left to the maintainer.

**Verification**
- Tests reproduce the skip, prove healing, confirm post-ship edits don't re-run, and verify a failing batch rolls back whole.
- The real 56-migration journal is checked to confirm every `when` is distinct.

<sup>Written for commit 361a5e6797b38384dbe58418a80cef118c368b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local database updates so previously skipped migrations can be applied correctly.
  - Prevented already-applied migrations from running again, including when migration files change.
  - Ensured database updates roll back safely if any migration fails.

- **Reliability**
  - Added validation to help maintain consistent migration ordering and prevent incomplete database upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->