### PR TITLE
chore: add optional RepoRoad building

### DIFF
--- a/.reporoad.yml
+++ b/.reporoad.yml
@@ -1,0 +1,11 @@
+# Optional building on https://reporoad.org
+# After merging, submit this repository at https://reporoad.org to join.
+version: 1
+style: greenhouse
+color: "#778565"
+roof: gable
+signText: Superset
+garden: true
+support:
+  sponsor: false
+  helpWanted: false


### PR DESCRIPTION
## What & why

Hi! I’m building [RepoRoad](https://reporoad.org), an open-source project that represents GitHub repositories as buildings along a shared voxel road with a live lo-fi driving stream. This is an optional invitation from its creator—not a bug fix, required integration, or existing partnership.

Superset’s coding-agent workspace fits the developer-tool theme of the road; I chose a greenhouse-style building as an initial design.

This PR adds only a root `.reporoad.yml`: a greenhouse building, #778565 accent, gabled roof, garden, and “Superset” sign. Height is calculated from public GitHub stars. Sponsor/help-wanted markers are off; no funding files or sponsorship destinations are changed.

### Where to view and how to opt in

- Visit **https://reporoad.org** to see the live road and building editor.
- Before merging, download this PR’s YAML and open it in the **Add** tab to preview/customise the design. This repository is not enrolled by this PR alone.
- If you would like to join, merge the file into the default branch and use **Submit repository** on RepoRoad with `superset-sh/superset`. Direct verification avoids GitHub search-index delays.
- Later changes can be made in the YAML and re-submitted. Removing the file opts out once RepoRoad rechecks it (cached entries can persist for up to 24 hours).

No package, workflow, executable code, dependency, or repository secret is added. The file only contains declarative appearance settings read by RepoRoad; no payment is required. RepoRoad source: https://github.com/reporoad/reporoad.

If third-party directory configuration is not something you want to maintain here, please feel free to close this invitation—no action is needed.

## How I tested it

- Validated the exact YAML with RepoRoad’s current `parseBuildingConfig` validator.
- Confirmed no existing root `.reporoad.yml` is replaced.
- Application builds/tests were not run: this changes only external-service metadata, not application code.
- Prepared with AI assistance; the file and proposed settings were checked against RepoRoad’s schema.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` (not run; configuration-only invitation)
- [x] Allow edits from maintainers


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `.reporoad.yml` so Superset can appear as a greenhouse building on RepoRoad (reporoad.org). This file is declarative metadata only; it doesn't change application code, dependencies, or behavior. To activate, merge this file and submit the repository at RepoRoad.

<sup>Written for commit b7e7b3ce0028dfe00f244a8f91c3945f2400cc7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for the RepRoad project display, including its visual style, roof type, sign text, and garden setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->