### PR TITLE
fix(mcp): fail loud when workspaces_create agent launch fails

### DIFF
--- a/apps/docs/content/docs/mcp-server.mdx
+++ b/apps/docs/content/docs/mcp-server.mdx
@@ -305,7 +305,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 | Tool | Description |
 |------|-------------|
 | `workspaces_list` | List workspaces on a host (get the hostId from `hosts_list`) |
-| `workspaces_create` | Create a workspace on a host, optionally launching agents with per-launch model and effort overrides |
+| `workspaces_create` | Create a workspace on a host, optionally launching agents with per-launch model and effort overrides. When `agents` is set, every launch must succeed (`agents[].ok`) or the tool returns an error — the workspace may still exist on the host. |
 | `workspaces_update` | Update fields on a workspace on its host |
 | `workspaces_delete` | Delete a workspace by UUID on its host |
 

--- a/packages/mcp/src/tools/workspaces/create.test.ts
+++ b/packages/mcp/src/tools/workspaces/create.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHarness } from "./test-harness";
+
+const harness = createHarness();
+
+mock.module("../../define-tool", () => ({
+	defineTool: harness.defineTool,
+}));
+mock.module("../../host-service-client", () => ({
+	hostServiceCall: harness.hostServiceCall,
+}));
+
+const mod = await import("./create");
+const tool = harness.register(mod);
+
+const PROJECT_ID = "11111111-1111-4111-8111-111111111111";
+const WORKSPACE_ID = "22222222-2222-4222-8222-222222222222";
+
+function okAgent() {
+	return {
+		ok: true as const,
+		kind: "terminal" as const,
+		sessionId: "sess-1",
+		label: "Claude",
+	};
+}
+
+beforeEach(() => {
+	harness.calls.length = 0;
+	harness.setResponse({
+		workspace: {
+			id: WORKSPACE_ID,
+			projectId: PROJECT_ID,
+			name: "probe",
+			branch: "fix/probe",
+		},
+		terminals: [],
+		agents: [],
+		alreadyExists: false,
+	});
+});
+
+describe("workspaces_create", () => {
+	test("is a non-destructive tool", () => {
+		expect(tool.name).toBe("workspaces_create");
+		expect(tool.annotations).toEqual({ destructiveHint: false });
+	});
+
+	test("fails loud when a requested agent never launched (#5767)", async () => {
+		harness.setResponse({
+			workspace: {
+				id: WORKSPACE_ID,
+				projectId: PROJECT_ID,
+				name: "probe",
+				branch: "fix/probe",
+			},
+			terminals: [],
+			agents: [{ ok: false, error: "no agent config for `claude`" }],
+			alreadyExists: false,
+		});
+
+		await expect(
+			harness.invoke(tool, {
+				projectId: PROJECT_ID,
+				name: "probe",
+				branch: "fix/probe",
+				hostId: "host-1",
+				agents: [{ agent: "claude", prompt: "do the thing" }],
+			}),
+		).rejects.toThrow(
+			/Agent launch failed: no agent config for `claude`.*Workspace 22222222-2222-4222-8222-222222222222/,
+		);
+
+		expect(harness.calls[0]?.procedure).toBe("workspaces.create");
+	});
+
+	test("reports every failed launch, not just the first", async () => {
+		harness.setResponse({
+			workspace: {
+				id: WORKSPACE_ID,
+				projectId: PROJECT_ID,
+				name: "probe",
+				branch: "fix/probe",
+			},
+			terminals: [],
+			agents: [
+				{ ok: false, error: "first failure" },
+				{ ok: false, error: "second failure" },
+			],
+			alreadyExists: false,
+		});
+
+		await expect(
+			harness.invoke(tool, {
+				projectId: PROJECT_ID,
+				name: "probe",
+				branch: "fix/probe",
+				hostId: "host-1",
+				agents: [
+					{ agent: "claude", prompt: "a" },
+					{ agent: "codex", prompt: "b" },
+				],
+			}),
+		).rejects.toThrow(/first failure; second failure/);
+	});
+
+	test("fails a project-less session the same way", async () => {
+		harness.setResponse({
+			workspace: {
+				id: WORKSPACE_ID,
+				projectId: null,
+				name: "scratch",
+				branch: "",
+			},
+			terminals: [],
+			agents: [{ ok: false, error: "spawn failed" }],
+		});
+
+		await expect(
+			harness.invoke(tool, {
+				name: "scratch",
+				hostId: "host-1",
+				agents: [{ agent: "claude", prompt: "probe" }],
+			}),
+		).rejects.toThrow(/Agent launch failed: spawn failed/);
+
+		expect(harness.calls[0]?.procedure).toBe("workspaces.createSession");
+	});
+
+	test("succeeds when every requested agent launched", async () => {
+		harness.setResponse({
+			workspace: {
+				id: WORKSPACE_ID,
+				projectId: PROJECT_ID,
+				name: "probe",
+				branch: "fix/probe",
+			},
+			terminals: [],
+			agents: [okAgent()],
+			alreadyExists: false,
+		});
+
+		const result = await harness.invoke(tool, {
+			projectId: PROJECT_ID,
+			name: "probe",
+			branch: "fix/probe",
+			hostId: "host-1",
+			agents: [{ agent: "claude", prompt: "do the thing" }],
+		});
+
+		expect(result).toMatchObject({
+			workspace: { id: WORKSPACE_ID },
+			agents: [{ ok: true, sessionId: "sess-1" }],
+		});
+	});
+
+	test("succeeds when no agents were requested even if agents[] is empty", async () => {
+		const result = await harness.invoke(tool, {
+			projectId: PROJECT_ID,
+			name: "probe",
+			branch: "fix/probe",
+			hostId: "host-1",
+		});
+
+		expect(result).toMatchObject({
+			workspace: { id: WORKSPACE_ID },
+			agents: [],
+		});
+	});
+});

