### PR TITLE
fix(desktop): register zod's English locale so validation errors say what failed

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -28,6 +28,7 @@ import {
 	PLATFORM,
 	PROTOCOL_SCHEME,
 } from "shared/constants";
+import { configureZodLocale } from "shared/zod-locale";
 import { sweepDevAppProfiles } from "./dev-app-profile-sweep";
 import { initAppState } from "./lib/app-state";
 import { requestAppleEventsAccess } from "./lib/apple-events-permission";
@@ -477,6 +478,7 @@ if (!gotTheLock) {
 		ensureProjectIconsDir();
 		setWorkspaceDockIcon();
 		initSentry();
+		configureZodLocale();
 		await initAppState();
 		initTanstackDbPersistence();
 

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,6 +1,8 @@
+import { configureZodLocale } from "shared/zod-locale";
 import { initSentry } from "./lib/sentry";
 
 initSentry();
+configureZodLocale();
 
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import ReactDom from "react-dom/client";

--- a/apps/desktop/src/shared/zod-locale.ts
+++ b/apps/desktop/src/shared/zod-locale.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { en } from "zod/locales";
+
+/**
+ * zod ships its English messages as a locale that its own entry module
+ * registers with a top-level `config(en())`. That statement does not survive
+ * all of our production bundles: on a release build the renderer and main
+ * bundles carry no locale at all, so every issue falls back to zod's bare
+ * "Invalid input" and the failing check is lost — DESKTOP-151/152/153 each
+ * named the field but not what was wrong with it, the difference between
+ * "Invalid UUID" and no diagnosis. (The host-service bundle happens to retain
+ * the registration, so it does not call this.)
+ *
+ * Called from app code the registration cannot be tree-shaken. `config()` is
+ * read when an issue is formatted, not when a schema is built, so schemas
+ * created before this call still get the messages.
+ */
+export function configureZodLocale(): void {
+	z.config(en());
+}


### PR DESCRIPTION
## Problem

Every zod validation error in a shipped desktop build reports the bare string `Invalid input`, with no indication of which check failed. `DESKTOP-151`, `DESKTOP-152` and `DESKTOP-153` all arrived as:

```
SchemaValidationError: Update validation failed:
- Invalid input - path: sectionId
```

That names the field but not the defect — the same text is emitted for a failed uuid format, a failed min-length, and a type mismatch. Triage has to reconstruct which one it was from the schema at that release.

## Root cause

zod ships its English messages as a *locale*, registered by a top-level `config(en())` inside `zod/v4/classic/external.js`. When that registration is absent, `finalizeIssue` walks its message chain and lands on the final literal fallback:

```js
// zod/v4/core/util.js
const message = iss.message ? iss.message
  : (unwrapMessage(iss.inst?._zod.def?.error?.(iss))
  ?? unwrapMessage(ctx?.error?.(iss))
  ?? unwrapMessage(config.customError?.(iss))
  ?? unwrapMessage(config.localeError?.(iss))
  ?? "Invalid input");
```

That registration does not survive our production bundles. Measured on a real `electron-vite build`, grepping each bundle for a literal that only the `en` locale contains (`"E.164 number"`):

| bundle | before | after |
| --- | --- | --- |
| `dist/renderer/assets/*` | 0 chunks | 1 chunk |
| `dist/main/index.js` | 0 | 1 |
| `dist/main/host-service.js` | 1 (already had it) | 1 (unchanged) |
| `dist/preload/index.js` | 0 | 0 |

Note this is **not** zod's `"sideEffects": false` field, which was my first hypothesis and is wrong: with that field removed entirely from the installed package, a plain top-level side effect added to the same module still does not survive the bundle. The registration is dropped regardless of that metadata.

## Fix

Register the locale from app code, where it cannot be tree-shaken, via one small module called from the entries that need it. Scoped deliberately to the two bundles measured to be missing it — `host-service` already retains the registration and is left alone rather than given a redundant call.

`config()` is read when an issue is *formatted*, not when a schema is built, so schemas constructed before the call still get the messages.

No typed `cause` is added: nothing reads one here, and this changes no control flow — only the text of an already-thrown error.

## Verification

Behaviour, bundled through this repo's own vite 7.3.5 (a synthetic entry, control vs. explicit registration):

```
control                MESSAGE: Invalid input
explicit z.config(en()) MESSAGE: Invalid UUID
```

Schemas built via `zod` and via `zod/v4` (both specifiers are used in this repo) share one config registry, so a single call covers both:

```
via zod/v4 : Invalid UUID
via zod    : Invalid UUID
```

`bunx biome check` on changed files:
```
Checked 5 files in 33ms. No fixes applied.
```

`bun run typecheck` (apps/desktop):
```
$ tsc --noEmit
typecheck exit: 0
```

`bun test` (full apps/desktop package suite, three runs):
```
 3672 pass
 0 fail
Ran 3672 tests across 397 files. [25.30s]
 3672 pass
 0 fail
Ran 3672 tests across 397 files. [23.62s]
 3672 pass
 0 fail
Ran 3672 tests across 397 files. [23.90s]
```

The suite runs unbundled source, where the locale is already registered, so it cannot exercise this fix — the bundle measurement above is the evidence that matters.

Refs DESKTOP-151
Refs DESKTOP-152
Refs DESKTOP-153

https://claude.ai/code/session_01TWS92GzGjAkUJCANqkuzdS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop validation errors reporting only `Invalid input`, without naming the failed check, by registering zod's English locale from app code so it survives production bundles.

**Bug Fixes**
- Scoped to the main and renderer entries; the host-service bundle already retains the registration.
- Locale is read when an error is formatted, so schemas built before the call still get the specific messages.
- Changes only error text, not control flow or `cause`; addresses DESKTOP-151, 152, and 153.

<sup>Written for commit fd308ab433ef9d38e9f3a9c49433d26c4076e40d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation feedback throughout the desktop app by consistently displaying clear English error messages.
  - Prevented validation errors from falling back to the unhelpful “Invalid input” message in released builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->