### PR TITLE
fix(desktop): stop partial module mocks leaking across test files

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/AddRepositoryModals/hooks/useFolderFirstImport/useFolderFirstImport.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-// Static import so the real store loads (with real react) before the partial
-// "react" mock below registers.
+import * as reactActual from "react";
+// Static imports so the real modules are captured before the mocks below
+// replace them.
+import * as hostServiceClientActual from "renderer/lib/host-service-client";
+import * as projectsActual from "renderer/react-query/projects";
+import * as localHostServiceActual from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
 import * as gitInitConfirmActual from "renderer/stores/git-init-confirm";
 
 const hostUrl = "http://host-service";
@@ -37,7 +41,12 @@ const createMock = mock(async () => ({
 const finalizeSetupMock = mock(() => undefined);
 const requestGitInitMock = mock(async () => false);
 
+// Spread the real module for the same reason the store mock below does: bun's
+// mock.module is process-global and permanent, so dropping an export here
+// deletes it for every test file that runs after this one. `useCallback` is
+// identity so the hook can be exercised outside a render.
 mock.module("react", () => ({
+	...reactActual,
 	useCallback: <T extends (...args: never[]) => unknown>(callback: T) =>
 		callback,
 }));
@@ -53,6 +62,7 @@ mock.module("renderer/lib/electron-trpc", () => ({
 }));
 
 mock.module("renderer/lib/host-service-client", () => ({
+	...hostServiceClientActual,
 	getHostServiceClientByUrl: () => ({
 		project: {
 			findByPath: { query: findByPathMock },
@@ -63,12 +73,14 @@ mock.module("renderer/lib/host-service-client", () => ({
 }));
 
 mock.module("renderer/react-query/projects", () => ({
+	...projectsActual,
 	useFinalizeProjectSetup: () => finalizeSetupMock,
 }));
 
 mock.module(
 	"renderer/routes/_authenticated/providers/LocalHostServiceProvider",
 	() => ({
+		...localHostServiceActual,
 		useLocalHostService: () => ({
 			activeHostUrl: hostUrl,
 			waitForHostReady: async () => hostUrl,

--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.test.ts
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/FileViewerPane/hooks/useFileContent/useFileContent.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+// Static import so the real module is captured before the mock below replaces it.
+import * as reactActual from "react";
 
 let rawQueryResult: {
 	data?: {
@@ -19,7 +21,12 @@ const readFileUseQuery = mock(
 );
 const emptyUseQuery = mock(() => ({ data: undefined, isLoading: false }));
 
+// Spread the real module: bun's mock.module is process-global and permanent,
+// so dropping an export here deletes it for every test file that runs after
+// this one. `useMemo` runs eagerly so the hook can be exercised outside a
+// render.
 mock.module("react", () => ({
+	...reactActual,
 	useMemo: <T>(factory: () => T) => factory(),
 }));
 


### PR DESCRIPTION
## Problem

The full `apps/desktop` suite was red on `main`, deterministically, with a failure that has nothing to do with the file it lands in:

```
=== full-suite run 1 ===   3664 pass | 1 fail | 1 error | Ran 3665 tests across 397 files.
=== full-suite run 2 ===   3664 pass | 1 fail | 1 error | Ran 3665 tests across 397 files.
=== full-suite run 3 ===   3664 pass | 1 fail | 1 error | Ran 3665 tests across 397 files.
```

```
src/renderer/.../useSidebarDnd/useSidebarDnd.test.ts:
# Unhandled error between tests
13 | const DndMonitorContext = /*#__PURE__*/React.createContext(null);
TypeError: React.createContext is not a function.
      at @dnd-kit/core/dist/core.cjs.development.js:13:46
```

The victim file is fine on its own — `8 pass, 0 fail`. Worse than one red test: its 8 tests were silently not running in the suite, so the sidebar drag-and-drop logic was effectively untested in CI.

## Root cause

`bun test` runs every file in one process, and `mock.module` is process-global and never restored. Two files replaced the *entire* `react` module with a one-hook object:

```ts
mock.module("react", () => ({ useCallback: (cb) => cb }));   // useFolderFirstImport.test.ts
mock.module("react", () => ({ useMemo: (f) => f() }));       // useFileContent.test.ts
```

From the moment either ran, every later import of `react` in that process got a React with no `createContext`, and `@dnd-kit/core` calls it at module scope.

Minimal reproduction, isolating the polluter:

```
=== A: useFileContent + useSidebarDnd ===        10 pass | 0 fail
=== B: useFolderFirstImport + useSidebarDnd ===   0 pass | 2 fail | 2 errors
```

The same file had three more partial mocks with the same defect, masked behind the react one — they drop real exports (`hostServiceQueryRetryDelay` among them) that later files import. Fixing only react surfaced the next:

```
SyntaxError: Export named 'hostServiceQueryRetryDelay' not found in module '.../host-service-client.ts'
```

## Fix

The file already documented the correct shape for one of its own mocks:

```ts
// Spread the real module — bun's mock.module is process-global, and a partial
// mock would break other test files importing the real store.
mock.module("renderer/stores/git-init-confirm", () => ({ ...gitInitConfirmActual, ... }));
```

This applies that consistently to the remaining mocks in both files: spread the real module, override only the export under test. No mock deletes an export for the files that run after it.

Deliberately *not* done: converting these to `renderHook`. That is the repo's other convention for hook tests and would remove the global mocks entirely, but it is a rewrite of both files' testing style, and the defect here is that a mock deletes exports — which spreading fixes exactly. The residual (an identity `useCallback`/`useMemo` visible to later files) is the shape the file already chose for its store mock; worth revisiting separately if it ever bites.

## Verification

Previously-failing pair:
```
 11 pass
 0 fail
Ran 11 tests across 2 files. [320.00ms]
```

`bunx biome check` on changed files:
```
Checked 5 files in 33ms. No fixes applied.
```

`bun run typecheck` (apps/desktop):
```
$ tsc --noEmit
typecheck exit: 0
```

`bun test` (full apps/desktop package suite, three runs) — note 3672 tests now run where 3665 did before, because the 8 previously-dead tests execute:
```
 3672 pass
 0 fail
Ran 3672 tests across 397 files. [25.30s]
 3672 pass
 0 fail
Ran 3672 tests across 397 files. [23.62s]
 3672 pass
 0 fail
Ran 3672 tests across 397 files. [23.90s]
```

https://claude.ai/code/session_01TWS92GzGjAkUJCANqkuzdS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops partial module mocks in two `apps/desktop` test files from leaking into later files, which was silently skipping 8 tests in `useSidebarDnd`.

**What changed**
- `mock.module` is process-global and never restored; the two files replaced whole modules like `react` with single-hook objects, so later imports got a React without `createContext` and `@dnd-kit/core` crashed at module scope.
- Each mock now spreads the real module and overrides only the export under test, matching the pattern the store mock already used.
- Three full-suite runs went from 3664 pass / 1 fail / 1 error to 3672 pass / 0 fail.

<sup>Written for commit 5db1258b4937bfd9522f0a5965151b201d1fc12a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by preserving unrelated module behavior when applying targeted mocks.
  - Updated test setup to retain all React exports across test files.
  - Added comments clarifying mock persistence and hook execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->