### PR TITLE
fix(desktop): key the onboarding gate on the rendered route, not the pending one

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -6,6 +6,7 @@ import {
 	Outlet,
 	useLocation,
 	useNavigate,
+	useRouterState,
 } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { DndProvider } from "react-dnd";
@@ -87,6 +88,15 @@ function AuthenticatedLayout() {
 	const isOnline = useOnlineStatus();
 	const navigate = useNavigate();
 	const location = useLocation();
+	// The onboarding gate below must key off the route being RENDERED, not
+	// `useLocation()`. `location` is the pending navigation, so the instant the
+	// redirect to /onboarding starts, the gate re-opens while `matches` still
+	// holds the route we are leaving — remounting it, and re-firing its own
+	// mount-time redirect, which cancels ours. The two then bounce forever
+	// (DESKTOP-E3). `matches` only advances once the destination commits.
+	const renderedPathname = useRouterState({
+		select: (state) => state.matches[state.matches.length - 1]?.pathname ?? "",
+	});
 	const setOriginRoute = useSettingsStore((s) => s.setOriginRoute);
 	const utils = electronTrpc.useUtils();
 	const shownWorkspaceInitWarningsRef = useRef(new Set<string>());
@@ -283,7 +293,7 @@ function AuthenticatedLayout() {
 	if (
 		session?.user &&
 		!session.user.onboardedAt &&
-		!location.pathname.startsWith("/onboarding")
+		!renderedPathname.startsWith("/onboarding")
 	) {
 		return onboardingRedirect;
 	}


### PR DESCRIPTION
## Problem

An un-onboarded user who lands on a route that redirects on mount never reaches
the onboarding screen. The app ping-pongs `/onboarding` ⇄ `/new-workspace` about
26 round trips in ~200 ms, React aborts the commit with *Maximum update depth
exceeded* (error #185), and the **root** `errorComponent` replaces the entire
window with "Something went wrong. Reload to try again." The user has to reload
the app to get back in, seconds after signing in.

DESKTOP-E3: 2,480 events, 321 in the last 14 days (284 of them on 1.24.2),
ongoing since 2026-05-11.

Breadcrumbs from three different users on two releases are identical — this one
is representative (sign-in completes, then the bounce, then the error):

```
48.829  navigation  /#/sign-in       -> /#/workspace
48.831  navigation  /#/workspace     -> /#/onboarding
48.949  navigation  /#/onboarding    -> /#/new-workspace
48.955  navigation  /#/new-workspace -> /#/onboarding
48.964  navigation  /#/onboarding    -> /#/new-workspace
        ... 26 round trips, ~7 ms each ...
49.164  console     Error: Minified React error #185
49.168  console     [renderer] Route error caught: ...
```

The Radix `compose-refs` → `dispatchSetState` frames in the Sentry stack are not
the cause. `nestedUpdateCount` is incremented per *commit*; `getRootForUpdatedFiber`
throws on whatever `setState` runs after the 50th. In this loop that is a Radix
ref detaching while the outgoing route subtree is deleted — the 51st update, not
the engine. No drag-and-drop is involved anywhere in these sessions.

## Root cause

`AuthenticatedLayout`'s onboarding gate decided which tree to render by reading
`useLocation()`:

```tsx
if (session?.user && !session.user.onboardedAt &&
    !location.pathname.startsWith("/onboarding")) return onboardingRedirect;
```

`useLocation()` returns the router's **pending** location, which updates the
moment a navigation starts. `state.matches` — what `<Outlet/>` actually renders —
only advances once the destination commits. So the two disagree mid-navigation:

```
guard location=/new-workspace  matches=__root__,/new-workspace   <- gate ON, redirect starts
guard location=/onboarding     matches=__root__,/new-workspace   <- gate OFF, but /new-workspace is still what renders
```

That second render remounts the route the gate is trying to leave. For a v2 user
that route is `/workspace`, whose index page navigates to `/new-workspace` on
every mount (`_dashboard/workspace/page.tsx`). Its redirect cancels the gate's,
the gate turns back on, unmounts it, redirects again — and the two mount-scoped
redirects trade the location back and forth. Each `<Redirect>` is individually
loop-proof (#6354), but neither can see the other, and nothing bounds the fight.

Entry points that put an un-onboarded user on such a route are ordinary: signing
in (`/sign-in` → `/workspace`), or the persisted hash history restoring the last
route at launch.

## Fix

Key the gate on the route being rendered rather than the one being navigated to.
One selector, one predicate changed — no cap, no catch, no deferral.

```tsx
const renderedPathname = useRouterState({
  select: (state) => state.matches[state.matches.length - 1]?.pathname ?? "",
});
```

Now the gate holds the redirect until `/onboarding` actually commits, so an
un-onboarded user's tree is only ever an onboarding route or the bare redirect —
which is what the gate was always meant to guarantee. This closes the class, not
just this pair: no dashboard route can mount underneath the gate any more.

No typed `cause` is added — nothing reads one here, and this is a renderer render
path, not a tRPC throw site.

## Verification

Reproduced and fixed in a router harness driving the real `Redirect` component
plus the two guards verbatim (`useLocation()` gate + `/workspace`'s mount-effect
redirect), started from `/workspace` with an un-onboarded session:

```
### BEFORE (gate reads useLocation) ###
[BEFORE] /workspace -> final=/onboarding navigations=52 THREW: Maximum update depth exceeded

### AFTER (gate reads rendered matches) ###
[AFTER ] /workspace         -> final=/onboarding         navigations=1 html=<div><div>onboarding-page</div></div>
[AFTER ] /new-workspace     -> final=/onboarding         navigations=1 html=<div><div>onboarding-page</div></div>
[AFTER ] /onboarding        -> final=/onboarding         navigations=0 html=<div><div>onboarding-page</div></div>
[AFTER ] /onboarding/project-> final=/onboarding/project navigations=0 html=<div><div>onboarding-project</div></div>
```

52 navigations is exactly the 52 history writes in the production breadcrumbs.
The harness is scratch (it exercises the pattern, not the real component, which
would need the whole authenticated tree mocked) and is not committed.

```
$ bunx biome check apps/desktop/src/renderer/routes/_authenticated/layout.tsx
Checked 1 file in 12ms. No fixes applied.

$ cd apps/desktop && bun run typecheck
$ bun run generate:icons && bun run generate:routes
$ tsc --noEmit          (clean)

$ bun test src/renderer/routes src/renderer/components/Redirect
 1006 pass, 1 fail, 1 error       Ran 1007 tests across 147 files

$ bun test                        # full apps/desktop suite
 3628 pass, 1 fail, 1 error       Ran 3629 tests across 393 files
```

The one failure is `useSidebarDnd.test.ts` (`React.createContext is not a
function` from `@dnd-kit/core`, reported as "Unhandled error between tests" —
cross-file globals pollution). It is **pre-existing**: reverting this change and
re-running the same command gives the identical `1006 pass / 1 fail / 1 error`,
and the file passes on its own (`95 pass, 0 fail`).

## Reality check

1. **Harm.** An un-onboarded user — every new sign-up, plus anyone whose restored
   route is `/workspace` — gets the whole app replaced by the root error page
   seconds after signing in, and must reload. 321 events in 14 days.
2. **Reach.** The events come from the shipped renderer bundle; the guard is
   unchanged between `desktop-v1.24.2` (284 of the 14-day events) and `main`.
   The fix is renderer-only and ships in the next desktop release to everyone
   who updates.
3. **Why code.** Archiving hides a first-run failure that costs new users their
   first session. There is no Sentry-side option that is permitted here anyway
   (repo law: classify at throw sites, never filter). The code path is not being
   deleted or restructured by anything in flight — `/onboarding` and the gate are
   untouched since #5185/#4802.

## Adjacent, deliberately not touched

- `_dashboard/workspace/page.tsx` navigates to `/new-workspace` from a mount
  effect for v2 users. It is the other party here, and it is the same anti-pattern
  the `Redirect` docstring warns about; the repo's own idiom for a static target
  is `beforeLoad: () => { throw redirect(...) }` (see `settings/page.tsx`,
  `tasks/page.tsx`). It needs `isV2CloudEnabled` in a router context, which is a
  separate change.
- `_dashboard/layout.tsx`'s `versionMismatch` redirect derives from
  `useMatchRoute()`, which matches against the same pending location — same flaw
  class, different pair, not implicated in DESKTOP-E3.

Refs DESKTOP-E3

https://claude.ai/code/session_018R51FivxKu9tBfUtxGVqy7


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop onboarding gate so un-onboarded users who land on a route that redirects on mount no longer get stuck in an infinite redirect loop that aborts with "Maximum update depth exceeded" and replaces the whole window with the error page.

- The gate previously read the pending navigation location, so the instant the redirect to `/onboarding` began it reopened while the outgoing route still rendered, remounting it and re-firing its mount-time redirect.
- The gate now reads the rendered route from `state.matches`, so an un-onboarded user's tree only ever contains an onboarding route or the redirect.
- Refs DESKTOP-E3.

<sup>Written for commit 4f9795f6635d8326ec85829f9d18d020657b047b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could cause repeated redirects and route remounts when navigating through onboarding.
  - Navigation now remains stable while transitioning between authenticated routes and onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->