### PR TITLE
fix(host-service): delete worktrees pinned by a read-only directory

### DIFF
--- a/packages/host-service/src/trpc/router/workspace-cleanup/remove-directory-tree.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/remove-directory-tree.ts
@@ -1,0 +1,89 @@
+import type { Dirent, Stats } from "node:fs";
+import { chmod, lstat, readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+/** Owner read + write + execute — what deleting a directory's contents needs:
+ * read to list it, write to unlink its entries, execute to descend into it. */
+const OWNER_ACCESS = 0o700;
+
+/**
+ * `rm -rf` with one recovery pass for the single removal failure a delete can
+ * undo by itself: a directory inside the tree whose owner write bit was
+ * cleared. Unlinking an entry is a write to the directory *holding* it, so one
+ * such directory makes its whole subtree undeletable — by us, by
+ * `git worktree remove`, and by the user's own `rm -rf` — and every retry
+ * fails identically until the bit comes back (HOST-SERVICE-5J).
+ *
+ * The producers are ordinary tooling, not corruption: `go mod download`
+ * leaves every module directory in its cache at 0555 by design, and
+ * eval/report runners often do the same to an output folder. Both were
+ * observed inside worktrees.
+ *
+ * Only EACCES takes the recovery path. Every other failure — ENOTEMPTY from a
+ * live writer re-creating files, EBUSY, or an EPERM from an immutable flag
+ * that chmod could not clear anyway — is rethrown untouched so the caller
+ * reports it exactly as before.
+ */
+export async function removeDirectoryTree(path: string): Promise<void> {
+	try {
+		await rm(path, { recursive: true, force: true });
+		return;
+	} catch (error) {
+		if (!isPermissionDenied(error)) throw error;
+	}
+	await restoreOwnerDirectoryAccess(path);
+	// One retry, not a loop: the pass above is exhaustive over the tree, so a
+	// second denial is something chmod cannot fix and belongs in the report.
+	await rm(path, { recursive: true, force: true });
+}
+
+/**
+ * Read off the errno rather than the prototype: an fs error that has crossed
+ * a worker boundary keeps `code` but loses its class. Deliberately EACCES
+ * alone — EPERM is the immutable-flag/ownership denial, which a chmod by this
+ * process cannot lift, and the rest are not permission failures at all.
+ */
+export function isPermissionDenied(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		(error as { code?: unknown }).code === "EACCES"
+	);
+}
+
+/**
+ * Give the owner full access to every directory in the tree, root first so
+ * each one is readable before it is listed. Directories only: unlinking a file
+ * needs write permission on the directory holding it, never on the file
+ * itself. Symlinks are never followed — a link's dirent reports as a link, not
+ * a directory — so the pass cannot reach outside the tree its caller already
+ * gated. A failure at any node is left alone; the retry then gets as far as
+ * the permissions allow and reports what still blocks it.
+ */
+async function restoreOwnerDirectoryAccess(root: string): Promise<void> {
+	let stats: Stats;
+	try {
+		stats = await lstat(root);
+	} catch {
+		return;
+	}
+	if (!stats.isDirectory()) return;
+	if ((stats.mode & OWNER_ACCESS) !== OWNER_ACCESS) {
+		try {
+			await chmod(root, stats.mode | OWNER_ACCESS);
+		} catch {
+			return;
+		}
+	}
+	let entries: Dirent[];
+	try {
+		entries = await readdir(root, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			await restoreOwnerDirectoryAccess(join(root, entry.name));
+		}
+	}
+}

--- a/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/workspace-cleanup.ts
@@ -30,6 +30,7 @@ import { isInsideSessionsRoot } from "../workspace-creation/shared/session-paths
 import { isInsideProjectWorktreesRoot } from "../workspace-creation/shared/worktree-paths";
 import { cleanupGitOps, isIndeterminateGitTaskFailure } from "./git-ops";
 import { isMainWorkspace } from "./is-main-workspace";
