### PR TITLE
fix(web): stop the mesh gradient's CSS-variable poll when the canvas unmounts

### DIFF
--- a/packages/ui/src/components/mesh-gradient.tsx
+++ b/packages/ui/src/components/mesh-gradient.tsx
@@ -12,7 +12,7 @@ interface MeshGradientProps {
 interface GradientInstance {
 	initGradient: (selector: string) => void;
 	disconnect?: () => void;
-	pause?: () => void;
+	waitForCssVars?: () => void;
 	el?: HTMLElement | null;
 	conf?: { playing?: boolean };
 	uniforms?: {
@@ -64,14 +64,17 @@ export function MeshGradient({
 		const gradient = new Gradient() as GradientInstance;
 
 		const teardown = () => {
-			if (gradient.pause) {
-				gradient.pause();
-			}
 			if (gradient.conf) {
 				gradient.conf.playing = false;
 			}
-			// stripe-gradient's delayed init reads both el.parentElement and el
-			// children after we unmount, so the decoy needs a parent AND a child.
+			// Nothing the library exposes stops what it has already scheduled:
+			// `pause` is only the assignment above and `disconnect` drops window
+			// listeners. Its CSS-variable poll reschedules itself for 200 frames,
+			// then rebuilds the material from the empty colour list a detached
+			// canvas reports, which throws (WEB-30); its isLoaded hook walks
+			// el.parentElement three seconds later. So end the poll, and leave
+			// the hook a decoy element with both a parent AND a child.
+			gradient.waitForCssVars = () => {};
 			const dummy = document.createElement("div");
 			dummy.appendChild(document.createElement("div"));
 			document.createElement("div").appendChild(dummy);


### PR DESCRIPTION
Triage of four Sentry issues. One is a real bug in our code and is fixed here.
Two never existed on `main`. One is a browser extension and needs a Sentry-side
filter, not a code change. Evidence for each below.

## Problem

**WEB-30** — `TypeError: can't access property "getDeclaration", this.value[0] is
undefined`. 4 events, 1 user, Firefox 154 / macOS, `environment:production`,
release `81ab39e`, `https://app.superset.sh/agents`. Every frame is inside
`stripe-gradient@1.0.1`, which `packages/ui/src/components/mesh-gradient.tsx`
bundles, so `thirdPartyErrorFilterIntegration` correctly keeps it: this is our
bundle. `mechanism: auto.browser.browserapierrors.requestAnimationFrame` and
`extra.arguments: [387394.46]` — the crash is in a `requestAnimationFrame`
callback 387 seconds into the session.

`/agents` renders `DownloadSuperset` → `ProductDemo`, which mounts **four**
`MeshGradient`s at once. Four gradients, four events.

## Root cause

Two defects meeting. Line numbers are
`node_modules/.bun/stripe-gradient@1.0.1/node_modules/stripe-gradient/dist/main.js`.

**1. The library's fallback path is broken by construction.** `connect()` captures
`getComputedStyle(this.el)` one frame after `initGradient`, then polls for
`--gradient-color-1` on a self-rescheduling frame, up to `maxCssVarRetries`
(200):

```js
// 511
if (this.computedCanvasStyle && -1 !== this.computedCanvasStyle.getPropertyValue("--gradient-color-1").indexOf("#")) this.init(), this.addIsLoadedClass();
else {
    // 513
    if (this.cssVarRetries += 1, this.cssVarRetries > this.maxCssVarRetries) return this.sectionColors = [
        16711680, 16711680, 16711935, 65280, 255
    ], void this.init();   // 519
    requestAnimationFrame(()=>this.waitForCssVars());   // 520
}
```

The exhaustion branch sets five default colours and then calls `init()` — which
starts with `initGradientColors()`, re-reading the very variables that just
failed 200 times and overwriting the defaults with `[].filter(Boolean)`, i.e.
nothing. `initMaterial()` then fills `u_waveLayers` from `sectionColors[1..]`, so
it stays empty, and `getDeclaration` does `uniform.value[0].getDeclaration(...)`
on an empty array. The defaults are dead code; reaching that branch is always a
crash.

**2. We guarantee that branch is reached.** `MeshGradient`'s teardown pointed
`gradient.el` at a **detached** decoy `<div>` and stopped nothing: `pause()` only
ends the render loop and `disconnect()` only removes window listeners. A detached
element reports no custom properties at all, so once we unmount, the poll cannot
succeed — it can only count to 200 and crash. Measured in Chrome, same element,
same inline custom property:

```
{"attached":"#7f1d1d","detached":""}
```

That also explains the 387 s timestamp: 200 frames is ~3.3 s of *rendered*
frames, and `requestAnimationFrame` does not run while a tab is hidden or the
main thread is busy, so the count accumulates across the session.

The window is narrow — the unmount has to land before the library's first read —
which matches 4 events from 1 user rather than a steady stream.

## Fix

One line in `teardown()`: shadow `waitForCssVars` with a no-op so the pending
frame ends the chain instead of continuing it. Nothing on the mounted path
changes — an attached canvas answers on the first check with `cssVarRetries: 0`,
so the poll being neutered at unmount can never affect a live gradient.

The duplicated `pause()` call goes with it. The library defines it as exactly the
statement on the following line:

```js
(this, "pause", ()=>{ this.conf.playing = false; })
```

and unlike `if (gradient.conf) { gradient.conf.playing = false; }` it throws when
`conf` is unset — which is the state teardown is in when it runs from the
`catch` around `initGradient`.

## Deliberately not in this change

**ADMIN-R (`useGrowthRange needs GrowthRangeProvider`) and ADMIN-T (hydration
mismatch) — no code change; they cannot happen on `main`.** Both events carry
`release: 42bd65b92c7c7e30187160af8c3fca49b0f7556a`, and the files in their stacks
did not exist at that commit:

```
$ git log -1 --format='%h %ad %s' --date=iso 42bd65b92c7c7e30187160af8c3fca49b0f7556a
42bd65b92 2026-09-05 ... fix(review-host): the App Store review host was 21 days stale ... (#7199)

$ git show 42bd65b92c7c7e30187160af8c3fca49b0f7556a:"apps/admin/src/app/(dashboard)/growth/components/TopReferrersTile/TopReferrersTile.tsx"
fatal: path '...' exists on disk, but not in '42bd65b92c7c7e30187160af8c3fca49b0f7556a'

$ git log --oneline --all -- "apps/admin/src/app/(dashboard)/growth"
a9c51b999 feat(admin): Growth page with every growth signal, movable tiles, and PostHog drilldowns (#7205)
```

`a9c51b999` landed `2026-09-05 14:50:07 -0700`. All four events fall in a
six-minute window from `17:42:38Z` to `17:48:05Z` (10:42–10:48 PDT), ~4 hours
earlier, from one user on `http://localhost:4143/growth` with `turbopack: True`
and a `runWithFiberInDEV` frame — a developer's `next dev` against an
uncommitted tree, mid-PR.

ADMIN-T even shows what was fixed before merge: `<GridLayout ... width={1280}>`
hydrating. 1280 is `react-grid-layout`'s `WidthProvider` fallback, and the
shipped `TileGrid` replaced it, with the reason in the code —

> Measured here rather than with the library's hook, whose fallback width
> (1280) is wider than the content column and drew the grid over the edge.

— and gates on `width > 0`, so on `main` the grid is not server-rendered at all
and cannot mismatch. Confirmed by loading the page (see Verification).

What a user still experiences: nothing on either. The two issues describe a tree
that was never merged.

**WEB-2Q — a crypto-wallet browser extension. Needs a Sentry filter, not code.**
Every one of the 10 events is a non-`Error` promise rejection whose only stack is
a content script:

```
extension id  acmacodkjbdgmoleebolmdjonilkdbch  = Rabby Wallet (Chrome Web Store)

"code": 4001, "message": "User rejected the request.",
"stack": "Error: User rejected the request.
    at a (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/content-script.js:423:123184)
    at Object.userRejectedRequest (chrome-extension://.../content-script.js:423:124412)
    at h._dispose (chrome-extension://.../content-script.js:423:297239)
    at h.dispose (chrome-extension://.../content-script.js:423:297934)
    at x (chrome-extension://.../content-script.js:423:299264)"

"code": 4900, "message": "Message channel disconnected",
"stack": "MessageDisconnectedError: Message channel disconnected
    at chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/content-script.js:464:298227"
```

4001 and 4900 are EIP-1193 provider error codes (user rejected the request /
provider disconnected). Zero frames from our bundles, and
`grep -rniE "window\.ethereum|web3|walletconnect|eth_requestAccounts|@wagmi|viem" apps/web/src`
returns nothing — we never ask for a wallet. Same extension id across 4 users in
Andorra, South Korea (×2 IPs) and Australia, always on an auth page
(`/oauth/consent`, `/cli/auth/code`, `/auth/desktop/success`), always in pairs.

Why our existing filters miss it, from `@sentry/core@10.67.0`: both key off stack
frames, and a plain-object rejection has none.

```js
// integrations/eventFilters.js:153 — denyUrls
function _getEventFilterUrl(event) { ... const frames = rootException?.stacktrace?.frames; ...
// :134
const url = _getEventFilterUrl(event);
return !url ? false : string.stringMatchesSomePattern(url, denyUrls);

// integrations/third-party-errors-filter.js:93
const frames = stacktrace.getFramesFromEvent(event);
if (!frames) { return void 0; }   // -> frameKeys undefined -> filter skipped
```

So `SENTRY_DENY_URLS`' `/^chrome-extension:\/\//` never sees a URL to match. It
needs a Sentry-side inbound filter, and it is your call which:

1. **Recommended — a project inbound filter on the error message**
   `Object captured as promise rejection with keys: code, message, stack`
   (Sentry → web → Settings → Inbound Filters → Custom Filters). Cost: it also
   drops any *own* non-`Error` rejection with that exact key set. We throw
   `Error`s, so the blast radius is small, but it is not zero.
2. **Delete & discard the issue.** Narrowest, but a new extension version
   re-groups and it comes back.

The built-in "Filter out errors known to be caused by browser extensions" toggle
will **not** catch these — it matches on stack frame URLs, which is exactly what
this event lacks.

What a user still experiences after filtering: nothing changes for them. The
wallet extension injects a provider into our auth pages, its request is rejected
or its channel closes, and it fails to handle its own rejection. Our auth flow is
unaffected.

**Not patching `stripe-gradient`.** `patches/` exists and a patch to `init()`
would fix the library's fallback for everyone, but the branch is only reachable
because we detach the element while its poll runs. Ending the poll is smaller and
local, and avoids carrying a patch for a dependency last published in 2022.

**Not rewriting the rest of the teardown.** The decoy element with a parent and a
child is still needed: `addIsLoadedClass` walks `this.el.parentElement` three
seconds after a successful init.

## Verification

Everything below was run in this workspace on the committed diff.

**biome** — `bun run lint`

```
$ ./scripts/lint.sh
Saved lockfile
Checked 7424 files in 3s. No fixes applied.
```

**typecheck** — `bunx turbo typecheck --filter=@superset/ui --filter=@superset/web --force`

```
@superset/web:typecheck: cache bypass, force executing cd200e11a1f1581c
@superset/web:typecheck: $ tsc --noEmit
@superset/ui:typecheck: $ tsc --noEmit --emitDeclarationOnly false

 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    13.939s
```

**Full test suite, `packages/ui`** (the package changed). It has no `test` script,
so `turbo test` skips it — run directly, all 12 files:

```
$ cd packages/ui && bun test
bun test v1.3.14 (0d9b296a)

 64 pass
 0 fail
 96 expect() calls
Ran 64 tests across 12 files. [371.00ms]
```

**Full test suite, `apps/web`** (the consumer):

```
$ cd apps/web && bun run test
$ bun test src
bun test v1.3.14 (0d9b296a)

 34 pass
 0 fail
 34 expect() calls
Ran 34 tests across 1 file. [12.00ms]
```

No failures, so nothing to bisect against a reverted diff. No user-facing strings
changed, so no `check:i18n` run.

### WEB-30 reproduced and fixed, in the real component

Temporary probe route in `apps/web` rendering `<MeshGradient>` and unmounting it
before the library's first frame (deferring only the first
`requestAnimationFrame` by 150 ms, which is what a busy main thread or a hidden
tab does anyway). Route removed; `git status` is clean apart from the one file.

Before, in the real Next.js app:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'getDeclaration')
  --- requestAnimationFrame ---  (x25 shown)
  ... and 610 more frames
```

After, identical scenario, 12 s wait — only the unrelated dev API:

```
[error] Failed to load resource: net::ERR_CONNECTION_REFUSED
```

Mounted path still correct after the fix — `isLoaded` is the class the library
adds only on the success branch, so this proves `init()` ran normally:

```json
{"className":"w-full h-full isLoaded","isLoaded":true,"size":[700,600]}
```

and the gradient renders (screenshot taken in-app).

### The stack matches the Sentry event frame for frame

Isolated repro serving the real `dist/main.js` with the component's teardown
copied verbatim, then waiting out the 200 retries:

| Sentry WEB-30 | repro |
| --- | --- |
| `main.js:520:44 (waitForCssVars/<)` | `at (stripe-gradient.js:520:44)` |
| `main.js:519:26 (waitForCssVars)` | `at waitForCssVars (…:519:26)` |
| `main.js:505:41 (init)` | `at init (…:505:41)` |
| `main.js:487:30 (initMesh)` | `at initMesh (…:487:30)` |
| `main.js:484:25 (initMaterial)` | `at initMaterial (…:484:25)` |
| `main.js:37:288 (Material.value)` | `at value (…:37:288)` |
| `main.js:33:61 (getUniformVariableDeclarations)` | `at getUniformVariableDeclarations (…:33:61)` |
| `main.js:78:59 (Uniform.getDeclaration)` | `at getDeclaration (…:78:83)` |

Line 519 is the `maxCssVarRetries` branch, confirming the crash is on the
exhaustion path, not the success path. Happy path in the same harness, canvas
left attached:

```json
{"sectionColors":[[0.498,0.114,0.114],[0.6,0.106,0.106],[0.271,0.039,0.039],[0.102,0.102,0.180]],
 "waveLayers":3,"retries":0,"errors":[]}
```

`retries: 0` — there is no poll at all when the element is attached.

### ADMIN-R / ADMIN-T checked against a running app

`apps/admin` on `next dev`, `/growth` rendered through a temporary
unauthenticated probe route (removed afterwards; the real route is behind a
company session). Console carried only `ERR_CONNECTION_REFUSED` from the dev
API — no hydration error, no provider error — and every tile mounted and ran its
query:

```json
{"gridLayouts":6,"gridItems":20,"titlesRendered":20,
 "titles":["Visitors by channel", …, "Top referring sites, last 84 days", …]}
```

"Top referring sites, last 84 days" is the exact string ADMIN-T reported as the
*server* half of its mismatch, and it now renders on the client too. The SSR HTML
contains no tile titles at all, confirming the grid is client-only and cannot
mismatch. Also exercised the stacked path at 700 px wide: 20 tiles, full-width,
no errors.

Refs WEB-30, ADMIN-R, ADMIN-T, WEB-2Q

https://claude.ai/code/session_01PjYKUpsHRdKN8W6FZGLCPp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WEB-30: unmounting a `MeshGradient` no longer crashes. The `stripe-gradient` CSS-variable poll kept running after unmount, exhausted its 200 retries against the detached element, and hit a broken fallback branch that threw `getDeclaration`. Teardown now ends the poll by no-op'ing `waitForCssVars` and drops the duplicate `pause()` call that threw when `conf` was unset. The mounted path is unchanged — an attached canvas answers on the first check with zero retries, so no live gradient is affected.

<sup>Written for commit adf512b5993b476b6b3f5dd452f72e2848ef7474. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mesh gradient cleanup when components are removed, preventing lingering visual or background activity.
  - Updated gradient lifecycle handling for more reliable teardown and smoother behavior during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->