### PR TITLE
fix(desktop): launch host-service through the crash-port-clearing spawn-helper

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -221,6 +221,37 @@ export function parseEtime(etime: string): number | null {
 	);
 }
 
+/**
+ * macOS inherits the task's Mach exception ports across fork and exec, so a
+ * plain spawn hands host-service, and every git, hook, login shell and agent
+ * CLI it launches, the port Crashpad registered in this process: their crashes
+ * upload as Superset minidumps carrying an unrelated program's memory. node-pty's
+ * spawn-helper (patched, see patches/README.md) clears those ports before exec,
+ * and launching host-service through it detaches the whole subtree. host-service's
+ * own crashes are reported by handleChildExit with the exit signal and output
+ * tail; pty-daemon's are not reported at all after this. The helper is built
+ * by the native rebuild alongside pty.node, so it is resolved the way node-pty
+ * resolves it and the plain spawn is kept for a tree without the build.
+ */
+function crashPortClearingLauncher(): string | null {
+	if (process.platform !== "darwin") return null;
+	let helper: string;
+	try {
+		helper = path
+			.join(
+				path.dirname(require.resolve("node-pty")),
+				"..",
+				"build",
+				"Release",
+				"spawn-helper",
+			)
+			.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
+	} catch {
+		return null;
+	}
+	return fs.existsSync(helper) ? helper : null;
+}
+
 function isValidPort(port: number | null | undefined): port is number {
 	return (
 		typeof port === "number" &&
@@ -846,9 +877,19 @@ export class HostServiceCoordinator extends EventEmitter {
 		// lines must not.
 		logStream?.on("error", () => {});
 
+		const launcher = crashPortClearingLauncher();
+		if (process.platform === "darwin" && !launcher) {
+			log.warn(
+				`[host-service:${organizationId}] node-pty spawn-helper not built; the child will inherit this process's crash handler`,
+			);
+		}
+		// spawn-helper's first argument is a cwd to chdir into; empty keeps ours.
+		const [command, args] = launcher
+			? [launcher, ["", process.execPath, this.scriptPath]]
+			: [process.execPath, [this.scriptPath]];
 		let child: ReturnType<typeof childProcess.spawn>;
 		try {
-			child = childProcess.spawn(process.execPath, [this.scriptPath], {
+			child = childProcess.spawn(command, args, {
 				detached: false,
 				stdio: ["ignore", "pipe", "pipe"],
 				env: childEnv,

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -232,6 +232,17 @@ export function parseEtime(etime: string): number | null {
  * tail; pty-daemon's are not reported at all after this. The helper is built
  * by the native rebuild alongside pty.node, so it is resolved the way node-pty
  * resolves it and the plain spawn is kept for a tree without the build.
+ *
+ * Two properties of the helper this relies on, both checked on macOS:
+ * - Before exec it runs `close(open(ttyname(STDIN_FILENO), O_RDWR))` to attach
+ *   a pty's controlling terminal. The spawn below gives it /dev/null as stdin,
+ *   for which ttyname() returns NULL (ENOTTY), and open(NULL) fails with
+ *   EFAULT instead of faulting, so the step is inert. It could only act if
+ *   stdin were a terminal, and even then this spawn creates no new session,
+ *   so the terminal would not be acquired.
+ * - A failed execvp exits 1, so a helper that cannot run electron surfaces
+ *   through handleChildExit as a nonzero exit rather than silently; the plain
+ *   spawn fallback only needs to cover the helper not being built.
  */
 function crashPortClearingLauncher(): string | null {
 	if (process.platform !== "darwin") return null;

--- a/patches/README.md
+++ b/patches/README.md
@@ -162,14 +162,30 @@ silently do nothing. Clearing to `MACH_PORT_NULL` does not cost the user their
 own crash logs — macOS still writes its usual report to
 `~/Library/Logs/DiagnosticReports`.
 
-The boundary is process ancestry, not a tag or heuristic: only processes
-launched *into a pty* are detached. Electron's own main, renderer, GPU and
-utility processes, and the node children the app spawns with
-`child_process.spawn` (host-service, pty daemon — the renderer/node OOM family
-this was measured against), are not spawned through node-pty and keep reporting
-exactly as before. The known, accepted gap is that a Superset binary a user runs
-*themselves* in a terminal (e.g. the bundled `superset` CLI) is on the detached
-side.
+The boundary is process ancestry, not a tag or heuristic. Two launch points
+detach a subtree, and both go through this helper:
+
+- **pty children.** Everything launched into a terminal.
+- **host-service and everything under it.** `host-service-coordinator.ts`
+  launches host-service through the same `spawn-helper`
+  (`spawn-helper "" <electron> host-service.js`), so its login-shell env probe,
+  git and the hooks git runs, `gh`, the agent CLIs it runs for workspace naming
+  and chat, and the pty daemon it supervises all start without the port. Measured
+  2026-09-07, two weeks after the pty patch shipped (1.24.2): about half of the
+  minidumps from patched releases were still foreign, and the host-service tree
+  was the one remaining path our code reaches. host-service's own crashes keep
+  reaching Sentry through the coordinator's exit handler (`host-service crashed
+  (signal …)`, with the output tail), which already carried ~6x more events than
+  its minidumps did. The pty daemon's native crashes are no longer captured by
+  anything.
+
+Electron's own main, renderer, GPU and utility processes, and the terminal-host
+daemon (its only children are the pty subprocesses, which go through node-pty),
+keep reporting exactly as before. Two paths stay leaky and are not ours to fix
+here: Squirrel.Mac unzips updates with an in-process `ditto`, and a detached
+daemon started by a pre-1.24.2 install keeps its old handler until the machine
+reboots. A Superset binary a user runs *themselves* in a terminal (e.g. the
+bundled `superset` CLI) is on the detached side.
 
 `spawn-helper` is compiled from this source by the node-gyp rebuild that
 `bun run install:deps` and electron-builder's `npmRebuild` perform, and
@@ -193,5 +209,6 @@ bun test apps/desktop/src/pty-crash-ports-patch.test.ts
 
 **Removing:** upstream could do this properly for every embedder by setting the
 ports on the spawn attributes it already builds in `pty_posix_spawn`
-(`posix_spawnattr_setexceptionports_np`). If node-pty ships that, drop the patch
-and the `patchedDependencies` entry.
+(`posix_spawnattr_setexceptionports_np`). If node-pty ships that, the pty side
+no longer needs the patch, but `host-service-coordinator.ts` still needs a
+port-clearing exec trampoline; keep the patched helper (or ship our own) for it.


### PR DESCRIPTION
## Problem

Minidumps of programs that are not Superset are still uploaded to the desktop Sentry project on releases that carry the pty fix from #6738. Each is a memory dump of someone else's process, so this is a privacy defect, not telemetry noise.

Measured 2026-09-07 over 14 days: 2,623 minidumps. 59% come from releases before 1.24.2, which nothing can reach (the pty patch verifiably ships from 1.24.2: the tag contains #6738 and the packaged 1.24.2 `build/Release/spawn-helper` references `task_set_exception_ports`). Of the 1,073 on patched releases, roughly a third are ours (host-service V8 out-of-memory aborts DESKTOP-DN/12V/13V/HZ, browser process DESKTOP-88, Chromium frames), about half are foreign (a user's Rust test binary under DESKTOP-6V, Homebrew `node` and other dyld aborts under DESKTOP-4J/55, a small FSEvents program under DESKTOP-3R, `ditto` under DESKTOP-1S), and the rest are unsymbolicated small programs.

Foreign dumps on patched builds arrive by three paths. Only the first is reachable from our code:

1. **host-service's children.** Its login-shell env probe, git and the hooks git runs, `gh`, the agent CLIs it runs for workspace naming and chat, and the pty daemon it supervises.
2. **Squirrel.Mac's `ditto`.** The updater unzips with an in-process NSTask inside the Electron main process (`_dittoTask` in Squirrel.framework). Not reachable from JavaScript.
3. **Stale pre-patch daemon trees.** Detached daemons from an older install keep the old handler's port; events show 1.17.0 and 1.23.0 handlers (`crashpad._version`) uploading under a 1.26.0 app. Reboots retire these.

## Root cause

macOS inherits the task's Mach exception ports across fork and exec, to any depth. `child_process.spawn(process.execPath, [host-service.js])` from the main process, where the Sentry SDK has started `crashReporter`, hands host-service Crashpad's port, and host-service hands it to everything it spawns. #6738 patched node-pty's `spawn-helper` to clear the ports before exec, which covers pty children only.

Reproduced against Electron 41.10.3 with `crashReporter` started, reading the ports with a `task_get_exception_ports` probe (no Sentry involved):

```
[electron main itself]                                   live_crash_ports=1 -> INHERITED
[main -> child_process.spawn(probe)]                     live_crash_ports=1 -> INHERITED
[main -> node child (host-service shape) -> probe]       live_crash_ports=1 -> INHERITED
[main -> /bin/sh -c 'exec node child' (pty-daemon) ...]  live_crash_ports=1 -> INHERITED
[main -> spawn-helper trampoline -> probe]               live_crash_ports=0 -> clear
[main -> spawn-helper -> node child -> probe]            live_crash_ports=0 -> clear
```

Electron's node mode does not re-register a port, so a child launched clear stays clear along with its subtree.

## Fix

Launch host-service through node-pty's patched `spawn-helper` (`spawn-helper "" <electron> host-service.js`) on macOS. One choke point detaches the whole host-service tree; no per-call-site wrapper, no new native code, the helper is already built and shipped in `app.asar.unpacked` for the terminals. The helper is resolved the way node-pty resolves it (`require.resolve("node-pty")`, `build/Release`, asar-unpacked), and a tree without the native build falls back to the plain spawn with a warning.

What this trades away, on purpose and agreed with the maintainer: host-service and pty-daemon no longer produce minidumps. host-service's crashes are already reported by the coordinator's exit handler as `host-service crashed (signal SIGABRT)` with the output tail: 649 events on 1.26.0 in 14 days against about 100 minidumps for the same process. pty-daemon crashes are reported by nothing after this. Electron's own processes and the terminal-host daemon (whose only children are pty subprocesses) keep reporting as before. `patches/README.md` is updated to say so.

Exact spawn shape verified (async spawn, stdin ignored, `ELECTRON_RUN_AS_NODE`): the child's pid is the exec'd node process, argv0 and env survive, the grandchild is clear.

```
[plain spawn (before)      ] child.pid=3270 | node child pid=3270 argv0=Electron ELECTRON_RUN_AS_NODE=1 | grandchild: pid=3271 ppid=3270 entries=2 live_crash_ports=1 -> INHERITED (leak)
[through spawn-helper (after)] child.pid=3273 | node child pid=3273 argv0=Electron ELECTRON_RUN_AS_NODE=1 | grandchild: pid=3274 ppid=3273 entries=1 live_crash_ports=0 -> clear
```

The coordinator's manifest identity check matches on the script basename in the `ps` command line, which is unchanged after exec. No typed cause added; nothing throws here.

## Verification

`bunx biome check apps/desktop/src/main/lib/host-service-coordinator.ts patches/README.md`
```
Checked 1 file in 35ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck`
```
$ tsc --noEmit
typecheck exit: 0
```

`cd apps/desktop && bun test` (full package suite, with this diff)
```
 3620 pass
 1 fail
 1 error
 2 snapshots, 59247 expect() calls
Ran 3621 tests across 392 files. [29.61s]
```

The failure and the error are the same pre-existing item, `src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useSidebarDnd/useSidebarDnd.test.ts` (`React.createContext is not a function` from a module mock leaking into `@dnd-kit/core`). Same suite with only this diff reverted (`git checkout` of the two files):
```
 3620 pass
 1 fail
 1 error
 2 snapshots, 59247 expect() calls
Ran 3621 tests across 392 files. [25.80s]
```

Helper resolution from `apps/desktop` in this tree:
```
.../node_modules/node-pty/build/Release/spawn-helper true
```

Probe run inside a terminal of the running canary (pty path, unchanged by this PR): `live_crash_ports=0 -> clear`.

## Out of scope

- The V8 out-of-memory aborts in host-service (DESKTOP-DN readdir callback, DESKTOP-12V `JSON.stringify` on a worker message) are a real defect of ours and keep reporting via the coordinator's event.
- Squirrel's `ditto` abort on a truncated download (DESKTOP-1S) is an updater problem.
- The Electron main process still spawns `afplay`, `osascript`, `ps`, `locale`, and `security` directly; none appeared in the sample.

Refs DESKTOP-3R
Refs DESKTOP-1S
Refs DESKTOP-55
Refs DESKTOP-3G
Refs DESKTOP-DN
Refs DESKTOP-4J
Refs DESKTOP-N8
Refs DESKTOP-43
Refs DESKTOP-AW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launches host-service through node-pty's crash-port-clearing spawn-helper on macOS so its children no longer upload foreign minidumps to the desktop Sentry project. Previously, host-service and everything it spawned (git, login shells, agent CLIs, the pty daemon) inherited Crashpad's Mach exception ports and uploaded memory dumps of unrelated programs.

**Side effects**
- host-service's own crashes still reach Sentry via the coordinator's exit handler.
- pty-daemon native crashes are no longer captured.
- Falls back to plain spawn with a warning if the native helper isn't built.

<sup>Written for commit 40787e7e12eb1c4f160ef3a609d2d74e116d806e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved crash isolation for host-service processes on macOS.
  - Preserved existing process-launch behavior on other platforms and when the macOS helper is unavailable.
  - Added a warning when the expected macOS crash-isolation helper cannot be found.

- **Documentation**
  - Clarified crash reporting behavior and remaining limitations for macOS process trees.
  - Updated guidance for retaining the macOS helper until an alternative is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->