### PR TITLE
fix(desktop): Failed OS notification is not Complete

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -43,6 +43,21 @@ describe("getV2NativeNotificationContent", () => {
 		});
 	});
 
+	it("labels Failed as Failed, not Complete", () => {
+		const result = getV2NativeNotificationContent({
+			workspaceName: "Improve notifications",
+			payload: payload({
+				eventType: "Failed",
+				agent: { agentId: "claude" },
+			}),
+		});
+		expect(result).toMatchObject({
+			title: "Claude - Failed",
+			body: "Improve notifications",
+		});
+		expect(result.title).not.toContain("Complete");
+	});
+
 	it("falls back to generic labels", () => {
 		expect(
 			getV2NativeNotificationContent({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -1,3 +1,5 @@
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
 import {
 	AGENT_IDENTITY_LABELS,
 	type AgentIdentityId,
@@ -21,7 +23,7 @@ export function getV2NativeNotificationContent({
 		payload.eventType === "PermissionRequest"
 			? "Needs Attention"
 			: payload.eventType === "Failed"
-				? "Failed"
+				? i18n._(msg({ message: "Failed" }))
 				: "Complete";
 	const workspaceLabel = cleanLabel(workspaceName) ?? "Workspace";
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -18,7 +18,11 @@ export function getV2NativeNotificationContent({
 }: V2NativeNotificationContentOptions): { title: string; body: string } {
 	const agentLabel = getAgentLabel(payload.agent);
 	const action =
-		payload.eventType === "PermissionRequest" ? "Needs Attention" : "Complete";
+		payload.eventType === "PermissionRequest"
+			? "Needs Attention"
+			: payload.eventType === "Failed"
+				? "Failed"
+				: "Complete";
 	const workspaceLabel = cleanLabel(workspaceName) ?? "Workspace";
 
 	return {


### PR DESCRIPTION
## What & why

I got paged that an agent was "Complete" when it had Failed. Host already maps `StopFailure` → `Failed`, but v2 `notificationContent` treated every non-`PermissionRequest` as Complete — so Failed chimed like success.

I trust OS notifications for attention; Failed chiming Complete is how I miss a real stop. Failed → title `… - Failed`. PermissionRequest stays Needs Attention. Other events stay Complete.

This changes failure labels only; it does not address the subagent notification frequency reported in #6929.

## How I tested it

Tip: `ee661211f8c629330430ce00f665ea5943c4f835`.

`getV2NativeNotificationContent` branched only on PermissionRequest vs else→Complete; Failed fell into Complete. Now Failed maps to Failed (host `map-event-type` StopFailure→Failed).

- Units: `bun test` on `notificationContent.test.ts` → 4 pass / 0 fail @ tip `ee661211f`
- Fork tip-match: https://github.com/owieschon/superset/pull/39 @ exact tip
- Fork CI: https://github.com/owieschon/superset/actions/runs/34217591823 — owned jobs SUCCESS (Neon allowlisted)

## Checklist

- [x] Failed notification title is not Complete
- [x] PermissionRequest still Needs Attention
- [x] Scope = notificationContent + test only
- [x] Fork CI green at exact tip

## Maintainer verification

The Failed label now uses the shared Lingui instance and existing translations. Focused desktop tests: 12 pass. Typecheck, lint, and strict i18n catalog checks pass. The original change was verified through the real host notification flow before/after, including a normal Stop control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed notifications now display the correct “Failed” status instead of “Complete.”
  - Notification titles continue to include the relevant workspace name.
  - Status labels are now localized for supported languages.

- **Tests**
  - Added coverage to verify the correct label and workspace name for failed lifecycle notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->