### PR TITLE
fix(desktop): retire v1 runtimes after locked migration

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-runner.ts
+++ b/apps/desktop/src/lib/trpc/routers/changes/workers/git-task-runner.ts
@@ -19,6 +19,12 @@ const WORKER_DEBUG = process.env.SUPERSET_WORKER_DEBUG === "1";
 let gitTaskRunner: WorkerTaskRunner | null = null;
 let didRegisterDisposeHook = false;
 
+export async function disposeGitTaskRunner(): Promise<void> {
+	const runner = gitTaskRunner;
+	gitTaskRunner = null;
+	await runner?.dispose();
+}
+
 function getWorkerScriptPath(): string {
 	try {
 		// Lazy require avoids test/runtime issues where electron is unavailable.
@@ -43,8 +49,7 @@ function getRunner(): WorkerTaskRunner {
 			try {
 				const { app } = require("electron") as typeof import("electron");
 				app?.once("before-quit", () => {
-					void gitTaskRunner?.dispose();
-					gitTaskRunner = null;
+					void disposeGitTaskRunner();
 				});
 				didRegisterDisposeHook = true;
 			} catch (error) {

--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -11,6 +11,7 @@ import { eq, isNotNull, isNull } from "drizzle-orm";
 import { SUPERSET_HOME_DIR } from "main/lib/app-environment";
 import { appState } from "main/lib/app-state";
 import { localDb } from "main/lib/local-db";
+import { v1RuntimeRetirement } from "main/lib/v1-runtime-retirement";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 
@@ -24,6 +25,22 @@ const ledgerEntrySchema = z.object({
 
 export const createMigrationRouter = () => {
 	return router({
+		reportV1Runtime: publicProcedure
+			.input(
+				z.object({
+					organizationId: z.string().min(1),
+					migratedAtBoot: z.boolean(),
+					v2Enabled: z.boolean(),
+				}),
+			)
+			.mutation(async ({ ctx, input }) => {
+				if (!ctx.senderWindow) return { retired: false };
+				const retired = await v1RuntimeRetirement.report(
+					ctx.senderWindow.id,
+					input,
+				);
+				return { retired };
+			}),
 		readV1Projects: publicProcedure.query(() => {
 			// Only surface pinned projects. v1's `hideProject` nulls tab_order
 			// when the last workspace in a project is deleted, effectively

--- a/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
@@ -3,6 +3,7 @@ import {
 	createFsHostService,
 	type FsHostService,
 	FsWatcherManager,
+	invalidateSearchIndexesForRoot,
 } from "@superset/workspace-fs/host";
 import { TRPCError } from "@trpc/server";
 import { shell } from "electron";
@@ -52,6 +53,12 @@ export function resolveWorkspaceRootPath(workspaceId: string): string {
 }
 
 const serviceCache = new Map<string, FsHostService>();
+
+export async function disposeWorkspaceFilesystem(): Promise<void> {
+	for (const root of serviceCache.keys()) invalidateSearchIndexesForRoot(root);
+	serviceCache.clear();
+	await filesystemWatcherManager.close();
+}
 
 export function getServiceForRootPath(rootPath: string): FsHostService {
 	let service = serviceCache.get(rootPath);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -53,10 +53,6 @@ import { ensureProjectIconsDir, getProjectIconPath } from "./lib/project-icons";
 import { runQuitCleanup } from "./lib/quit-sequence";
 import { initSentry } from "./lib/sentry";
 import {
-	prewarmTerminalRuntime,
-	reconcileDaemonSessions,
-} from "./lib/terminal";
-import {
 	disposeTerminalHostClient,
 	getTerminalHostClient,
 } from "./lib/terminal-host/client";
@@ -505,9 +501,8 @@ if (!gotTheLock) {
 
 		await loadWebviewBrowserExtension();
 
-		// Must happen before renderer restore runs
-		await reconcileDaemonSessions();
-		prewarmTerminalRuntime();
+		// V1RuntimeLifecycle reconciles legacy sessions only after the renderer
+		// knows whether its migration lock took effect. Do not spawn v1 for v2.
 
 		// Must be listening before any host-service spawns: the child learns the
 		// bridge endpoint/secret from its env, so a late bridge means browser

--- a/apps/desktop/src/main/lib/notifications/v1-agent-sessions.test.ts
+++ b/apps/desktop/src/main/lib/notifications/v1-agent-sessions.test.ts
@@ -20,6 +20,45 @@ function record(
 }
 
 describe("applyV1AgentHookEvent", () => {
+	it("keeps a migrated agent resumable when shutdown's goodbye arrives after disconnect", () => {
+		const event = {
+			rawEventType: "SessionEnd",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 100,
+		};
+		expect(applyV1AgentHookEvent(record(), event)).toEqual(
+			record({ endedAt: T0 + 100, updatedAt: T0 + 100 }),
+		);
+		expect(
+			applyV1AgentHookEvent(record(), event, {
+				agentSessionId: "session-a",
+				at: T0,
+			}),
+		).toBeUndefined();
+	});
+
+	it("retirement does not suppress another session's goodbye or a later clean exit", () => {
+		const event = {
+			rawEventType: "SessionEnd",
+			agentId: "claude",
+			agentSessionId: "session-a",
+			at: T0 + 100,
+		};
+		expect(
+			applyV1AgentHookEvent(record(), event, {
+				agentSessionId: "other",
+				at: T0,
+			})?.endedAt,
+		).toBe(T0 + 100);
+		expect(
+			applyV1AgentHookEvent(
+				record(),
+				{ ...event, at: T0 + 30_001 },
+				{ agentSessionId: "session-a", at: T0 },
+			)?.endedAt,
+		).toBe(T0 + 30_001);
+	});
 	it("starts a fresh un-prompted record on SessionStart", () => {
 		const next = applyV1AgentHookEvent(undefined, {
 			rawEventType: "SessionStart",

--- a/apps/desktop/src/main/lib/notifications/v1-agent-sessions.ts
+++ b/apps/desktop/src/main/lib/notifications/v1-agent-sessions.ts
@@ -40,6 +40,25 @@ const DEATH_GASP_WINDOW_MS = 30_000;
 /** Mirrors host-service END_STRAGGLER_WINDOW_MS. */
 const END_STRAGGLER_WINDOW_MS = 30_000;
 
+// Shutdown disconnects the daemon client before every final hook arrives.
+// Remember only the sessions being retired, briefly, so their SIGHUP goodbye
+// cannot erase the resume candidate that migration is carrying into v2.
+const retiringSessions = new Map<
+	string,
+	{ agentSessionId: string; at: number }
+>();
+
+export function markV1TerminalRetiring(paneId: string): void {
+	const session = appState.data.v1AgentSessions?.[paneId];
+	if (!session || session.endedAt !== undefined) return;
+	const retirement = { agentSessionId: session.agentSessionId, at: Date.now() };
+	retiringSessions.set(paneId, retirement);
+	setTimeout(() => {
+		if (retiringSessions.get(paneId) === retirement)
+			retiringSessions.delete(paneId);
+	}, DEATH_GASP_WINDOW_MS).unref();
+}
+
 export interface V1AgentHookEvent {
 	rawEventType: string;
 	agentId: string;
@@ -54,11 +73,18 @@ export interface V1AgentHookEvent {
 export function applyV1AgentHookEvent(
 	existing: V1PaneAgentSession | undefined,
 	event: V1AgentHookEvent,
+	retirement?: { agentSessionId: string; at: number },
 ): V1PaneAgentSession | undefined {
 	const { rawEventType, agentId, agentSessionId, at } = event;
 
 	if (SESSION_END_EVENTS.has(rawEventType)) {
 		if (!existing || existing.endedAt !== undefined) return undefined;
+		if (
+			retirement?.agentSessionId === existing.agentSessionId &&
+			at >= retirement.at &&
+			at - retirement.at <= DEATH_GASP_WINDOW_MS
+		)
+			return undefined;
 		// A goodbye from some other agent or session must not end this one.
 		if (agentId !== existing.agentId) return undefined;
 		if (
@@ -146,9 +172,12 @@ export function recordV1AgentHookEvent(
 	paneId: string,
 	event: V1AgentHookEvent,
 ): void {
+	if (SESSION_START_EVENTS.has(event.rawEventType))
+		retiringSessions.delete(paneId);
 	const next = applyV1AgentHookEvent(
 		appState.data.v1AgentSessions?.[paneId],
 		event,
+		retiringSessions.get(paneId),
 	);
 	if (next) persist(paneId, next);
 }

--- a/apps/desktop/src/main/lib/terminal-host/client-runtime-block.test.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client-runtime-block.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Socket } from "node:net";
+import { setV1RuntimeBlockedCheck } from "../v1-runtime-retirement/access";
+import type { TerminalHostClient as Client } from "./client";
+import type { CreateOrAttachRequest } from "./types";
+
+// Other suites mock the public singleton; exercise the actual client class.
+const clientModule = "./client.ts?runtime-block-tests";
+const { TerminalHostClient, TerminalHostClientDisposedError } = await import(
+	clientModule
+);
+
+interface ClientInternals {
+	connectAndAuthenticate(): Promise<void>;
+	spawnDaemon(): Promise<void>;
+	tryConnectControl(): Promise<boolean>;
+	tryConnectStream(): Promise<boolean>;
+	authenticateStream(options: { token: string }): Promise<void>;
+	readAuthToken(): string;
+	sendRequest(type: string, payload: unknown): Promise<unknown>;
+	controlSocket: Socket | null;
+	streamSocket: Socket | null;
+	controlAuthenticated: boolean;
+	streamAuthenticated: boolean;
+}
+
+const clients: Client[] = [];
+afterEach(() => {
+	for (const client of clients.splice(0)) client.dispose();
+	setV1RuntimeBlockedCheck(() => false);
+});
+
+function makeClient() {
+	const client = new TerminalHostClient() as Client;
+	clients.push(client);
+	return { client, internals: client as unknown as ClientInternals };
+}
+
+describe("legacy connection retirement races", () => {
+	test("a lock during stream connection prevents stream authentication", async () => {
+		let blocked = false;
+		setV1RuntimeBlockedCheck(() => blocked);
+		const { client, internals } = makeClient();
+		internals.controlSocket = new Socket();
+		internals.controlAuthenticated = true;
+		internals.readAuthToken = () => "test-token";
+		internals.tryConnectStream = async () => {
+			blocked = true;
+			return true;
+		};
+		const authenticate = mock(async () => {});
+		internals.authenticateStream = authenticate;
+		await expect(client.ensureConnected()).rejects.toBeInstanceOf(
+			TerminalHostClientDisposedError,
+		);
+		expect(authenticate).not.toHaveBeenCalled();
+	});
+
+	test("a lock while awaiting daemon availability prevents a second control probe", async () => {
+		let blocked = false;
+		setV1RuntimeBlockedCheck(() => blocked);
+		const { client, internals } = makeClient();
+		const probe = mock(async () => false);
+		internals.tryConnectControl = probe;
+		internals.spawnDaemon = async () => {
+			blocked = true;
+		};
+		await expect(client.ensureConnected()).rejects.toBeInstanceOf(
+			TerminalHostClientDisposedError,
+		);
+		expect(probe).toHaveBeenCalledTimes(1);
+	});
+
+	test("a lock during authentication rejects the connection and waiting callers", async () => {
+		let blocked = false;
+		setV1RuntimeBlockedCheck(() => blocked);
+		const { client, internals } = makeClient();
+		const gate = Promise.withResolvers<void>();
+		const control = new Socket();
+		const stream = new Socket();
+		internals.connectAndAuthenticate = async () => {
+			await gate.promise;
+			internals.controlSocket = control;
+			internals.streamSocket = stream;
+			internals.controlAuthenticated = true;
+			internals.streamAuthenticated = true;
+		};
+		const connected = mock(() => {});
+		client.on("connected", connected);
+		const first = client.ensureConnected();
+		const waiter = client.ensureConnected();
+		const outcomes = Promise.allSettled([first, waiter]);
+		blocked = true;
+		gate.resolve();
+		for (const result of await outcomes) {
+			expect(result.status).toBe("rejected");
+			if (result.status === "rejected")
+				expect(result.reason).toBeInstanceOf(TerminalHostClientDisposedError);
+		}
+		expect(connected).not.toHaveBeenCalled();
+		expect(control.destroyed).toBe(true);
+		expect(stream.destroyed).toBe(true);
+	});
+
+	test("a lock between ensureConnected and request dispatch prevents session creation", async () => {
+		let blocked = false;
+		setV1RuntimeBlockedCheck(() => blocked);
+		const { client, internals } = makeClient();
+		const request = mock(async () => ({ pid: null }));
+		internals.sendRequest = request;
+		client.ensureConnected = async () => {
+			blocked = true;
+		};
+		await expect(
+			client.createOrAttach({ sessionId: "race" } as CreateOrAttachRequest),
+		).rejects.toBeInstanceOf(TerminalHostClientDisposedError);
+		expect(request).not.toHaveBeenCalled();
+	});
+
+	test("a lock during the control probe prevents daemon spawning", async () => {
+		let blocked = false;
+		setV1RuntimeBlockedCheck(() => blocked);
+		const { client, internals } = makeClient();
+		internals.tryConnectControl = async () => {
+			blocked = true;
+			return false;
+		};
+		const spawn = mock(async () => {
+			throw new Error("spawn attempted");
+		});
+		internals.spawnDaemon = spawn;
+		await expect(client.ensureConnected()).rejects.toBeInstanceOf(
+			TerminalHostClientDisposedError,
+		);
+		expect(spawn).not.toHaveBeenCalled();
+	});
+});

--- a/apps/desktop/src/main/lib/terminal-host/client.ts
+++ b/apps/desktop/src/main/lib/terminal-host/client.ts
@@ -34,6 +34,7 @@ import { app } from "electron";
 import { SUPERSET_DIR_NAME } from "shared/constants";
 import { throwIfAborted } from "../terminal/abort";
 import { TerminalAttachCanceledError } from "../terminal/errors";
+import { isV1RuntimeBlocked } from "../v1-runtime-retirement/access";
 import {
 	type CancelCreateOrAttachRequest,
 	type ClearScrollbackRequest,
@@ -212,6 +213,7 @@ export class TerminalHostClient extends EventEmitter {
 	 * Spawns daemon if needed.
 	 */
 	async ensureConnected(): Promise<void> {
+		this.assertRuntimeAllowed();
 		// Already connected - fast path (no logging to avoid noise on every API call)
 		if (
 			this.connectionState === ConnectionState.CONNECTED &&
@@ -235,6 +237,10 @@ export class TerminalHostClient extends EventEmitter {
 				const WAIT_TIMEOUT_MS = 10000; // 10 seconds max wait
 
 				const checkConnection = () => {
+					if (this.disposed || isV1RuntimeBlocked()) {
+						reject(new TerminalHostClientDisposedError());
+						return;
+					}
 					if (
 						this.connectionState === ConnectionState.CONNECTED &&
 						this.controlSocket &&
@@ -267,6 +273,7 @@ export class TerminalHostClient extends EventEmitter {
 
 		try {
 			await this.connectAndAuthenticate();
+			this.assertRuntimeAllowed();
 			this.connectionState = ConnectionState.CONNECTED;
 			this.disconnectArmed = false;
 			this.emit("connected");
@@ -363,12 +370,19 @@ export class TerminalHostClient extends EventEmitter {
 		);
 	}
 
+	private assertRuntimeAllowed(): void {
+		if (this.disposed || isV1RuntimeBlocked()) {
+			throw new TerminalHostClientDisposedError();
+		}
+	}
+
 	/**
 	 * Connect and authenticate both control + stream sockets.
 	 * Handles protocol mismatch by shutting down a legacy daemon and retrying once.
 	 */
 	private async connectAndAuthenticate(): Promise<void> {
 		for (let attempt = 0; attempt < 2; attempt++) {
+			this.assertRuntimeAllowed();
 			if (
 				attempt === 0 &&
 				process.env.NODE_ENV === "development" &&
@@ -386,9 +400,12 @@ export class TerminalHostClient extends EventEmitter {
 
 			if (!this.controlSocket) {
 				let controlConnected = await this.tryConnectControl();
+				this.assertRuntimeAllowed();
 				if (!controlConnected) {
 					await this.spawnDaemon();
+					this.assertRuntimeAllowed();
 					controlConnected = await this.tryConnectControl();
+					this.assertRuntimeAllowed();
 					if (!controlConnected) {
 						throw new Error("Failed to connect control socket after spawn");
 					}
@@ -399,6 +416,7 @@ export class TerminalHostClient extends EventEmitter {
 			try {
 				token = this.readAuthToken();
 			} catch (error) {
+				this.assertRuntimeAllowed();
 				if (attempt === 0) {
 					if (DEBUG_CLIENT) {
 						console.log(
@@ -418,6 +436,7 @@ export class TerminalHostClient extends EventEmitter {
 				try {
 					await this.authenticateControl({ token });
 				} catch (error) {
+					this.assertRuntimeAllowed();
 					if (attempt === 0 && this.isProtocolMismatchError(error)) {
 						if (DEBUG_CLIENT) {
 							console.log(
@@ -442,8 +461,10 @@ export class TerminalHostClient extends EventEmitter {
 				}
 			}
 
+			this.assertRuntimeAllowed();
 			if (!this.streamSocket) {
 				const streamConnected = await this.tryConnectStream();
+				this.assertRuntimeAllowed();
 				if (!streamConnected) {
 					throw new Error("Failed to connect stream socket");
 				}
@@ -1158,10 +1179,12 @@ export class TerminalHostClient extends EventEmitter {
 	 * Spawn the daemon process if not running
 	 */
 	private async spawnDaemon(): Promise<void> {
+		this.assertRuntimeAllowed();
 		// Check if socket is live first - this is the authoritative check
 		// PID file can be stale if daemon crashed and PID was reused by another process
 		if (existsSync(SOCKET_PATH)) {
 			const isLive = await this.isSocketLive();
+			this.assertRuntimeAllowed();
 			if (isLive) {
 				if (DEBUG_CLIENT) {
 					console.log("[TerminalHostClient] Socket is live, daemon is running");
@@ -1187,6 +1210,7 @@ export class TerminalHostClient extends EventEmitter {
 				console.log("[TerminalHostClient] Killing daemon from stale PID file");
 			}
 			await this.killDaemonFromPidFile();
+			this.assertRuntimeAllowed();
 			if (DEBUG_CLIENT) {
 				console.log("[TerminalHostClient] Removing stale PID file");
 			}
@@ -1206,6 +1230,7 @@ export class TerminalHostClient extends EventEmitter {
 			}
 			// Wait for the other spawn to complete
 			await this.waitForDaemon();
+			this.assertRuntimeAllowed();
 			return;
 		}
 
@@ -1262,6 +1287,7 @@ export class TerminalHostClient extends EventEmitter {
 			const isDev = !app.isPackaged;
 			let child: ReturnType<typeof spawn> | null = null;
 			try {
+				this.assertRuntimeAllowed();
 				child = spawn(process.execPath, [daemonScript], {
 					detached: !isDev,
 					stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
@@ -1298,6 +1324,10 @@ export class TerminalHostClient extends EventEmitter {
 				console.log("[TerminalHostClient] Waiting for daemon to start...");
 			}
 			await this.waitForDaemon();
+			// Retirement may have begun during spawn. Reject this connection;
+			// the retirement coordinator owns shutdown after checking sessions.
+			// A daemon is shared with other app instances, so never kill it here.
+			this.assertRuntimeAllowed();
 
 			// In development mode, save the script mtime to detect rebuilds
 			if (process.env.NODE_ENV === "development") {
@@ -1461,6 +1491,7 @@ export class TerminalHostClient extends EventEmitter {
 		throwIfAborted(signal);
 		await this.ensureConnected();
 		throwIfAborted(signal);
+		this.assertRuntimeAllowed();
 		if (
 			request.requestId &&
 			this.canceledCreateOrAttachKeys.delete(

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.test.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.test.ts
@@ -240,6 +240,14 @@ mock.module("./history-manager", () => ({
 const { DaemonTerminalManager } = await import("./daemon-manager");
 
 describe("DaemonTerminalManager kill tracking", () => {
+	it("reports a failed startup inventory as retryable instead of successful reconciliation", async () => {
+		const manager = new DaemonTerminalManager();
+		mockClient.listSessionsIfRunningError = new Error("probe failed");
+		expect(await manager.reconcileOnStartup()).toBe(false);
+		mockClient.listSessionsIfRunningError = null;
+		mockClient.listSessionsIfRunningResult = { sessions: [] };
+		expect(await manager.reconcileOnStartup()).toBe(true);
+	});
 	beforeEach(() => {
 		mockClient = new MockTerminalHostClient();
 	});

--- a/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
+++ b/apps/desktop/src/main/lib/terminal/daemon/daemon-manager.ts
@@ -92,13 +92,13 @@ export class DaemonTerminalManager extends EventEmitter {
 		return response ?? { sessions: [] };
 	}
 
-	async reconcileOnStartup(): Promise<void> {
+	async reconcileOnStartup(): Promise<boolean> {
 		try {
 			const response = await this.listExistingDaemonSessions();
 			if (response.sessions.length === 0) {
 				this.daemonAliveSessionIds.clear();
 				this.daemonSessionIdsHydrated = true;
-				return;
+				return true;
 			}
 
 			console.log(
@@ -151,11 +151,13 @@ export class DaemonTerminalManager extends EventEmitter {
 					`[DaemonTerminalManager] Preserving ${preservedCount} sessions for reattach`,
 				);
 			}
+			return true;
 		} catch (error) {
 			console.warn(
 				"[DaemonTerminalManager] Failed to reconcile sessions:",
 				error,
 			);
+			return false;
 		}
 	}
 

--- a/apps/desktop/src/main/lib/terminal/index.test.ts
+++ b/apps/desktop/src/main/lib/terminal/index.test.ts
@@ -15,6 +15,7 @@ let listSessionsIfRunningError: Error | null = null;
 let shutdownIfRunningError: Error | null = null;
 let shutdownIfRunningCalls = 0;
 let resetCalls = 0;
+let reconcileResult = true;
 
 function makeSession(
 	overrides: Partial<ListSessionsResponse["sessions"][number]> = {},
@@ -56,13 +57,15 @@ mock.module("./daemon", () => ({
 		reset: () => {
 			resetCalls++;
 		},
-		reconcileOnStartup: async () => {},
+		reconcileOnStartup: async () => reconcileResult,
 	}),
 }));
 
-const { restartDaemon, tryListExistingDaemonSessions } = await import(
-	"./index"
-);
+const {
+	reconcileDaemonSessions,
+	restartDaemon,
+	tryListExistingDaemonSessions,
+} = await import("./index");
 
 describe("terminal index", () => {
 	beforeAll(() => {
@@ -80,6 +83,14 @@ describe("terminal index", () => {
 		shutdownIfRunningError = null;
 		shutdownIfRunningCalls = 0;
 		resetCalls = 0;
+		reconcileResult = true;
+	});
+
+	it("propagates unsuccessful reconciliation so the lifecycle can retry", async () => {
+		reconcileResult = false;
+		expect(await reconcileDaemonSessions()).toBe(false);
+		reconcileResult = true;
+		expect(await reconcileDaemonSessions()).toBe(true);
 	});
 
 	it("resets the daemon manager when no daemon is running", async () => {

--- a/apps/desktop/src/main/lib/terminal/index.ts
+++ b/apps/desktop/src/main/lib/terminal/index.ts
@@ -20,15 +20,16 @@ let prewarmInFlight: Promise<void> | null = null;
  * Cleans up stale sessions from previous app runs and preserves sessions
  * that can be retained.
  */
-export async function reconcileDaemonSessions(): Promise<void> {
+export async function reconcileDaemonSessions(): Promise<boolean> {
 	try {
 		const manager = getDaemonTerminalManager();
-		await manager.reconcileOnStartup();
+		return await manager.reconcileOnStartup();
 	} catch (error) {
 		console.warn(
 			"[TerminalManager] Failed to reconcile daemon sessions:",
 			error,
 		);
+		return false;
 	}
 }
 

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/README.md
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/README.md
@@ -1,0 +1,28 @@
+# Temporary v1 runtime lifecycle
+
+`index.ts` owns v1 startup reconciliation and retirement. Its public surface is
+`report(windowId, report)` and `forget(windowId)`; the migration router forwards
+renderer reports, and platform windows invalidate them on navigation or close.
+`controller.ts` handles window eligibility and concurrent retirement attempts;
+`retire.ts` probes and shuts down the legacy daemon through injected operations.
+
+The terminal client imports only `access.ts` to avoid a dependency cycle with the
+lifecycle. `isV1RuntimeBlocked()` means every window has a locked migration, even
+if an attached session or a failed probe has deferred actual cleanup. Keep that
+distinction: blocking new connections must not wait for shutdown to succeed.
+
+## When v1 is removed
+
+- Delete this directory and the renderer's `V1RuntimeLifecycle` component and
+  authenticated-layout mount.
+- Remove `migration.reportV1Runtime`, the platform-window `forget` calls, and
+  the terminal client's access guard along with the legacy terminal runtime.
+- Remove the v1 filesystem service and git worker runner with their callers.
+  Their disposal functions remain owned by those resources until then.
+- Remove the retirement-only `markV1TerminalRetiring` handling when removing
+  v1 agent hook tracking. Keep migration ledgers and resume data for as long as
+  upgrades from v1 are supported.
+
+The host-service root policy and workspace-fs search cap protect v2 as well.
+They must survive removal of this desktop lifecycle. Any persisted renderer
+keys whose writers disappear belong in `DEAD_KEYS` per `apps/desktop/AGENTS.md`.

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/access.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/access.ts
@@ -1,0 +1,13 @@
+// Installed by the migration lifecycle; kept separate from runtime ownership
+// so the terminal client does not import the coordinator's dependencies.
+// Eligibility blocks new connections even when an attached legacy session
+// temporarily prevents shutdown. It does not mean cleanup has completed.
+let isBlocked = () => false;
+
+export function setV1RuntimeBlockedCheck(check: () => boolean): void {
+	isBlocked = check;
+}
+
+export function isV1RuntimeBlocked(): boolean {
+	return isBlocked();
+}

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/controller.test.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/controller.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+import type { ListSessionsResponse } from "../terminal-host/types";
+import { V1RuntimeRetirementController } from "./controller";
+import { retireV1Runtime } from "./retire";
+
+const migrated = {
+	organizationId: "org",
+	migratedAtBoot: true,
+	v2Enabled: true,
+};
+
+function fixture() {
+	let windows: Array<{ id: number; organizationId: string | null }> = [
+		{ id: 1, organizationId: "org" },
+	];
+	let inventory: ListSessionsResponse | null = { sessions: [] };
+	let migratedWorkspaces = new Set(["workspace"]);
+	let shutdowns = 0;
+	let cleanups = 0;
+	let probes = 0;
+	let probeError = false;
+	let shutdownError = false;
+	let afterProbe = () => {};
+	const controller = new V1RuntimeRetirementController(
+		() => windows,
+		(eligible) =>
+			retireV1Runtime(
+				{
+					listSessions: async () => {
+						probes++;
+						if (probeError) throw new Error("daemon unreachable");
+						afterProbe();
+						return inventory;
+					},
+					isWorkspaceMigrated: (id) => migratedWorkspaces.has(id),
+					shutdown: async () => {
+						if (shutdownError) throw new Error("shutdown failed");
+						shutdowns++;
+					},
+					cleanup: async () => {
+						cleanups++;
+					},
+				},
+				eligible,
+			),
+	);
+	return {
+		controller,
+		setWindows: (value: typeof windows) => {
+			windows = value;
+		},
+		setInventory: (value: typeof inventory) => {
+			inventory = value;
+		},
+		setMigrated: (value: string[]) => {
+			migratedWorkspaces = new Set(value);
+		},
+		setProbeError: (value: boolean) => {
+			probeError = value;
+		},
+		setShutdownError: (value: boolean) => {
+			shutdownError = value;
+		},
+		afterProbe: (value: () => void) => {
+			afterProbe = value;
+		},
+		counts: () => ({ probes, shutdowns, cleanups }),
+	};
+}
+
+function session(
+	overrides: Partial<ListSessionsResponse["sessions"][number]> = {},
+) {
+	return {
+		sessionId: "session",
+		paneId: "pane",
+		workspaceId: "workspace",
+		isAlive: true,
+		attachedClients: 0,
+		pid: 123,
+		...overrides,
+	};
+}
+
+describe("v1 runtime retirement", () => {
+	test.each([
+		["v1", { ...migrated, migratedAtBoot: false, v2Enabled: false }],
+		["reversible v2 opt-in", { ...migrated, migratedAtBoot: false }],
+		[
+			"forced v2 without completed migration",
+			{ ...migrated, migratedAtBoot: false },
+		],
+		["completion during live v1 session", { ...migrated, v2Enabled: false }],
+	])("preserves %s without probing or killing", async (_name, report) => {
+		const f = fixture();
+		expect(await f.controller.report(1, report)).toBe(false);
+		expect(f.counts()).toEqual({ probes: 0, shutdowns: 0, cleanups: 0 });
+	});
+
+	test("kills detached migrated jobs and retires once across duplicate reports", async () => {
+		const f = fixture();
+		f.setInventory({ sessions: [session()] });
+		expect(
+			await Promise.all([
+				f.controller.report(1, migrated),
+				f.controller.report(1, migrated),
+			]),
+		).toEqual([true, true]);
+		expect(await f.controller.report(1, migrated)).toBe(true);
+		expect(f.counts()).toEqual({ probes: 1, shutdowns: 1, cleanups: 1 });
+	});
+
+	test("does not spawn a missing daemon; still clears local resources", async () => {
+		const f = fixture();
+		f.setInventory(null);
+		expect(await f.controller.report(1, migrated)).toBe(true);
+		expect(f.counts()).toEqual({ probes: 1, shutdowns: 0, cleanups: 1 });
+	});
+
+	test("unknown window vetoes until both report a completed locked migration", async () => {
+		const f = fixture();
+		f.setWindows([
+			{ id: 1, organizationId: "org" },
+			{ id: 2, organizationId: "org" },
+		]);
+		expect(await f.controller.report(1, migrated)).toBe(false);
+		expect(f.counts().probes).toBe(0);
+		expect(
+			await f.controller.report(2, { ...migrated, migratedAtBoot: false }),
+		).toBe(false);
+		expect(await f.controller.report(2, migrated)).toBe(true);
+	});
+
+	test("scopes cleanup to every eligible organization, without duplicates", async () => {
+		const scopes: string[][] = [];
+		const controller = new V1RuntimeRetirementController(
+			() => [
+				{ id: 1, organizationId: "org" },
+				{ id: 2, organizationId: "other" },
+				{ id: 3, organizationId: "org" },
+			],
+			async (_eligible, organizationIds) => {
+				scopes.push(organizationIds);
+				return true;
+			},
+		);
+		expect(await controller.report(1, migrated)).toBe(false);
+		expect(await controller.report(3, migrated)).toBe(false);
+		expect(scopes).toEqual([]);
+		expect(
+			await controller.report(2, { ...migrated, organizationId: "other" }),
+		).toBe(true);
+		expect(scopes).toEqual([["org", "other"]]);
+	});
+
+	test("rejects an unregistered sender and a report from the previous organization", async () => {
+		const f = fixture();
+		expect(await f.controller.report(99, migrated)).toBe(false);
+		expect(
+			await f.controller.report(1, { ...migrated, organizationId: "other" }),
+		).toBe(false);
+		expect(f.counts().probes).toBe(0);
+	});
+
+	test("organization switch and renderer reload invalidate eligibility", async () => {
+		const f = fixture();
+		expect(await f.controller.report(1, migrated)).toBe(true);
+		f.setWindows([{ id: 1, organizationId: "other" }]);
+		expect(f.controller.isEligible()).toBe(false);
+		expect(
+			await f.controller.report(1, {
+				...migrated,
+				organizationId: "other",
+				migratedAtBoot: false,
+			}),
+		).toBe(false);
+		f.controller.forget(1);
+		expect(f.controller.isEligible()).toBe(false);
+	});
+
+	test("a new locked window after retirement triggers a fresh cleanup", async () => {
+		const f = fixture();
+		expect(await f.controller.report(1, migrated)).toBe(true);
+		f.setWindows([
+			{ id: 1, organizationId: "org" },
+			{ id: 2, organizationId: "org" },
+		]);
+		expect(await f.controller.report(2, migrated)).toBe(true);
+		expect(f.counts().shutdowns).toBe(2);
+		f.controller.forget(2);
+		expect(await f.controller.report(2, migrated)).toBe(true);
+		expect(f.counts().shutdowns).toBe(3);
+	});
+
+	test("a v1 window opening during the async probe cancels retirement", async () => {
+		const f = fixture();
+		f.afterProbe(() =>
+			f.setWindows([
+				{ id: 1, organizationId: "org" },
+				{ id: 2, organizationId: "other" },
+			]),
+		);
+		expect(await f.controller.report(1, migrated)).toBe(false);
+		expect(f.counts()).toEqual({ probes: 1, shutdowns: 0, cleanups: 0 });
+	});
+
+	test("closing the vetoing window allows the next report to retire", async () => {
+		const f = fixture();
+		f.setWindows([
+			{ id: 1, organizationId: "org" },
+			{ id: 2, organizationId: "org" },
+		]);
+		expect(await f.controller.report(1, migrated)).toBe(false);
+		f.setWindows([{ id: 1, organizationId: "org" }]);
+		expect(await f.controller.report(1, migrated)).toBe(true);
+	});
+
+	test("no live windows is not permission to retire", () => {
+		const f = fixture();
+		f.setWindows([]);
+		expect(f.controller.isEligible()).toBe(false);
+	});
+
+	test("live sessions without successful migration are preserved", async () => {
+		const f = fixture();
+		f.setInventory({
+			sessions: [session(), session({ workspaceId: "unmigrated" })],
+		});
+		expect(await f.controller.report(1, migrated)).toBe(false);
+		expect(f.counts().shutdowns).toBe(0);
+		f.setMigrated(["workspace", "unmigrated"]);
+		expect(await f.controller.report(1, migrated)).toBe(true);
+	});
+
+	test("an attached v1 session vetoes cleanup, including from another app instance", async () => {
+		const f = fixture();
+		f.setInventory({ sessions: [session({ attachedClients: 1 })] });
+		expect(await f.controller.report(1, migrated)).toBe(false);
+		expect(f.counts().shutdowns).toBe(0);
+		f.setInventory({ sessions: [session()] });
+		expect(await f.controller.report(1, migrated)).toBe(true);
+	});
+
+	test("failed inventory is not absence; retry succeeds", async () => {
+		const f = fixture();
+		f.setProbeError(true);
+		await expect(f.controller.report(1, migrated)).rejects.toThrow(
+			"daemon unreachable",
+		);
+		expect(f.counts().shutdowns).toBe(0);
+		f.setProbeError(false);
+		expect(await f.controller.report(1, migrated)).toBe(true);
+	});
+
+	test("failed shutdown does not mark resources retired", async () => {
+		const f = fixture();
+		f.setShutdownError(true);
+		await expect(f.controller.report(1, migrated)).rejects.toThrow(
+			"shutdown failed",
+		);
+		expect(f.counts().cleanups).toBe(0);
+		f.setShutdownError(false);
+		expect(await f.controller.report(1, migrated)).toBe(true);
+	});
+});

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/controller.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/controller.ts
@@ -1,0 +1,100 @@
+export interface V1RuntimeReport {
+	organizationId: string;
+	/** The persisted migration marker was present when this renderer booted. */
+	migratedAtBoot: boolean;
+	v2Enabled: boolean;
+}
+
+interface RuntimeWindow {
+	id: number;
+	organizationId: string | null;
+}
+
+/**
+ * The v1 daemon is shared. Unknown windows and reversible v2 opt-ins must
+ * veto retirement. Reports are scoped to both window and organization so
+ * switching orgs cannot reuse the previous org's migration permission.
+ */
+export class V1RuntimeRetirementController {
+	private reports = new Map<number, V1RuntimeReport>();
+	private pending: Promise<boolean> | null = null;
+	private retired = false;
+
+	constructor(
+		private readonly windows: () => RuntimeWindow[],
+		private readonly retire: (
+			stillEligible: () => boolean,
+			organizationIds: string[],
+		) => Promise<boolean>,
+	) {}
+
+	forget(windowId: number): void {
+		this.reports.delete(windowId);
+		this.retired = false;
+	}
+
+	report(windowId: number, report: V1RuntimeReport): Promise<boolean> {
+		// A new window, reload or org switch may have used v1 since the last
+		// successful cleanup. Its eventual locked report needs a fresh probe.
+		if (!this.isEligible()) this.retired = false;
+		const windows = this.windows();
+		for (const id of this.reports.keys()) {
+			if (!windows.some((window) => window.id === id)) this.reports.delete(id);
+		}
+		const window = windows.find((candidate) => candidate.id === windowId);
+		if (!window || window.organizationId !== report.organizationId) {
+			this.forget(windowId);
+			return Promise.resolve(false);
+		}
+		this.reports.set(windowId, report);
+		if (!this.isEligible()) {
+			this.retired = false;
+			return Promise.resolve(false);
+		}
+		if (this.retired) return Promise.resolve(true);
+		if (this.pending) return this.pending;
+		const windowSet = this.windowSet();
+		this.pending = this.retire(
+			() => this.isEligible() && this.windowSet() === windowSet,
+			// Eligibility guarantees an organization for each window. Pass this
+			// attempt's scope to cleanup instead of having it query the controller.
+			[
+				...new Set(
+					windows.flatMap((window) =>
+						window.organizationId ? [window.organizationId] : [],
+					),
+				),
+			],
+		)
+			.then((retired) => {
+				this.retired =
+					retired && this.isEligible() && this.windowSet() === windowSet;
+				return this.retired;
+			})
+			.finally(() => {
+				this.pending = null;
+			});
+		return this.pending;
+	}
+
+	private windowSet(): string {
+		return JSON.stringify(
+			this.windows().map(({ id, organizationId }) => [id, organizationId]),
+		);
+	}
+
+	isEligible(): boolean {
+		const windows = this.windows();
+		return (
+			windows.length > 0 &&
+			windows.every((window) => {
+				const report = this.reports.get(window.id);
+				return (
+					report?.organizationId === window.organizationId &&
+					report?.migratedAtBoot === true &&
+					report.v2Enabled
+				);
+			})
+		);
+	}
+}

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/index.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/index.ts
@@ -1,0 +1,104 @@
+import { v1MigrationState } from "@superset/local-db";
+import { eq } from "drizzle-orm";
+import { disposeGitTaskRunner } from "lib/trpc/routers/changes/workers/git-task-runner";
+import { disposeWorkspaceFilesystem } from "lib/trpc/routers/workspace-fs-service";
+import { localDb } from "../local-db";
+import { markV1TerminalRetiring } from "../notifications/v1-agent-sessions";
+import { prewarmTerminalRuntime, reconcileDaemonSessions } from "../terminal";
+import { getDaemonTerminalManager } from "../terminal/daemon";
+import { portManager } from "../terminal/port-manager";
+import { getTerminalHostClient } from "../terminal-host/client";
+import { getAllWindows, getOrg } from "../window-registry/window-registry";
+import { setV1RuntimeBlockedCheck } from "./access";
+import {
+	type V1RuntimeReport,
+	V1RuntimeRetirementController,
+} from "./controller";
+import { retireV1Runtime } from "./retire";
+import { V1RuntimeStartup } from "./startup";
+
+const startup = new V1RuntimeStartup({
+	reconcile: reconcileDaemonSessions,
+	prewarm: prewarmTerminalRuntime,
+});
+
+const controller = new V1RuntimeRetirementController(
+	() =>
+		getAllWindows().map((window) => ({
+			id: window.id,
+			organizationId: getOrg(window.id),
+		})),
+	async (stillEligible, organizationIds) => {
+		const migratedByOrg = organizationIds.map(
+			(organizationId) =>
+				new Set(
+					localDb
+						.select()
+						.from(v1MigrationState)
+						.where(eq(v1MigrationState.organizationId, organizationId))
+						.all()
+						.filter(
+							(entry) =>
+								entry.kind === "workspace" &&
+								(entry.status === "success" || entry.status === "linked") &&
+								entry.v2Id,
+						)
+						.map((entry) => entry.v1Id),
+				),
+		);
+		const client = getTerminalHostClient();
+		const retired = await retireV1Runtime(
+			{
+				listSessions: () => client.listSessionsIfRunning(),
+				isWorkspaceMigrated: (workspaceId) =>
+					migratedByOrg.length > 0 &&
+					migratedByOrg.every((ids) => ids.has(workspaceId)),
+				shutdown: () => client.shutdownIfRunning({ killSessions: true }),
+				beforeShutdown: (sessions) => {
+					for (const session of sessions) {
+						if (session.isAlive) markV1TerminalRetiring(session.paneId);
+					}
+				},
+				cleanup: async (sessions) => {
+					startup.reset();
+					for (const session of sessions)
+						portManager.unregisterSession(session.paneId);
+					portManager.stopPeriodicScan();
+					// reset aborts pending attaches, closes history writers and clears
+					// session caches without deleting histories or project rows.
+					getDaemonTerminalManager().reset();
+					await Promise.all([
+						disposeWorkspaceFilesystem(),
+						disposeGitTaskRunner(),
+					]);
+				},
+			},
+			stillEligible,
+		);
+		if (retired)
+			console.log("[v1-migration] retired v1 runtime after locked migration");
+		return retired;
+	},
+);
+
+setV1RuntimeBlockedCheck(() => controller.isEligible());
+
+/** Temporary v1 integration boundary; see README.md for its removal path. */
+export const v1RuntimeRetirement = {
+	async report(windowId: number, report: V1RuntimeReport): Promise<boolean> {
+		if (getOrg(windowId) !== report.organizationId) return false;
+		const retired = await controller.report(windowId, report);
+		if (!report.migratedAtBoot) {
+			await startup.start(
+				!report.v2Enabled,
+				() =>
+					getOrg(windowId) === report.organizationId &&
+					!controller.isEligible(),
+			);
+		}
+		return retired;
+	},
+	forget(windowId: number): void {
+		controller.forget(windowId);
+	},
+};

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/retire.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/retire.ts
@@ -1,0 +1,38 @@
+import type { ListSessionsResponse } from "../terminal-host/types";
+
+export interface RetirementDependencies {
+	listSessions(): Promise<ListSessionsResponse | null>;
+	isWorkspaceMigrated(workspaceId: string): boolean;
+	beforeShutdown?(sessions: ListSessionsResponse["sessions"]): void;
+	shutdown(): Promise<unknown>;
+	cleanup(sessions: ListSessionsResponse["sessions"]): Promise<void>;
+}
+
+/**
+ * Probe only: cleanup must never spawn the daemon it is trying to remove.
+ * Existing sessions need a successful workspace ledger entry. An attached
+ * session may belong to another app instance still on v1; leave it alone.
+ */
+export async function retireV1Runtime(
+	dependencies: RetirementDependencies,
+	stillEligible: () => boolean,
+): Promise<boolean> {
+	if (!stillEligible()) return false;
+	const inventory = await dependencies.listSessions();
+	if (!stillEligible()) return false;
+	if (
+		inventory?.sessions.some(
+			(session) =>
+				session.attachedClients > 0 ||
+				(session.isAlive &&
+					!dependencies.isWorkspaceMigrated(session.workspaceId)),
+		)
+	)
+		return false;
+	if (inventory) {
+		dependencies.beforeShutdown?.(inventory.sessions);
+		await dependencies.shutdown();
+	}
+	await dependencies.cleanup(inventory?.sessions ?? []);
+	return true;
+}

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/startup.test.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/startup.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { V1RuntimeStartup } from "./startup";
+
+describe("v1 runtime startup", () => {
+	test("a reversible v2 report cannot consume a later v1 window's warmup", async () => {
+		let reconciles = 0;
+		let warmups = 0;
+		const startup = new V1RuntimeStartup({
+			reconcile: async () => {
+				reconciles++;
+				return true;
+			},
+			prewarm: () => {
+				warmups++;
+			},
+		});
+		await startup.start(false, () => true);
+		expect(warmups).toBe(0);
+		await Promise.all([
+			startup.start(true, () => true),
+			startup.start(true, () => true),
+		]);
+		expect({ reconciles, warmups }).toEqual({ reconciles: 1, warmups: 1 });
+	});
+
+	test.each([
+		false,
+		true,
+	])("retries unsuccessful reconciliation (throws: %s)", async (throws) => {
+		let reconciles = 0;
+		let warmups = 0;
+		const startup = new V1RuntimeStartup({
+			reconcile: async () => {
+				if (++reconciles === 1) {
+					if (throws) throw new Error("offline");
+					return false;
+				}
+				return true;
+			},
+			prewarm: () => {
+				warmups++;
+			},
+		});
+		if (throws)
+			await expect(startup.start(true, () => true)).rejects.toThrow("offline");
+		else await startup.start(true, () => true);
+		expect(warmups).toBe(0);
+		await startup.start(true, () => true);
+		expect({ reconciles, warmups }).toEqual({ reconciles: 2, warmups: 1 });
+	});
+
+	test("shares an in-flight probe and skips warmup when the window becomes locked", async () => {
+		const probe = Promise.withResolvers<boolean>();
+		let reconciles = 0;
+		let warmups = 0;
+		let allowed = true;
+		const startup = new V1RuntimeStartup({
+			reconcile: () => {
+				reconciles++;
+				return probe.promise;
+			},
+			prewarm: () => {
+				warmups++;
+			},
+		});
+		const pending = [
+			startup.start(true, () => allowed),
+			startup.start(true, () => allowed),
+		];
+		allowed = false;
+		probe.resolve(true);
+		await Promise.all(pending);
+		expect({ reconciles, warmups }).toEqual({ reconciles: 1, warmups: 0 });
+		await startup.start(true, () => false);
+		expect(reconciles).toBe(1);
+	});
+
+	test("retirement resets startup and invalidates an old pending warmup", async () => {
+		const probe = Promise.withResolvers<boolean>();
+		let reconciles = 0;
+		let warmups = 0;
+		const startup = new V1RuntimeStartup({
+			reconcile: () =>
+				++reconciles === 1 ? probe.promise : Promise.resolve(true),
+			prewarm: () => {
+				warmups++;
+			},
+		});
+		const old = startup.start(true, () => true);
+		startup.reset();
+		probe.resolve(true);
+		await old;
+		expect(warmups).toBe(0);
+		await startup.start(true, () => true);
+		expect({ reconciles, warmups }).toEqual({ reconciles: 2, warmups: 1 });
+	});
+});

--- a/apps/desktop/src/main/lib/v1-runtime-retirement/startup.ts
+++ b/apps/desktop/src/main/lib/v1-runtime-retirement/startup.ts
@@ -1,0 +1,43 @@
+interface StartupDependencies {
+	reconcile(): Promise<boolean>;
+	prewarm(): void;
+}
+
+/** Share reconciliation across windows while keeping v1 warmup independent. */
+export class V1RuntimeStartup {
+	private reconciliation: Promise<boolean> | null = null;
+	private prewarmed = false;
+
+	constructor(private readonly dependencies: StartupDependencies) {}
+
+	async start(prewarm: boolean, stillAllowed: () => boolean): Promise<void> {
+		if (!stillAllowed()) return;
+		if (!this.reconciliation) {
+			const attempt = this.dependencies.reconcile();
+			this.reconciliation = attempt;
+			// Only successful work consumes the latch. Identity checks preserve
+			// a newer attempt if retirement reset this one while it was running.
+			void attempt.then(
+				(success) => {
+					if (!success && this.reconciliation === attempt)
+						this.reconciliation = null;
+				},
+				() => {
+					if (this.reconciliation === attempt) this.reconciliation = null;
+				},
+			);
+		}
+		const attempt = this.reconciliation;
+		const success = await attempt;
+		if (!success || this.reconciliation !== attempt || !stillAllowed()) return;
+		if (prewarm && !this.prewarmed) {
+			this.dependencies.prewarm();
+			this.prewarmed = true;
+		}
+	}
+
+	reset(): void {
+		this.reconciliation = null;
+		this.prewarmed = false;
+	}
+}

--- a/apps/desktop/src/main/windows/main.ts
+++ b/apps/desktop/src/main/windows/main.ts
@@ -40,6 +40,7 @@ import {
 	getWorkspaceName,
 } from "../lib/notifications/utils";
 import { recordV1TerminalExit } from "../lib/notifications/v1-agent-sessions";
+import { v1RuntimeRetirement } from "../lib/v1-runtime-retirement";
 import {
 	getAllWindows,
 	getFocusedOrLastWindow,
@@ -422,6 +423,12 @@ export async function createPlatformWindow({
 	});
 
 	registerWindow({ window, orgId, key: key ?? randomUUID() });
+	window.webContents.on(
+		"did-start-navigation",
+		(_event, _url, isInPlace, isMainFrame) => {
+			if (isMainFrame && !isInPlace) v1RuntimeRetirement.forget(window.id);
+		},
+	);
 	window.on("focus", () => markFocused(window.id));
 
 	attachEditContextMenu(window.webContents);
@@ -594,6 +601,7 @@ export async function createPlatformWindow({
 
 		ipcHandler?.detachWindow(window);
 		unregisterWindow(window.id);
+		v1RuntimeRetirement.forget(window.id);
 
 		// A user closing one window (app keeps running) updates the restore set.
 		// During app quit we skip this — before-quit snapshots the full set so

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.test.tsx
@@ -109,6 +109,18 @@ describe("useIsV1FlipLocked", () => {
 		expect(readProbe("org-optin", true)).toEqual({ locked: false, v2: true });
 	});
 
+	test("completion during a live v1 session does not grant retirement permission", () => {
+		expect(readProbe("org-completes-mid-session", false)).toEqual({
+			locked: false,
+			v2: false,
+		});
+		markV1MigrationComplete("org-completes-mid-session");
+		expect(readProbe("org-completes-mid-session", false)).toEqual({
+			locked: false,
+			v2: false,
+		});
+	});
+
 	test("forced-flip backstop locks the flip without a marker", () => {
 		forcedFlipActive = true;
 		try {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
@@ -37,7 +37,10 @@ const createMock = mock(async () => ({
 const finalizeSetupMock = mock(() => undefined);
 const requestGitInitMock = mock(async () => false);
 
+// Module mocks are process-wide; preserve React exports used by later suites.
+const actualReact = { ...(await import("react")) };
 mock.module("react", () => ({
+	...actualReact,
 	useCallback: <T extends (...args: never[]) => unknown>(callback: T) =>
 		callback,
 }));

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1RuntimeLifecycle/V1RuntimeLifecycle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1RuntimeLifecycle/V1RuntimeLifecycle.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId";
+import {
+	useIsV1FlipLocked,
+	useIsV2CloudEnabled,
+} from "renderer/hooks/useIsV2CloudEnabled";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
+import { isV1MigrationCompleteAtBoot } from "renderer/lib/v1-migration/completion";
+
+/** Tell main when the next-launch migration lock has actually taken effect. */
+export function V1RuntimeLifecycle() {
+	const organizationId = useActiveOrganizationId();
+	const flipLocked = useIsV1FlipLocked();
+	const v2Enabled = useIsV2CloudEnabled();
+	const migratedAtBoot =
+		flipLocked && isV1MigrationCompleteAtBoot(organizationId);
+
+	useEffect(() => {
+		if (!organizationId) return;
+		let stopped = false;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		const report = async () => {
+			try {
+				await electronTrpcClient.migration.reportV1Runtime.mutate({
+					organizationId,
+					migratedAtBoot,
+					v2Enabled,
+				});
+			} catch (error) {
+				console.warn("[v1-migration] runtime retirement will retry", error);
+			}
+			// Keep observing after success: another window can temporarily use v1
+			// and close again. Main skips probes while retirement remains valid.
+			// Also retries failed probes and multi-window vetoes.
+			if (!stopped) timeout = setTimeout(report, 10_000);
+		};
+		void report();
+		return () => {
+			stopped = true;
+			clearTimeout(timeout);
+		};
+	}, [organizationId, migratedAtBoot, v2Enabled]);
+	return null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1RuntimeLifecycle/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1RuntimeLifecycle/index.ts
@@ -1,0 +1,1 @@
+export { V1RuntimeLifecycle } from "./V1RuntimeLifecycle";

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -41,6 +41,7 @@ import {
 	V2FlipWelcome,
 } from "renderer/routes/_authenticated/components/V1FlipNotice";
 import { V1ImportModal } from "renderer/routes/_authenticated/components/V1ImportModal";
+import { V1RuntimeLifecycle } from "renderer/routes/_authenticated/components/V1RuntimeLifecycle";
 import { useZoomHotkeys } from "renderer/routes/_authenticated/hooks/useZoomHotkeys";
 import { WorkspaceInitEffects } from "renderer/screens/main/components/WorkspaceInitEffects";
 import { useSettingsStore } from "renderer/stores/settings-state";
@@ -320,6 +321,7 @@ function AuthenticatedLayout() {
 									<V1FlipNotice />
 								)}
 								<V1AutoMigration />
+								<V1RuntimeLifecycle />
 								<WorkspaceInitEffects />
 								{isV2CloudEnabled ? (
 									<DashboardNewWorkspaceModal />

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.test.ts
@@ -19,7 +19,10 @@ const readFileUseQuery = mock(
 );
 const emptyUseQuery = mock(() => ({ data: undefined, isLoading: false }));
 
+// Module mocks are process-wide; preserve React exports used by later suites.
+const actualReact = { ...(await import("react")) };
 mock.module("react", () => ({
+	...actualReact,
 	useMemo: <T>(factory: () => T) => factory(),
 }));
 


### PR DESCRIPTION
After a locked v2 migration, desktop startup can still launch legacy terminal and filesystem services. This change retires those v1 resources once every renderer has reported a locked migration, blocks new v1 connections while retired, and restores startup for reversible v1/v2 switches.

The lifecycle owner handles concurrent reports, window teardown, retryable reconciliation/prewarm failures, and retirement races across terminal connection awaits. Its README identifies the deletion boundary when v1 support is removed.

Extracted from #7247 so Home workspace performance can ship independently. Runtime implementation and tests are preserved from that PR's `88d96951af` state; the combined branch previously passed 3,581 desktop tests and desktop typechecking. This standalone draft has not had a separate full app verification run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires v1 terminal and filesystem runtimes once every window reports a locked v2 migration, so startup no longer spawns legacy services after migration. Reversible v1/v2 switches keep the normal startup path.

**V1 runtime lifecycle**
- New `v1-runtime-retirement` main-process module plus renderer `V1RuntimeLifecycle` that reports migration state through `migration.reportV1Runtime`.
- Startup reconciliation and prewarm now wait for renderer reports, are shared across windows, and retry on failure.
- Retirement vetoes when a v1 session is attached, a workspace isn't migrated, a window is unknown, or a v2 opt-in is reversible.

**Shutdown and connection blocking**
- Terminal host client rejects new v1 connections at each connect, authenticate, and request step while retirement is in progress.
- Successful retirement shuts down the daemon, then disposes the workspace filesystem, git task runner, and terminal manager state.
- Retiring v1 agent sessions are marked so shutdown goodbyes can't erase migration resume data.

<sup>Written for commit cef634945cf026fcc4c6a28cff51eb24b6cadd9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

