### PR TITLE
fix(desktop): fail loud when create agents[] launch fails

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -72,11 +72,13 @@ export interface UseHostWorkspacesResult {
 	 */
 	hostsSettled: boolean;
 	/**
-	 * Hosts whose live list answered this session. Absence of a workspace
-	 * from `workspaces` is evidence that it is gone only for these hosts: a
-	 * host that errored, is still loading, or is serving nothing but a
-	 * saved snapshot contributes no rows, and its silence is not a statement
-	 * about any particular workspace.
+	 * Hosts whose live list is currently answering — membership is the
+	 * query's `isSuccess` right now, not a record of having answered once,
+	 * so a host that answered and then failed a refetch leaves the set.
+	 * Absence of a workspace from `workspaces` is evidence that it is gone
+	 * only for these hosts: having rows is not the same as having answered,
+	 * because a host still renders its saved snapshot and keeps its prior
+	 * rows across a failed refetch.
 	 */
 	answeredHostIds: ReadonlySet<string>;
 	cache: HostWorkspacesCacheOps;

--- a/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
+++ b/apps/desktop/src/renderer/hooks/host-workspaces/useHostWorkspaces/useHostWorkspaces.ts
@@ -71,6 +71,14 @@ export interface UseHostWorkspacesResult {
 	 * cover only the local host.
 	 */
 	hostsSettled: boolean;
+	/**
+	 * Hosts whose live list answered this session. Absence of a workspace
+	 * from `workspaces` is evidence that it is gone only for these hosts: a
+	 * host that errored, is still loading, or is serving nothing but a
+	 * saved snapshot contributes no rows, and its silence is not a statement
+	 * about any particular workspace.
+	 */
+	answeredHostIds: ReadonlySet<string>;
 	cache: HostWorkspacesCacheOps;
 }
 
@@ -403,6 +411,19 @@ export function useHostWorkspacesSource(
 					query.isSuccess || query.isError || targets[index]?.hostUrl === null,
 			));
 
+	// Success only: react-query retains a host's prior rows across a failed
+	// refetch, and an offline host renders from its IndexedDB snapshot, so
+	// having rows is not the same as having answered.
+	const answeredHostIds = useMemo(
+		() =>
+			new Set(
+				targets
+					.filter((_target, index) => queries[index]?.isSuccess)
+					.map((target) => target.machineId),
+			),
+		[targets, queries],
+	);
+
 	const cache = useMemo<HostWorkspacesCacheOps>(() => {
 		const targetFor = (hostId: string) =>
 			targets.find((target) => target.machineId === hostId);
@@ -455,5 +476,11 @@ export function useHostWorkspacesSource(
 		};
 	}, [targets, queryClient]);
 
