### PR TITLE
fix(api): keep webhook bookkeeping out of the failure path, and select only the host columns dispatch reads

### DIFF
--- a/apps/api/src/app/api/github/webhook/route.ts
+++ b/apps/api/src/app/api/github/webhook/route.ts
@@ -1,7 +1,9 @@
 import { db } from "@superset/db/client";
 import { githubInstallations, webhookEvents } from "@superset/db/schema";
 import { eq } from "drizzle-orm";
+import type { IngestOutcome } from "@/lib/automations/ingestAutomationEvent";
 import { ingestAutomationEvent } from "@/lib/automations/ingestAutomationEvent";
+import { databaseErrorMessage } from "@/lib/databaseErrorMessage";
 import { recordWebhookDelivery } from "@/lib/ingest/recordWebhookDelivery";
 import { stripNullChars } from "@/lib/strip-null-chars";
 import {
@@ -66,7 +68,11 @@ export async function POST(request: Request) {
 		return Response.json({ success: true, message: "Event not ready" });
 	}
 
-	// Process the verified event
+	// Process the verified event. The catch covers the work and nothing else:
+	// recording the outcome below is bookkeeping, and a failure to record it is
+	// not a failure of the work that already happened.
+	let outcome: IngestOutcome | null = null;
+	let failure: string | null = null;
 	try {
 		await webhooks.receive({
 			id: deliveryId ?? "",
@@ -89,7 +95,7 @@ export async function POST(request: Request) {
 						),
 						columns: { organizationId: true },
 					});
-		const outcome = installation
+		outcome = installation
 			? await ingestAutomationEvent(
 					db,
 					normalizeGithubDelivery({
@@ -101,28 +107,34 @@ export async function POST(request: Request) {
 					}),
 				)
 			: null;
-
-		await db
-			.update(webhookEvents)
-			.set({ status: "processed", processedAt: new Date() })
-			.where(eq(webhookEvents.id, webhookEvent.id));
-
-		return Response.json({ success: true, outcome });
 	} catch (error) {
-		console.error("[github/webhook] Webhook processing error:", error);
-
-		await db
-			.update(webhookEvents)
-			.set({
-				status: "failed",
-				error: error instanceof Error ? error.message : "Unknown error",
-				retryCount: webhookEvent.retryCount + 1,
-			})
-			.where(eq(webhookEvents.id, webhookEvent.id));
-
-		return Response.json(
-			{ error: "Webhook processing failed" },
-			{ status: 500 },
-		);
+		// The driver's message, not Drizzle's: this one is stored on the row and
+		// logged, and Drizzle's carries every bind parameter — the whole webhook
+		// body among them, since recordAutomationEvent binds it.
+		failure = databaseErrorMessage(error);
+		console.error("[github/webhook] Webhook processing error:", failure);
 	}
+
+	// One write for either outcome, and it is deliberately outside the catch
+	// above. When the database is what failed, a second write to it cannot
+	// report that: it throws in turn and replaces the original error with its
+	// own. Letting this one throw reports what actually broke and leaves the
+	// delivery `pending` for a redelivery, rather than marking work that
+	// succeeded as `failed` and inviting it to be done twice.
+	await db
+		.update(webhookEvents)
+		.set(
+			failure === null
+				? { status: "processed", processedAt: new Date() }
+				: {
+						status: "failed",
+						error: failure,
+						retryCount: webhookEvent.retryCount + 1,
+					},
+		)
+		.where(eq(webhookEvents.id, webhookEvent.id));
+
+	return failure === null
+		? Response.json({ success: true, outcome })
+		: Response.json({ error: "Webhook processing failed" }, { status: 500 });
 }

--- a/apps/api/src/lib/databaseErrorMessage.ts
+++ b/apps/api/src/lib/databaseErrorMessage.ts
@@ -1,0 +1,20 @@
+import { DrizzleQueryError } from "drizzle-orm";
+
+/**
+ * An error's message with no bind parameters in it.
+ *
+ * Drizzle builds a DrizzleQueryError's message as the statement text followed
+ * by every bind parameter, so `error.message` on a failed query is unsafe to
+ * store or report: on the ingest paths one of those parameters is the whole
+ * webhook body, which would put a third party's payload into an error column
+ * and into the error tracker. The driver error underneath carries the same
+ * diagnosis — code, severity, what the database actually said — without them.
+ */
+export function databaseErrorMessage(error: unknown): string {
+	if (error instanceof DrizzleQueryError) {
+		return error.cause instanceof Error
+			? error.cause.message
+			: "unknown database error";
+	}
+	return error instanceof Error ? error.message : "Unknown error";
+}

--- a/apps/api/src/lib/ingest/recordWebhookDelivery.ts
+++ b/apps/api/src/lib/ingest/recordWebhookDelivery.ts
@@ -1,6 +1,7 @@
 import { db } from "@superset/db/client";
 import type { integrationProvider } from "@superset/db/schema";
 import { DrizzleQueryError, sql } from "drizzle-orm";
+import { databaseErrorMessage } from "@/lib/databaseErrorMessage";
 
 type Provider = (typeof integrationProvider.enumValues)[number];
 
@@ -12,22 +13,17 @@ export interface RecordedDelivery {
 }
 
 /**
- * Drizzle wraps a failed query in a DrizzleQueryError whose message, and own
- * `query`/`params` properties, are the statement text followed by every bind
- * parameter. One of ours is the entire webhook body, so reporting that error
- * unmodified publishes a third party's payload into the error tracker.
- *
- * Rethrow with the operation, the provider and the driver's own message, and
- * the driver error as the cause so its code and stack still reach the report:
- * a failure says what broke and why, without the body. Anything that is not
- * the wrapper carries no bind parameters and is left exactly as it was.
+ * Rethrow a failed write with the operation, the provider and the driver's own
+ * message, and the driver error as the cause so its code and stack still reach
+ * the report: a failure says what broke and why, without the bind parameters —
+ * one of ours is the entire webhook body. Anything that is not Drizzle's
+ * wrapper carries no bind parameters and is left exactly as it was.
  */
 function withoutBoundParameters(provider: Provider, error: unknown): unknown {
 	if (!(error instanceof DrizzleQueryError)) return error;
-	const cause = error.cause;
 	return new Error(
-		`recordWebhookDelivery failed for ${provider} writing ingest.webhook_events and ingest.webhook_payloads: ${cause?.message ?? "unknown database error"}`,
-		{ cause },
+		`recordWebhookDelivery failed for ${provider} writing ingest.webhook_events and ingest.webhook_payloads: ${databaseErrorMessage(error)}`,
+		{ cause: error.cause },
 	);
 }
 

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -66,15 +66,27 @@ export type DispatchOptions = {
 	relayUrl: string;
 } & DispatchCause;
 
+/**
+ * The columns a candidate is built from, named once so both queries below
+ * project the same ones. A bare `.select()` would instead project whatever the
+ * schema currently declares, which couples dispatch to columns it never reads:
+ * a column dropped from `v2_hosts` breaks every deployment still running the
+ * previous build, since it goes on selecting a column the database no longer
+ * has.
+ */
+const hostCandidateColumns = {
+	organizationId: v2Hosts.organizationId,
+	machineId: v2Hosts.machineId,
+	name: v2Hosts.name,
+	wakeCommand: v2Hosts.wakeCommand,
+	createdByUserId: v2Hosts.createdByUserId,
+	createdAt: v2Hosts.createdAt,
+	updatedAt: v2Hosts.updatedAt,
+};
+
 type HostCandidate = Pick<
 	typeof v2Hosts.$inferSelect,
-	| "organizationId"
-	| "machineId"
-	| "name"
-	| "wakeCommand"
-	| "createdByUserId"
-	| "createdAt"
-	| "updatedAt"
+	keyof typeof hostCandidateColumns
 >;
 
 /**
@@ -287,7 +299,7 @@ async function resolveCandidateHosts(
 ): Promise<HostCandidate[]> {
 	if (automation.targetHostId) {
 		const [host] = await db
-			.select()
+			.select(hostCandidateColumns)
 			.from(v2Hosts)
 			.where(
 				and(
@@ -301,15 +313,7 @@ async function resolveCandidateHosts(
 	}
 
 	return db
-		.select({
-			organizationId: v2Hosts.organizationId,
-			machineId: v2Hosts.machineId,
-			name: v2Hosts.name,
-			wakeCommand: v2Hosts.wakeCommand,
-			createdByUserId: v2Hosts.createdByUserId,
-			createdAt: v2Hosts.createdAt,
-			updatedAt: v2Hosts.updatedAt,
-		})
+		.select(hostCandidateColumns)
 		.from(v2Hosts)
 		.innerJoin(
 			v2UsersHosts,


### PR DESCRIPTION
## Problem

Three Sentry issues, handed over as one family — "the same Neon connection-permit
family as API-18, on routes #7289 deliberately did not touch". Reading the latest
event of each, they are three different failures, and only one of them is about
connections at all.

| issue | events / users | reported error | underlying |
| --- | --- | --- | --- |
| **API-2H** | 3 / 2 | `recordWebhookDelivery failed for github …` | `NeonDbError: Database request failed` |
| **API-2D** | 2 / 2 | `Failed query: update ingest.webhook_events set status, error, retry_count …` | `NeonDbError: … {"message":"no more connections allowed (max_client_conn)","code":"08P01","neon:retryable":true}` |
| **API-2K** | 2 / 1 | `Failed query: select … from v2_hosts …` | `NeonDbError: column "is_online" does not exist` |

API-2K is not a connection failure. Neither, at root, is API-2H.

For scale: the GitHub route is the largest ingest stream in the product —
**1,808,239 deliveries in 24 hours** (~21/s), against 2 rows in `failed` state
over the same period. These issues are rare events on a route that is not
chronically broken, which is why the fix is about what happens *when* a query
fails, not about how many queries there are.

## Root cause

### API-2D — the failure path is itself a database write

Read the reported error's parameters: `failed`, then a *second* error string, then
`1`, then a row id. The message stored as `$2` is `Failed query: update
"ingest"."webhook_events" set "status" = $1, "processed_at" = $2` — the
**success** update. So the sequence was:

1. `webhooks.receive`, the installation lookup and `ingestAutomationEvent` all succeeded;
2. `update … set status = 'processed'` failed on `max_client_conn`;
3. that threw into the `catch`, which ran `update … set status = 'failed'`;
4. that failed the same way, and — being outside any `try` — escaped `POST`.

Three defects fall out of one shape, the success bookkeeping sitting inside the
try whose catch does another write:

- **A second write cannot report that writing failed.** When the database is the
  reason for the catch, the catch's own update throws in turn and *replaces* the
  original error. The reported exception is the recovery attempt; the real
  failure survives only as a bind parameter inside it.
- **Work that succeeded gets marked `failed`.** Had step 3 landed, a fully
  processed delivery would be `failed` with `retry_count` 1 — and
  `recordWebhookDelivery` reopens a `failed` row as `pending`, so a redelivery
  would redo work already done.
- **The stored message carries the payload.** Verified against the installed
  source (`drizzle-orm@0.45.2/errors.js`): `DrizzleQueryError` is constructed as
  ``super(`Failed query: ${query}\nparams: ${params}`)``. `recordAutomationEvent`
  binds the whole webhook body, so a failure there writes a third party's payload
  into `webhook_events.error`, into the log line, and into the reported error.
  `withoutBoundParameters` in `recordWebhookDelivery.ts` exists precisely to stop
  this; this path defeated it.

The *connection* exhaustion behind step 2 is not this route's doing. Measured on
a copy of production, per second across the API-2D window:

```
         sec         | gh | lin | total
 2026-08-30 15:03:33 |  9 | 240 |   249   <- API-2D fires here
 2026-08-30 15:03:34 |  4 | 200 |   204
 2026-08-30 15:03:35 |  3 | 489 |   492
 2026-08-30 15:03:38 |  7 | 470 |   477
```

Linear was writing 170–490 rows/second while GitHub wrote 3–26. That is the
fan-out #7289 removes. GitHub was a bystander — which is exactly why its fix is a
different one.

### API-2H — environmental, and proved so

`recordWebhookDelivery` itself failed, so no row exists and the delivery is gone.
The cause was not this route. At 11:00:07 UTC on 2026-09-04, ingest stopped for
**every** provider:

```
 2026-09-04 11:00:04 |  8 |   0 |     8
 2026-09-04 11:00:11 | 31 |   0 |    31   <- 6.74s with nothing recorded, at all
```

Over a 12-hour window containing **999,376** GitHub deliveries, that is the only
gap longer than two seconds — one, and it is 6.74s:

```
 gaps_over_2s | gaps_over_4s | gaps_over_5s |     biggest     | total_deliveries
            1 |            1 |            1 | 00:00:06.743473 |           999376
```

The route already does the right thing here: it refuses to acknowledge a delivery
it could not record. **No code change can record a delivery while the database is
unreachable**, so this is classified environmental rather than fixed.

**What the user still experiences.** Those deliveries are lost. GitHub's docs are
explicit — a server must "respond with a 2XX response within 10 seconds", after
which GitHub "terminates the connection and considers the delivery a failure", and
there is no automatic retry: "if your server goes down, you should redeliver
missed webhooks once your server is back up". So the automations those 3
deliveries would have triggered never ran, and recovery is a manual redelivery
from GitHub's UI. This PR does not change that; it does make the *next* such blip
report what actually broke instead of the recovery attempt.

### API-2K — a dropped column, not a connection

`resolveCandidateHosts` has two branches returning the same `HostCandidate[]`. One
listed its columns explicitly. The other used a bare `.select()`, which projects
whatever the schema declares — including `is_online`, which the function never
reads.

Migration `0107_drop_v2_hosts_is_online` (commit `734b1b0bf`, 2026-09-04
23:38:15 -0700) dropped the column. The failing release is `8c0ecfe5e`, committed
23:29:35 -0700 — **nine minutes earlier**, and `git merge-base --is-ancestor`
confirms it does not contain the drop. The events fired at 23:41 PDT: the
migration had been applied while the previous build was still serving, and that
build went on asking for a column the database no longer had. Two events twelve
seconds apart, then never again, because the next deploy carried the schema
without it.

The drop was correct. What made it fatal was a query coupled to columns it does
not use — and the sibling branch three lines below was already immune.

## Fix

**`route.ts`** — the `try` now covers the work and nothing else, and there is one
bookkeeping write for either outcome instead of two, placed after it. This is the
shape the Linear route already uses. A failure to record the outcome now
propagates as itself: no doomed second write, no original error destroyed, and
a delivery whose work succeeded can no longer be marked `failed`. It still
answers 500, so the row stays `pending` and GitHub shows the delivery as failed —
honest, because the outcome genuinely was not recorded.

**`databaseErrorMessage.ts`** — the general half of `withoutBoundParameters`,
which was private to `recordWebhookDelivery.ts` and used once. Now used twice, by
that function and by the route's catch, so the message that reaches the row, the
log and Sentry is the driver's own — the code, the severity and what the database
actually said, with no bind parameters.

**`dispatch.ts`** — both branches project one shared `hostCandidateColumns`, and
`HostCandidate` is derived from it, so the type and the two queries cannot drift.
Net −8 lines: one duplicated column literal and one over-select replaced by one
constant.

Verified rather than asserted, with a throwaway repro against a `v2_hosts` still
declaring `is_online`:

```
bare .select()      -> select "organization_id", "machine_id", "name", "wake_command", "created_by_user_id", "created_at", "updated_at", "is_online" from "v2_hosts"
.select(columns)    -> select "organization_id", "machine_id", "name", "wake_command", "created_by_user_id", "created_at", "updated_at" from "v2_hosts"

bare mentions is_online     : true
projected mentions is_online: false

raw error.message           : "Failed query: insert into \"automation_events\" (\"payload\") values ($1)\nparams: {\"action\":\"opened\",\"secret_looking_field\":\"PAYLOAD-CANARY\"}"
databaseErrorMessage(error) : "no more connections allowed (max_client_conn)"
raw leaks the body          : true
sanitized leaks the body    : false
```

The bare select reproduces API-2K's reported statement exactly.

## Deliberately not in this change

- **No retry, no try/catch around the failing query, no `ignoreErrors`.** The
  connection exhaustion behind API-2D is Linear's fan-out and is #7289's to fix;
  quieting it here would hide a real signal on the busiest route in the product.
- **No ack-then-process for GitHub.** This is the open question, and it is a
  product decision rather than a cleanup — see below. #7289's `process-delivery`
  and `sweep-abandoned` are not on `main` yet, so building GitHub's copy now would
  add a second way to do the same thing.
- **No bounded fan-out, and no change to `check_run`'s loop.** Measured, rather
  than assumed: over an hour of `check_run` deliveries the loop runs 0 or 1 times,
  twice it ran 2. It is not the slow tail and not a connection cost.

  ```
   prs |   n
     0 |  9770
     1 | 15212
     2 |    56
  ```
- **The Notion route has the same defect** — its success update sits inside the
  try whose catch writes again (`notion/webhook/route.ts:207`). It has no Sentry
  issue and no traffic evidence, and it fans out per connection, so restructuring
  it is a different and larger change than this one. Left alone rather than
  half-done.
- **No Sentry issue state changed.**

## The open question, for a decision

**28,460 GitHub deliveries in the last 14 days took longer than GitHub's 10-second
timeout** (p50 of that group 17.7s, p99 96.9s, max 120.9s), out of 14,043,400.
GitHub recorded every one as a failed delivery. The route keeps running to
`maxDuration = 60` and usually still writes its rows, so this is mostly lost
*acknowledgement* rather than lost work — but it is ~2,000 deliveries a day that
GitHub believes failed.

It is not query depth: the route issues 4–9 sequential queries with no fan-out,
and the `check_run` loop is 0–1 iterations. Overall p50 is 496ms and p95 968ms, so
this is a tail — cold starts and the QStash publish — not a hot path.

Two options, and I did not want to guess between them:

1. **Ack-then-process, as #7289 does for Linear.** Record, publish a pointer,
   return; process off the clock. Removes the tail entirely and gives GitHub
   deliveries a retry they currently do not have. Costs a consumer, a sweep and a
   QStash schedule — and should land *after* #7289 so it reuses that machinery
   instead of duplicating it.
2. **Leave it.** 0.2% of deliveries, work mostly still completes, and the
   product-visible effect is failed entries in GitHub's delivery UI.

I'd recommend (1), sequenced after #7289 merges. Happy to do it as the follow-up.

## Verification

`bunx biome check src` in `apps/api`:

```
Checked 157 files in 45ms. No fixes applied.
```

`bunx biome check src` in `packages/trpc`:

```
Checked 203 files in 61ms. No fixes applied.
```

`bunx tsc --noEmit` in `apps/api` — exit 0, no output.
`bunx tsc --noEmit` in `packages/trpc` — exit 0, no output.

`bun test src` in `apps/api` (whole app, not just the touched files):

```
 33 pass
 0 fail
 58 expect() calls
Ran 33 tests across 5 files. [65.00ms]
```

`bun test src` in `packages/trpc` (whole package):

```
 236 pass
 4 fail
 4 errors
 539 expect() calls
Ran 240 tests across 25 files. [70.00ms]
```

The 4 failures are pre-existing and unrelated — `src/lib/growth/sitemap.test.ts`,
`src/lib/growth/search-console.test.ts`, `src/lib/growth/github.test.ts` and
`src/router/plugins/oauth.test.ts`, all failing with `error: Invalid environment
variables` out of `@t3-oss/env-core`. Proved by reverting only this diff
(`git checkout --` the three modified files, `rm` the new one, `git status`
clean) and re-running:

```
 236 pass
 4 fail
 4 errors
 539 expect() calls
Ran 240 tests across 25 files. [75.00ms]
```

Identical. The diff was then restored.

All measurements above were run against a copy of production (`ingest.webhook_events`
at 147.9M rows, current through 2026-09-08 05:24 UTC), read-only. The two
behavioural claims the fix rests on — that a bare `.select()` projects dropped
columns, and that `DrizzleQueryError.message` carries bind parameters that
`databaseErrorMessage` removes — were run as a throwaway repro rather than
reasoned about, output above. `DrizzleQueryError`'s constructor was read in
`node_modules`, not assumed.

Not verified end to end against live GitHub traffic: the failure this changes
requires the database to be unavailable mid-request, which cannot be staged
locally against Neon. Worth watching API-2D and API-2H after it lands.

Refs API-2H, API-2D, API-2K

https://claude.ai/code/session_013RHydvZdrQRaMEWRGs1xfk


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Sentry issues on the GitHub webhook route and host dispatch: webhook bookkeeping now sits outside the failure path so a failed write reports itself instead of a doomed second write, and dispatch stops selecting columns it never reads.

- One bookkeeping write now handles both outcomes, outside the catch, so the original error survives and processed work can't be marked `failed`.
- A failure to record the outcome still answers 500, leaving the row `pending` for redelivery.
- Error messages go through a new `databaseErrorMessage` helper that strips Drizzle's bind parameters, one of which was the whole webhook body.
- Both `resolveCandidateHosts` branches project the same `hostCandidateColumns`, replacing a bare `.select()` that still selected the dropped `is_online` column.

API-2H is environmental: ingest stopped for every provider for 6.74 seconds, and no code change can record a delivery while the database is unreachable. The fix ensures the next such blip reports what actually broke.

Not in this change: retry or ack-then-process (open question, recommended as a follow-up after #7289 merges), and the Notion route has the same bookkeeping defect but no Sentry issue or traffic evidence, so it's left alone.

<sup>Written for commit 2c70d5e8d83c1a0cf84f725dc3e8b2300af1df17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook delivery processing so successful and failed outcomes are recorded consistently.
  * Failed webhook deliveries now return clearer error messages and update retry information for subsequent attempts.
  * Database errors are reported using the underlying cause when available, making troubleshooting more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->