### PR TITLE
fix(desktop): wait for the terminal daemon on the right signal, and say what went wrong

### DIFF
--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -87,13 +87,21 @@ const SCRIPT_MTIME_PATH = join(SUPERSET_HOME_DIR, "terminal-host.mtime");
 
 // Connection timeouts
 const CONNECT_TIMEOUT_MS = 5000;
-const SPAWN_WAIT_MS = 2000;
 const REQUEST_TIMEOUT_MS = 30000;
 const SPAWN_LOCK_TIMEOUT_MS = 10000; // Max time to hold spawn lock
+// How long a spawned daemon gets to start accepting connections. A cold
+// `ELECTRON_RUN_AS_NODE` process start is not fast on a loaded machine, and
+// giving up early spawns a second daemon on top of the one still booting, so
+// this matches the window the spawn lock itself allows a spawn to take.
+const DAEMON_READY_TIMEOUT_MS = SPAWN_LOCK_TIMEOUT_MS;
+// Max wait for a connection attempt started elsewhere in this client to settle.
+const CONNECT_SETTLE_TIMEOUT_MS = 10000;
 
 // Queue limits
 const MAX_NOTIFY_QUEUE_BYTES = 2_000_000; // 2MB cap to prevent OOM
 const MAX_DAEMON_LOG_BYTES = 5 * 1024 * 1024; // 5MB cap for daemon.log
+// How many timed-out request ids to keep so a later reply can be recognized.
+const MAX_TIMED_OUT_REQUESTS = 16;
 
 // =============================================================================
 // NDJSON Parser
