### PR TITLE
docs(recipe): Needs review is not shipped without tip-native proof

### DIFF
--- a/docs/proof-gate-needs-review-receipt.md
+++ b/docs/proof-gate-needs-review-receipt.md
@@ -1,0 +1,42 @@
+# Proof gate: "Needs review" is not shipped
+
+> Draft. This is an operator-trust rule, not product code. It is not implemented and not merged.
+
+## What
+
+A workspace in the **Needs review** board column is not done.
+
+The app puts a workspace there when an agent's **Stop** event lands and its pull
+request is open, draft, or queued (see `deriveBoardColumn.ts`). The Stop only
+proves the agent finished. Nothing in that column proves the code is safe to ship.
+
+Before I treat a Needs-review workspace as shipped, I require a tip-native proof
+artifact. Tip-native means the pipeline produced it and it is pinned to the exact
+commit at the branch tip, by full SHA. The artifact is one of two things: check
+runs that CI actually ran against that SHA (for example `gh checks <sha>`, all
+green), or a receipt that names the SHA.
+
+## Why
+
+The stakes are first-person. I am the operator who merges. If I read "Needs
+review" as "ready", I ship whatever the agent left — maybe failing CI, maybe a
+commit I never actually verified. A bot saying "looks good" is an opinion, not
+proof. A check run pinned to a concrete SHA is proof, because I can read it back
+and pin it to the same commit I will merge.
+
+## The rule
+
+Needs review means "needs review", always. It does not mean "ready".
+
+- No proof, no ship. Without a check run or receipt pinned to the tip SHA, the
+  workspace stays in Needs review.
+- Bot QC alone is not proof.
+- This rule adds no board column. It uses the columns that already exist: Needs
+  review, Needs attention, Merged, Deleted.
+
+## Not in scope
+
+- Nothing here changes `agentStatus` (idle, working, permission, review, failed).
+  That stays the single source of truth for agent state and lives in its own
+  work (#7007). This rule only constrains how I act on it.
+- No new columns, no hook changes, no product code.


### PR DESCRIPTION
## What & why

Adds one docs page: `docs/proof-gate-needs-review-receipt.md`.

**Needs review** on the board is not shipped. Tip-native proof (check runs or a receipt pinned to the exact branch-tip SHA) is required first. Without that bar, Operators treat chrome as done and the product keeps lying about finished work.

## How I tested it

- Docs-only diff vs **upstream** `main` (single file) — branch cut from `superset-sh/superset` tip, not fork-main drift
- Stay **DRAFT** — no undraft without CoS→Owen

## Checklist

- [x] Thin docs brick only (no host-service / product code)
- [x] Attested board nouns; no invented ReadyVerified column
- [x] Fence Todd #7007 agentStatus SoT; no hooks #7252/#7263

Supersedes #7296/#7297 (those heads sat on fork-main commits not yet in upstream).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs page establishing that a workspace in Needs review is not shipped: operators must first see tip-native proof, either CI check runs or a receipt pinned to the exact branch-tip SHA.

This is a draft docs-only rule; it does not change product behavior, board columns, or `agentStatus`.

<sup>Written for commit f42156340fbdd528efa6b316e5793aee5b2270d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Mechanism

Docs-only operator recipe. One page states that **Needs review** is a board column meaning needs review — not shipped — until a tip-native proof artifact (check runs or receipt) is pinned to the exact branch-tip SHA. No new columns, no host-service code, no `agentStatus` SoT changes (Todd #7007).

Session: OpenCode Alibaba overnight proof-gate → thin re-cut from upstream/main as `docs/proof-gate-thin-upstream` after fork-main drift closed #7296/#7297.

## How I tested it

- **RECEIPT_PATH**=`/workspace/handoffs/pr7298-receipt-f42156340.md`
- **Tip:** `f42156340fbdd528efa6b316e5793aee5b2270d5`
- **Fork tip-match (authoritative #34 only):** https://github.com/owieschon/superset/pull/34
- **Fork CI:** https://github.com/owieschon/superset/actions/runs/34185079885 — owned jobs **SUCCESS** (Lint/Test/Typecheck/Build/Sherif/Vale/Version Sync/Build CLI×4); Neon allowlist OK
- **Docs self-check:** single-file tip vs upstream/main; recipe asserts Needs review ≠ shipped
- Stay **DRAFT** — no undraft without CoS→Owen