### PR TITLE
chore(host-service): log worker results big enough to abort serialization

### DIFF
--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -48,30 +48,64 @@ const CRASH_WINDOW_MS = 60_000;
 const LARGE_RESULT_ROWS = 50_000;
 const LARGE_RESULT_BYTES = 4 * 1024 * 1024;
 
+/** Deepest a result keeps its bulk: `{ diffs: [ { oldFile: { contents } } ] }`
+ * puts a string four levels down, and the bytes have to be reachable there. */
+const MAX_PROBE_DEPTH = 4;
+
 /**
- * Rows and bytes a result carries. Arrays are counted, never walked — the
- * length is the whole diagnostic, and walking a 200k-row result would cost as
- * much as the serialization this is trying to describe. Depth stops at 2,
- * which reaches every worker result's bulk (`{ snapshot: { unstaged: [...] } }`
- * is the deepest).
+ * Rows and bytes a result carries.
+ *
+ * The walk stops as soon as `bytes` passes the threshold, which is what makes
+ * descending into array elements affordable: a result past the threshold is
+ * one this is about to log anyway, so nothing further can change the decision,
+ * and a 200k-row result is never walked in full. Both counts are therefore
+ * floors rather than totals once the walk stops — enough to tell the shape
+ * apart, which is all they are for. Elements are walked at all because the
+ * shape this is hunting could well be an array whose *elements* carry the
+ * bytes — a length-only count reports that as `rows: 1, bytes: 0` and stays
+ * silent on exactly the candidate it exists to catch.
+ *
+ * String lengths are UTF-16 code units, deliberately — not UTF-8 bytes. The
+ * fatal being chased is bounded by V8's `String::kMaxLength` and by heap held
+ * as UTF-16, so this is the unit the thresholds were derived in; re-encoding
+ * would make the number less comparable and cost a full encode per string.
  */
