### PR TITLE
fix(desktop): keep workspace panes usable while reconnecting

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/state/fileDocumentStore/fileDocumentStore.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { acquireDocument, releaseDocument } from "./fileDocumentStore";
+
+test("a failed host save preserves the dirty document across pane reopen and explicit retry", async () => {
+	let online = false;
+	let writes = 0;
+	const client = {
+		filesystem: {
+			readFile: {
+				query: async () => ({
+					kind: "text",
+					content: "original",
+					revision: "revision-1",
+					byteLength: 8,
+				}),
+			},
+			writeFile: {
+				mutate: async () => {
+					writes++;
+					if (!online) throw new Error("Host disconnected");
+					return { ok: true, revision: "revision-2" };
+				},
+			},
+		},
+	} as unknown as Parameters<typeof acquireDocument>[2];
+	const workspaceId = crypto.randomUUID();
+	const path = "/workspace/reconnect.txt";
+	const doc = acquireDocument(workspaceId, path, client);
+	await Promise.resolve();
+	expect(doc.content.kind).toBe("text");
+	doc.setContent("unsaved work");
+	expect((await doc.save()).status).toBe("error");
+	expect(doc.saveError?.message).toBe("Host disconnected");
+	expect(doc.pendingSave).toBe(false);
+	expect(doc.dirty).toBe(true);
+	expect(doc.content).toMatchObject({ value: "unsaved work" });
+	releaseDocument(workspaceId, path);
+
+	const reopened = acquireDocument(workspaceId, path, client);
+	expect(reopened.id).toBe(doc.id);
+	expect(reopened.dirty).toBe(true);
+	online = true;
+	expect(writes).toBe(1);
+	expect((await reopened.save()).status).toBe("saved");
+	expect(reopened.dirty).toBe(false);
+	expect(reopened.saveError).toBeNull();
+	expect(reopened.content).toMatchObject({ value: "unsaved work" });
+	expect(writes).toBe(2);
+	releaseDocument(workspaceId, path);
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.test.ts
@@ -2,12 +2,15 @@ import { afterAll, afterEach, expect, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 const NativeWebSocket = globalThis.WebSocket;
+const nativeFetch = globalThis.fetch;
+const NativeResponse = globalThis.Response;
 const NativeEvent = globalThis.Event;
 const NativeMessageEvent = globalThis.MessageEvent;
 const NativeEventTarget = globalThis.EventTarget;
 const alreadyRegistered = GlobalRegistrator.isRegistered;
 if (!alreadyRegistered) GlobalRegistrator.register();
 globalThis.WebSocket = NativeWebSocket;
+globalThis.fetch = nativeFetch;
 // partysocket may already be loaded by another suite and extends the native
 // EventTarget. Its dynamically created events must stay in that same realm.
 globalThis.Event = NativeEvent;
@@ -38,7 +41,7 @@ test("a slow handshake completes while the degraded notice is showing", async ()
 			// but within the relay's supported handshake budget.
 			await Bun.sleep(8_000);
 			if (instance.upgrade(request)) return;
-			return new Response("Upgrade cancelled", { status: 400 });
+			return new NativeResponse("Upgrade cancelled", { status: 400 });
 		},
 		websocket: { message() {} },
 	});
@@ -59,7 +62,7 @@ test("a slow handshake completes while the degraded notice is showing", async ()
 		expect(sawDegraded).toBe(true);
 		expect(result.current.hasConnected).toBe(true);
 		expect(result.current.isDegraded).toBe(false);
-		expect(result.current.isUnreachable).toBe(false);
+		expect(result.current.isAccessDenied).toBe(false);
 		expect(attempts).toBe(1);
 		unmount();
 	} finally {
@@ -68,3 +71,47 @@ test("a slow handshake completes while the degraded notice is showing", async ()
 		await server.stop(true);
 	}
 }, 20_000);
