### PR TITLE
fix(desktop): retry an agent launch whose terminal attach was cancelled

### DIFF
--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.test.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.test.ts
@@ -557,6 +557,210 @@ describe("DaemonTerminalManager kill tracking", () => {
 		await expect(initEffectsPromise).resolves.toMatchObject({ isNew: true });
 	});
 
+	/**
+	 * The #2748 fix stops the two racing attaches from cancelling each other,
+	 * but it does so by making the launch a *passenger* on the lifecycle hook's
+	 * request rather than an owner of its own. The AbortController stays with
+	 * the component, so when it later cancels that attach — an unmount, a
+	 * remount, a supersede, all routine while workspace init splits the agent
+	 * pane off the setup pane mid-render — the shared promise rejects and the
+	 * agent launch dies with it, even though the pane is alive and about to be
+	 * re-attached.
+	 *
+	 * This is why `ensureTerminalAttached` retries a cancelled attach instead
+	 * of treating it as a verdict on the pane; the test pins the daemon-side
+	 * semantics that make the retry necessary.
+	 */
+	it("rejects a joined launch when the attach owner cancels its own request", async () => {
+		const manager = new DaemonTerminalManager();
+		const paneId = "pane-joined-launch-canceled";
+		const requestId = "req-lifecycle-cancel";
+		const managerInternals = manager as unknown as {
+			daemonSessionIdsHydrated: boolean;
+			daemonAliveSessionIds: Set<string>;
+		};
+		managerInternals.daemonSessionIdsHydrated = true;
+		managerInternals.daemonAliveSessionIds = new Set([paneId]);
+
+		// Lifecycle hook attaches first and owns the request.
+		const lifecyclePromise = manager.createOrAttach({
+			paneId,
+			requestId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// The agent launch joins it rather than opening a second one.
+		const launchPromise = manager.createOrAttach({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+			joinPending: true,
+		});
+		expect(mockClient.createOrAttachCalls).toHaveLength(1);
+
+		// Settle both before cancelling: the shared promise rejects
+		// synchronously, so handlers have to be attached first.
+		const lifecycleOutcome = lifecyclePromise.catch(
+			(error: Error) => error.message,
+		);
+		const launchOutcome = launchPromise.catch((error: Error) => error.message);
+
+		// The component unmounts and cancels the attach it owns.
+		manager.cancelCreateOrAttach({ paneId, requestId });
+
+		expect(await lifecycleOutcome).toBe(TERMINAL_ATTACH_CANCELED_MESSAGE);
+		// The launch had no say in that cancellation, but dies with it.
+		expect(await launchOutcome).toBe(TERMINAL_ATTACH_CANCELED_MESSAGE);
+	});
+
+	/**
+	 * The recovery the launch-side retry depends on: once the owner's
+	 * cancellation has torn the shared request down, the pending entry is gone
+	 * and the tombstone is unset (nothing killed the pane), so a fresh
+	 * `joinPending` attach opens its own request and succeeds. That retry then
+	 * *owns* the pending entry, and because a joined entry is never superseded,
+	 * the component's later re-attach rides along instead of cancelling it
+	 * again.
+	 */
+	it("lets a retried joined attach succeed and own the request after an unmount cancel", async () => {
+		const manager = new DaemonTerminalManager();
+		const paneId = "pane-launch-retry-recovers";
+		const requestId = "req-lifecycle-retry";
+		const managerInternals = manager as unknown as {
+			daemonSessionIdsHydrated: boolean;
+			daemonAliveSessionIds: Set<string>;
+			pendingSessions: Map<string, unknown>;
+		};
+		managerInternals.daemonSessionIdsHydrated = true;
+		managerInternals.daemonAliveSessionIds = new Set([paneId]);
+
+		// The component wins the race and owns the attach; the launch joins it.
+		const lifecyclePromise = manager.createOrAttach({
+			paneId,
+			requestId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const launchPromise = manager.createOrAttach({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+			joinPending: true,
+		});
+		const lifecycleOutcome = lifecyclePromise.catch(
+			(error: Error) => error.message,
+		);
+		const launchOutcome = launchPromise.catch((error: Error) => error.message);
+
+		manager.cancelCreateOrAttach({ paneId, requestId });
+		expect(await lifecycleOutcome).toBe(TERMINAL_ATTACH_CANCELED_MESSAGE);
+		expect(await launchOutcome).toBe(TERMINAL_ATTACH_CANCELED_MESSAGE);
+
+		// Nothing killed the pane, so no tombstone blocks a retry, and the
+		// cancelled request left no pending entry behind.
+		expect(managerInternals.pendingSessions.has(paneId)).toBe(false);
+
+		// The retry the launch performs.
+		const retryPromise = manager.createOrAttach({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+			joinPending: true,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		// The component re-attaches; it joins the retry rather than superseding it.
+		const reattachPromise = manager.createOrAttach({
+			paneId,
+			requestId: "req-lifecycle-reattach",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+		});
+
+		const retryRequestId = mockClient.createOrAttachCalls.at(-1)?.requestId;
+		expect(typeof retryRequestId).toBe("string");
+		mockClient.resolveCreateOrAttach(retryRequestId ?? "");
+
+		await expect(retryPromise).resolves.toBeDefined();
+		await expect(reattachPromise).resolves.toBeDefined();
+	});
+
+	/**
+	 * The other half of the retry contract, and the case the launch-side doc
+	 * must not overstate: `useTerminalLifecycle` supersedes itself by cancelling
+	 * and *synchronously* issuing the replacement, so by the time the retry runs
+	 * the component already owns a fresh non-join entry. The retry therefore
+	 * joins that one rather than owning anything — which still resolves the
+	 * launch, because the replacement is the attach that goes on to succeed.
+	 */
+	it("lets a retry join the replacement when the component supersedes itself", async () => {
+		const manager = new DaemonTerminalManager();
+		const paneId = "pane-launch-retry-supersede";
+		const managerInternals = manager as unknown as {
+			daemonSessionIdsHydrated: boolean;
+			daemonAliveSessionIds: Set<string>;
+		};
+		managerInternals.daemonSessionIdsHydrated = true;
+		managerInternals.daemonAliveSessionIds = new Set([paneId]);
+
+		const firstPromise = manager.createOrAttach({
+			paneId,
+			requestId: "req-first",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const launchPromise = manager.createOrAttach({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+			joinPending: true,
+		});
+		const firstOutcome = firstPromise.catch((error: Error) => error.message);
+		const launchOutcome = launchPromise.catch((error: Error) => error.message);
+
+		// Cancel + synchronous replacement, the way the lifecycle hook does it.
+		manager.cancelCreateOrAttach({ paneId, requestId: "req-first" });
+		const replacementPromise = manager.createOrAttach({
+			paneId,
+			requestId: "req-replacement",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+		});
+
+		expect(await firstOutcome).toBe(TERMINAL_ATTACH_CANCELED_MESSAGE);
+		expect(await launchOutcome).toBe(TERMINAL_ATTACH_CANCELED_MESSAGE);
+
+		// The retry finds the replacement already pending and rides it.
+		const retryPromise = manager.createOrAttach({
+			paneId,
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			skipColdRestore: true,
+			joinPending: true,
+		});
+
+		const replacementRequestId =
+			mockClient.createOrAttachCalls.at(-1)?.requestId;
+		expect(replacementRequestId).toBe("req-replacement");
+		mockClient.resolveCreateOrAttach(replacementRequestId ?? "");
+
+		await expect(replacementPromise).resolves.toBeDefined();
+		await expect(retryPromise).resolves.toBeDefined();
+	});
+
 	it("propagates probe failures from forceKillAll instead of silently no-oping", async () => {
 		const manager = new DaemonTerminalManager();
 		mockClient.listSessionsIfRunningError = new Error("probe failed");

--- a/apps/desktop/src/renderer/lib/terminal/attach-cancel.ts
+++ b/apps/desktop/src/renderer/lib/terminal/attach-cancel.ts
@@ -1,0 +1,23 @@
+export const TERMINAL_ATTACH_CANCELED_MESSAGE = "TERMINAL_ATTACH_CANCELED";
+export const TERMINAL_SESSION_KILLED_MESSAGE = "TERMINAL_SESSION_KILLED";
+
+export function isTerminalAttachCanceledMessage(message?: string): boolean {
+	return message?.includes(TERMINAL_ATTACH_CANCELED_MESSAGE) ?? false;
+}
+
+export function isTerminalSessionKilledMessage(message?: string): boolean {
+	return message?.includes(TERMINAL_SESSION_KILLED_MESSAGE) ?? false;
+}
+
+/**
+ * Both sentinels mean the same thing to anything launching into a pane: the
+ * pane went away before its session came up. They are backend protocol strings,
+ * never display text, so a user-facing surface must map them to prose rather
+ * than render `result.error` directly.
+ */
+export function isPaneGoneBeforeStartMessage(message?: string): boolean {
+	return (
+		isTerminalAttachCanceledMessage(message) ||
+		isTerminalSessionKilledMessage(message)
+	);
+}

--- a/apps/desktop/src/renderer/lib/terminal/debug.ts
+++ b/apps/desktop/src/renderer/lib/terminal/debug.ts
@@ -1,0 +1,18 @@
+/**
+ * Terminal lifecycle debug logging, enabled from DevTools with
+ * `localStorage.setItem("SUPERSET_TERMINAL_DEBUG", "1")`.
+ *
+ * A function rather than a bare constant so a caller can pick the flag up
+ * without a reload; `DEBUG_TERMINAL` snapshots it at module load for the hot
+ * paths that check it per frame.
+ */
+export function isTerminalDebugEnabled(): boolean {
+	try {
+		return (
+			typeof localStorage !== "undefined" &&
+			localStorage.getItem("SUPERSET_TERMINAL_DEBUG") === "1"
+		);
+	} catch {
+		return false;
+	}
+}

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
+	ATTACH_ATTEMPT_LIMIT,
 	buildTerminalCommand,
+	ensureTerminalAttached,
 	launchCommandInPane,
 	writeCommandsInPane,
 } from "./launch-command";
@@ -173,5 +175,119 @@ describe("writeCommandsInPane", () => {
 		});
 
 		expect(write).not.toHaveBeenCalled();
+	});
+});
+
+describe("ensureTerminalAttached cancellation retries", () => {
+	const canceled = () => new Error("TERMINAL_ATTACH_CANCELED");
+
+	it("retries when the owner of the joined attach cancels it", async () => {
+		let calls = 0;
+		const createOrAttach = mock(async () => {
+			calls += 1;
+			if (calls === 1) throw canceled();
+			return {};
+		});
+		const write = mock(async () => ({}));
+
+		await launchCommandInPane({
+			paneId: "pane-canceled-once",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			command: "claude",
+			createOrAttach,
+			write,
+		});
+
+		expect(calls).toBe(2);
+		expect(write).toHaveBeenCalledWith({
+			paneId: "pane-canceled-once",
+			data: "claude\n",
+			throwOnError: true,
+		});
+	});
+
+	it("surfaces the cancellation once the retry budget is spent", async () => {
+		const createOrAttach = mock(async () => {
+			throw canceled();
+		});
+		const write = mock(async () => ({}));
+
+		await expect(
+			launchCommandInPane({
+				paneId: "pane-canceled-always",
+				tabId: "tab-1",
+				workspaceId: "ws-1",
+				command: "claude",
+				createOrAttach,
+				write,
+			}),
+		).rejects.toThrow("TERMINAL_ATTACH_CANCELED");
+
+		expect(createOrAttach).toHaveBeenCalledTimes(ATTACH_ATTEMPT_LIMIT);
+		expect(write).not.toHaveBeenCalled();
+	});
+
+	it("does not retry a pane whose session was killed", async () => {
+		const createOrAttach = mock(async () => {
+			throw new Error("TERMINAL_SESSION_KILLED");
+		});
+		const write = mock(async () => ({}));
+
+		await expect(
+			launchCommandInPane({
+				paneId: "pane-killed",
+				tabId: "tab-1",
+				workspaceId: "ws-1",
+				command: "claude",
+				createOrAttach,
+				write,
+			}),
+		).rejects.toThrow("TERMINAL_SESSION_KILLED");
+
+		expect(createOrAttach).toHaveBeenCalledTimes(1);
+		expect(write).not.toHaveBeenCalled();
+	});
+
+	it("does not retry unrelated attach failures", async () => {
+		const createOrAttach = mock(async () => {
+			throw new Error("WORKTREE_GONE");
+		});
+		const write = mock(async () => ({}));
+
+		await expect(
+			launchCommandInPane({
+				paneId: "pane-worktree-gone",
+				tabId: "tab-1",
+				workspaceId: "ws-1",
+				command: "claude",
+				createOrAttach,
+				write,
+			}),
+		).rejects.toThrow("WORKTREE_GONE");
+
+		expect(createOrAttach).toHaveBeenCalledTimes(1);
+		expect(write).not.toHaveBeenCalled();
+	});
+
+	it("keeps joining the pending attach on every retry", async () => {
+		const inputs: Array<{ joinPending?: boolean }> = [];
+		const createOrAttach = async (input: { joinPending?: boolean }) => {
+			inputs.push(input);
+			if (inputs.length === 1) throw canceled();
+			return {};
+		};
+
+		await ensureTerminalAttached({
+			paneId: "pane-join-flag",
+			tabId: "tab-1",
+			workspaceId: "ws-1",
+			createOrAttach,
+		});
+
+		expect(inputs).toHaveLength(2);
+		for (const input of inputs) {
+			expect(input.joinPending).toBe(true);
+		}
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/launch-command.ts
+++ b/apps/desktop/src/renderer/lib/terminal/launch-command.ts
@@ -1,3 +1,4 @@
+import { isTerminalAttachCanceledMessage } from "./attach-cancel";
 import { waitForTerminalSessionReady } from "./session-readiness";
 
 interface TerminalCreateOrAttachInput {
@@ -106,6 +107,47 @@ export async function launchCommandInPane({
 	await writeCommandInPane({ paneId, command, write, noExecute });
 }
 
+/** Attach attempts per launch, including the first. */
+export const ATTACH_ATTEMPT_LIMIT = 3;
+
+/**
+ * Spaces the retries out rather than burning the budget inside one render, so
+ * a component that is mid-remount has time to settle on the attach the retry
+ * will ride.
+ */
+const ATTACH_RETRY_DELAY_MS = 25;
+
+function isCanceledAttach(error: unknown): boolean {
+	return isTerminalAttachCanceledMessage(
+		error instanceof Error ? error.message : String(error),
+	);
+}
+
+/**
+ * Attaches the pane a command is about to be written into, retrying when the
+ * attach is cancelled out from under us.
+ *
+ * A launch attaches with `joinPending: true`, so when the pane's `<Terminal>`
+ * already has an attach in flight the launch rides on that request instead of
+ * owning one (#2748). The AbortController stays with the component, though, so
+ * when it unmounts or supersedes its own attach — routine while workspace init
+ * brings an agent pane up mid-render — the shared request is aborted and the
+ * passenger launch dies with it, even though the pane is alive and about to be
+ * re-attached.
+ *
+ * A cancellation is therefore transient for a launch, never a verdict on the
+ * pane, so we retry. Where the component cancelled on the way out, the retry
+ * opens its own request and owns it. Where the component cancelled to supersede
+ * itself, it has already issued the replacement synchronously, so the retry
+ * joins that instead — which is just as good, since that attach is the one
+ * about to succeed. What the budget buys is surviving a burst of supersedes;
+ * it is not unbounded, so a pane that thrashes its attach more than
+ * ATTACH_ATTEMPT_LIMIT times still fails, and now fails loudly instead of
+ * silently.
+ *
+ * A pane that is genuinely gone rejects with TERMINAL_SESSION_KILLED instead,
+ * which is not retried — only cancellations are.
+ */
 export async function ensureTerminalAttached({
 	paneId,
 	tabId,
@@ -119,11 +161,23 @@ export async function ensureTerminalAttached({
 	cwd?: string;
 	createOrAttach: (input: TerminalCreateOrAttachInput) => Promise<unknown>;
 }): Promise<void> {
-	await createOrAttach({
-		paneId,
-		tabId,
-		workspaceId,
-		cwd,
-		joinPending: true,
-	});
+	for (let attempt = 1; ; attempt++) {
+		try {
+			await createOrAttach({
+				paneId,
+				tabId,
+				workspaceId,
+				cwd,
+				joinPending: true,
+			});
+			return;
+		} catch (error) {
+			if (attempt >= ATTACH_ATTEMPT_LIMIT || !isCanceledAttach(error)) {
+				throw error;
+			}
+			await new Promise((resolve) =>
+				setTimeout(resolve, ATTACH_RETRY_DELAY_MS),
+			);
+		}
+	}
 }

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceInitEffects.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceInitEffects.tsx
@@ -10,8 +10,11 @@ import { useCallback, useEffect, useRef } from "react";
 import { useCreateOrAttachWithTheme } from "renderer/hooks/useCreateOrAttachWithTheme";
 import { launchAgentSession } from "renderer/lib/agent-session-orchestrator";
 import { electronTrpc } from "renderer/lib/electron-trpc";
+import {
+	isPaneGoneBeforeStartMessage,
+	isTerminalAttachCanceledMessage,
+} from "renderer/lib/terminal/attach-cancel";
 import { writeCommandsInPane } from "renderer/lib/terminal/launch-command";
-import { isTerminalAttachCanceledMessage } from "renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/attach-cancel";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { useTabsWithPresets } from "renderer/stores/tabs/useTabsWithPresets";
 import {
@@ -123,10 +126,25 @@ export function WorkspaceInitEffects() {
 				write: (input) => terminalWrite.mutateAsync(input),
 			}).then((result) => {
 				if (result.status !== "failed") return;
-				if (isTerminalAttachCanceledMessage(result.error ?? undefined)) return;
+				console.error(
+					"[WorkspaceInitEffects] Failed to start agent:",
+					result.error,
+				);
+				// A cancellation used to be swallowed here, because a launch that
+				// joins the pane's in-flight attach is cancelled whenever the
+				// `<Terminal>` that owns it unmounts or re-attaches. That is now
+				// retried in `ensureTerminalAttached`, so one surviving this far
+				// means the pane really never came up — the workspace ends up with
+				// its setup terminal and no agent, which the user has to be told.
+				//
+				// Both pane-gone sentinels reach us as raw protocol strings, and a
+				// retry that lands after the pane was killed swaps one for the
+				// other, so they share the prose rather than leaking either.
 				toast.error("Failed to start agent", {
-					description:
-						result.error ?? "Failed to start agent session in workspace setup.",
+					description: isPaneGoneBeforeStartMessage(result.error ?? undefined)
+						? "The agent terminal was closed before it could start. Start the agent again from the workspace."
+						: (result.error ??
+							"Failed to start agent session in workspace setup."),
 				});
 			});
 		},

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/attach-cancel.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/attach-cancel.ts
@@ -1,5 +1,0 @@
-export const TERMINAL_ATTACH_CANCELED_MESSAGE = "TERMINAL_ATTACH_CANCELED";
-
-export function isTerminalAttachCanceledMessage(message?: string): boolean {
-	return message?.includes(TERMINAL_ATTACH_CANCELED_MESSAGE) ?? false;
-}

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/config.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_TERMINAL_FONT_FAMILY as SHARED_DEFAULT_TERMINAL_FONT_FAMILY,
 	DEFAULT_TERMINAL_FONT_SIZE as SHARED_DEFAULT_TERMINAL_FONT_SIZE,
 } from "renderer/lib/terminal/appearance";
+import { isTerminalDebugEnabled } from "renderer/lib/terminal/debug";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 
 // Use user's theme
@@ -13,9 +14,7 @@ export const FIRST_RENDER_RESTORE_FALLBACK_MS = 250;
 
 // Debug logging for terminal lifecycle (enable via localStorage)
 // Run in DevTools console: localStorage.setItem('SUPERSET_TERMINAL_DEBUG', '1')
-export const DEBUG_TERMINAL =
-	typeof localStorage !== "undefined" &&
-	localStorage.getItem("SUPERSET_TERMINAL_DEBUG") === "1";
+export const DEBUG_TERMINAL = isTerminalDebugEnabled();
 
 // Shared terminal font defaults are serialized as a valid CSS font-family value.
 export const DEFAULT_TERMINAL_FONT_FAMILY = SHARED_DEFAULT_TERMINAL_FONT_FAMILY;

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalColdRestore.ts
@@ -1,8 +1,8 @@
 import { FRESH_SHELL_INPUT_MODE_RESET } from "@superset/shared/leaked-input-mode-reclaim";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import { useCallback, useRef, useState } from "react";
+import { isTerminalAttachCanceledMessage } from "renderer/lib/terminal/attach-cancel";
 import { electronTrpcClient as trpcClient } from "renderer/lib/trpc-client";
-import { isTerminalAttachCanceledMessage } from "../attach-cancel";
 import { coldRestoreState } from "../state";
 import type {
 	CreateOrAttachMutate,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/Terminal/hooks/useTerminalLifecycle.ts
@@ -4,6 +4,7 @@ import type { SearchAddon } from "@xterm/addon-search";
 import type { IDisposable, ITheme, Terminal as XTerm } from "@xterm/xterm";
 import type { MutableRefObject, RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isTerminalAttachCanceledMessage } from "renderer/lib/terminal/attach-cancel";
 import { writeCommandInPane } from "renderer/lib/terminal/launch-command";
 import type { DetectedLink } from "renderer/lib/terminal/links";
 import { runWhenParserIdle } from "renderer/lib/terminal/parser-idle-gate";
@@ -16,7 +17,6 @@ import { installTerminalKeyEventHandler } from "renderer/lib/terminal/terminal-k
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { useTabsStore } from "renderer/stores/tabs/store";
 import { killTerminalForPane } from "renderer/stores/tabs/utils/terminal-cleanup";
-import { isTerminalAttachCanceledMessage } from "../attach-cancel";
 import { scheduleTerminalAttach } from "../attach-scheduler";
 import { isCommandEchoed, sanitizeForTitle } from "../commandBuffer";
 import { DEBUG_TERMINAL, FIRST_RENDER_RESTORE_FALLBACK_MS } from "../config";
@@ -822,7 +822,7 @@ export function useTerminalLifecycle({
 
 			if (paneDestroyed) {
 				// Pane was explicitly destroyed — full cleanup.
-				killTerminalForPane(paneId);
+				killTerminalForPane(paneId, "pane-destroyed-on-unmount");
 				coldRestoreState.delete(paneId);
 				pendingDetaches.delete(paneId);
 				v1TerminalCache.dispose(paneId);

--- a/apps/desktop/src/renderer/stores/tabs/store.ts
+++ b/apps/desktop/src/renderer/stores/tabs/store.ts
@@ -338,7 +338,7 @@ export const useTabsStore = create<TabsStore>()(
 						// Only kill terminal sessions for terminal panes (avoids unnecessary IPC for file-viewers)
 						const pane = state.panes[paneId];
 						if (pane?.type === "terminal") {
-							killTerminalForPane(paneId);
+							killTerminalForPane(paneId, "remove-tab");
 						}
 
 						cleanupEditorPaneState(paneId);
@@ -516,7 +516,7 @@ export const useTabsStore = create<TabsStore>()(
 						// in layouts - we must not delete those when they're "removed"
 						if (pane && pane.tabId === tabId) {
 							if (pane.type === "terminal") {
-								killTerminalForPane(paneId);
+								killTerminalForPane(paneId, "update-tab-layout");
 							}
 							delete newPanes[paneId];
 						}
@@ -991,7 +991,7 @@ export const useTabsStore = create<TabsStore>()(
 					// Kill terminal sessions for terminal panes
 					for (const id of paneIdsToRemove) {
 						if (state.panes[id]?.type === "terminal") {
-							killTerminalForPane(id);
+							killTerminalForPane(id, "remove-pane");
 						}
 
 						cleanupEditorPaneState(id);

--- a/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
+++ b/apps/desktop/src/renderer/stores/tabs/utils/terminal-cleanup.ts
@@ -1,10 +1,32 @@
+import { isTerminalDebugEnabled } from "../../../lib/terminal/debug";
 import { rejectTerminalSessionReady } from "../../../lib/terminal/session-readiness";
 import { electronTrpcClient } from "../../../lib/trpc-client";
 
 /**
+ * Why a pane's terminal session is being killed. Every destructive path routes
+ * through here, so the reason is the only record of *which* one ran — without
+ * it a pane that dies seconds after it was created is indistinguishable in the
+ * logs from one the user closed on purpose, which is why panes disappearing
+ * mid-launch has gone undiagnosed since April 2026.
+ */
+export type TerminalKillReason =
+	| "remove-pane"
+	| "remove-tab"
+	| "update-tab-layout"
+	| "pane-destroyed-on-unmount";
+
+/**
  * Uses standalone tRPC client to avoid React hook dependencies
  */
-export const killTerminalForPane = (paneId: string): void => {
+export const killTerminalForPane = (
+	paneId: string,
+	reason: TerminalKillReason,
+): void => {
+	if (isTerminalDebugEnabled()) {
+		console.log(`[terminal] killing pane ${paneId} (${reason})`);
+		console.trace(`[terminal] kill origin for ${paneId}`);
+	}
+
 	rejectTerminalSessionReady(
 		paneId,
 		new Error("Terminal pane was closed before the session became ready"),


### PR DESCRIPTION
## What & why

Creating a workspace with a prompt sometimes gives you the setup terminal and **no agent**, with no error anywhere. I hit it repeatedly on a loaded machine (16GB MBA, disk near full); my `~/.superset/daemon.log` has 29 occurrences, the oldest from **2026-04-17**, so this is long-standing rather than new.

**Root cause.** A launch attaches with `joinPending: true`, so when the pane's `<Terminal>` already has an attach in flight the launch rides on that request rather than owning one (the #2748 fix). The `AbortController` stays with the component, though. When the component unmounts or supersedes its own attach — routine while workspace init brings an agent pane up mid-render — the shared request is aborted and the **passenger launch dies with it**, even though the pane is alive and about to be re-attached. `launchTerminalAdapter` then catches and calls `removePane`, killing the pane.

Normally the launch wins the race (one microtask, vs React's scheduler committing on a macrotask) and owns the attach, which is why this is intermittent and load-sensitive. The host has no `joinPending` concept at all (`terminal-host.ts:84` aborts any existing pending attach unconditionally); the join only exists in `DaemonTerminalManager`.

**Why it was invisible.** #5925 added `if (isTerminalAttachCanceledMessage(...)) return;` to `WorkspaceInitEffects`, which silenced the symptom instead of the race. No toast, no log, no retry — the workspace just quietly ends up without its agent.

**The fix.** Retry a cancelled attach instead of treating it as a verdict on the pane. The retry lives inside `ensureTerminalAttached`, which runs inside the adapter's `try`, so the pane is never destroyed in the first place. Only cancellations retry; `TERMINAL_SESSION_KILLED` (a genuinely gone pane) fails immediately.

Plus two things that stand on their own:
- Stop swallowing the failure, and map **both** pane-gone sentinels to prose so neither leaks raw into a toast.
- Thread a typed `reason` through `killTerminalForPane`. Every destructive path funnels through it and it recorded nothing, which is exactly why a pane dying 60ms after creation was indistinguishable in the logs from one the user closed on purpose.

## Evidence

From my own machine, a failing vs. a succeeding creation:

```
FAIL  .079 pane created (setup)      SUCCESS  .474 pane created (setup)
      .114 Creating/attaching …079            .509 Creating/attaching …474
      .172 pane created (agent)                .576 pane created (agent)
      .198 Creating/attaching …172             .591 Creating/attaching …576
      .202 Session …172 killed                 .840 Session …576 created
      .217 Session …172 killed                 .847 Session …474 created
      .469 TERMINAL_ATTACH_CANCELED
      .470 Session …079 created
```

Terminal history confirms which pane is which: on the failing run the survivor ran the setup script and the killed pane has **zero history — it never reached `claude`**. Persisted tab state shows the same thing: the success case keeps `{row, first: setup, second: agent}`, the failure collapses back to the bare setup pane.

Two details that took a while to read correctly, and are worth knowing if you touch this code:
- The host's `CANCELED` log line is emitted when its queued spawn **unwinds**, not when the abort fires — it sits behind `spawnLimiter` (`MAX_CONCURRENT_SPAWNS = 3`). That is why it appears several hundred ms late, next to the *other* pane's `created` line. Reading it as the moment of cancellation inverts the whole causality.
- The two kills ~10ms apart are `removePane` followed by the unmount with `paneDestroyed=true`. That is also the signature of a normal pane close, which is what made this so hard to spot in logs.

## How I tested it

`bun test` in `apps/desktop`: **3653 pass / 2 fail / 1 error**, against a **3645 / 2 / 1** baseline measured on a clean tree at HEAD (I reverted the whole diff, ran the suite, and restored). That is +8 tests, +8 passing, failures unchanged. The two failures are pre-existing and unrelated — `getProcessEnvWithShellPath` in `git.test.ts` (fails identically on clean HEAD) and a `@dnd-kit`/React module-interop error in `useSidebarDnd.test.ts` that only appears in full-suite runs and passes in isolation.

`tsc --noEmit` clean, `biome check` clean across 3702 files, i18n enforcement 82 pass, `sherif` 0 errors.

New tests:
- `launch-command.test.ts` — retries a cancel, gives up after the budget, does **not** retry a killed pane or unrelated failures, keeps `joinPending` on every attempt.
- `daemon-manager.test.ts` — pins the join-then-cancel semantics the retry exists for (the #2748 tests only covered two racing attaches, never the owner cancelling afterwards), the unmount case where the retry owns the request, and the supersede case where it joins the replacement instead.

## Confidence — please read before merging

**What I'm confident about**, because it's proven in tests or in the logs above:
- The passenger race is real and previously untested. The owner's cancel does kill a joined launch.
- The recovery works: after the cancel there's no tombstone and no pending entry, so the retry attaches cleanly.
- The silent swallow is real, and a raw `TERMINAL_SESSION_KILLED` would otherwise have leaked into a toast (caught in review of this branch).
- No regressions, measured against a clean-tree baseline rather than assumed.

**What is not verified**, and why I'd like a second opinion:
- **I have not watched a real workspace creation fail and then succeed on the retry.** The mechanism and the recovery are proven in tests; the end-to-end gate is not closed. I could not attach CDP to a packaged build to catch a live repro.
- I never identified *which* caller ultimately destroys the pane in every case. The evidence points at `launchTerminalAdapter`'s catch as the consequence of the cancel, but `updateTabLayout` (`store.ts:519`) also kills panes purely from a layout diff and I could not rule it out from logs alone. **That is what the kill-reason instrumentation is for**: if a report ever comes back with `update-tab-layout` or `remove-tab`, this diagnosis is wrong and the fix is treating a symptom.
- The retry budget survives a burst of supersedes but is not unbounded, so a pane that thrashes its attach more than 3 times still fails — loudly now, rather than silently.

**Follow-ups I deliberately left out** to keep this reviewable:
- The deeper fix is giving a joined attach its own lifetime in `DaemonTerminalManager` (refcount, so the owner's cancel doesn't tear down joiners). The retry gets the same outcome with far less blast radius.
- `pendingTerminalSetups` (`stores/workspace-init.ts`) is non-persisted zustand, and the recovery path at `WorkspaceInitEffects.tsx:406-448` rebuilds from `getSetupCommands`, which carries no agent. Restart mid-init and the agent is lost with no way back.
- `settledByIdempotency` (`agent-session-orchestrator.ts:17`) is a module-level `Map` that is never cleared, so a failed launch with an idempotency key can never be retried for the session's lifetime. Latent — this path sets no key.

Related: #6774 is the CLI/cross-host analogue of the same "agent launch fails, error swallowed" shape.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

https://claude.ai/code/session_014FCFavVKRFSXBfuV7de6gp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries an agent launch when its terminal attach is cancelled, so workspace creation no longer silently ends up with the setup terminal and no agent. The launch now retries a cancelled attach instead of treating it as a verdict on the pane, and surfaces real failures instead of swallowing them.

- A cancelled attach is retried up to 3 times; a killed session fails immediately.
- Pane-gone errors now map to a user-facing message instead of leaking raw protocol strings.
- `killTerminalForPane` now records why a pane was killed, so mid-launch pane deaths are distinguishable from user closes.

<sup>Written for commit f7f8bbaf67a18f227fc2ffaa1d42c381dfee234c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Terminal launches now automatically retry when an attach request is canceled, up to three attempts.
  - Canceled terminal sessions are handled without replacing active pending requests.
  - Terminal sessions that close before starting now display a clear error notification instead of being silently ignored.
  - Other terminal failures continue to surface immediately without unnecessary retries.

- **Diagnostics**
  - Added optional terminal lifecycle debug logging to help trace terminal cleanup and closure events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->