### PR TITLE
fix(desktop): answer a terminal attach that races the session being reaped

### DIFF
--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -467,6 +467,14 @@ export class TerminalHostClient extends EventEmitter {
 			if (!this.streamSocket) {
 				const streamConnected = await this.tryConnectStream();
 				if (!streamConnected) {
+					// Both legs dial the same socket seconds apart, so a daemon that
+					// went away in between fails the stream leg alone. The control leg
+					// above already knows how to spawn one and start over; give it the
+					// attempt this loop is here for instead of failing outright.
+					if (attempt === 0) {
+						this.resetConnectionState({ emitDisconnected: false });
+						continue;
+					}
 					throw new Error("Failed to connect stream socket");
 				}
 			}

--- a/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
+++ b/apps/desktop/src/main/lib/terminal-host/headless-emulator.ts
@@ -73,6 +73,9 @@ export class HeadlessEmulator {
 	// Buffer for partial escape sequences that span chunk boundaries
 	private escapeSequenceBuffer = "";
 
+	// Callers waiting on flush(), so dispose() can release them
+	private pendingFlushes = new Set<() => void>();
+
 	// Maximum buffer size to prevent unbounded growth (safety cap)
 	private static readonly MAX_ESCAPE_BUFFER_SIZE = 1024;
 
@@ -220,7 +223,11 @@ export class HeadlessEmulator {
 		if (this.disposed) return;
 		// Write an empty string with callback to ensure all pending writes are processed
 		return new Promise<void>((resolve) => {
-			this.terminal.write("", () => resolve());
+			this.pendingFlushes.add(resolve);
+			this.terminal.write("", () => {
+				this.pendingFlushes.delete(resolve);
+				resolve();
+			});
 		});
 	}
 
@@ -299,15 +306,6 @@ export class HeadlessEmulator {
 	}
 
 	/**
-	 * Generate a complete snapshot after flushing pending writes.
-	 * This is the preferred method for getting consistent snapshots.
-	 */
-	async getSnapshotAsync(): Promise<TerminalSnapshot> {
-		await this.flush();
-		return this.getSnapshot();
-	}
-
-	/**
 	 * Clear terminal buffer
 	 */
 	clear(): void {
@@ -331,6 +329,12 @@ export class HeadlessEmulator {
 		if (this.disposed) return;
 		this.disposed = true;
 		this.terminal.dispose();
+
+		// Disposing the terminal drops the write callbacks xterm still had
+		// queued, so a flush() already in flight would never be answered.
+		const waiting = this.pendingFlushes;
+		this.pendingFlushes = new Set();
+		for (const resolve of waiting) resolve();
 	}
 
 	// ===========================================================================

--- a/apps/desktop/src/main/terminal-host/session.ts
+++ b/apps/desktop/src/main/terminal-host/session.ts
@@ -892,6 +892,9 @@ export class Session {
 
 			await raceWithAbort(this.emulator.flush(), signal);
 			throwIfAborted(signal);
+			// The session can be reaped while the emulator catches up — the shell
+			// exits, or another attach to this session force-disposes it.
+			if (this.disposed) throw new Error("Session disposed");
 			return this.emulator.getSnapshot();
 		} catch (error) {
 			if (isTerminalAttachCanceledError(error)) {


### PR DESCRIPTION
## Problem

**DESKTOP-2C** — `Request timeout: createOrAttach`, 551 events / 90d, every release
back to 1.1.x, flat. #7299 left it reporting because "we could never learn whether
the daemon answers eventually, which is the whole question."

**The answer is no. There is nothing to arrive.** The daemon abandons the request:
it never reaches `sendSuccess` or `sendError`, so no reply is ever written.

What the events establish:

- Of every request type the client sends over 90d, only `createOrAttach` times out
  at volume: `createOrAttach` 551, `kill` 18, `hello` 3, `listSessions` 2. That is
  not exposure — `hello` runs on every connect and `listSessions` on every launch.
  `createOrAttach` is the **only daemon handler that is `async`**. `hello`, `write`,
  `resize`, `detach`, `signal`, `kill`, `listSessions`, `cancelCreateOrAttach`,
  `clearScrollback` and `killAll` all reply in the same tick — they can be *late*,
  never *lost*. The 23 timeouts spread across those are the daemon's event loop
  running late. The 551 are a different failure.
- The machine was not asleep, which #7299 could not rule out. Latest event
  (`2f94004b…`, AU): the request goes out at 05:27:27.06 right after a sidebar click
  navigates workspaces, the timeout logs at 05:27:57.06. Across that whole window the
  main process reaps an `lsof` child every ~2.5s (27:29, :31, :34, :36, :39, :41, :44,
  :46, :49, :51, :54, :56) and the renderer completes a tRPC poll every 5s. Both
  processes were awake and the loop was turning for all 30 seconds.
- Timeouts arrive in same-second bursts — `0bd9294c…`/`57681b7d…`/`64dbcdfb…` all at
  07:41:56, sent 07:41:26 — i.e. every pane of one workspace at once.

**DESKTOP-CW / DESKTOP-A6** — `Failed to connect stream socket`, same line, split by
caller (`kill` vs `createOrAttach`). The control socket connected and `hello`
succeeded, so a daemon *was* there; the stream connect to the same path failed
moments later.

## Root cause

`TerminalHost.createOrAttach` awaits three things. Two are bounded:
`spawnLimiter.acquire()` (permit released in a `finally`, held ≤ `SPAWN_READY_TIMEOUT_MS`)
and `flushToSnapshotBoundary(ATTACH_FLUSH_TIMEOUT_MS)` (raced against a 500 ms timer).
The third, `emulator.flush()` in `Session.attach()`, has no bound — and on the pinned
`@xterm/headless@6.1.0-beta.302`, disposing the terminal drops the write callbacks it
still had queued:

```
$ node orphan-pinned.mjs
@xterm/headless 6.1.0-beta.302

idle emulator, no dispose         -> flush() settled within 3s: true
busy emulator, no dispose         -> flush() settled within 3s: true
idle emulator, disposed mid-flush -> flush() settled within 3s: false
busy emulator, disposed mid-flush -> flush() settled within 3s: false
```

`flush()` guards `if (this.disposed) return` on *entry*, so this only bites when
disposal lands while the flush is already waiting — i.e. attaching to a pane that is
actively producing output, which is exactly when a snapshot is worth flushing for.
`Session.dispose()` → `emulator.dispose()` is reached from several ordinary places:
the shell exits and the session is reaped, `kill`, `detach` on a dead session, and
`createOrAttach` itself force-disposing a session that is terminating or no longer
alive — which a *second* attach to the same pane does to the *first* one still in
flight. Same-second bursts follow: several panes, one reap.

The session already resolves every waiter it owns when it tears down —
`resetProcessState()` calls `resolveAllSnapshotBoundaryWaiters()` and drains
`emulatorFlushWaiters`. The one waiter that lives inside the emulator was never given
the same treatment. That is the whole defect: teardown releases every waiter but one.

Probe over the real `Session`, disposing 10 ms into an attach, varying how long the
pane is allowed to settle first (`attach settled` = the daemon would reply at all):

```
  settleBeforeAttach=   0ms -> attach settled: false
  settleBeforeAttach= 100ms -> attach settled: false
  settleBeforeAttach= 300ms -> attach settled: true
  settleBeforeAttach= 520ms -> attach settled: true
  settleBeforeAttach= 900ms -> attach settled: true
```

**Two named candidates are refuted, not assumed.** The unbounded `emulator.flush()`
was named in #7299 as a suspect on volume grounds — that is wrong, volume is not the
problem. Against the pinned build, a *healthy* flush is fast at any backlog xterm will
hold (it throws at 50 MB), and the synchronous steps either side are cheap:

```
backlog  1MB -> flush() 0.02s        serialize(5000 rows) -> 37ms (0.91MB)
backlog  8MB -> flush() 0.12s        resize(reflow 5040 rows) -> 17ms
backlog 32MB -> flush() 0.41s
backlog 49MB -> flush() 0.56s
```

And `child_process.spawn` of a large binary does not block the daemon's loop
(`max event-loop lag during the run = 0.8ms` over five spawns), so a slow PTY spawn
cannot stall it either. Disposal is the only way this wait becomes unbounded.

For **CW / A6**: `connectAndAuthenticate` dials the same socket twice, seconds apart.
The control leg handles "no daemon there" by spawning one and retrying; the stream leg
threw. Both errors date from the original implementation (#619) — the asymmetry is an
accident, not a decision. A daemon that goes away between the two connects is therefore
fatal on one leg and recoverable on the other.

## Fix

- `HeadlessEmulator.flush()` records its callers; `dispose()` resolves them. The
  emulator's contract becomes total: a flush finishes when the writes are processed,
  or at once when there is nothing left to flush.
- `Session.attach()` re-checks `this.disposed` after the flush and throws the same
  `Session disposed` error it already throws when entered on a disposed session,
  rather than serializing a disposed terminal.
- Deleted `getSnapshotAsync()` — dead, and the only other caller of `flush()`.
- `connectAndAuthenticate` lets a failed stream connect take the second pass the retry
  loop already exists to give (the same `resetConnectionState` + `continue` the
  protocol-mismatch and missing-token cases use), instead of a bespoke throw.

**What the user sees change:** a pane whose session is reaped mid-attach now fails
immediately with `CREATE_ATTACH_FAILED: Session disposed` instead of sitting dead for
30 s and then failing anyway. Same outcome, 30 s sooner, and the daemon stops leaking
an abandoned attach per occurrence.

## Deliberately not in this change

- **DESKTOP-C3** (`Host service failed to start within 30000ms`, 79 events). Different
  subsystem — `HostServiceCoordinator.spawn`, the v2 host-service, not the terminal
  daemon. The child spawns, does not exit, and never answers `/health` in 30 s. The
  code already separates cancelled / exited / timed-out and captures `outputTail`;
  the latest event (`b778dbd5…`) is a 16 GB M3 with 1.17 GB free, booted 72 s before
  the app and 104 s before the failure, on a manual `hostServiceCoordinator.restart`.
  I could not find a defect to fix, and I am not going to widen a timeout to make it
  go away. It wants its own look at what the child is doing for those 30 s.
- **Retrying** a mid-attach dispose by creating a fresh session. `createOrAttach`
  already replaces a dead session found at entry; extending that to one reaped
  mid-flight changes behaviour a user feels and is your call, not mine. Failing with
  the error the function already has is the conservative half.
- **No new tests.** The two repros above ran as throwaway files and were deleted;
  say the word and I'll land the `HeadlessEmulator` one, which is four lines and
  deterministic.
- The stream socket has a one-microtask window with no `data` listener between
  `sendRequestOnStream` removing its own and `setupStreamSocketHandlers` attaching the
  permanent one; Node does not re-pause on `removeListener`, so terminal output landing
  there is dropped. Real, unrelated to these four, untouched.

## Verification

`bunx biome check` on the three changed files:

```
Checked 3 files in 27ms. No fixes applied.
```

`bun run lint` (repo-wide):

```
$ ./scripts/lint.sh
Checked 7424 files in 2s. No fixes applied.
```

`bun run typecheck` in `apps/desktop`:

```
$ bun run generate:icons && bun run generate:routes
$ bun run scripts/generate-file-icons.ts
Generated file icons: 1067 SVGs copied, 2046 file names, 1152 extensions, 4528 folder names
$ tsr generate
$ tsc --noEmit
```

Full `apps/desktop` suite (`bun test`, all 397 files):

```
 3664 pass
 1 fail
 1 error
 2 snapshots, 59363 expect() calls
Ran 3665 tests across 397 files. [25.18s]
```

The one failure is `useSidebarDnd.test.ts`, a renderer test that dies loading
`@dnd-kit/core`:

```
# Unhandled error between tests
13 | const DndMonitorContext = /*#__PURE__*/React.createContext(null);
TypeError: React.createContext is not a function.
   at node_modules/.bun/@dnd-kit+core@6.3.1+67f6792bdf102c28/node_modules/@dnd-kit/core/dist/core.cjs.development.js:13:46
```

Pre-existing. With this diff reverted (`git apply -R`) and nothing else changed:

```
 3664 pass
 1 fail
 1 error
 2 snapshots, 59363 expect() calls
Ran 3665 tests across 397 files. [24.64s]
```

Same file, same counts. Nothing this change touches is in the renderer.

Repro, before the fix:

```
(fail) REPRO DESKTOP-2C > HeadlessEmulator.flush() settles when dispose() lands mid-flush [3016.37ms]
(fail) REPRO DESKTOP-2C > Session.attach() answers when the session is reaped mid-attach [3302.52ms]
 0 pass
 2 fail
```

and after:

```
 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [423.00ms]
```

`check:i18n` not run — no user-facing strings; `Session disposed` is daemon-internal
and already exists verbatim at the top of the same function.

Refs DESKTOP-2C
Refs DESKTOP-CW
Refs DESKTOP-A6

https://claude.ai/code/session_013rkVmyiu9fLZWAicYw8WnB


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `createOrAttach` request timeouts by resolving the emulator flush when a session is reaped mid-attach, so the request fails immediately with `Session disposed` instead of hanging for 30 seconds and then timing out anyway.

**Bug Fixes**
- `HeadlessEmulator.flush()` tracks its callers and `dispose()` resolves them, so teardown releases every waiter.
- `Session.attach()` re-checks disposal after the flush and throws the same "Session disposed" error it already uses on entry.
- The dead `getSnapshotAsync()` method is removed.
- `connectAndAuthenticate` retries a failed stream connect on the first attempt instead of throwing, matching the control connect's existing recovery path for a missing daemon.

<sup>Written for commit 9ea49f8e3a343eba632837c80f3cae1f69d51bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal connection recovery when the stream connection fails during setup.
  - Ensured pending terminal updates complete when a terminal session is disposed.
  - Prevented disposed sessions from returning outdated terminal snapshots.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->