+
+test("relay access denial is visible before the notice grace and clears after recovery", async () => {
+	let denied = true;
+	const server = Bun.serve({
+		port: 0,
+		fetch(request, instance) {
+			if (new URL(request.url).pathname.endsWith("/_whoowns")) {
+				return new NativeResponse(null, { status: denied ? 403 : 200 });
+			}
+			if (!denied && instance.upgrade(request)) return;
+			return new NativeResponse(null, { status: 403 });
+		},
+		websocket: { message() {} },
+	});
+	const hostUrl = `http://127.0.0.1:${server.port}/hosts/test-host`;
+	setHostServiceSecret(hostUrl, "test-token");
+	try {
+		const { result, unmount } = renderHook(() => useHostReachability(hostUrl));
+		const denialDeadline = Date.now() + 1_000;
+		while (!result.current.isAccessDenied && Date.now() < denialDeadline) {
+			await act(async () => {
+				await Bun.sleep(10);
+			});
+		}
+		expect(result.current.isAccessDenied).toBe(true);
+		expect(result.current.isDegraded).toBe(false);
+		expect(result.current.detail).toContain("Settings > Security");
+		denied = false;
+		act(() => result.current.retry());
+		const recoveryDeadline = Date.now() + 1_000;
+		while (!result.current.hasConnected && Date.now() < recoveryDeadline) {
+			await act(async () => {
+				await Bun.sleep(10);
+			});
+		}
+		expect(result.current.hasConnected).toBe(true);
+		expect(result.current.isAccessDenied).toBe(false);
+		unmount();
+	} finally {
+		cleanup();
+		removeHostServiceSecret(hostUrl);
+		await server.stop(true);
+	}
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/hooks/useHostReachability/useHostReachability.ts
@@ -18,33 +18,11 @@ import { getHostEventBus } from "renderer/lib/host-event-bus";
  */
 const DEGRADED_GRACE_MS = 2_000;
 
-/**
- * How long the host has to stay unreachable before the workspace hands over to
- * the unreachable screen. The socket reconnects on its own backoff, so a relay
- * redeploy, a laptop lid, or a half-open TCP flap resolves well inside this
- * window — taking the screen over for those would be the false-positive that
- * got the earlier cloud-presence gate reverted twice (#4430, #4727).
- */
-const UNREACHABLE_GRACE_MS = 10_000;
-
-export interface HostReachabilityOptions {
-	/**
-	 * How long the host may stay down before `isUnreachable`. Callers that know
-	 * the outage is expected and self-healing (the local host service mid-
-	 * restart) hold the takeover longer; `isDegraded` keeps the user informed
-	 * in the meantime.
-	 */
-	unreachableAfterMs?: number;
-}
-
 export interface HostReachability {
-	/**
-	 * Down long enough to say so, not long enough to take the screen over.
-	 * Panes stay usable; show a non-blocking notice.
-	 */
+	/** Down long enough to show a non-blocking notice. */
 	isDegraded: boolean;
-	/** Sustained loss of the host connection — safe to take the screen over. */
-	isUnreachable: boolean;
+	/** The relay definitively rejected access; report this without a grace period. */
+	isAccessDenied: boolean;
 	/** A dial is in flight right now (auto-backoff or a manual retry). */
 	isReconnecting: boolean;
 	/**
@@ -52,7 +30,7 @@ export interface HostReachability {
 	 * reconnect rather than a first connection that hasn't landed yet.
 	 */
 	hasConnected: boolean;
-	/** What the relay preflight says is wrong. Only read while unreachable. */
+	/** What the relay preflight says is wrong. Shown on demand in connection details. */
 	detail: string;
 	/** Dial now instead of waiting out the backoff. */
 	retry: () => void;
@@ -121,14 +99,9 @@ function describeFailure(
  * so it reflects what the UI can actually do rather than the cloud's `isOnline`
  * flag (which drifts through relay redeploys and API blips).
  */
-export function useHostReachability(
-	hostUrl: string,
-	{ unreachableAfterMs = UNREACHABLE_GRACE_MS }: HostReachabilityOptions = {},
-): HostReachability {
+export function useHostReachability(hostUrl: string): HostReachability {
 	const bus = useMemo(() => getHostEventBus(hostUrl), [hostUrl]);
-	// Hold the connection open for as long as this screen is mounted: the
-	// panes that normally keep the bus alive are gone once we take over, and a
-	// closed socket would never observe the host coming back.
+	// Keep observing recovery even when no pane subscribes to host events.
 	useEffect(() => bus.retain(), [bus]);
 
 	const status = useSyncExternalStore(
@@ -143,17 +116,13 @@ export function useHostReachability(
 	}, [isDown]);
 
 	const isDegraded = useDelayElapsed(isDown, DEGRADED_GRACE_MS);
-	const graceElapsed = useDelayElapsed(isDown, unreachableAfterMs);
-	// A 403 preflight is definitive — the relay only 403s a verified token, so
-	// no amount of redialling changes the answer. Waiting out the grace there
-	// only delays telling the user they lack access.
-	const isUnreachable =
-		graceElapsed || (isDown && status.probe?.status === 403);
+	// A 403 is definitive: redialling cannot restore missing permissions.
+	const isAccessDenied = isDown && status.probe?.status === 403;
 	const isRelayHost = /\/hosts\/[^/]+/.test(hostUrl);
 
 	return {
 		isDegraded,
-		isUnreachable,
+		isAccessDenied,
 		isReconnecting: isDown && status.state !== "closed",
 		hasConnected,
 		detail: describeFailure(status, isRelayHost),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/WorkspaceHostGate.tsx
@@ -5,29 +5,13 @@ import type { ReactNode } from "react";
 import type { HostShapedWorkspace } from "renderer/hooks/host-workspaces/useHostWorkspaces";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { StateScreenShell } from "../../../../components/StateScreenShell";
-import { WorkspaceHostUnreachableState } from "../../../../components/WorkspaceHostUnreachableState";
 import { useHostReachability } from "../../../../hooks/useHostReachability";
 import { LOCAL_HOST_SERVICE_DETAIL } from "../../utils/localHostServiceDetail";
 import { HostConnectionStrip } from "./components/HostConnectionStrip";
 
 const HOST_LIST_STALE_MS = 30_000;
 
-/**
- * A local host-service restart is back in a few seconds and the strip covers
- * it. Only a restart that runs this long deserves the takeover — and by then
- * "restart it from the tray" is advice worth giving.
- */
-const LOCAL_RESTART_TAKEOVER_MS = 30_000;
-
-/**
- * Tells the workspace what its host connection is doing, in two steps. A host
- * that has been down for a couple of seconds gets a non-blocking strip over
- * live, usable panes; one that stays down gets the unreachable takeover.
- * Overlays rather than replaces: panes keep their live state (terminal
- * scrollback, unsaved editor documents, in-flight agent sessions) so a dropped
- * connection costs nothing once the host is back.
- */
+/** Keeps loaded panes accessible while reporting the shared host connection. */
 export function WorkspaceHostGate({
 	workspace,
 	children,
@@ -39,25 +23,16 @@ export function WorkspaceHostGate({
 	const hostUrl = useWorkspaceHostUrl();
 	const { machineId, hostServiceStatus } = useLocalHostService();
 
-	// A local host that dropped because the coordinator is mid-restart is not
-	// "unreachable, go restart it from the tray" — that advises the user to do
-	// what is already happening. Only "starting" is overridden: a service the
-	// coordinator believes is running yet stays unreachable is a real wedge,
-	// and for that the default advice stands.
 	const isLocalRestartInFlight =
 		workspace.hostId === machineId && hostServiceStatus === "starting";
 	const {
 		isDegraded,
-		isUnreachable,
+		isAccessDenied,
 		isReconnecting,
 		hasConnected,
 		detail,
 		retry,
-	} = useHostReachability(hostUrl, {
-		unreachableAfterMs: isLocalRestartInFlight
-			? LOCAL_RESTART_TAKEOVER_MS
-			: undefined,
-	});
+	} = useHostReachability(hostUrl);
 	const { data: hostRows = [] } = cloudTrpc.v2Host.list.useQuery(undefined, {
 		staleTime: HOST_LIST_STALE_MS,
 	});
@@ -81,38 +56,22 @@ export function WorkspaceHostGate({
 	// workspace on every reconnect.
 	return (
 		<div className="relative flex min-h-0 min-w-0 flex-1">
-			{/* Covered panes stay mounted, so without `inert` they keep taking Tab
-			    stops and screen-reader focus behind the takeover. */}
-			<div className="flex min-h-0 min-w-0 flex-1" inert={isUnreachable}>
-				{children}
-			</div>
-			{isDegraded && !isUnreachable ? (
+			<div className="flex min-h-0 min-w-0 flex-1">{children}</div>
+			{isDegraded || isAccessDenied ? (
 				<HostConnectionStrip
+					hostId={workspace.hostId}
 					hostName={hostName}
+					isAccessDenied={isAccessDenied}
+					detail={
+						isLocalRestartInFlight
+							? i18n._(LOCAL_HOST_SERVICE_DETAIL.starting)
+							: detail
+					}
 					isReconnecting={isReconnecting}
 					hasConnected={hasConnected}
 					isLocalRestartInFlight={isLocalRestartInFlight}
 					onRetry={retry}
 				/>
-			) : null}
-			{/* Translucent on purpose: the panes are still there, and letting them
-			    show through says so better than the copy can. */}
-			{isUnreachable ? (
-				<div className="absolute inset-0 z-50 bg-background/80 backdrop-blur-sm">
-					<StateScreenShell>
-						<WorkspaceHostUnreachableState
-							hostId={workspace.hostId}
-							hostName={hostName}
-							detail={
-								isLocalRestartInFlight
-									? i18n._(LOCAL_HOST_SERVICE_DETAIL.starting)
-									: detail
-							}
-							isReconnecting={isReconnecting || isLocalRestartInFlight}
-							onRetry={retry}
-						/>
-					</StateScreenShell>
-				</div>
 			) : null}
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/HostConnectionStrip.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider/components/WorkspaceHostGate/components/HostConnectionStrip/HostConnectionStrip.tsx
@@ -1,9 +1,14 @@
 import { useLingui } from "@lingui/react/macro";
+import { Popover, PopoverContent, PopoverTrigger } from "@superset/ui/popover";
 import { cn } from "@superset/ui/utils";
+import { Link } from "@tanstack/react-router";
 
 interface HostConnectionStripProps {
+	hostId: string;
 	hostName: string;
-	/** A dial is in flight (the socket's own backoff or a forced redial). */
+	detail: string;
+	isAccessDenied: boolean;
+	/** The socket is retrying, including time spent in its native backoff. */
 	isReconnecting: boolean;
 	/** The socket has opened before, so this is a drop rather than a first dial. */
 	hasConnected: boolean;
@@ -12,50 +17,79 @@ interface HostConnectionStripProps {
 	onRetry: () => void;
 }
 
-/**
- * Non-blocking notice for a host that has been down for a few seconds. Panes
- * stay visible and usable underneath while the socket redials; escalating to
- * the full takeover is WorkspaceHostGate's call.
- */
+/** Persistent, nonmodal connection status. Recovery advice opens only on request. */
 export function HostConnectionStrip({
+	hostId,
 	hostName,
+	detail,
+	isAccessDenied,
 	isReconnecting,
 	hasConnected,
 	isLocalRestartInFlight,
 	onRetry,
 }: HostConnectionStripProps) {
 	const { t } = useLingui();
-	const isDialing = isReconnecting || isLocalRestartInFlight;
-	const label = isLocalRestartInFlight
-		? t({ message: "Restarting…" })
-		: !isReconnecting
-			? t({ message: "Disconnected" })
-			: hasConnected
-				? t({ message: "Reconnecting…" })
-				: t({ message: "Connecting…" });
+	const isDialing =
+		!isAccessDenied && (isReconnecting || isLocalRestartInFlight);
+	const label = isAccessDenied
+		? t({ message: "Access denied" })
+		: isLocalRestartInFlight
+			? t({ message: "Restarting…" })
+			: !isReconnecting
+				? t({ message: "Disconnected" })
+				: hasConnected
+					? t({ message: "Reconnecting…" })
+					: t({ message: "Connecting…" });
 
 	return (
-		<div
-			aria-live="polite"
-			className="pointer-events-none absolute inset-x-0 top-2 z-40 flex justify-center"
-		>
-			<div className="pointer-events-auto flex items-center gap-2 rounded-full border border-border/60 bg-background/95 py-1.5 pl-3 pr-1.5 text-[12px] text-muted-foreground shadow-sm backdrop-blur-sm">
+		<div className="pointer-events-none absolute inset-x-0 top-2 z-40 flex justify-center px-2">
+			<div className="pointer-events-auto flex min-w-0 max-w-full items-center gap-2 rounded-full border border-border/60 bg-background/95 py-1.5 pl-3 pr-1.5 text-[12px] text-muted-foreground shadow-sm backdrop-blur-sm">
 				<span
 					aria-hidden="true"
 					className={cn(
 						"size-1.5 shrink-0 rounded-full",
-						isDialing
-							? "animate-pulse bg-yellow-500"
-							: "bg-muted-foreground/40",
+						isAccessDenied
+							? "bg-destructive"
+							: isDialing
+								? "animate-pulse bg-yellow-500"
+								: "bg-muted-foreground/40",
 					)}
 				/>
-				<span className="min-w-0 truncate" title={hostName}>
+				<span aria-live="polite" className="min-w-0 truncate" title={hostName}>
 					{label}
 				</span>
+				<Popover>
+					<PopoverTrigger asChild>
+						<button
+							type="button"
+							className="shrink-0 rounded-full px-1.5 py-0.5 font-medium text-foreground hover:bg-muted/60"
+						>
+							{t({ message: "Details" })}
+						</button>
+					</PopoverTrigger>
+					<PopoverContent
+						align="end"
+						sideOffset={8}
+						aria-label={t({ message: "Details" })}
+						className="w-80 max-w-[calc(100vw-2rem)] space-y-2 text-[13px]"
+					>
+						<p className="break-words font-medium">{hostName}</p>
+						<p className="select-text leading-relaxed text-muted-foreground">
+							{detail}
+						</p>
+						<Link
+							to="/settings/hosts/$hostId"
+							params={{ hostId }}
+							className="inline-block font-medium underline underline-offset-4"
+						>
+							{t({ message: "Host settings" })}
+						</Link>
+					</PopoverContent>
+				</Popover>
 				<button
 					type="button"
 					onClick={onRetry}
-					className="rounded-full px-1.5 py-0.5 font-medium text-foreground hover:bg-muted/60"
+					className="shrink-0 rounded-full px-1.5 py-0.5 font-medium text-foreground hover:bg-muted/60"
 				>
 					{t({ message: "Retry" })}
 				</button>

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Přijmout pozvánku"
 msgid "Accept terms"
 msgstr "Přijmout podmínky"
 
+msgid "Access denied"
+msgstr "Přístup odepřen"
+
 msgid "Access your email address"
 msgstr "číst vaši e-mailovou adresu"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Einladung annehmen"
 msgid "Accept terms"
 msgstr "Bedingungen akzeptieren"
 
+msgid "Access denied"
+msgstr "Zugriff verweigert"
+
 msgid "Access your email address"
 msgstr "Auf deine E-Mail-Adresse zugreifen"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Accept invitation"
 msgid "Accept terms"
 msgstr "Accept terms"
 
+msgid "Access denied"
+msgstr "Access denied"
+
 msgid "Access your email address"
 msgstr "Access your email address"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Aceptar la invitación"
 msgid "Accept terms"
 msgstr "Aceptar las condiciones"
 
+msgid "Access denied"
+msgstr "Acceso denegado"
+
 msgid "Access your email address"
 msgstr "Acceder a tu dirección de correo electrónico"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Accepter l'invitation"
 msgid "Accept terms"
 msgstr "Accepter les conditions"
 
+msgid "Access denied"
+msgstr "Accès refusé"
+
 msgid "Access your email address"
 msgstr "Accéder à votre adresse e-mail"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Terima undangan"
 msgid "Accept terms"
 msgstr "Terima ketentuan"
 
+msgid "Access denied"
+msgstr "Akses ditolak"
+
 msgid "Access your email address"
 msgstr "Mengakses alamat email Anda"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Accetta l'invito"
 msgid "Accept terms"
 msgstr "Accetta i termini"
 
+msgid "Access denied"
+msgstr "Accesso negato"
+
 msgid "Access your email address"
 msgstr "Accedere al tuo indirizzo email"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -1233,6 +1233,9 @@ msgstr "招待を承諾"
 msgid "Accept terms"
 msgstr "利用規約に同意する"
 
+msgid "Access denied"
+msgstr "アクセスが拒否されました"
+
 msgid "Access your email address"
 msgstr "メールアドレスへのアクセス"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -1233,6 +1233,9 @@ msgstr "초대 수락"
 msgid "Accept terms"
 msgstr "약관 동의"
 
+msgid "Access denied"
+msgstr "접근이 거부되었습니다"
+
 msgid "Access your email address"
 msgstr "이메일 주소 접근"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Uitnodiging accepteren"
 msgid "Accept terms"
 msgstr "Voorwaarden accepteren"
 
+msgid "Access denied"
+msgstr "Toegang geweigerd"
+
 msgid "Access your email address"
 msgstr "Je e-mailadres inzien"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Przyjmij zaproszenie"
 msgid "Accept terms"
 msgstr "Akceptuję warunki"
 
+msgid "Access denied"
+msgstr "Odmowa dostępu"
+
 msgid "Access your email address"
 msgstr "Uzyskać dostęp do Twojego adresu e-mail"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Aceitar convite"
 msgid "Accept terms"
 msgstr "Aceitar os termos"
 
+msgid "Access denied"
+msgstr "Acesso negado"
+
 msgid "Access your email address"
 msgstr "Acessar seu endereço de e-mail"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Принять приглашение"
 msgid "Accept terms"
 msgstr "Принять условия"
 
+msgid "Access denied"
+msgstr "Доступ запрещён"
+
 msgid "Access your email address"
 msgstr "получить доступ к вашему адресу email"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Daveti kabul et"
 msgid "Accept terms"
 msgstr "Koşulları kabul et"
 
+msgid "Access denied"
+msgstr "Erişim reddedildi"
+
 msgid "Access your email address"
 msgstr "E-posta adresinize erişme"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -1233,6 +1233,9 @@ msgstr "Chấp nhận lời mời"
 msgid "Accept terms"
 msgstr "Chấp nhận điều khoản"
 
+msgid "Access denied"
+msgstr "Truy cập bị từ chối"
+
 msgid "Access your email address"
 msgstr "Truy cập địa chỉ email của bạn"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -1233,6 +1233,9 @@ msgstr "接受邀请"
 msgid "Accept terms"
 msgstr "接受条款"
 
+msgid "Access denied"
+msgstr "访问被拒绝"
+
 msgid "Access your email address"
 msgstr "访问你的邮箱地址"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -1233,6 +1233,9 @@ msgstr "接受邀請"
 msgid "Accept terms"
 msgstr "接受條款"
 
+msgid "Access denied"
+msgstr "存取遭拒"
+
 msgid "Access your email address"
 msgstr "存取你的電子郵件地址"
 

--- a/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
+++ b/packages/workspace-client/src/lib/relaySocket/relaySocket.ts
@@ -45,8 +45,6 @@ function signUrl(url: string, token: string | null): string {
 	return u.toString();
 }
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
 /**
  * Reconnecting WebSocket for host-service endpoints (direct or relay-fronted).
  * partysocket evaluates the async URL provider before EVERY attempt, so each
@@ -57,6 +55,17 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  */
 export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 	let socket: ReconnectingWebSocket | null = null;
+	let cancelAccessDeniedWait: (() => void) | undefined;
+	const waitAfterAccessDenied = (ms: number) =>
+		new Promise<void>((resolve) => {
+			const finish = () => {
+				clearTimeout(timer);
+				cancelAccessDeniedWait = undefined;
+				resolve();
+			};
+			const timer = setTimeout(finish, ms);
+			cancelAccessDeniedWait = finish;
+		});
 
 	// Per-dial epoch so a slow preflight from a superseded dial (URL swap,
 	// reconnect) can't publish its probe after a newer dial has started —
@@ -73,7 +82,7 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 			if (opts.accessDeniedRetryMs == null) {
 				socket?.close(1000, "relay access denied");
 			} else {
-				await sleep(opts.accessDeniedRetryMs);
+				await waitAfterAccessDenied(opts.accessDeniedRetryMs);
 			}
 			// Rejecting aborts this attempt; partysocket surfaces it as an error
 			// event and re-enters its backoff loop (no-op once close() was called).
@@ -89,6 +98,20 @@ export function createRelaySocket(opts: RelaySocketOptions): RelaySocket {
 		connectionTimeout: opts.connectionTimeout,
 		maxEnqueuedMessages: opts.maxEnqueuedMessages ?? 0,
 	});
+
+	// The URL provider holds partysocket's connection lock while awaiting the
+	// denial cooldown. Wake it on explicit retry/close so the provider settles
+	// promptly and the native retry loop can honor the user's action.
+	const reconnect = socket.reconnect.bind(socket);
+	socket.reconnect = (code, reason) => {
+		cancelAccessDeniedWait?.();
+		reconnect(code, reason);
+	};
+	const close = socket.close.bind(socket);
+	socket.close = (code, reason) => {
+		cancelAccessDeniedWait?.();
+		close(code, reason);
+	};
 
 	return socket;
 }


### PR DESCRIPTION
## What & why

A sustained host outage currently makes every pane inert and covers the workspace after 10 seconds (30 seconds during a local restart). This follow-up to #7264 keeps the compact reconnect notice visible for the entire outage, so loaded panes remain accessible.

Details opens a nonmodal popover with the device name, recovery advice, and Host settings. Relay 403s show “Access denied” immediately. Retry also now interrupts the five-minute permission-check cooldown; a real-socket regression test caught it previously waiting behind the pending URL provider.

[Interactive design](https://app.superset.sh/page/stay-in-your-workspace-reconnect-design-o04r2i)

## How I tested it
- Production desktop build and typecheck; Biome, i18n, and plugin checks.
- Real-socket tests for an 8-second handshake and immediate permission retry; dirty-document test covers failed save, pane reopen, and explicit retry.
- Built Electron app in this worktree, authenticated against its local API: sustained event-stream outage for 35+ seconds, zero inert pane wrappers, Details opened with real input, a file opened and edited alongside the mounted terminal, and the edit retained when reconnection cleared the notice. Screenshots and sanitized lifecycle logs captured locally.
- Workspace-client suite and paired terminal/hook/document tests.

The outage UI check used a controlled event-stream proxy after a real local host restart; it does not simulate every host operation being offline. Failed saves are covered separately by the document-store test. Initial setup without a host endpoint still uses its existing pending screen, and host operations retain their existing connection/error handling.

## Checklist

- [x] PR title follows conventional commits.
- [x] Desktop typecheck, scoped Biome, i18n, and plugin checks pass.
- [ ] Full repository lint/typecheck (CI).
- Allow edits from maintainers: same-repository branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps workspace panes usable during a sustained host outage by replacing the full-screen takeover with a persistent compact reconnect notice.

- The notice stays visible for the entire outage instead of covering the workspace after 10 seconds, so loaded panes remain interactive.
- Details opens a nonmodal popover with the device name, recovery advice, and a Host settings link.
- Relay 403s now show “Access denied” immediately instead of waiting out the grace period.
- Retry interrupts the five-minute access-denied cooldown so redialing starts right away.
- Failed host saves preserve the dirty document across pane reopen and explicit retry.

<sup>Written for commit 73ebd29617f947f4fe4f12cecee6d25c471a0910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Displays clear host connection states, including access denial, degraded connectivity, and restart progress.
  - Provides diagnostic details, host settings access, and retry controls from the connection notice.
  - Keeps workspace panes available while host connectivity is degraded.
  - Supports recovery after access is restored without requiring a full workspace reload.

- **Bug Fixes**
  - Preserves document content and unsaved status after a failed save and reopening.

- **Localization**
  - Added “Access denied” translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->