### PR TITLE
fix(api): bound the Linear sweep's lock hold and its QStash publishes

### DIFF
--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
@@ -75,6 +75,32 @@ const MAX_ROWS = 500;
 const MAX_CONSECUTIVE_PUBLISH_FAILURES = 3;
 
 /**
+ * How long a run may spend publishing before it leaves the rest to the next
+ * run.
+ *
+ * `singleFlight` holds its advisory lock inside the transaction on `tx`, and
+ * every re-queue below is an HTTP publish made off that connection, so the
+ * connection sits `idle in transaction` for as long as this loop runs. Two
+ * clocks end a run that overruns and both end it the same way: `maxDuration`
+ * above kills the invocation at sixty seconds, and Postgres closes an
+ * idle-in-transaction connection at five minutes, taking the lock with it
+ * while the run is still going. Either way the write-back below never commits,
+ * so deliveries that *were* handed to QStash go uncounted and are re-queued
+ * again next run without ever spending one of their five attempts — a delivery
+ * that can never be given up on, which is the one thing that counter exists to
+ * prevent.
+ *
+ * `MAX_CONSECUTIVE_PUBLISH_FAILURES` bounds publishes that fail, and gets
+ * there first when they do — three of them is nine seconds at worst. This
+ * bounds publishes that merely go slow, which is what actually runs a run out
+ * of time and which that breaker never sees. Thirty seconds, plus at most one
+ * `PUBLISH_TIMEOUT_MS` of overshoot on the publish in flight when the budget
+ * expires, ends a run by thirty-three of `maxDuration`'s sixty and leaves the
+ * write-back and the commit the rest.
+ */
+const PUBLISH_BUDGET_MS = 30_000;
+
+/**
  * Re-queues Linear deliveries that were accepted but never carried through,
  * and gives up on the ones that have had enough attempts.
  *
@@ -111,6 +137,8 @@ export async function POST(request: Request): Promise<Response> {
 	// deliveries twice, and a run is held open across its QStash publishes, so
 	// the lock also bounds this route to a single connection.
 	const attempt = await singleFlight("linear.sweep-abandoned", async (tx) => {
+		// The lock is held from here, so the budget is measured from here too.
+		const startedAt = Date.now();
 		const { rows } = await tx.execute<AbandonedRow>(sql`
 			WITH band AS MATERIALIZED (
 				SELECT id, provider, status, event_id, received_at, retry_count
@@ -167,6 +195,13 @@ export async function POST(request: Request): Promise<Response> {
 		const failed: string[] = [];
 		let consecutiveFailures = 0;
 		for (const { observedRetryCount, ...work } of plan.requeue) {
+			// Leaving the rest unexamined is the trade `MAX_REQUEUES` and
+			// `MAX_ROWS` already make, and it stops in the right order: the band
+			// is read oldest first, so what goes unpublished is its youngest —
+			// rows that entered most recently and still pass under later runs
+			// before they age out. Nothing is written for them, so the next run
+			// finds them exactly as they were.
+			if (Date.now() - startedAt >= PUBLISH_BUDGET_MS) break;
 			try {
 				await enqueueLinearDelivery(work);
 				requeued.push({ observedRetryCount, ...work });
@@ -223,6 +258,10 @@ export async function POST(request: Request): Promise<Response> {
 			requeued: requeued.length,
 			abandoned: plan.exhausted.length,
 			failed: failed.length,
+			// Planned re-queues this run never attempted, whether it stopped on
+			// the budget or on the failure breaker. Without this a run that stops
+			// early is indistinguishable from one that found nothing more to do.
+			deferred: plan.requeue.length - requeued.length - failed.length,
 			truncated: rows.length === MAX_ROWS,
 		};
 	});
@@ -231,7 +270,11 @@ export async function POST(request: Request): Promise<Response> {
 	// skipped by standing down.
 	if (!attempt.ran) return Response.json({ skipped: "already running" });
 
-	if (attempt.result.requeued > 0 || attempt.result.abandoned > 0) {
+	if (
+		attempt.result.requeued > 0 ||
+		attempt.result.abandoned > 0 ||
+		attempt.result.deferred > 0
+	) {
 		console.log("[linear/sweep-abandoned]", attempt.result);
 	}
 	return Response.json(attempt.result);

--- a/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
+++ b/apps/api/src/app/api/integrations/linear/jobs/sweep-abandoned/route.ts
@@ -138,7 +138,9 @@ export async function POST(request: Request): Promise<Response> {
 	// the lock also bounds this route to a single connection.
 	const attempt = await singleFlight("linear.sweep-abandoned", async (tx) => {
 		// The lock is held from here, so the budget is measured from here too.
-		const startedAt = Date.now();
+		// Monotonic: the wall clock can step backwards mid-run (NTP), which would
+		// read as less elapsed time and extend the lock hold past the budget.
+		const startedAt = performance.now();
 		const { rows } = await tx.execute<AbandonedRow>(sql`
 			WITH band AS MATERIALIZED (
 				SELECT id, provider, status, event_id, received_at, retry_count
@@ -201,7 +203,7 @@ export async function POST(request: Request): Promise<Response> {
 			// rows that entered most recently and still pass under later runs
 			// before they age out. Nothing is written for them, so the next run
 			// finds them exactly as they were.
-			if (Date.now() - startedAt >= PUBLISH_BUDGET_MS) break;
+			if (performance.now() - startedAt >= PUBLISH_BUDGET_MS) break;
 			try {
 				await enqueueLinearDelivery(work);
 				requeued.push({ observedRetryCount, ...work });

--- a/apps/api/src/app/api/integrations/linear/webhook/queue.ts
+++ b/apps/api/src/app/api/integrations/linear/webhook/queue.ts
@@ -29,6 +29,22 @@ const qstash = new Client({
 	retry: { retries: 1, backoff: () => 150 },
 });
 
+/**
+ * Ceiling on one publish, covering both of the client's attempts and the
+ * backoff between them.
+ *
+ * The client takes neither a timeout nor an `AbortSignal` — it builds its
+ * fetch options from method, headers, body and keepalive and nothing else — so
+ * without this a publish is bounded only by the platform's fetch defaults,
+ * which is minutes. (`publishJSON` does take a `timeout`, but that is the
+ * ceiling QStash puts on calling our consumer, not on this call.) Both callers
+ * have a far shorter clock over them: the webhook route answers Linear inside
+ * five seconds, and `jobs/sweep-abandoned` holds an advisory lock open across
+ * its publishes. Three seconds is an order of magnitude above a healthy
+ * publish and still leaves the webhook route most of Linear's five.
+ */
+const PUBLISH_TIMEOUT_MS = 3_000;
+
 export const PROCESS_PATH =
 	"/api/integrations/linear/jobs/process-delivery" as const;
 const PROCESS_URL = `${env.NEXT_PUBLIC_API_URL}${PROCESS_PATH}`;
