### PR TITLE
feat(billing): close the paywall funnel through Stripe payment outcomes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -99,6 +99,9 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 			plan: "pro",
 			annual,
 			seats: memberCount,
+			// `plan` here is the tier they are on now — same shape as the plans
+			// page, so both sources group together.
+			previous_plan: plan,
 			source: "billing_overview",
 		};
 		track("checkout_started", checkoutProperties);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/components/BillingOverview/BillingOverview.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { rawErrorMessage } from "@superset/i18n/errors";
 import { formatPrice } from "@superset/i18n/format";
 import { isPaymentFailingStatus } from "@superset/shared/billing";
 import { Button } from "@superset/ui/button";
@@ -9,6 +10,7 @@ import { HiArrowRight } from "react-icons/hi2";
 import { env } from "renderer/env.renderer";
 import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId";
 import { resolveCurrentPlan } from "renderer/hooks/useCurrentPlan";
+import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { electronTrpc } from "renderer/lib/electron-trpc";
@@ -91,6 +93,16 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 	const handleUpgrade = async (annual = false) => {
 		if (!activeOrgId || memberCount === undefined) return;
 
+		// Second route into Stripe Checkout, alongside the plans page. `source`
+		// is what lets the funnel tell them apart.
+		const checkoutProperties = {
+			plan: "pro",
+			annual,
+			seats: memberCount,
+			source: "billing_overview",
+		};
+		track("checkout_started", checkoutProperties);
+
 		setIsUpgrading(true);
 		try {
 			await authClient.subscription.upgrade(
@@ -106,8 +118,18 @@ export function BillingOverview({ visibleItems }: BillingOverviewProps) {
 				{
 					onSuccess: (ctx) => {
 						if (ctx.data?.url) {
+							track("checkout_redirected", checkoutProperties);
 							window.open(ctx.data.url, "_blank");
 						}
+					},
+					// Better Auth resolves rather than throws, so without this hook a
+					// failed checkout is invisible: the button just resets.
+					onError: (ctx) => {
+						track("checkout_failed", {
+							...checkoutProperties,
+							status: ctx.response?.status,
+							error: rawErrorMessage(ctx.error),
+						});
 					},
 				},
 			);

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -2,6 +2,7 @@ import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { i18n } from "@superset/i18n";
+import { rawErrorMessage } from "@superset/i18n/errors";
 import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { toast } from "@superset/ui/sonner";
@@ -452,6 +453,19 @@ function PlansPage() {
 
 		if (memberCount === undefined) return;
 
+		// The actual intent-to-pay step — this is what mints the Stripe Checkout
+		// session. `paywall_upgrade_clicked` only navigates to this page.
+		// `previous_plan` separates a new conversion (`free`) from an existing
+		// subscriber changing billing interval (`pro`), which shares this action.
+		const checkoutProperties = {
+			plan: "pro",
+			annual: isYearly,
+			seats: memberCount,
+			previous_plan: currentPlan,
+			source: "billing_plans",
+		};
+		track("checkout_started", checkoutProperties);
+
 		setIsUpgrading(true);
 		try {
 			await authClient.subscription.upgrade(
@@ -468,8 +482,20 @@ function PlansPage() {
 				{
 					onSuccess: (ctx) => {
 						if (ctx.data?.url) {
+							// Last thing we can see client-side; everything after this
+							// happens on Stripe and comes back through the webhook.
+							track("checkout_redirected", checkoutProperties);
 							window.open(ctx.data.url, "_blank");
 						}
+					},
+					// Better Auth resolves rather than throws, so without this hook a
+					// failed checkout is invisible: the button just resets.
+					onError: (ctx) => {
+						track("checkout_failed", {
+							...checkoutProperties,
+							status: ctx.response?.status,
+							error: rawErrorMessage(ctx.error),
+						});
 					},
 				},
 			);

--- a/packages/auth/src/lib/analytics.ts
+++ b/packages/auth/src/lib/analytics.ts
@@ -1,0 +1,15 @@
+import { PostHog } from "posthog-node";
+
+import { env } from "../env";
+
+// Singleton — every server-side capture in this package goes through it.
+// flushAt: 1, flushInterval: 0 mirrors packages/trpc and apps/api so events
+// survive short-lived processes (Vercel functions, edge handlers). The request
+// timeout is bounded because this client is awaited inside request handlers
+// (signup, Stripe webhooks) where a slow PostHog must not stall the caller.
+export const posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
+	host: env.NEXT_PUBLIC_POSTHOG_HOST,
+	flushAt: 1,
+	flushInterval: 0,
+	requestTimeout: 3000,
+});

--- a/packages/auth/src/lib/billing-analytics.ts
+++ b/packages/auth/src/lib/billing-analytics.ts
@@ -1,0 +1,75 @@
+import { getOrganizationOwners } from "../utils";
+import { posthog } from "./analytics";
+
+type BillingEvent =
+	| "subscription_started"
+	| "checkout_abandoned"
+	| "payment_succeeded"
+	| "payment_failed";
+
+type CaptureArgs = {
+	event: BillingEvent;
+	organizationId: string;
+	/**
+	 * `metadata.userId` off the Stripe object. Better Auth stamps it on both the
+	 * checkout session and the subscription it creates.
+	 */
+	initiatedByUserId?: string | null;
+	properties?: Record<string, unknown>;
+};
+
+/**
+ * Attributes a Stripe outcome to the user who started it, so it lands on the
+ * same PostHog person timeline as `paywall_opened` and can be a funnel step.
+ * The desktop app identifies with the Better Auth user id, and Better Auth
+ * stamps that same id into Stripe metadata — so no id mapping is needed.
+ *
+ * Organizations subscribed outside the app (a Stripe-side action, an enterprise
+ * deal closed by hand) carry no initiator. The owner is the closest honest
+ * answer there, and `attribution` records which one we used so a funnel built on
+ * these events can tell measured conversions from inferred ones.
+ *
+ * Never throws: a webhook must not fail because analytics did.
+ */
+export async function captureBillingEvent({
+	event,
+	organizationId,
+	initiatedByUserId,
+	properties,
+}: CaptureArgs): Promise<void> {
+	try {
+		let distinctId = initiatedByUserId ?? null;
+		let attribution: "initiator" | "owner" = "initiator";
+
+		if (!distinctId) {
+			const [owner] = await getOrganizationOwners(organizationId);
+			distinctId = owner?.id ?? null;
+			attribution = "owner";
+		}
+
+		// Falling back to the organization id would mint a phantom person and
+		// silently inflate every funnel built on these events. Dropping is the
+		// lesser harm, and the warning is what makes it visible.
+		if (!distinctId) {
+			console.warn(
+				`[billing-analytics] No user to attribute ${event} to for organization ${organizationId}`,
+			);
+			return;
+		}
+
+		posthog.capture({
+			distinctId,
+			event,
+			properties: {
+				...(properties ?? {}),
+				organization_id: organizationId,
+				attribution,
+			},
+			groups: { organization: organizationId },
+		});
+
+		await posthog.flush();
+	} catch (error) {
+		console.error(`[billing-analytics] Failed to capture ${event}:`, error);
+	}
+}

--- a/packages/auth/src/lib/billing-analytics.ts
+++ b/packages/auth/src/lib/billing-analytics.ts
@@ -77,8 +77,14 @@ export async function captureBillingEvent({
 		let attribution: "initiator" | "owner" = "initiator";
 
 		if (!distinctId) {
-			const [owner] = await getOrganizationOwners(organizationId);
-			distinctId = owner?.id ?? null;
+			// Lowest id, not first row: the query is unordered, so on a retry an
+			// organization with several owners could pick a different one. The uuid
+			// and timestamp would still match but the distinct id would not, and
+			// de-duplication needs all three.
+			const owners = await getOrganizationOwners(organizationId);
+			distinctId =
+				owners.map((owner) => owner.id).sort((a, b) => a.localeCompare(b))[0] ??
+				null;
 			attribution = "owner";
 		}
 

--- a/packages/auth/src/lib/billing-analytics.ts
+++ b/packages/auth/src/lib/billing-analytics.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { getOrganizationOwners } from "../utils";
 import { posthog } from "./analytics";
 
@@ -15,8 +17,34 @@ type CaptureArgs = {
 	 * checkout session and the subscription it creates.
 	 */
 	initiatedByUserId?: string | null;
+	/**
+	 * A Stripe id that is stable across webhook retries — the event id where we
+	 * have one, otherwise the subscription id. See `idempotencyUuid`.
+	 */
+	idempotencyKey: string;
+	/** When Stripe says it happened, not when we got around to processing it. */
+	occurredAt: Date;
 	properties?: Record<string, unknown>;
 };
+
+/**
+ * PostHog de-duplicates on (uuid, event name, timestamp, distinct_id), so a
+ * retried Stripe webhook only collapses if all four are stable — which is why
+ * callers pass `occurredAt` rather than letting it default to now().
+ *
+ * Stripe ids are not UUIDs and the column is, so the id is hashed into the
+ * UUID shape. Same input, same uuid, on every retry.
+ */
+function idempotencyUuid(event: BillingEvent, key: string): string {
+	const hex = createHash("sha256").update(`${event}:${key}`).digest("hex");
+	return [
+		hex.slice(0, 8),
+		hex.slice(8, 12),
+		hex.slice(12, 16),
+		hex.slice(16, 20),
+		hex.slice(20, 32),
+	].join("-");
+}
 
 /**
  * Attributes a Stripe outcome to the user who started it, so it lands on the
@@ -29,12 +57,19 @@ type CaptureArgs = {
  * answer there, and `attribution` records which one we used so a funnel built on
  * these events can tell measured conversions from inferred ones.
  *
+ * Safe to run twice: Stripe retries a webhook whenever the handler fails or
+ * times out, and this one does enough before reaching here (emails, QStash) to
+ * make that a real possibility rather than a theoretical one. Without the
+ * de-duplication below, a retry would bill `payment_succeeded` twice.
+ *
  * Never throws: a webhook must not fail because analytics did.
  */
 export async function captureBillingEvent({
 	event,
 	organizationId,
 	initiatedByUserId,
+	idempotencyKey,
+	occurredAt,
 	properties,
 }: CaptureArgs): Promise<void> {
 	try {
@@ -60,6 +95,8 @@ export async function captureBillingEvent({
 		posthog.capture({
 			distinctId,
 			event,
+			uuid: idempotencyUuid(event, idempotencyKey),
+			timestamp: occurredAt,
 			properties: {
 				...(properties ?? {}),
 				organization_id: organizationId,

--- a/packages/auth/src/lib/lifecycle.ts
+++ b/packages/auth/src/lib/lifecycle.ts
@@ -1,17 +1,6 @@
-import { PostHog } from "posthog-node";
-
-import { env } from "../env";
+import { posthog } from "./analytics";
 
 export const ACTIVATION_CAMPAIGN_FLAG = "activation-email-campaign";
-
-const posthog = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
-	host: env.NEXT_PUBLIC_POSTHOG_HOST,
-	flushAt: 1,
-	flushInterval: 0,
-	// This is awaited inside the signup hook, and the SDK default is 10s — long
-	// enough that a slow PostHog would stall signup rather than fail open.
-	requestTimeout: 3000,
-});
 
 /**
  * Arm for the activation-drip A/B. `getFeatureFlag` emits the

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -34,6 +34,7 @@ import { and, asc, count, desc, eq, inArray, ne, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 import { env } from "./env";
 import { acceptInvitationEndpoint } from "./lib/accept-invitation-endpoint";
+import { captureBillingEvent } from "./lib/billing-analytics";
 import { jwksAdapter } from "./lib/cached-jwks";
 import { generateMagicTokenForInvite } from "./lib/generate-magic-token";
 import { getActivationVariant } from "./lib/lifecycle";
@@ -1214,6 +1215,28 @@ export const auth = betterAuth({
 							error,
 						);
 					}
+
+					// The paid conversion. Emitted here rather than from an
+					// `onEvent` case for `checkout.session.completed` because Better
+					// Auth calls both for that one webhook, and this hook is the side
+					// that already knows the plan, seat count and interval.
+					await captureBillingEvent({
+						event: "subscription_started",
+						organizationId: subscription.referenceId,
+						initiatedByUserId: stripeSubscription.metadata?.userId,
+						properties: {
+							plan: plan.name,
+							billing_interval: billingInterval,
+							seats: subscription.seats ?? 1,
+							// Deliberately not `revenue`: that property is what PostHog
+							// revenue analytics sums, and `payment_succeeded` below is the
+							// one event where money actually moved. Naming it here too
+							// would double-count every subscription.
+							subscription_value: pricePerSeat * (subscription.seats ?? 1),
+							currency,
+							stripe_subscription_id: stripeSubscription.id,
+						},
+					});
 				},
 
 				onSubscriptionCancel: async ({
@@ -1373,6 +1396,22 @@ export const auth = betterAuth({
 								);
 							}
 						}
+
+						await captureBillingEvent({
+							event: "payment_failed",
+							organizationId: org.id,
+							initiatedByUserId:
+								invoice.parent?.subscription_details?.metadata?.userId,
+							properties: {
+								// No money moved, so this must not be `revenue`.
+								amount_due: invoice.amount_due,
+								currency: invoice.currency,
+								attempt_count: invoice.attempt_count ?? 0,
+								is_final_attempt: isFinalAttempt,
+								already_cancelled: alreadyCancelled,
+								stripe_subscription_id: stripeSubId ?? null,
+							},
+						});
 					}
 
 					if (event.type === "invoice.upcoming") {
@@ -1440,8 +1479,11 @@ export const auth = betterAuth({
 					if (event.type === "invoice.paid") {
 						const invoice = event.data.object as Stripe.Invoice;
 
-						const stripeSubId = invoice.parent?.subscription_details
-							?.subscription as string | undefined;
+						const subscriptionDetails =
+							invoice.parent?.subscription_details ?? undefined;
+						const stripeSubId = subscriptionDetails?.subscription as
+							| string
+							| undefined;
 
 						if (stripeSubId) {
 							try {
@@ -1463,6 +1505,50 @@ export const auth = betterAuth({
 									error,
 								);
 							}
+						}
+
+						// `referenceId` is the organization id — Better Auth writes it
+						// onto the subscription, and Stripe copies subscription metadata
+						// onto every invoice it raises, so this needs no lookup.
+						const organizationId = subscriptionDetails?.metadata?.referenceId;
+
+						if (organizationId) {
+							await captureBillingEvent({
+								event: "payment_succeeded",
+								organizationId,
+								initiatedByUserId: subscriptionDetails?.metadata?.userId,
+								properties: {
+									revenue: invoice.amount_paid,
+									currency: invoice.currency,
+									// `subscription_create` is the first payment, everything
+									// else is a renewal or a seat change.
+									billing_reason: invoice.billing_reason,
+									stripe_subscription_id: stripeSubId ?? null,
+								},
+							});
+						}
+					}
+
+					// Stripe expires an unpaid Checkout session ~24h after it opens, so
+					// this arrives late by design. It is the only signal that someone
+					// reached the payment page and did not pay — the paid side comes
+					// through `onSubscriptionComplete` instead.
+					if (event.type === "checkout.session.expired") {
+						const session = event.data.object as Stripe.Checkout.Session;
+						const organizationId = session.metadata?.organizationId;
+
+						if (organizationId) {
+							await captureBillingEvent({
+								event: "checkout_abandoned",
+								organizationId,
+								initiatedByUserId: session.metadata?.userId,
+								properties: {
+									// No money moved, so this must not be `revenue`.
+									abandoned_value: session.amount_total ?? 0,
+									currency: session.currency ?? "usd",
+									stripe_session_id: session.id,
+								},
+							});
 						}
 					}
 

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1224,6 +1224,11 @@ export const auth = betterAuth({
 						event: "subscription_started",
 						organizationId: subscription.referenceId,
 						initiatedByUserId: stripeSubscription.metadata?.userId,
+						// This hook is handed the subscription, not the webhook event, so
+						// the subscription id is the stable key. One `subscription_started`
+						// per subscription is the intended meaning anyway.
+						idempotencyKey: stripeSubscription.id,
+						occurredAt: new Date(stripeSubscription.created * 1000),
 						properties: {
 							plan: plan.name,
 							billing_interval: billingInterval,
@@ -1402,6 +1407,8 @@ export const auth = betterAuth({
 							organizationId: org.id,
 							initiatedByUserId:
 								invoice.parent?.subscription_details?.metadata?.userId,
+							idempotencyKey: event.id,
+							occurredAt: new Date(event.created * 1000),
 							properties: {
 								// No money moved, so this must not be `revenue`.
 								amount_due: invoice.amount_due,
@@ -1517,6 +1524,8 @@ export const auth = betterAuth({
 								event: "payment_succeeded",
 								organizationId,
 								initiatedByUserId: subscriptionDetails?.metadata?.userId,
+								idempotencyKey: event.id,
+								occurredAt: new Date(event.created * 1000),
 								properties: {
 									revenue: invoice.amount_paid,
 									currency: invoice.currency,
@@ -1542,6 +1551,8 @@ export const auth = betterAuth({
 								event: "checkout_abandoned",
 								organizationId,
 								initiatedByUserId: session.metadata?.userId,
+								idempotencyKey: event.id,
+								occurredAt: new Date(event.created * 1000),
 								properties: {
 									// No money moved, so this must not be `revenue`.
 									abandoned_value: session.amount_total ?? 0,


### PR DESCRIPTION
## Why

We could not answer "how many people who hit a paywall actually pay". The funnel ended at `paywall_upgrade_clicked`, which despite its name only calls `navigate({ to: "/settings/billing/plans" })` — no money intent yet. Everything after that was invisible.

Measured over the last 30 days, the missing half:

| Step | Persons | Where it was measured |
|---|---|---|
| `paywall_opened` | 4,662 | PostHog |
| `paywall_upgrade_clicked` (→ plans page) | 730 | PostHog |
| Plans page viewed | 839 | only incidentally, via `$pageview` |
| **Upgrade clicked → Checkout session created** | — | **nothing** |
| **Checkout paid** | 199 | **Stripe only** |
| **Checkout expired unpaid** | 191 (47.4%) | **Stripe only** |

So ~47% of everyone who reached the Stripe page walked away and we had no way to see it.

## What changed

**Client (`plans/page.tsx`, `BillingOverview.tsx`)** — both routes into Checkout now emit `checkout_started`, `checkout_redirected` (the moment the Stripe URL opens) and `checkout_failed`, with a `source` property to tell the two entry points apart. `previous_plan` separates a new conversion from an existing subscriber changing billing interval, which shares the same action.

The failure path had no handling at all. Better Auth resolves rather than throws, so `try/finally` never saw it and a failed upgrade just reset the button — no toast, no telemetry, nothing in `$exception`. Instrumented via `onError`, which is the hook that actually fires.

**Server (`packages/auth/src/server.ts`)** — the Stripe webhook hooks now capture outcomes:

- `onSubscriptionComplete` → `subscription_started`
- `invoice.paid` → `payment_succeeded` (carries `billing_reason` so first payment ≠ renewal)
- `invoice.payment_failed` → `payment_failed`
- **`checkout.session.expired` → `checkout_abandoned`** — this event type had no handler at all, and it is the only signal for that 47%

**Attribution needs no id mapping.** Better Auth already stamps `metadata.userId` onto the checkout session and the subscription, and Stripe copies subscription metadata onto every invoice. That id is the Better Auth user id, which is exactly what the desktop app calls `posthog.identify()` with — so these events land on the same person timeline as `paywall_opened`. I sampled 40 live checkout sessions spread across 90 days: 100% carry `userId` and `organizationId`.

Where no initiator exists (an org subscribed by hand), it falls back to the org owner and records which one it used in an `attribution` property, so a funnel can tell measured conversions from inferred ones. It never mints a synthetic person, and it never throws — a webhook must not fail because analytics did.

**Retries are safe.** Stripe re-delivers a webhook whenever the handler fails or times out, and this one does enough beforehand (Resend batch sends, QStash publishes, a subscription read) that it happens. PostHog de-duplicates on (uuid, event name, timestamp, distinct_id), so both the uuid and the timestamp are derived from Stripe rather than from processing time. Without that, a retry would have double-counted `payment_succeeded` revenue.

`packages/auth` had no shared posthog-node client (`lib/lifecycle.ts` held a private one for feature flags); that is now `lib/analytics.ts` with the same options, and lifecycle uses it.

## ⚠️ This is inert until the Stripe webhook endpoint is updated

`https://api.superset.sh/api/auth/stripe/webhook` is subscribed to **4 event types only**:

```
checkout.session.completed
customer.subscription.created
customer.subscription.deleted
customer.subscription.updated
```

It needs `invoice.paid`, `invoice.payment_failed` and `checkout.session.expired` added, or three of the four new captures never fire.

**This also means existing code has never run in production.** `onEvent` already handles `invoice.payment_failed`, `invoice.upcoming` and `invoice.paid` — dunning email, renewal-upcoming email, payment-succeeded Slack notification. Stripe only delivers subscribed types, so none of those have ever fired, while Stripe recorded 100+ of each in the last 30 days. That is a separate bug this PR surfaces but does not fix; it needs the same endpoint change.

I have not touched the endpoint — it is live payment infrastructure and wants a deliberate hand.

## The client half fills in gradually, and that skews the funnel one way

`checkout_started`, `checkout_redirected` and `checkout_failed` are client-side, so they only exist in builds carrying this PR. Paywall events today come from installs going back to 1.15, so for a while a large share of real checkouts will emit no `checkout_started` at all.

The trap is that this is **not symmetric**: `subscription_started` is server-side and complete from the first webhook, while `checkout_started` is not. In an ordered funnel a required step 3 would discard every payer still on an older version — under-reporting *paid conversions*, not just the checkout step.

So `checkout_started` is marked `optionalInFunnel` on the [full-funnel tile](https://us.posthog.com/project/264803/insights/sdWW7kXQ). Payers on old builds still count; the step fills in as the release rolls out. Make it required once version adoption is high, at which point the step 2 → 3 drop-off becomes meaningful on its own.

Same reason the server half is worth more than the client half here: it is complete the moment the endpoint is subscribed, with no client rollout to wait on.

## Deliberately not in scope

- **No revenue double-count.** Only `payment_succeeded` uses the `revenue` property that PostHog revenue analytics sums. `subscription_started` uses `subscription_value`, and the failed/abandoned events use `amount_due`/`abandoned_value` — no money moved there.
- **`paywall_upgrade_clicked` is not renamed** despite being misleading; 90 days of history keys off it. Better handled with a description in data management.
- **No toast on `checkout_failed`.** That is a real UX gap, but a new user-facing string drags in catalog work across 17 locales. Worth a follow-up.
- The dashboard fixes (the funnel's second step is an optional browse action that under-reports conversion 8.6% vs 15.66%) are PostHog-side config, not code.

## Testing

- `packages/auth` typecheck + tests: 8 pass
- `apps/desktop` typecheck clean; full suite 3,698 pass / 1 fail — `useSidebarDnd.test.ts`, a `@dnd-kit`/React module-registry pollution flake that passes in isolation and touches nothing here
- `bun run check:i18n` clean, no catalog changes (no new user-facing strings)
- Live Stripe data verified read-only via CLI; no Stripe configuration was modified

https://claude.ai/code/session_01VUNZ5xR4d5nT6qwntPwAbg
