### PR TITLE
chore: drop the last Electric traces — subprocessor entry and orphaned Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,0 @@
-{
-auto_https disable_redirects
-}
-
-https://localhost:{$CADDY_ELECTRIC_PORT} {
-reverse_proxy localhost:{$WRANGLER_PORT} {
-flush_interval -1
-}
-}

--- a/apps/marketing/content/legal/subprocessors.mdx
+++ b/apps/marketing/content/legal/subprocessors.mdx
@@ -1,14 +1,13 @@
 ---
 title: Subprocessors
 description: List of third-party subprocessors that Superset engages to provide its services.
-lastUpdated: 2026-03-23
+lastUpdated: 2026-09-08
 ---
 
 ## List of Subprocessors
 
 - **Anthropic, PBC (USA)**: Artificial intelligence
 - **Cloudflare, Inc. (USA)**: Edge proxy and web application firewall
-- **ElectricSQL Ltd (USA)**: Real-time data sync and streaming
 - **Neon Inc. (USA)**: Cloud database
 - **PostHog, Inc. (USA)**: Product analytics
 - **Resend, Inc. (USA)**: Email delivery


### PR DESCRIPTION
Electric Cloud is decommissioned as of today. Shape sync was replaced with tRPC + React Query in #6328 (shipped in `desktop-v1.21.0`) and the proxy's source was deleted in #6667. These are the two remaining references in the repo.

## Changes

- **`subprocessors.mdx`** — remove ElectricSQL Ltd. As of today it processes none of our data, so listing it overstates the subprocessor set.
- **`Caddyfile`** — delete. Its only content was the TLS shim fronting the Electric proxy (`CADDY_ELECTRIC_PORT` → wrangler). Verified nothing invokes `caddy` anywhere in `.superset/`, `scripts/`, `tooling/`, `package.json`, or `turbo.jsonc` — it has been dead since #6667 removed Caddy from the dev stack.

## Infrastructure done outside this PR

- Electric Cloud source deleted (by Satya). Electric dropped its own replication slot and publication on the way out.
- Production Postgres: dropped the leftover `electric_publication_default`. Prod now has **0 logical replication slots and 0 publications**; the 2 remaining slots are Neon's own physical `wal_proposer_slot` / `wal_retention_slot`.
- `NEXT_PUBLIC_ELECTRIC_URL` GitHub secret was already gone.

The slot mattered: it had no `max_slot_wal_keep_size` cap, so had Electric's service gone dark while the slot remained, WAL retention would have grown unbounded against production with no safety net.

## Deliberately not included

- **`agent_commands` table drop.** Zero references outside schema/migrations, so it is droppable, but it wants its own migration and its own risk review.
- **The stale `caddy` prereq in the 17 READMEs.** `bun dev` has not run caddy since #6667, so `brew install jq caddy && caddy trust` is already wrong. Fixing it touches 16 hand-maintained translations and deserves a separate review.

## Risk

Doc + dead-config only; no runtime code. The user-visible half of this shutdown is the `electric-proxy` Worker deletion, which is separate and breaks sync for ~4,286 users on pre-1.21.0 builds — a knowingly accepted cost.

https://claude.ai/code/session_019bjPymf8tNyyhNXPpJTkh8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the last two Electric Cloud references from the repo: the ElectricSQL Ltd. entry from the subprocessors page and the orphaned Caddyfile that fronted the deleted Electric proxy.

**Context**

- Electric Cloud is decommissioned; shape sync was replaced in #6328 and the proxy source was deleted in #6667.
- The production Postgres replication slot and publication were dropped outside this PR; there are now 0 logical replication slots and 0 publications in prod.
- The slot had no `max_slot_wal_keep_size` cap, so leaving it would have risked unbounded WAL retention.

**Deliberately not included**

- The `agent_commands` table drop, which needs its own migration and risk review.
- Stale `caddy` prerequisites in the READMEs, which predate this change and touch 16 hand-maintained translations.

<sup>Written for commit 73982b583ef07412ca857f85c69c4c034ac3a5fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Subprocessors legal page’s last-updated date to September 8, 2026.
  * Removed ElectricSQL Ltd. from the listed subprocessors.

* **Infrastructure**
  * Removed the previous local proxy and HTTPS redirect configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->