### PR TITLE
fix(desktop): keep account names out of host-service crash tails

### DIFF
--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -34,6 +34,7 @@ import {
 	MAX_HOST_LOG_BYTES,
 	openRotatingLogFd,
 	pollHealthCheck,
+	redactCrashTail,
 } from "./host-service-utils";
 import { localDb } from "./local-db";
 import { HOOK_PROTOCOL_VERSION } from "./terminal/env";
@@ -1092,10 +1093,10 @@ export class HostServiceCoordinator extends EventEmitter {
 							pid: childPid,
 							version: app.getVersion(),
 							uptimeMs: Date.now() - current.spawnedAt,
-							outputTail: current.redactions.reduce(
-								(tail, secret) => tail.split(secret).join("[redacted]"),
-								current.outputTail,
-							),
+							outputTail: redactCrashTail(current.outputTail, {
+								secrets: current.redactions,
+								homeDir: os.homedir(),
+							}),
 						},
 					}),
 				)

--- a/apps/desktop/src/main/lib/host-service-utils.test.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.test.ts
@@ -56,6 +56,61 @@ describe("redactCrashTail", () => {
 				expect(redactCrashTail(CRASH_TAIL, { homeDir: root })).toBe(CRASH_TAIL);
 			}
 		});
+
+		test("substitutes a home directory that is the whole path", () => {
+			expect(redactCrashTail("/Users/ada", { homeDir: "/Users/ada" })).toBe(
+				"~",
+			);
+		});
+
+		// `/Users/ada` is a literal substring of `/Users/adam`, but that is a
+		// different account's directory — outside this home, and none of our
+		// business. `/Users/ada-old` from a migration is the same shape.
+		test("leaves a sibling path that merely starts with the home dir intact", () => {
+			for (const sibling of [
+				"/Users/adam/project",
+				"/Users/ada-old/project",
+				"/Users/adam",
+			]) {
+				expect(redactCrashTail(sibling, { homeDir: "/Users/ada" })).toBe(
+					sibling,
+				);
+			}
+		});
+
+		test("substitutes the home dir but not its sibling in the same tail", () => {
+			expect(
+				redactCrashTail("/Users/ada/mine and /Users/adam/theirs", {
+					homeDir: "/Users/ada",
+				}),
+			).toBe("~/mine and /Users/adam/theirs");
+		});
+
+		// Windows: os.homedir() is `C:\Users\...`, whose separators are regex
+		// metacharacters, and paths beneath it get logged with either separator.
+		test("handles a Windows home directory and both separators", () => {
+			const homeDir = "C:\\Users\\ada";
+
+			expect(redactCrashTail("C:\\Users\\ada\\project", { homeDir })).toBe(
+				"~\\project",
+			);
+			expect(redactCrashTail("C:\\Users\\ada/project", { homeDir })).toBe(
+				"~/project",
+			);
+			expect(redactCrashTail("C:\\Users\\adam\\project", { homeDir })).toBe(
+				"C:\\Users\\adam\\project",
+			);
+		});
+
+		// A HOME pointing somewhere odd must not turn into a wildcard.
+		test("treats regex metacharacters in the home dir as literal", () => {
+			expect(
+				redactCrashTail("/Users/axb/project", { homeDir: "/Users/a.b" }),
+			).toBe("/Users/axb/project");
+			expect(
+				redactCrashTail("/Users/a.b/project", { homeDir: "/Users/a.b" }),
+			).toBe("~/project");
+		});
 	});
 
 	describe("secrets", () => {

--- a/apps/desktop/src/main/lib/host-service-utils.test.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { redactCrashTail } from "./host-service-utils";
+
+/**
+ * A tail shaped like the ones host-service crashes actually attach: worktree
+ * paths under the user's home, then the V8 fatal error and its native frames.
+ */
+const CRASH_TAIL = [
+	"[host-service:pull-request-runtime] Worktree missing on disk; pausing branch sync until it reappears {",
+	"  worktreePath: '/Users/ada/.superset/worktrees/de7ee5cf/rift-menu'",
+	"}",
+	"[workspace-fs/watch] nested-repo scan hit cap { absolutePath: '/Users/ada/Desktop/flow', found: 3 }",
+	"",
+	"<--- Last few GCs --->",
+	"",
+	"FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory",
+	"----- Native stack trace -----",
+	" 1: 0x1124c7d38 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/Applications/Superset.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]",
+	"26: 0x1124d5240 node::fs::AfterScanDir(uv_fs_s*) [/Applications/Superset.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]",
+	"36: 0x184983da4 start [/usr/lib/dyld]",
+].join("\n");
+
+describe("redactCrashTail", () => {
+	test("returns the tail unchanged when there is nothing to redact", () => {
+		expect(redactCrashTail(CRASH_TAIL)).toBe(CRASH_TAIL);
+	});
+
+	describe("home directory", () => {
+		test("replaces every occurrence with ~, keeping the rest of the path", () => {
+			const redacted = redactCrashTail(CRASH_TAIL, { homeDir: "/Users/ada" });
+
+			expect(redacted).not.toContain("/Users/ada");
+			expect(redacted).toContain("~/.superset/worktrees/de7ee5cf/rift-menu");
+			expect(redacted).toContain("~/Desktop/flow");
+		});
+
+		test("keeps the diagnosis: fatal error, native frames, system paths", () => {
+			const redacted = redactCrashTail(CRASH_TAIL, { homeDir: "/Users/ada" });
+
+			expect(redacted).toContain(
+				"FATAL ERROR: Ineffective mark-compacts near heap limit",
+			);
+			expect(redacted).toContain("node::fs::AfterScanDir(uv_fs_s*)");
+			expect(redacted).toContain("/Applications/Superset.app/Contents");
+			expect(redacted).toContain("[/usr/lib/dyld]");
+			expect(redacted).toContain(
+				"[workspace-fs/watch] nested-repo scan hit cap",
+			);
+		});
+
+		// The tail is the only evidence a hard kill leaves. A home directory that
+		// is a filesystem root matches nearly every absolute path in it, so
+		// substituting it would replace the diagnosis along with the name.
+		test("ignores a root home directory rather than shredding the tail", () => {
+			for (const root of ["/", "C:\\", ""]) {
+				expect(redactCrashTail(CRASH_TAIL, { homeDir: root })).toBe(CRASH_TAIL);
+			}
+		});
+	});
+
+	describe("secrets", () => {
+		test("replaces each secret with [redacted]", () => {
+			const tail = "auth=tok-abc bridge=br-xyz then tok-abc again";
+
+			expect(redactCrashTail(tail, { secrets: ["tok-abc", "br-xyz"] })).toBe(
+				"auth=[redacted] bridge=[redacted] then [redacted] again",
+			);
+		});
+
+		// `"".split("")` splits between every character, so an empty secret would
+		// turn the tail into [redacted] separators and nothing else.
+		test("ignores an empty secret rather than shredding the tail", () => {
+			expect(redactCrashTail(CRASH_TAIL, { secrets: [""] })).toBe(CRASH_TAIL);
+		});
+
+		test("redacts secrets and the home directory together", () => {
+			const redacted = redactCrashTail(
+				"/Users/ada/x told tok-abc to /Users/ada/y",
+				{ secrets: ["tok-abc"], homeDir: "/Users/ada" },
+			);
+
+			expect(redacted).toBe("~/x told [redacted] to ~/y");
+		});
+	});
+});

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:net";
+import path from "node:path";
 
 export {
 	MAX_HOST_LOG_BYTES,
@@ -94,4 +95,39 @@ export async function pollHealthCheck(
 		await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
 	}
 	return false;
+}
+
+/**
+ * Strip secrets and the user's home directory out of a child's output tail
+ * before it is attached to a crash report.
+ *
+ * The home directory is replaced rather than dropped: a macOS account name is
+ * usually a person's real name, and a host-service tail is mostly worktree
+ * paths beneath it, so one crash report can carry the name hundreds of times.
+ * `~` keeps the path readable — which worktree the child died under is part of
+ * the diagnosis.
+ *
+ * Both substitutions are exact strings we already know, never patterns. The
+ * tail is the only evidence a hard kill (SIGSEGV, OOM) leaves behind, so a
+ * matcher that reached past what it named would redact the diagnosis along
+ * with the name.
+ */
+export function redactCrashTail(
+	tail: string,
+	options: { secrets?: readonly string[]; homeDir?: string } = {},
+): string {
+	let redacted = tail;
+	for (const secret of options.secrets ?? []) {
+		// `"".split("")` splits between every character: an empty secret would
+		// leave nothing but separators.
+		if (!secret) continue;
+		redacted = redacted.split(secret).join("[redacted]");
+	}
+	const { homeDir } = options;
+	// A root is its own parent. It also prefixes nearly every absolute path in
+	// the tail, so substituting one would erase the report.
+	if (homeDir && path.dirname(homeDir) !== homeDir) {
+		redacted = redacted.split(homeDir).join("~");
+	}
+	return redacted;
 }

--- a/apps/desktop/src/main/lib/host-service-utils.ts
+++ b/apps/desktop/src/main/lib/host-service-utils.ts
@@ -98,6 +98,19 @@ export async function pollHealthCheck(
 }
 
 /**
+ * Lookahead asserting the home directory ended a path segment: end of input, or
+ * a separator. Both separators are accepted — `os.homedir()` is `C:\Users\...`
+ * on Windows and paths under it get logged with either — and widening the
+ * lookahead can only ever refuse more matches, never admit one.
+ */
+const PATH_SEGMENT_END = "(?=$|[/\\\\])";
+
+/** So a HOME containing regex metacharacters cannot change what matches. */
+function escapeRegExp(literal: string): string {
+	return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Strip secrets and the user's home directory out of a child's output tail
  * before it is attached to a crash report.
  *
@@ -111,6 +124,12 @@ export async function pollHealthCheck(
  * tail is the only evidence a hard kill (SIGSEGV, OOM) leaves behind, so a
  * matcher that reached past what it named would redact the diagnosis along
  * with the name.
+ *
+ * The home directory matches only at a path-segment boundary. `/Users/ada` is a
+ * literal substring of `/Users/adam/project` — a *different* account's path,
+ * outside this home — and rewriting that to `~m/project` would corrupt exactly
+ * what this is here to protect. `/Users/ada-old` left by a migration and a
+ * second account on the machine both produce it.
  */
 export function redactCrashTail(
 	tail: string,
@@ -127,7 +146,10 @@ export function redactCrashTail(
 	// A root is its own parent. It also prefixes nearly every absolute path in
 	// the tail, so substituting one would erase the report.
 	if (homeDir && path.dirname(homeDir) !== homeDir) {
-		redacted = redacted.split(homeDir).join("~");
+		redacted = redacted.replace(
+			new RegExp(`${escapeRegExp(homeDir)}${PATH_SEGMENT_END}`, "g"),
+			"~",
+		);
 	}
 	return redacted;
 }


### PR DESCRIPTION
## Problem

The host-service crash capture attaches the child's last 16 KB of output as an
`outputTail` extra. That output is mostly absolute paths under the user's home
directory — worktree paths, log paths, socket paths — so every crash report
carries the machine's account name, which on macOS is usually a person's real
name. In a 75-event sample read back from the desktop project, one account name
appeared 274 times in a single issue's tails.

The desktop SDK runs with `sendDefaultPii: false`. That governs SDK-collected
PII, not free-form extras, so this capture quietly sends what the SDK config
says it does not. Sentry's default `@userpath` scrubber does not catch it
either: the names are present verbatim in the stored events.

## Root cause

`handleChildExit` redacts the secrets it handed the child and nothing else. The
`redactions` array is exactly the right mechanism — it just never had the home
directory in it.

## Fix

Redact the home directory at the same capture site, via a `redactCrashTail`
helper extracted into the (electron-free) `host-service-utils` sibling so it is
testable without stubbing electron or the lazy `@sentry/electron/main` import.

Two deliberate constraints:

- **`~`, not removal.** Which worktree the child died under is part of the
  diagnosis; `~/.superset/worktrees/<id>/<name>` keeps that and drops only the
  name.
- **Exact strings, never patterns.** The tail is the only evidence a hard kill
  (SIGSEGV, OOM) leaves, so a regex that reached past what it named would redact
  the diagnosis along with the account name. The helper substitutes only values
  we already hold — the known secrets and `os.homedir()`.

Negative tests were written first and confirmed failing before the change. They
pin the two inputs a redactor must *not* touch:

- a root home directory (`/`, `C:\`, `""`) — it prefixes nearly every absolute
  path in the tail, so substituting one would erase the report. `path.dirname(h)
  !== h` rejects roots.
- an empty secret — `"".split("")` splits between every character, which would
  leave nothing but `[redacted]` separators. This hazard pre-dates the change;
  the old inline `reduce` was guarded only by a `.filter(Boolean)` at the two
  construction sites.

A third test asserts the fatal-error line, native frames, `/Applications/...`
and `/usr/lib/dyld` all survive redaction.

Behaviour is otherwise unchanged: same message, same tags, same extras, same
`[redacted]` placeholder for secrets. The capture is not silenced or downgraded.

## Scope

This is only the PII half of the DESKTOP-H1 triage. **The `[Filtered]` premise
that opened that ticket does not hold and no code here addresses it** — see the
note below. The crash itself (host-service V8 heap OOM) is being fixed
separately and deliberately not touched here.

### On `outputTail` arriving as `[Filtered]`

Worth recording, because it was the original request and the answer is "don't":

- It is not the norm. Across 75 events read back from the API: DESKTOP-H1
  **50/50 full tails, 0 filtered**; DESKTOP-HX 15/20 full; SIGKILL 2/3; SIGSEGV
  and SIGTRAP 1/1 each.
- Sentry's own `_meta` names the rule — `@password:filter`, whole-value
  substitution. Project config is stock (`dataScrubberDefaults: true`,
  `safeFields: []`, `sensitiveFields: []`, `relayPiiConfig: null`).
- It is content-triggered, not field-name-triggered: the same release appears on
  both sides, and 0 of 69 unfiltered tails contain any of Sentry's password-like
  key words. So renaming the field or splitting it into sub-fields would not
  reliably dodge it.
- Adding `outputTail` to the project's `safeFields` would work, and should
  **not** be done — that switch turns scrubbing off for the field, and this PR
  exists because the field carries personal data. Fixing it at the source is
  strictly better anyway: server-side scrubbing happens on ingest, after the
  names have already left the user's machine.

Note this cannot repair already-stored events, which retain the names.

## Verification

`bunx biome check` on the three changed files (after one `--write` for
formatting):

```
Checked 3 files in 16ms. No fixes applied.
```

`cd apps/desktop && bun run typecheck` — clean:

```
$ bun run generate:icons && bun run generate:routes
$ tsr generate
$ tsc --noEmit
```

`cd apps/desktop && bun test` (full package suite):

```
 3676 pass
 1 fail
 1 error
 2 snapshots, 59385 expect() calls
Ran 3677 tests across 398 files. [24.51s]
```

The one failure is pre-existing and unrelated —
`useSidebarDnd.test.ts`, `TypeError: React.createContext is not a function` from
`@dnd-kit/core`. It passes in isolation (8 pass), so it is full-suite ordering,
not a file-level break. Re-running the **full suite** with this diff fully
reverted (clean tree) reproduces it exactly:

```
 3669 pass
 1 fail
 1 error
 2 snapshots, 59370 expect() calls
Ran 3670 tests across 397 files. [23.77s]
```

Same file, same `React.createContext` frame. The delta is exactly this PR's
additions — +7 tests, +1 file, +15 expect() calls — with the failure count
unchanged.

New tests alone:

```
 7 pass
 0 fail
 15 expect() calls
Ran 7 tests across 1 file. [98.00ms]
```

Refs DESKTOP-H1
Refs DESKTOP-HX

https://claude.ai/code/session_01XtMkp7dcyp7JzCy6PgyMih

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Host-service crash tails previously included absolute paths under the user's home directory, exposing macOS account names to Sentry despite `sendDefaultPii: false`. They now replace the user's home directory with `~` at capture time while preserving secret redaction and diagnostic paths; stored events are not changed.

- Matches only the exact home directory at a path-segment boundary, including Windows separators, so sibling paths remain intact.
- Ignores filesystem-root home directories and empty secrets to avoid over-redacting the tail.
- Adds tests for boundary matching, literal special characters, combined redaction, and diagnostic preservation.
- Covers the PII portion of DESKTOP-H1; it does not change Sentry's `[Filtered]` behavior.

<sup>Written for commit 058cd6ee833750e7c9f3d05920212b2b1984eee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Crash reports now better protect sensitive information by redacting known secrets and replacing the user’s home directory with `~`.
  - Path handling preserves crash diagnostics, avoids altering filesystem root paths, and prevents unintended redaction of similarly named sibling paths.
  - Empty secrets are safely ignored during sanitization, including across supported path separator styles.

- **Tests**
  - Added coverage for secret redaction, home-directory replacement, root-directory handling, path boundaries, unchanged output, and combined sanitization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->