--- a/packages/mcp/src/tools/workspaces/create.ts
+++ b/packages/mcp/src/tools/workspaces/create.ts
@@ -3,6 +3,33 @@ import { z } from "zod";
 import { defineTool } from "../../define-tool";
 import { hostServiceCall } from "../../host-service-client";
 
+type AgentLaunchResult =
+	| { ok: true; kind: "terminal"; sessionId: string; label: string }
+	| { ok: false; error: string };
+
+/**
+ * The host keeps the workspace when a requested agent fails to spawn: the
+ * launch outcome comes back per entry in `agents[]` instead of throwing. A
+ * caller that passed `agents` asked for work to start, so a spawn failure is
+ * a failed create — return an MCP error envelope instead of a success body
+ * over an empty worktree (sibling of CLI #7275 / #5767).
+ */
+function requireAgentsLaunched(
+	requested: readonly unknown[] | undefined,
+	agents: readonly AgentLaunchResult[] | undefined,
+	workspaceId: string,
+): void {
+	if (requested === undefined || requested.length === 0) return;
+	const errors = (agents ?? [])
+		.filter((agent): agent is { ok: false; error: string } => !agent.ok)
+		.map((agent) => agent.error ?? "unknown error");
+	if (errors.length === 0) return;
+
+	throw new Error(
+		`Agent launch failed: ${errors.join("; ")}. Workspace ${workspaceId} exists without the agent — retry with agents_create.`,
+	);
+}
+
 const agentLaunchSchema = z.object({
 	agent: z
 		.string()
@@ -38,7 +65,7 @@ export function register(server: McpServer): void {
 		name: "workspaces_create",
 		annotations: { destructiveHint: false },
 		description:
-			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. When `projectId` is set, provide exactly one of `branch` or `pr`. Omit `projectId` (and `branch`/`pr`/`baseBranch`/`taskId`) to create a project-less session instead — a managed scratch folder (its own git repo, no branch/PR semantics). Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_create` against the new workspace), and/or pass `command` to run a one-off shell command in the worktree. Use projects_list and hosts_list first to get the projectId and hostId.",
+			"Create a workspace on a host. A workspace is a branch-scoped working copy of a project. The host service materializes the git worktree on disk before returning. When `projectId` is set, provide exactly one of `branch` or `pr`. Omit `projectId` (and `branch`/`pr`/`baseBranch`/`taskId`) to create a project-less session instead — a managed scratch folder (its own git repo, no branch/PR semantics). Optionally pass `agents` to spawn one or more agents in the workspace as soon as it is ready (each entry runs the equivalent of `agents_create` against the new workspace); if any requested launch returns `ok: false`, this tool errors (the workspace may still exist). And/or pass `command` to run a one-off shell command in the worktree. Use projects_list and hosts_list first to get the projectId and hostId.",
 		inputSchema: {
 			projectId: z
 				.string()
@@ -104,7 +131,7 @@ export function register(server: McpServer): void {
 						);
 					}
 				}
-				return hostServiceCall<{
+				const result = await hostServiceCall<{
 					workspace: {
 						id: string;
 						projectId: string | null;
@@ -112,10 +139,7 @@ export function register(server: McpServer): void {
 						branch: string;
 					};
 					terminals: Array<{ terminalId: string; label?: string }>;
-					agents: Array<
-						| { ok: true; kind: "terminal"; sessionId: string; label: string }
-						| { ok: false; error: string }
-					>;
+					agents: Array<AgentLaunchResult>;
 				}>(
 					{
 						relayUrl: ctx.relayUrl,
@@ -131,8 +155,10 @@ export function register(server: McpServer): void {
 						command: input.command,
 					},
 				);
+				requireAgentsLaunched(input.agents, result.agents, result.workspace.id);
+				return result;
 			}
-			return hostServiceCall<{
+			const result = await hostServiceCall<{
 				workspace: {
 					id: string;
 					projectId: string;
@@ -140,10 +166,7 @@ export function register(server: McpServer): void {
 					branch: string;
 				};
 				terminals: Array<{ terminalId: string; label?: string }>;
-				agents: Array<
-					| { ok: true; kind: "terminal"; sessionId: string; label: string }
-					| { ok: false; error: string }
-				>;
+				agents: Array<AgentLaunchResult>;
 				alreadyExists: boolean;
 			}>(
 				{
@@ -165,6 +188,8 @@ export function register(server: McpServer): void {
 					command: input.command,
 				},
 			);
+			requireAgentsLaunched(input.agents, result.agents, result.workspace.id);
+			return result;
 		},
 	});
 }

--- a/packages/mcp/src/tools/workspaces/test-harness.ts
+++ b/packages/mcp/src/tools/workspaces/test-harness.ts
@@ -1,0 +1,74 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { type ZodRawShape, z } from "zod";
+import type { McpContext } from "../../auth";
+
+/**
+ * Test double for `defineTool` and `hostServiceCall`.
+ *
+ * The real `defineTool` reaches the database client through the MCP auth
+ * module, which needs credentials these tools never use. Mocking that seam
+ * keeps the tests to what the tool files themselves decide: the declared
+ * schema, the input the handler builds for the host, and the errors it raises
+ * after the host returns.
+ */
+export interface CapturedTool {
+	name: string;
+	annotations?: ToolAnnotations;
+	description: string;
+	inputSchema: ZodRawShape;
+	handler: (input: unknown, ctx: McpContext) => Promise<unknown>;
+}
+
+export interface CapturedCall {
+	procedure: string;
+	method: string;
+	input: unknown;
+	hostId: string;
+}
+
+const CTX = {
+	relayUrl: "https://relay.test",
+	organizationId: "org-1",
+	bearerToken: "bearer",
+} as McpContext;
+
+export function createHarness() {
+	const tools: CapturedTool[] = [];
+	const calls: CapturedCall[] = [];
+	let response: unknown = {};
+	let failure: Error | undefined;
+
+	return {
+		calls,
+		setResponse(next: unknown) {
+			response = next;
+			failure = undefined;
+		},
+		setFailure(next: Error) {
+			failure = next;
+		},
+		defineTool(_server: unknown, def: CapturedTool) {
+			tools.push(def);
+		},
+		hostServiceCall(
+			options: { hostId: string },
+			procedure: string,
+			method: string,
+			input: unknown,
+		) {
+			calls.push({ procedure, method, input, hostId: options.hostId });
+			return failure ? Promise.reject(failure) : Promise.resolve(response);
+		},
+		register(mod: { register: (server: McpServer) => void }): CapturedTool {
+			tools.length = 0;
+			mod.register({} as McpServer);
+			const tool = tools[0];
+			if (!tool) throw new Error("register() defined no tool");
+			return tool;
+		},
+		invoke(tool: CapturedTool, input: Record<string, unknown>) {
+			return tool.handler(z.object(tool.inputSchema).parse(input), CTX);
+		},
+	};
+}


### PR DESCRIPTION
## What & why

When `workspaces_create` is asked to spawn agents and the host returns any `agents[].ok === false`, the tool used to return a success envelope over an empty worktree. Callers that requested agents asked for work to start — a spawn failure must be an MCP error (`isError: true`) with the host errors and the surviving workspace id.

Same honesty contract as CLI #7275 / #5767, on the MCP path. Create without `agents` (or every launch ok) still succeeds.

## How I tested it

After `workspaces.create` / `createSession`, MCP `workspaces_create` inspects host `agents[]`. Any `ok: false` while `agents` was requested → throw → `defineTool` `isError: true` with joined host errors + surviving workspace id (retry via `agents_create`). No agents / all ok → success envelope unchanged.

- Tip: `9d7bef061ff658ab1c3f0dc76f683b9825cd84e9`
- Units: `bun test packages/mcp/src/tools/workspaces/create.test.ts` → 6 pass / 0 fail
- Live MCP on host `447e38a10a4884d2d4c34ce99141d850`:
  - bad agent → `isError`; workspace created then cleaned
  - no agents → ok; cleaned
  - `claude` → ok with session id; cleaned
- Fork tip-match CI: https://github.com/owieschon/superset/actions/runs/34220815332 (owned SUCCESS; Neon allowlisted)

## Checklist

- [x] Thin scope (mcp create + test-harness + mcp-server docs only)
- [x] Based on upstream `main`
- [x] Tip-native proof + fork CI cited
