### PR TITLE
fix(host-service): classify a deliberate worker abort as a non-500

### DIFF
--- a/packages/host-service/src/trpc/off-loop.test.ts
+++ b/packages/host-service/src/trpc/off-loop.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
+import { TRPCError } from "@trpc/server";
 import type { HostServiceContext } from "../types";
 import { defineWorkerTask } from "../workers/define-worker-task";
 import { HostWorkerPool } from "../workers/host-worker-pool";
+import {
+	WORKER_CRASH_ERROR_NAME,
+	WorkerTaskAbortedError,
+	WorkerTaskError,
+} from "../workers/WorkerTaskRunner";
 import { createOffLoop } from "./off-loop";
 
 const echoTask = defineWorkerTask<{ value: string }, string>({
@@ -92,5 +98,87 @@ describe("offLoop", () => {
 			"prepare failed",
 		);
 		expect(ran).toBe(false);
+	});
+
+	describe("pool rejections", () => {
+		function rejectingResolver(error: unknown) {
+			const offLoop = createOffLoop(() => ({
+				run: async () => {
+					throw error;
+				},
+			}));
+			const resolver = offLoop({
+				task: echoTask,
+				prepare: () => ({ value: "x" }),
+			});
+			return async () => {
+				try {
+					await resolver({ ctx: fakeCtx, input: undefined });
+				} catch (thrown) {
+					return thrown;
+				}
+				throw new Error("resolver must reject");
+			};
+		}
+
+		// Negatives first: every rejection that is a real failure has to keep
+		// its 500, which is the only thing the Sentry middleware looks at.
+		test("a task timeout still reports", async () => {
+			const timeout = new WorkerTaskError(
+				'[host-worker] Task "usage/leaderboardPayload" timed out after 110000ms',
+			);
+			expect(await rejectingResolver(timeout)()).toBe(timeout);
+		});
+
+		test("a worker crash still reports", async () => {
+			const crash = new WorkerTaskError("Worker exited with code 1", {
+				name: WORKER_CRASH_ERROR_NAME,
+				message: "Worker exited with code 1",
+			});
+			expect(await rejectingResolver(crash)()).toBe(crash);
+		});
+
+		test("a task-handler error that only borrows the abort name still reports", async () => {
+			const impostor = new WorkerTaskError("boom", {
+				name: "WorkerTaskAbortedError",
+				message: "boom",
+			});
+			expect(await rejectingResolver(impostor)()).toBe(impostor);
+		});
+
+		test("an ordinary failure still reports", async () => {
+			const plain = new Error("fatal: bad object");
+			expect(await rejectingResolver(plain)()).toBe(plain);
+		});
+
+		test("a client that hung up is not a server error", async () => {
+			const thrown = await rejectingResolver(
+				new WorkerTaskAbortedError("cancelled"),
+			)();
+			expect(thrown).toBeInstanceOf(TRPCError);
+			expect((thrown as TRPCError).code).toBe("CLIENT_CLOSED_REQUEST");
+			expect((thrown as TRPCError).message).toBe("Worker task aborted");
+		});
+
+		test("shutdown is retryable rather than a server error", async () => {
+			const thrown = await rejectingResolver(
+				new WorkerTaskAbortedError("disposed", "Worker runner disposed"),
+			)();
+			expect((thrown as TRPCError).code).toBe("SERVICE_UNAVAILABLE");
+			expect((thrown as TRPCError).message).toBe("Worker runner disposed");
+		});
+
+		test("a superseded task is not a server error", async () => {
+			const thrown = await rejectingResolver(
+				new WorkerTaskAbortedError(
+					"superseded",
+					"Task superseded by a newer request",
+				),
+			)();
+			expect((thrown as TRPCError).code).toBe("CLIENT_CLOSED_REQUEST");
+			expect((thrown as TRPCError).message).toBe(
+				"Task superseded by a newer request",
+			);
+		});
 	});
 });

--- a/packages/host-service/src/trpc/off-loop.ts
+++ b/packages/host-service/src/trpc/off-loop.ts
@@ -12,6 +12,7 @@ import {
 	type HostWorkerPool,
 } from "../workers/host-worker-pool";
 import type { WorkerTaskOptions } from "../workers/WorkerTaskRunner";
