### PR TITLE
fix(desktop): stop re-entering Squirrel.Mac staging while an update is already staged

### DIFF
--- a/apps/desktop/src/main/lib/auto-updater.ts
+++ b/apps/desktop/src/main/lib/auto-updater.ts
@@ -146,6 +146,13 @@ export function getUpdateStatus(): AutoUpdateStatusEvent {
 	};
 }
 
+// True from the moment electron-updater hands the archive to Squirrel.Mac,
+// which unpacks ~2GB into ~/Library/Caches/<appId>.ShipIt and then verifies it.
+// That work outlives the download promise, so it is also the window in which a
+// second check must not start: Squirrel gates its own check on a ReactiveObjC
+// command that is disabled until the app relaunches, so a repeat check cannot
+// stage anything newer — it only re-downloads the archive and points a second
+// staging run at the same cache directory.
 export function isUpdateReadyToInstall(): boolean {
 	return isInstalling || currentStatus === AUTO_UPDATE_STATUS.READY;
 }
@@ -194,6 +201,12 @@ export function checkForUpdates(): void {
 	if (env.NODE_ENV === "development" || !IS_AUTO_UPDATE_PLATFORM) {
 		return;
 	}
+	if (isUpdateReadyToInstall()) {
+		log.info(
+			`[auto-updater] Check skipped: ${currentVersion} is already staged and installs on restart`,
+		);
+		return;
+	}
 	isDismissed = false;
 	emitStatus(AUTO_UPDATE_STATUS.CHECKING);
 	autoUpdater
@@ -232,6 +245,25 @@ export function checkForUpdatesInteractive(): void {
 					message: "Auto-updates are only available on macOS and Linux.",
 				}),
 			),
+		});
+		return;
+	}
+
+	if (isUpdateReadyToInstall()) {
+		dialog.showMessageBox({
+			type: "info",
+			title: i18n._(msg({ message: "Updates" })),
+			message: i18n._(
+				msg({
+					message: "An update is ready to install.",
+				}),
+			),
+			detail: i18n._({
+				...msg({
+					message: "Version {version} installs the next time you restart.",
+				}),
+				values: { version: currentVersion },
+			}),
 		});
 		return;
 	}
@@ -404,13 +436,16 @@ export function setupAutoUpdater(): void {
 		);
 		void clearCachedUpdate(`error: ${error?.message ?? "unknown"}`);
 		emitStatus(AUTO_UPDATE_STATUS.ERROR, undefined, error.message);
-		if (
-			!isEnvironmentUpdateError(
-				error?.message ?? String(error),
-				freeStagingBytes(),
-			)
-		) {
-			Sentry.captureException(redactUpdateError(error));
+		const freeBytes = freeStagingBytes();
+		if (!isEnvironmentUpdateError(error?.message ?? String(error), freeBytes)) {
+			// Squirrel unpacks the archive beside itself under the same volume, so
+			// how much room it had is the one fact that separates a release defect
+			// from a machine that could never have held the staged copy. The
+			// classifier reads it and then throws it away; report it too, or every
+			// staging failure arrives undecidable.
+			Sentry.captureException(redactUpdateError(error), {
+				contexts: { update_staging: { free_bytes: freeBytes } },
+			});
 		}
 	});
 

--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -40,7 +40,10 @@ const AUTHORIZATION_DENIED_EN =
 	"The operation couldn’t be completed. (OSStatus error -60005.)";
 const AUTHORIZATION_DENIED_DE =
 	"Der Vorgang konnte nicht abgeschlossen werden. (OSStatus-Fehler -60005.)";
-const LAUNCHD_JOB_DISABLED = "The command is disabled and cannot be executed";
+// ReactiveObjC's RACCommand refusing an execute while Squirrel.Mac is already
+// staging an update. Ours, not the machine's.
+const SQUIRREL_CHECK_REENTERED =
+	"The command is disabled and cannot be executed";
 const CACHE_PATH_IS_A_FILE =
 	"ENOTDIR: not a directory, mkdir '/Users/<user>/Library/Caches/@supersetdesktop-updater/pending'";
 const DOWNLOAD_GATEWAY_TIMEOUT =
@@ -173,10 +176,10 @@ describe("isEnvironmentUpdateError", () => {
 		}
 	});
 