+import { removeDirectoryTree } from "./remove-directory-tree";
 
 /**
  * Process-local guard against concurrent destroys of the same workspace.
@@ -576,7 +577,7 @@ async function runDestroyPhases(
 					);
 				} else {
 					try {
-						await rm(local.worktreePath, { recursive: true, force: true });
+						await removeDirectoryTree(local.worktreePath);
 					} catch (err) {
 						const message = err instanceof Error ? err.message : String(err);
 						throw new TRPCError({

--- a/packages/host-service/test/remove-directory-tree.test.ts
+++ b/packages/host-service/test/remove-directory-tree.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	isPermissionDenied,
+	removeDirectoryTree,
+} from "../src/trpc/router/workspace-cleanup/remove-directory-tree";
+
+/** Test teardown only: a read-only directory defeats `rmSync` exactly as it
+ * defeats the code under test. */
+function restoreOwnerAccess(root: string): void {
+	chmodSync(root, 0o700);
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		if (entry.isDirectory()) restoreOwnerAccess(join(root, entry.name));
+	}
+}
+
+describe("isPermissionDenied", () => {
+	test("matches EACCES and nothing else", () => {
+		expect(isPermissionDenied({ code: "EACCES" })).toBe(true);
+
+		// Every one of these shares HOST-SERVICE-5J's fingerprint, and none is
+		// a cleared write bit: rescuing them would silence a real failure.
+		// ENOTEMPTY is a live writer re-creating files under the delete; EPERM
+		// is an immutable flag or foreign ownership, which a chmod by this
+		// process cannot lift either.
+		expect(isPermissionDenied({ code: "ENOTEMPTY" })).toBe(false);
+		expect(isPermissionDenied({ code: "EPERM" })).toBe(false);
+		expect(isPermissionDenied({ code: "EBUSY" })).toBe(false);
+		expect(isPermissionDenied({ code: "ENOTDIR" })).toBe(false);
+		expect(isPermissionDenied(new Error("EACCES: permission denied"))).toBe(
+			false,
+		);
+		expect(isPermissionDenied("EACCES")).toBe(false);
+		expect(isPermissionDenied(null)).toBe(false);
+		expect(isPermissionDenied(undefined)).toBe(false);
+	});
+});
+
+describe("removeDirectoryTree", () => {
+	test("removes a tree a read-only directory would otherwise pin", async () => {
+		const root = mkdtempSync(join(tmpdir(), "remove-tree-"));
+		const tree = join(root, "worktree");
+		const output = join(tree, "evals", "results");
+		mkdirSync(output, { recursive: true });
+		writeFileSync(join(output, "run.json"), "{}");
+		chmodSync(join(tree, "evals"), 0o555);
+		try {
+			await removeDirectoryTree(tree);
+			expect(existsSync(tree)).toBe(false);
+		} finally {
+			restoreOwnerAccess(root);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("rethrows a non-permission failure untouched", async () => {
+		const root = mkdtempSync(join(tmpdir(), "remove-tree-"));
+		writeFileSync(join(root, "a-file"), "x");
+		try {
+			// A path that walks through a regular file: ENOTDIR, which `force`
+			// does not swallow and the recovery pass must not swallow either.
+			await expect(
+				removeDirectoryTree(join(root, "a-file", "nested")),
+			).rejects.toMatchObject({ code: "ENOTDIR" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("does not follow a symlink out of the tree", async () => {
+		const root = mkdtempSync(join(tmpdir(), "remove-tree-"));
+		const tree = join(root, "worktree");
+		const outside = join(root, "outside");
+		mkdirSync(join(outside, "keep"), { recursive: true });
+		writeFileSync(join(outside, "keep", "user-data.txt"), "keep me");
+		chmodSync(join(outside, "keep"), 0o555);
+		mkdirSync(join(tree, "pinned"), { recursive: true });
+		writeFileSync(join(tree, "pinned", "f"), "x");
+		symlinkSync(outside, join(tree, "link"));
+		chmodSync(join(tree, "pinned"), 0o555);
+		try {
+			await removeDirectoryTree(tree);
+			expect(existsSync(tree)).toBe(false);
+			// The linked-to directory keeps both its contents and its mode: the
+			// pass walked the tree, not the link.
+			expect(existsSync(join(outside, "keep", "user-data.txt"))).toBe(true);
+			expect(statSync(join(outside, "keep")).mode & 0o777).toBe(0o555);
+		} finally {
+			restoreOwnerAccess(root);
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -1,10 +1,13 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+	chmodSync,
 	existsSync,
 	lstatSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	rmSync,
+	statSync,
 	symlinkSync,
 	writeFileSync,
 } from "node:fs";
@@ -77,6 +80,16 @@ Object.assign(cleanupGitOps, {
 	deleteLocalBranch: async () =>
 		gitOpsSpec.deleteBranch ? gitOpsSpec.deleteBranch() : { deleted: true },
 } satisfies typeof realGitOps);
+
+/** Test teardown only: a directory whose write bit is cleared defeats
+ * `rmSync` exactly as it defeats the code under test, so the fixtures below
+ * hand their permissions back before deleting themselves. */
+function restoreOwnerAccess(root: string): void {
+	chmodSync(root, 0o700);
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		if (entry.isDirectory()) restoreOwnerAccess(join(root, entry.name));
+	}
+}
 
 function makeCtx(spec: ContextSpec): HostServiceContext & {
 	__mocks: {
@@ -460,6 +473,100 @@ describe("workspaceCleanup.destroy cleanup ordering", () => {
 			expect(result.worktreeRemoved).toBe(true);
 			expect(existsSync(worktree)).toBe(false);
 		} finally {
+			rmSync(base, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("git unregisters the worktree and a read-only directory blocks the delete: destroy restores write permission and removes it", async () => {
+		// Removing an entry is a write to the directory that holds it, so a
+		// single directory inside the worktree with its owner write bit
+		// cleared makes its whole subtree undeletable — by git's recursive
+		// delete and by the fallback rm alike, on every retry
+		// (HOST-SERVICE-5J). Both shapes below were seen in the wild: a
+		// tool's own output folder, and a Go module cache, which `go mod
+		// download` leaves read-only by design.
+		const base = mkdtempSync(join(tmpdir(), "worktrees-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		const worktree = join(base, "p-1", "wt-readonly");
+		const results = join(worktree, "evals", "results");
+		const goModule = join(worktree, "pkg", "mod", "gopkg.in", "yaml.v3");
+		mkdirSync(results, { recursive: true });
+		mkdirSync(goModule, { recursive: true });
+		writeFileSync(join(results, "run.json"), "{}");
+		writeFileSync(join(goModule, "README.md"), "read-only");
+		chmodSync(join(goModule, "README.md"), 0o444);
+		chmodSync(goModule, 0o555);
+		chmodSync(join(worktree, "evals"), 0o555);
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				removeWorktree: async () => ({
+					stillRegistered: false,
+					removeError:
+						"error: failed to delete 'wt-readonly': Permission denied",
+				}),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			const result = await caller.destroy({
+				workspaceId: "ws-1",
+				deleteBranch: false,
+				force: true,
+			});
+			expect(result.success).toBe(true);
+			expect(result.worktreeRemoved).toBe(true);
+			expect(existsSync(worktree)).toBe(false);
+		} finally {
+			restoreOwnerAccess(base);
+			rmSync(base, { recursive: true, force: true });
+			rmSync(repo, { recursive: true, force: true });
+		}
+	});
+
+	test("a permission denial above the worktree is not repaired: destroy reports it and leaves the folder", async () => {
+		// The recovery pass descends the worktree it was handed and stops
+		// there. A managed-root directory *containing* the worktree that
+		// denies writes is not ours to widen, so this stays exactly the
+		// failure it is today — reported, folder on disk, row retryable.
+		const base = mkdtempSync(join(tmpdir(), "worktrees-base-"));
+		const repo = mkdtempSync(join(tmpdir(), "workspace-delete-repo-"));
+		const projectRoot = join(base, "p-1");
+		const worktree = join(projectRoot, "wt-parent-readonly");
+		mkdirSync(worktree, { recursive: true });
+		writeFileSync(join(worktree, "tracked.txt"), "x");
+		chmodSync(projectRoot, 0o555);
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: worktree,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: repo, worktreeBaseDir: base },
+				removeWorktree: async () => ({ stillRegistered: false }),
+			});
+			const caller = workspaceCleanupRouter.createCaller(ctx);
+
+			await expect(
+				caller.destroy({
+					workspaceId: "ws-1",
+					deleteBranch: false,
+					force: true,
+				}),
+			).rejects.toThrow(/could not be removed/i);
+			expect(existsSync(worktree)).toBe(true);
+			// The pass never climbed out of the worktree to get its way.
+			expect(statSync(projectRoot).mode & 0o777).toBe(0o555);
+		} finally {
+			restoreOwnerAccess(base);
 			rmSync(base, { recursive: true, force: true });
 			rmSync(repo, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Problem

Deleting a workspace fails, permanently, on a worktree that contains a directory whose owner **write bit has been cleared**. The destroy saga asks git to remove the worktree; git drops the registration and then fails partway through its own recursive delete with `Permission denied`. The guarded fallback `rm -rf` fails the same way, the handler throws, and `runDestroy`'s catch un-archives the row — by design, so the workspace stays visible and retryable rather than orphaning disk. The user retries and gets the identical failure, forever. Nothing in the app can clear it; the only way out is a terminal and `chmod -R u+w`.

Two machines in `HOST-SERVICE-5J` show back-to-back retries seconds apart on the same worktree, which is that loop.

**Harm:** a user who deletes a workspace containing a read-only directory cannot remove it through the product at all, and the failed row keeps coming back into their sidebar. Roughly 6 events across 3 machines in 7 days on 1.27.0.

**Reach:** the change ships in the next desktop/host-service release (shared version, next after 1.27.0) and reaches every desktop user, since destroy runs in the bundled host-service. The affected code path is the one the reported events execute.

**Why code, and not something else:** archiving is wrong — the user is genuinely stuck, this is not a telemetry artifact. A Sentry-side filter is repo-law forbidden and would leave the user just as stuck. Deleting the fallback branch is not an option: it exists because git's unregister and its delete are not atomic (#6730). Fixing it at a different layer means telling the user to run `chmod` themselves, which is strictly worse than doing the one thing that unblocks the delete. No in-flight work removes or restructures this branch (see *Neighbours*).

## Root cause

Removing a directory entry requires write permission on the directory **holding** it, not on the entry. One read-only directory therefore pins its entire subtree against every remover — git, Node's `rm`, and the user's own `rm -rf`.

Reproduced locally against both syscall shapes in the issue:

```
--- parent dir 0o555, child dir empty-able
  code=EACCES syscall=rmdir path=<tree>/evals/results
--- dir itself 0o555 with children
  code=EACCES syscall=unlink path=<tree>/evals/results/out.json
--- dir 0o000
  code=EACCES syscall=scandir path=<tree>/evals/results
```

Those match the two distinct sampled events exactly — one `rmdir '<worktree>/evals/results'` (a runner's output folder), one `unlink '<worktree>/pkg/mod/gopkg.in/yaml.v3@v3.0.1/README.md'`. The second names the cause outright: `go mod download` marks every directory in the module cache `0555`, which is why `go clean -modcache` exists. This is normal tooling output, not corruption, so the condition will keep recurring.

Note the failing path in the `unlink` shape is a **file** — chmod'ing it changes nothing; the directory above it is what denies. That rules out repairing the single path named in the error.

## Fix

New `remove-directory-tree.ts`, called from the one throw site in the events:

```ts
try {
  await rm(path, { recursive: true, force: true });
  return;
} catch (error) {
  if (!isPermissionDenied(error)) throw error;
}
await restoreOwnerDirectoryAccess(path);
await rm(path, { recursive: true, force: true });
```

- **One retry, not a loop.** The recovery pass is exhaustive over the tree, so a second denial is something chmod cannot fix and must be reported.
- **A full pass, not a targeted chmod.** Measured: a per-error-path chmod needs one retry *per* read-only directory — 4 retries for a 3-directory fixture, and a module cache has thousands. A 1001-read-only-directory tree is cleared by the full pass plus one retry in **149 ms**.
- **Directories only, symlinks never followed.** A link's dirent reports as a link, so the pass cannot leave the tree. It only ever adds owner bits (`mode | 0o700`), never widens group or other.
- **Blast radius is the existing gate.** The pass is rooted at `local.worktreePath`, which `isInsideProjectWorktreesRoot` has already cleared; no second, weaker check was added.
- **No behaviour change for anything else.** The thrown `TRPCError`, its message, the un-archive, and the `isMissingPath` disk-state recheck that reports the outcome are all untouched.
- **No typed cause.** Nothing reads one here — no renderer branch, no retry decision, no test — so the throw stays a plain `TRPCError({ code, message })`.

### What the matcher must not match

`isPermissionDenied` is `code === "EACCES"` and nothing else. It is checked off the errno, not the prototype, per the worker-boundary rule; it also cannot key off the message, because Bun reports the failing syscall as `rm` where Node reports `rmdir`/`unlink`.

Every one of these shares this exact Sentry fingerprint and must keep failing as it does today:

| errno | why it must not be rescued |
|---|---|
| `ENOTEMPTY` | a live writer re-creating files under the delete — 5+ events in this same issue |
| `EPERM` | immutable flag or foreign ownership; a chmod by this process cannot lift it either |
| `EBUSY` | not a permission failure |
| `Error` with no `code`, a string, `null` | not an fs error at all |

`ENOTEMPTY` is the one that matters: it is in this fingerprint right now, and silencing it would hide a real bug.

## Verification

**The new test reproduces the issue on unmodified `main` and passes after** (`test/workspace-cleanup.test.ts`):

```
TRPCError: Worktree at <base>/p-1/wt-readonly is no longer registered with git,
but its folder could not be removed: EACCES: permission denied, rm '<base>/p-1/wt-readonly'
(git worktree remove: error: failed to delete 'wt-readonly': Permission denied)
  at runDestroyPhases (.../workspace-cleanup.ts:582:13)
(fail) ... destroy restores write permission and removes it [2.53ms]
 32 pass / 1 fail
```

The negative tests were written first and pass **both** before and after — they are regression guards on behaviour that must not move. Tests added: a read-only `evals/results` **and** a module-cache-shaped subtree are removed end-to-end through the router; a permission denial *above* the worktree still throws and leaves the folder, with the containing directory's mode asserted unchanged (the pass does not climb out); the errno table above; a non-permission failure (`ENOTDIR`) rethrown untouched; a symlink to an outside read-only directory left with both its contents and its mode intact.

```
$ bunx biome check <4 changed files>
Checked 4 files in 15ms. No fixes applied.

$ cd packages/host-service && bun run typecheck
$ tsc --noEmit --emitDeclarationOnly false      # exit 0, no diagnostics

$ cd packages/host-service && bun test
 1696 pass
 8 todo
 0 fail
 3967 expect() calls
Ran 1704 tests across 165 files. [222.49s]
```

Production runs the host-service under Node, but the suite runs under Bun, and the two have different `fs.rm` implementations — so the shipped module was also exercised directly under Node:

```
node v26.8.1: read-only tree removed = true
node v26.8.1: isPermissionDenied EACCES=true ENOTEMPTY=false
```

No desktop git code was touched, so `apps/desktop/src/no-main-process-blocking.test.ts` does not apply. Repo-wide `bun run lint` was not run (hangs on cross-worktree bun locks).

## Neighbours

Based on `origin/main`. Both open PRs against this file were read:

- **#7094** `fix/worktree-delete-parallel-rm` — its only hunk in `workspace-cleanup.ts` is at the `cleanupGitOps.removeWorktree` call (~L526-552); mine is at ~L579. **No textual conflict.** Semantically it does interact: it moves the native `rm` into `gitWorktreeRemoveTask` *before* git unregisters, and that `rm` is unguarded, so once it lands this failure would surface earlier as `Failed to verify worktree removal` and never reach the branch fixed here. The follow-up is one import — have that task call `removeDirectoryTree` — but it is not built here, since #7094 is unmerged and guessing at its final shape would be speculative.
- **#7209** `archive-delete-experience` — restructures tombstone bookkeeping and rewrites comments in `runDestroyPhases`, but its hunks are at L2-23, L153-227, L248-276, L347-362, L382-389 and L679-687. **None touch L550-600.** The only expected conflict is trivial: we both add to the import block at the top of the file. Neither PR touches `test/workspace-cleanup.test.ts`.

## Adjacent throw sites, left alone

Two other `rm(local.worktreePath, …)` call sites in the same function have the same latent exposure and are deliberately unchanged, since neither appears in the reported events: the session-folder removal (~L455, gated by `isInsideSessionsRoot`) and the project-repo-missing removal (~L500). The session branch does appear in this Sentry fingerprint, but with `ENOTEMPTY`, which is a different cause.

Note `HOST-SERVICE-5J` is a **mixed group** — its 27 events span at least five root causes (this one, `ENOTEMPTY` live-writer races, git `validation failed`, and ~10 `git/removeWorktree` 120 s timeouts, which are #6887 / #7094's territory). This PR fixes the permission slice only, so the issue will keep receiving events; it should not be resolved on this merge.

Refs HOST-SERVICE-5J

https://claude.ai/code/session_0183p4FE6szo6NcATmp1kvwY


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace deletion failing permanently when a worktree contains a read-only directory. The destroy flow now restores owner write access on blocked directories and retries the removal once.

**Bug Fixes**
- Replaces the plain `rm` fallback with `removeDirectoryTree`, which recovers only from `EACCES` and rethrows `ENOTEMPTY`, `EPERM`, and `EBUSY` untouched.
- The recovery pass chmods directories only, never follows symlinks, and stays within the already-gated `local.worktreePath`.
- Adds tests for read-only `evals/results` and Go module cache-shaped subtrees, a permission denial above the worktree, and symlink escapes.
- Only the permission slice is fixed; `HOST-SERVICE-5J` will keep receiving events for other root causes and should not be resolved on this merge.

<sup>Written for commit ae59914058c5c7f2e865a141aade53e99baff9e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace cleanup now successfully removes worktrees containing read-only directories by restoring required owner permissions and retrying deletion.
  - Cleanup preserves existing error behavior for failures unrelated to permissions.
  - Permission problems outside the worktree remain reported without altering the affected project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->