### PR TITLE
fix(desktop): align review chrome to Needs review

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
@@ -46,7 +46,7 @@ export const V2_WORKSPACES_AGENT_STATUS_LABELS: Record<
 		message: "Needs permission",
 	}),
 	review: msg({
-		message: "Ready for review",
+		message: "Needs review",
 	}),
 	failed: msg({
 		message: "Failed",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/utils/deriveBoardColumn/deriveBoardColumn.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/utils/deriveBoardColumn/deriveBoardColumn.ts
@@ -62,7 +62,7 @@ type BoardColumnInputs = Pick<
  *
  * A finished agent alone counts as review-worthy on main and worktree
  * workspaces: both are project checkouts a person is driving, and the
- * sidebar, dock badge and "Ready for review" filter already treat them that
+ * sidebar, dock badge and "Needs review" filter already treat them that
  * way. Only session workspaces (automation and chat runs with no project
  * checkout) are excluded: they arrive in volume, and routing them to
  * "review" buries the real candidates (the bucket answers "what needs me").

--- a/apps/desktop/src/renderer/screens/main/components/StatusIndicator/StatusIndicator.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/StatusIndicator/StatusIndicator.tsx
@@ -28,7 +28,7 @@ const STATUS_CONFIG = {
 		pingColor: "",
 		dotColor: "bg-green-500",
 		pulse: false,
-		tooltip: "Ready for review",
+		tooltip: "Needs review",
 	},
 } as const satisfies Record<
 	ActivePaneStatus,


### PR DESCRIPTION
## What & why

The board column says “Needs review,” while its filter and status tooltip say “Ready for review.” This makes all three use “Needs review” consistently. Review-state detection is unchanged.

## How I tested it

- Tip: `bef5ae2f7c386b00fdc52e372634f66f429f778f`
- Diff: 3 files / 3 lines (filter store, StatusIndicator tooltip, deriveBoardColumn comment)
- `rg 'Ready for review' apps/desktop` → PRStatusGroup only (Avi draft→ready chrome; untouched)
- Fork tip-match: https://github.com/owieschon/superset/pull/41

## Checklist

- [x] Filter label = Needs review
- [x] StatusIndicator tooltip = Needs review
- [x] PRStatusGroup untouched
- [x] Based on upstream main
- [x] Draft