### PR TITLE
fix(desktop): say 'Stopped' not 'Complete' in agent lifecycle notifications

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.test.ts
@@ -23,7 +23,7 @@ describe("getV2NativeNotificationContent", () => {
 				}),
 			}),
 		).toEqual({
-			title: "Codex - Complete",
+			title: "Codex - Stopped",
 			body: "Improve notifications",
 		});
 	});
@@ -50,7 +50,7 @@ describe("getV2NativeNotificationContent", () => {
 				payload: payload({ agent: { agentId: "droid" } }),
 			}),
 		).toEqual({
-			title: "Droid - Complete",
+			title: "Droid - Stopped",
 			body: "Workspace",
 		});
 
@@ -60,7 +60,7 @@ describe("getV2NativeNotificationContent", () => {
 				payload: payload({ agent: undefined }),
 			}),
 		).toMatchObject({
-			title: "Agent - Complete",
+			title: "Agent - Stopped",
 			body: "Workspace",
 		});
 	});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V2NotificationController/lib/notificationContent.ts
@@ -18,7 +18,7 @@ export function getV2NativeNotificationContent({
 }: V2NativeNotificationContentOptions): { title: string; body: string } {
 	const agentLabel = getAgentLabel(payload.agent);
 	const action =
-		payload.eventType === "PermissionRequest" ? "Needs Attention" : "Complete";
+		payload.eventType === "PermissionRequest" ? "Needs Attention" : "Stopped";
 	const workspaceLabel = cleanLabel(workspaceName) ?? "Workspace";
 
 	return {


### PR DESCRIPTION
## What & why

Native lifecycle notifications used “Complete” for every non-Failed `Stop`, including interrupts. That title claims the agent finished when it only stopped.

Maps those events to “Stopped.” Failed stays Failed (#7294). PermissionRequest stays Needs Attention. No board/status detection change.

## How I tested it

- Tip: `a7ceb279a9d297a7dbcd830e95951f29f9742887`
- `bun test` on `notificationContent.test.ts` (string + branch update)
- Scope: `notificationContent.ts` + test only

## Checklist

- [x] Non-failed Stop title = Stopped
- [x] Failed path unchanged (#7294)
- [x] Draft