-function measureResultBulk(
-	value: unknown,
-	depth = 0,
-): { rows: number; bytes: number } {
-	if (typeof value === "string") return { rows: 0, bytes: value.length };
-	if (ArrayBuffer.isView(value)) return { rows: 0, bytes: value.byteLength };
-	if (Array.isArray(value)) return { rows: value.length, bytes: 0 };
-	if (depth >= 2 || value === null || typeof value !== "object") {
-		return { rows: 0, bytes: 0 };
-	}
+function measureResultBulk(result: unknown): { rows: number; bytes: number } {
 	let rows = 0;
 	let bytes = 0;
-	for (const child of Object.values(value)) {
-		const inner = measureResultBulk(child, depth + 1);
-		rows += inner.rows;
-		bytes += inner.bytes;
-	}
+
+	const visit = (value: unknown, depth: number): void => {
+		if (bytes >= LARGE_RESULT_BYTES) return;
+		if (typeof value === "string") {
+			bytes += value.length;
+			return;
+		}
+		// `isView` covers typed arrays and DataView but not a raw ArrayBuffer.
+		if (ArrayBuffer.isView(value)) {
+			bytes += value.byteLength;
+			return;
+		}
+		if (value instanceof ArrayBuffer) {
+			bytes += value.byteLength;
+			return;
+		}
+		if (Array.isArray(value)) {
+			rows += value.length;
+			if (depth >= MAX_PROBE_DEPTH) return;
+			for (const element of value) visit(element, depth + 1);
+			return;
+		}
+		if (
+			depth >= MAX_PROBE_DEPTH ||
+			value === null ||
+			typeof value !== "object"
+		) {
+			return;
+		}
+		for (const child of Object.values(value)) visit(child, depth + 1);
+	};
+
+	visit(result, 0);
 	return { rows, bytes };
 }
 

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -33,6 +33,48 @@ const IDLE_TIMEOUT_MS = 30_000;
 const CRASH_BUDGET = 3;
 const CRASH_WINDOW_MS = 60_000;
 
+/**
+ * A worker result at or above either of these is in the size range that can
+ * abort host-service outright while its tRPC response is serialized — the
+ * unattributed half of DESKTOP-H1, whose fatal runs no handler and leaves
+ * nothing behind but the log tail. Smaller results cannot be that crash, so
+ * they stay silent.
+ *
+ * Both numbers are reported because they behave differently: rows cost heap
+ * and serialize about 1:1, while off-heap bytes cost no heap at all and
+ * expand ~4x as JSON (a Buffer becomes `[104,101,…]`), so a result that looks
+ * small by every heap metric can still be the one that dies.
+ */
+const LARGE_RESULT_ROWS = 50_000;
+const LARGE_RESULT_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Rows and bytes a result carries. Arrays are counted, never walked — the
+ * length is the whole diagnostic, and walking a 200k-row result would cost as
+ * much as the serialization this is trying to describe. Depth stops at 2,
+ * which reaches every worker result's bulk (`{ snapshot: { unstaged: [...] } }`
+ * is the deepest).
+ */
+function measureResultBulk(
+	value: unknown,
+	depth = 0,
+): { rows: number; bytes: number } {
+	if (typeof value === "string") return { rows: 0, bytes: value.length };
+	if (ArrayBuffer.isView(value)) return { rows: 0, bytes: value.byteLength };
+	if (Array.isArray(value)) return { rows: value.length, bytes: 0 };
+	if (depth >= 2 || value === null || typeof value !== "object") {
+		return { rows: 0, bytes: 0 };
+	}
+	let rows = 0;
+	let bytes = 0;
+	for (const child of Object.values(value)) {
+		const inner = measureResultBulk(child, depth + 1);
+		rows += inner.rows;
+		bytes += inner.bytes;
+	}
+	return { rows, bytes };
+}
+
 export function resolveHostWorkerScriptPath(): string | null {
 	const override = process.env.SUPERSET_HOST_WORKER_SCRIPT_PATH;
 	if (override) return existsSync(override) ? override : null;
@@ -114,6 +156,23 @@ export class HostWorkerPool {
 	}
 
 	async run<TInput, TResult>(
+		def: WorkerTaskDefinition<TInput, TResult>,
+		input: TInput,
+		options?: WorkerTaskOptions,
+	): Promise<TResult> {
+		const result = await this.runWithFallback(def, input, options);
+		const { rows, bytes } = measureResultBulk(result);
+		if (rows >= LARGE_RESULT_ROWS || bytes >= LARGE_RESULT_BYTES) {
+			console.warn("[host-service:worker] large task result", {
+				taskType: def.type,
+				rows,
+				bytes,
+			});
+		}
+		return result;
+	}
+
+	private async runWithFallback<TInput, TResult>(
 		def: WorkerTaskDefinition<TInput, TResult>,
 		input: TInput,
 		options?: WorkerTaskOptions,


### PR DESCRIPTION
## Problem

#7327 fixed mode A of DESKTOP-H1 (the 4 GB heap OOM from unbounded nested-repo scans). **Mode B is still roughly half the volume** and is a different fatal: `Zone Allocation failed - process out of memory` at a **~110 MB heap**, with `Builtin_JsonStringify` ← `MessagePort::OnMessage` on the stack (DESKTOP-12V).

You asked me to settle it by measurement rather than by shipping enrichment blind. I did. **The answer is (c): neither `git/getStatusSnapshot` nor `git/getCommitFiles` can produce it, so the producer is something I have not identified.** This PR ships the enrichment, and it is shaped by what the measurements found rather than being a generic "log the task type".

All numbers below are from the **exact crash runtime** — the installed `/Applications/Superset.app` is Electron 41.10.3 / Node 24.18.0 / V8 14.6, matching the `runtime` and `node` tags on every mode-B event — driven via `ELECTRON_RUN_AS_NODE=1`.

## What ruled the two suspects out

**1. By size.** I built git repos whose untracked tree mirrors this monorepo's real `node_modules` (215,306 files, mean path 109.6 chars — an unignored `node_modules` being the realistic worst case for a dirty agent worktree), and ran the real `getGitStatusSnapshot` against them:

| untracked files | compute | JSON |
|---|---|---|
| 10,000 | 923 ms | 1.47 MB |
| 50,000 | 3,065 ms | 8.37 MB |
| 215,306 (a whole `node_modules`) | 11,601 ms | **35.04 MB** |

~171 bytes/entry, linear. Reaching even 128 MB of JSON needs **~786,000 untracked files in one worktree**. Real `getCommitFiles` for the largest diff this repo can produce (root commit → HEAD, every file ever touched — 9,308 files) is **1.37 MB**; it would need ~870,000 files in a single commit.

**2. By shape — the decisive one.** A payload of that shape cannot produce this fatal *at any size*. Scaling a synthetic row array up until it breaks:

| JSON output | heap | result |
|---|---|---|
| 133.1 MB | 111.6 MB | ok |
| 418.3 MB | 343.8 MB | ok |
| 502.2 MB | 412.1 MB | ok |
| — | 446.3 MB | **`RangeError: Invalid string length`** |

Row-shaped payloads hit V8's `String::kMaxLength` and throw something catchable long before the zone can fail. Confirmed on the *real* payload too, scaled in the production runtime:

| scale | entries | payload heap | JSON | result |
|---|---|---|---|---|
| ×1 (real) | 215,304 | 50.6 MB | 36.5 MB | ok |
| ×4 | 861,216 | 81.6 MB | 145.9 MB | ok |
| ×12 | 2,583,648 | 174.5 MB | 438.1 MB | ok |

At ×12 the payload alone needs 174.5 MB of heap — more than the entire heap these crashes die at — and it *still* serializes.

**3. The shape that does fit, and why it is also not enough.** Only one shape pairs a tiny heap with an enormous output: off-heap bytes. A 96 MB `Buffer` produces **402.7 M chars** of JSON at a **2.3 MB heap** — 4.2× expansion for zero heap cost, which is exactly the mode-B signature. The only worker result of that shape is `readDiffSideFile`'s `content: Buffer`, so I measured it through the real transform (`superjson.serialize` → `JSON.stringify`): at its cap, **10 MB → 40 MB JSON at a 2.7 MB heap, exactly 4×**. But `maxBytes` is `.max(DIFF_SIDE_FILE_MAX_BYTES)` **in the zod schema**, so 10 MB is a hard ceiling and 40 MB is short of a fatal.

Attribution to a worker-task continuation does hold, so the search space really is the worker results: at the start of a `MessagePort` callback the microtask queue is empty (Node drains it after every macrotask), so everything the checkpoint runs was queued by that callback.

**One thing I could not prove:** I never reproduced a `Zone Allocation failed` at all — on a machine with free RAM, `Zone::Expand` succeeded to ~1 GB. So whether the fatal is a `malloc` failure under pressure or a hard internal limit is still unknown. That is a further reason to stop theorising and read it off a real crash.

## Fix

One log line, at the one seam every worker-backed procedure passes through (`HostWorkerPool.run` — all 14 call sites use it), emitted **before** the response is serialized, because a V8 fatal runs no handler and leaves nothing behind but the log tail that DESKTOP-H1 already captures as `outputTail`.

It reports **rows and bytes separately**, because that is the discriminator the measurements established: rows cost heap and serialize ~1:1 and provably cannot cause this fatal; off-heap bytes cost no heap and expand 4×. So the next mode-B event will not just name the producer, it will say which failure mode it is — or show a producer that is neither, which is itself the answer.

It stays silent below 50,000 rows / 4 MB, because a result smaller than that cannot be this crash.

Arrays are walked into, not just counted — an array whose *elements* carry the bytes is a completely plausible shape for the producer nobody has named, and a length-only count reports that as `rows: 1, bytes: 0` and stays silent on exactly the candidate it exists to catch (caught in review by CodeRabbit). The walk stops the moment `bytes` passes the threshold, so a 215k-row result is still never walked in full and the cost property survives. Both counts are floors rather than totals once it stops; telling the shapes apart is all they are for.

Verified against the real payloads plus the shapes the earlier version missed:

```
[host-service:worker] large task result { taskType: "git/getStatusSnapshot (real, 215k untracked)", rows: 215304, bytes: 4194369 }
  ↑ pool.run overhead 5.05ms          (walks ~13% of the array, then exits)
  ↑ git/getStatusSnapshot (clean worktree) — silent, 0.03ms
[host-service:worker] large task result { taskType: "readDiffSideFile (10 MB blob)", rows: 0, bytes: 10485765 }
  ↑ 0.02ms
[host-service:worker] large task result { taskType: "git/getDiffPatch (32 MB patch)", rows: 0, bytes: 33554432 }
  ↑ 0.02ms
  ↑ git/getCommitFiles (9,308 files) — silent, 1.08ms
[host-service:worker] large task result { taskType: "NEW array-of-rows carrying 20 MB of strings", rows: 200, bytes: 4202196 }
  ↑ 0.02ms                            (was silent before the review fix)
[host-service:worker] large task result { taskType: "NEW array-of-rows carrying 10 MB of Buffers", rows: 40, bytes: 4194598 }
  ↑ 0.02ms                            (was silent before the review fix)
[host-service:worker] large task result { taskType: "NEW raw ArrayBuffer (not a view)", rows: 0, bytes: 8388608 }
  ↑ 0.02ms                            (ArrayBuffer.isView does not match a bare ArrayBuffer)
```

String lengths stay UTF-16 code units, deliberately — the fatal is bounded by `String::kMaxLength` and by heap held as UTF-16, which is the unit the thresholds above were derived in. Re-encoding to UTF-8 would make the number less comparable and cost a full encode per string; [reasoning on the thread](https://github.com/superset-sh/superset/pull/7328#discussion_r3960806812).

## Deliberately not in this change

- **No cap on either suspect.** They were measured and excluded; a cap on a producer that was never the problem is permanently maintained code that fixed nothing.
- **`git.getDiffBulk` left alone**, as instructed — still unbounded, still no caller, recorded.
- **`filesystem.readFile` takes `maxBytes: z.number().optional()` with no `.max()`**, unlike `readDiffSideFile`'s `.max(DIFF_SIDE_FILE_MAX_BYTES)` right next to it. Noting it because I saw it while enumerating byte-shaped surfaces; it is not a worker result so it is not mode B, and I am not touching it on a hunch.
- **No Sentry issue state changed.** DESKTOP-H1 stays open.
- This is instrumentation with a job to do. When it names the producer it should come back out.

## Verification

`bun run --cwd packages/host-service typecheck`:
```
$ tsc --noEmit --emitDeclarationOnly false
```

`bunx @biomejs/biome@2.4.2 check packages/host-service/src/workers/host-worker-pool.ts`:
```
Checked 1 file in 27ms. No fixes applied.
```

Full `packages/host-service` suite:
```
 1690 pass
 8 todo
 0 fail
 3947 expect() calls
Ran 1698 tests across 164 files. [222.42s]
```

An earlier run of this same tree reported `4 fail / 2 errors` — and took 1400s against this run's 232s, because two other agents were running heavy jobs on the machine at the time. I re-ran the identical tree (diff still applied, nothing reverted) and it came back green, so the failures were timeout flakes under load rather than anything in this change. `bun test src/workers` in isolation: `14 pass, 0 fail`. Both the suite and the integration test above were re-run after the review fix.

`bun test` does not match `*.node-test.ts`, so the worker pool's own integration test needs `bun run test:integration:workers`:
```
✔ WorkerTaskRunner termination (1349.80925ms)
ℹ tests 4
ℹ pass 4
ℹ fail 0
```

Refs DESKTOP-H1

https://claude.ai/code/session_01FdhA7QAX8tFEP4iPTmvpnh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved measurement of worker result sizes across strings, arrays, typed arrays, data views, and array buffers.
  * Added support for measuring nested result values to provide more accurate row and byte-size estimates.
  * Large results are now evaluated efficiently with measurement stopping once the configured size threshold is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->