@@ -193,6 +201,13 @@ export class TerminalHostClient extends EventEmitter {
 	private disconnectArmed = false;
 	private clientId = randomUUID();
 	private canceledCreateOrAttachKeys = new Set<string>();
+	private connectAttempt: Promise<void> | null = null;
+	/** When the daemon last sent anything on either socket. 0 = never. */
+	private lastDaemonMessageAt = 0;
+	/** Requests we stopped waiting for, by id, so a late reply is recognized. */
+	private timedOutRequests = new Map<string, number>();
+	private lateAnswerCount = 0;
+	private lastLateAnswerMs: number | null = null;
 
 	constructor() {
 		super();
@@ -210,57 +225,41 @@ export class TerminalHostClient extends EventEmitter {
 	// Connection Management
 	// ===========================================================================
 
+	private get isFullyConnected(): boolean {
+		return (
+			this.connectionState === ConnectionState.CONNECTED &&
+			this.controlSocket !== null &&
+			this.streamSocket !== null &&
+			this.controlAuthenticated &&
+			this.streamAuthenticated
+		);
+	}
+
 	/**
 	 * Ensure we have a connected, authenticated socket.
 	 * Spawns daemon if needed.
 	 */
 	async ensureConnected(): Promise<void> {
 		// Already connected - fast path (no logging to avoid noise on every API call)
-		if (
-			this.connectionState === ConnectionState.CONNECTED &&
-			this.controlSocket &&
-			this.streamSocket &&
-			this.controlAuthenticated &&
-			this.streamAuthenticated
-		) {
-			return;
-		}
+		if (this.isFullyConnected) return;
 
-		// Another connection in progress - wait with timeout
-		if (this.connectionState === ConnectionState.CONNECTING) {
-			if (DEBUG_CLIENT) {
-				console.log(
-					"[TerminalHostClient] Connection already in progress, waiting...",
-				);
-			}
-			return new Promise((resolve, reject) => {
-				const startTime = Date.now();
-				const WAIT_TIMEOUT_MS = 10000; // 10 seconds max wait
+		// Concurrent callers share the one attempt, so all of them settle on what
+		// actually happened. Watching `connectionState` from the outside instead
+		// reported "Connection failed while waiting", which named neither the
+		// failure nor the caller that hit it.
+		this.connectAttempt ??= this.connectOnce().finally(() => {
+			this.connectAttempt = null;
+		});
+		return this.connectAttempt;
+	}
 
-				const checkConnection = () => {
-					if (
-						this.connectionState === ConnectionState.CONNECTED &&
-						this.controlSocket &&
-						this.streamSocket &&
-						this.controlAuthenticated &&
-						this.streamAuthenticated
-					) {
-						resolve();
-					} else if (this.connectionState === ConnectionState.DISCONNECTED) {
-						reject(new Error("Connection failed while waiting"));
-					} else if (Date.now() - startTime > WAIT_TIMEOUT_MS) {
-						reject(
-							new Error(
-								"Timeout waiting for connection - daemon may be unresponsive",
-							),
-						);
-					} else {
-						setTimeout(checkConnection, 100);
-					}
-				};
-				checkConnection();
-			});
-		}
+	private async connectOnce(): Promise<void> {
+		// `tryConnectAndAuthenticate` may already own CONNECTING; two attempts
+		// destroy each other's control socket. Wait for that probe to settle —
+		// a probe that finds no daemon leaves us DISCONNECTED, which is not a
+		// failure here, because we spawn one below.
+		await this.waitForConnectionToSettle();
+		if (this.isFullyConnected) return;
 
 		this.connectionState = ConnectionState.CONNECTING;
 		this.disconnectArmed = false;
@@ -277,6 +276,26 @@ export class TerminalHostClient extends EventEmitter {
 			// Reset without emitting disconnected (connection never became usable)
 			this.resetConnectionState({ emitDisconnected: false });
 			throw error;
+		}
+	}
+
+	private async waitForConnectionToSettle(): Promise<void> {
+		if (this.connectionState !== ConnectionState.CONNECTING) return;
+
+		if (DEBUG_CLIENT) {
+			console.log(
+				"[TerminalHostClient] Connection already in progress, waiting...",
+			);
+		}
+
+		const startTime = Date.now();
+		while (this.connectionState === ConnectionState.CONNECTING) {
+			if (Date.now() - startTime > CONNECT_SETTLE_TIMEOUT_MS) {
+				throw new Error(
+					"Timeout waiting for connection - daemon may be unresponsive",
+				);
+			}
+			await this.sleep(100);
 		}
 	}
 
@@ -720,11 +739,15 @@ export class TerminalHostClient extends EventEmitter {
 	 * Handle incoming message (response or event)
 	 */
 	private handleMessage(message: IpcResponse | IpcEvent): void {
+		this.lastDaemonMessageAt = Date.now();
+
 		// Type guard: responses have 'id' field, events have 'type: event'
 		if ("id" in message) {
 			// Response to a request
 			const pending = this.pendingRequests.get(message.id);
-			if (pending) {
+			if (!pending) {
+				this.recordLateAnswer(message.id);
+			} else {
 				this.pendingRequests.delete(message.id);
 				clearTimeout(pending.timeoutId);
 
@@ -824,6 +847,10 @@ export class TerminalHostClient extends EventEmitter {
 			pending.reject(pendingRequestError ?? new Error("Connection lost"));
 			this.pendingRequests.delete(id);
 		}
+
+		// Nothing can answer these now, so they are not evidence of a daemon that
+		// never answers.
+		this.timedOutRequests.clear();
 
 		if (emitDisconnected) {
 			this.emit("disconnected");
@@ -1296,13 +1323,28 @@ export class TerminalHostClient extends EventEmitter {
 				);
 			}
 
+			// Watch the child we just started. Nothing observed it before, so a
+			// daemon that could not exec or died on startup was indistinguishable
+			// from a slow one, and an unhandled "error" event would have taken the
+			// main process down with it.
+			const startupFailure: { reason: string | null } = { reason: null };
+			child.on("error", (error) => {
+				startupFailure.reason ??= `could not be spawned (${error.message})`;
+				console.warn(`[TerminalHostClient] Daemon ${startupFailure.reason}`);
+			});
+			child.once("exit", (code, signal) => {
+				startupFailure.reason ??= signal
+					? `was killed by ${signal} during startup`
+					: `exited with code ${code} during startup`;
+			});
+
 			if (!isDev) child.unref();
 
 			// Wait for daemon to start
 			if (DEBUG_CLIENT) {
 				console.log("[TerminalHostClient] Waiting for daemon to start...");
 			}
-			await this.waitForDaemon();
+			await this.waitForDaemon(startupFailure);
 
 			// In development mode, save the script mtime to detect rebuilds
 			if (process.env.NODE_ENV === "development") {
@@ -1332,16 +1374,23 @@ export class TerminalHostClient extends EventEmitter {
 	}
 
 	/**
-	 * Wait for daemon to be ready
+	 * Wait for the daemon to accept connections.
+	 *
+	 * `startupFailure` carries what the process we spawned did, when we were the
+	 * spawner. A daemon that dies on startup is a different thing from one that
+	 * is merely slow, and only the socket answering means it is actually ready —
+	 * the socket file appears at `listen()` but polling for the file alone had to
+	 * guess at the rest with a fixed sleep.
 	 */
-	private async waitForDaemon(): Promise<void> {
+	private async waitForDaemon(startupFailure?: {
+		reason: string | null;
+	}): Promise<void> {
 		const startTime = Date.now();
 
-		while (Date.now() - startTime < SPAWN_WAIT_MS) {
-			if (existsSync(SOCKET_PATH)) {
-				// Give it a moment to start listening
-				await this.sleep(200);
-				return;
+		while (Date.now() - startTime < DAEMON_READY_TIMEOUT_MS) {
+			if (await this.isSocketLive()) return;
+			if (startupFailure?.reason) {
+				throw new Error(`Daemon ${startupFailure.reason}`);
 			}
 			await this.sleep(100);
 		}
@@ -1358,6 +1407,37 @@ export class TerminalHostClient extends EventEmitter {
 	// ===========================================================================
 
 	/**
+	 * Note that a request we gave up on was answered after all, and how late.
+	 * A daemon that always answers eventually is a slow or suspended machine; a
+	 * daemon that never does is a daemon that is actually stuck.
+	 */
+	private recordLateAnswer(id: string): void {
+		const timedOutAt = this.timedOutRequests.get(id);
+		if (timedOutAt === undefined) return;
+		this.timedOutRequests.delete(id);
+		this.lateAnswerCount++;
+		this.lastLateAnswerMs = Date.now() - timedOutAt;
+	}
+
+	/**
+	 * What we know about the daemon at the moment a request gave up. Without
+	 * this the timeout says only which request it was, which cannot tell a
+	 * wedged daemon apart from a machine that stopped running either process.
+	 */
+	private describeRequestTimeout(sentAt: number): string {
+		const facts = [
+			this.lastDaemonMessageAt > sentAt
+				? `daemon last spoke ${Date.now() - this.lastDaemonMessageAt}ms ago`
+				: "daemon sent nothing while we waited",
+			`${this.pendingRequests.size} other request(s) in flight`,
+			this.lateAnswerCount === 0
+				? "no earlier timeout has ever been answered"
+				: `${this.lateAnswerCount} earlier timeout(s) answered late, most recent ${this.lastLateAnswerMs}ms after giving up`,
+		];
+		return ` after ${Date.now() - sentAt}ms (${facts.join("; ")})`;
+	}
+
+	/**
 	 * Send a request to the daemon and wait for response
 	 */
 	private sendRequest<T>(type: string, payload: unknown): Promise<T> {
@@ -1368,10 +1448,20 @@ export class TerminalHostClient extends EventEmitter {
 			}
 
 			const id = `req_${++this.requestCounter}`;
+			const sentAt = Date.now();
 
 			const timeoutId = setTimeout(() => {
 				this.pendingRequests.delete(id);
-				reject(new Error(`Request timeout: ${type}`));
+				if (this.timedOutRequests.size >= MAX_TIMED_OUT_REQUESTS) {
+					const oldest = this.timedOutRequests.keys().next().value;
+					if (oldest) this.timedOutRequests.delete(oldest);
+				}
+				this.timedOutRequests.set(id, Date.now());
+				reject(
+					new Error(
+						`Request timeout: ${type}${this.describeRequestTimeout(sentAt)}`,
+					),
+				);
 			}, REQUEST_TIMEOUT_MS);
 
 			// Cast resolve to unknown handler - safe because response type matches T


### PR DESCRIPTION
Three failure modes of the terminal host daemon's lifecycle, all reported as 500s. They are not the same condition and they do not get the same answer. #7284 handled the *PTY spawn* half of terminal failures and deliberately left these; this is the *daemon* half.

## Reality check

**1. User-visible harm.** A terminal pane fails to open — either instantly, or after a 30-second wait — and the user gets `[Connection lost. Reconnecting...]` instead of a shell. Two of the three are the app giving up on a daemon that was working or about to work; when several panes attach at once, they all fail together.

**2. Does the change reach the reported failure?** Yes. All three throw in `apps/desktop/src/main/lib/terminal-host/client.ts`, in the Electron main process, on the same code path the events come from (`trpc_path: terminal.createOrAttach` on every event of all three issues). Events are still arriving on `1.26.0`, the current release; this ships in the next desktop release and reaches every desktop user on update. `DESKTOP-2C` has been reported continuously since `1.1.3`, so nothing has removed the path.

**3. Is code the right instrument?** For `DESKTOP-8D`, the throw site is being deleted, so nothing else applies. For `DESKTOP-E4`, archiving would hide the app spawning a second daemon on top of one still booting. `DESKTOP-2C` is the one where doing nothing was a live option — but the message cannot tell a wedged daemon from a machine that stopped running either process, so archiving would be archiving an unknown. No in-flight work touches this file (last change: #7284, merged). No Sentry-side suppression anywhere — classification is at throw sites only.

## Problem

- **`DESKTOP-8D` — `Connection failed while waiting` (97 events).** Not a distinct failure at all. `ensureConnected` let the first caller connect and had every concurrent caller poll `connectionState` from the outside, then synthesize its own error. Every one of these 97 events is some *other* real failure with its cause stripped off.
- **`DESKTOP-E4` — `Daemon failed to start in time` (80 events).** `waitForDaemon` polled `existsSync(SOCKET_PATH)` for 2s, then slept 200ms and declared the daemon ready. The sampled event fired 26s after app start on a machine with 296 MB free of 17 GB — a daemon still booting, not a broken one.
- **`DESKTOP-2C` — `Request timeout: createOrAttach` (3,826 events, ~38/week).** Events arrive in same-second groups of two and three, so a whole daemon goes quiet, not one request. Beyond that the event says nothing.

## Root cause

**`ensureConnected` did not share its in-flight attempt.** Watchers polled state and manufactured `Connection failed while waiting`, discarding the leader's real error. Worse, the state they watched is also owned by `tryConnectAndAuthenticate` — the startup `listSessions` probe. A pane attaching while that probe runs waits for it, sees the probe finish `DISCONNECTED` because there is *no daemon yet*, and reports a failed connection. That is precisely the case where the correct action is to spawn one. A recoverable "no daemon" became a failed terminal open.

**`waitForDaemon` waited on the wrong signal and never watched what it spawned.** The socket file appearing is not the daemon listening, so the 200ms sleep was guessing at the rest; nothing observed the child, so a daemon that could not exec or died at startup was indistinguishable from a slow one; and an unhandled `error` event on the child would have taken the main process down. The 2s deadline was never a statement about health — it is a bet on how fast a cold `ELECTRON_RUN_AS_NODE` start is, and losing it is not free. The caller retries, finds no socket and no pid file (the daemon writes its pid inside the `listen` callback, `main/terminal-host/index.ts:788`), and spawns a **second** daemon on top of the one still booting — on a machine already slow enough to miss the deadline. The loser exits via "Another daemon is already running", having burned a full Electron process start.

**The request timeout discarded the only evidence that could explain it.** On timeout `sendRequest` deleted the pending entry, so a reply that arrived at 31s hit `handleMessage`, matched nothing, and was dropped in silence. We could never find out whether the daemon answers eventually — which is the whole question, since a daemon that always answers late is a slow or suspended machine and one that never does is genuinely stuck.

## Fix

**`DESKTOP-8D` — fixed; the throw site is gone.** Concurrent callers share one `connectAttempt`, so all of them settle on the error that actually happened, and a caller racing the probe waits for it and then connects itself instead of being told the connection failed. `Connection failed while waiting` no longer exists. These failures now report as their real cause, so this stops being a separate issue rather than going quiet.

**`DESKTOP-E4` — still reports, and should now mean something.** `waitForDaemon` polls `isSocketLive()` (a real connect probe, already in this file), fails immediately with the child's exit code, signal, or spawn error when there is one, and otherwise allows a cold start the same window the spawn lock already allows a spawn to take (`SPAWN_LOCK_TIMEOUT_MS`). The child now has an `error` listener, which it did not before. `Daemon failed to start in time` is kept for the case where the daemon never listens and never exits — that is a real defect and keeps reporting.

**`DESKTOP-2C` — still reports, with enrichment; deliberately not reclassified.** I could not establish that this is environmental, and the task's own instruction is not to call a hang environmental just because the client gave up. It stays `INTERNAL_SERVER_ERROR`. The message now carries how long it really waited, whether the daemon spoke at all during the wait, how many other requests were stuck, and how many earlier timeouts were answered late (bounded at 16 tracked ids, cleared on disconnect since nothing can answer those). Example shape:

```
Request timeout: createOrAttach after 30012ms (daemon last spoke 120ms ago; 2 other request(s) in flight; 3 earlier timeout(s) answered late, most recent 240ms after giving up)
```

"daemon last spoke 120ms ago" with a stuck `createOrAttach` is a daemon bug. "daemon sent nothing while we waited" plus late answers on every earlier timeout is a machine that stopped running both processes. The next batch of events decides it; today's cannot.

**No typed causes added.** Nothing reads one — no renderer branch, no retry decision, no test — so per the rule these throw plain errors. Nothing was reclassified to a non-500, so the middleware keeps reporting exactly what it should.

**No retries added, nothing swallowed, no Sentry-side filtering.** Existing messages are preserved verbatim where the condition still exists (`Daemon failed to start in time`, `Timeout waiting for connection - daemon may be unresponsive`).

## Adjacent, deliberately left alone

- `sendRequestOnStream` (`client.ts`) has its own 30s timeout with the same `Request timeout:` shape, used only for the stream-socket `hello`. Not in these issues; untouched.
- `waitForExistingDaemonProbe` still polls `connectionState`. It is the probe's own path, returns a boolean rather than throwing a synthesized error, and is not in these issues.
- The daemon-side `attach()` awaits `emulator.flush()` unbounded while `flushToSnapshotBoundary` is capped at 500ms — a candidate for the 2C hang, but a candidate is not a cause. The enrichment is what tells us whether to go there.

## Verification

`bunx biome check apps/desktop/src/main/lib/terminal-host/client.ts`
```
Checked 1 file in 18ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`
```
$ tsr generate
$ tsc --noEmit
```
(clean, no diagnostics)

`cd apps/desktop && bun test src/main/lib/terminal-host src/main/lib/terminal src/main/terminal-host src/no-main-process-blocking.test.ts`
```
 208 pass
 0 fail
 452 expect() calls
Ran 208 tests across 13 files. [1210.00ms]
```

Full desktop package suite, `cd apps/desktop && bun test`:
```
 3669 pass
 1 fail
 1 error
 2 snapshots, 59370 expect() calls
Ran 3670 tests across 397 files. [28.21s]
```
The one failure is `useSidebarDnd.test.ts` (`TypeError: React.createContext is not a function` from `@dnd-kit/core`). It is pre-existing, not mine: the same full run on unmodified `HEAD` gives the identical `3669 pass / 1 fail`, and the file passes in isolation (`8 pass, 0 fail`) — cross-file module-registry pollution in the full run, in renderer code this diff does not touch.

**The `ensureConnected` change was verified against the real class before and after.** A throwaway `bun test` file (not committed) drove `TerminalHostClient` with `connectAndAuthenticate` stubbed to throw a known error, then made three concurrent `ensureConnected()` calls. After the fix: one attempt, and all three reject with the *identical* error instance. Against unmodified `HEAD` the same file fails, with callers 2 and 3 rejecting on:
```
Received: 250 | reject(new Error("Connection failed while waiting"));
      at checkConnection (.../terminal-host/client.ts:250:18)
(fail) ensureConnected shares one attempt > gives every concurrent caller the real failure, once
```
— which is `DESKTOP-8D` itself, reproduced from its own throw site. A second case confirms a later caller starts a fresh attempt after a failure, and that the connected fast path starts no attempt at all.

No new test file is committed, per this repo's standing preference against unprompted tests; nothing here adds a classifier or matcher that would require a negative test.

Refs DESKTOP-2C
Refs DESKTOP-E4
Refs DESKTOP-8D

https://claude.ai/code/session_016Gasn4tBMyzp9d4xGKiiPq


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three terminal daemon lifecycle failures that all reported as 500s (DESKTOP-8D, DESKTOP-E4, DESKTOP-2C): concurrent callers were told "Connection failed while waiting" instead of the real error, daemon startup waited on the socket file rather than the daemon listening, and request timeouts discarded late replies that could show whether the daemon answers eventually. No retries or Sentry-side filtering were added; existing error messages are preserved where the condition still exists.

**Bug Fixes**
- Concurrent callers share one connect attempt and settle on the actual error; a caller racing the startup probe now connects itself instead of being told the connection failed.
- `waitForDaemon` polls `isSocketLive()` instead of the socket file, fails immediately when the child exits or errors, and gives a cold start the same window the spawn lock allows.
- The spawned child now has `error` and `exit` listeners; an unhandled error previously would have taken the main process down.
- Request timeouts now include how long they waited, whether the daemon spoke during the wait, how many other requests were stuck, and how many earlier timeouts were answered late.

<sup>Written for commit e41855a6b8c27241b2020409d9cb03939f283478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal connection reliability by preventing duplicate connection attempts and better coordinating connection checks.
  - Improved daemon startup detection, including clearer handling of startup failures and unexpected exits.
  - Added more robust timeout handling for connection and terminal requests.
  - Improved diagnostics when requests time out, including clearer status information.
  - Improved handling of delayed responses and connection resets to reduce stale or misleading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->