### PR TITLE
fix(workspace-fs): bound what nested-repo scans hold while watchers attach

### DIFF
--- a/packages/workspace-fs/src/find-nested-repos.test.ts
+++ b/packages/workspace-fs/src/find-nested-repos.test.ts
@@ -100,16 +100,17 @@ describe("findNestedRepoRoots", () => {
 		expect(roots.length).toBe(2);
 	});
 
-	it("reports truncation when the directory cap is hit", async () => {
+	it("reports truncation when the queued-directory cap is hit", async () => {
 		const root = await createTempRoot();
-		// A wide, repo-free tree so the scan is bounded by maxDirs, not maxRoots.
+		// A wide, repo-free tree so the scan is bounded by the queue cap, not
+		// maxRoots.
 		for (let i = 0; i < 10; i++) {
 			await mkdirp(root, `d-${i}`, "child");
 		}
 
 		const { truncated } = await findNestedRepoRoots(root, {
 			pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
-			maxDirs: 3,
+			maxQueuedDirs: 3,
 		});
 
 		expect(truncated).toBe(true);

--- a/packages/workspace-fs/src/find-nested-repos.ts
+++ b/packages/workspace-fs/src/find-nested-repos.ts
@@ -6,14 +6,20 @@ import path from "node:path";
 // repo boundary and at every ignored directory, so a normal tree is scanned in
 // full and a pathological one (a project holding thousands of agent worktrees)
 // is bounded by the count of worktree roots, not their contents.
-const DEFAULT_MAX_DIRS = 50_000;
+const DEFAULT_MAX_QUEUED_DIRS = 50_000;
 const DEFAULT_MAX_ROOTS = 5_000;
 
 export interface FindNestedRepoRootsOptions {
 	/** Directory basenames to skip while traversing (node_modules, .git, …). */
 	pruneDirNames: ReadonlySet<string>;
-	/** Stop after scanning this many directories. */
-	maxDirs?: number;
+	/**
+	 * Most directory paths the traversal queue may hold. Bounds the work — a
+	 * directory is only ever visited after being queued — and, unlike a cap on
+	 * directories *visited*, it also bounds what the scan is holding while it
+	 * runs: the queue is the breadth-first frontier and is retained until the
+	 * scan returns.
+	 */
+	maxQueuedDirs?: number;
 	/** Stop after discovering this many nested roots. */
 	maxRoots?: number;
 	/**
@@ -42,7 +48,11 @@ export interface FindNestedRepoRootsResult {
  *
  * Traversal is breadth-first, so when a cap truncates the scan the shallow
  * nested repos (the piled-up worktree roots near the top) are found before a
- * deep non-repo subtree can exhaust the budget.
+ * deep non-repo subtree can exhaust the budget. Breadth-first also means the
+ * queue holds every directory discovered but not yet visited, which is why
+ * `maxQueuedDirs` caps the queue rather than the visit count: the frontier is
+ * what a scan is still holding when a deadline stops it, and every watcher
+ * attaching at the same time holds one of its own.
  *
  * Symlinked directories are skipped (`Dirent.isDirectory()` is false for them),
  * which also avoids cycles and escaping the tree.
@@ -51,7 +61,7 @@ export async function findNestedRepoRoots(
 	rootPath: string,
 	options: FindNestedRepoRootsOptions,
 ): Promise<FindNestedRepoRootsResult> {
-	const maxDirs = options.maxDirs ?? DEFAULT_MAX_DIRS;
+	const maxQueuedDirs = options.maxQueuedDirs ?? DEFAULT_MAX_QUEUED_DIRS;
 	const maxRoots = options.maxRoots ?? DEFAULT_MAX_ROOTS;
 	const now = options.now ?? Date.now;
 	const deadline =
@@ -60,18 +70,13 @@ export async function findNestedRepoRoots(
 	// FIFO queue with a head cursor — plain `shift()` would be O(n) per dequeue.
 	const queue: string[] = [rootPath];
 	let head = 0;
-	let scanned = 0;
+	let truncated = false;
 
 	while (head < queue.length) {
-		if (
-			roots.length >= maxRoots ||
-			scanned >= maxDirs ||
-			(deadline !== null && now() >= deadline)
-		) {
+		if (roots.length >= maxRoots || (deadline !== null && now() >= deadline)) {
 			return { roots, truncated: true };
 		}
 		const dir = queue[head++] as string;
-		scanned += 1;
 
 		// Vanished or unreadable mid-scan — nothing to prune here.
 		const entries = await readdir(dir, { withFileTypes: true }).catch(
@@ -93,9 +98,16 @@ export async function findNestedRepoRoots(
 			if (options.pruneDirNames.has(entry.name)) {
 				continue;
 			}
+			if (queue.length >= maxQueuedDirs) {
+				// Stop widening, but keep draining what is already queued: those
+				// directories are shallower than the ones being dropped, and
+				// shallow is where the piled-up worktree roots are.
+				truncated = true;
+				break;
+			}
 			queue.push(path.join(dir, entry.name));
 		}
 	}
 
-	return { roots, truncated: false };
+	return { roots, truncated };
 }

--- a/packages/workspace-fs/src/watch.ts
+++ b/packages/workspace-fs/src/watch.ts
@@ -72,6 +72,17 @@ function escapeGlobMagic(input: string): string {
 const NESTED_REPO_SCAN_DEADLINE_MS = 3_000;
 
 /**
+ * Nested-repo scans allowed to run at once. Watcher attaches arrive in bursts —
+ * every non-archived workspace registers git interest at the same time — and a
+ * scan holds its whole breadth-first frontier until it returns. Running them
+ * all together stacks those frontiers without finishing any of them sooner:
+ * `readdir` is served by libuv's threadpool and a scan awaits one at a time, so
+ * one scan can only ever keep one thread busy. Unbounded, that is how
+ * host-service reached V8's heap limit and aborted (DESKTOP-H1).
+ */
+const NESTED_REPO_SCAN_CONCURRENCY = 4;
+
+/**
  * Whether a root-relative path falls under any pruned directory: a static
  * default (any path segment in DEFAULT_IGNORE_DIR_NAMES, plus the multi-
  * segment `.claude/worktrees` convention), or one of the per-root dynamic
@@ -256,6 +267,12 @@ export class FsWatcherManager {
 	 * needs to bump `fs.inotify.max_user_watches` and restart.
 	 */
 	private enospcErrorLogged = false;
+
+	/** Slots held/queued for `computeNestedRepoRelDirs`. A finishing scan hands
+	 * its slot straight to the next waiter, so the count only moves when a slot
+	 * is created or released. */
+	private runningNestedRepoScans = 0;
+	private readonly waitingNestedRepoScans: (() => void)[] = [];
 
 	constructor(options: FsWatcherManagerOptions = {}) {
 		this.debounceMs = options.debounceMs ?? 75;
@@ -627,6 +644,13 @@ export class FsWatcherManager {
 	 * pre-existing behavior, not a crash).
 	 */
 	private async computeNestedRepoRelDirs(realPath: string): Promise<string[]> {
+		if (this.runningNestedRepoScans >= NESTED_REPO_SCAN_CONCURRENCY) {
+			await new Promise<void>((resolve) =>
+				this.waitingNestedRepoScans.push(resolve),
+			);
+		} else {
+			this.runningNestedRepoScans += 1;
+		}
 		try {
 			const { roots, truncated } = await findNestedRepoRoots(realPath, {
 				pruneDirNames: DEFAULT_IGNORE_DIR_NAMES,
@@ -645,6 +669,10 @@ export class FsWatcherManager {
 				error: toErrorMessage(error),
 			});
 			return [];
+		} finally {
+			const next = this.waitingNestedRepoScans.shift();
+			if (next) next();
+			else this.runningNestedRepoScans -= 1;
 		}
 	}
 


### PR DESCRIPTION
## Problem

`host-service crashed (signal SIGABRT)` — 4,237 events in 14 days, the largest unresolved issue in the org. While host-service is dead the user has no git status, no terminals and no PR sync; the desktop silently restarts it, so the breakage is invisible and the restart feeds the next crash.

Reading the latest events, the SIGABRT is a V8 fatal and there are **two distinct fatals** grouped under one signal-based fingerprint:

| mode | fatal | crash frame | minidump sibling | 14d |
|---|---|---|---|---|
| A | `Ineffective mark-compacts near heap limit` at **~3,985 MB** | `node::fs::AfterScanDir` → JS | DESKTOP-DN | 109 |
| B | `Zone Allocation failed` with a **~110 MB** heap | `Builtin_JsonStringify` ← `MessagePort::OnMessage` | DESKTOP-12V | 95 |

This PR fixes mode A. Mode B is written up under *Deliberately not in this change* — I could not attribute it to a producer without guessing.

Events read: `a2e60c2a` (Prague, B), `ed4c4a7c` (Vancouver, A), `003c6c2f` (Sydney, A), `de63ad16` (Japan, B), plus DESKTOP-DN and DESKTOP-12V latest. `003c6c2f` and `ed4c4a7c` are machines in a permanent crash loop — `respawnAttempts` 8 and 2, uptime 211s and 100s, and the same install reappears every ~45–105s in the event list.

## Root cause

The `outputTail` on both mode-A events is dominated by one line, dozens of times:

```
[workspace-fs/watch] nested-repo scan hit cap — some nested repos may still be watched
  { absolutePath: '/Users/…/.superset/worktrees/flow-prod/veil-region', found: 0 }
```

Every watcher attach runs `findNestedRepoRoots` (`attachNativeSubscription` → `computeNestedRepoRelDirs`), and the sidebar registers git interest in **every non-archived workspace at once** — "observed in the hundreds", per the comment on `MAX_GIT_WATCHES_PER_CLIENT`. So hundreds of scans start in the same tick.

The scan is breadth-first, and BFS retains its whole frontier: `queue` only grows, `head` only advances. Its three caps — `maxDirs`, `maxRoots`, `deadlineMs` — bound *directories visited*, *roots found* and *wall-clock*. **None of them bounds the queue**, and the queue is the memory. Live memory is therefore the sum of every concurrent scan's frontier, bounded by nothing.

The 3s deadline makes it worse rather than better. N simultaneous scans share one libuv threadpool (4 threads, not raised anywhere in the repo) and each scan awaits one `readdir` at a time, so each gets ~1/N of the throughput and spends its whole budget on the shallow, high-fanout levels — the worst possible frontier-to-visited ratio. Measured on my own home directory: **2.8 queued per visited at 1 scan, 7.0 at 200**. `found: 0` in the log is the tell — a genuinely huge tree finds *some* nested repos on the way (the `$HOME` root in the same log found 140); finding zero while truncating means the scan barely started.

Then host-service dies, the desktop restarts it, the client re-subscribes, and the burst repeats. Forever.

**Reproduced.** 200 simultaneous scans of a real repo worktree, driving the actual `findNestedRepoRoots`, live (post-`gc()`) heap:

```
{"count":200,"concurrency":"unbounded","wallClockMs":3032,"peakLiveHeapMB":156.5,"truncatedScans":200,"rootsFoundMax":0}
{"count":200,"concurrency":4,       "wallClockMs":11323,"peakLiveHeapMB":12.1,"truncatedScans":0,  "rootsFoundMax":0}
```

`truncatedScans: 200, rootsFoundMax: 0` in the unbounded arm is the production log line, reproduced exactly. Scale that 156 MB by the affected installs — hundreds of workspaces, worktree graveyards, plus home-directory-sized project roots (one crash log scans `/Users/<user>` itself) — and 4 GB is where it lands.

## Fix

Two bounds in `packages/workspace-fs`, ~30 lines.

**1. Cap the frontier, not the visit count.** `maxDirs` → `maxQueuedDirs`. A directory is only ever visited after being queued, so `visited ≤ queue.length` always: one cap replaces two, keeps the same work budget (still 50,000), and now bounds memory too. When the queue is full the scan stops widening but keeps draining — what is already queued is *shallower* than what is dropped, and shallow is where piled-up worktree roots are. Isolating just this cap on one `$HOME` scan with the deadline disabled:

```
{"maxQueuedDirs":50000,     "ms": 5821,"peakLiveHeapMB":27.5,"roots":2074,"truncated":true}
{"maxQueuedDirs":100000000,"ms":35111,"peakLiveHeapMB":82.5,"roots":2085,"truncated":false}
```

3× the memory and 6× the time, for 11 of 2,085 roots (0.5%).

**2. Run the scans a few at a time** (`NESTED_REPO_SCAN_CONCURRENCY = 4`, the libuv threadpool width). This is the load-bearing half: it turns O(watchers) live frontiers into O(1). It is not a throughput trade — the work is threadpool-bound either way — and it makes the scans *correct*, because each one now gets a full thread instead of 1/200th. In the measurement above, gating took truncation from 200/200 to 0/200; on `$HOME` it took roots found from 2 to 2,074.

A finishing scan hands its slot straight to the next waiter, so the count only moves when a slot is created or released — no overshoot when several waiters wake in the same tick.

**Cost, stated plainly:** the last watcher in a burst attaches later. Realistic root, 200 workspaces: 3.0s → 11.3s. Worst case, if every root really were home-directory-sized: 200 × 3s / 4 ≈ 150s. The evidence says the affected installs are the starved case, not that case. Against a host-service that currently dies at 35s and takes fs and git events with it, later is strictly better than never — but it is a real behaviour change and it is your call whether 4 is the right number.

## Deliberately not in this change

- **Mode B — `Zone Allocation failed` inside `JSON.stringify`** (DESKTOP-12V, ~47% of the sampled crashes). The stack is unambiguous about the *shape*: `MessagePort::OnMessage` → microtask → `Builtin_JsonStringify` → `Zone::Expand`, and the worker pool is the only `MessagePort` in host-service, so it is a tRPC response serializing a worker-task result. I could not identify *which* producer without guessing, so I did not ship a cap. What I established: `getDiffPatch` is already capped (`MAX_PATCH_BYTES`, 32 MB, from HOST-SERVICE-5C); `usage/history` is explicitly bounded; the uncapped worker results left are `git/getStatusSnapshot` (`ChangedFile[]` ×3 + `ignoredPaths` + `expandUntrackedDirectories`, no cap, and it fires per-workspace on every reconnect — my prime suspect) and `git/getCommitFiles`. The cheap way to settle it is to put the in-flight task type into the crash context; happy to do that next.
- **`git.getDiffBulk` is unbounded and has no caller** — up to 2,000 files × both full sides with no byte cap, while its single-file sibling caps each side at 10 MB. Repo-wide grep finds only its own definition, its test, and three comments referring to it. Deleting it would remove real unbounded surface and a second way to do what `getDiffPatch` + `getDiff` already do, but removing a procedure breaks any older client still calling it — that is your call, not mine.
- **Raising `--max-old-space-size`.** Explicitly rejected, and the measurements agree: the quantity is unbounded, so a bigger number moves the crash rather than removing it.
- **`computeGitIgnoredRelDirs` runs ungated too**, spawning one `git` per workspace in the same burst. Real fan-out, but processes and fds, not heap — out of scope here.
- **No new test.** Asserting the gate holds at 4 means either mocking `findNestedRepoRoots` or widening the API to expose scan state; both cut against house rules. The existing cap test moved to `maxQueuedDirs`. Say the word and I will add one.
- **No Sentry issue state changed.**

## Verification

`bun run --cwd packages/workspace-fs typecheck` (changed package):
```
$ tsc --noEmit --emitDeclarationOnly false
```

`bun run --cwd packages/host-service typecheck` (consumer):
```
$ tsc --noEmit --emitDeclarationOnly false
```

`bunx @biomejs/biome@2.4.2 check` on the three changed files:
```
Checked 3 files in 15ms. No fixes applied.
```

Full `packages/workspace-fs` suite:
```
 101 pass
 0 fail
 237 expect() calls
Ran 101 tests across 16 files. [14.96s]
```

Full `packages/host-service` suite:
```
 1690 pass
 8 todo
 0 fail
 3947 expect() calls
Ran 1698 tests across 164 files. [229.95s]
```

Nothing failed, so there was no pre-existing failure to isolate.

Refs DESKTOP-H1

https://claude.ai/code/session_01FdhA7QAX8tFEP4iPTmvpnh


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes host-service OOM aborts (`SIGABRT`) on installs with many workspaces: every watcher attach runs a breadth-first nested-repo scan that holds its whole queue in memory, hundreds attach at once, and nothing bounded live memory (DESKTOP-H1).

**Changes**
- Replaced the directories-visited cap with a queue cap (`maxQueuedDirs`) in `findNestedRepoRoots`, so scan memory is bounded alongside work.
- Gated nested-repo scans at 4 concurrent in `watch.ts`, matching libuv's threadpool width, so bursts don't stack frontiers and starve each other.
- Behavior change: the last watcher in a burst attaches later — measured ~3.0s → ~11.3s at 200 workspaces.
- Does not address the separate `Zone Allocation failed` crash inside `JSON.stringify` (mode B), which needs more attribution.

<sup>Written for commit 11a52fcc0055e0a09ff59a52d84ad7d179e2966d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nested repository discovery so scans continue processing directories already queued while safely limiting additional work.
  - Updated scan truncation reporting to accurately indicate when directory discovery is capped.
  - Limited simultaneous nested-repository scans during workspace watching to improve responsiveness and resource usage.
  - Updated related scan configuration and validation to reflect the revised directory-queue limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->