### PR TITLE
docs: document board columns and the attention-authoritative rule

### DIFF
--- a/apps/docs/content/docs/agent-status.mdx
+++ b/apps/docs/content/docs/agent-status.mdx
@@ -22,6 +22,21 @@ Superset installs lifecycle hooks and command wrappers into each agent's config 
 
 The hooks no-op outside Superset terminals (they check for a Superset-supplied env var). To remove them from an agent's config entirely, turn off the agent's **Superset hooks** toggle in **Settings → Agents**.
 
+## The Board Columns
+
+The workspace board sorts every workspace into one of six columns. The columns are fixed and never reorderable — they follow the workflow, not anyone's preference.
+
+| Column | What it means |
+|--------|---------------|
+| **Idle** | No agent running, no PR open. Nothing to do here. |
+| **Working** | An agent is actively running. |
+| **Needs attention** | **This is the authoritative "page a human" signal.** The agent is blocked waiting for your input — permission to run a tool, approval on a plan, or an answer to a question. When a workspace lands here, the operator must look at it. The dock badge, notification sound, and sidebar highlight all route through this column. |
+| **Needs review** | The agent stopped. It might have finished its work, or it might have been interrupted. The board doesn't know which — it only knows the agent stopped. "Needs review" means "look at this," not "this is ready." |
+| **Merged** | The PR was merged and the workspace is archived. |
+| **Deleted** | The workspace was deleted — a tombstone kept for the activity feed. |
+
+The columns are not a status machine. An agent stopping and starting again moves the workspace from "Needs review" back to "Working" — the board reflects what is happening now, not what happened last.
+
 ## Notifications
 
 - **Finished / waiting for input**: get notified when an agent finishes or pauses for your input. Configure sounds in Settings.


### PR DESCRIPTION
## What & why

The board columns are the workspace workflow, but the docs never named them. An operator with a fleet of agents needs to know which column means "page me now" and which means "look when you can."

This adds the six board columns to `agent-status.mdx` with a one-line definition of each:

- **Idle** — nothing happening
- **Working** — agent is running
- **Needs attention** — the authoritative "page a human" signal; the agent is blocked waiting for input
- **Needs review** — the agent stopped; the board does not know whether the work is complete
- **Merged** — PR merged, workspace archived
- **Deleted** — tombstone

"Needs attention" is called out as the authoritative signal. The dock badge, notification sound, and sidebar highlight all route through this column. "Needs review" is defined as what it literally is: the agent stopped, and the board does not know whether the work is complete — "look at this," not "this is ready."

The columns are not a status machine. An agent stopping and starting again moves the workspace from "Needs review" back to "Working" — the board reflects what is happening now, not what happened last.

No new product state, no new column, no second `agentStatus` source of truth. Just the existing board nouns, documented for the first time.

## How I tested it

- Tip: `7cc10745b` on `docs/attention-authoritative`
- Docs-only change; verified the table renders correctly by reading the source
- Column definitions match the board column labels in `deriveBoardColumn.ts` and the filter store

## Checklist

- [x] Self-review: I read my own diff
- [x] Conventional commit title
- [x] Allow maintainer edits
- [x] DRAFT — stays draft until tip-native proof is confirmed
- [x] No new product state, no second agentStatus SoT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the six board columns in `agent-status.mdx`, naming "Needs attention" as the authoritative page-a-human signal.

- Defines each column with one line; "Needs review" means the agent stopped, not that work is ready.
- Clarifies the board is not a status machine — it reflects current state, so a restarting agent moves the workspace back to "Working".
- Docs-only change; no new product state or second `agentStatus` source of truth.

<sup>Written for commit 7cc10745b467acb608699fe96c138ea5e166c6f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