-	test("classifies launchd refusing a disabled ShipIt job", () => {
-		expect(isEnvironmentUpdateError(LAUNCHD_JOB_DISABLED, ROOMY_VOLUME)).toBe(
-			true,
-		);
+	test("keeps reporting a re-entered Squirrel staging command", () => {
+		expect(
+			isEnvironmentUpdateError(SQUIRREL_CHECK_REENTERED, ROOMY_VOLUME),
+		).toBe(false);
 	});
 
 	test("classifies a file sitting where the updater cache must be", () => {

--- a/apps/desktop/src/main/lib/update-error-classification.test.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.test.ts
@@ -216,25 +216,15 @@ describe("isEnvironmentUpdateError", () => {
 		).toBe(false);
 	});
 
-	test("does not take the ShipIt name alone as proof of a staging failure", () => {
-		expect(
-			isEnvironmentUpdateError(
-				"ditto: /Applications/ShipIt Tools/Superset.app/Contents/Resources/app.asar: No such file or directory",
-				ROOMY_VOLUME,
-			),
-		).toBe(false);
-	});
-
-	test("classifies a staged copy that lost a file under ShipIt's directory", () => {
+	test("keeps reporting a staged copy that lost a file under ShipIt's directory", () => {
+		// Squirrel sweeps sibling `update.*` directories out of its cache
+		// (-removeUpdateDirectoriesInStorageURL:excludingURL:), so a vanished
+		// staging tree is not proof the machine did it. A full volume still is.
 		expect(
 			isEnvironmentUpdateError(DITTO_STAGING_FILE_MISSING, ROOMY_VOLUME),
-		).toBe(true);
-		// ditto complaining about the installed bundle is not a staging failure.
-		expect(
-			isEnvironmentUpdateError(
-				"ditto: /Applications/Superset.app/Contents/Resources/app.asar: No such file or directory",
-				ROOMY_VOLUME,
-			),
 		).toBe(false);
+		expect(
+			isEnvironmentUpdateError(DITTO_STAGING_FILE_MISSING, FULL_VOLUME),
+		).toBe(true);
 	});
 });

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -44,10 +44,6 @@ const AUTHORIZATION_OSSTATUS = /OSStatus\D*-6000[56](?!\d)/;
 const DOWNLOAD_SERVER_ERROR =
 	/^Cannot download ".*\.(?:zip|dmg|exe|AppImage|deb|rpm)", status 5\d\d(?!\d)/;
 
-// Squirrel.Mac stages every update under this cache directory, one
-// `update.<id>` directory per attempt.
-const SHIPIT_STAGING_PATH = /\/com\.superset\.desktop\.shipit\/update\.[^/]+\//;
-
 // Update failures owned by the user's machine, not by us. A full volume is the
 // common one, and neither staging tool gives us a code to match: `ditto` prints
 // an errno-free line and Squirrel forwards NSError text localised to the user's
@@ -76,17 +72,6 @@ export function isEnvironmentUpdateError(
 		lowerMessage.includes("the request timed out") ||
 		AUTHORIZATION_OSSTATUS.test(message) ||
 		DOWNLOAD_SERVER_ERROR.test(message)
-	) {
-		return true;
-	}
-	// ditto naming a file it could not find under ShipIt's staging directory is
-	// a staged copy that lost its parent mid-unpack. It prints no errno, and
-	// nothing reuses it: Squirrel stages every attempt into a fresh directory
-	// and the download it was unpacked from is cleared on error.
-	if (
-		lowerMessage.startsWith("ditto:") &&
-		SHIPIT_STAGING_PATH.test(lowerMessage) &&
-		lowerMessage.includes("no such file or directory")
 	) {
 		return true;
 	}

--- a/apps/desktop/src/main/lib/update-error-classification.ts
+++ b/apps/desktop/src/main/lib/update-error-classification.ts
@@ -37,10 +37,6 @@ const UPDATER_DEFECT_PATTERNS = [
 // other OSStatus keeps reporting: a signing failure wears the same sentence.
 const AUTHORIZATION_OSSTATUS = /OSStatus\D*-6000[56](?!\d)/;
 
-// launchd refusing to start the ShipIt job because the user or their MDM
-// disabled it. Nothing but this sentence reaches us for it.
-const LAUNCHD_JOB_DISABLED = "the command is disabled and cannot be executed";
-
 // A server error from the release-artifact download is the CDN, not the
 // artifact. A 4xx stays reported: an asset that is not there is ours to
 // publish. Only the packaged app counts; a 5xx while fetching the feed
@@ -78,7 +74,6 @@ export function isEnvironmentUpdateError(
 	if (
 		lowerMessage.includes("read-only volume") ||
 		lowerMessage.includes("the request timed out") ||
-		lowerMessage.includes(LAUNCHD_JOB_DISABLED) ||
 		AUTHORIZATION_OSSTATUS.test(message) ||
 		DOWNLOAD_SERVER_ERROR.test(message)
 	) {

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Izolovaný git worktree, kde agent běží, aniž by sáhl na váš hlav
 msgid "An unknown error occurred"
 msgstr "Došlo k neznámé chybě"
 
+msgid "An update is ready to install."
+msgstr "Aktualizace je připravena k instalaci."
+
 msgid "Animate the active terminal cursor."
 msgstr "Animovat kurzor v aktivním terminálu."
 
@@ -15156,6 +15159,9 @@ msgstr "Verze {0}"
 
 msgid "Version {version}"
 msgstr "Verze {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Verze {version} se nainstaluje při příštím restartu."
 
 msgid "Version {version} is the latest version."
 msgstr "Verze {version} je nejnovější."

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Ein isolierter Git-Worktree, in dem ein Agent arbeitet, ohne dein Haupt-
 msgid "An unknown error occurred"
 msgstr "Ein unbekannter Fehler ist aufgetreten"
 
+msgid "An update is ready to install."
+msgstr "Ein Update ist bereit zur Installation."
+
 msgid "Animate the active terminal cursor."
 msgstr "Den aktiven Terminal-Cursor animieren."
 
@@ -15156,6 +15159,9 @@ msgstr "Version {0}"
 
 msgid "Version {version}"
 msgstr "Version {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Version {version} wird beim nächsten Neustart installiert."
 
 msgid "Version {version} is the latest version."
 msgstr "Version {version} ist die neueste Version."

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -1811,6 +1811,9 @@ msgstr "An isolated git worktree where an agent runs without touching your main 
 msgid "An unknown error occurred"
 msgstr "An unknown error occurred"
 
+msgid "An update is ready to install."
+msgstr "An update is ready to install."
+
 msgid "Animate the active terminal cursor."
 msgstr "Animate the active terminal cursor."
 
@@ -15156,6 +15159,9 @@ msgstr "Version {0}"
 
 msgid "Version {version}"
 msgstr "Version {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Version {version} installs the next time you restart."
 
 msgid "Version {version} is the latest version."
 msgstr "Version {version} is the latest version."

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Un worktree de git aislado donde un agente trabaja sin tocar tu checkout
 msgid "An unknown error occurred"
 msgstr "Se produjo un error desconocido"
 
+msgid "An update is ready to install."
+msgstr "Hay una actualización lista para instalar."
+
 msgid "Animate the active terminal cursor."
 msgstr "Anima el cursor del terminal activo."
 
@@ -15156,6 +15159,9 @@ msgstr "Versión {0}"
 
 msgid "Version {version}"
 msgstr "Versión {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "La versión {version} se instalará la próxima vez que reinicies."
 
 msgid "Version {version} is the latest version."
 msgstr "La versión {version} es la más reciente."

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Un worktree git isolé où un agent s'exécute sans toucher à votre cop
 msgid "An unknown error occurred"
 msgstr "Une erreur inconnue est survenue"
 
+msgid "An update is ready to install."
+msgstr "Une mise à jour est prête à être installée."
+
 msgid "Animate the active terminal cursor."
 msgstr "Animer le curseur du terminal actif."
 
@@ -15156,6 +15159,9 @@ msgstr "Version {0}"
 
 msgid "Version {version}"
 msgstr "Version {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "La version {version} s'installera au prochain redémarrage."
 
 msgid "Version {version} is the latest version."
 msgstr "La version {version} est la dernière version."

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Worktree git terisolasi tempat agen berjalan tanpa menyentuh checkout ut
 msgid "An unknown error occurred"
 msgstr "Terjadi kesalahan yang tidak diketahui"
 
+msgid "An update is ready to install."
+msgstr "Pembaruan siap dipasang."
+
 msgid "Animate the active terminal cursor."
 msgstr "Animasikan kursor terminal yang aktif."
 
@@ -15156,6 +15159,9 @@ msgstr "Versi {0}"
 
 msgid "Version {version}"
 msgstr "Versi {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Versi {version} akan dipasang saat Anda memulai ulang berikutnya."
 
 msgid "Version {version} is the latest version."
 msgstr "Versi {version} adalah versi terbaru."

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Un worktree git isolato in cui un agente lavora senza toccare il tuo che
 msgid "An unknown error occurred"
 msgstr "Si è verificato un errore sconosciuto"
 
+msgid "An update is ready to install."
+msgstr "Un aggiornamento è pronto per l'installazione."
+
 msgid "Animate the active terminal cursor."
 msgstr "Anima il cursore del terminale attivo."
 
@@ -15156,6 +15159,9 @@ msgstr "Versione {0}"
 
 msgid "Version {version}"
 msgstr "Versione {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "La versione {version} verrà installata al prossimo riavvio."
 
 msgid "Version {version} is the latest version."
 msgstr "La versione {version} è l'ultima disponibile."

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -1811,6 +1811,9 @@ msgstr "メインのチェックアウトに触れずにエージェントを動
 msgid "An unknown error occurred"
 msgstr "不明なエラーが発生しました"
 
+msgid "An update is ready to install."
+msgstr "アップデートをインストールする準備ができました。"
+
 msgid "Animate the active terminal cursor."
 msgstr "アクティブなターミナルカーソルをアニメーションします。"
 
@@ -15156,6 +15159,9 @@ msgstr "バージョン{0}"
 
 msgid "Version {version}"
 msgstr "バージョン{version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "バージョン{version}は次回の再起動時にインストールされます。"
 
 msgid "Version {version} is the latest version."
 msgstr "バージョン{version}が最新です。"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -15161,7 +15161,7 @@ msgid "Version {version}"
 msgstr "버전 {version}"
 
 msgid "Version {version} installs the next time you restart."
-msgstr "버전 {version}은 다음에 재시작할 때 설치됩니다."
+msgstr "다음에 재시작하면 {version} 버전이 설치됩니다."
 
 msgid "Version {version} is the latest version."
 msgstr "버전 {version}이 최신 버전입니다."

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -1811,6 +1811,9 @@ msgstr "에이전트가 메인 체크아웃을 건드리지 않고 실행되는 
 msgid "An unknown error occurred"
 msgstr "알 수 없는 오류가 발생했습니다"
 
+msgid "An update is ready to install."
+msgstr "설치할 업데이트가 준비되었습니다."
+
 msgid "Animate the active terminal cursor."
 msgstr "활성 터미널 커서를 깜박이게 합니다."
 
@@ -15156,6 +15159,9 @@ msgstr "버전 {0}"
 
 msgid "Version {version}"
 msgstr "버전 {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "버전 {version}은 다음에 재시작할 때 설치됩니다."
 
 msgid "Version {version} is the latest version."
 msgstr "버전 {version}이 최신 버전입니다."

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Een geïsoleerde git-worktree waarin een agent draait zonder je hoofdche
 msgid "An unknown error occurred"
 msgstr "Er is een onbekende fout opgetreden"
 
+msgid "An update is ready to install."
+msgstr "Er staat een update klaar om te installeren."
+
 msgid "Animate the active terminal cursor."
 msgstr "Laat de actieve terminalcursor knipperen."
 
@@ -15156,6 +15159,9 @@ msgstr "Versie {0}"
 
 msgid "Version {version}"
 msgstr "Versie {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Versie {version} wordt geïnstalleerd zodra je opnieuw opstart."
 
 msgid "Version {version} is the latest version."
 msgstr "Versie {version} is de nieuwste versie."

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Izolowany worktree gita, w którym agent pracuje bez dotykania Twojego g
 msgid "An unknown error occurred"
 msgstr "Wystąpił nieznany błąd"
 
+msgid "An update is ready to install."
+msgstr "Aktualizacja jest gotowa do zainstalowania."
+
 msgid "Animate the active terminal cursor."
 msgstr "Animuj kursor w aktywnym terminalu."
 
@@ -15156,6 +15159,9 @@ msgstr "Wersja {0}"
 
 msgid "Version {version}"
 msgstr "Wersja {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Wersja {version} zainstaluje się przy następnym ponownym uruchomieniu."
 
 msgid "Version {version} is the latest version."
 msgstr "Wersja {version} jest najnowsza."

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Uma worktree isolada do git onde um agente roda sem tocar no seu checkou
 msgid "An unknown error occurred"
 msgstr "Ocorreu um erro desconhecido"
 
+msgid "An update is ready to install."
+msgstr "Há uma atualização pronta para instalar."
+
 msgid "Animate the active terminal cursor."
 msgstr "Anima o cursor do terminal ativo."
 
@@ -15156,6 +15159,9 @@ msgstr "Versão {0}"
 
 msgid "Version {version}"
 msgstr "Versão {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "A versão {version} será instalada na próxima vez que você reiniciar."
 
 msgid "Version {version} is the latest version."
 msgstr "A versão {version} é a mais recente."

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Изолированный git worktree, где агент работа�
 msgid "An unknown error occurred"
 msgstr "Произошла неизвестная ошибка"
 
+msgid "An update is ready to install."
+msgstr "Обновление готово к установке."
+
 msgid "Animate the active terminal cursor."
 msgstr "Анимировать курсор активного терминала."
 
@@ -15156,6 +15159,9 @@ msgstr "Версия {0}"
 
 msgid "Version {version}"
 msgstr "Версия {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Версия {version} установится при следующем перезапуске."
 
 msgid "Version {version} is the latest version."
 msgstr "Версия {version} — самая свежая."

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Ajanın, ana checkout'unuza dokunmadan çalıştığı yalıtılmış bi
 msgid "An unknown error occurred"
 msgstr "Bilinmeyen bir hata oluştu"
 
+msgid "An update is ready to install."
+msgstr "Yüklenmeye hazır bir güncelleme var."
+
 msgid "Animate the active terminal cursor."
 msgstr "Etkin terminal imlecini canlandır."
 
@@ -15156,6 +15159,9 @@ msgstr "Sürüm {0}"
 
 msgid "Version {version}"
 msgstr "Sürüm {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "{version} sürümü bir sonraki yeniden başlatmada yüklenecek."
 
 msgid "Version {version} is the latest version."
 msgstr "{version} sürümü en son sürümdür."

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -1811,6 +1811,9 @@ msgstr "Một git worktree riêng biệt nơi agent chạy mà không đụng t�
 msgid "An unknown error occurred"
 msgstr "Đã xảy ra lỗi không xác định"
 
+msgid "An update is ready to install."
+msgstr "Đã có bản cập nhật sẵn sàng để cài đặt."
+
 msgid "Animate the active terminal cursor."
 msgstr "Cho con trỏ terminal đang hoạt động nhấp nháy."
 
@@ -15156,6 +15159,9 @@ msgstr "Phiên bản {0}"
 
 msgid "Version {version}"
 msgstr "Phiên bản {version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "Phiên bản {version} sẽ được cài đặt trong lần khởi động lại tiếp theo."
 
 msgid "Version {version} is the latest version."
 msgstr "Phiên bản {version} là phiên bản mới nhất."

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -1811,6 +1811,9 @@ msgstr "一个隔离的git worktree，智能体在其中运行，不会动到你
 msgid "An unknown error occurred"
 msgstr "发生未知错误"
 
+msgid "An update is ready to install."
+msgstr "更新已准备好安装。"
+
 msgid "Animate the active terminal cursor."
 msgstr "让当前终端光标闪烁。"
 
@@ -15156,6 +15159,9 @@ msgstr "版本{0}"
 
 msgid "Version {version}"
 msgstr "版本{version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "版本{version}将在下次重启时安装。"
 
 msgid "Version {version} is the latest version."
 msgstr "版本{version}已是最新版本。"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -1811,6 +1811,9 @@ msgstr "一個隔離的git worktree，代理程式在其中執行，不會動到
 msgid "An unknown error occurred"
 msgstr "發生未知錯誤"
 
+msgid "An update is ready to install."
+msgstr "更新已準備好安裝。"
+
 msgid "Animate the active terminal cursor."
 msgstr "讓目前終端游標閃爍。"
 
@@ -15156,6 +15159,9 @@ msgstr "版本{0}"
 
 msgid "Version {version}"
 msgstr "版本{version}"
+
+msgid "Version {version} installs the next time you restart."
+msgstr "版本{version}將在下次重新啟動時安裝。"
 
 msgid "Version {version} is the latest version."
 msgstr "版本{version}已是最新版本。"


### PR DESCRIPTION
## Problem

Seven fingerprints, one family, ~38 events since 2026-08-30, macOS/arm64 only:
Squirrel.Mac refuses the app it staged in `~/Library/Caches/com.superset.desktop.ShipIt/update.<id>/Superset.app`.

| Issue | Reason string | OSStatus |
|---|---|---|
| DESKTOP-14Y (25) | code failed to satisfy specified code requirement(s) | -67050 |
| DESKTOP-15M (4) | code object is not signed at all | -67062 |
| DESKTOP-150 (2) | 代码对象根本未签名 (same, localised) | -67062 |
| DESKTOP-15K (2) | invalid resource directory (directory or signature have been modified) | — |
| DESKTOP-14S (2) | the code cannot be read by the verifier (file system permissions etc.) | — |
| DESKTOP-16E (1) | UNIX[Operation not permitted] | — |
| DESKTOP-169 (2) | `ditto: …/app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude: No such file or directory` | — |

The update never installs, so the user stays on an old version. DESKTOP-14Y is
one machine on a metronome — `06:21:24, 10:21:25, 14:21:38, 18:24:20, 22:24:13,
02:24:13 …` — exactly `UPDATE_CHECK_INTERVAL_MS` (4h), from 2026-09-04 to
2026-09-08 and still going. Because `clearCachedUpdate()` wipes the cache on
every error, each cycle re-pulls the whole 431 MB archive from GitHub.

## Root cause

**First, what it is not.** The strong lead in the brief — something written into
or removed from the bundle after signing, `asar.unpacked`, notarization, the
bundled agent-sdk binary — is disproven. I downloaded the exact artifact the
stable updater fetches and ran Squirrel's own pipeline over it:

```
### sha512 vs manifest (expect hXEnp3FoyrgmXlikKrQhXSCfQf6q0+fn9R5kVVGB3m4BThG3mc9U53w/p1nRxAfliZjPFDKcpICHzdzalDi1Uw==)
hXEnp3FoyrgmXlikKrQhXSCfQf6q0+fn9R5kVVGB3m4BThG3mc9U53w/p1nRxAfliZjPFDKcpICHzdzalDi1Uw==
### ditto -x -k (exactly what Squirrel.Mac runs)
ditto exit=0
Superset.app
### codesign --verify --deep --strict
out/Superset.app: valid on disk
out/Superset.app: satisfies its Designated Requirement
### does it satisfy the DR of the INSTALLED 1.24.2 stable app (Squirrel's actual test)?
DR: identifier "com.superset.desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2HVBK29S3C"
out/Superset.app: valid on disk
out/Superset.app: satisfies its Designated Requirement
out/Superset.app: explicit requirement satisfied
```

I also round-tripped a shipped bundle through the archiver electron-builder
actually uses for the mac zip (`7za a -bd -mx=7 -mtc=off -mm=Deflate -mcu`, from
`app-builder-lib/out/targets/archive.js`) and back out through `ditto -x -k`: all
14 framework symlinks survive and the extracted copy is `valid on disk` /
`satisfies its Designated Requirement`. **The artifact is sound. There is no
build or packaging fix to make.** `Contents/CodeResources` (the staple ticket,
written after signing) is excluded from the seal by design, and the installed
bundle's mtimes show nothing written after it.

**What the seven fingerprints actually are.** They are one call site.
`nm -u` / `strings` on the shipped `Squirrel.framework`:

```
_SecCodeCopySelf
_SecCodeCopyDesignatedRequirement
_SecStaticCodeCreateWithPath
_SecStaticCodeCheckValidityWithErrors
_SecCopyErrorMessageString
...
SQRLCodeSignature.m
Code signature at URL %@ did not pass validation
/usr/bin/ditto
DITTOABORT
```

So Squirrel takes the *running* app's designated requirement, runs
`SecStaticCodeCheckValidityWithErrors` over the staged copy, and prints
`SecCopyErrorMessageString(status)` — which is why one variant arrives in
Chinese. Seven fingerprints are seven OSStatus values describing one thing: the
staged copy was not a complete, readable, signed bundle at the moment it was
checked.

**What we do that puts two staging runs against that directory.**
`MacUpdater.updateDownloaded()` resolves its promise on the proxy response's
`finish` event — i.e. when the archive has finished *streaming to Squirrel*, not
when Squirrel has finished unpacking ~2 GB and verifying it. On this machine
that gap is over two minutes (`20:12:54 … requested by Squirrel.Mac` →
`20:14:50 Proxy server … is closed`). Inside that gap both of electron-updater's
guards (`checkForUpdatesPromise`, `downloadPromise`) are already null, so any of
the six entry points into `checkForUpdates()` — startup, the 4-hour timer, the
updates pill, the notice dialog, the update-required page, the menu/tray — runs
the whole cycle again, hits the download cache, and calls
`nativeUpdater.checkForUpdates()` a second time. (Squirrel refuses *that*
particular call — see below — so this is a second staging **request**, not a
proven second concurrent unpack.) The ShipIt log shows the shape of it:

```
2026-08-21 19:03:31.312 ShipIt[87825] Detected this as an install request
2026-08-21 21:31:28.820 ShipIt[9617]  Detected this as an install request
2026-08-21 22:40:54.800 ShipIt[9617]  Beginning installation
```

Squirrel answers the second request by refusing: its `checkForUpdatesCommand` is
built with `initWithEnabled:signalBlock:` and a `RACCommand` will not run while
disabled or already executing. The refusal message is
`"The command is disabled and cannot be executed"` — and that string lives in
**ReactiveObjC**, next to `RACCommandErrorDomain` and `RACUnderlyingCommandErrorKey`:

```
$ strings -a Superset.app/Contents/Frameworks/ReactiveObjC.framework/Versions/A/ReactiveObjC | grep -i "command is disabled"
The command is disabled and cannot be executed
```

`update-error-classification.ts` matched that exact sentence as
`LAUNCHD_JOB_DISABLED`, commented *"launchd refusing to start the ShipIt job
because the user or their MDM disabled it"*, and dropped it as environmental.
It is not launchd. It is us asking Squirrel to stage an update it is already
staging, silently reclassified as the user's machine.

## Fix

- Gate both check entry points on `isUpdateReadyToInstall()`, the pending-update
  state we already track. Once electron-updater hands the archive over, a repeat
  check cannot stage anything newer anyway — Squirrel is committed until the app
  relaunches — so today it only re-downloads the archive and points a second
  staging run at the same cache directory. `checkForUpdatesInteractive()` says so
  instead of silently doing nothing. No new predicate: the existing one is exactly
  the window.
- Delete the `LAUNCHD_JOB_DISABLED` rule and its wrong comment, and flip the test
  that asserted the misattribution. This *starts* reporting that error rather than
  quieting one; if it still fires after this change, the guard is incomplete and
  we want to know.
- Attach the free-space figure to the report. `freeStagingBytes()` is already
  computed on every error for classification and then thrown away, and it is the
  one fact that separates a release defect from a volume that could never have
  held a 431 MB archive plus its ~2.1 GB expansion. Without it every staging
  failure arrives undecidable — which is why I cannot honestly classify the
  remaining fingerprints either way today.

Net: −5 lines of wrong classifier, one reused predicate, one field on an existing
`captureException`.

### Second pass: the `ditto` rule below it (added in review)

The rule directly under the one above is justified by the same kind of
unverified premise:

> ditto naming a file it could not find under ShipIt's staging directory is a
> staged copy that lost its parent mid-unpack. It prints no errno, and **nothing
> reuses it: Squirrel stages every attempt into a fresh directory** and the
> download it was unpacked from is cleared on error.

**First, a correction to my own writeup.** The claim that this PR already
disproves that premise is not something I established. What I proved is that a
concurrent `checkForUpdates()` is *refused* by Squirrel's RACCommand — which
argues against two concurrent unpacks, not for them. "Fresh directory per
attempt" is also true on the evidence: DESKTOP-14S shows the same user with
`update.xe9Xc1e` and `update.LbdolAd` on two different days.

The premise is false for a different reason, which I found by dumping Squirrel's
selector table:

```
$ otool -v -s __TEXT __objc_methname Squirrel.framework/Versions/A/Squirrel | tr ' ' '\n' | grep -aE '^(removeUpdate|uniqueTemporary|storageURL|unzipArchive)'
removeUpdateDirectoriesInStorageURL:excludingURL:
storageURL
uniqueTemporaryDirectoryForUpdate
unzipArchiveAtURL:intoDirectoryAtURL:
```

`storageURL` is `~/Library/Caches/<appId>.ShipIt`. So Squirrel makes a unique
`update.<id>` **and sweeps every other `update.*` out of that directory**. A
fresh directory per attempt is not an isolation guarantee — it is the *trigger*
for deleting the other trees. The comment reads the sweep's precondition as
proof that nothing touches the tree, when the sweep is the thing that touches it,
and the sweep needs no concurrency at all: any later staging run removes an
earlier one.

**Why (b) is not available.** I looked for an environmental shape the
double-staging shape cannot produce, and there isn't one *in the message*.
Disk-full is already handled ahead of this rule (ENOSPC text plus the free-space
check). What is left is "an ancestor of the staging path disappeared mid-unpack",
and `ditto: <path>: No such file or directory` is byte-identical whether the
remover was macOS purging `~/Library/Caches`, a cleaner app, the user, or
Squirrel's own sweep. There is no field to match on, so the rule cannot be
re-derived to match a real distinction.

So: **(a)**. Rule deleted, `SHIPIT_STAGING_PATH` deleted with it (its only
caller), test flipped to expect a report. The message carries no `ENOENT:`
token, so it falls through to reported rather than being caught by the generic
errno rule. I also deleted the "does not take the ShipIt name alone as proof"
test: with the rule gone every `ditto:` shape returns `false`, so both of its
negatives asserted nothing. The flipped test keeps one real assertion — the same
message on a full volume is *still* environmental, pinning that the free-space
check stays ahead of it.

I cannot prove this is what happened in DESKTOP-169, and I am not claiming it.
That is the point: I cannot prove it either way, and a wrong "environmental" is
invisible while a wrong "ours" gets triaged.

### The two rules I did not touch

- **`"read-only volume"`** — asserts the volume the updater runs on is mounted
  read-only, a fixed property of the machine for the whole session; sweeping a
  sibling `update.*` directory cannot make a volume read-only, so the
  double-staging path cannot produce it. (Worth noting separately: I could not
  find that exact phrase emitted by electron-updater 6.8.3, Squirrel, or the
  Electron framework, so the pattern may be matching nothing — dead weight
  rather than a wrong silence, and out of scope here.)
- **`"the request timed out"`** — Foundation's `NSURLErrorTimedOut` text, i.e. a
  transport failure fetching the feed or the archive; the staging path produces
  vanished-tree and partially-written-bundle shapes, never a timeout. One honest
  caveat: Squirrel fetches the archive from a server inside *our* main process,
  so a stalled event loop could in principle starve that read into a timeout —
  self-inflicted, but not the double-staging path.

Both are English-only substring matches, and DESKTOP-150 (`代码对象根本未签名`)
proves this text reaches us localised — so they under-match for non-English
users, which errs toward reporting.

## Deliberately not in this change

- **No issue is reclassified as environmental.** I could not prove it per
  fingerprint, and the events carry no disk telemetry to prove it with. That is
  what the new context field is for.
- **DESKTOP-169 is already fixed on main and unreleased.** `16aad61a1` (#7283,
  2026-09-07 19:51 PT) classifies `ditto:` + ShipIt staging path + "No such file
  or directory" as environmental. The event is 2026-09-07 10:21 PT, the user was
  on 1.26.0, and `git tag --contains 16aad61a1` is empty. It stops on its own when
  1.27.0 ships. I did not touch it.
- **Every one of these errors can be reported to Sentry twice, and I did not
  dedupe it.** `MacUpdater` emits `error` from its constructor listener, and while
  the archive is still streaming it *also* rejects the `updateDownloaded` promise,
  which `downloadUpdate().catch` turns into a second `emit("error")`. Evidence:
  DESKTOP-150, -15K, -15M and -169 each have exactly two events at the identical
  second, while DESKTOP-14Y's 25 are all distinct (its `once("error")` had already
  been removed on `finish`); and `main.log` logs "Network unavailable, will retry
  later" twice per occurrence. Fixing it halves the event count on issues you are
  deliberately watching, so that is your call, not mine.
- **`UPDATE_STAGING_MIN_FREE_BYTES` is 1 GiB and its comment is wrong.** Staging
  needs electron-updater's 431 MB pending archive *plus* Squirrel's own copy *plus*
  the ~2.1 GB expansion — measured, not estimated. Raising it widens the
  environmental bucket, which is exactly what you told me not to do on
  unproven ground, so I left it.
- **electron-updater never deletes the pending archive after a successful
  install.** This machine is running `1.27.0-canary.20260908001920` and
  `~/Library/Caches/@supersetdesktop-updater/pending/Superset-Canary-1.27.0-canary.20260908001920-arm64.zip`
  (411 MB) is still there. Separate leak, separate change.
- **This does not claim to fix all seven.** It removes one proven source of
  concurrent staging and one proven misclassification. I did not prove that
  re-entrancy is what truncates each individual staged copy — unlinking the
  pending archive does not break an in-flight read on macOS, and `server.close()`
  does not kill in-flight sockets, so I am not claiming a mechanism I could not
  demonstrate.

## Verification

`bunx biome check apps/desktop/src/main/lib/`:

```
Checked 154 files in 90ms. No fixes applied.
```

`bun run typecheck` (apps/desktop):

```
$ bun run generate:icons && bun run generate:routes
$ bun run scripts/generate-file-icons.ts
Generated file icons: 1067 SVGs copied, 2046 file names, 1152 extensions, 4528 folder names
$ tsr generate
$ tsc --noEmit
```

`bun run check:i18n` — both new strings translated into all 16 non-English locales, by hand:

```
$ bunx --bun lingui compile --strict --verbose --workers 1
Compiling message catalogs…
en ⇒ locales/en/messages.ts
ja ⇒ locales/ja/messages.ts
zh-CN ⇒ locales/zh-CN/messages.ts
fr ⇒ locales/fr/messages.ts
ko ⇒ locales/ko/messages.ts
zh-TW ⇒ locales/zh-TW/messages.ts
es ⇒ locales/es/messages.ts
de ⇒ locales/de/messages.ts
pt-BR ⇒ locales/pt-BR/messages.ts
it ⇒ locales/it/messages.ts
ru ⇒ locales/ru/messages.ts
tr ⇒ locales/tr/messages.ts
pl ⇒ locales/pl/messages.ts
nl ⇒ locales/nl/messages.ts
id ⇒ locales/id/messages.ts
cs ⇒ locales/cs/messages.ts
vi ⇒ locales/vi/messages.ts
Done in 536ms
```

Full `bun test` for the package (not just the touched files):

```
 3663 pass
 1 fail
 1 error
Ran 3664 tests across 397 files. [25.00s]
```

(3664 rather than 3665: the vacuous ShipIt-name test was deleted, as above.)

The one failure is pre-existing and unrelated — a module-mock leak that breaks
`@dnd-kit/core` at import time in
`src/renderer/.../useSidebarDnd/useSidebarDnd.test.ts`:

```
# Unhandled error between tests
13 | const DndMonitorContext = /*#__PURE__*/React.createContext(null);
                                                  ^
TypeError: React.createContext is not a function. (In 'React.createContext(null)', 'React.createContext' is undefined)
      at <anonymous> (…/@dnd-kit/core/dist/core.cjs.development.js:13:46)
```

Proven pre-existing by reverting only my diff (`git checkout -- apps/desktop packages/i18n`) and re-running:

```
=== BASELINE (my diff reverted) ===
exit=1
# Unhandled error between tests
 3664 pass
 1 fail
Ran 3665 tests across 397 files. [24.84s]
```

Identical count and identical error. The diff was then re-applied from a patch
and the touched suites re-run:

```
 39 pass
 0 fail
 116 expect() calls
Ran 39 tests across 2 files. [155.00ms]
```

Refs DESKTOP-14Y, DESKTOP-15M, DESKTOP-15K, DESKTOP-150, DESKTOP-14S, DESKTOP-16E, DESKTOP-169

https://claude.ai/code/session_01GKgqvJqxDZv9qiWUDz7NVW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the macOS updater from re-entering Squirrel.Mac staging while an update is already staged, which was failing code-signature verification on arm64 and leaving users stuck on old versions.

- Gates `checkForUpdates()` and `checkForUpdatesInteractive()` on the existing pending-update state, so a repeat check can no longer point a second staging run at the same ShipIt cache.
- The interactive path now tells the user the update installs at restart instead of silently doing nothing.
- Removes the wrong launchd classifier so Squirrel.Mac's refusal message now reaches Sentry instead of being dropped as environmental.
- Adds the free-staging-bytes figure to every staging error so the events become decidable.
- Adds the two new dialog strings to all locale catalogs; the Korean string keeps its particle on the word so it renders correctly with any version number.

Refs DESKTOP-14Y, DESKTOP-15M, DESKTOP-15K, DESKTOP-150, DESKTOP-14S, DESKTOP-16E, DESKTOP-169.

<sup>Written for commit 601eaf7c81c05a394b2a20ef469ab4b3191d2d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Update checks now recognize when an update is already ready to install, avoiding unnecessary network checks.
  - Interactive update actions explain that the update will be installed on the next restart.
  - Added localized update-status messages across supported languages.

- **Bug Fixes**
  - Improved update error reporting with available storage context.
  - Refined update installation error classification for more accurate diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
