### PR TITLE
docs(recipe): worked example for tip-native proof before shipped

### DIFF
--- a/docs/proof-gate-worked-example.md
+++ b/docs/proof-gate-worked-example.md
@@ -1,0 +1,25 @@
+# Proof gate worked example
+
+Companion to [proof-gate-needs-review-receipt.md](./proof-gate-needs-review-receipt.md).
+
+**Needs review** is not shipped. Tip-native proof means the artifact is pinned to the
+exact commit SHA at the branch tip — not "CI was green earlier," not bot rollup alone.
+
+## Worked pattern (desktop honesty brick)
+
+Example: Failed OS notification copy must not read as Complete ([#6929](https://github.com/superset-sh/superset/issues/6929) / draft proof path).
+
+Before treating that change as ready for review to merge:
+
+1. Record the tip SHA under test.
+2. Run the focused unit at that tip (or cite fork Actions **Test** at the same SHA).
+3. Keep a receipt that names the tip, the unit or CI URL, and **Overall: PASS**.
+4. Cite `RECEIPT_PATH` and the fork tip-match Actions run URL in the PR body under
+   **How I tested it**.
+5. Stay draft until that proof exists — board **Needs review** does not waive it.
+
+## What this is not
+
+- Not a new board column.
+- Not a second `agentStatus` source of truth (leave Todd's CLI/SDK work alone).
+- Not a substitute for maintainer review — only the bar before calling work shipped.


### PR DESCRIPTION
## What & why

Adds `docs/proof-gate-worked-example.md` — a companion to the Needs review proof-gate recipe.

Operators still treat board chrome as done. This page shows the tip-SHA + receipt + fork CI pattern so **Needs review** cannot be read as shipped without tip-native proof. Matters for anyone merging overnight honesty bricks; keeps the hire-line invariant teachable without inventing a new column.

## How I tested it

- Docs-only diff vs upstream `main` (single file)
- Cut from upstream/main (no fork-main drift)
- Stay **DRAFT** — no undraft without CoS→Owen

## Mechanism

Docs-only. No product code. Lexicon: Needs review / tip-native proof / receipt — no ReadyVerified column. Fence Todd #7007 agentStatus SoT; no hooks; no dock #6506.

## Checklist

- [x] Single docs file vs upstream main
- [x] Companion to proof-gate-needs-review-receipt recipe
- [x] Stay DRAFT until CoS READY + Owen undraft

## How I tested it

- **RECEIPT_PATH**=`/workspace/handoffs/pr7302-receipt-59e373fd3.md`
- **Tip:** `59e373fd3fa81feb6d0bb0f3a54c424a2ca74cc1`
- **Fork tip-match (authoritative #35 only):** https://github.com/owieschon/superset/pull/35 @ `59e373fd3`
- **Fork CI:** https://github.com/owieschon/superset/actions/runs/34185762012 — owned jobs **SUCCESS** (Lint/Test/Typecheck/Build/Sherif/Vale/Version Sync/Build CLI×4); Neon Deploy Database FAIL allowlisted
- **Docs self-check:** single-file tip vs upstream/main
- Stay **DRAFT**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs-only worked example for the proof-gate recipe, showing how tip-SHA plus receipt plus fork CI proves a change is testable at the branch tip before it can be treated as shipped.

**New Features**
- Documents the 5-step proof pattern: record tip SHA, run the focused test at that tip, keep a receipt with Overall: PASS, cite the receipt and fork CI URL in the PR body, and stay draft until that proof exists.
- States explicitly that board **Needs review** does not waive the proof requirement, and that this is not a new column, not a second `agentStatus` source of truth, and not a substitute for maintainer review.
- Stays DRAFT until CoS gives READY and Owen undrafts.

<sup>Written for commit 59e373fd3fa81feb6d0bb0f3a54c424a2ca74cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->