@@ -50,9 +66,10 @@ export const linearDeliveryWorkSchema = z.object({
 export type LinearDeliveryWork = z.infer<typeof linearDeliveryWorkSchema>;
 
 /**
- * Throws if QStash will not take the message. The caller must not acknowledge
- * a delivery it has failed to queue: the row is durable but nothing would ever
- * pick it up, and a webhook lost in silence is worse than one Linear retries.
+ * Throws if QStash will not take the message, or does not answer inside
+ * `PUBLISH_TIMEOUT_MS`. The caller must not acknowledge a delivery it has
+ * failed to queue: the row is durable but nothing would ever pick it up, and a
+ * webhook lost in silence is worse than one Linear retries.
  */
 export async function enqueueLinearDelivery(
 	work: LinearDeliveryWork,
@@ -65,9 +82,32 @@ export async function enqueueLinearDelivery(
 	// right lifetime — the route queues nothing whose row is already carried
 	// through, and `recordWebhookDelivery` reopens a failed one so a redelivery
 	// is queued again. A duplicate that does get through costs one query.
-	await qstash.publishJSON({
+	const publish = qstash.publishJSON({
 		url: PROCESS_URL,
 		body: { ...work, receivedAt: work.receivedAt.toISOString() },
 		retries: 3,
 	});
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			publish,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(
+					() =>
+						reject(
+							new Error(`QStash publish exceeded ${PUBLISH_TIMEOUT_MS}ms`),
+						),
+					PUBLISH_TIMEOUT_MS,
+				);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+		// Nothing can cancel the fetch, so a publish this stopped waiting for is
+		// still in flight and may land, or reject, long after the throw. Nobody
+		// is reading it by then; this keeps it off the unhandled-rejection path.
+		// A late success costs the one duplicate query priced above.
+		publish.catch(() => {});
+	}
 }


### PR DESCRIPTION
## Problem

`jobs/sweep-abandoned` (#7289) runs its whole body inside
`singleFlight("linear.sweep-abandoned", …)`, and inside that transaction it
loops over up to `MAX_REQUEUES` (50) deliveries making one QStash publish per
row, writing the `retryCount` increments only after the loop. Nothing bounded
that loop in wall clock.

The failure is not the lock being held a bit long. It is what the lost commit
does to the attempt counter: deliveries that **were** handed to QStash go
uncounted, so every later sweep re-queues them again without ever spending one
of their five attempts. A delivery that can never be given up on is the exact
opposite of what `MAX_ATTEMPTS` exists for, and it also means a fresh duplicate
fan-out each run.

The route is currently inert — the QStash schedule that would call it does not
exist yet — so this is a correctness fix ahead of that schedule, not an
incident.

## Root cause

Two separate missing bounds, and the second is why bounding only the loop would
not have been enough.

**1. The loop has no wall-clock bound.** `singleFlight` holds its advisory lock
inside a transaction on `tx`, and every publish is made off that connection, so
the connection sits `idle in transaction` for as long as the loop runs. Two
clocks end an overrunning run and both end it the same way — `maxDuration = 60`
on this route kills the invocation at sixty seconds, and Postgres closes an
idle-in-transaction connection at five minutes and takes the lock with it
mid-run (the shape #7330 documents on `singleFlight` itself). For this route the
sixty-second kill lands first, so the exposure is *more* likely than the
five-minute story, not less. Either way the write-back after the loop never
commits.

`MAX_CONSECUTIVE_PUBLISH_FAILURES` does not cover this. It catches publishes
that **fail**; a publish that merely goes **slow** never increments it. Slow is
the case that runs out the clock. #7289's own comment on that breaker already
names this harm ("can outrun `maxDuration` and kill the run before the
write-back below commits") — the breaker just only closes the fast-failure half
of it.

**2. A single publish has no bound at all**, so a loop bound alone would still
let one hung publish hold the lock past both clocks. Verified against the
installed client rather than the docs — `@upstash/qstash@2.10.1`:

- `ClientConfig` has `baseUrl`, `token`, `retry`, `headers`, telemetry. No
  timeout.
- `UpstashRequest` has no `signal` field, and `HttpClient.processRequest` builds
  its fetch options as `{ method, headers, body, keepalive }` — an
  `AbortSignal` has nowhere to go even if one were passed.
- `publishJSON` *does* take a `timeout`, which is a trap: its own doc says it is
  "the HTTP timeout value to use while calling the destination URL" — QStash's
  ceiling on calling our consumer, not a ceiling on this call.
- `retry: { retries: 1 }` maps to `attempts: 1` and a `for (index = 0; index <=
  attempts)` loop, so two fetch attempts — and the retry only catches a fetch
  that *throws*, so a hang is waited out in full and then waited out again.

So a publish is bounded only by the platform's fetch defaults. Against a server
that accepts the connection and never answers, using this file's exact client
config, one publish was still outstanding at 65s — past this route's whole
`maxDuration`:

```
[server] request 1 received; never responding
[watch] still pending at 10s (server saw 1 request(s))
[watch] still pending at 20s (server saw 1 request(s))
[watch] still pending at 30s (server saw 1 request(s))
[watch] still pending at 40s (server saw 1 request(s))
[watch] still pending at 50s (server saw 1 request(s))
[watch] still pending at 60s (server saw 1 request(s))
[result] after 65003ms the publish is still outstanding; server saw 1 request(s)
```

## Fix

**`PUBLISH_BUDGET_MS = 30_000` on the sweep's loop**, following #7330's shape —
measured from the top of the `singleFlight` callback (where the lock is taken,
so the band query counts against it), checked at the top of each iteration,
leaving the remainder to the next run. Thirty seconds plus at most one publish
timeout of overshoot ends a run by thirty-three of `maxDuration`'s sixty, so the
write-back and the commit always get the rest.

I checked the "stopping early is safe" claim against the band arithmetic rather
than assuming it, since leaving rows unexamined is what that reasoning is about:

- The band is `[now-75min, now-60min)`, 15 minutes wide, against an intended
  5-minute cadence — each delivery passes under three runs.
- The query is `ORDER BY received_at` **ascending** and `planSweep` preserves
  that order, so the loop publishes oldest first. Rows dropped by an early stop
  are therefore the band's *youngest* — the ones that entered most recently and
  still have later runs ahead of them. The stop drops the rows with the most
  chances left, which is the right direction.
- Leaving rows is a trade the route already makes twice, via `MAX_ROWS` (500)
  and `MAX_REQUEUES` (50), and once more via the failure breaker.
- Rows not reached are not written to at all, so the next run finds them
  unchanged. The `abandoned` give-up marking runs *before* the loop, so the
  budget never delays a give-up.

Compared with today the budget strictly *reduces* mis-handled rows: today a run
that overruns loses the counts for everything it published, which is worse than
not publishing those rows at all.

**`PUBLISH_TIMEOUT_MS = 3_000` in `enqueueLinearDelivery`.** Yes, the publish
needs its own bound — a loop bound alone still lets one hung publish hold the
lock indefinitely, as the 65s trace above shows. Since the client accepts no
signal, the call is raced against a timer at the one place the publish is made.
Putting it there rather than in the sweep also fixes the same hole on the other
caller: the webhook route publishes against Linear's five-second clock, and a
hung publish there is a delivery Linear times out on and eventually a webhook
Linear disables. That is the lighter shape — one bound where the publish is,
not a guard per caller. Three seconds is an order of magnitude above a healthy
publish and leaves the webhook route most of Linear's five, consistent with the
existing decision in that file to cut the client's default 4.3s of backoff down
to 150ms for the same reason.

The race leaves the underlying fetch running, since nothing can cancel it, so
the abandoned promise gets a `.catch()` to keep a late rejection off the
unhandled-rejection path. A late *success* costs one duplicate, which is the
cost the `deduplicationId` comment right above already prices.

Verified the wrapper does the job, does not mask real errors, and does not leak
rejections:

```
[ok] hanging server: threw after 3006ms: QStash publish exceeded 3000ms
[ok] failing server: threw after 9ms: nope
[ok] budgeted loop: attempted 10/50, stopped at 30027ms
[ok] no unhandled rejections
```

**`deferred` in the result.** Planned re-queues a run never attempted, from
either exit. Without it a run that stopped early is indistinguishable from one
that found nothing more to do, and the run is logged when it is non-zero.

### The `retryCount` ordering: kept as #7289 has it (publish, then count)

I did not reverse it. Counting before publishing would make every failed or
timed-out publish spend one of a delivery's five attempts — during a QStash
outage five sweeps would mark deliveries `abandoned` that were never actually
retried, which is silent webhook loss and unrecoverable. The current order's
cost is the opposite and much cheaper: a re-queue that happened but was not
committed gets re-queued again, costing a duplicate the consumer dedupes for one
query. #7289 chose correctly.

The ordering was never the bug. The unbounded hold was: it took the residual
risk in that trade — "the process dies between publish and commit" — and made it
reachable on any slow run. With the run bounded to ~33s of a 60s ceiling and
~11% of the idle-in-transaction limit, that window is back to being an
infrastructure failure rather than a routine outcome.

## Deliberately not in this change

- **`singleFlight.ts` untouched.** #7330 owns it and is still open.
- **No per-row write-back.** Incrementing `retryCount` inside the loop would
  survive an infra kill and would keep the connection from going idle, but it
  costs a statement per row and breaks the existing grouped write-back
  (at most `MAX_ATTEMPTS` statements, fenced on the observed count). Not worth
  it now that the run is bounded.
- **`MAX_CONSECUTIVE_PUBLISH_FAILURES` kept.** It is not made redundant by the
  budget: in a fast-failure outage 50 doomed publishes take well under thirty
  seconds, so the budget would never fire and the breaker is the only thing
  stopping them. The two cover disjoint cases — fast failures, slow successes —
  and the constant's doc now says which is which.
- **Not replacing the QStash SDK with raw `fetch` + `AbortSignal.timeout`.**
  It would cancel the socket properly instead of abandoning it, but it means
  reimplementing auth, headers and error typing for one call. The abandoned
  fetch is harmless in a function that is about to end.
- **No new tests.** `planSweep` holds the pure decision logic and is already
  covered; the two new bounds are wall-clock behaviour of a route with no
  harness, and the repros above cover them better than a mocked clock would.
- **The QStash schedule is still not created.** Out of scope here; this is the
  correctness work that had to land before it exists.

## Verification

```
$ bunx biome check apps/api/src/app/api/integrations/linear/
Checked 20 files in 10ms. No fixes applied.
```

```
$ cd apps/api && bun run typecheck
$ tsc --noEmit
```

Full `apps/api` package suite, not just the touched files:

```
$ cd apps/api && bun test src

 69 pass
 0 fail
 124 expect() calls
Ran 69 tests across 9 files. [62.00ms]
```

No failures, so nothing needed the revert-and-rerun check. The stderr lines the
run prints (`[linear/webhook] failed to queue delivery: … qstash unavailable`
and friends) are the deliberate `console.error` output of the negative tests,
not failures. `webhook/route.test.ts` mocks `./queue` wholesale, so it exercises
the caller contract and is unaffected by the timeout added inside it.

Refs API-18.

https://claude.ai/code/session_016ETgyauAQyxzHRSKq7ox7K

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the Linear sweep's QStash publish loop at 30 seconds and each publish at 3 seconds, so a run can no longer overrun its time budget and lose the retry-count write-back. The old unbounded loop could run into the route's 60-second kill or Postgres's idle-in-transaction limit, leaving published deliveries uncounted and re-queued on every later run.

- Adds a `PUBLISH_BUDGET_MS` check measured on a monotonic clock; stopped runs log a `deferred` count so they are distinguishable from empty runs.
- Races `enqueueLinearDelivery` publishes against a timer and rejects on timeout, with a `.catch()` on the abandoned fetch to avoid unhandled rejections.
- Keeps the publish-then-count ordering; counting first would spend delivery attempts on failed publishes and risk silent webhook loss.
- The QStash schedule for this route still does not exist, so this is pre-rollout correctness work. Refs API-18.

<sup>Written for commit b96f67b67fb7e655ce158cca0baf8e7c024d93b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Webhook delivery publishing now times out when the publishing service does not respond, preventing requests from waiting indefinitely.
  - Abandoned-delivery cleanup now observes a 30-second processing window and stops scheduling additional retries after the limit is reached.
  - Results and logs now clearly indicate when planned retries were deferred for later processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->