### PR TITLE
fix(api): bound the redispatch sweep's advisory-lock transaction

### DIFF
--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -45,8 +45,8 @@ function scheduleFromConfig(
  * sweep finished, and a sweep that is still going is not worth joining.
  */
 async function sweepUndispatched() {
-	const sweep = await singleFlight("automations.redispatch", () =>
-		redispatchUndispatched(),
+	const sweep = await singleFlight("automations.redispatch", (tx) =>
+		redispatchUndispatched(tx),
 	);
 	return sweep.ran ? sweep.result : { skipped: true };
 }

--- a/apps/api/src/lib/automations/redispatchUndispatched.ts
+++ b/apps/api/src/lib/automations/redispatchUndispatched.ts
@@ -1,6 +1,6 @@
-import { db } from "@superset/db/client";
 import { automationEvents } from "@superset/db/schema";
 import { and, asc, gt, isNotNull, isNull, lt } from "drizzle-orm";
+import type { SingleFlightTx } from "@/lib/singleFlight";
 import { dispatchMatchingTriggers } from "./dispatchMatchingTriggers";
 
 /** Long enough that an in-flight delivery is not mistaken for a stuck one. */
@@ -22,18 +22,38 @@ const LOOKBACK_MS = 24 * 60 * 60 * 1000;
 const BATCH_SIZE = 200;
 
 /**
+ * How long the row loop may run before it leaves the rest to the next tick.
+ *
+ * This is what keeps the batch a batch. `singleFlight` holds its advisory lock
+ * in a transaction on `tx`, and every row here costs a publish that runs off
+ * that connection, so the connection sits `idle in transaction` for as long as
+ * this loop does. Postgres closes it at five minutes and drops the lock with
+ * it, mid-sweep, which is how a full 200-row batch took the guard down and
+ * left the commit talking to a dead socket. A minute is the same ceiling the
+ * Linear sweep publishes under, and leaves five times the headroom.
+ */
+const TIME_BUDGET_MS = 60_000;
+
+/**
  * Retries the one step neither the sender nor QStash retries: the handoff
  * from a recorded event to QStash. Rows past the grace period with no
  * `dispatchedAt` are re-run through the dispatcher from their stored input;
  * `dispatchMatchingTriggers` marks them once the publish succeeds, and QStash
  * dedupes on trigger+event so a row that half-published does not double-run.
+ *
+ * Runs on the caller's `singleFlight` transaction and within a time budget, so
+ * the lock it holds cannot outlive the idle-in-transaction timeout. Stopping
+ * early is safe at any point: a row is marked only once its publish lands, so
+ * whatever this run did not reach is still unmarked and still stuck, and the
+ * next tick selects it again.
  */
-export async function redispatchUndispatched(): Promise<{
+export async function redispatchUndispatched(tx: SingleFlightTx): Promise<{
 	attempted: number;
 	failed: number;
+	more: boolean;
 }> {
-	const now = Date.now();
-	const stuck = await db
+	const startedAt = Date.now();
+	const stuck = await tx
 		.select({
 			id: automationEvents.id,
 			organizationId: automationEvents.organizationId,
@@ -44,15 +64,18 @@ export async function redispatchUndispatched(): Promise<{
 			and(
 				isNull(automationEvents.dispatchedAt),
 				isNotNull(automationEvents.dispatchInput),
-				gt(automationEvents.receivedAt, new Date(now - LOOKBACK_MS)),
-				lt(automationEvents.receivedAt, new Date(now - GRACE_MS)),
+				gt(automationEvents.receivedAt, new Date(startedAt - LOOKBACK_MS)),
+				lt(automationEvents.receivedAt, new Date(startedAt - GRACE_MS)),
 			),
 		)
 		.orderBy(asc(automationEvents.receivedAt))
 		.limit(BATCH_SIZE);
 
+	let attempted = 0;
 	let failed = 0;
 	for (const row of stuck) {
+		if (Date.now() - startedAt >= TIME_BUDGET_MS) break;
+		attempted++;
 		if (!row.dispatchInput) continue;
 		try {
 			await dispatchMatchingTriggers({
@@ -68,5 +91,10 @@ export async function redispatchUndispatched(): Promise<{
 			console.error(`[automations/redispatch] event ${row.id} failed:`, error);
 		}
 	}
-	return { attempted: stuck.length, failed };
+	// Whether the run stopped on a limit rather than running out of work.
+	return {
+		attempted,
+		failed,
+		more: attempted < stuck.length || stuck.length === BATCH_SIZE,
+	};
 }

--- a/apps/api/src/lib/singleFlight.ts
+++ b/apps/api/src/lib/singleFlight.ts
@@ -4,6 +4,9 @@ import type { PgTransaction } from "drizzle-orm/pg-core";
 
 export type SingleFlightResult<T> = { ran: true; result: T } | { ran: false };
 
+// biome-ignore lint/suspicious/noExplicitAny: Transaction type varies by client (Neon, PostgresJs, etc)
+export type SingleFlightTx = PgTransaction<any, any, any>;
+
 /**
  * Runs `fn` under a job-scoped advisory lock, or reports `ran: false` without
  * running it when another invocation already holds the lock.
@@ -19,6 +22,14 @@ export type SingleFlightResult<T> = { ran: true; result: T } | { ran: false };
  * should run on the transaction handed to `fn`, which keeps the lock and the
  * statement on one connection.
  *
+ * That cuts both ways: because the lock lives in this transaction, `fn` must
+ * not leave the connection idle for long. Postgres closes a connection sitting
+ * `idle in transaction` for five minutes, and it takes the lock with it while
+ * `fn` is still running — so the guard fails open on exactly the slow run it
+ * exists to bound, and the commit that follows fails on a dead socket. Work
+ * `fn` does off this connection, above all a network call per row, has to be
+ * bounded by something well under that.
+ *
  * Batch jobs take the lock per batch rather than around their whole loop.
  * That keeps each batch transaction short, which is what their batch sizes
  * were chosen for, and still bounds the job to one batch in flight: a
@@ -28,8 +39,7 @@ export type SingleFlightResult<T> = { ran: true; result: T } | { ran: false };
  */
 export async function singleFlight<T>(
 	job: string,
-	// biome-ignore lint/suspicious/noExplicitAny: Transaction type varies by client (Neon, PostgresJs, etc)
-	fn: (tx: PgTransaction<any, any, any>) => Promise<T>,
+	fn: (tx: SingleFlightTx) => Promise<T>,
 ): Promise<SingleFlightResult<T>> {
 	return dbWs.transaction(async (tx) => {
 		const { rows } = await tx.execute<{ locked: boolean }>(


### PR DESCRIPTION
## Problem

The minute-cadence automations evaluate tick ends by running the undispatched-event sweep under `singleFlight`, which holds a **transaction-scoped** advisory lock. The sweep selects up to 200 stuck rows and does a network publish per row — all on *other* connections (`db` is neon-http, the lock is on the `dbWs` websocket pool). So the lock connection sits `idle in transaction` for the entire loop.

Confirmed on the same Neon platform as production: `idle_in_transaction_session_timeout = 5min` (`idle_session_timeout = 0`, `statement_timeout = 0`). At five minutes Postgres terminates that backend. Two things follow, one per issue:

- The driver receives the termination with no listener attached → fatal uncaught exception (API-2N, `handled: no`, `onuncaughtexception`).
- Drizzle's transaction wrapper then fails its commit and fails the rollback behind it → `Failed query: rollback` escapes `POST` (API-2P).

Both fire on the same trace, same second, 7 pairs between 13:45 and 16:05 UTC on 2026-09-08.

**The user-visible harm is not the Sentry entry.** The sweep's own work survives — it runs on connections the kill does not touch. What dies is the guard: an advisory xact lock is released when Postgres aborts its transaction, so from the five-minute mark the sweep is running **unprotected**, and every subsequent minute-tick takes the now-free lock and starts another concurrent sweep over the same still-unmarked rows. That is exactly the stacking `singleFlight` was introduced to stop (#7114 — the doc records 24 concurrent copies of *this* sweep, "every one pinning a backend for minutes"). The guard fails open on precisely the slow run it exists to bound, and customers get an API whose backends are pinned by duplicate sweeps.

## Root cause

`automations.redispatch` was the only `singleFlight` caller that ignored the `tx` it was handed and did its work on the global client instead, so nothing kept the lock transaction short. `singleFlight`'s doc already stated the contract — "Batch work should run on the transaction handed to `fn`" and "each batch transaction short, which is what their batch sizes were chosen for" — but a batch size of 200 does not bound a transaction when each row costs a network round trip.

## Fix

- The batch select runs on `tx`, so the lock and the statement share a connection.
- The row loop stops at `TIME_BUDGET_MS = 60_000` — the same ceiling the Linear sweep publishes under (`maxDuration = 60`), leaving 5× headroom under the five-minute timeout.
- The result gains `more`, matching the pruner's "stopped on a limit rather than running out of work".
- `SingleFlightTx` is exported so the extracted callback can name the type; this removes a duplicated `any` triple rather than adding one.

**A sweep interrupted mid-batch stays safe.** Rows are marked by `dispatchMatchingTriggers` only once the publish lands, so anything the budget did not reach is still unmarked, still inside the lookback window, and selected again by the next tick. Partial progress is never lost and never double-counted; a row that half-published is absorbed by the existing QStash dedup on trigger+event.

### Why the loop was not moved outside the lock

The obvious reading — take the lock per batch and publish outside it — would have removed single-flight rather than fixed it. The `ran: false` handoff works for the pruner and the retention job because *all* of their work is the one statement inside the lock, so a competing tick reliably finds the lock taken. Publishing outside would leave the lock held for the microseconds of a select, i.e. ~1% of the run, so every stacked tick would win it and run concurrently — reopening #7114. There is no claim column on `automation_events` to fence rows with instead, and claiming by marking before publishing would lose a row outright if the run died between the two (the Linear sweep documents the same publish-then-count ordering deliberately). Bounding the in-transaction time is what keeps both properties.

### Still reporting

Per-row publish failures still `console.error` and count into `failed`, unchanged. A genuinely broken lock connection still throws from `singleFlight`. No throw site was added, removed, or reclassified — so **no typed `cause`**: nothing reads a `kind` here, and adding one would be code maintained for nothing.

## Verification

`bunx biome check` on the three changed files:
```
Checked 3 files in 5ms. No fixes applied.
```

`cd apps/api && bun run typecheck`:
```
$ tsc --noEmit
```
(clean, no diagnostics)

`cd apps/api && bun test src` (full package, not just the touched directory):
```
 69 pass
 0 fail
 124 expect() calls
Ran 69 tests across 9 files. [62.00ms]
```

No desktop git code touched, so `no-main-process-blocking.test.ts` does not apply. No new test: the change adds no classifier or matcher, and these two files have no existing suite to extend — covering the budget would mean mocking the dispatcher and a fake transaction.

## Adjacent, deliberately not fixed

- `dbWs` (`packages/db/src/client.ts`) is a `Pool` with no `error` listener, which is why a dying connection surfaces as a *fatal uncaught* exception rather than a rejected promise. Any future connection death — a Neon restart, a deploy — has the same shape. Real, but a separate defect from this root cause, and not evidenced by anything beyond these two issues.
- `/api/automations/evaluate` declares no `maxDuration`, unlike every comparable job route (dispatch 60, prune 300, Linear sweep 60).

Refs API-2N
Refs API-2P

https://claude.ai/code/session_01FFtxjCk7tRaYmjvB4svJcW


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the redispatch sweep so the advisory lock `singleFlight` holds can't be dropped mid-run by Postgres's idle-in-transaction timeout: the sweep previously ran its 200-row select and publish loop on the global client while the lock sat idle on a separate connection, so slow runs lost the lock at five minutes and concurrent sweeps stacked. The select now runs on the lock transaction and the loop stops after 60 seconds, leaving the rest for the next tick.

**Bug Fixes**
- A budget-interrupted sweep stays safe: rows are marked only once their publish lands, so unmarked rows are picked up by the next tick.
- The result now reports `more` when the run stopped on the limit rather than running out of work.

<sup>Written for commit 6ecdb769381c9932a7855df1433e7c963e7394bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation recovery processing to run safely within its transaction window.
  * Prevented long-running recovery sweeps from exceeding database connection limits.
  * Improved handling of partially completed recovery work so remaining items can be processed in subsequent runs.
  * Ensured recovery attempts are tracked accurately during each processing cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->