### PR TITLE
fix(desktop): migrate v1 groups to v2 tags

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/migration/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/migration/index.ts
@@ -4,6 +4,7 @@ import {
 	projects,
 	settings,
 	v1MigrationState,
+	workspaceSections,
 	workspaces,
 	worktrees,
 } from "@superset/local-db";
@@ -41,6 +42,10 @@ export const createMigrationRouter = () => {
 				.from(workspaces)
 				.where(isNull(workspaces.deletingAt))
 				.all();
+		}),
+
+		readV1Groups: publicProcedure.query(() => {
+			return localDb.select().from(workspaceSections).all();
 		}),
 
 		readV1Worktrees: publicProcedure.query(() => {

--- a/apps/desktop/src/renderer/lib/v1-migration/groups.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/groups.ts
@@ -1,0 +1,163 @@
+import { normalizeWorkspaceTags } from "@superset/shared/workspace-tags";
+import type { HostServiceClient } from "renderer/lib/host-service-client";
+import { mintFolderTag } from "renderer/routes/_authenticated/utils/workspaceTagFolders/workspaceTagFolders";
+import type { V1GroupRow, V1MigrationIpc } from "./ipc";
+import {
+	isTerminalStatus,
+	ledgerKey,
+	loadV1MigrationLedger,
+	type V1LedgerOutcome,
+} from "./ledger";
+import { emptySummary } from "./summary";
+
+export type V1GroupTarget = (
+	group: V1GroupRow,
+	projectId: string,
+	tag: string,
+) => void;
+
+/**
+ * Group presentation and memberships have independent settings-ledger entries:
+ * workspace adoption may already be complete, or a member may arrive later.
+ * Persist the chosen tag BEFORE host writes so partial runs never mint a new
+ * suffix. Completed entries also preserve subsequent v2 edits/removals.
+ */
+export async function migrateV1Groups({
+	organizationId,
+	hostClient,
+	ipc,
+	groupTarget,
+}: {
+	organizationId: string;
+	hostClient: HostServiceClient;
+	ipc: V1MigrationIpc;
+	groupTarget?: V1GroupTarget;
+}) {
+	const summary = emptySummary();
+	const groups = await ipc.readV1Groups();
+	if (groups.length === 0) return summary;
+	const [ledger, workspaces, hostWorkspaces, folders] = await Promise.all([
+		loadV1MigrationLedger(ipc, organizationId),
+		ipc.readV1Workspaces(),
+		hostClient.workspace.list.query(),
+		hostClient.tagFolders.list.query(),
+	]);
+	const hostById = new Map(hostWorkspaces.map((w) => [w.id, w]));
+	const takenByProject = new Map<string, Set<string>>();
+	const takenFor = (projectId: string) => {
+		let taken = takenByProject.get(projectId);
+		if (!taken) {
+			taken = new Set([
+				...folders.filter((f) => f.scope === projectId).map((f) => f.tag),
+				...hostWorkspaces
+					.filter((w) => w.projectId === projectId)
+					.flatMap((w) => w.tags),
+			]);
+			takenByProject.set(projectId, taken);
+		}
+		return taken;
+	};
+	const record = async (entry: V1LedgerOutcome) => {
+		await ipc.ledgerRecord(organizationId, [entry]);
+		ledger.set(ledgerKey(entry.kind, entry.v1Id), {
+			status: entry.status,
+			v2Id: entry.v2Id ?? null,
+		});
+	};
+	// Reserve even unfinished assignments before minting for any other group.
+	for (const group of groups) {
+		const project = ledger.get(ledgerKey("project", group.projectId));
+		const assigned = ledger.get(ledgerKey("settings", `group-tag:${group.id}`));
+		if (project?.v2Id && assigned?.v2Id)
+			takenFor(project.v2Id).add(assigned.v2Id);
+	}
+	for (const group of groups) {
+		const project = ledger.get(ledgerKey("project", group.projectId));
+		if (!project?.v2Id || !isTerminalStatus(project.status)) {
+			summary.skipped++;
+			continue;
+		}
+		const scope = project.v2Id;
+		const assignmentId = `group-tag:${group.id}`;
+		const assigned = ledger.get(ledgerKey("settings", assignmentId));
+		const tag = assigned?.v2Id ?? mintFolderTag(group.name, takenFor(scope));
+		takenFor(scope).add(tag);
+		try {
+			if (!assigned?.v2Id) {
+				await record({
+					kind: "settings",
+					v1Id: assignmentId,
+					status: "skipped",
+					v2Id: tag,
+				});
+			}
+			if (!assigned || !isTerminalStatus(assigned.status)) {
+				await hostClient.tagFolders.upsert.mutate({
+					scope,
+					tag,
+					displayName: group.name.trim() || tag,
+					color: group.color,
+					tabOrder: group.tabOrder,
+				});
+				await record({
+					kind: "settings",
+					v1Id: assignmentId,
+					status: "success",
+					v2Id: tag,
+				});
+				summary.migrated++;
+			}
+
+			const localId = `group-local:${group.id}`;
+			const localDone = ledger.get(ledgerKey("settings", localId));
+			if (groupTarget && (!localDone || !isTerminalStatus(localDone.status))) {
+				groupTarget(group, scope, tag);
+				await record({
+					kind: "settings",
+					v1Id: localId,
+					status: "success",
+					v2Id: tag,
+				});
+			}
+			for (const workspace of workspaces) {
+				if (
+					workspace.sectionId !== group.id ||
+					workspace.projectId !== group.projectId
+				)
+					continue;
+				const memberId = `group-member:${group.id}:${workspace.id}`;
+				const done = ledger.get(ledgerKey("settings", memberId));
+				if (done && isTerminalStatus(done.status)) continue;
+				const mapped = ledger.get(ledgerKey("workspace", workspace.id));
+				if (!mapped?.v2Id || !isTerminalStatus(mapped.status)) {
+					// Permanently skipped worktrees must not keep follow-up armed.
+					if (mapped?.status === "error") summary.deferred++;
+					else summary.skipped++;
+					continue;
+				}
+				const host = hostById.get(mapped.v2Id);
+				if (!host || host.projectId !== scope) {
+					summary.skipped++;
+					continue;
+				}
+				const tags = normalizeWorkspaceTags([...host.tags, tag]);
+				await hostClient.workspace.update.mutate({ id: host.id, tags });
+				host.tags = tags;
+				await record({
+					kind: "settings",
+					v1Id: memberId,
+					status: "success",
+					v2Id: host.id,
+				});
+				summary.migrated++;
+			}
+		} catch (err) {
+			summary.failed++;
+			console.error("[v1-migration] group migration failed", {
+				groupId: group.id,
+				err,
+			});
+		}
+	}
+	return summary;
+}

--- a/apps/desktop/src/renderer/lib/v1-migration/groups.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/groups.ts
@@ -95,7 +95,9 @@ export async function migrateV1Groups({
 				await hostClient.tagFolders.upsert.mutate({
 					scope,
 					tag,
-					displayName: group.name.trim() || tag,
+					// v1 names were unbounded; the host accepts at most 200 chars.
+					// Keep the original in v1 and the local presentation row.
+					displayName: group.name.trim().slice(0, 200) || tag,
 					color: group.color,
 					tabOrder: group.tabOrder,
 				});

--- a/apps/desktop/src/renderer/lib/v1-migration/ipc.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/ipc.ts
@@ -21,7 +21,18 @@ export interface V1ProjectRow {
 	branchPrefixCustom: string | null;
 }
 
+export interface V1GroupRow {
+	isCollapsed?: boolean | null;
+	createdAt?: number;
+	id: string;
+	projectId: string;
+	name: string;
+	color: string | null;
+	tabOrder: number;
+}
+
 export interface V1WorkspaceRow {
+	sectionId?: string | null;
 	id: string;
 	projectId: string;
 	worktreeId: string | null;
@@ -52,6 +63,7 @@ export interface V1TerminalPaneRow {
  * runV1Migration is testable end-to-end with in-memory fakes.
  */
 export interface V1MigrationIpc {
+	readV1Groups(): Promise<V1GroupRow[]>;
 	readV1Projects(): Promise<V1ProjectRow[]>;
 	readV1Workspaces(): Promise<V1WorkspaceRow[]>;
 	readV1Worktrees(): Promise<V1WorktreeRow[]>;
@@ -66,6 +78,7 @@ export interface V1MigrationIpc {
 }
 
 export const electronV1MigrationIpc: V1MigrationIpc = {
+	readV1Groups: () => electronTrpcClient.migration.readV1Groups.query(),
 	readV1Projects: () => electronTrpcClient.migration.readV1Projects.query(),
 	readV1Workspaces: () => electronTrpcClient.migration.readV1Workspaces.query(),
 	readV1Worktrees: () => electronTrpcClient.migration.readV1Worktrees.query(),

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.test.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.test.ts
@@ -157,6 +157,8 @@ class FakeHost {
 				list: { query: async () => this.folders },
 				upsert: {
 					mutate: async (args: FakeHost["folders"][number]) => {
+						if (args.displayName.length > 200)
+							throw new Error("Display name too long");
 						this.folders = this.folders.filter(
 							(f) => f.scope !== args.scope || f.tag !== args.tag,
 						);
@@ -648,6 +650,18 @@ describe("v1 groups to tags", () => {
 		});
 		expect(host.folders).toHaveLength(1);
 		expect(host.workspaces[0].tags).toEqual(["review"]);
+	});
+
+	test("imports unbounded v1 group names within the host display-name limit", async () => {
+		const { ipc, host } = await setup();
+		const original = `Long ${"x".repeat(220)}`;
+		ipc.groups[0].name = original;
+		expect((await run(ipc, host)).settings.failed).toBe(0);
+		expect(host.folders[0].displayName).toBe(original.slice(0, 200));
+		expect(ipc.groups[0].name).toBe(original);
+		expect(host.workspaces[0].tags).toEqual([host.folders[0].tag]);
+		await run(ipc, host);
+		expect(host.folders).toHaveLength(1);
 	});
 
 	test("skips groups belonging to projects that were not migrated", async () => {

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.test.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { HostServiceClient } from "renderer/lib/host-service-client";
 import type {
+	V1GroupRow,
 	V1MigrationIpc,
 	V1ProjectRow,
 	V1WorkspaceRow,
@@ -22,6 +23,7 @@ interface HostProject {
 	repoPath: string;
 }
 interface HostWorkspace {
+	tags: string[];
 	id: string;
 	projectId: string;
 	branch: string;
@@ -36,6 +38,14 @@ class FakeHost {
 	brokenRepos = new Map<string, string>();
 	/** Throw the next N adopt calls (transient host fault). */
 	adoptFaults = 0;
+	tagFaults = 0;
+	folders: Array<{
+		scope: string;
+		tag: string;
+		displayName: string;
+		color: string | null;
+		tabOrder: number;
+	}> = [];
 	mutations: Array<{ kind: string; args: unknown }> = [];
 	private seq = 0;
 
@@ -87,6 +97,7 @@ class FakeHost {
 						const project = { id: this.id("v2p"), repoPath: mode.repoPath };
 						this.projects.push(project);
 						const main = {
+							tags: [],
 							id: this.id("v2w"),
 							projectId: project.id,
 							branch: "main",
@@ -141,7 +152,30 @@ class FakeHost {
 					},
 				},
 			},
-			workspace: { list: { query: async () => [...this.workspaces] } },
+
+			tagFolders: {
+				list: { query: async () => this.folders },
+				upsert: {
+					mutate: async (args: FakeHost["folders"][number]) => {
+						this.folders = this.folders.filter(
+							(f) => f.scope !== args.scope || f.tag !== args.tag,
+						);
+						this.folders.push(args);
+					},
+				},
+			},
+			workspace: {
+				list: { query: async () => this.workspaces.map((w) => ({ ...w })) },
+				update: {
+					mutate: async (args: { id: string; tags: string[] }) => {
+						if (this.tagFaults-- > 0) throw new Error("tag write failed");
+						const row = this.workspaces.find((w) => w.id === args.id);
+						if (!row) throw new Error("missing workspace");
+						row.tags = args.tags;
+						this.mutations.push({ kind: "workspace.update", args });
+					},
+				},
+			},
 			workspaceCreation: {
 				listProjectWorktrees: {
 					query: async ({ projectId }: { projectId: string }) => {
@@ -170,6 +204,7 @@ class FakeHost {
 						);
 						if (existing) return { workspace: existing, alreadyExists: true };
 						const row = {
+							tags: [],
 							id: this.id("v2w"),
 							projectId: args.projectId,
 							branch: args.branch,
@@ -184,6 +219,7 @@ class FakeHost {
 }
 
 class FakeIpc implements V1MigrationIpc {
+	groups: V1GroupRow[] = [];
 	projects: V1ProjectRow[] = [];
 	workspaces: V1WorkspaceRow[] = [];
 	worktrees: V1WorktreeRow[] = [];
@@ -192,6 +228,9 @@ class FakeIpc implements V1MigrationIpc {
 	ledgerHistory = new Map<string, string[]>();
 	failNextLedgerRecords = 0;
 
+	async readV1Groups() {
+		return this.groups;
+	}
 	async readV1Projects() {
 		return [...this.projects];
 	}
@@ -505,5 +544,117 @@ describe("runV1Migration invariants (seeded fuzz)", () => {
 			await run(ipc, host);
 			expect(host.mutations.length).toBe(before);
 		}
+	});
+});
+
+describe("v1 groups to tags", () => {
+	const setup = async () => {
+		const ipc = new FakeIpc();
+		const host = new FakeHost();
+		ipc.projects = [project("p", "/repo")];
+		ipc.workspaces = [{ ...workspace("w", "p", "main"), sectionId: "g" }];
+		await run(ipc, host); // Backfill a migration that finished before groups existed.
+		ipc.groups = [
+			{
+				id: "g",
+				projectId: "p",
+				name: "Review",
+				color: "#ff0000",
+				tabOrder: 3,
+			},
+		];
+		return { ipc, host };
+	};
+
+	test("backfills existing workspaces, preserves tags and presentation, respects later v2 edits", async () => {
+		const { ipc, host } = await setup();
+		host.workspaces[0].tags = ["existing"];
+		await run(ipc, host);
+		expect(host.workspaces[0].tags).toEqual(["existing", "review"]);
+		expect(host.folders[0]).toMatchObject({
+			tag: "review",
+			displayName: "Review",
+			color: "#ff0000",
+			tabOrder: 3,
+		});
+		host.workspaces[0].tags = ["existing"]; // user removes migrated membership
+		host.folders[0].displayName = "Renamed";
+		const writes = host.mutations.length;
+		await run(ipc, host);
+		expect(host.mutations.length).toBe(writes);
+		expect(host.workspaces[0].tags).toEqual(["existing"]);
+		expect(host.folders[0].displayName).toBe("Renamed");
+	});
+
+	test("reserves collision-free tags and reuses them after a rejected membership write", async () => {
+		const { ipc, host } = await setup();
+		host.workspaces[0].tags = ["review"];
+		ipc.groups.push({ ...ipc.groups[0], id: "empty" });
+		host.tagFaults = 1;
+		expect((await run(ipc, host)).settings.failed).toBe(1);
+		expect(host.folders.map((f) => f.tag)).toEqual(["review-2", "review-3"]);
+		await run(ipc, host);
+		expect(host.workspaces[0].tags).toEqual(["review", "review-2"]);
+		expect(host.folders.map((f) => f.tag)).toEqual(["review-2", "review-3"]);
+	});
+
+	test("imports late members without recreating or retagging the group", async () => {
+		const { ipc, host } = await setup();
+		ipc.workspaces.push({ ...workspace("late", "p", "feat"), sectionId: "g" });
+		host.diskBranches.set("/repo", new Set(["main", "feat"]));
+		host.adoptFaults = 1;
+		expect((await run(ipc, host)).settings.deferred).toBe(1);
+		await run(ipc, host);
+		expect(host.workspaces.find((w) => w.branch === "feat")?.tags).toEqual([
+			"review",
+		]);
+		expect(host.folders).toHaveLength(1);
+	});
+
+	test("does not write host state when reserving the tag fails", async () => {
+		const { ipc, host } = await setup();
+		ipc.failNextLedgerRecords = 1;
+		expect((await run(ipc, host)).settings.failed).toBe(1);
+		expect(host.folders).toHaveLength(0);
+		expect(host.workspaces[0].tags).toEqual([]);
+		await run(ipc, host);
+		expect(host.folders[0].tag).toBe("review");
+	});
+
+	test("retries local presentation after failure and seeds it only once", async () => {
+		const { ipc, host } = await setup();
+		ipc.groups[0].isCollapsed = true;
+		const imported: unknown[] = [];
+		let fail = true;
+		const groupTarget = (group: V1GroupRow, projectId: string, tag: string) => {
+			if (fail) throw new Error("local write failed");
+			imported.push({ group, projectId, tag });
+		};
+		const pass = () =>
+			runV1Migration({
+				organizationId: "org",
+				ipc,
+				hostClient: host.client(),
+				groupTarget,
+			});
+		expect((await pass()).settings.failed).toBe(1);
+		fail = false;
+		await pass();
+		await pass();
+		expect(imported).toHaveLength(1);
+		expect(imported[0]).toMatchObject({
+			group: { isCollapsed: true },
+			tag: "review",
+		});
+		expect(host.folders).toHaveLength(1);
+		expect(host.workspaces[0].tags).toEqual(["review"]);
+	});
+
+	test("skips groups belonging to projects that were not migrated", async () => {
+		const { ipc, host } = await setup();
+		ipc.groups[0].projectId = "hidden";
+		await run(ipc, host);
+		expect(host.folders).toHaveLength(0);
+		expect(host.workspaces[0].tags).toEqual([]);
 	});
 });

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
@@ -1,5 +1,6 @@
 import type { HostServiceClient } from "renderer/lib/host-service-client";
 import type { V2TerminalPresetRow } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal";
+import { migrateV1Groups, type V1GroupTarget } from "./groups";
 import type { V1MigrationIpc } from "./ipc";
 import {
 	isTerminalStatus,
@@ -45,6 +46,7 @@ export interface V1MigrationSummary {
 }
 
 export interface RunV1MigrationDeps {
+	groupTarget?: V1GroupTarget;
 	organizationId: string;
 	hostClient: HostServiceClient;
 	/** Electron-main reads/writes; inject fakes in tests. */
@@ -117,8 +119,12 @@ export async function runV1Migration(
 		await flush();
 		workspaces = await migrateWorkspaces(deps, ledger, outcomes);
 		await flush();
+		const groups = await migrateV1Groups(deps);
 		settings = await migrateSettings(deps, ledger, outcomes);
 		await flush();
+		for (const key of Object.keys(settings) as (keyof KindSummary)[]) {
+			settings[key] += groups[key];
+		}
 		terminals = await migrateTerminals(deps, ledger, outcomes);
 		await flush();
 		presets = await migratePresets(deps, ledger, outcomes);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1AutoMigration/V1AutoMigration.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1AutoMigration/V1AutoMigration.tsx
@@ -15,12 +15,17 @@ import {
 	markV1MigrationComplete,
 	setV1FollowUpPending,
 } from "renderer/lib/v1-migration/completion";
+import {
+	migrateV1Groups,
+	type V1GroupTarget,
+} from "renderer/lib/v1-migration/groups";
 import { electronV1MigrationIpc } from "renderer/lib/v1-migration/ipc";
 import { v1MigrationEventProps } from "renderer/lib/v1-migration/telemetry";
 import { useFinalizeProjectSetup } from "renderer/react-query/projects";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { buildSidebarFolderKey } from "renderer/routes/_authenticated/utils/workspaceTagFolders/workspaceTagFolders";
 import { appendPendingMigratedTerminals } from "renderer/stores/workspace-creates/appendPendingMigratedTerminals";
 
 /**
@@ -28,10 +33,12 @@ import { appendPendingMigratedTerminals } from "renderer/stores/workspace-create
  * runs one pass per boot once the preconditions hold, records everything in
  * the ledger, and marks the org complete when the flip gate (projects +
  * workspaces) is satisfied — the NEXT launch then lands on v2 with data
- * already in place. On the v2 surface it keeps running only while there is
+ * already in place. On the v2 surface the full pass runs while there is
  * outstanding work: best-effort kinds (settings/presets/terminals) that
  * were still failing when the gate completed (D4), or everything on
  * machines the forced-flip backstop moved before their gate completed.
+ * Completed v2 migrations still run the ledger-guarded group backfill, since
+ * older passes omitted groups entirely.
  * Cross-instance single-flight via a main-process lock file; failures retry
  * next boot.
  */
@@ -63,11 +70,12 @@ export function V1AutoMigration() {
 		if (!organizationId || !onboarded || !activeHostUrl || !agentsSettled) {
 			return;
 		}
+		let groupsOnly = false;
 		if (isV2CloudEnabled) {
 			const followUp =
 				isV1FollowUpPending(organizationId) ||
 				(isV1ForcedFlipActive() && !isV1MigrationComplete(organizationId));
-			if (!followUp) return;
+			groupsOnly = !followUp;
 		} else if (migrationFlagEnabled !== true) {
 			return;
 		}
@@ -84,7 +92,34 @@ export function V1AutoMigration() {
 				if (!lock.acquired) return;
 				locked = true;
 
+				const groupTarget: V1GroupTarget = (group, projectId, tag) => {
+					const sectionId = buildSidebarFolderKey(projectId, tag);
+					if (collections.v2SidebarSections.get(sectionId)) return;
+					collections.v2SidebarSections.insert({
+						sectionId,
+						projectId,
+						tag,
+						name: group.name.trim() || tag,
+						color: group.color,
+						tabOrder: group.tabOrder,
+						isCollapsed: group.isCollapsed ?? false,
+						createdAt: new Date(group.createdAt ?? Date.now()),
+					});
+				};
+				// Older completed migrations never imported v1 groups. Backfill on
+				// v2 boots too; the ledger preserves later v2 customizations.
+				if (groupsOnly) {
+					await migrateV1Groups({
+						groupTarget,
+						organizationId,
+						hostClient: getHostServiceClientByUrl(hostUrl),
+						ipc: electronV1MigrationIpc,
+					});
+					return;
+				}
+
 				const summary = await runV1Migration({
+					groupTarget,
 					organizationId,
 					hostClient: getHostServiceClientByUrl(hostUrl),
 					ipc: electronV1MigrationIpc,


### PR DESCRIPTION
## What & why

The v1 migrator imported projects and workspaces but omitted workspace groups, so their organization disappeared in v2. Import each v1 group as a tag folder, preserving its name, color, order, collapsed state, and workspace membership while retaining existing tags.

Backfill groups on v2 boots even when an older migration already completed. Persist tag reservations before host writes to prevent collisions and duplicate tags on retries; track presentation and membership independently so late workspace imports are included and completed migrations preserve subsequent v2 edits.

## How I tested it

- Migration suite: 56 tests pass, including backfilling already-imported workspaces, name collisions, rejected writes, late members, local presentation retries, and preserving later v2 edits.
- `bun run lint`: passes.
- `bun run typecheck`: passes across all 38 tasks.
- `bun run check:plugins`: passes.
- `bun run test`: stopped in `@superset/trpc` because required environment variables are missing.
- CDP verified this worktree's Electron app (renderer 4905, API 4901, CDP 9499): v1 group creation/membership/collapse, v2 backfill, duplicate names, empty groups, Unicode names, rename/delete persistence across reloads, real host rejection at the 32-tag limit and recovery after freeing a slot, and missing/deleting workspaces.
- A controlled local fixture passed the automatic completion gate with no migration console errors, showed the v1 upgrade notice, and opened v2 with the group on the next renderer boot and after a native app restart. The original project selection was restored and disposable projects were removed.
- CDP found an additional bug with legacy names over 200 characters. The host-facing label is now capped at the existing API limit; the original v1/local name is retained. A 225-character live case and a regression test now pass.
- Before/after screenshots and JSON snapshots were captured locally; they are not attached to this PR.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not applicable: branch is in the main repository)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates v1 workspace groups into v2 tag folders so group organization survives the upgrade.

**Details**
- Imports each v1 group as a tag folder, preserving name, color, order, collapsed state, and workspace membership.
- Backfills groups on v2 boots even when an older migration already completed.
- Reserves tags before host writes to prevent collisions and duplicate tags on retries.
- Tracks presentation and membership independently so late workspace imports are included and completed migrations preserve later v2 edits.

<sup>Written for commit df0aa98c2d795ccf142c0d3bce2b948b8e26cd1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic migration of legacy groups into tag folders and workspace memberships.
  * Added support for importing groups during both full migrations and completed-migration backfills.
  * Added migration tracking to safely handle retries, skipped groups, and individual failures.
* **Bug Fixes**
  * Improved migration resilience by continuing other groups when one group encounters an error.
  * Prevented overly long group names from exceeding tag folder limits.
* **Tests**
  * Added coverage for group migration, tag conflicts, late workspace imports, retries, and unmigrated projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