-	return { workspaces, isReady, hostsSettled: knownHostsSettled, cache };
+	return {
+		workspaces,
+		isReady,
+		hostsSettled: knownHostsSettled,
+		answeredHostIds,
+		cache,
+	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -63,7 +63,10 @@ import {
 import { useFailedAutomations } from "renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations";
 import { AGENT_STORAGE_KEY } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import {
+	reportableAgentLaunchError,
+	useWorkspaceCreates,
+} from "renderer/stores/workspace-creates";
 import { AutomationRow } from "./components/AutomationRow";
 import { AutomationStatCards } from "./components/AutomationStatCards";
 import { AutomationsEmptyState } from "./components/AutomationsEmptyState";
@@ -553,10 +556,14 @@ function AutomationsPage() {
 		});
 		// The store shows a create that never produced a workspace on the
 		// optimistic sidebar row. An agent that fails to launch inside a created
-		// workspace is not shown there — the user is already in the workspace and
-		// sees the missing agent pane. This just re-arms the button if the user
-		// navigates back.
-		void completed.finally(() => setCreatingWithAgent(false));
+		// workspace is not shown there — the user is dropped into the workspace
+		// with an empty agent pane and nothing else says why.
+		void completed
+			.then((outcome) => {
+				const launchError = reportableAgentLaunchError(outcome);
+				if (launchError !== null) toast.error(launchError);
+			})
+			.finally(() => setCreatingWithAgent(false));
 		navigate({
 			to: "/v2-workspace/$workspaceId",
 			params: { workspaceId },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -551,8 +551,11 @@ function AutomationsPage() {
 				agents: [{ agent, prompt: AUTOMATION_AGENT_PROMPT }],
 			},
 		});
-		// The store shows creation failures on the optimistic sidebar row; this
-		// just re-arms the button if the user navigates back.
+		// The store shows a create that never produced a workspace on the
+		// optimistic sidebar row. An agent that fails to launch inside a created
+		// workspace is not shown there — the user is already in the workspace and
+		// sees the missing agent pane. This just re-arms the button if the user
+		// navigates back.
 		void completed.finally(() => setCreatingWithAgent(false));
 		navigate({
 			to: "/v2-workspace/$workspaceId",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
@@ -5,7 +5,10 @@ import { useState } from "react";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
 import { AGENT_STORAGE_KEY } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import {
+	reportableAgentLaunchError,
+	useWorkspaceCreates,
+} from "renderer/stores/workspace-creates";
 import { PAGE_AGENT_PROMPT } from "./constants";
 
 export function useCreatePageWithAgent() {
@@ -51,10 +54,14 @@ export function useCreatePageWithAgent() {
 		});
 		// The store shows a create that never produced a workspace on the
 		// optimistic sidebar row. An agent that fails to launch inside a created
-		// workspace is not shown there — the user is already in the workspace and
-		// sees the missing agent pane. This just re-arms the button if the user
-		// navigates back.
-		void completed.finally(() => setCreatingWithAgent(false));
+		// workspace is not shown there — the user is dropped into the workspace
+		// with an empty agent pane and nothing else says why.
+		void completed
+			.then((outcome) => {
+				const launchError = reportableAgentLaunchError(outcome);
+				if (launchError !== null) toast.error(launchError);
+			})
+			.finally(() => setCreatingWithAgent(false));
 		navigate({
 			to: "/v2-workspace/$workspaceId",
 			params: { workspaceId },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
@@ -49,8 +49,11 @@ export function useCreatePageWithAgent() {
 				agents: [{ agent, prompt: PAGE_AGENT_PROMPT }],
 			},
 		});
-		// The store shows creation failures on the optimistic sidebar row; this
-		// just re-arms the button if the user navigates back.
+		// The store shows a create that never produced a workspace on the
+		// optimistic sidebar row. An agent that fails to launch inside a created
+		// workspace is not shown there — the user is already in the workspace and
+		// sees the missing agent pane. This just re-arms the button if the user
+		// navigates back.
 		void completed.finally(() => setCreatingWithAgent(false));
 		navigate({
 			to: "/v2-workspace/$workspaceId",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -9,14 +9,10 @@ import { parsePatchFiles } from "@pierre/diffs";
 import { CodeView, type CodeViewHandle } from "@pierre/diffs/react";
 import { FileTree as PierreFileTree, useFileTree } from "@pierre/trees/react";
 import { errorMessage } from "@superset/i18n/errors";
-import { sanitizePromptForPty } from "@superset/shared/agent-prompt-launch";
 import { toast } from "@superset/ui/sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-	type AgentPromptFileSide,
-	formatAgentPromptWithFileContext,
-} from "renderer/hooks/host-service/useSendToTerminalAgent";
+import type { AgentPromptFileSide } from "renderer/hooks/host-service/useSendToTerminalAgent";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import {
 	createPierreTreeStyle,
@@ -24,9 +20,7 @@ import {
 	PIERRE_TREE_UNSAFE_CSS,
 	type PierreGitStatus,
 } from "renderer/lib/pierreTree";
-import { normalizeTerminalCommand } from "renderer/lib/terminal/launch-command";
 import { WorkItemDetailState } from "renderer/routes/_authenticated/_dashboard/components/WorkItemDetailState";
-import type { AgentTarget } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/AgentCommentComposer/hooks/useDiffCommentTarget";
 import { useDiffCardCodeViewTheme } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme";
 import { DiffFileCollapseButton } from "renderer/screens/main/components/DiffFileCollapseButton";
 import { DiffFileHeaderName } from "renderer/screens/main/components/DiffFileHeaderName";
@@ -35,6 +29,10 @@ import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel"
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates/useWorkspaceCreates";
 import { PullRequestCommentComposer } from "../PullRequestCommentComposer";
 import { PullRequestCommentThread } from "../PullRequestCommentThread";
+import {
+	type SendCommentToAgentInput,
+	sendCommentToAgent as sendCommentToAgentRequest,
+} from "./sendCommentToAgent";
 
 interface PullRequestCodeTabProps {
 	projectId: string;
@@ -434,73 +432,50 @@ export function PullRequestCodeTab({
 		staleTime: 30_000,
 		gcTime: 10 * 60_000,
 	});
-	const linkedWorkspaceId = linkedWorkspaceData?.workspaceId ?? null;
+	// A PR-checkout workspace this tab created. It outlives a failed agent
+	// launch and stays linked to the PR, so it is the workspace the next send
+	// belongs in — the linked-workspace query alone would keep returning `null`
+	// for up to its 30s staleTime and check the PR out a second time. Tagged
+	// with the PR it was created for; this component is reused across PRs.
+	const createdWorkspaceRef = useRef<{
+		projectId: string;
+		prNumber: number;
+		workspaceId: string;
+	} | null>(null);
+	const readCreatedWorkspaceId = useCallback(() => {
+		const created = createdWorkspaceRef.current;
+		if (created === null) return null;
+		if (created.projectId !== projectId) return null;
+		if (created.prNumber !== prNumber) return null;
+		return created.workspaceId;
+	}, [projectId, prNumber]);
+	const linkedWorkspaceId =
+		linkedWorkspaceData?.workspaceId ?? readCreatedWorkspaceId();
 	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
 
-	// Mirrors DiffPane's split between "send to an existing terminal" and
-	// "create a new agent session", but the PR tab has no fixed workspace to
-	// launch a new session *in* — when no workspace is linked to this PR yet,
-	// "new" means spinning up a whole PR-checkout workspace (via the same
-	// useWorkspaceCreates path "Start Workspace" uses) with the prompt baked
-	// into its first agent launch, not just a fresh terminal in one that
-	// already exists.
 	const sendCommentToAgent = useMutation({
-		mutationFn: async (input: {
-			comment: string;
-			target: AgentTarget;
-			path: string;
-			startLine: number;
-			endLine: number;
-			side: AgentPromptFileSide;
-		}) => {
-			const text = formatAgentPromptWithFileContext({
-				comment: input.comment,
-				file: {
-					path: input.path,
-					startLine: input.startLine,
-					endLine: input.endLine,
-					side: input.side,
-				},
-			});
-
-			if (input.target.kind === "existing") {
-				if (!linkedWorkspaceId) {
-					throw new Error("No workspace open for this session");
-				}
-				const client = getHostServiceClientByUrl(hostUrl);
-				await client.terminal.writeInput.mutate({
-					workspaceId: linkedWorkspaceId,
-					terminalId: input.target.terminalId,
-					data: normalizeTerminalCommand(sanitizePromptForPty(text)),
-				});
-				return;
-			}
-
-			if (linkedWorkspaceId) {
-				const client = getHostServiceClientByUrl(hostUrl);
-				await client.agents.run.mutate({
-					workspaceId: linkedWorkspaceId,
-					agent: input.target.configId,
-					prompt: text,
-				});
-				return;
-			}
-
-			if (!hostId) {
-				throw new Error("No host available to create a workspace");
-			}
-			const { completed } = submitWorkspaceCreate({
-				hostId,
-				snapshot: {
-					id: crypto.randomUUID(),
+		mutationFn: (input: SendCommentToAgentInput) =>
+			sendCommentToAgentRequest(
+				{
+					hostId,
 					projectId,
-					pr: prNumber,
-					agents: [{ agent: input.target.configId, prompt: text }],
+					prNumber,
+					getLinkedWorkspaceId: () =>
+						linkedWorkspaceData?.workspaceId ?? readCreatedWorkspaceId(),
+					writeTerminalInput: (args) =>
+						getHostServiceClientByUrl(hostUrl).terminal.writeInput.mutate(args),
+					runAgent: (args) =>
+						getHostServiceClientByUrl(hostUrl).agents.run.mutate(args),
+					submitWorkspaceCreate,
+					onWorkspaceCreated: (workspaceId) => {
+						createdWorkspaceRef.current = { projectId, prNumber, workspaceId };
+						void queryClient.invalidateQueries({
+							queryKey: linkedWorkspaceQueryKey,
+						});
+					},
 				},
-			});
-			const outcome = await completed;
-			if (!outcome.ok) throw new Error(outcome.error);
-		},
+				input,
+			),
 		onSuccess: () => {
 			void queryClient.invalidateQueries({ queryKey: linkedWorkspaceQueryKey });
 			toast.success(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -22,6 +22,7 @@ import {
 } from "renderer/lib/pierreTree";
 import { WorkItemDetailState } from "renderer/routes/_authenticated/_dashboard/components/WorkItemDetailState";
 import { useDiffCardCodeViewTheme } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/hooks/useDiffCodeViewTheme";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { DiffFileCollapseButton } from "renderer/screens/main/components/DiffFileCollapseButton";
 import { DiffFileHeaderName } from "renderer/screens/main/components/DiffFileHeaderName";
 import { DiffViewToolbar } from "renderer/screens/main/components/DiffViewToolbar";
@@ -29,6 +30,10 @@ import { ResizablePanel } from "renderer/screens/main/components/ResizablePanel"
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates/useWorkspaceCreates";
 import { PullRequestCommentComposer } from "../PullRequestCommentComposer";
 import { PullRequestCommentThread } from "../PullRequestCommentThread";
+import {
+	type LinkedWorkspace,
+	resolveLinkedWorkspaceId,
+} from "./resolveLinkedWorkspaceId";
 import {
 	type SendCommentToAgentInput,
 	sendCommentToAgent as sendCommentToAgentRequest,
@@ -420,7 +425,7 @@ export function PullRequestCodeTab({
 		hostUrl,
 		prNumber,
 	];
-	const { data: linkedWorkspaceData } = useQuery({
+	const { data: linkedWorkspaceData } = useQuery<LinkedWorkspace>({
 		queryKey: linkedWorkspaceQueryKey,
 		queryFn: async () => {
 			const client = getHostServiceClientByUrl(hostUrl);
@@ -432,25 +437,19 @@ export function PullRequestCodeTab({
 		staleTime: 30_000,
 		gcTime: 10 * 60_000,
 	});
-	// A PR-checkout workspace this tab created. It outlives a failed agent
-	// launch and stays linked to the PR, so it is the workspace the next send
-	// belongs in — the linked-workspace query alone would keep returning `null`
-	// for up to its 30s staleTime and check the PR out a second time. Tagged
-	// with the PR it was created for; this component is reused across PRs.
-	const createdWorkspaceRef = useRef<{
-		projectId: string;
-		prNumber: number;
-		workspaceId: string;
-	} | null>(null);
-	const readCreatedWorkspaceId = useCallback(() => {
-		const created = createdWorkspaceRef.current;
-		if (created === null) return null;
-		if (created.projectId !== projectId) return null;
-		if (created.prNumber !== prNumber) return null;
-		return created.workspaceId;
-	}, [projectId, prNumber]);
-	const linkedWorkspaceId =
-		linkedWorkspaceData?.workspaceId ?? readCreatedWorkspaceId();
+	const { workspaces: liveWorkspaces, isReady: liveWorkspacesReady } =
+		useHostWorkspaces();
+	const liveWorkspaceIds = useMemo(
+		() =>
+			liveWorkspacesReady
+				? new Set(liveWorkspaces.map((workspace) => workspace.id))
+				: null,
+		[liveWorkspaces, liveWorkspacesReady],
+	);
+	const linkedWorkspaceId = resolveLinkedWorkspaceId({
+		workspaceId: linkedWorkspaceData?.workspaceId,
+		liveWorkspaceIds,
+	});
 	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
 
 	const sendCommentToAgent = useMutation({
@@ -460,24 +459,39 @@ export function PullRequestCodeTab({
 					hostId,
 					projectId,
 					prNumber,
+					// The cache, not the render's copy of it: a create earlier in
+					// this same send seeds the id there, and the retry that
+					// follows must see it.
 					getLinkedWorkspaceId: () =>
-						linkedWorkspaceData?.workspaceId ?? readCreatedWorkspaceId(),
+						resolveLinkedWorkspaceId({
+							workspaceId: queryClient.getQueryData<LinkedWorkspace>(
+								linkedWorkspaceQueryKey,
+							)?.workspaceId,
+							liveWorkspaceIds,
+						}),
 					writeTerminalInput: (args) =>
 						getHostServiceClientByUrl(hostUrl).terminal.writeInput.mutate(args),
 					runAgent: (args) =>
 						getHostServiceClientByUrl(hostUrl).agents.run.mutate(args),
 					submitWorkspaceCreate,
+					// A create whose agent failed still leaves the PR checked out,
+					// and the next send belongs in that workspace. The host links
+					// `workspaces.pullRequestId` from its own PR sync, which can
+					// land after this tab refetches, so seed the answer rather
+					// than invalidating: a cached `null` would survive the tab's
+					// unmount for the query's whole staleTime and check the PR
+					// out a second time.
 					onWorkspaceCreated: (workspaceId) => {
-						createdWorkspaceRef.current = { projectId, prNumber, workspaceId };
-						void queryClient.invalidateQueries({
-							queryKey: linkedWorkspaceQueryKey,
-						});
+						queryClient.setQueryData(linkedWorkspaceQueryKey, { workspaceId });
 					},
 				},
 				input,
 			),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: linkedWorkspaceQueryKey });
+			// No invalidation: the only send that changes which workspace is
+			// linked is the create branch, and that one seeds the id above. A
+			// refetch here would race the host's PR sync and could replace a
+			// known id with the `null` it has not linked yet.
 			toast.success(
 				t({
 					message: "Sent to agent",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -31,7 +31,11 @@ import { useWorkspaceCreates } from "renderer/stores/workspace-creates/useWorksp
 import { PullRequestCommentComposer } from "../PullRequestCommentComposer";
 import { PullRequestCommentThread } from "../PullRequestCommentThread";
 import {
-	type LinkedWorkspace,
+	type CachedLinkedWorkspace,
+	mergeLinkedWorkspace,
+} from "./mergeLinkedWorkspace";
+import {
+	liveWorkspaceIdsForHost,
 	resolveLinkedWorkspaceId,
 } from "./resolveLinkedWorkspaceId";
 import {
@@ -425,26 +429,35 @@ export function PullRequestCodeTab({
 		hostUrl,
 		prNumber,
 	];
-	const { data: linkedWorkspaceData } = useQuery<LinkedWorkspace>({
+	const { data: linkedWorkspaceData } = useQuery<CachedLinkedWorkspace>({
 		queryKey: linkedWorkspaceQueryKey,
 		queryFn: async () => {
 			const client = getHostServiceClientByUrl(hostUrl);
-			return client.pullRequests.getLinkedWorkspace.query({
+			const answered = await client.pullRequests.getLinkedWorkspace.query({
 				projectId,
 				prNumber,
 			});
+			// The host's pull-request sync can trail this tab's own create by
+			// minutes, so a `null` here does not retire an id we seeded.
+			return mergeLinkedWorkspace(
+				queryClient.getQueryData<CachedLinkedWorkspace>(
+					linkedWorkspaceQueryKey,
+				),
+				answered,
+			);
 		},
 		staleTime: 30_000,
 		gcTime: 10 * 60_000,
 	});
-	const { workspaces: liveWorkspaces, isReady: liveWorkspacesReady } =
-		useHostWorkspaces();
+	const { workspaces: liveWorkspaces, answeredHostIds } = useHostWorkspaces();
 	const liveWorkspaceIds = useMemo(
 		() =>
-			liveWorkspacesReady
-				? new Set(liveWorkspaces.map((workspace) => workspace.id))
-				: null,
-		[liveWorkspaces, liveWorkspacesReady],
+			liveWorkspaceIdsForHost({
+				hostId,
+				workspaces: liveWorkspaces,
+				answeredHostIds,
+			}),
+		[hostId, liveWorkspaces, answeredHostIds],
 	);
 	const linkedWorkspaceId = resolveLinkedWorkspaceId({
 		workspaceId: linkedWorkspaceData?.workspaceId,
@@ -464,7 +477,7 @@ export function PullRequestCodeTab({
 					// follows must see it.
 					getLinkedWorkspaceId: () =>
 						resolveLinkedWorkspaceId({
-							workspaceId: queryClient.getQueryData<LinkedWorkspace>(
+							workspaceId: queryClient.getQueryData<CachedLinkedWorkspace>(
 								linkedWorkspaceQueryKey,
 							)?.workspaceId,
 							liveWorkspaceIds,
@@ -477,12 +490,15 @@ export function PullRequestCodeTab({
 					// A create whose agent failed still leaves the PR checked out,
 					// and the next send belongs in that workspace. The host links
 					// `workspaces.pullRequestId` from its own PR sync, which can
-					// land after this tab refetches, so seed the answer rather
-					// than invalidating: a cached `null` would survive the tab's
-					// unmount for the query's whole staleTime and check the PR
-					// out a second time.
+					// land long after this tab refetches, so seed the answer
+					// rather than invalidating. `seeded` is what keeps it: the
+					// merge above holds it against every `null` the host answers
+					// until the host confirms a link.
 					onWorkspaceCreated: (workspaceId) => {
-						queryClient.setQueryData(linkedWorkspaceQueryKey, { workspaceId });
+						queryClient.setQueryData(linkedWorkspaceQueryKey, {
+							workspaceId,
+							seeded: true,
+						});
 					},
 				},
 				input,
@@ -490,8 +506,8 @@ export function PullRequestCodeTab({
 		onSuccess: () => {
 			// No invalidation: the only send that changes which workspace is
 			// linked is the create branch, and that one seeds the id above. A
-			// refetch here would race the host's PR sync and could replace a
-			// known id with the `null` it has not linked yet.
+			// refetch here would race the host's PR sync for nothing — the
+			// merge would answer with the seeded id anyway.
 			toast.success(
 				t({
 					message: "Sent to agent",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/PullRequestCodeTab.tsx
@@ -33,6 +33,7 @@ import { PullRequestCommentThread } from "../PullRequestCommentThread";
 import {
 	type CachedLinkedWorkspace,
 	mergeLinkedWorkspace,
+	reconcileCachedLinkedWorkspace,
 } from "./mergeLinkedWorkspace";
 import {
 	liveWorkspaceIdsForHost,
@@ -423,12 +424,10 @@ export function PullRequestCodeTab({
 			);
 		},
 	});
-	const linkedWorkspaceQueryKey = [
-		"pull-request-linked-workspace",
-		projectId,
-		hostUrl,
-		prNumber,
-	];
+	const linkedWorkspaceQueryKey = useMemo(
+		() => ["pull-request-linked-workspace", projectId, hostUrl, prNumber],
+		[projectId, hostUrl, prNumber],
+	);
 	const { data: linkedWorkspaceData } = useQuery<CachedLinkedWorkspace>({
 		queryKey: linkedWorkspaceQueryKey,
 		queryFn: async () => {
@@ -463,6 +462,23 @@ export function PullRequestCodeTab({
 		workspaceId: linkedWorkspaceData?.workspaceId,
 		liveWorkspaceIds,
 	});
+	useEffect(() => {
+		// Write down what the host's list proves instead of only recomputing
+		// it every render: a seeded id survives every `null` the host answers,
+		// so an id left in the cache comes back the moment a failed
+		// `workspace.list` refetch takes the evidence against it away.
+		const write = reconcileCachedLinkedWorkspace({
+			cached: linkedWorkspaceData,
+			liveWorkspaceIds,
+		});
+		if (!write) return;
+		queryClient.setQueryData(linkedWorkspaceQueryKey, write);
+	}, [
+		linkedWorkspaceData,
+		liveWorkspaceIds,
+		queryClient,
+		linkedWorkspaceQueryKey,
+	]);
 	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
 
 	const sendCommentToAgent = useMutation({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { mergeLinkedWorkspace } from "./mergeLinkedWorkspace";
+
+describe("mergeLinkedWorkspace", () => {
+	test("takes the host's link when it has one", () => {
+		expect(mergeLinkedWorkspace(undefined, { workspaceId: "ws-1" })).toEqual({
+			workspaceId: "ws-1",
+		});
+	});
+
+	test("keeps a seeded id when the host has not linked it yet", () => {
+		// The refetch after the 30s staleness window is where the seed used to
+		// die: the host answers null, the next send creates a second checkout.
+		expect(
+			mergeLinkedWorkspace(
+				{ workspaceId: "ws-1", seeded: true },
+				{ workspaceId: null },
+			),
+		).toEqual({ workspaceId: "ws-1", seeded: true });
+	});
+
+	test("lets the host's own link replace a seeded id", () => {
+		expect(
+			mergeLinkedWorkspace(
+				{ workspaceId: "ws-1", seeded: true },
+				{ workspaceId: "ws-2" },
+			),
+		).toEqual({ workspaceId: "ws-2" });
+	});
+
+	test("does not resurrect an id the host itself had answered", () => {
+		expect(
+			mergeLinkedWorkspace({ workspaceId: "ws-1" }, { workspaceId: null }),
+		).toEqual({ workspaceId: null });
+	});
+
+	test("carries nothing forward from an empty seed", () => {
+		expect(
+			mergeLinkedWorkspace(
+				{ workspaceId: null, seeded: true },
+				{ workspaceId: null },
+			),
+		).toEqual({ workspaceId: null });
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { mergeLinkedWorkspace } from "./mergeLinkedWorkspace";
+import {
+	mergeLinkedWorkspace,
+	reconcileCachedLinkedWorkspace,
+} from "./mergeLinkedWorkspace";
 
 describe("mergeLinkedWorkspace", () => {
 	test("takes the host's link when it has one", () => {
@@ -41,5 +44,69 @@ describe("mergeLinkedWorkspace", () => {
 				{ workspaceId: null },
 			),
 		).toEqual({ workspaceId: null });
+	});
+});
+
+describe("reconcileCachedLinkedWorkspace", () => {
+	test("records the first list the workspace appears in", () => {
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: { workspaceId: "ws-1", seeded: true },
+				liveWorkspaceIds: new Set(["ws-1"]),
+			}),
+		).toEqual({ workspaceId: "ws-1", seeded: true, listed: true });
+	});
+
+	test("writes nothing once the workspace is already recorded", () => {
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: { workspaceId: "ws-1", seeded: true, listed: true },
+				liveWorkspaceIds: new Set(["ws-1"]),
+			}),
+		).toBeNull();
+	});
+
+	test("retires an id the host listed before and no longer lists", () => {
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: { workspaceId: "ws-1", seeded: true, listed: true },
+				liveWorkspaceIds: new Set(["ws-2"]),
+			}),
+		).toEqual({ workspaceId: null });
+	});
+
+	test("waits for a workspace the host has never listed", () => {
+		// A create the host answered with a different canonical id has no row
+		// until the host broadcasts it; retiring here checks the PR out twice.
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: { workspaceId: "ws-1", seeded: true },
+				liveWorkspaceIds: new Set(),
+			}),
+		).toBeNull();
+	});
+
+	test("writes nothing while the host is reporting nothing", () => {
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: { workspaceId: "ws-1", seeded: true, listed: true },
+				liveWorkspaceIds: null,
+			}),
+		).toBeNull();
+	});
+
+	test("has nothing to reconcile without a cached id", () => {
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: undefined,
+				liveWorkspaceIds: new Set(["ws-1"]),
+			}),
+		).toBeNull();
+		expect(
+			reconcileCachedLinkedWorkspace({
+				cached: { workspaceId: null },
+				liveWorkspaceIds: new Set(["ws-1"]),
+			}),
+		).toBeNull();
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.ts
@@ -1,0 +1,34 @@
+import type { LinkedWorkspace } from "./resolveLinkedWorkspaceId";
+
+/** The link as the tab caches it: the host's answer, or an id it seeded. */
+export interface CachedLinkedWorkspace extends LinkedWorkspace {
+	/**
+	 * The id came from a create in this tab and the host has not confirmed
+	 * the link yet. Only a real link from the host replaces a seeded id.
+	 */
+	seeded?: boolean;
+}
+
+/**
+ * What the linked-workspace cache should hold once the host has answered.
+ *
+ * The host writes `workspaces.pullRequestId` from its own pull-request sync,
+ * behind a GitHub fetch, so it can keep answering `null` about a workspace
+ * this tab just created and checked out on the PR. The seeded id survives
+ * only the query's staleness window; the refetch after it would take that
+ * `null` at face value, send the next comment down the create path, and check
+ * the pull request out a second time. So a seeded id outlives a `null`
+ * answer and is displaced only by a link the host confirms.
+ *
+ * That leaves the seed to be retired by proof rather than by silence:
+ * `resolveLinkedWorkspaceId` drops it once the host lists its live
+ * workspaces without it.
+ */
+export function mergeLinkedWorkspace(
+	cached: CachedLinkedWorkspace | undefined,
+	answered: LinkedWorkspace,
+): CachedLinkedWorkspace {
+	if (answered.workspaceId) return { workspaceId: answered.workspaceId };
+	if (cached?.seeded && cached.workspaceId) return cached;
+	return { workspaceId: null };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/mergeLinkedWorkspace.ts
@@ -7,6 +7,13 @@ export interface CachedLinkedWorkspace extends LinkedWorkspace {
 	 * the link yet. Only a real link from the host replaces a seeded id.
 	 */
 	seeded?: boolean;
+	/**
+	 * The host has listed this workspace among its live ones at least once.
+	 * Until it has, the workspace's absence from that list means "not there
+	 * yet" rather than "deleted" — a create whose host answered with a
+	 * different canonical id has no row until the host broadcasts it.
+	 */
+	listed?: boolean;
 }
 
 /**
@@ -21,8 +28,9 @@ export interface CachedLinkedWorkspace extends LinkedWorkspace {
  * answer and is displaced only by a link the host confirms.
  *
  * That leaves the seed to be retired by proof rather than by silence:
- * `resolveLinkedWorkspaceId` drops it once the host lists its live
- * workspaces without it.
+ * `reconcileCachedLinkedWorkspace` below writes the retirement down once the
+ * host has listed its live workspaces without an id it had listed before, so
+ * a later failed list — which proves nothing — has no seed left to resurrect.
  */
 export function mergeLinkedWorkspace(
 	cached: CachedLinkedWorkspace | undefined,
@@ -31,4 +39,38 @@ export function mergeLinkedWorkspace(
 	if (answered.workspaceId) return { workspaceId: answered.workspaceId };
 	if (cached?.seeded && cached.workspaceId) return cached;
 	return { workspaceId: null };
+}
+
+interface ReconcileCachedLinkedWorkspaceArgs {
+	cached: CachedLinkedWorkspace | undefined;
+	/** `liveWorkspaceIdsForHost` — `null` when the host reported nothing. */
+	liveWorkspaceIds: ReadonlySet<string> | null;
+}
+
+/**
+ * The cache write the host's live workspace list calls for, or `null` for none.
+ *
+ * `resolveLinkedWorkspaceId` drops a deleted id per render and writes nothing
+ * back, so the dead id sits in the cache waiting for the evidence against it
+ * to disappear: one failed `workspace.list` refetch takes the host out of
+ * `answeredHostIds`, the resolve loses its evidence, and the workspace the
+ * user deleted comes back. Recording what the list proves is what stops later
+ * silence from resurrecting it.
+ *
+ * A list without the id proves it gone only once the id has been in one. A
+ * create the host answers with a different canonical id than the optimistic
+ * row has no row until the host broadcasts it, and retiring the id in that
+ * window would check the pull request out a second time — the thing the seed
+ * exists to prevent.
+ */
+export function reconcileCachedLinkedWorkspace({
+	cached,
+	liveWorkspaceIds,
+}: ReconcileCachedLinkedWorkspaceArgs): CachedLinkedWorkspace | null {
+	const workspaceId = cached?.workspaceId;
+	if (!workspaceId || liveWorkspaceIds === null) return null;
+	if (liveWorkspaceIds.has(workspaceId)) {
+		return cached?.listed ? null : { ...cached, workspaceId, listed: true };
+	}
+	return cached?.listed ? { workspaceId: null } : null;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { resolveLinkedWorkspaceId } from "./resolveLinkedWorkspaceId";
+
+describe("resolveLinkedWorkspaceId", () => {
+	test("has nothing to resolve before the link answers", () => {
+		expect(
+			resolveLinkedWorkspaceId({
+				workspaceId: undefined,
+				liveWorkspaceIds: new Set(["ws-1"]),
+			}),
+		).toBeNull();
+		expect(
+			resolveLinkedWorkspaceId({
+				workspaceId: null,
+				liveWorkspaceIds: new Set(["ws-1"]),
+			}),
+		).toBeNull();
+	});
+
+	test("keeps an id the mirror still lists", () => {
+		expect(
+			resolveLinkedWorkspaceId({
+				workspaceId: "ws-1",
+				liveWorkspaceIds: new Set(["ws-1", "ws-2"]),
+			}),
+		).toBe("ws-1");
+	});
+
+	test("drops an archived id: the mirror settled without it", () => {
+		expect(
+			resolveLinkedWorkspaceId({
+				workspaceId: "ws-1",
+				liveWorkspaceIds: new Set(["ws-2"]),
+			}),
+		).toBeNull();
+	});
+
+	test("keeps the id while the mirror is still settling", () => {
+		// Dropping it here would create the second PR checkout the seeded id
+		// exists to prevent.
+		expect(
+			resolveLinkedWorkspaceId({
+				workspaceId: "ws-1",
+				liveWorkspaceIds: null,
+			}),
+		).toBe("ws-1");
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { resolveLinkedWorkspaceId } from "./resolveLinkedWorkspaceId";
+import {
+	liveWorkspaceIdsForHost,
+	resolveLinkedWorkspaceId,
+} from "./resolveLinkedWorkspaceId";
 
 describe("resolveLinkedWorkspaceId", () => {
 	test("has nothing to resolve before the link answers", () => {
@@ -35,7 +38,7 @@ describe("resolveLinkedWorkspaceId", () => {
 		).toBeNull();
 	});
 
-	test("keeps the id while the mirror is still settling", () => {
+	test("keeps the id when the host reported nothing", () => {
 		// Dropping it here would create the second PR checkout the seeded id
 		// exists to prevent.
 		expect(
@@ -44,5 +47,67 @@ describe("resolveLinkedWorkspaceId", () => {
 				liveWorkspaceIds: null,
 			}),
 		).toBe("ws-1");
+	});
+});
+
+describe("liveWorkspaceIdsForHost", () => {
+	const workspaces = [
+		{ id: "ws-1", hostId: "host-1" },
+		{ id: "ws-2", hostId: "host-1" },
+		{ id: "ws-3", hostId: "host-2" },
+	];
+
+	test("reports only the workspaces the host itself answered with", () => {
+		expect(
+			liveWorkspaceIdsForHost({
+				hostId: "host-1",
+				workspaces,
+				answeredHostIds: new Set(["host-1", "host-2"]),
+			}),
+		).toEqual(new Set(["ws-1", "ws-2"]));
+	});
+
+	test("reports nothing from a host whose list errored", () => {
+		// The failed list leaves no rows behind, and reading that as "every
+		// workspace is gone" throws away the id the create path just wrote.
+		expect(
+			liveWorkspaceIdsForHost({
+				hostId: "host-1",
+				workspaces: [],
+				answeredHostIds: new Set(["host-2"]),
+			}),
+		).toBeNull();
+	});
+
+	test("reports nothing before the host has answered", () => {
+		expect(
+			liveWorkspaceIdsForHost({
+				hostId: "host-1",
+				workspaces,
+				answeredHostIds: new Set(),
+			}),
+		).toBeNull();
+	});
+
+	test("reports nothing before the host resolves", () => {
+		expect(
+			liveWorkspaceIdsForHost({
+				hostId: null,
+				workspaces,
+				answeredHostIds: new Set(["host-1"]),
+			}),
+		).toBeNull();
+	});
+
+	test("an answering host with no workspaces left does prove an id gone", () => {
+		const liveWorkspaceIds = liveWorkspaceIdsForHost({
+			hostId: "host-1",
+			workspaces: [],
+			answeredHostIds: new Set(["host-1"]),
+		});
+		expect(liveWorkspaceIds).toEqual(new Set());
+		expect(
+			resolveLinkedWorkspaceId({ workspaceId: "ws-1", liveWorkspaceIds }),
+		).toBeNull();
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.ts
@@ -1,4 +1,4 @@
-/** What `pullRequests.getLinkedWorkspace` answers, and what the tab caches. */
+/** What `pullRequests.getLinkedWorkspace` answers. */
 export interface LinkedWorkspace {
 	workspaceId: string | null;
 }
@@ -7,11 +7,44 @@ interface ResolveLinkedWorkspaceIdArgs {
 	/** The cached or freshly queried link, `undefined` before it answers. */
 	workspaceId: string | null | undefined;
 	/**
-	 * Ids of every live workspace, or `null` while the mirror is still
-	 * settling. Archived workspaces leave the mirror but keep their row, so
-	 * absence from a settled mirror is what marks an id as no longer usable.
+	 * Ids of every live workspace on this pull request's host, or `null` when
+	 * the mirror holds no evidence about that host at all. Archived
+	 * workspaces leave the mirror but keep their row, so absence from a set
+	 * the host actually answered is what marks an id as no longer usable.
 	 */
 	liveWorkspaceIds: ReadonlySet<string> | null;
+}
+
+interface LiveWorkspaceIdsForHostArgs {
+	/** The host this pull request is read from, `null` before it resolves. */
+	hostId: string | null;
+	workspaces: readonly { id: string; hostId: string }[];
+	/** `useHostWorkspaces().answeredHostIds`. */
+	answeredHostIds: ReadonlySet<string>;
+}
+
+/**
+ * The live workspaces `hostId` reported, or `null` when it reported nothing.
+ *
+ * The mirror merges every host into one list, and a host that errored, is
+ * still loading, or is rendering an offline snapshot contributes no rows to
+ * it. Reading that silence as "the workspace is gone" would throw away an id
+ * this tab's own create just wrote and check the pull request out a second
+ * time — so only a host that answered gets to speak about its workspaces.
+ * The answer may legitimately be an empty set: a user who deleted their last
+ * workspace has proven the id gone.
+ */
+export function liveWorkspaceIdsForHost({
+	hostId,
+	workspaces,
+	answeredHostIds,
+}: LiveWorkspaceIdsForHostArgs): ReadonlySet<string> | null {
+	if (!hostId || !answeredHostIds.has(hostId)) return null;
+	return new Set(
+		workspaces
+			.filter((workspace) => workspace.hostId === hostId)
+			.map((workspace) => workspace.id),
+	);
 }
 
 /**
@@ -22,9 +55,9 @@ interface ResolveLinkedWorkspaceIdArgs {
  * outlives the workspace being deleted: deletion archives the row rather than
  * removing it, and `agents.run` looks a workspace up by id without checking
  * `archivedAt`, so sending into an archived id reports "Sent to agent" into a
- * workspace the user deleted. Drop the id once the mirror has settled without
- * it — never while it is still settling, which would create the second
- * checkout this seed exists to prevent.
+ * workspace the user deleted. Drop the id once the host has answered without
+ * it — never on silence, which would create the second checkout this seed
+ * exists to prevent.
  */
 export function resolveLinkedWorkspaceId({
 	workspaceId,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/resolveLinkedWorkspaceId.ts
@@ -1,0 +1,36 @@
+/** What `pullRequests.getLinkedWorkspace` answers, and what the tab caches. */
+export interface LinkedWorkspace {
+	workspaceId: string | null;
+}
+
+interface ResolveLinkedWorkspaceIdArgs {
+	/** The cached or freshly queried link, `undefined` before it answers. */
+	workspaceId: string | null | undefined;
+	/**
+	 * Ids of every live workspace, or `null` while the mirror is still
+	 * settling. Archived workspaces leave the mirror but keep their row, so
+	 * absence from a settled mirror is what marks an id as no longer usable.
+	 */
+	liveWorkspaceIds: ReadonlySet<string> | null;
+}
+
+/**
+ * The workspace a PR comment should be sent into, or `null` to create one.
+ *
+ * The tab seeds this query with the workspace a failed agent launch left
+ * behind, which is how a retry avoids checking the PR out twice. That seed
+ * outlives the workspace being deleted: deletion archives the row rather than
+ * removing it, and `agents.run` looks a workspace up by id without checking
+ * `archivedAt`, so sending into an archived id reports "Sent to agent" into a
+ * workspace the user deleted. Drop the id once the mirror has settled without
+ * it — never while it is still settling, which would create the second
+ * checkout this seed exists to prevent.
+ */
+export function resolveLinkedWorkspaceId({
+	workspaceId,
+	liveWorkspaceIds,
+}: ResolveLinkedWorkspaceIdArgs): string | null {
+	if (!workspaceId) return null;
+	if (liveWorkspaceIds === null) return workspaceId;
+	return liveWorkspaceIds.has(workspaceId) ? workspaceId : null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
@@ -4,6 +4,7 @@ import type { SubmitOutcome } from "renderer/stores/workspace-creates";
 import {
 	type CachedLinkedWorkspace,
 	mergeLinkedWorkspace,
+	reconcileCachedLinkedWorkspace,
 } from "./mergeLinkedWorkspace";
 import {
 	liveWorkspaceIdsForHost,
@@ -52,6 +53,12 @@ function harness(outcomes: SubmitOutcome[]) {
 		async (_args: { workspaceId: string; agent: string; prompt: string }) =>
 			undefined,
 	);
+	/** The host's `workspace:changed` broadcast landing a row in the mirror. */
+	const list = (workspaceId: string) => {
+		if (!live.some((workspace) => workspace.id === workspaceId)) {
+			live.push({ id: workspaceId, hostId: "host-1" });
+		}
+	};
 	const archive = (workspaceId: string) => {
 		const index = live.findIndex((workspace) => workspace.id === workspaceId);
 		if (index >= 0) live.splice(index, 1);
@@ -66,35 +73,52 @@ function harness(outcomes: SubmitOutcome[]) {
 			),
 		);
 	};
-	const mount = (): SendCommentToAgentDeps => ({
-		hostId: "host-1",
-		projectId: "project-1",
-		prNumber: 42,
-		getLinkedWorkspaceId: () =>
-			resolveLinkedWorkspaceId({
-				workspaceId:
-					queryClient.getQueryData<CachedLinkedWorkspace>(LINKED_WORKSPACE_KEY)
-						?.workspaceId,
-				liveWorkspaceIds: liveWorkspaceIdsForHost({
-					hostId: "host-1",
-					workspaces: live,
-					answeredHostIds,
-				}),
+	const mount = (): SendCommentToAgentDeps => {
+		// The tab's reconcile effect, on the values the render computes it
+		// from: what the host's list proves about the cached id is written
+		// down, so later silence has nothing to hand back.
+		const write = reconcileCachedLinkedWorkspace({
+			cached:
+				queryClient.getQueryData<CachedLinkedWorkspace>(LINKED_WORKSPACE_KEY),
+			liveWorkspaceIds: liveWorkspaceIdsForHost({
+				hostId: "host-1",
+				workspaces: live,
+				answeredHostIds,
 			}),
-		writeTerminalInput: mock(async () => undefined),
-		runAgent,
-		submitWorkspaceCreate,
-		onWorkspaceCreated: (workspaceId) => {
-			queryClient.setQueryData(LINKED_WORKSPACE_KEY, {
-				workspaceId,
-				seeded: true,
-			});
-		},
-	});
+		});
+		if (write) queryClient.setQueryData(LINKED_WORKSPACE_KEY, write);
+		return {
+			hostId: "host-1",
+			projectId: "project-1",
+			prNumber: 42,
+			getLinkedWorkspaceId: () =>
+				resolveLinkedWorkspaceId({
+					workspaceId:
+						queryClient.getQueryData<CachedLinkedWorkspace>(
+							LINKED_WORKSPACE_KEY,
+						)?.workspaceId,
+					liveWorkspaceIds: liveWorkspaceIdsForHost({
+						hostId: "host-1",
+						workspaces: live,
+						answeredHostIds,
+					}),
+				}),
+			writeTerminalInput: mock(async () => undefined),
+			runAgent,
+			submitWorkspaceCreate,
+			onWorkspaceCreated: (workspaceId) => {
+				queryClient.setQueryData(LINKED_WORKSPACE_KEY, {
+					workspaceId,
+					seeded: true,
+				});
+			},
+		};
+	};
 	return {
 		mount,
 		submitWorkspaceCreate,
 		runAgent,
+		list,
 		archive,
 		refetchLink,
 		answeredHostIds,
@@ -181,6 +205,53 @@ test("a host that stopped answering its workspace list does not lose the workspa
 	);
 	// The list query errors out: no rows, and no statement about ws-1 either.
 	answeredHostIds.delete("host-1");
+	await sendCommentToAgent(mount(), input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(1);
+	expect(runAgent.mock.calls[0][0]).toMatchObject({ workspaceId: "ws-1" });
+});
+
+test("a workspace the host proved gone stays gone once its list errors", async () => {
+	const { mount, submitWorkspaceCreate, runAgent, archive, answeredHostIds } =
+		harness([
+			{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+			{ ok: true, workspaceId: "ws-2" },
+		]);
+
+	await expect(sendCommentToAgent(mount(), input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	// The tab renders on with the workspace the failed launch left behind:
+	// the host lists it, which is what makes a later list without it proof.
+	mount();
+	// The user deletes ws-1. The host keeps answering `null` about the link
+	// forever — it filters archived rows out — so only its workspace list can
+	// prove the id gone, and here it does.
+	archive("ws-1");
+	mount();
+	// Then one `workspace.list` refetch fails. The host says nothing at all,
+	// which must not hand back the workspace its own answer already retired.
+	answeredHostIds.delete("host-1");
+	await sendCommentToAgent(mount(), input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(2);
+	expect(runAgent).not.toHaveBeenCalled();
+});
+
+test("a workspace the host has not listed yet is not retired", async () => {
+	const { mount, submitWorkspaceCreate, runAgent, archive, list } = harness([
+		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+	]);
+
+	await expect(sendCommentToAgent(mount(), input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	// A create the host answers with a different canonical id than the
+	// optimistic row leaves the tab holding an id the list has not caught up
+	// to. Retiring it here would check the PR out a second time.
+	archive("ws-1");
+	mount();
+	list("ws-1");
 	await sendCommentToAgent(mount(), input);
 
 	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
@@ -1,5 +1,10 @@
 import { expect, mock, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
 import type { SubmitOutcome } from "renderer/stores/workspace-creates";
+import {
+	type LinkedWorkspace,
+	resolveLinkedWorkspaceId,
+} from "./resolveLinkedWorkspaceId";
 import {
 	type SendCommentToAgentDeps,
 	type SendCommentToAgentInput,
@@ -15,11 +20,23 @@ const input: SendCommentToAgentInput = {
 	side: "additions",
 };
 
+const LINKED_WORKSPACE_KEY = ["pull-request-linked-workspace", "project-1", 42];
+
+/**
+ * Wires the deps the way PullRequestCodeTab does — the query cache carries the
+ * workspace a failed launch left behind, and the live-workspace mirror decides
+ * whether that id is still usable. `mount()` rebuilds only what the component
+ * rebuilds, so a test can leave the Code tab and come back.
+ */
 function harness(outcomes: SubmitOutcome[]) {
-	let linkedWorkspaceId: string | null = null;
+	const queryClient = new QueryClient();
+	const liveWorkspaceIds = new Set<string>();
 	const submitWorkspaceCreate = mock(() => {
 		const outcome = outcomes.shift();
 		if (!outcome) throw new Error("unexpected create");
+		if (outcome.workspaceId !== undefined) {
+			liveWorkspaceIds.add(outcome.workspaceId);
+		}
 		return {
 			workspaceId: "optimistic",
 			completed: Promise.resolve(outcome),
@@ -29,27 +46,32 @@ function harness(outcomes: SubmitOutcome[]) {
 		async (_args: { workspaceId: string; agent: string; prompt: string }) =>
 			undefined,
 	);
-	const deps: SendCommentToAgentDeps = {
+	const mount = (): SendCommentToAgentDeps => ({
 		hostId: "host-1",
 		projectId: "project-1",
 		prNumber: 42,
-		getLinkedWorkspaceId: () => linkedWorkspaceId,
+		getLinkedWorkspaceId: () =>
+			resolveLinkedWorkspaceId({
+				workspaceId:
+					queryClient.getQueryData<LinkedWorkspace>(LINKED_WORKSPACE_KEY)
+						?.workspaceId,
+				liveWorkspaceIds,
+			}),
 		writeTerminalInput: mock(async () => undefined),
 		runAgent,
 		submitWorkspaceCreate,
-		// The real caller also invalidates the linked-workspace query; the ref it
-		// writes is what the next send reads, which is what this stands in for.
 		onWorkspaceCreated: (workspaceId) => {
-			linkedWorkspaceId = workspaceId;
+			queryClient.setQueryData(LINKED_WORKSPACE_KEY, { workspaceId });
 		},
-	};
-	return { deps, submitWorkspaceCreate, runAgent };
+	});
+	return { mount, submitWorkspaceCreate, runAgent, liveWorkspaceIds };
 }
 
 test("a retry after a failed agent launch reuses the workspace instead of creating a second one", async () => {
-	const { deps, submitWorkspaceCreate, runAgent } = harness([
+	const { mount, submitWorkspaceCreate, runAgent } = harness([
 		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
 	]);
+	const deps = mount();
 
 	await expect(sendCommentToAgent(deps, input)).rejects.toThrow(
 		"Agent launch failed: boom",
@@ -64,11 +86,46 @@ test("a retry after a failed agent launch reuses the workspace instead of creati
 	});
 });
 
+test("the workspace survives leaving the Code tab and coming back", async () => {
+	const { mount, submitWorkspaceCreate, runAgent } = harness([
+		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+	]);
+
+	await expect(sendCommentToAgent(mount(), input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	// Everything the component holds is gone; only the query cache is left.
+	await sendCommentToAgent(mount(), input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(1);
+	expect(runAgent).toHaveBeenCalledTimes(1);
+	expect(runAgent.mock.calls[0][0]).toMatchObject({ workspaceId: "ws-1" });
+});
+
+test("a workspace archived after the failed launch is not sent into", async () => {
+	const { mount, submitWorkspaceCreate, runAgent, liveWorkspaceIds } = harness([
+		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+		{ ok: true, workspaceId: "ws-2" },
+	]);
+
+	await expect(sendCommentToAgent(mount(), input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	// Deleting a workspace archives it; the live mirror drops the row while the
+	// seeded id and the host's own row both survive.
+	liveWorkspaceIds.delete("ws-1");
+	await sendCommentToAgent(mount(), input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(2);
+	expect(runAgent).not.toHaveBeenCalled();
+});
+
 test("a create that produced no workspace leaves the next send on the create path", async () => {
-	const { deps, submitWorkspaceCreate, runAgent } = harness([
+	const { mount, submitWorkspaceCreate, runAgent } = harness([
 		{ ok: false, error: "Host service is not running" },
 		{ ok: true, workspaceId: "ws-2" },
 	]);
+	const deps = mount();
 
 	await expect(sendCommentToAgent(deps, input)).rejects.toThrow(
 		"Host service is not running",

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
@@ -2,7 +2,11 @@ import { expect, mock, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
 import type { SubmitOutcome } from "renderer/stores/workspace-creates";
 import {
-	type LinkedWorkspace,
+	type CachedLinkedWorkspace,
+	mergeLinkedWorkspace,
+} from "./mergeLinkedWorkspace";
+import {
+	liveWorkspaceIdsForHost,
 	resolveLinkedWorkspaceId,
 } from "./resolveLinkedWorkspaceId";
 import {
@@ -30,12 +34,14 @@ const LINKED_WORKSPACE_KEY = ["pull-request-linked-workspace", "project-1", 42];
  */
 function harness(outcomes: SubmitOutcome[]) {
 	const queryClient = new QueryClient();
-	const liveWorkspaceIds = new Set<string>();
+	const live: { id: string; hostId: string }[] = [];
+	// The host answers its workspace list until a test says it stopped.
+	const answeredHostIds = new Set(["host-1"]);
 	const submitWorkspaceCreate = mock(() => {
 		const outcome = outcomes.shift();
 		if (!outcome) throw new Error("unexpected create");
 		if (outcome.workspaceId !== undefined) {
-			liveWorkspaceIds.add(outcome.workspaceId);
+			live.push({ id: outcome.workspaceId, hostId: "host-1" });
 		}
 		return {
 			workspaceId: "optimistic",
@@ -46,6 +52,20 @@ function harness(outcomes: SubmitOutcome[]) {
 		async (_args: { workspaceId: string; agent: string; prompt: string }) =>
 			undefined,
 	);
+	const archive = (workspaceId: string) => {
+		const index = live.findIndex((workspace) => workspace.id === workspaceId);
+		if (index >= 0) live.splice(index, 1);
+	};
+	/** The linked-workspace query answering, exactly as the tab caches it. */
+	const refetchLink = (answered: string | null) => {
+		queryClient.setQueryData(
+			LINKED_WORKSPACE_KEY,
+			mergeLinkedWorkspace(
+				queryClient.getQueryData<CachedLinkedWorkspace>(LINKED_WORKSPACE_KEY),
+				{ workspaceId: answered },
+			),
+		);
+	};
 	const mount = (): SendCommentToAgentDeps => ({
 		hostId: "host-1",
 		projectId: "project-1",
@@ -53,18 +73,32 @@ function harness(outcomes: SubmitOutcome[]) {
 		getLinkedWorkspaceId: () =>
 			resolveLinkedWorkspaceId({
 				workspaceId:
-					queryClient.getQueryData<LinkedWorkspace>(LINKED_WORKSPACE_KEY)
+					queryClient.getQueryData<CachedLinkedWorkspace>(LINKED_WORKSPACE_KEY)
 						?.workspaceId,
-				liveWorkspaceIds,
+				liveWorkspaceIds: liveWorkspaceIdsForHost({
+					hostId: "host-1",
+					workspaces: live,
+					answeredHostIds,
+				}),
 			}),
 		writeTerminalInput: mock(async () => undefined),
 		runAgent,
 		submitWorkspaceCreate,
 		onWorkspaceCreated: (workspaceId) => {
-			queryClient.setQueryData(LINKED_WORKSPACE_KEY, { workspaceId });
+			queryClient.setQueryData(LINKED_WORKSPACE_KEY, {
+				workspaceId,
+				seeded: true,
+			});
 		},
 	});
-	return { mount, submitWorkspaceCreate, runAgent, liveWorkspaceIds };
+	return {
+		mount,
+		submitWorkspaceCreate,
+		runAgent,
+		archive,
+		refetchLink,
+		answeredHostIds,
+	};
 }
 
 test("a retry after a failed agent launch reuses the workspace instead of creating a second one", async () => {
@@ -103,7 +137,7 @@ test("the workspace survives leaving the Code tab and coming back", async () => 
 });
 
 test("a workspace archived after the failed launch is not sent into", async () => {
-	const { mount, submitWorkspaceCreate, runAgent, liveWorkspaceIds } = harness([
+	const { mount, submitWorkspaceCreate, runAgent, archive } = harness([
 		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
 		{ ok: true, workspaceId: "ws-2" },
 	]);
@@ -113,11 +147,44 @@ test("a workspace archived after the failed launch is not sent into", async () =
 	);
 	// Deleting a workspace archives it; the live mirror drops the row while the
 	// seeded id and the host's own row both survive.
-	liveWorkspaceIds.delete("ws-1");
+	archive("ws-1");
 	await sendCommentToAgent(mount(), input);
 
 	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(2);
 	expect(runAgent).not.toHaveBeenCalled();
+});
+
+test("a link refetch that has not caught up does not check the PR out twice", async () => {
+	const { mount, submitWorkspaceCreate, runAgent, refetchLink } = harness([
+		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+	]);
+
+	await expect(sendCommentToAgent(mount(), input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	// Past the query's staleness window the tab refetches, and the host's PR
+	// sync has not linked the workspace yet.
+	refetchLink(null);
+	await sendCommentToAgent(mount(), input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(1);
+	expect(runAgent.mock.calls[0][0]).toMatchObject({ workspaceId: "ws-1" });
+});
+
+test("a host that stopped answering its workspace list does not lose the workspace", async () => {
+	const { mount, submitWorkspaceCreate, runAgent, answeredHostIds } = harness([
+		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+	]);
+
+	await expect(sendCommentToAgent(mount(), input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	// The list query errors out: no rows, and no statement about ws-1 either.
+	answeredHostIds.delete("host-1");
+	await sendCommentToAgent(mount(), input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(1);
+	expect(runAgent.mock.calls[0][0]).toMatchObject({ workspaceId: "ws-1" });
 });
 
 test("a create that produced no workspace leaves the next send on the create path", async () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.test.ts
@@ -1,0 +1,80 @@
+import { expect, mock, test } from "bun:test";
+import type { SubmitOutcome } from "renderer/stores/workspace-creates";
+import {
+	type SendCommentToAgentDeps,
+	type SendCommentToAgentInput,
+	sendCommentToAgent,
+} from "./sendCommentToAgent";
+
+const input: SendCommentToAgentInput = {
+	comment: "please fix this",
+	target: { kind: "new", configId: "claude", placement: "split-pane" },
+	path: "src/index.ts",
+	startLine: 3,
+	endLine: 5,
+	side: "additions",
+};
+
+function harness(outcomes: SubmitOutcome[]) {
+	let linkedWorkspaceId: string | null = null;
+	const submitWorkspaceCreate = mock(() => {
+		const outcome = outcomes.shift();
+		if (!outcome) throw new Error("unexpected create");
+		return {
+			workspaceId: "optimistic",
+			completed: Promise.resolve(outcome),
+		};
+	});
+	const runAgent = mock(
+		async (_args: { workspaceId: string; agent: string; prompt: string }) =>
+			undefined,
+	);
+	const deps: SendCommentToAgentDeps = {
+		hostId: "host-1",
+		projectId: "project-1",
+		prNumber: 42,
+		getLinkedWorkspaceId: () => linkedWorkspaceId,
+		writeTerminalInput: mock(async () => undefined),
+		runAgent,
+		submitWorkspaceCreate,
+		// The real caller also invalidates the linked-workspace query; the ref it
+		// writes is what the next send reads, which is what this stands in for.
+		onWorkspaceCreated: (workspaceId) => {
+			linkedWorkspaceId = workspaceId;
+		},
+	};
+	return { deps, submitWorkspaceCreate, runAgent };
+}
+
+test("a retry after a failed agent launch reuses the workspace instead of creating a second one", async () => {
+	const { deps, submitWorkspaceCreate, runAgent } = harness([
+		{ ok: false, workspaceId: "ws-1", error: "Agent launch failed: boom" },
+	]);
+
+	await expect(sendCommentToAgent(deps, input)).rejects.toThrow(
+		"Agent launch failed: boom",
+	);
+	await sendCommentToAgent(deps, input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(1);
+	expect(runAgent).toHaveBeenCalledTimes(1);
+	expect(runAgent.mock.calls[0][0]).toMatchObject({
+		workspaceId: "ws-1",
+		agent: "claude",
+	});
+});
+
+test("a create that produced no workspace leaves the next send on the create path", async () => {
+	const { deps, submitWorkspaceCreate, runAgent } = harness([
+		{ ok: false, error: "Host service is not running" },
+		{ ok: true, workspaceId: "ws-2" },
+	]);
+
+	await expect(sendCommentToAgent(deps, input)).rejects.toThrow(
+		"Host service is not running",
+	);
+	await sendCommentToAgent(deps, input);
+
+	expect(submitWorkspaceCreate).toHaveBeenCalledTimes(2);
+	expect(runAgent).not.toHaveBeenCalled();
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.ts
@@ -1,0 +1,111 @@
+import { sanitizePromptForPty } from "@superset/shared/agent-prompt-launch";
+import {
+	type AgentPromptFileSide,
+	formatAgentPromptWithFileContext,
+} from "renderer/hooks/host-service/useSendToTerminalAgent";
+import { normalizeTerminalCommand } from "renderer/lib/terminal/launch-command";
+import type { AgentTarget } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/AgentCommentComposer/hooks/useDiffCommentTarget";
+import type {
+	SubmitArgs,
+	SubmitHandle,
+} from "renderer/stores/workspace-creates";
+
+export interface SendCommentToAgentDeps {
+	hostId: string | null;
+	projectId: string;
+	prNumber: number;
+	/**
+	 * Read when the send runs, not when the composer rendered. A create whose
+	 * agent failed to launch still leaves a workspace checked out on this PR,
+	 * and the next send must reuse it instead of checking the PR out again.
+	 */
+	getLinkedWorkspaceId: () => string | null;
+	writeTerminalInput: (args: {
+		workspaceId: string;
+		terminalId: string;
+		data: string;
+	}) => Promise<unknown>;
+	runAgent: (args: {
+		workspaceId: string;
+		agent: string;
+		prompt: string;
+	}) => Promise<unknown>;
+	submitWorkspaceCreate: (args: SubmitArgs) => SubmitHandle;
+	/** Records a workspace this send created, a failed agent launch included. */
+	onWorkspaceCreated: (workspaceId: string) => void;
+}
+
+export interface SendCommentToAgentInput {
+	comment: string;
+	target: AgentTarget;
+	path: string;
+	startLine: number;
+	endLine: number;
+	side: AgentPromptFileSide;
+}
+
+/**
+ * Mirrors DiffPane's split between "send to an existing terminal" and "create a
+ * new agent session", but the PR tab has no fixed workspace to launch a new
+ * session *in* — when no workspace is linked to this PR yet, "new" means
+ * spinning up a whole PR-checkout workspace (via the same useWorkspaceCreates
+ * path "Start Workspace" uses) with the prompt baked into its first agent
+ * launch, not just a fresh terminal in one that already exists.
+ */
+export async function sendCommentToAgent(
+	deps: SendCommentToAgentDeps,
+	input: SendCommentToAgentInput,
+): Promise<void> {
+	const text = formatAgentPromptWithFileContext({
+		comment: input.comment,
+		file: {
+			path: input.path,
+			startLine: input.startLine,
+			endLine: input.endLine,
+			side: input.side,
+		},
+	});
+	const linkedWorkspaceId = deps.getLinkedWorkspaceId();
+
+	if (input.target.kind === "existing") {
+		if (!linkedWorkspaceId) {
+			throw new Error("No workspace open for this session");
+		}
+		await deps.writeTerminalInput({
+			workspaceId: linkedWorkspaceId,
+			terminalId: input.target.terminalId,
+			data: normalizeTerminalCommand(sanitizePromptForPty(text)),
+		});
+		return;
+	}
+
+	if (linkedWorkspaceId) {
+		await deps.runAgent({
+			workspaceId: linkedWorkspaceId,
+			agent: input.target.configId,
+			prompt: text,
+		});
+		return;
+	}
+
+	if (!deps.hostId) {
+		throw new Error("No host available to create a workspace");
+	}
+	const { completed } = deps.submitWorkspaceCreate({
+		hostId: deps.hostId,
+		snapshot: {
+			id: crypto.randomUUID(),
+			projectId: deps.projectId,
+			pr: deps.prNumber,
+			agents: [{ agent: input.target.configId, prompt: text }],
+		},
+	});
+	const outcome = await completed;
+	// Report the workspace before throwing: an agent that never launched leaves
+	// the checkout behind, and a retry that did not know about it would create a
+	// second one.
+	if (outcome.workspaceId !== undefined) {
+		deps.onWorkspaceCreated(outcome.workspaceId);
+	}
+	if (!outcome.ok) throw new Error(outcome.error);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/$prNumber/components/PullRequestCodeTab/sendCommentToAgent.ts
@@ -17,7 +17,8 @@ export interface SendCommentToAgentDeps {
 	/**
 	 * Read when the send runs, not when the composer rendered. A create whose
 	 * agent failed to launch still leaves a workspace checked out on this PR,
-	 * and the next send must reuse it instead of checking the PR out again.
+	 * and the next send must reuse it instead of checking the PR out again —
+	 * unless it has since been archived, which this must not hand back.
 	 */
 	getLinkedWorkspaceId: () => string | null;
 	writeTerminalInput: (args: {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
@@ -22,7 +22,10 @@ import { ProjectThumbnail } from "renderer/routes/_authenticated/components/Proj
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { deriveBranchName } from "renderer/routes/_authenticated/utils/deriveBranchName";
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
-import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import {
+	reportableAgentLaunchError,
+	useWorkspaceCreates,
+} from "renderer/stores/workspace-creates";
 import type { TaskWithStatus } from "../../../../../components/TasksView/hooks/useTasksTable";
 
 const AGENT_STORAGE_KEY = "lastSelectedV2TaskAgent";
@@ -254,8 +257,11 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 
 		void completed.then((outcome) => {
 			// A failed agent launch is the one failure the store records no
-			// failed-create row for, so this toast is its only channel.
-			if (!outcome.ok) toast.error(outcome.error);
+			// failed-create row for, so this toast is its only channel. Every
+			// other failure already shows the create-error card on the route the
+			// user lands on.
+			const launchError = reportableAgentLaunchError(outcome);
+			if (launchError !== null) toast.error(launchError);
 			if (
 				outcome.workspaceId !== undefined &&
 				outcome.workspaceId !== snapshotId

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/$taskId/components/PropertiesSidebar/components/OpenInWorkspaceV2/OpenInWorkspaceV2.tsx
@@ -253,8 +253,13 @@ export function OpenInWorkspaceV2({ task }: OpenInWorkspaceV2Props) {
 		});
 
 		void completed.then((outcome) => {
-			if (!outcome.ok) return;
-			if (outcome.workspaceId !== snapshotId) {
+			// A failed agent launch is the one failure the store records no
+			// failed-create row for, so this toast is its only channel.
+			if (!outcome.ok) toast.error(outcome.error);
+			if (
+				outcome.workspaceId !== undefined &&
+				outcome.workspaceId !== snapshotId
+			) {
 				void navigate({
 					to: "/v2-workspace/$workspaceId",
 					params: { workspaceId: outcome.workspaceId },

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunInWorkspacePopoverV2/RunInWorkspacePopoverV2.tsx
@@ -29,6 +29,7 @@ import { deriveBranchName } from "renderer/routes/_authenticated/utils/deriveBra
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import type { TaskWithStatus } from "../../../../hooks/useTasksTable";
+import { useBatchWorkspaceCreateReport } from "../../hooks/useBatchWorkspaceCreateReport";
 
 const AGENT_STORAGE_KEY = "lastSelectedV2TaskBatchAgent";
 const NONE = "none" as const;
@@ -60,6 +61,7 @@ export function RunInWorkspacePopoverV2({
 	const { machineId, activeHostUrl } = hostService;
 	const { otherHosts } = useWorkspaceHostOptions();
 	const { submit } = useWorkspaceCreates();
+	const reportBatchOutcome = useBatchWorkspaceCreateReport();
 
 	const lastHostId = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.lastHostId,
@@ -245,15 +247,8 @@ export function RunInWorkspacePopoverV2({
 
 		const promise = Promise.all(handles.map((handle) => handle.completed)).then(
 			(outcomes) => {
-				const failed = outcomes.filter((outcome) => !outcome.ok).length;
-				if (failed > 0) {
-					const firstFailure = outcomes.find((outcome) => !outcome.ok);
-					const details =
-						firstFailure && !firstFailure.ok ? `: ${firstFailure.error}` : "";
-					throw new Error(
-						`${outcomes.length - failed} of ${outcomes.length} succeeded${details}`,
-					);
-				}
+				const report = reportBatchOutcome(outcomes);
+				if (report !== null) throw new Error(report);
 				return outcomes.length;
 			},
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunIssuesInWorkspacePopover/RunIssuesInWorkspacePopover.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/components/RunIssuesInWorkspacePopover/RunIssuesInWorkspacePopover.tsx
@@ -29,6 +29,7 @@ import { deriveBranchName } from "renderer/routes/_authenticated/utils/deriveBra
 import { useV2WorkspaceCreateDefaultsStore } from "renderer/stores/v2-workspace-create-defaults";
 import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
 import type { SelectedIssue } from "../../../GitHubIssuesContent";
+import { useBatchWorkspaceCreateReport } from "../../hooks/useBatchWorkspaceCreateReport";
 
 const AGENT_STORAGE_KEY = "lastSelectedV2IssueBatchAgent";
 const NONE = "none" as const;
@@ -64,6 +65,7 @@ export function RunIssuesInWorkspacePopover({
 	const { machineId, activeHostUrl } = hostService;
 	const { otherHosts } = useWorkspaceHostOptions();
 	const { submit } = useWorkspaceCreates();
+	const reportBatchOutcome = useBatchWorkspaceCreateReport();
 
 	const lastHostId = useV2WorkspaceCreateDefaultsStore(
 		(state) => state.lastHostId,
@@ -257,15 +259,8 @@ export function RunIssuesInWorkspacePopover({
 
 		const promise = Promise.all(handles.map((handle) => handle.completed)).then(
 			(outcomes) => {
-				const failed = outcomes.filter((outcome) => !outcome.ok).length;
-				if (failed > 0) {
-					const firstFailure = outcomes.find((outcome) => !outcome.ok);
-					const details =
-						firstFailure && !firstFailure.ok ? `: ${firstFailure.error}` : "";
-					throw new Error(
-						`${outcomes.length - failed} of ${outcomes.length} succeeded${details}`,
-					);
-				}
+				const report = reportBatchOutcome(outcomes);
+				if (report !== null) throw new Error(report);
 				return outcomes.length;
 			},
 		);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/index.ts
@@ -1,0 +1,5 @@
+export {
+	type BatchWorkspaceCreateFailures,
+	summarizeBatchWorkspaceCreates,
+} from "./summarizeBatchWorkspaceCreates";
+export { useBatchWorkspaceCreateReport } from "./useBatchWorkspaceCreateReport";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/summarizeBatchWorkspaceCreates.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/summarizeBatchWorkspaceCreates.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { SubmitOutcome } from "renderer/stores/workspace-creates";
+import { summarizeBatchWorkspaceCreates } from "./summarizeBatchWorkspaceCreates";
+
+const created: SubmitOutcome = { ok: true, workspaceId: "ws-1" };
+const notCreated: SubmitOutcome = { ok: false, error: "no host" };
+const agentFailed: SubmitOutcome = {
+	ok: false,
+	workspaceId: "ws-2",
+	error: "Agent launch failed: boom",
+};
+
+describe("summarizeBatchWorkspaceCreates", () => {
+	test("returns null when every create succeeded", () => {
+		expect(summarizeBatchWorkspaceCreates([created, created])).toBeNull();
+	});
+
+	test("counts a surviving workspace as an agent failure, not a create failure", () => {
+		expect(summarizeBatchWorkspaceCreates([created, agentFailed])).toEqual({
+			notCreated: 0,
+			agentFailed: 1,
+			firstNotCreatedError: null,
+			firstAgentError: "Agent launch failed: boom",
+		});
+	});
+
+	test("counts a create that produced no workspace separately", () => {
+		expect(summarizeBatchWorkspaceCreates([notCreated, created])).toEqual({
+			notCreated: 1,
+			agentFailed: 0,
+			firstNotCreatedError: "no host",
+			firstAgentError: null,
+		});
+	});
+
+	test("keeps the two kinds apart in one batch, each with its own first error", () => {
+		expect(
+			summarizeBatchWorkspaceCreates([
+				agentFailed,
+				notCreated,
+				{ ok: false, error: "second host failure" },
+			]),
+		).toEqual({
+			notCreated: 2,
+			agentFailed: 1,
+			firstNotCreatedError: "no host",
+			firstAgentError: "Agent launch failed: boom",
+		});
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/summarizeBatchWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/summarizeBatchWorkspaceCreates.ts
@@ -1,0 +1,43 @@
+import type { SubmitOutcome } from "renderer/stores/workspace-creates";
+
+export interface BatchWorkspaceCreateFailures {
+	/** Creates that produced no workspace at all. */
+	notCreated: number;
+	/** Creates whose workspace survived an agent that never launched. */
+	agentFailed: number;
+	/** The first host error of each kind; null when that kind did not occur. */
+	firstNotCreatedError: string | null;
+	firstAgentError: string | null;
+}
+
+/**
+ * Splits a batch's outcomes by what actually failed.
+ *
+ * The two are not interchangeable in a report: a workspace whose agent failed
+ * to launch is in the sidebar, checked out and usable, and counting it as a
+ * create that did not happen tells the user to go looking for something that
+ * is already there. `workspaceId` on the failure arm is what separates them —
+ * the store sets it only when it kept the workspace.
+ *
+ * Returns null when nothing failed.
+ */
+export function summarizeBatchWorkspaceCreates(
+	outcomes: readonly SubmitOutcome[],
+): BatchWorkspaceCreateFailures | null {
+	let notCreated = 0;
+	let agentFailed = 0;
+	let firstNotCreatedError: string | null = null;
+	let firstAgentError: string | null = null;
+	for (const outcome of outcomes) {
+		if (outcome.ok) continue;
+		if (outcome.workspaceId === undefined) {
+			notCreated += 1;
+			firstNotCreatedError ??= outcome.error;
+			continue;
+		}
+		agentFailed += 1;
+		firstAgentError ??= outcome.error;
+	}
+	if (notCreated === 0 && agentFailed === 0) return null;
+	return { notCreated, agentFailed, firstNotCreatedError, firstAgentError };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/useBatchWorkspaceCreateReport.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/useBatchWorkspaceCreateReport.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, afterEach, describe, expect, it } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { SubmitOutcome } from "renderer/stores/workspace-creates";
+
+// happy-dom over the preloaded plain-object document. Process-wide, so this
+// unregisters in afterAll to leave the other renderer suites their document.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { cleanup, renderHook } = await import("@testing-library/react");
+const { useBatchWorkspaceCreateReport } = await import(
+	"./useBatchWorkspaceCreateReport"
+);
+
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+function report(outcomes: SubmitOutcome[]): string | null {
+	const { result } = renderHook(() => useBatchWorkspaceCreateReport());
+	return result.current(outcomes);
+}
+
+describe("useBatchWorkspaceCreateReport", () => {
+	it("says nothing when every workspace was created with its agent", () => {
+		expect(report([{ ok: true, workspaceId: "ws-1" }])).toBeNull();
+	});
+
+	it("closes the first sentence when a batch fails both ways at once", () => {
+		expect(
+			report([
+				{ ok: false, error: "Host service is not running" },
+				{ ok: false, error: "Host service is not running" },
+				{
+					ok: false,
+					workspaceId: "ws-1",
+					error: "Agent launch failed: spawn claude ENOENT",
+				},
+			]),
+		).toBe(
+			"Couldn't create 2 workspaces: Host service is not running. " +
+				"The agent didn't start in 1 workspace: Agent launch failed: spawn claude ENOENT",
+		);
+	});
+
+	it("does not double the period when the host error closed itself", () => {
+		expect(
+			report([
+				{ ok: false, error: "Host service is not running." },
+				{ ok: false, workspaceId: "ws-1", error: "Agent launch failed." },
+			]),
+		).toBe(
+			"Couldn't create 1 workspace: Host service is not running. " +
+				"The agent didn't start in 1 workspace: Agent launch failed.",
+		);
+	});
+
+	it("leaves a single failure kind exactly as it read before", () => {
+		expect(report([{ ok: false, error: "Host service is not running" }])).toBe(
+			"Couldn't create 1 workspace: Host service is not running",
+		);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/useBatchWorkspaceCreateReport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/useBatchWorkspaceCreateReport.ts
@@ -1,0 +1,48 @@
+import { plural } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react/macro";
+import { useCallback } from "react";
+import type { SubmitOutcome } from "renderer/stores/workspace-creates";
+import { summarizeBatchWorkspaceCreates } from "./summarizeBatchWorkspaceCreates";
+
+/**
+ * The failure line a batch create shows, or null when every workspace was
+ * created with its agent running. Reports the two failure kinds separately:
+ * an agent that never launched left a usable workspace behind, and calling
+ * that a create failure sends the user looking for a workspace that exists.
+ */
+export function useBatchWorkspaceCreateReport() {
+	const { t } = useLingui();
+	return useCallback(
+		(outcomes: readonly SubmitOutcome[]): string | null => {
+			const failures = summarizeBatchWorkspaceCreates(outcomes);
+			if (failures === null) return null;
+			const lines: string[] = [];
+			if (failures.notCreated > 0) {
+				const error = failures.firstNotCreatedError ?? "";
+				lines.push(
+					t({
+						message: plural(failures.notCreated, {
+							one: `Couldn't create # workspace: ${error}`,
+							other: `Couldn't create # workspaces: ${error}`,
+						}),
+					}),
+				);
+			}
+			if (failures.agentFailed > 0) {
+				const error = failures.firstAgentError ?? "";
+				lines.push(
+					t({
+						message: plural(failures.agentFailed, {
+							// The count is the failing subset, not the batch: naming
+							// what was created would read as the batch's total.
+							one: `The agent didn't start in # workspace: ${error}`,
+							other: `The agents didn't start in # workspaces: ${error}`,
+						}),
+					}),
+				);
+			}
+			return lines.join(" ");
+		},
+		[t],
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/useBatchWorkspaceCreateReport.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/tasks/components/TasksView/components/TasksTopBar/hooks/useBatchWorkspaceCreateReport/useBatchWorkspaceCreateReport.ts
@@ -41,7 +41,15 @@ export function useBatchWorkspaceCreateReport() {
 					}),
 				);
 			}
-			return lines.join(" ");
+			// Every line ends with a raw host error, which carries no
+			// punctuation of its own, so a bare space runs the two sentences
+			// together: "...is not running The agents didn't start...". Close
+			// each line another one follows; the last stays as it reads alone.
+			return lines
+				.map((line, index) =>
+					index === lines.length - 1 || /[.!?]$/.test(line) ? line : `${line}.`,
+				)
+				.join(" ");
 		},
 		[t],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceCreateErrorState/WorkspaceCreateErrorState.tsx
@@ -1,5 +1,6 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Button } from "@superset/ui/button";
+import { toast } from "@superset/ui/sonner";
 import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, GitBranch } from "lucide-react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
@@ -27,7 +28,16 @@ export function WorkspaceCreateErrorState({
 			snapshot: entry.input,
 		});
 		void completed.then((outcome) => {
-			if (outcome.ok && outcome.workspaceId !== workspaceId) {
+			// Submitting cleared this card. A retry that creates the workspace but
+			// fails its agent never records a new one, so nothing would replace the
+			// screen the user is looking at — report it here instead.
+			if (!outcome.ok && outcome.workspaceId !== undefined) {
+				toast.error(outcome.error);
+			}
+			if (
+				outcome.workspaceId !== undefined &&
+				outcome.workspaceId !== workspaceId
+			) {
 				void navigate({
 					to: "/v2-workspace/$workspaceId",
 					params: { workspaceId: outcome.workspaceId },

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -290,10 +290,15 @@ export function useSubmitWorkspace(
 		};
 
 		void completed.then((outcome) => {
-			if (!outcome.ok) return;
+			// A failed agent launch is the one failure the store records no
+			// failed-create row for, so this toast is its only channel.
+			if (!outcome.ok) toast.error(outcome.error);
 
 			// The server can resolve the optimistic workspace to a different
 			// canonical id; follow it only if we're still on the optimistic route.
+			// The failure outcome carries that id too — the local state behind the
+			// optimistic route has already been deleted.
+			if (outcome.workspaceId === undefined) return;
 			if (outcome.workspaceId === workspaceId) return;
 			if (!isViewingOptimisticWorkspace()) return;
 			void navigate({

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -7,7 +7,10 @@ import { cloudTrpc, cloudTrpcClient } from "renderer/lib/cloud-trpc";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import type { NewWorkspacePromptContextApi } from "renderer/stores/new-workspace-prompt-context";
 import { usePromptHistoryStore } from "renderer/stores/prompt-history";
-import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import {
+	reportableAgentLaunchError,
+	useWorkspaceCreates,
+} from "renderer/stores/workspace-creates";
 import { useDashboardNewWorkspaceDraft } from "../../../../../DashboardNewWorkspaceDraftContext";
 import { CLOUD_HOST_ID } from "../../../components/DevicePicker/DevicePicker";
 import type { WorkspaceCreateAgent } from "../../types";
@@ -291,8 +294,10 @@ export function useSubmitWorkspace(
 
 		void completed.then((outcome) => {
 			// A failed agent launch is the one failure the store records no
-			// failed-create row for, so this toast is its only channel.
-			if (!outcome.ok) toast.error(outcome.error);
+			// failed-create row for, so this toast is its only channel. Every
+			// other failure already shows the create-error card on this route.
+			const launchError = reportableAgentLaunchError(outcome);
+			if (launchError !== null) toast.error(launchError);
 
 			// The server can resolve the optimistic workspace to a different
 			// canonical id; follow it only if we're still on the optimistic route.

--- a/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.test.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.test.ts
@@ -11,10 +11,7 @@ describe("agentLaunchFailureDetail", () => {
 
 	test("returns null when every launch succeeded", () => {
 		expect(
-			agentLaunchFailureDetail(
-				[{ ok: true }, { ok: true, error: "ignored" }],
-				UNKNOWN,
-			),
+			agentLaunchFailureDetail([{ ok: true }, { ok: true }], UNKNOWN),
 		).toBeNull();
 	});
 
@@ -40,7 +37,24 @@ describe("agentLaunchFailureDetail", () => {
 		).toBe("first failure; second failure");
 	});
 
-	test("falls back to the caller's stand-in when the host omitted a message", () => {
-		expect(agentLaunchFailureDetail([{ ok: false }], UNKNOWN)).toBe(UNKNOWN);
+	test("stands in for a blank host message instead of returning a falsy detail", () => {
+		expect(agentLaunchFailureDetail([{ ok: false, error: "" }], UNKNOWN)).toBe(
+			UNKNOWN,
+		);
+		expect(
+			agentLaunchFailureDetail([{ ok: false, error: "   " }], UNKNOWN),
+		).toBe(UNKNOWN);
+	});
+
+	test("keeps the stand-in in place when only one of several is blank", () => {
+		expect(
+			agentLaunchFailureDetail(
+				[
+					{ ok: false, error: "" },
+					{ ok: false, error: "boom" },
+				],
+				UNKNOWN,
+			),
+		).toBe(`${UNKNOWN}; boom`);
 	});
 });

--- a/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.test.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { agentLaunchFailureDetail } from "./agentLaunchFailures";
+
+const UNKNOWN = "unknown error";
+
+describe("agentLaunchFailureDetail", () => {
+	test("returns null when no agents were reported", () => {
+		expect(agentLaunchFailureDetail(undefined, UNKNOWN)).toBeNull();
+		expect(agentLaunchFailureDetail([], UNKNOWN)).toBeNull();
+	});
+
+	test("returns null when every launch succeeded", () => {
+		expect(
+			agentLaunchFailureDetail(
+				[{ ok: true }, { ok: true, error: "ignored" }],
+				UNKNOWN,
+			),
+		).toBeNull();
+	});
+
+	test("reports a single host error", () => {
+		expect(
+			agentLaunchFailureDetail(
+				[{ ok: false, error: "no agent config for `claude`" }],
+				UNKNOWN,
+			),
+		).toBe("no agent config for `claude`");
+	});
+
+	test("joins every failed launch, not just the first", () => {
+		expect(
+			agentLaunchFailureDetail(
+				[
+					{ ok: false, error: "first failure" },
+					{ ok: true },
+					{ ok: false, error: "second failure" },
+				],
+				UNKNOWN,
+			),
+		).toBe("first failure; second failure");
+	});
+
+	test("falls back to the caller's stand-in when the host omitted a message", () => {
+		expect(agentLaunchFailureDetail([{ ok: false }], UNKNOWN)).toBe(UNKNOWN);
+	});
+});

--- a/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.test.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.test.ts
@@ -46,6 +46,16 @@ describe("agentLaunchFailureDetail", () => {
 		).toBe(UNKNOWN);
 	});
 
+	test("stands in for a host that omitted `error` instead of throwing", () => {
+		// A union-violating payload: nothing validates the event on the way in,
+		// and a throw here would be caught as a *create* failure and delete a
+		// workspace the host kept.
+		const malformed = [{ ok: false }] as unknown as Parameters<
+			typeof agentLaunchFailureDetail
+		>[0];
+		expect(agentLaunchFailureDetail(malformed, UNKNOWN)).toBe(UNKNOWN);
+	});
+
 	test("keeps the stand-in in place when only one of several is blank", () => {
 		expect(
 			agentLaunchFailureDetail(

--- a/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.ts
@@ -1,0 +1,20 @@
+/**
+ * The host keeps the workspace when a requested agent fails to spawn: the
+ * launch outcome comes back per entry in `agents[]` instead of throwing. A
+ * caller that passed `agents` asked for work to start, so a spawn failure is
+ * a failed create outcome — surface the host errors instead of soft-succeeding
+ * with "Workspace created" / "Sent to agent" over an empty agent pane.
+ *
+ * Returns the host's own error text, which is not translated; `unknownError`
+ * carries the caller's translated stand-in for a failure the host left blank.
+ */
+export function agentLaunchFailureDetail(
+	agents: ReadonlyArray<{ ok: boolean; error?: string }> | undefined,
+	unknownError: string,
+): string | null {
+	const errors = (agents ?? [])
+		.filter((agent) => !agent.ok)
+		.map((agent) => agent.error ?? unknownError);
+	if (errors.length === 0) return null;
+	return errors.join("; ");
+}

--- a/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.ts
@@ -6,8 +6,9 @@
  * with "Workspace created" / "Sent to agent" over an empty agent pane.
  *
  * Returns the host's own error text, which is not translated. The host builds
- * that text from `err.message`, so it can be blank; `unknownError` carries the
- * caller's translated stand-in for those.
+ * that text from `err.message`, so it can be blank, and nothing validates the
+ * payload at the transport; `unknownError` carries the caller's translated
+ * stand-in for a blank or absent message.
  */
 export function agentLaunchFailureDetail(
 	agents:
@@ -18,7 +19,13 @@ export function agentLaunchFailureDetail(
 	const errors: string[] = [];
 	for (const agent of agents ?? []) {
 		if (agent.ok) continue;
-		errors.push(agent.error.trim() || unknownError);
+		// Event payloads are forwarded without runtime validation, so a host
+		// that violates the union and omits `error` must still read as a
+		// failed launch. Reading it as a string would throw here, and the
+		// throw lands in the create path's catch, which deletes a workspace
+		// the host actually kept.
+		const reported = typeof agent.error === "string" ? agent.error.trim() : "";
+		errors.push(reported || unknownError);
 	}
 	if (errors.length === 0) return null;
 	return errors.join("; ");

--- a/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/agentLaunchFailures.ts
@@ -5,16 +5,21 @@
  * a failed create outcome — surface the host errors instead of soft-succeeding
  * with "Workspace created" / "Sent to agent" over an empty agent pane.
  *
- * Returns the host's own error text, which is not translated; `unknownError`
- * carries the caller's translated stand-in for a failure the host left blank.
+ * Returns the host's own error text, which is not translated. The host builds
+ * that text from `err.message`, so it can be blank; `unknownError` carries the
+ * caller's translated stand-in for those.
  */
 export function agentLaunchFailureDetail(
-	agents: ReadonlyArray<{ ok: boolean; error?: string }> | undefined,
+	agents:
+		| ReadonlyArray<{ ok: true } | { ok: false; error: string }>
+		| undefined,
 	unknownError: string,
 ): string | null {
-	const errors = (agents ?? [])
-		.filter((agent) => !agent.ok)
-		.map((agent) => agent.error ?? unknownError);
+	const errors: string[] = [];
+	for (const agent of agents ?? []) {
+		if (agent.ok) continue;
+		errors.push(agent.error.trim() || unknownError);
+	}
 	if (errors.length === 0) return null;
 	return errors.join("; ");
 }

--- a/apps/desktop/src/renderer/stores/workspace-creates/completeWorkspaceCreate.test.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/completeWorkspaceCreate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { completeWorkspaceCreate } from "./completeWorkspaceCreate";
+
+const UNKNOWN = "unknown error";
+
+function harness() {
+	const calls: string[] = [];
+	return {
+		calls,
+		effects: {
+			recordWorkspaceCreated: () => {
+				calls.push("recordWorkspaceCreated");
+			},
+			queueCreationPresets: (workspace: { id: string; projectId: string }) => {
+				calls.push(`queueCreationPresets:${workspace.id}`);
+			},
+		},
+	};
+}
+
+const newProjectWorkspace = {
+	workspace: { id: "ws-1", projectId: "project-1" },
+	alreadyExists: false,
+	requestedAgents: true,
+	skipsCreationPresets: false,
+	unknownError: UNKNOWN,
+};
+
+describe("completeWorkspaceCreate", () => {
+	test("keeps the created workspace's presets and star-nag count when an agent fails", () => {
+		const { calls, effects } = harness();
+
+		const detail = completeWorkspaceCreate(
+			{ ...newProjectWorkspace, agents: [{ ok: false, error: "boom" }] },
+			effects,
+		);
+
+		expect(detail).toBe("boom");
+		expect(calls).toEqual([
+			"recordWorkspaceCreated",
+			"queueCreationPresets:ws-1",
+		]);
+	});
+
+	test("runs the same bookkeeping when every agent launched", () => {
+		const { calls, effects } = harness();
+
+		const detail = completeWorkspaceCreate(
+			{ ...newProjectWorkspace, agents: [{ ok: true }] },
+			effects,
+		);
+
+		expect(detail).toBeNull();
+		expect(calls).toEqual([
+			"recordWorkspaceCreated",
+			"queueCreationPresets:ws-1",
+		]);
+	});
+
+	test("skips presets but still counts the workspace when the create opted out", () => {
+		const { calls, effects } = harness();
+
+		completeWorkspaceCreate(
+			{
+				...newProjectWorkspace,
+				skipsCreationPresets: true,
+				agents: [{ ok: false, error: "boom" }],
+			},
+			effects,
+		);
+
+		expect(calls).toEqual(["recordWorkspaceCreated"]);
+	});
+
+	test("counts neither a reopened workspace nor a session", () => {
+		const reopened = harness();
+		completeWorkspaceCreate(
+			{ ...newProjectWorkspace, alreadyExists: true, agents: [{ ok: true }] },
+			reopened.effects,
+		);
+		expect(reopened.calls).toEqual([]);
+
+		const session = harness();
+		completeWorkspaceCreate(
+			{
+				...newProjectWorkspace,
+				workspace: { id: "ws-2", projectId: null },
+				agents: [{ ok: true }],
+			},
+			session.effects,
+		);
+		expect(session.calls).toEqual([]);
+	});
+
+	test("reports no failure when the caller asked for no agents", () => {
+		const { effects } = harness();
+
+		expect(
+			completeWorkspaceCreate(
+				{
+					...newProjectWorkspace,
+					requestedAgents: false,
+					agents: [{ ok: false, error: "boom" }],
+				},
+				effects,
+			),
+		).toBeNull();
+	});
+});

--- a/apps/desktop/src/renderer/stores/workspace-creates/completeWorkspaceCreate.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/completeWorkspaceCreate.ts
@@ -1,0 +1,51 @@
+import { agentLaunchFailureDetail } from "./agentLaunchFailures";
+
+export interface CompleteWorkspaceCreateArgs {
+	workspace: { id: string; projectId: string | null };
+	agents: ReadonlyArray<{ ok: true } | { ok: false; error: string }>;
+	alreadyExists?: boolean;
+	/**
+	 * The caller asked for agents. The two recovery paths resolve with an empty
+	 * `agents[]` they never observed, and must not be read as a launch failure.
+	 */
+	requestedAgents: boolean;
+	/**
+	 * Adopting an existing worktree (the host reports that as new), or a create
+	 * that opted out of setup — e.g. "Import worktrees" with "Run setup" off.
+	 */
+	skipsCreationPresets: boolean;
+	unknownError: string;
+}
+
+export interface CompleteWorkspaceCreateEffects {
+	recordWorkspaceCreated: () => void;
+	queueCreationPresets: (workspace: { id: string; projectId: string }) => void;
+}
+
+/**
+ * Runs the bookkeeping a created workspace is owed, then reports whether a
+ * requested agent failed to launch — `null` when none did.
+ *
+ * A failed agent launch keeps the workspace and navigates the user into it, so
+ * the workspace is owed its creation presets and its star-nag count either way.
+ * Ordering the two here is what stops the failure outcome from being returned
+ * before them.
+ */
+export function completeWorkspaceCreate(
+	args: CompleteWorkspaceCreateArgs,
+	effects: CompleteWorkspaceCreateEffects,
+): string | null {
+	// Only genuinely new worktrees count as created — never reopened ones or
+	// project-less sessions (createSession has no alreadyExists signal, so an
+	// undefined value here is treated as "not new").
+	const { id, projectId } = args.workspace;
+	if (projectId !== null && args.alreadyExists === false) {
+		effects.recordWorkspaceCreated();
+		if (!args.skipsCreationPresets) {
+			effects.queueCreationPresets({ id, projectId });
+		}
+	}
+
+	if (!args.requestedAgents) return null;
+	return agentLaunchFailureDetail(args.agents, args.unknownError);
+}

--- a/apps/desktop/src/renderer/stores/workspace-creates/index.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/index.ts
@@ -1,3 +1,4 @@
+export { reportableAgentLaunchError } from "./reportableAgentLaunchError";
 export {
 	type SubmitArgs,
 	type SubmitHandle,

--- a/apps/desktop/src/renderer/stores/workspace-creates/reportableAgentLaunchError.test.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/reportableAgentLaunchError.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { reportableAgentLaunchError } from "./reportableAgentLaunchError";
+
+test("a surviving workspace with a failed agent is the caller's to report", () => {
+	expect(
+		reportableAgentLaunchError({
+			ok: false,
+			workspaceId: "ws-1",
+			error: "Agent launch failed: boom",
+		}),
+	).toBe("Agent launch failed: boom");
+});
+
+test("a create that produced no workspace is left to the failed-create row", () => {
+	expect(
+		reportableAgentLaunchError({
+			ok: false,
+			error: "Host service is not running",
+		}),
+	).toBeNull();
+});
+
+test("a successful create reports nothing", () => {
+	expect(
+		reportableAgentLaunchError({ ok: true, workspaceId: "ws-1" }),
+	).toBeNull();
+});

--- a/apps/desktop/src/renderer/stores/workspace-creates/reportableAgentLaunchError.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/reportableAgentLaunchError.ts
@@ -1,0 +1,20 @@
+import type { SubmitOutcome } from "./useWorkspaceCreates";
+
+/**
+ * The error a caller must report itself, or `null` when the store already
+ * reported it.
+ *
+ * A create that fails before it produces a workspace is recorded as a
+ * failed-create row, and the user gets the full-screen "Couldn't create
+ * workspace" card carrying the same text. A create whose workspace survives an
+ * agent that never launched has no such row — `workspaceId` on the failure arm
+ * is what distinguishes the two — so the caller's toast is that error's only
+ * channel.
+ */
+export function reportableAgentLaunchError(
+	outcome: SubmitOutcome,
+): string | null {
+	if (outcome.ok) return null;
+	if (outcome.workspaceId === undefined) return null;
+	return outcome.error;
+}

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -24,6 +24,7 @@ import type {
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useStarNagStore } from "renderer/stores/star-nag";
+import { agentLaunchFailureDetail } from "./agentLaunchFailures";
 import { queueWorkspaceCreationPresets } from "./queueWorkspaceCreationPresets";
 import { useWorkspaceTransactionsStore } from "./workspaceTransactions";
 import { writeWorkspacePaneLayout } from "./writeWorkspacePaneLayout";
@@ -410,6 +411,29 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 					if (result.workspace.id !== workspaceId) {
 						deleteWorkspaceLocalState(workspaceId);
 						hostWorkspacesCache.removeWorkspace(args.hostId, workspaceId);
+					}
+					// Requested agents that never spawned: keep the workspace (and any
+					// panes already written) but fail the submit outcome so create
+					// toasts cannot soft-succeed over an empty agent pane.
+					if (snapshot.agents?.length) {
+						const detail = agentLaunchFailureDetail(
+							result.agents,
+							i18n._(
+								msg({
+									message: "Unknown error",
+								}),
+							),
+						);
+						if (detail) {
+							return {
+								ok: false,
+								error: i18n._(
+									msg({
+										message: `Agent launch failed: ${detail}`,
+									}),
+								),
+							};
+						}
 					}
 					// Only genuinely new worktrees count as created — never reopened
 					// ones or project-less sessions (createSession has no

--- a/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
+++ b/apps/desktop/src/renderer/stores/workspace-creates/useWorkspaceCreates.ts
@@ -24,7 +24,7 @@ import type {
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import { useStarNagStore } from "renderer/stores/star-nag";
-import { agentLaunchFailureDetail } from "./agentLaunchFailures";
+import { completeWorkspaceCreate } from "./completeWorkspaceCreate";
 import { queueWorkspaceCreationPresets } from "./queueWorkspaceCreationPresets";
 import { useWorkspaceTransactionsStore } from "./workspaceTransactions";
 import { writeWorkspacePaneLayout } from "./writeWorkspacePaneLayout";
@@ -39,7 +39,12 @@ export interface SubmitArgs {
 
 export type SubmitOutcome =
 	| { ok: true; workspaceId: string }
-	| { ok: false; error: string };
+	/**
+	 * `workspaceId` is set only when the create kept a workspace it then failed
+	 * inside — a requested agent that never launched. Callers that navigate
+	 * must follow it; there is no failed-create row to fall back on.
+	 */
+	| { ok: false; error: string; workspaceId?: string };
 
 export interface SubmitHandle {
 	workspaceId: string;
@@ -412,52 +417,44 @@ export function useWorkspaceCreates(): UseWorkspaceCreatesApi {
 						deleteWorkspaceLocalState(workspaceId);
 						hostWorkspacesCache.removeWorkspace(args.hostId, workspaceId);
 					}
-					// Requested agents that never spawned: keep the workspace (and any
-					// panes already written) but fail the submit outcome so create
-					// toasts cannot soft-succeed over an empty agent pane.
-					if (snapshot.agents?.length) {
-						const detail = agentLaunchFailureDetail(
-							result.agents,
-							i18n._(
+					const adoptsWorktree =
+						"worktreePath" in snapshot && !!snapshot.worktreePath;
+					const skipsSetup =
+						"runSetup" in snapshot && snapshot.runSetup === false;
+					const detail = completeWorkspaceCreate(
+						{
+							workspace: result.workspace,
+							agents: result.agents,
+							alreadyExists: result.alreadyExists,
+							requestedAgents: !!snapshot.agents?.length,
+							skipsCreationPresets: adoptsWorktree || skipsSetup,
+							unknownError: i18n._(
 								msg({
 									message: "Unknown error",
 								}),
 							),
-						);
-						if (detail) {
-							return {
-								ok: false,
-								error: i18n._(
-									msg({
-										message: `Agent launch failed: ${detail}`,
-									}),
-								),
-							};
-						}
-					}
-					// Only genuinely new worktrees count as created — never reopened
-					// ones or project-less sessions (createSession has no
-					// alreadyExists signal, so an undefined value here is treated as
-					// "not new").
-					if (
-						result.workspace.projectId !== null &&
-						result.alreadyExists === false
-					) {
-						useStarNagStore.getState().recordWorkspaceCreated();
-						// Creation presets follow the same rule, and additionally skip
-						// adopting an existing worktree (the host reports that as new)
-						// and creates that opted out of setup, e.g. "Import worktrees"
-						// with "Run setup" off.
-						const adoptsWorktree =
-							"worktreePath" in snapshot && !!snapshot.worktreePath;
-						const skipsSetup =
-							"runSetup" in snapshot && snapshot.runSetup === false;
-						if (!adoptsWorktree && !skipsSetup) {
-							queueWorkspaceCreationPresets(collections, {
-								id: result.workspace.id,
-								projectId: result.workspace.projectId,
-							});
-						}
+						},
+						{
+							recordWorkspaceCreated: () =>
+								useStarNagStore.getState().recordWorkspaceCreated(),
+							queueCreationPresets: (workspace) =>
+								queueWorkspaceCreationPresets(collections, workspace),
+						},
+					);
+					// Requested agents that never spawned: keep the workspace, the
+					// panes already written and the bookkeeping above, but fail the
+					// submit outcome so create toasts cannot soft-succeed over an
+					// empty agent pane.
+					if (detail !== null) {
+						return {
+							ok: false,
+							workspaceId: result.workspace.id,
+							error: i18n._(
+								msg({
+									message: `Agent launch failed: ${detail}`,
+								}),
+							),
+						};
 					}
 					return {
 						ok: true,

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# pracovní prostor} few {# pracovní prostory} many {#
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {# běžící agent stále používá předchozí účet — přepnutí platí jen pro nová spuštění.} few {# běžící agenti stále používají předchozí účet — přepnutí platí jen pro nová spuštění.} many {# běžícího agenta stále používá předchozí účet — přepnutí platí jen pro nová spuštění.} other {# běžících agentů stále používá předchozí účet — přepnutí platí jen pro nová spuštění.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Nepodařilo se vytvořit # pracovní prostor: {error}} few {Nepodařilo se vytvořit # pracovní prostory: {error}} many {Nepodařilo se vytvořit # pracovního prostoru: {error}} other {Nepodařilo se vytvořit # pracovních prostorů: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Spustit # pracovní prostor} few {Spustit # pracovní p
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Zobrazit ještě # řádek} few {Zobrazit ještě # řádky} many {Zobrazit ještě # řádku} other {Zobrazit ještě # řádků}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Agent se nespustil v # pracovním prostoru: {error}} few {Agenti se nespustili v # pracovních prostorech: {error}} many {Agenti se nespustili v # pracovních prostorech: {error}} other {Agenti se nespustili v # pracovních prostorech: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Nezávislost na agentovi"
 msgid "Agent launch configuration"
 msgstr "Konfigurace spuštění agenta"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Spuštění agenta se nezdařilo: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Výběr agenta (Claude, Codex, Cursor…) používaný ve všech tocích vytváření relace"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Agenten-Unabhängigkeit"
 msgid "Agent launch configuration"
 msgstr "Startkonfiguration des Agenten"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Start des Agenten fehlgeschlagen: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Agentenauswahl (Claude, Codex, Cursor…), die jeder Sitzungserstellung zugrunde liegt"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# Arbeitsbereich} other {# Arbeitsbereiche}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Ein laufender Agent nutzt noch das vorherige Konto — der Wechsel gilt nur für neue Starts.} other {# laufende Agenten nutzen noch das vorherige Konto — der Wechsel gilt nur für neue Starts.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {# Arbeitsbereich konnte nicht erstellt werden: {error}} other {# Arbeitsbereiche konnten nicht erstellt werden: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {# Arbeitsbereich ausführen} other {# Arbeitsbereiche a
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {# weitere Zeile anzeigen} other {# weitere Zeilen anzeigen}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Der Agent wurde in # Arbeitsbereich nicht gestartet: {error}} other {Die Agenten wurden in # Arbeitsbereichen nicht gestartet: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# workspace} other {# workspaces}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Run # Workspace} other {Run # Workspaces}}"
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Show # more line} other {Show # more lines}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Agent Independence"
 msgid "Agent launch configuration"
 msgstr "Agent launch configuration"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Agent launch failed: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Independencia de agente"
 msgid "Agent launch configuration"
 msgstr "Configuración de lanzamiento del agente"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Error al lanzar el agente: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Selector de agente (Claude, Codex, Cursor…) que usan todos los flujos de creación de sesiones"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# espacio de trabajo} other {# espacios de trabajo}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Un agente en marcha sigue usando la cuenta anterior; el cambio solo se aplica a los nuevos lanzamientos.} other {# agentes en marcha siguen usando la cuenta anterior; el cambio solo se aplica a los nuevos lanzamientos.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {No se pudo crear # espacio de trabajo: {error}} other {No se pudieron crear # espacios de trabajo: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Ejecutar # espacio de trabajo} other {Ejecutar # espaci
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Mostrar # línea más} other {Mostrar # líneas más}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {El agente no se inició en # espacio de trabajo: {error}} other {Los agentes no se iniciaron en # espacios de trabajo: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# espace de travail} other {# espaces de travail}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Un agent en cours utilise encore le compte précédent — le changement ne s'applique qu'aux nouveaux lancements.} other {# agents en cours utilisent encore le compte précédent — le changement ne s'applique qu'aux nouveaux lancements.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Impossible de créer # espace de travail : {error}} other {Impossible de créer # espaces de travail : {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Exécuter # espace de travail} other {Exécuter # espac
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Afficher # ligne de plus} other {Afficher # lignes de plus}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {L'agent n'a pas démarré dans # espace de travail : {error}} other {Les agents n'ont pas démarré dans # espaces de travail : {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Indépendance des agents"
 msgid "Agent launch configuration"
 msgstr "Configuration de lancement de l'agent"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Échec du lancement de l'agent : {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Sélecteur d'agent (Claude, Codex, Cursor…) utilisé par tous les flux de création de session"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Independensi Agen"
 msgid "Agent launch configuration"
 msgstr "Konfigurasi peluncuran agen"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Gagal meluncurkan agen: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Pemilih agen (Claude, Codex, Cursor…) yang dipakai tiap alur pembuatan sesi"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# workspace} other {# workspace}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {# agen yang sedang berjalan masih memakai akun sebelumnya — pergantian hanya berlaku untuk peluncuran baru.} other {# agen yang sedang berjalan masih memakai akun sebelumnya — pergantian hanya berlaku untuk peluncuran baru.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Tidak bisa membuat # workspace: {error}} other {Tidak bisa membuat # workspace: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Jalankan # Workspace} other {Jalankan # Workspace}}"
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Tampilkan # baris lagi} other {Tampilkan # baris lagi}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Agen tidak berjalan di # workspace: {error}} other {Agen tidak berjalan di # workspace: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Indipendenza dagli agenti"
 msgid "Agent launch configuration"
 msgstr "Configurazione di avvio dell'agente"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Avvio dell'agente non riuscito: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Selettore di agente (Claude, Codex, Cursor…) usato da ogni flusso di creazione delle sessioni"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# workspace} other {# workspace}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Un agente in esecuzione usa ancora l'account precedente: il cambio vale solo per i nuovi avvii.} other {# agenti in esecuzione usano ancora l'account precedente: il cambio vale solo per i nuovi avvii.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Impossibile creare # workspace: {error}} other {Impossibile creare # workspace: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Esegui # workspace} other {Esegui # workspace}}"
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Mostra # altra riga} other {Mostra altre # righe}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {L'agente non è stato avviato in # workspace: {error}} other {Gli agenti non sono stati avviati in # workspace: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -1530,6 +1530,9 @@ msgstr "エージェント非依存"
 msgid "Agent launch configuration"
 msgstr "エージェント起動設定"
 
+msgid "Agent launch failed: {detail}"
+msgstr "エージェントの起動に失敗しました: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "すべてのセッション作成フローで使うエージェントピッカー(Claude、Codex、Cursor…)"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {#件のワークスペース} other {#件のワーク�
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {実行中の#件のエージェントはまだ以前のアカウントを使用しています。切り替えが適用されるのは新規起動のみです。} other {実行中の#件のエージェントはまだ以前のアカウントを使用しています。切り替えが適用されるのは新規起動のみです。}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {#件のワークスペースを作成できませんでした: {error}} other {#件のワークスペースを作成できませんでした: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {#件のワークスペースで実行} other {#件の�
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {さらに#行を表示} other {さらに#行を表示}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {#件のワークスペースでエージェントが起動しませんでした: {error}} other {#件のワークスペースでエージェントが起動しませんでした: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {워크스페이스 #개} other {워크스페이스 #개
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {실행 중인 에이전트 #개가 아직 이전 계정을 사용하고 있습니다. 전환은 새 실행에만 적용됩니다.} other {실행 중인 에이전트 #개가 아직 이전 계정을 사용하고 있습니다. 전환은 새 실행에만 적용됩니다.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {워크스페이스 #개를 만들지 못했습니다: {error}} other {워크스페이스 #개를 만들지 못했습니다: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {워크스페이스 #개 실행} other {워크스페이�
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {#줄 더 보기} other {#줄 더 보기}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {워크스페이스 #개에서 에이전트가 시작되지 않았습니다: {error}} other {워크스페이스 #개에서 에이전트가 시작되지 않았습니다: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -1530,6 +1530,9 @@ msgstr "에이전트 독립성"
 msgid "Agent launch configuration"
 msgstr "에이전트 실행 구성"
 
+msgid "Agent launch failed: {detail}"
+msgstr "에이전트 실행 실패: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "모든 세션 생성 흐름에서 쓰는 에이전트 선택기(Claude, Codex, Cursor…)"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# werkruimte} other {# werkruimtes}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Eén draaiende agent gebruikt nog het vorige account — de wissel geldt alleen voor nieuwe starts.} other {# draaiende agents gebruiken nog het vorige account — de wissel geldt alleen voor nieuwe starts.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Kan # werkruimte niet aanmaken: {error}} other {Kan # werkruimtes niet aanmaken: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {# werkruimte uitvoeren} other {# werkruimtes uitvoeren}
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {# regel meer tonen} other {# regels meer tonen}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {De agent is niet gestart in # werkruimte: {error}} other {De agents zijn niet gestart in # werkruimtes: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Agentonafhankelijkheid"
 msgid "Agent launch configuration"
 msgstr "Startconfiguratie van de agent"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Starten van de agent mislukt: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Agentkiezer (Claude, Codex, Cursor…) die elke flow voor sessiecreatie gebruikt"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# obszar roboczy} few {# obszary robocze} many {# obsza
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {# działający agent nadal korzysta z poprzedniego konta — zmiana obejmuje tylko nowe uruchomienia.} few {# działających agentów nadal korzysta z poprzedniego konta — zmiana obejmuje tylko nowe uruchomienia.} many {# działających agentów nadal korzysta z poprzedniego konta — zmiana obejmuje tylko nowe uruchomienia.} other {# działającego agenta nadal korzysta z poprzedniego konta — zmiana obejmuje tylko nowe uruchomienia.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Nie udało się utworzyć # obszaru roboczego: {error}} few {Nie udało się utworzyć # obszarów roboczych: {error}} many {Nie udało się utworzyć # obszarów roboczych: {error}} other {Nie udało się utworzyć # obszaru roboczego: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Uruchom # obszar roboczy} few {Uruchom # obszary robocz
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Pokaż jeszcze # wiersz} few {Pokaż jeszcze # wiersze} many {Pokaż jeszcze # wierszy} other {Pokaż jeszcze # wiersza}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Agent nie wystartował w # obszarze roboczym: {error}} few {Agenci nie wystartowali w # obszarach roboczych: {error}} many {Agenci nie wystartowali w # obszarach roboczych: {error}} other {Agenci nie wystartowali w # obszarach roboczych: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Niezależność od agenta"
 msgid "Agent launch configuration"
 msgstr "Konfiguracja uruchamiania agenta"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Nie udało się uruchomić agenta: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Wybór agenta (Claude, Codex, Cursor…) używany w każdym przepływie tworzenia sesji"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# área de trabalho} other {# áreas de trabalho}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Um agente em execução ainda usa a conta anterior — a troca só vale para novos lançamentos.} other {# agentes em execução ainda usam a conta anterior — a troca só vale para novos lançamentos.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Não foi possível criar # área de trabalho: {error}} other {Não foi possível criar # áreas de trabalho: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Executar # área de trabalho} other {Executar # áreas 
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Mostrar mais # linha} other {Mostrar mais # linhas}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {O agente não iniciou em # área de trabalho: {error}} other {Os agentes não iniciaram em # áreas de trabalho: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Independência de agente"
 msgid "Agent launch configuration"
 msgstr "Configuração de execução do agente"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Falha ao iniciar o agente: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Seletor de agente (Claude, Codex, Cursor…) usado em todo fluxo de criação de sessão"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Независимость от агента"
 msgid "Agent launch configuration"
 msgstr "Конфигурация запуска агента"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Не удалось запустить агента: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Выбор агента (Claude, Codex, Cursor…), используемый во всех сценариях создания сессий"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# рабочая область} few {# рабочие 
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {# работающий агент всё ещё использует прежний аккаунт — переключение действует только для новых запусков.} few {# работающих агента всё ещё используют прежний аккаунт — переключение действует только для новых запусков.} many {# работающих агентов всё ещё используют прежний аккаунт — переключение действует только для новых запусков.} other {# работающего агента всё ещё использует прежний аккаунт — переключение действует только для новых запусков.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Не удалось создать # рабочую область: {error}} few {Не удалось создать # рабочие области: {error}} many {Не удалось создать # рабочих областей: {error}} other {Не удалось создать # рабочих областей: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Запустить # рабочую область} few
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Показать ещё # строку} few {Показать ещё # строки} many {Показать ещё # строк} other {Показать ещё # строки}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Агент не запустился в # рабочей области: {error}} few {Агенты не запустились в # рабочих областях: {error}} many {Агенты не запустились в # рабочих областях: {error}} other {Агенты не запустились в # рабочих областях: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Ajan bağımsızlığı"
 msgid "Agent launch configuration"
 msgstr "Ajan başlatma yapılandırması"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Ajan başlatılamadı: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Her oturum oluşturma akışının kullandığı ajan seçici (Claude, Codex, Cursor…)"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# çalışma alanı} other {# çalışma alanı}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {Çalışan bir ajan hâlâ önceki hesabı kullanıyor — geçiş yalnızca yeni başlatmalar için geçerli.} other {Çalışan # ajan hâlâ önceki hesabı kullanıyor — geçiş yalnızca yeni başlatmalar için geçerli.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {# çalışma alanı oluşturulamadı: {error}} other {# çalışma alanı oluşturulamadı: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {# çalışma alanı çalıştır} other {# çalışma a
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {# satır daha göster} other {# satır daha göster}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Ajan # çalışma alanında başlatılamadı: {error}} other {Ajanlar # çalışma alanında başlatılamadı: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -1530,6 +1530,9 @@ msgstr "Độc lập với agent"
 msgid "Agent launch configuration"
 msgstr "Cấu hình khởi chạy agent"
 
+msgid "Agent launch failed: {detail}"
+msgstr "Khởi chạy agent thất bại: {detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "Bộ chọn agent (Claude, Codex, Cursor…) dùng trong mọi luồng tạo phiên"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {# workspace} other {# workspace}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {# agent đang chạy vẫn dùng tài khoản trước — việc chuyển chỉ áp dụng cho lần khởi chạy mới.} other {# agent đang chạy vẫn dùng tài khoản trước — việc chuyển chỉ áp dụng cho lần khởi chạy mới.}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {Không thể tạo # workspace: {error}} other {Không thể tạo # workspace: {error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {Chạy # workspace} other {Chạy # workspace}}"
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {Hiện thêm # dòng} other {Hiện thêm # dòng}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {Agent không khởi chạy trong # workspace: {error}} other {Agent không khởi chạy trong # workspace: {error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {#个工作区} other {#个工作区}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {#个运行中的智能体仍在使用之前的账户。切换只对新启动生效。} other {#个运行中的智能体仍在使用之前的账户。切换只对新启动生效。}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {无法创建#个工作区：{error}} other {无法创建#个工作区：{error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {运行#个工作区} other {运行#个工作区}}"
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {再显示#行} other {再显示#行}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {#个工作区中的智能体未启动：{error}} other {#个工作区中的智能体未启动：{error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -1530,6 +1530,9 @@ msgstr "智能体无关"
 msgid "Agent launch configuration"
 msgstr "智能体启动配置"
 
+msgid "Agent launch failed: {detail}"
+msgstr "智能体启动失败：{detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "智能体选择器（Claude、Codex、Cursor…），所有创建会话的流程都在用"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -1530,6 +1530,9 @@ msgstr "代理程式無關"
 msgid "Agent launch configuration"
 msgstr "代理程式啟動配置"
 
+msgid "Agent launch failed: {detail}"
+msgstr "代理程式啟動失敗：{detail}"
+
 msgid "Agent picker (Claude, Codex, Cursor…) used by every session-creation flow"
 msgstr "代理程式選擇器（Claude、Codex、Cursor…），所有建立會話的流程都在用"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -223,6 +223,10 @@ msgstr "{0, plural, one {#個工作區} other {#個工作區}}"
 msgid "{0, plural, one {A running agent still uses the previous account — the switch only reaches new launches.} other {# running agents still use the previous account — the switch only reaches new launches.}}"
 msgstr "{0, plural, one {#個執行中的代理程式仍在使用先前的帳戶。切換只對新啟動生效。} other {#個執行中的代理程式仍在使用先前的帳戶。切換只對新啟動生效。}}"
 
+#. placeholder {0}: failures.notCreated
+msgid "{0, plural, one {Couldn't create # workspace: {error}} other {Couldn't create # workspaces: {error}}}"
+msgstr "{0, plural, one {無法建立#個工作區：{error}} other {無法建立#個工作區：{error}}}"
+
 #. placeholder {0}: failures.length
 #. placeholder {0}: nextFailures.length
 msgid "{0, plural, one {Couldn’t delete # workspace} other {Couldn’t delete # workspaces}}"
@@ -266,6 +270,10 @@ msgstr "{0, plural, one {執行#個工作區} other {執行#個工作區}}"
 #. placeholder {0}: lines.length - MAX_VISIBLE_LINES
 msgid "{0, plural, one {Show # more line} other {Show # more lines}}"
 msgstr "{0, plural, one {再顯示#行} other {再顯示#行}}"
+
+#. placeholder {0}: failures.agentFailed
+msgid "{0, plural, one {The agent didn't start in # workspace: {error}} other {The agents didn't start in # workspaces: {error}}}"
+msgstr "{0, plural, one {#個工作區中的代理程式未啟動：{error}} other {#個工作區中的代理程式未啟動：{error}}}"
 
 #. placeholder {0}: importableWorktrees.length
 msgid "{0, plural, one {This will import # existing worktree into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.} other {This will import # existing worktrees into Superset as workspaces. Each worktree on disk will be tracked and appear in your sidebar. No files will be modified.}}"


### PR DESCRIPTION
## What & why

When a workspace is created with an agent from the desktop (Run in workspace, PR send-to-agent, and the other `useWorkspaceCreates` callers), the host can return `agents[].ok === false` and still leave the workspace in place. The renderer ignored that field and resolved the submit as success, so the success toast said the work had started even though no agent pane appeared. Someone retrying an overnight launch deserves the host error, not a green "Created workspace" / "Sent to agent" over an empty worktree.

This is the desktop sibling of the CLI and MCP fail-loud create paths: `useWorkspaceCreates` fails the submit outcome when agents were requested and any launch reported `ok: false`, without pretending the workspace itself failed to create.

## What changed

- `completeWorkspaceCreate` runs the workspace bookkeeping (`recordWorkspaceCreated`, creation presets) before the agent check, so a kept workspace keeps its presets; the failure outcome is returned only after that, and carries the surviving `workspaceId`.
- `agentLaunchFailureDetail` treats a blank host error as unknown (translated "Unknown error") instead of as success, and its type matches the host's `WorkspaceCreateAgentLaunch`.
- Every desktop create path that requests agents now surfaces the host error: the New Workspace modal, Open-in-workspace from a task, the two batch popovers, the PR comment composer, Automations, and Pages. Ordinary create failures are not double-reported; the full-screen create-error card remains their surface.
- The PR comment composer keeps the surviving workspace across a retry (query cache, not component state), never launches into an archived workspace, and does not create a second PR checkout after a failed agent launch.
- The batch popovers say "created, agent failed" rather than "not created", with Lingui plurals in all 17 catalogs, and a batch that failed both ways renders as two sentences.

## How I tested it

- Tip: `cd0933a64dabe1a54ab71e9702e164adc4ae26ba`, rebased on upstream `main`.
- Fork CI on that exact SHA: https://github.com/owieschon/superset/actions/runs/34383815689 — 11/11 jobs green, including `Lint` and its `Check i18n catalogs` step. (`Deploy Preview` fails on the fork only for a missing Neon secret.)
- `bun test` from `apps/desktop` on the touched directories: 101 pass, 0 fail, 21 files. `bunx tsc --noEmit` and `biome check` clean; `packages/i18n` compile `--strict` for all 17 locales.

With `agents` requested and any `agents[].ok === false`:

| Create path | Shows the host error | Green success suppressed |
|---|---|---|
| New Workspace modal (`useSubmitWorkspace`) | yes — toast | yes |
| Open in workspace, from a task (`OpenInWorkspaceV2`) | yes — toast | yes |
| Run in workspace, batch (`RunInWorkspacePopoverV2`) | yes — error worded as an agent failure | yes |
| Run issues in workspace (`RunIssuesInWorkspacePopover`) | yes — same | yes |
| PR comment → new workspace (`PullRequestCodeTab`) | yes — "Couldn't send comment" with the host error | yes |
| Automations → create with agent | yes — toast | yes |
| Pages → create page with agent | yes — toast | yes |

Retry from the create-error screen re-submits one of the seven and shows the same error.

## Checklist

- [x] Thin scope (workspace-creates store, the agent-carrying callers, their tests, catalogs)
- [x] Based on upstream `main`
- [x] Draft
- [x] Does not touch PRStatusGroup / Ready nouns / Todd #7007

