### PR TITLE
fix(desktop): stop session+review from bumping the dock badge

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.test.ts
@@ -56,7 +56,7 @@ describe("countsTowardDockAttention", () => {
 		).toBe(false);
 	});
 
-	it("counts review when workspace type is unknown (fail closed)", () => {
+	it("counts review when the workspace type is not cached yet", () => {
 		expect(
 			countsTowardDockAttention({
 				status: "review",

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.test.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { countsTowardDockAttention } from "./countsTowardDockAttention";
+
+describe("countsTowardDockAttention", () => {
+	it("excludes session workspaces whose only attention signal is review", () => {
+		expect(
+			countsTowardDockAttention({
+				status: "review",
+				workspaceType: "session",
+			}),
+		).toBe(false);
+	});
+
+	it("still counts worktree and main workspaces in review", () => {
+		expect(
+			countsTowardDockAttention({
+				status: "review",
+				workspaceType: "worktree",
+			}),
+		).toBe(true);
+		expect(
+			countsTowardDockAttention({
+				status: "review",
+				workspaceType: "main",
+			}),
+		).toBe(true);
+	});
+
+	it("still counts session workspaces in permission or failed", () => {
+		expect(
+			countsTowardDockAttention({
+				status: "permission",
+				workspaceType: "session",
+			}),
+		).toBe(true);
+		expect(
+			countsTowardDockAttention({
+				status: "failed",
+				workspaceType: "session",
+			}),
+		).toBe(true);
+	});
+
+	it("does not count working or idle for any type", () => {
+		expect(
+			countsTowardDockAttention({
+				status: "working",
+				workspaceType: "worktree",
+			}),
+		).toBe(false);
+		expect(
+			countsTowardDockAttention({
+				status: "idle",
+				workspaceType: "session",
+			}),
+		).toBe(false);
+	});
+
+	it("counts review when workspace type is unknown (fail closed)", () => {
+		expect(
+			countsTowardDockAttention({
+				status: "review",
+				workspaceType: undefined,
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.ts
@@ -1,0 +1,28 @@
+import type { PaneStatus } from "shared/tabs-types";
+
+export type DockAttentionWorkspaceType = "main" | "worktree" | "session";
+
+/**
+ * Whether a derived terminal status should bump the OS dock badge for a
+ * workspace. Aligns with board `deriveBoardColumn` (#6506): a finished agent
+ * alone (`review`) is review-worthy on main/worktree, but session workspaces
+ * (automation/chat runs with no project checkout) land in Idle on the board —
+ * so they must not badge the dock either. permission/failed still page for
+ * every type (board → Needs attention).
+ */
+export function countsTowardDockAttention({
+	status,
+	workspaceType,
+}: {
+	status: PaneStatus | null | undefined;
+	workspaceType: DockAttentionWorkspaceType | undefined;
+}): boolean {
+	if (status === "permission" || status === "failed") return true;
+	if (status === "review") {
+		// Unknown type stays counted (fail closed on missing cache); only an
+		// explicit session is excluded, matching deriveBoardColumn's
+		// `type !== "session"` gate.
+		return workspaceType !== "session";
+	}
+	return false;
+}

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.ts
@@ -19,9 +19,12 @@ export function countsTowardDockAttention({
 }): boolean {
 	if (status === "permission" || status === "failed") return true;
 	if (status === "review") {
-		// Unknown type stays counted (fail closed on missing cache); only an
-		// explicit session is excluded, matching deriveBoardColumn's
-		// `type !== "session"` gate.
+		// Unknown type stays counted: a row missing from the cache is treated
+		// as a checkout, never silently dropped. Rows from the IndexedDB
+		// snapshot before the live host list lands sit in component state, not
+		// the query cache, so a session can badge briefly after boot then drop
+		// once the live list arrives. Only an explicit session is excluded,
+		// matching deriveBoardColumn's `type !== "session"` gate.
 		return workspaceType !== "session";
 	}
 	return false;

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
@@ -1,3 +1,4 @@
+export { countsTowardDockAttention } from "./countsTowardDockAttention";
 export {
 	useV2AttentionWorkspaceCount,
 	useV2PaneNotificationStatus,

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/index.ts
@@ -1,4 +1,3 @@
-export { countsTowardDockAttention } from "./countsTowardDockAttention";
 export {
 	useV2AttentionWorkspaceCount,
 	useV2PaneNotificationStatus,

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -18,8 +18,8 @@ import {
 	useTerminalAgentStatuses,
 } from "../useTerminalAgentStatuses";
 import {
-	type DockAttentionWorkspaceType,
 	countsTowardDockAttention,
+	type DockAttentionWorkspaceType,
 } from "./countsTowardDockAttention";
 
 const TERMINAL_PREFIX = "terminal:";
@@ -102,11 +102,11 @@ export function useV2AttentionWorkspaceCount(): number {
 	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
 	return useMemo(() => {
 		const workspaceTypeById = new Map<string, DockAttentionWorkspaceType>();
-		const hostWorkspaceEntries = queryClient.getQueriesData<
-			HostWorkspaceRow[]
-		>({
-			queryKey: ["host-service", "workspaces", "list"],
-		});
+		const hostWorkspaceEntries = queryClient.getQueriesData<HostWorkspaceRow[]>(
+			{
+				queryKey: ["host-service", "workspaces", "list"],
+			},
+		);
 		for (const [, rows] of hostWorkspaceEntries) {
 			for (const row of rows ?? []) {
 				workspaceTypeById.set(row.id, row.type);

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -92,7 +92,9 @@ export function useV2AttentionWorkspaceCount(): number {
 			const key0 = event.query.queryKey[0];
 			if (
 				key0 === "terminal-agent-bindings" ||
-				(key0 === "host-service" && event.query.queryKey[1] === "workspaces")
+				(key0 === "host-service" &&
+					event.query.queryKey[1] === "workspaces" &&
+					event.query.queryKey[2] === "list")
 			) {
 				setCacheVersion((version) => version + 1);
 			}

--- a/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/useV2NotificationStatus.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
+import type { HostWorkspaceRow } from "renderer/hooks/host-workspaces/useHostWorkspaces";
 import {
 	getV2NotificationSourceKey,
 	getV2NotificationSourcesForPane,
@@ -16,6 +17,10 @@ import {
 	deriveTerminalAgentStatus,
 	useTerminalAgentStatuses,
 } from "../useTerminalAgentStatuses";
+import {
+	type DockAttentionWorkspaceType,
+	countsTowardDockAttention,
+} from "./countsTowardDockAttention";
 
 const TERMINAL_PREFIX = "terminal:";
 
@@ -59,11 +64,14 @@ export function useV2PaneNotificationStatus(
 }
 
 /**
- * Number of distinct workspaces needing attention (any derived terminal
- * status other than `working`, or a manual unread mark). Drives the OS dock
- * badge. Aggregates over the bindings queries already mounted by the
- * sidebar's workspace status provider via the react-query cache; workspaces
- * with no observed bindings query contribute only their manual unread mark.
+ * Number of distinct workspaces needing attention (permission/failed, or
+ * review on a non-session workspace, or a manual unread mark). Drives the OS
+ * dock badge. Aggregates over the bindings queries already mounted by the
+ * sidebar's workspace status provider via the react-query cache; workspace
+ * types come from the host-workspaces list cache so session+review does not
+ * badge while the board (#6506 / deriveBoardColumn) parks those in Idle.
+ * Workspaces with no observed bindings query contribute only their manual
+ * unread mark.
  */
 export function useV2AttentionWorkspaceCount(): number {
 	const queryClient = useQueryClient();
@@ -81,7 +89,11 @@ export function useV2AttentionWorkspaceCount(): number {
 			if (event.type !== "updated" && event.type !== "removed") {
 				return;
 			}
-			if (event.query.queryKey[0] === "terminal-agent-bindings") {
+			const key0 = event.query.queryKey[0];
+			if (
+				key0 === "terminal-agent-bindings" ||
+				(key0 === "host-service" && event.query.queryKey[1] === "workspaces")
+			) {
 				setCacheVersion((version) => version + 1);
 			}
 		});
@@ -89,6 +101,18 @@ export function useV2AttentionWorkspaceCount(): number {
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: cacheVersion re-reads the query cache
 	return useMemo(() => {
+		const workspaceTypeById = new Map<string, DockAttentionWorkspaceType>();
+		const hostWorkspaceEntries = queryClient.getQueriesData<
+			HostWorkspaceRow[]
+		>({
+			queryKey: ["host-service", "workspaces", "list"],
+		});
+		for (const [, rows] of hostWorkspaceEntries) {
+			for (const row of rows ?? []) {
+				workspaceTypeById.set(row.id, row.type);
+			}
+		}
+
 		const workspaceIds = new Set(Object.keys(manualUnread));
 		const entries = queryClient.getQueriesData<TerminalAgentBinding[]>({
 			queryKey: ["terminal-agent-bindings"],
@@ -101,9 +125,10 @@ export function useV2AttentionWorkspaceCount(): number {
 					lastSeenAt: terminalSeenAt[binding.terminalId],
 				});
 				if (
-					status === "permission" ||
-					status === "review" ||
-					status === "failed"
+					countsTowardDockAttention({
+						status,
+						workspaceType: workspaceTypeById.get(binding.workspaceId),
+					})
 				) {
 					workspaceIds.add(binding.workspaceId);
 				}


### PR DESCRIPTION
## What & why

I kept hitting a dock badge that said something needed me when the board said Idle. #6506 already fixed the board: a finished agent alone is Needs review only on main/worktree — session runs (automations/chats) stay Idle so they do not bury real review candidates. The dock badge never got that filter, so session+`review` still bumped the OS count.

This aligns the dock's session-review gate with `deriveBoardColumn`: session+`review` no longer counts; session+`permission`/`failed` still do (board → Needs attention). It does not claim full board parity — the board also sends open/draft/queued PRs to Needs review, and the dock still ignores PR state. Workspace types come from the existing host-workspaces list cache — no new fan-out.

## How I tested it

Board gates review with `agentStatus === "review" && type !== "session"`. Dock previously ignored type. Extracted `countsTowardDockAttention` and wired the host-workspaces RQ cache so session+review is excluded while permission/failed stay for every type.

- Tip: `6f42d7b9ca559dc5a39b523196891c3a02498bbd`
- Units: `bun test apps/desktop/src/renderer/hooks/host-service/useV2NotificationStatus/countsTowardDockAttention.test.ts` → 5 pass / 0 fail
- Fork tip-match: https://github.com/owieschon/superset/pull/40 @ exact tip — owned jobs SUCCESS (Neon allowlisted)

## Checklist

- [x] session+review does not bump dock count
- [x] session permission/failed still count
- [x] worktree/main review still count
- [x] Thin scope; based on upstream `main`