+import { rethrowWorkerTaskAbort } from "./worker-abort";
 
 export interface OffLoopArgs<TInput> {
 	ctx: HostServiceContext;
@@ -37,10 +38,15 @@ export function createOffLoop(getPool: () => Pick<HostWorkerPool, "run">) {
 	): (args: OffLoopArgs<TInput>) => Promise<TResult> {
 		return async (args) => {
 			const taskInput = await spec.prepare(args);
-			return getPool().run(spec.task, taskInput, {
-				...spec.options?.(args),
-				signal: args.signal,
-			});
+			try {
+				return await getPool().run(spec.task, taskInput, {
+					...spec.options?.(args),
+					signal: args.signal,
+				});
+			} catch (error) {
+				rethrowWorkerTaskAbort(error);
+				throw error;
+			}
 		};
 	};
 }

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -19,6 +19,7 @@ import {
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
+import { rethrowWorkerTaskAbort } from "../../worker-abort";
 import { resolveGithubRepo } from "../workspace-creation/shared/project-helpers";
 import type {
 	ChangedFile,
@@ -245,6 +246,9 @@ export const gitRouter = router({
 			try {
 				return await runStatusSnapshot(ctx, input);
 			} catch (error) {
+				// A pane closing mid-request aborts the task; that is the client
+				// leaving, not a status failure.
+				rethrowWorkerTaskAbort(error);
 				// The worker boundary strips prototypes, so a simple-git failure
 				// arrives as a plain error — classify it by message here. The
 				// worktree can vanish between resolveWorktreePath's existsSync

--- a/packages/host-service/src/trpc/worker-abort.ts
+++ b/packages/host-service/src/trpc/worker-abort.ts
@@ -1,0 +1,53 @@
+// The pool gives up on a task on purpose in three situations: host-service
+// shutdown, a newer request superseding this one, and the caller's signal
+// firing — which tRPC does for us the moment the desktop drops the
+// connection, so closing a pane cancels the batch it was still waiting on.
+// None of the three is a failure, but all three used to reach the boundary
+// as INTERNAL_SERVER_ERROR, the one code sentryMiddleware reports on.
+
+import { TRPCError } from "@trpc/server";
+import {
+	type WorkerTaskAbortedError,
+	WorkerTaskError,
+} from "../workers/WorkerTaskRunner";
+
+/**
+ * Reclassify a deliberate abort; leave every other rejection alone so it
+ * keeps its 500. Timeouts, worker crashes, and errors thrown by the task
+ * handler itself all stay reported.
+ */
+export function rethrowWorkerTaskAbort(error: unknown): void {
+	// Anything that crossed the worker boundary arrives as a WorkerTaskError
+	// carrying the original `name`, so a handler that threw something named
+	// like our abort can never be mistaken for one. Checking the class first
+	// is what keeps the name check below honest.
+	if (error instanceof WorkerTaskError) return;
+	if (!(error instanceof Error)) return;
+	if (error.name !== "WorkerTaskAbortedError") return;
+
+	const kind = (error as WorkerTaskAbortedError).kind;
+	switch (kind) {
+		case "disposed":
+			// The host is on its way down and the client is still there: the
+			// renderer retries SERVICE_UNAVAILABLE, so the query survives the
+			// restart instead of settling into a permanent error.
+			throw new TRPCError({
+				code: "SERVICE_UNAVAILABLE",
+				message: error.message,
+			});
+		case "superseded":
+		case "cancelled":
+			throw new TRPCError({
+				code: "CLIENT_CLOSED_REQUEST",
+				message: error.message,
+			});
+		default: {
+			// A new kind must be classified deliberately; until it is, the
+			// build fails here and the runtime keeps reporting it.
+			const exhaustive: never = kind;
+			throw new Error(`Unhandled worker abort kind: ${exhaustive}`, {
+				cause: error,
+			});
+		}
+	}
+}

--- a/packages/host-service/src/workers/WorkerTaskRunner.ts
+++ b/packages/host-service/src/workers/WorkerTaskRunner.ts
@@ -24,10 +24,18 @@ export class WorkerTaskError extends Error {
 	}
 }
 
+/** Why the runner gave up on a task on purpose; none of these is a worker
+ * failure. Kept as a field rather than read back out of the message so the
+ * tRPC boundary never has to match on our own wording. */
+export type WorkerTaskAbortKind = "disposed" | "superseded" | "cancelled";
+
 export class WorkerTaskAbortedError extends Error {
-	constructor(message = "Worker task aborted") {
+	public readonly kind: WorkerTaskAbortKind;
+
+	constructor(kind: WorkerTaskAbortKind, message = "Worker task aborted") {
 		super(message);
 		this.name = "WorkerTaskAbortedError";
+		this.kind = kind;
 	}
 }
 
@@ -217,7 +225,7 @@ export class WorkerTaskRunner {
 		for (const taskId of [...this.queue]) {
 			this.rejectTask(
 				taskId,
-				new WorkerTaskAbortedError("Worker runner disposed"),
+				new WorkerTaskAbortedError("disposed", "Worker runner disposed"),
 			);
 		}
 		this.queue.length = 0;
@@ -227,7 +235,7 @@ export class WorkerTaskRunner {
 			if (slot.activeTaskId) {
 				this.rejectTask(
 					slot.activeTaskId,
-					new WorkerTaskAbortedError("Worker runner disposed"),
+					new WorkerTaskAbortedError("disposed", "Worker runner disposed"),
 				);
 			}
 			exits.push(
@@ -308,7 +316,10 @@ export class WorkerTaskRunner {
 					if (!task) continue;
 
 					if (task.abortSignal?.aborted) {
-						this.rejectTask(task.taskId, new WorkerTaskAbortedError());
+						this.rejectTask(
+							task.taskId,
+							new WorkerTaskAbortedError("cancelled"),
+						);
 						continue;
 					}
 
@@ -444,7 +455,10 @@ export class WorkerTaskRunner {
 			) {
 				this.rejectTask(
 					task.taskId,
-					new WorkerTaskAbortedError("Task superseded by a newer request"),
+					new WorkerTaskAbortedError(
+						"superseded",
+						"Task superseded by a newer request",
+					),
 				);
 			} else {
 				this.resolveTask(task.taskId, response.result);
@@ -513,7 +527,7 @@ export class WorkerTaskRunner {
 		const task = this.tasks.get(taskId);
 		if (!task) return;
 
-		this.rejectTask(taskId, new WorkerTaskAbortedError());
+		this.rejectTask(taskId, new WorkerTaskAbortedError("cancelled"));
 
 		if (task.slotId) {
 			const slot = this.workerSlots.get(task.slotId);
@@ -557,7 +571,10 @@ export class WorkerTaskRunner {
 			this.queue.splice(i, 1);
 			this.rejectTask(
 				queuedTask.taskId,
-				new WorkerTaskAbortedError("Task superseded by a newer request"),
+				new WorkerTaskAbortedError(
+					"superseded",
+					"Task superseded by a newer request",
+				),
 			);
 		}
 	}

--- a/packages/host-service/src/workers/host-worker-pool.ts
+++ b/packages/host-service/src/workers/host-worker-pool.ts
@@ -253,7 +253,7 @@ export class HostWorkerPool {
 		input: TInput,
 		options?: WorkerTaskOptions,
 	): Promise<TResult> {
-		if (options?.signal?.aborted) throw new WorkerTaskAbortedError();
+		if (options?.signal?.aborted) throw new WorkerTaskAbortedError("cancelled");
 
 		return new Promise<TResult>((resolve, reject) => {
 			let settled = false;
@@ -265,7 +265,8 @@ export class HostWorkerPool {
 				cleanup();
 				fn();
 			};
-			const onAbort = () => settle(() => reject(new WorkerTaskAbortedError()));
+			const onAbort = () =>
+				settle(() => reject(new WorkerTaskAbortedError("cancelled")));
 			// Same default and zero-means-instant semantics as the worker path.
 			const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 			const timeoutHandle = setTimeout(


### PR DESCRIPTION
## Problem

The host worker pool rejects an in-flight task with `WorkerTaskAbortedError` in three ordinary lifecycle situations, and all three arrived at the tRPC boundary as `INTERNAL_SERVER_ERROR` — the only thing `sentryMiddleware` looks at:

1. **The client hung up.** hono's node-server aborts the request signal ("Client connection prematurely closed") when the renderer navigates away or closes a pane, cancelling a batched query whose slowest member is still running. This is 68 of the 69 events: `usage.leaderboardPayload` in a 30-procedure batch (HOST-SERVICE-3N, 66 events) and standalone (HOST-SERVICE-59, 2 events).
2. **Shutdown.** `dispose()` rejects whatever each slot was holding (HOST-SERVICE-5K, 1 event, `git.getStatus`).
3. **Superseded** by a newer request for the same dedupe key.

**User-visible harm.** For (1) and (3), none — nobody is waiting for the answer (all three issues report `Users Impacted: 0` and HTTP 200). The cost is ours: together this family is the largest recurring non-bug reporter in host-service, still accruing at ~51 events/14d, and archiving the biggest of the three did not stop it.

For (2) the harm is real. `hostServiceQueryRetry` in the renderer retries only what `isHostServiceConnectionError` accepts, which is `SERVICE_UNAVAILABLE` / `BAD_GATEWAY`. Its own doc comment says it exists "so a query in flight during a host-service restart self-heals instead of settling into a permanent 'Failed to fetch' that only a manual 'Try again' click clears". Because the shutdown rejection was coded `INTERNAL_SERVER_ERROR`, that retry never fired for exactly the case it was built for: in HOST-SERVICE-5K the host-service went down 8s after start on a freshly booted machine and the open pane's `git.getStatus` failed permanently instead of retrying.

## Root cause

`WorkerTaskAbortedError` carried no discriminator, so the boundary had no way to tell a deliberate abort from a failure without matching on our own message text. It fell through to the default 500.

The desktop copy of this class already solved this and is ratified: `apps/desktop/src/lib/trpc/workers/WorkerTaskRunner.ts` declares `kind: "disposed" | "superseded" | "cancelled"`, and `git-task-runner.ts` name-checks and maps it. This finishes the same job on the host-service side.

## Fix

- `WorkerTaskAbortedError` takes `kind` as its first constructor argument, matching the desktop declaration exactly. All 8 throw sites (6 in `WorkerTaskRunner.ts`, 2 in `host-worker-pool.ts`) pass one. **Every message is unchanged.**
- New `src/trpc/worker-abort.ts` translates it: `disposed` → `SERVICE_UNAVAILABLE`, `superseded`/`cancelled` → `CLIENT_CLOSED_REQUEST`, with `const exhaustive: never = kind` in the default arm.
- Wired in at the two places the reported procedures reach the pool: `offLoop()` (covers `usage.leaderboardPayload`, `usage.history`, `settings.branchPrefix`) and the existing `git.getStatus` catch.

No typed `cause`. The consumer that reads this — `isHostServiceConnectionError` — branches on the tRPC **code**, so a `kind` on the cause would be maintained for nothing.

**Naming vs #7210.** That PR adds `WORKER_TASK_TIMEOUT_CODE` / `isWorkerTaskTimeout` on `WorkerTaskError.code`. This is a sibling on a different class (`WorkerTaskAbortedError.kind`) with a different field name; the two don't collide and neither depends on the other.

### What still reports on this path

Everything that is not a deliberate abort:

- **Task timeouts** — `WorkerTaskError`, and with #7210 `WorkerTaskTimeoutError` + `WORKER_TASK_TIMEOUT_CODE`.
- **Worker crashes / non-zero exits** — `WorkerCrashedError`.
- **Errors thrown by the task handler itself**, which cross the boundary as `WorkerTaskError` carrying their original `name` (`GitError`, `NotGitRepoError`, …).
- **Queue rejections at circuit-open** (`rejectQueuedTasks`).
- **An abort with an unrecognised `kind`** — the default arm throws a plain `Error`, so it stays a 500.

### Over-match, and what prevents it

Name-checking `error.name === "WorkerTaskAbortedError"` would on its own match an error a *task handler* threw, because the boundary rebuilds errors as `WorkerTaskError` carrying the original `name`. `rethrowWorkerTaskAbort` returns early on `error instanceof WorkerTaskError` before the name check, so anything that crossed the worker boundary can never be reclassified — only a locally-constructed abort can. There is no message matching anywhere in this change.

## Verification

Negative tests were written and run **before** the change. The four negatives passed pre-change (so they guard rather than ride a general failure) and only the three abort cases were red:

```
$ bun test src/trpc/off-loop.test.ts        # BEFORE the change
(fail) offLoop > pool rejections > a client that hung up is not a server error
  Expected constructor: [class TRPCError extends Error]
  Received value: WorkerTaskAbortedError: cancelled
(fail) offLoop > pool rejections > shutdown is retryable rather than a server error
  Expected: "SERVICE_UNAVAILABLE"   Received: undefined
(fail) offLoop > pool rejections > a superseded task is not a server error
  Expected: "CLIENT_CLOSED_REQUEST" Received: undefined
 8 pass
 3 fail
Ran 11 tests across 1 file. [32.00ms]
```

After:

```
$ bun test src/trpc/off-loop.test.ts
 11 pass
 0 fail
 17 expect() calls
Ran 11 tests across 1 file. [21.00ms]
```

The exhaustiveness guard was proved by temporarily adding a fourth variant:

```
$ bun run typecheck   # with "evicted" added to WorkerTaskAbortKind
src/trpc/worker-abort.ts(47,10): error TS2322: Type '"evicted"' is not assignable to type 'never'.
```

Biome (formatting fixes applied with `--write`, then re-checked clean):

```
$ bunx biome check --write <6 changed files>
Checked 6 files in 24ms. Fixed 2 files.
$ bunx biome check <6 changed files>
Checked 6 files in 14ms. No fixes applied.
```

Typecheck and the full package suite:

```
$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false
   (no output)

$ bun test src/
 1370 pass
 0 fail
 3034 expect() calls
Ran 1370 tests across 116 files. [88.26s]

$ bun test test/
 327 pass
 8 todo
 0 fail
 924 expect() calls
Ran 335 tests across 48 files. [136.45s]
```

No desktop git code was touched, so `no-main-process-blocking.test.ts` is not in scope.

## Left alone

Adjacent pool call sites that can also abort but are not in the reported family, and so keep their current classification: `git.commit` / `git.push` / `getDiffStatsByWorkspaces` and the other `getHostWorkerPool().run` sites in `git.ts`, `workspaces.ts:282`, `pull-requests/procedures/create-for-workspace.ts:42`, `workspace-cleanup/git-ops.ts` (which has its own `isIndeterminateGitTaskFailure` handling and is unchanged), and the PR-refs sync in `app.ts:150`, which is not a tRPC procedure.

Refs HOST-SERVICE-3N
Refs HOST-SERVICE-59
Refs HOST-SERVICE-5K

https://claude.ai/code/session_01FH9RULrVnhp78uaKRShmCq


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclassifies deliberate worker task aborts so they no longer surface as `INTERNAL_SERVER_ERROR`, the only code Sentry reports. Client hang-ups, host shutdown, and superseded tasks now map to `CLIENT_CLOSED_REQUEST` or `SERVICE_UNAVAILABLE`, making shutdown rejections retryable and stopping the largest recurring non-bug Sentry reporter in host-service.

**Details**
- `WorkerTaskAbortedError` now carries a `kind` discriminator (`disposed` | `superseded` | `cancelled`) matching the desktop declaration.
- A new `worker-abort.ts` maps kinds to tRPC codes with an exhaustive switch; unrecognized kinds stay 500s via a `never` guard.
- Wired in at `offLoop()` and the `git.getStatus` catch; other pool call sites keep their current classification.
- Timeouts, worker crashes, and task-handler errors keep their 500s — only locally-constructed aborts are reclassified, with negative tests guarding against over-matching.
- Refs HOST-SERVICE-3N, HOST-SERVICE-59, HOST-SERVICE-5K.

<sup>Written for commit 843357b039abda867f3be882fef62e4c765a835e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of interrupted background operations when a request is cancelled, superseded, or the host restarts.
  - Requests cancelled by a closed client now return the appropriate cancellation response instead of appearing as generic failures.
  - Host restart conditions are reported as temporarily unavailable, allowing supported clients to retry.
  - Genuine task failures continue to surface unchanged, preserving accurate error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->