### PR TITLE
fix(desktop): say 'Needs review' not 'Ready for review' in filter and status chrome

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/stores/v2WorkspacesFilterStore/v2WorkspacesFilterStore.ts
@@ -46,7 +46,7 @@ export const V2_WORKSPACES_AGENT_STATUS_LABELS: Record<
 		message: "Needs permission",
 	}),
 	review: msg({
-		message: "Ready for review",
+		message: "Needs review",
 	}),
 	failed: msg({
 		message: "Failed",

--- a/apps/desktop/src/renderer/screens/main/components/StatusIndicator/StatusIndicator.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/StatusIndicator/StatusIndicator.tsx
@@ -28,7 +28,7 @@ const STATUS_CONFIG = {
 		pingColor: "",
 		dotColor: "bg-green-500",
 		pulse: false,
-		tooltip: "Ready for review",
+		tooltip: "Needs review",
 	},
 } as const satisfies Record<
 	ActivePaneStatus,
@@ -45,7 +45,7 @@ interface StatusIndicatorProps {
  * - Yellow pulsing: needs user input (permission)
  * - Red pulsing: agent failed
  * - Amber pulsing: agent working
- * - Green static: ready for review
+ * - Green static: needs review
  */
 export function StatusIndicator({ status, className }: StatusIndicatorProps) {
 	const config = STATUS_CONFIG[status];

--- a/apps/desktop/src/shared/tabs-types.ts
+++ b/apps/desktop/src/shared/tabs-types.ts
@@ -21,7 +21,7 @@ export type PaneType =
  * - idle: No indicator shown (default)
  * - working: Agent actively processing (amber)
  * - permission: Agent blocked, needs user action (yellow)
- * - review: Agent completed, ready for review (green)
+ * - review: Agent stopped, unseen (green)
  * - failed: Agent turn/process ended in failure, needs attention (red)
  */
 export type PaneStatus =


### PR DESCRIPTION
## What & why

`#7321` aligned the board column label to "Needs review". The agent-status filter dropdown, the pane status indicator tooltip, and the `tabs-types` comment still said "Ready for review" — claiming a workspace is ready when the agent only stopped, with no proof the work is complete.

I can't know whether a stopped agent finished its task. The board noun is the authority: "Needs review" tells me to look, not that it's ready. The filter dropdown, status tooltip, and type comment now match.

Places cleaned up:
- Agent status filter dropdown label: "Ready for review" → "Needs review"
- Pane status indicator tooltip: "Ready for review" → "Needs review"
- `tabs-types.ts` comment: "Agent completed, ready for review" → "Agent stopped, unseen"

## How I tested it

- Tip: `6c0e53057` on `docs/needs-review-not-ready`
- These are copy-only changes to Lingui message descriptors and static tooltip strings; no logic change
- The board column is already "Needs review" from `#7321` — this aligns the remaining surfaces

## Checklist

- [x] Self-review: I read my own diff
- [x] Conventional commit title
- [x] Allow maintainer edits
- [x] DRAFT — stays draft until tip-native proof is confirmed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the remaining "Ready for review" labels with the board's "Needs review" wording. The agent-status filter dropdown, status tooltip, and type comment now say "Needs review" (and "Agent stopped, unseen" in the comment) because a stopped agent doesn't prove the work is complete.

<sup>Written for commit 6c0e530579ac6340b4a18281dafaa64c74a34ad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

