### PR TITLE
fix(host-service): bound the diff patch, and stop depending on the launch directory

### DIFF
--- a/apps/desktop/src/main/host-service/index.ts
+++ b/apps/desktop/src/main/host-service/index.ts
@@ -9,6 +9,7 @@ import { serve } from "@hono/node-server";
 import {
 	captureFatalStartupError,
 	createApp,
+	detachFromLaunchDirectory,
 	initSentry,
 	installProcessSafetyNet,
 	installUpgradeSocketGuard,
@@ -42,6 +43,11 @@ type Server = ReturnType<typeof serve>;
 
 async function main(): Promise<void> {
 	initSentry({ organizationId: env.ORGANIZATION_ID });
+
+	// Whatever directory the app was launched from can be deleted while this
+	// host runs — a workspace worktree, most of all — and a process sitting in
+	// a deleted directory cannot start a worker thread (HOST-SERVICE-5D).
+	detachFromLaunchDirectory();
 
 	// Install the parent watchdog before any awaits so a crash during
 	// startup can still reap this child. `serverRef` / `disposeRef` are filled

--- a/packages/host-service/src/index.ts
+++ b/packages/host-service/src/index.ts
@@ -15,6 +15,7 @@ export type { HostAuthProvider } from "./providers/host-auth";
 export { PskHostAuthProvider } from "./providers/host-auth";
 export { resolveBrowserBridgeFromEnv } from "./runtime/browser-bridge/env";
 export type { GitCredentialProvider, GitFactory } from "./runtime/git";
+export { detachFromLaunchDirectory } from "./runtime/working-directory";
 export { installProcessSafetyNet, installUpgradeSocketGuard } from "./safety";
 export { captureFatalStartupError, initSentry } from "./sentry";
 export { startTerminalReaper } from "./terminal/reaper";

--- a/packages/host-service/src/runtime/git/identity.test.ts
+++ b/packages/host-service/src/runtime/git/identity.test.ts
@@ -100,12 +100,15 @@ describe("getGitHubUsernameViaGh", () => {
 });
 
 describe("readGitIdentity", () => {
-	test("combines gh login with the process-env git author", async () => {
+	test("combines gh login with the home-anchored git author", async () => {
 		writeGhStub('echo "hubster"');
-		// The git read intentionally uses the process env (not shellEnv), so
-		// compare against the same read done directly.
+		// The git read intentionally uses the process env (not shellEnv) and
+		// is anchored at the home directory rather than wherever this process
+		// happens to be — compare against the same read done directly.
 		const { createUserSimpleGit } = await import("./simple-git");
-		const expectedAuthor = await getGitAuthorName(createUserSimpleGit());
+		const expectedAuthor = await getGitAuthorName(
+			createUserSimpleGit(os.homedir()),
+		);
 		expect(await readGitIdentity(stubGhEnv())).toEqual({
 			githubUsername: "hubster",
 			authorName: expectedAuthor,

--- a/packages/host-service/src/runtime/git/identity.test.ts
+++ b/packages/host-service/src/runtime/git/identity.test.ts
@@ -100,18 +100,48 @@ describe("getGitHubUsernameViaGh", () => {
 });
 
 describe("readGitIdentity", () => {
-	test("combines gh login with the home-anchored git author", async () => {
+	test("reads the author from home, not from the directory it runs in", async () => {
 		writeGhStub('echo "hubster"');
-		// The git read intentionally uses the process env (not shellEnv) and
-		// is anchored at the home directory rather than wherever this process
-		// happens to be — compare against the same read done directly.
-		const { createUserSimpleGit } = await import("./simple-git");
-		const expectedAuthor = await getGitAuthorName(
-			createUserSimpleGit(os.homedir()),
+		// Two identities that cannot be confused: one in the home git config
+		// the read is anchored to, one in the repository the process is
+		// standing in. The git read uses the process env (not shellEnv), so
+		// HOME is set here rather than passed in.
+		const home = path.join(tmpDir, "identity-home");
+		fs.mkdirSync(path.join(home, ".config"), { recursive: true });
+		fs.writeFileSync(
+			path.join(home, ".gitconfig"),
+			"[user]\n\tname = home-identity\n",
 		);
-		expect(await readGitIdentity(stubGhEnv())).toEqual({
-			githubUsername: "hubster",
-			authorName: expectedAuthor,
+		const cwdRepo = path.join(tmpDir, "identity-repo");
+		fs.mkdirSync(cwdRepo);
+		execFileSync("git", ["init"], { cwd: cwdRepo });
+		execFileSync("git", ["config", "user.name", "repo-identity"], {
+			cwd: cwdRepo,
 		});
+
+		const restore = {
+			home: process.env.HOME,
+			xdg: process.env.XDG_CONFIG_HOME,
+			cwd: process.cwd(),
+		};
+		try {
+			process.env.HOME = home;
+			process.env.XDG_CONFIG_HOME = path.join(home, ".config");
+			process.chdir(cwdRepo);
+
+			expect(await readGitIdentity(stubGhEnv())).toEqual({
+				githubUsername: "hubster",
+				authorName: "home-identity",
+			});
+		} finally {
+			process.chdir(restore.cwd);
+			setOrDelete("HOME", restore.home);
+			setOrDelete("XDG_CONFIG_HOME", restore.xdg);
+		}
 	});
 });
+
+function setOrDelete(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}

--- a/packages/host-service/src/runtime/git/identity.ts
+++ b/packages/host-service/src/runtime/git/identity.ts
@@ -2,6 +2,7 @@
 // the git/readGitIdentity worker task can bundle this module.
 
 import { execFile } from "node:child_process";
+import { homedir } from "node:os";
 import { promisify } from "node:util";
 import type { SimpleGit } from "simple-git";
 import { createUserSimpleGit } from "./simple-git";
@@ -49,13 +50,20 @@ export async function getGitHubUsernameViaGh(
  * Git identity used to preview `author`/`github` branch prefixes in settings.
  * `shellEnv` is only for the `gh` spawn; the git config read keeps the
  * process env — simple-git rejects env containing GIT_EDITOR as unsafe.
+ *
+ * The config read is anchored at the home directory rather than left to
+ * simple-git's default of the process working directory: this runs in a
+ * worker, and a worker must not depend on where the host was launched — that
+ * directory can be deleted while the host runs (HOST-SERVICE-5D), and which
+ * repository it happened to be would otherwise decide whose name a global
+ * setting previews.
  */
 export async function readGitIdentity(
 	shellEnv: Record<string, string>,
 ): Promise<ResolvedGitInfo> {
 	const [githubUsername, authorName] = await Promise.all([
 		getGitHubUsernameViaGh(shellEnv),
-		getGitAuthorName(createUserSimpleGit()),
+		getGitAuthorName(createUserSimpleGit(homedir())),
 	]);
 	return { githubUsername, authorName };
 }

--- a/packages/host-service/src/runtime/working-directory.test.ts
+++ b/packages/host-service/src/runtime/working-directory.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detachFromLaunchDirectory } from "./working-directory";
+
+describe("detachFromLaunchDirectory", () => {
+	test("leaves a launch directory that has been deleted", () => {
+		const launchDir = mkdtempSync(join(tmpdir(), "superset-launch-dir-"));
+		const original = process.cwd();
+		try {
+			process.chdir(launchDir);
+			rmSync(launchDir, { recursive: true, force: true });
+
+			detachFromLaunchDirectory();
+
+			// The invariant the worker bootstrap needs: the process sits in a
+			// directory that still exists. (macOS keeps reporting the deleted
+			// path from process.cwd() until something moves off it.)
+			expect(process.cwd()).not.toBe(launchDir);
+			expect(existsSync(process.cwd())).toBe(true);
+		} finally {
+			process.chdir(original);
+		}
+	});
+});

--- a/packages/host-service/src/runtime/working-directory.ts
+++ b/packages/host-service/src/runtime/working-directory.ts
@@ -1,0 +1,38 @@
+import { homedir, tmpdir } from "node:os";
+
+/**
+ * Moves the process off the directory it was launched from.
+ *
+ * host-service inherits its working directory from whoever started it — the
+ * shell `superset start` ran in, the desktop app's own — and it outlives that
+ * directory: deleting a workspace deletes a worktree, which is exactly where
+ * someone starts a host from. Nothing here needs it. Every path the host
+ * touches arrives absolute, from its config or from the request, and every
+ * git process is given the worktree it runs in.
+ *
+ * What does need it is Node: a worker thread reads the process's working
+ * directory while bootstrapping, before the task script even loads, so once
+ * that directory is unlinked no worker can start at all — `ENOENT ... uv_cwd`,
+ * three of them (HOST-SERVICE-5D) until HostWorkerPool's crash circuit opens
+ * and every git task runs on the event loop for the rest of the process's
+ * life. simple-git built without a base directory takes the same reading and
+ * throws from its factory.
+ *
+ * Home first because a host runs as the user and its children inherit this;
+ * the temp directory only if home is unusable (a service account pointed at
+ * a HOME that does not exist).
+ */
+export function detachFromLaunchDirectory(): void {
+	for (const target of [homedir(), tmpdir()]) {
+		try {
+			process.chdir(target);
+			return;
+		} catch {
+			// Try the next one — an unusable candidate is not fatal, it just
+			// leaves the process where the launcher put it.
+		}
+	}
+	console.warn(
+		"[host-service] could not leave the launch directory; deleting it will stop worker threads from starting",
+	);
+}

--- a/packages/host-service/src/serve.ts
+++ b/packages/host-service/src/serve.ts
@@ -15,6 +15,7 @@ import {
 import { provisionAgentIntegrations } from "./runtime/agent-provisioning";
 import { resolveBrowserBridgeFromEnv } from "./runtime/browser-bridge/env";
 import { applyLoginShellEnvToProcess } from "./runtime/login-shell-env";
+import { detachFromLaunchDirectory } from "./runtime/working-directory";
 import { installProcessSafetyNet, installUpgradeSocketGuard } from "./safety";
 import { captureFatalStartupError, initSentry } from "./sentry";
 import { startTerminalBaseEnvResolution } from "./terminal/env";
@@ -24,6 +25,11 @@ import { connectRelay } from "./tunnel";
 async function main(): Promise<void> {
 	installConsoleTimestamps();
 	initSentry({ organizationId: env.ORGANIZATION_ID });
+
+	// Before anything spawns a worker thread or a child process: a host
+	// started from a workspace outlives that directory (HOST-SERVICE-5D).
+	detachFromLaunchDirectory();
+
 	console.log(
 		`[host-service] starting (org=${env.ORGANIZATION_ID}, port=${env.PORT}, NODE_ENV=${process.env.NODE_ENV ?? "unset"})`,
 	);

--- a/packages/host-service/src/trpc/router/git/utils/diff-patch.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/diff-patch.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import simpleGit, { type SimpleGit } from "simple-git";
+import { buildDiffPatch } from "./diff-patch.ts";
+
+/**
+ * The bound exists because a working tree can hold a file of any size and an
+ * untracked file's diff is that whole file: unbounded, the patch is the
+ * repository, and V8 threw `RangeError: Invalid string length` building it
+ * (HOST-SERVICE-5C). These cases pin what the caller gets instead — whole
+ * file sections up to the bound, never half of one.
+ */
+
+const ENV = { GIT_OPTIONAL_LOCKS: "0", LC_ALL: "C" };
+
+async function initRepo(path: string): Promise<SimpleGit> {
+	const git = simpleGit(path);
+	await git.init();
+	await git.raw(["config", "user.email", "test@example.com"]);
+	await git.raw(["config", "user.name", "test"]);
+	await git.raw(["config", "commit.gpgsign", "false"]);
+	await git.raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+	return git;
+}
+
+function lines(count: number, marker: string): string {
+	return `${Array.from({ length: count }, (_, i) => `${marker} line ${i}`).join("\n")}\n`;
+}
+
+describe("buildDiffPatch", () => {
+	let repo: string;
+	let git: SimpleGit;
+
+	beforeEach(async () => {
+		repo = mkdtempSync(join(tmpdir(), "superset-diff-bound-"));
+		git = await initRepo(repo);
+	});
+
+	afterEach(() => {
+		rmSync(repo, { recursive: true, force: true });
+	});
+
+	test("cuts the patch on a file boundary instead of mid-section", async () => {
+		for (const name of ["a.txt", "b.txt", "c.txt"]) {
+			await writeFile(join(repo, name), lines(400, "old"));
+		}
+		await git.add(["."]);
+		await git.commit("initial");
+		for (const name of ["a.txt", "b.txt", "c.txt"]) {
+			await writeFile(join(repo, name), lines(400, "new"));
+		}
+
+		const request = {
+			cwd: repo,
+			env: ENV,
+			category: "unstaged" as const,
+			refs: {},
+		};
+		const full = await buildDiffPatch(request);
+		const bounded = await buildDiffPatch({
+			...request,
+			maxBytes: Math.floor(full.length / 2),
+		});
+
+		expect(bounded.length).toBeLessThan(full.length);
+		expect(bounded.length).toBeGreaterThan(0);
+		// A prefix of the real patch, ending exactly where a file section
+		// starts: no file is shown a diff missing its tail.
+		expect(full.startsWith(bounded)).toBe(true);
+		expect(full.slice(bounded.length).startsWith("diff --git ")).toBe(true);
+	});
+
+	test("an untracked file past the bound leaves the tracked patch intact", async () => {
+		await writeFile(join(repo, "tracked.txt"), "one\ntwo\nthree\n");
+		await git.add(["tracked.txt"]);
+		await git.commit("initial");
+		await writeFile(join(repo, "tracked.txt"), "one\nTWO\nthree\n");
+		await writeFile(join(repo, "huge.log"), lines(200_000, "noise"));
+
+		const patch = await buildDiffPatch({
+			cwd: repo,
+			env: ENV,
+			category: "unstaged",
+			refs: {},
+			untrackedPaths: ["huge.log"],
+			maxBytes: 64 * 1024,
+		});
+
+		expect(patch).toContain("diff --git a/tracked.txt b/tracked.txt");
+		expect(patch).toContain("+TWO");
+		expect(patch).not.toContain("huge.log");
+		expect(patch.length).toBeLessThanOrEqual(64 * 1024);
+	});
+
+	test("a bound nothing reaches keeps every section, last one included", async () => {
+		await writeFile(join(repo, "tracked.txt"), "one\ntwo\n");
+		await git.add(["tracked.txt"]);
+		await git.commit("initial");
+		await writeFile(join(repo, "tracked.txt"), "one\nTWO\n");
+		await writeFile(join(repo, "fresh.txt"), "brand new\n");
+
+		const request = {
+			cwd: repo,
+			env: ENV,
+			category: "unstaged" as const,
+			refs: {},
+			untrackedPaths: ["fresh.txt"],
+		};
+		const patch = await buildDiffPatch({ ...request, maxBytes: 1024 * 1024 });
+		expect(patch).toBe(await buildDiffPatch(request));
+		// The cut only ever applies to a diff that was stopped mid-stream: a
+		// patch that fit keeps its last file section, which is the one an
+		// over-eager cut would take.
+		expect(patch).toContain("+TWO");
+		expect(patch).toContain("+brand new");
+	});
+});

--- a/packages/host-service/src/trpc/router/git/utils/diff-patch.test.ts
+++ b/packages/host-service/src/trpc/router/git/utils/diff-patch.test.ts
@@ -73,6 +73,39 @@ describe("buildDiffPatch", () => {
 		expect(full.slice(bounded.length).startsWith("diff --git ")).toBe(true);
 	});
 
+	test("a bound expiring exactly between two sections keeps both", async () => {
+		for (const name of ["a.txt", "b.txt", "c.txt"]) {
+			await writeFile(join(repo, name), lines(400, "old"));
+		}
+		await git.add(["."]);
+		await git.commit("initial");
+		for (const name of ["a.txt", "b.txt", "c.txt"]) {
+			await writeFile(join(repo, name), lines(400, "new"));
+		}
+
+		const request = {
+			cwd: repo,
+			env: ENV,
+			category: "unstaged" as const,
+			refs: {},
+		};
+		const full = await buildDiffPatch(request);
+		// Every byte here is ASCII, so a string offset is a byte offset: this
+		// is exactly where the third file's section begins.
+		const thirdSection = full.lastIndexOf("\ndiff --git ") + 1;
+
+		const bounded = await buildDiffPatch({
+			...request,
+			maxBytes: thirdSection,
+		});
+
+		// The read stopped with nothing incomplete in hand, so both sections
+		// it holds are whole and neither may be dropped.
+		expect(bounded).toBe(full.slice(0, thirdSection));
+		expect(bounded).toContain("diff --git a/b.txt b/b.txt");
+		expect(bounded).not.toContain("c.txt");
+	});
+
 	test("an untracked file past the bound leaves the tracked patch intact", async () => {
 		await writeFile(join(repo, "tracked.txt"), "one\ntwo\nthree\n");
 		await git.add(["tracked.txt"]);

--- a/packages/host-service/src/trpc/router/git/utils/diff-patch.ts
+++ b/packages/host-service/src/trpc/router/git/utils/diff-patch.ts
@@ -96,14 +96,23 @@ interface DiffSection {
 	truncated: boolean;
 }
 
-/** Cuts a diff that was stopped mid-stream back to its last complete file
- * section. The renderer parses the patch into `diff --git` sections and shows
- * a placeholder for any file it finds none for; half a section would instead
- * render as a diff silently missing its hunks. Every content line is prefixed
- * (` `, `+`, `-`), so `diff --git ` at the start of a line is always a real
- * header, and the section it opens is the one that was cut. */
-function dropIncompleteFileSection(patch: string): string {
-	const lastHeader = patch.lastIndexOf("\ndiff --git ");
+/** What every file's section in a patch opens with. Every content line is
+ * prefixed (` `, `+`, `-`), so this at the start of a line is always a real
+ * header rather than diffed content. */
+const SECTION_HEADER = "diff --git ";
+
+/** What of a diff stopped mid-stream can be shown: whole file sections only.
+ * The renderer parses the patch into sections and shows a placeholder for any
+ * file it finds none for, whereas half a section would render as a diff
+ * silently missing its hunks.
+ *
+ * `overflow` is the first of the bytes the budget refused. When those begin
+ * the next file's section, the cut landed exactly on a boundary and
+ * everything read is already whole — dropping the last section there would
+ * put a file that was fully read behind a placeholder. */
+function keepCompleteSections(patch: string, overflow: string): string {
+	if (overflow.startsWith(SECTION_HEADER)) return patch;
+	const lastHeader = patch.lastIndexOf(`\n${SECTION_HEADER}`);
 	// No earlier header: the single section this output started is the
 	// incomplete one, and nothing of it can be shown.
 	if (lastHeader === -1) return "";
@@ -137,13 +146,26 @@ function runDiff(
 		const chunks: Buffer[] = [];
 		let stderr = "";
 		let truncated = false;
+		// Just enough of what the budget refused to tell a cut that landed on
+		// a section boundary from one that landed inside a section. Whatever
+		// git had already written is still readable after the kill; a shorter
+		// overflow than this only costs the last section.
+		let overflow = "";
+		const keepOverflow = (chunk: Buffer) => {
+			const wanted = SECTION_HEADER.length - overflow.length;
+			if (wanted > 0) overflow += chunk.subarray(0, wanted).toString("utf8");
+		};
 
 		child.stdout.on("data", (chunk: Buffer) => {
-			if (truncated) return;
+			if (truncated) {
+				keepOverflow(chunk);
+				return;
+			}
 			const granted = budget.take(chunk.byteLength);
 			if (granted > 0) chunks.push(chunk.subarray(0, granted));
 			if (granted === chunk.byteLength) return;
 			truncated = true;
+			keepOverflow(chunk.subarray(granted));
 			// Nothing more will be kept, and diffing the rest of a huge tree
 			// costs minutes of CPU whose output is thrown away.
 			child.kill("SIGKILL");
@@ -158,7 +180,7 @@ function runDiff(
 		child.once("close", (code) => {
 			const patch = Buffer.concat(chunks).toString("utf8");
 			if (truncated) {
-				resolve({ patch: dropIncompleteFileSection(patch), truncated });
+				resolve({ patch: keepCompleteSections(patch, overflow), truncated });
 				return;
 			}
 			// simple-git's own rule, kept so the same failures reject as

--- a/packages/host-service/src/trpc/router/git/utils/diff-patch.ts
+++ b/packages/host-service/src/trpc/router/git/utils/diff-patch.ts
@@ -1,4 +1,4 @@
-import type { SimpleGit } from "simple-git";
+import { spawn } from "node:child_process";
 import {
 	type DiffCategory,
 	type DiffCategoryRefs,
@@ -12,6 +12,28 @@ const PATCH_CONTEXT_LINES = 3;
 
 /** How many `git diff --no-index` calls for untracked files run at once. */
 const UNTRACKED_CONCURRENCY = 8;
+
+/**
+ * Most patch text one request may build, across the category's diff and every
+ * untracked file's section.
+ *
+ * A working tree can hold a file of any size — an unignored log, a database
+ * dump, a vendored tree — and an untracked file's diff is the whole file, so
+ * without a bound the patch is as big as the repository. V8 refuses strings
+ * past ~512 MB, and building the patch threw `RangeError: Invalid string
+ * length` out of the git worker (HOST-SERVICE-5C), which fails every file in
+ * the Changes pane rather than the one nobody could read anyway.
+ *
+ * 32 MB is far past any patch a person reads (it is also what #7279 bounds a
+ * transcript line to) and leaves the JSON-encoded response an order of
+ * magnitude clear of the limit.
+ */
+export const MAX_PATCH_BYTES = 32 * 1024 * 1024;
+
+/** Enough of git's stderr to explain a failure. Bounded for the same reason
+ * as the patch: `warning:` lines are per-file, so a big enough repository
+ * makes even the error message unbounded. */
+const MAX_STDERR_BYTES = 64 * 1024;
 
 const BASE_ARGS = [
 	"--no-color",
@@ -45,56 +67,182 @@ function diffArgsForCategory(
 	return ["diff", ...BASE_ARGS];
 }
 
+/** One request's shared byte allowance. The category diff and every
+ * `--no-index` run draw from the same budget because it is their
+ * concatenation that has to stay inside the limit. */
+class PatchBudget {
+	private remaining: number;
+
+	constructor(limit: number) {
+		this.remaining = limit;
+	}
+
+	get exhausted(): boolean {
+		return this.remaining <= 0;
+	}
+
+	/** Grants up to `bytes`, returning how many. A short grant means the
+	 * caller has just read the last output it may keep. */
+	take(bytes: number): number {
+		const granted = Math.min(bytes, this.remaining);
+		this.remaining -= granted;
+		return granted;
+	}
+}
+
+interface DiffSection {
+	patch: string;
+	/** The budget ran out first, so this diff is missing its tail. */
+	truncated: boolean;
+}
+
+/** Cuts a diff that was stopped mid-stream back to its last complete file
+ * section. The renderer parses the patch into `diff --git` sections and shows
+ * a placeholder for any file it finds none for; half a section would instead
+ * render as a diff silently missing its hunks. Every content line is prefixed
+ * (` `, `+`, `-`), so `diff --git ` at the start of a line is always a real
+ * header, and the section it opens is the one that was cut. */
+function dropIncompleteFileSection(patch: string): string {
+	const lastHeader = patch.lastIndexOf("\ndiff --git ");
+	// No earlier header: the single section this output started is the
+	// incomplete one, and nothing of it can be shown.
+	if (lastHeader === -1) return "";
+	return patch.slice(0, lastHeader + 1);
+}
+
+interface GitSpawnOptions {
+	/** Worktree the diff is taken in. */
+	cwd: string;
+	/** Credentials and locale for the git process. Replaces the environment
+	 * outright, which is what simple-git's `.env()` does with the same
+	 * object — `createGitEnvResolver` builds a complete environment. */
+	env: Record<string, string>;
+}
+
+/**
+ * Runs one `git diff` and keeps only what the budget still allows, killing
+ * git once it is spent. The patch is bounded as it is read rather than
+ * checked afterwards: the string that would be too long is never built, so no
+ * repository state can throw here.
+ */
+function runDiff(
+	args: string[],
+	options: GitSpawnOptions,
+	budget: PatchBudget,
+): Promise<DiffSection> {
+	if (budget.exhausted) return Promise.resolve({ patch: "", truncated: true });
+
+	return new Promise<DiffSection>((resolve, reject) => {
+		const child = spawn("git", args, { ...options, windowsHide: true });
+		const chunks: Buffer[] = [];
+		let stderr = "";
+		let truncated = false;
+
+		child.stdout.on("data", (chunk: Buffer) => {
+			if (truncated) return;
+			const granted = budget.take(chunk.byteLength);
+			if (granted > 0) chunks.push(chunk.subarray(0, granted));
+			if (granted === chunk.byteLength) return;
+			truncated = true;
+			// Nothing more will be kept, and diffing the rest of a huge tree
+			// costs minutes of CPU whose output is thrown away.
+			child.kill("SIGKILL");
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			if (stderr.length < MAX_STDERR_BYTES) stderr += chunk.toString("utf8");
+		});
+		// A spawn that never produced a process rejects with Node's own error,
+		// whose message ("spawn git ENOENT") is what spawn-failure-diagnostics
+		// matches on.
+		child.once("error", reject);
+		child.once("close", (code) => {
+			const patch = Buffer.concat(chunks).toString("utf8");
+			if (truncated) {
+				resolve({ patch: dropIncompleteFileSection(patch), truncated });
+				return;
+			}
+			// simple-git's own rule, kept so the same failures reject as
+			// before: a non-zero exit with nothing on stderr is `--no-index`
+			// reporting "differences found", not a failure. The message is
+			// git's stderr alone — simple-git prefixed stdout, which for this
+			// command is the very patch that has to stay bounded.
+			if (code !== 0 && stderr.length > 0) {
+				reject(new Error(stderr));
+				return;
+			}
+			resolve({ patch, truncated: false });
+		});
+	});
+}
+
 /** `git diff` never reports untracked files, but the Changes pane lists them,
- * so each one gets its own `--no-index` patch against /dev/null. Exit code 1
- * just means "differences found", which simple-git surfaces as a rejection
- * carrying the patch on stdout. */
+ * so each one gets its own `--no-index` patch against /dev/null. A file that
+ * fails on its own (deleted since the status snapshot, unreadable) yields no
+ * section, exactly as before — the rest of the patch still renders. */
 async function untrackedPatches(
-	git: SimpleGit,
 	paths: string[],
-): Promise<string[]> {
+	options: GitSpawnOptions,
+	budget: PatchBudget,
+): Promise<DiffSection[]> {
 	return mapWithConcurrency(paths, UNTRACKED_CONCURRENCY, async (path) => {
 		try {
-			return await git.raw([
-				"diff",
-				...BASE_ARGS,
-				"--no-index",
-				"--",
-				"/dev/null",
-				path,
-			]);
-		} catch (error) {
-			const stdout = (error as { stdout?: string })?.stdout;
-			return typeof stdout === "string" ? stdout : "";
+			return await runDiff(
+				["diff", ...BASE_ARGS, "--no-index", "--", "/dev/null", path],
+				options,
+				budget,
+			);
+		} catch {
+			return { patch: "", truncated: false };
 		}
 	});
 }
 
-export interface DiffPatchRequest {
+export interface DiffPatchRequest extends GitSpawnOptions {
 	category: DiffCategory;
 	refs: DiffCategoryRefs;
 	/** Restricts the patch to these paths; empty means the whole category. */
 	paths?: string[];
 	/** Paths git won't diff on its own — see `untrackedPatches`. */
 	untrackedPaths?: string[];
+	/** Overridable so a test can reach the bound without a huge repository. */
+	maxBytes?: number;
 }
 
-/** One patch covering a whole category, plus a section per untracked file.
- * The renderer parses this into per-file metadata (`parsePatchFiles`) and
- * fetches full contents later, only for files somebody expands or edits. */
-export async function buildDiffPatch(
-	git: SimpleGit,
-	{ category, refs, paths, untrackedPaths }: DiffPatchRequest,
-): Promise<string> {
+/** One patch covering a whole category, plus a section per untracked file,
+ * bounded by `maxBytes`. The renderer parses this into per-file metadata
+ * (`parsePatchFiles`) and fetches full contents later, only for files
+ * somebody expands or edits. Files past the bound get no section and render
+ * as placeholders, the same as any other file the patch has no section for. */
+export async function buildDiffPatch({
+	cwd,
+	env,
+	category,
+	refs,
+	paths,
+	untrackedPaths,
+	maxBytes = MAX_PATCH_BYTES,
+}: DiffPatchRequest): Promise<string> {
+	const budget = new PatchBudget(maxBytes);
+	const options = { cwd, env };
 	const args = diffArgsForCategory(category, refs);
 	if (paths?.length) args.push("--", ...paths);
 
 	// No `.catch` here on purpose: swallowing a failure would return an empty
 	// patch, which the renderer can't tell apart from "nothing changed" — it
 	// would render every file as a placeholder with no way to retry.
-	const tracked = await git.raw(args);
-	if (!untrackedPaths?.length) return tracked;
+	const tracked = await runDiff(args, options, budget);
+	const untracked = untrackedPaths?.length
+		? await untrackedPatches(untrackedPaths, options, budget)
+		: [];
 
-	const untracked = await untrackedPatches(git, untrackedPaths);
-	return [tracked, ...untracked].filter(Boolean).join("");
+	const sections = [tracked, ...untracked];
+	if (sections.some((section) => section.truncated)) {
+		console.warn(
+			`[git/getDiffPatch] ${cwd}: patch reached the ${maxBytes} byte bound; files past the cut render as placeholders`,
+		);
+	}
+	return sections
+		.map((section) => section.patch)
+		.filter(Boolean)
+		.join("");
 }

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -180,7 +180,9 @@ export const gitDiffPatchTask = defineWorkerTask<
 			commitHash,
 			fromHash,
 		});
-		const patch = await buildDiffPatch(git, {
+		const patch = await buildDiffPatch({
+			cwd: worktreePath,
+			env: gitEnv,
 			category,
 			refs,
 			paths,


### PR DESCRIPTION
Two host-service worker failures, both first seen 2026-09-07, unrelated except that both end in a worker. One root cause each, in its own section.

## Is this worth fixing?

**1. User-visible harm.** *5C:* in a workspace whose changeset produces more than ~512 MB of patch text — one unignored large file is enough, since an untracked file's diff is the whole file — every file in the Changes pane renders as "Unable to load diff" with a Retry that can never succeed, for as long as that file is on disk. It is deterministic for that working tree, not a flake. *5D:* on a host whose launch directory has been deleted (start a host from a shell inside a workspace, later delete that workspace — ordinary), no worker thread can start; after three attempts HostWorkerPool opens its crash circuit and every git status/diff runs on the host-service event loop for the rest of that process's life, which is exactly what the pool exists to prevent.

**2. Does the change reach the reported failure?** Yes for both. 5C came from 1.27.0 with the host-service bundled in the desktop app (`dist/main/host-worker.js` in the stack); 5D from a standalone 1.27.0 host on Linux (no `run_mode`/sandbox tags, so a CLI/systemd launch through `serve.ts`). Both files ship in the shared desktop/host-service/CLI release, so the fix reaches both surfaces in the next one; nothing here is behind a flag.

**3. Why code, and not something else?** Neither is a telemetry-only event. For 5C the throw happens in the host before any response exists, so no renderer-side handling can help, and the patch API is the Changes pane's primary data source — it cannot be deleted. For 5D the alternative is making each launcher pass an explicit cwd, which leaves systemd, docker, manual launches and the next launcher uncovered; one call inside the process covers all of them. An inbound Sentry filter is repo law (#6164) not to write, and would leave both failures in place. No in-flight PR restructures either path (#7210 touches `WorkerTaskRunner.ts`, which this does not).

No typed `cause` is added: nothing reads one on either path, so failures keep throwing what they threw before. No new Sentry capture.

---

## 5C — `RangeError: Invalid string length` in `git.getDiffPatch`

**Problem.** `buildDiffPatch` built one string for a whole category: `git diff` for the tracked side, plus a `--no-index` diff per untracked file, each buffered whole by simple-git and then concatenated. Its size is whatever the repository state makes it, so `Array.join` threw `RangeError: Invalid string length` at V8's ~512 MB string limit and the request 500'd. The same unbounded read sat on the failure path too: simple-git builds its error message as stdout + stderr, and stdout here *is* the patch.

**Root cause.** The patch was materialised without a bound, so a single working tree — one unignored log, dump or vendored tree — could exceed what the runtime can represent. Same class as #7279, different place.

**Fix.** git runs under a shared byte budget for the request. `runDiff` spawns git directly, keeps stdout only while the budget allows, kills git as soon as it is spent, and cuts the output back to its last complete `diff --git` section. So:

- The oversized string is never built, rather than caught afterwards.
- No file is ever shown a diff missing its hunks — a section is whole or absent.
- **What the Changes pane shows:** every file whose section fit renders normally; files past the cut get no section and fall into the placeholder the pane already shows for a file the patch has no section for. Today's failure fails *all* of them; after this, the giant file is the one that loses its diff. A dedicated "too large to display" placeholder would read better than the current "Unable to load diff", but that is renderer copy in 17 locales and not what makes the request fail — deliberately left out.
- The bound is 32 MB, the same one #7279 put on transcript lines: far past any patch a person reads, and an order of magnitude clear of the limit after JSON encoding.

Behaviour otherwise preserved: output is byte-identical to the simple-git path (checked below, including non-ASCII paths, which git quotes the same either way), simple-git's failure rule (non-zero exit *with* stderr) is kept so the same commands still reject, and an untracked file that fails on its own still yields no section instead of failing the request. The error message is now git's stderr alone, bounded at 64 KB — dropping the stdout prefix is the same bug in the same function.

## 5D — `ENOENT ... uv_cwd` from `process.cwd(worker_thread)`

**Problem.** Not a task failure: the reported frames are Node's own worker bootstrap (`node:internal/main/worker_thread`), reached before the task script loads, and the event arrives through the parent's `worker.on("error")`. Three events, which is exactly `CRASH_BUDGET`; after those the pool runs every git task inline on the event loop for the life of the process.

**Root cause.** host-service inherits its working directory from whoever launched it — for `superset start`, a shell that is very often inside a workspace — and then outlives that directory, because deleting a workspace deletes the worktree. Nothing in the host needs it (every path it touches arrives absolute), but Node reads the process working directory while bootstrapping a worker thread, so once it is unlinked no worker can start at all.

**Fix.** `detachFromLaunchDirectory()` moves the process to the home directory (temp directory if home is unusable) at startup, called from both entrypoints — `serve.ts` and the desktop's own bootstrap, which has its own `main()` and has been the half that kept crashing before (HOST-SERVICE-5). No try/catch around the failure, no retry: the dependency is removed.

The one worker task that read the process working directory implicitly — `readGitIdentity`, via a simple-git built with no base directory — is now given the home directory explicitly, so which repository the host happened to be launched from no longer decides whose name a global setting previews.

**Adjacent, deliberately left:** `resolve-repo.ts` builds simple-git with no base directory twice more (clone targets are absolute, so its cwd is irrelevant; the launch-directory fix covers them), and `loadFileDiffContent` in `git-helpers.ts` reads whole file contents with `git show` for the per-file diff path — the same unbounded-string class as 5C, in a different procedure, with no reported events.

## Verification

`bunx biome check` on all ten changed files:

```
Checked 10 files in 19ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck`, and the same in `apps/desktop` (both silent, no diagnostics):

```
$ tsc --noEmit --emitDeclarationOnly false
$ tsc --noEmit
```

Full host-service package suite, `bun test` (first pass; re-run below):

```
 1659 pass
 8 todo
 0 fail
 3857 expect() calls
Ran 1667 tests across 161 files. [228.02s]
```

`apps/desktop/src/no-main-process-blocking.test.ts` (desktop entrypoint touched; allowlisted counts unchanged):

```
 3 pass
 0 fail
 6 expect() calls
```

New `diff-patch.test.ts` pins the bound in both directions. It fails before the cut exists (patch runs past its last complete section) and fails again if the cut is applied unconditionally rather than only to a truncated read — the over-match case, checked by temporarily applying it to every diff:

```
(fail) buildDiffPatch > cuts the patch on a file boundary instead of mid-section
(fail) buildDiffPatch > an untracked file past the bound leaves the tracked patch intact
(fail) buildDiffPatch > a bound nothing reaches keeps every section, last one included
```

Output equivalence with the replaced simple-git path, on a temp repository with non-ASCII tracked and untracked paths:

```
identical: true
length before/after: 566 566
```

5D end to end, outside the test suite: a Node process started in a directory that is then deleted, spawning a worker before and after the fix (home path elided):

```
launch dir deleted, before the fix: FAILED: ENOENT: process.cwd failed with error no such file or directory, the current working directory was likely removed without changing the working directory, uv_cwd
cwd after detachFromLaunchDirectory(): <home>
after the fix: worker started (worker booted ok)
```

The reproduced stack matches the reported one frame for frame (`process.cwd (node:internal/main/worker_thread:130:19)` ← `MessagePort.<anonymous> (node:internal/main/worker_thread:147:50)`).

## Merge-gate fixes (22c558b)

Both findings were real; both are fixed in a second commit.

**1. A cut landing exactly on a section boundary discarded a complete section.** When the budget expired precisely where the next file's section began, nothing incomplete had been read, but the cut still looked for an earlier header — and dropped the last section, or returned "" when the boundary was the first one, putting a file whose diff was read whole behind the missing-section placeholder. `runDiff` now keeps the first bytes the budget refused (`SECTION_HEADER.length` of them, accumulated across chunks since git's already-written output stays readable after the kill), and `keepCompleteSections` returns the read unchanged when that overflow begins the next section. A new case constructs a budget that expires exactly between two sections and asserts both survive byte for byte:

```
(fail) buildDiffPatch > a bound expiring exactly between two sections keeps both
```

— that is the new test run against the pre-fix behaviour (the overflow check forced off); the other three cases still pass there, so it isolates this bug and nothing else.

**2. `identity.test.ts` could not have caught a regression.** It built `expectedAuthor` with the same home-anchored call the implementation makes, so a read that regressed to the process's own directory would have satisfied it. It now writes `user.name = home-identity` into a temporary home and `user.name = repo-identity` into a temporary repository, runs with the process standing in the repository, and asserts the home value literally. Against the pre-fix implementation (`createUserSimpleGit()` with no base directory):

```
error: expect(received).toEqual(expected)
-   "authorName": "home-identity",
+   "authorName": "repo-identity",
(fail) readGitIdentity > reads the author from home, not from the directory it runs in
```

**Re-run after both fixes.** `bunx biome check` on the three changed files:

```
Checked 3 files in 6ms. No fixes applied.
```

`cd packages/host-service && bun run typecheck` (silent):

```
$ tsc --noEmit --emitDeclarationOnly false
```

Full host-service package suite, `bun test` (one more test than the first pass):

```
 1660 pass
 8 todo
 0 fail
 3860 expect() calls
Ran 1668 tests across 161 files. [247.19s]
```

Refs HOST-SERVICE-5C
Refs HOST-SERVICE-5D

https://claude.ai/code/session_01AmxfJtNVEMuTLj5FsmdBvF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two host-service worker failures: unbounded diff patch size caused `RangeError: Invalid string length` on large repositories, and the process working directory could be deleted out from under the running host, preventing worker threads from starting.

**Bounded diff patch generation**

- `buildDiffPatch` now spawns git with a 32 MB byte budget shared across the tracked diff and all untracked file sections, killing git when the budget is spent.
- Output is cut to the last complete `diff --git` section; a budget that expires exactly between sections keeps everything already read. No file renders a truncated diff, and files past the bound show the existing placeholder — one giant file no longer takes down the whole Changes pane.
- Error messages are now bounded stderr (64 KB) instead of simple-git's stdout-as-patch prefix, which was the same unbounded string.
- Output is byte-identical to the previous simple-git path on non-ASCII paths, and simple-git's failure semantics (non-zero exit with stderr) are preserved.

**Stopped depending on the launch directory**

- Both entrypoints (`serve.ts` and the desktop bootstrap) now call `detachFromLaunchDirectory()` at startup, which moves the process to the home directory.
- Previously, launching the host from a workspace and then deleting that workspace left the process in a nonexistent directory, which made Node's worker bootstrap throw `ENOENT ... uv_cwd`; three such failures opened the crash circuit and ran all git tasks on the event loop.
- `readGitIdentity` no longer implicitly reads the launch directory — it now anchors its git config read at the home directory, so a global setting preview no longer depends on which repository the host happened to start in.

Refs HOST-SERVICE-5C, HOST-SERVICE-5D

<sup>Written for commit 22c558b730951f43b157ec0f26105a5331ad8f53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Host processes now continue running if the directory used to launch the app is deleted.
  - Git identity detection consistently uses the user’s home configuration.
  - Git diff generation now limits output size and preserves complete file sections.
  - Oversized untracked files are excluded from diffs when necessary to stay within size limits.

- **Tests**
  - Added coverage for launch-directory handling, Git identity detection, and Git diff size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
