### PR TITLE
feat(desktop): add Pages onboarding and polish creation flows

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationsEmptyState/AutomationsEmptyState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationsEmptyState/AutomationsEmptyState.tsx
@@ -1,92 +1,63 @@
-import { Trans, useLingui } from "@lingui/react/macro";
-import { useEffect, useState } from "react";
-import { LuSparkles } from "react-icons/lu";
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
+import { LuPlus, LuTimer } from "react-icons/lu";
 import {
 	type AutomationTemplate,
 	ONBOARDING_SUGGESTIONS,
 } from "../../templates";
 import { TemplateCard } from "../TemplateCard";
 
-const PLACEHOLDER_COUNT = 4;
-const PLACEHOLDER_INTERVAL_MS = 5000;
-
 interface AutomationsEmptyStateProps {
 	onSelectTemplate: (template: AutomationTemplate) => void;
-	/** Opens an agent session seeded to create an automation interactively. */
 	onCreateWithAgent: () => void;
+	isCreating: boolean;
+	onCreateManually: () => void;
+	isCreatingManually: boolean;
 }
-
 export function AutomationsEmptyState({
 	onSelectTemplate,
 	onCreateWithAgent,
+	isCreating,
+	onCreateManually,
+	isCreatingManually,
 }: AutomationsEmptyStateProps) {
-	const { t } = useLingui();
-	// Concrete, typeable examples (Cursor's rotating-placeholder pattern).
-	// See plans/automations-onboarding.md.
-	const placeholders = [
-		t({
-			message:
-				"Every weekday at 9am, triage new GitHub issues and draft replies for my review",
-		}),
-		t({
-			message: "Summarize failed CI runs every morning before standup",
-		}),
-		t({
-			message:
-				"Every Friday at 4pm, draft release notes from this week's merged PRs",
-		}),
-		t({
-			message: "Nightly at 2am, find one small bug, fix it, and open a PR",
-		}),
-	];
-	const [placeholderIndex, setPlaceholderIndex] = useState(0);
-	useEffect(() => {
-		const id = setInterval(
-			() => setPlaceholderIndex((i) => (i + 1) % PLACEHOLDER_COUNT),
-			PLACEHOLDER_INTERVAL_MS,
-		);
-		return () => clearInterval(id);
-	}, []);
-
 	return (
-		<div className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-10 pb-10">
-			<div className="flex w-full flex-col items-center gap-3 text-center">
-				<h2 className="text-lg font-semibold tracking-tight">
-					<Trans>What should run on a schedule?</Trans>
-				</h2>
-				{/* Opens an agent session that asks what to automate and creates it
-				    via the superset:automate skill / CLI. Swaps to the inline NL
-				    chat input in Phase 2. */}
-				<button
-					type="button"
-					onClick={onCreateWithAgent}
-					aria-label={t({
-						message: "Create an automation with an agent",
-					})}
-					className="flex w-full items-center gap-3 rounded-xl border border-border px-4 py-3.5 text-left transition-colors hover:border-border/80 hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-				>
-					<LuSparkles className="size-4 shrink-0 text-muted-foreground" />
-					{/* Rotating examples are decorative; the stable name is on the button. */}
-					<span
-						key={placeholderIndex}
-						aria-hidden="true"
-						className="min-w-0 truncate text-sm text-muted-foreground animate-in fade-in duration-300"
+		<div className="mx-auto flex w-full max-w-xl flex-1 flex-col justify-center gap-10 py-12">
+			<div className="flex flex-col items-start gap-4">
+				<div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+					<LuTimer className="size-5" />
+				</div>
+				<div className="space-y-2">
+					<h2 className="font-semibold text-lg tracking-tight">
+						<Trans>What should run on a schedule?</Trans>
+					</h2>
+					<p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+						<Trans>
+							Runs land in a workspace. Review the diff, merge what's good.
+						</Trans>
+					</p>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<Button size="sm" onClick={onCreateWithAgent} disabled={isCreating}>
+						<LuPlus className="size-3.5" />
+						<Trans>Create with AI</Trans>
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="text-muted-foreground"
+						onClick={onCreateManually}
+						disabled={isCreatingManually}
 					>
-						{placeholders[placeholderIndex]}
-					</span>
-				</button>
-				<p className="text-xs text-muted-foreground">
-					<Trans>
-						Runs land in a workspace. Review the diff, merge what's good.
-					</Trans>
-				</p>
+						<Trans>New automation</Trans>
+					</Button>
+				</div>
 			</div>
-
-			<div className="flex w-full flex-col gap-3">
-				<h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+			<div className="space-y-2 border-t border-border/60 pt-6">
+				<h3 className="mb-3 text-xs font-medium text-muted-foreground">
 					<Trans>Suggested</Trans>
 				</h3>
-				<div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+				<div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
 					{ONBOARDING_SUGGESTIONS.map((template) => (
 						<TemplateCard
 							key={template.id}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TemplateCard/TemplateCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TemplateCard/TemplateCard.tsx
@@ -11,13 +11,12 @@ export function TemplateCard({ template, onSelect }: TemplateCardProps) {
 		<button
 			type="button"
 			onClick={() => onSelect(template)}
-			className="flex flex-col items-start gap-1 rounded-lg border border-border px-3.5 py-3 text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+			className="flex flex-col items-start gap-1 rounded-md px-3 py-3 text-left transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 		>
 			<span className="flex items-center gap-2 text-sm font-medium">
-				<span className="text-base leading-none">{template.emoji}</span>
 				{i18n._(template.name)}
 			</span>
-			<span className="line-clamp-3 text-xs text-muted-foreground">
+			<span className="line-clamp-2 text-xs text-muted-foreground">
 				{i18n._(template.description)}
 			</span>
 		</button>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -41,12 +41,9 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-	LuCircleHelp,
-	LuPlus,
 	LuRotateCw,
 	LuSearch,
 	LuSearchX,
-	LuSparkles,
 	LuTerminal,
 	LuTriangleAlert,
 	LuX,
@@ -58,6 +55,7 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { DATA_TABLE_HEAD_CELL } from "renderer/routes/_authenticated/_dashboard/components/DataTableHeader";
+import { FeatureHeader } from "renderer/routes/_authenticated/_dashboard/components/FeatureHeader";
 import {
 	SortableHeader,
 	type SortDirection,
@@ -633,62 +631,18 @@ function AutomationsPage() {
 
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				<div className="mx-auto flex min-h-full w-full max-w-5xl flex-col px-8 pb-12">
-					<div className="flex items-center justify-between">
-						<h1 className="text-xl font-semibold tracking-tight">
-							<Trans>Automations</Trans>
-						</h1>
-						<div className="flex items-center gap-2">
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										asChild
-										variant="ghost"
-										size="icon-sm"
-										className="size-8 text-muted-foreground"
-									>
-										<a
-											href={`${COMPANY.DOCS_URL}/automations`}
-											target="_blank"
-											rel="noreferrer"
-											aria-label={t({
-												message: "Automations docs",
-											})}
-										>
-											<LuCircleHelp className="size-4" />
-										</a>
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent>
-									<Trans>Automations docs</Trans>
-								</TooltipContent>
-							</Tooltip>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								className="h-8 gap-1.5 px-3"
-								disabled={creatingWithAgent}
-								onClick={handleCreateWithAgent}
-							>
-								<LuSparkles className="size-4" />
-								<span>
-									<Trans>Create with AI</Trans>
-								</span>
-							</Button>
-							<Button
-								type="button"
-								size="sm"
-								className="h-8 gap-1.5 px-3"
-								disabled={createMutation.isPending}
-								onClick={() => createMutation.mutate(null)}
-							>
-								<LuPlus className="size-4" />
-								<span>
-									<Trans>New automation</Trans>
-								</span>
-							</Button>
-						</div>
-					</div>
+					<FeatureHeader
+						title={<Trans>Automations</Trans>}
+						docsUrl={`${COMPANY.DOCS_URL}/automations`}
+						onCreate={handleCreateWithAgent}
+						isCreating={creatingWithAgent}
+						showCreate={!orgEmpty}
+						secondaryAction={{
+							label: <Trans>New automation</Trans>,
+							onSelect: () => createMutation.mutate(null),
+							disabled: createMutation.isPending,
+						}}
+					/>
 
 					{/* Zero-count stats and search are noise while a tab is empty;
 					    with nothing in the org at all the tabs go too. */}
@@ -839,6 +793,9 @@ function AutomationsPage() {
 								<AutomationsEmptyState
 									onSelectTemplate={handleSelectTemplate}
 									onCreateWithAgent={handleCreateWithAgent}
+									isCreating={creatingWithAgent}
+									onCreateManually={() => createMutation.mutate(null)}
+									isCreatingManually={createMutation.isPending}
 								/>
 							</div>
 						) : showTeamEmptyState ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/FeatureHeader/FeatureHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/FeatureHeader/FeatureHeader.tsx
@@ -1,0 +1,99 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@superset/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import type { ReactNode } from "react";
+import { LuChevronDown, LuCircleHelp, LuPlus } from "react-icons/lu";
+
+interface FeatureHeaderProps {
+	title: ReactNode;
+	docsUrl: string;
+	onCreate: () => void;
+	isCreating: boolean;
+	showCreate?: boolean;
+	secondaryAction?: {
+		label: ReactNode;
+		onSelect: () => void;
+		disabled: boolean;
+	};
+}
+
+export function FeatureHeader({
+	title,
+	docsUrl,
+	onCreate,
+	isCreating,
+	showCreate = true,
+	secondaryAction,
+}: FeatureHeaderProps) {
+	const { t } = useLingui();
+	return (
+		<div className="flex flex-wrap items-center justify-between gap-3">
+			<div className="flex items-center gap-1.5">
+				<h1 className="font-semibold text-xl tracking-tight">{title}</h1>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							asChild
+							variant="ghost"
+							size="icon-xs"
+							className="text-muted-foreground/60 hover:text-foreground"
+						>
+							<a
+								href={docsUrl}
+								target="_blank"
+								rel="noopener noreferrer"
+								aria-label={t({ message: "Documentation" })}
+							>
+								<LuCircleHelp className="size-3.5" />
+							</a>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>
+						<Trans>Documentation</Trans>
+					</TooltipContent>
+				</Tooltip>
+			</div>
+			{showCreate && (
+				<div className="flex items-center">
+					<Button
+						size="sm"
+						disabled={isCreating}
+						onClick={onCreate}
+						className={secondaryAction ? "rounded-r-none" : undefined}
+					>
+						<LuPlus className="size-3.5" />
+						<Trans>Create with AI</Trans>
+					</Button>
+					{secondaryAction && (
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									size="icon-sm"
+									className="rounded-l-none border-primary-foreground/15 border-l"
+									aria-label={t({ message: "More options" })}
+								>
+									<LuChevronDown className="size-3.5" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								<DropdownMenuItem
+									disabled={secondaryAction.disabled}
+									onSelect={secondaryAction.onSelect}
+								>
+									<LuPlus className="size-4" />
+									{secondaryAction.label}
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/FeatureHeader/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/FeatureHeader/index.ts
@@ -1,0 +1,1 @@
+export { FeatureHeader } from "./FeatureHeader";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesGrid/PagesGrid.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesGrid/PagesGrid.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
 import {
 	Empty,
 	EmptyDescription,
@@ -7,7 +8,7 @@ import {
 	EmptyTitle,
 } from "@superset/ui/empty";
 import { Skeleton } from "@superset/ui/skeleton";
-import { LuFileText, LuSearchX } from "react-icons/lu";
+import { LuFileText, LuPlus, LuSearchX } from "react-icons/lu";
 import { PageCard, type PageCardItem } from "./components/PageCard";
 import { THUMBNAIL_ASPECT_RATIO } from "./constants";
 
@@ -21,6 +22,8 @@ const SKELETON_KEYS = [
 ] as const;
 
 interface PagesGridProps {
+	onCreate: () => void;
+	isCreating: boolean;
 	pages: PageCardItem[];
 	pinnedPageIds: ReadonlySet<string>;
 	currentUserId: string | undefined;
@@ -33,6 +36,8 @@ interface PagesGridProps {
 }
 
 export function PagesGrid({
+	onCreate,
+	isCreating,
 	pages,
 	pinnedPageIds,
 	currentUserId,
@@ -71,8 +76,8 @@ export function PagesGrid({
 
 	if (pages.length === 0) {
 		return (
-			<Empty className="mt-10">
-				<EmptyHeader>
+			<Empty className="my-auto min-h-80 items-start border-0 px-0 py-20 text-left max-w-md mx-auto w-full md:px-0 md:py-20">
+				<EmptyHeader className="items-start text-left">
 					<EmptyMedia variant="icon">
 						{hasFilters ? (
 							<LuSearchX className="size-5" />
@@ -92,12 +97,17 @@ export function PagesGrid({
 							<Trans>Try a different search or filter.</Trans>
 						) : (
 							<Trans>
-								Publish a page from an agent or the CLI and it will show up
-								here.
+								Share designs and reports. Let your agent handle the feedback.
 							</Trans>
 						)}
 					</EmptyDescription>
 				</EmptyHeader>
+				{!hasFilters && (
+					<Button size="sm" onClick={onCreate} disabled={isCreating}>
+						<LuPlus className="size-3.5" />
+						<Trans>Create with AI</Trans>
+					</Button>
+				)}
 			</Empty>
 		);
 	}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/PagesView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/PagesView.tsx
@@ -1,4 +1,5 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { COMPANY } from "@superset/shared/constants";
 import { Input } from "@superset/ui/input";
 import { toast } from "@superset/ui/sonner";
 import { Tabs, TabsList, TabsTrigger } from "@superset/ui/tabs";
@@ -6,6 +7,7 @@ import { useEffect, useMemo } from "react";
 import { LuSearch } from "react-icons/lu";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { FeatureHeader } from "renderer/routes/_authenticated/_dashboard/components/FeatureHeader";
 import {
 	isPaneModifier,
 	useOpenPage,
@@ -17,6 +19,7 @@ import {
 	sortPinnedFirst,
 } from "../../utils/filterPages";
 import { PagesGrid } from "../PagesGrid";
+import { useCreatePageWithAgent } from "./hooks/useCreatePageWithAgent";
 import { usePageFavorites } from "./hooks/usePageFavorites";
 
 const TABS: Array<{ value: PageScope }> = [
@@ -40,6 +43,7 @@ export function PagesView({
 	onScopeChange,
 }: PagesViewProps) {
 	const { t } = useLingui();
+	const { creatingWithAgent, handleCreateWithAgent } = useCreatePageWithAgent();
 	const { data: session } = authClient.useSession();
 	const utils = cloudTrpc.useUtils();
 	const pages = cloudTrpc.page.list.useQuery({});
@@ -108,59 +112,69 @@ export function PagesView({
 		[all, search, activeScope, favoritePageIdSet],
 	);
 
+	const orgEmpty = !pages.isPending && !pages.error && all.length === 0;
+
 	return (
 		<div className="flex h-full w-full flex-1 flex-col overflow-hidden">
 			<div className="drag h-10 shrink-0" />
 
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				<div className="mx-auto flex min-h-full w-full max-w-5xl flex-col px-8 pb-12">
-					<div className="flex items-center justify-between">
-						<h1 className="font-semibold text-xl tracking-tight">
-							<Trans>Pages</Trans>
-						</h1>
-					</div>
+					<FeatureHeader
+						title={<Trans>Pages</Trans>}
+						docsUrl={`${COMPANY.DOCS_URL}/pages`}
+						onCreate={handleCreateWithAgent}
+						isCreating={creatingWithAgent}
+						showCreate={!orgEmpty}
+					/>
 
-					<div className="mt-6 flex items-center justify-between gap-2">
-						<Tabs
-							value={activeScope}
-							onValueChange={(value) => onScopeChange(value as PageScope)}
-						>
-							<TabsList className="h-8 gap-1 bg-transparent p-0">
-								{tabs.map((tab) => (
-									<TabsTrigger
-										key={tab.value}
-										value={tab.value}
-										className="h-8 rounded-md px-3 data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground"
-									>
-										<span className="text-sm">{tabLabels[tab.value]}</span>
-										<span className="ml-1 text-muted-foreground text-xs tabular-nums">
-											{counts[tab.value]}
-										</span>
-									</TabsTrigger>
-								))}
-							</TabsList>
-						</Tabs>
+					{!orgEmpty && (
+						<div className="mt-6 flex flex-wrap items-center justify-between gap-2">
+							<Tabs
+								value={activeScope}
+								onValueChange={(value) => onScopeChange(value as PageScope)}
+							>
+								<TabsList className="h-8 gap-1 bg-transparent p-0">
+									{tabs.map((tab) => (
+										<TabsTrigger
+											key={tab.value}
+											value={tab.value}
+											className="h-8 rounded-md px-3 data-[state=active]:bg-accent data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground"
+										>
+											<span className="text-sm">{tabLabels[tab.value]}</span>
+											<span className="ml-1 text-muted-foreground text-xs tabular-nums">
+												{counts[tab.value]}
+											</span>
+										</TabsTrigger>
+									))}
+								</TabsList>
+							</Tabs>
 
-						<div className="relative w-56">
-							<LuSearch className="-translate-y-1/2 absolute top-1/2 left-2 size-3.5 text-muted-foreground" />
-							<Input
-								value={search}
-								onChange={(event) => onSearchChange(event.target.value)}
-								placeholder={t({
-									message: "Search pages",
-								})}
-								className="h-8 pl-7 text-sm"
-							/>
+							<div className="relative w-56">
+								<LuSearch className="-translate-y-1/2 absolute top-1/2 left-2 size-3.5 text-muted-foreground" />
+								<Input
+									value={search}
+									onChange={(event) => onSearchChange(event.target.value)}
+									placeholder={t({
+										message: "Search pages",
+									})}
+									className="h-8 pl-7 text-sm"
+								/>
+							</div>
 						</div>
-					</div>
+					)}
 
 					<PagesGrid
 						pages={visible}
+						onCreate={handleCreateWithAgent}
+						isCreating={creatingWithAgent}
 						pinnedPageIds={favoritePageIdSet}
 						currentUserId={session?.user.id}
 						isPending={pages.isPending}
 						error={pages.error?.message}
-						hasFilters={Boolean(search.trim()) || activeScope !== "all"}
+						hasFilters={
+							!orgEmpty && (Boolean(search.trim()) || activeScope !== "all")
+						}
 						onOpen={(page, event) =>
 							openPage(page, { inPane: isPaneModifier(event) })
 						}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/constants.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/constants.ts
@@ -1,0 +1,13 @@
+// Agent instructions, not interface copy. Claude plugins use superset:page;
+// managed skill directories expose the same skill as superset-page.
+export const PAGE_AGENT_PROMPT = `Help me create and publish a Superset Page using the Superset Pages skill.
+
+First load and follow the Pages skill: superset:page in the Superset plugin, or superset-page in your available skills. Read its SKILL.md before creating content. If neither name is available, look for the installed Superset Pages skill; if it is missing, explain that setup is needed instead of substituting a generic HTML workflow.
+
+Explain briefly that you will publish a page my teammates can open and comment on, then ask what I want to create and who it is for. Examples include a design doc, report, or proposal. Gather any source material needed.
+
+Before building, run superset pages --help and superset auth whoami to check that the CLI supports Pages and is authenticated. Follow the skill's content policy and design guidance. Keep the source inside this workspace and verify it renders correctly.
+
+Publish with superset pages publish, following the skill's instructions. Creating an HTML file or opening a local preview does not complete this task. Only report it as published after the command succeeds and returns a page URL. Verify that the publish result reports watching: true for this agent session; if not, explain that comment delivery is not active and what needs fixing.
+
+Return the published link and explain how teammates can pin comments to the page. When feedback arrives, update the source, republish to the same page, reply with what changed, and resolve only the threads you addressed. If authentication, upload, or watching fails, report the failing command and actual error clearly; do not claim the page or feedback loop is ready.`;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/index.ts
@@ -1,0 +1,1 @@
+export { useCreatePageWithAgent } from "./useCreatePageWithAgent";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
@@ -1,0 +1,59 @@
+import { useLingui } from "@lingui/react/macro";
+import { toast } from "@superset/ui/sonner";
+import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
+import { AGENT_STORAGE_KEY } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
+import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
+import { useWorkspaceCreates } from "renderer/stores/workspace-creates";
+import { PAGE_AGENT_PROMPT } from "./constants";
+
+export function useCreatePageWithAgent() {
+	const { t } = useLingui();
+	const navigate = useNavigate();
+	const { machineId, activeHostUrl } = useLocalHostService();
+	const { agents: agentChoices } = useV2AgentChoices(activeHostUrl);
+	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
+	const [creatingWithAgent, setCreatingWithAgent] = useState(false);
+	const handleCreateWithAgent = () => {
+		if (creatingWithAgent) return;
+		if (!machineId) {
+			toast.error(
+				t({
+					message: "Host service is not running",
+				}),
+			);
+			return;
+		}
+		const terminalAgents = agentChoices.filter((a) => a.id !== "superset");
+		const stored = window.localStorage.getItem(AGENT_STORAGE_KEY);
+		const agent =
+			terminalAgents.find((a) => a.id === stored)?.id ?? terminalAgents[0]?.id;
+		if (!agent) {
+			toast.error(
+				t({
+					message: "No terminal agent is configured on this device",
+				}),
+			);
+			return;
+		}
+		setCreatingWithAgent(true);
+		const { workspaceId, completed } = submitWorkspaceCreate({
+			hostId: machineId,
+			snapshot: {
+				id: crypto.randomUUID(),
+				projectId: null,
+				agents: [{ agent, prompt: PAGE_AGENT_PROMPT }],
+			},
+		});
+		// The store shows creation failures on the optimistic sidebar row; this
+		// just re-arms the button if the user navigates back.
+		void completed.finally(() => setCreatingWithAgent(false));
+		navigate({
+			to: "/v2-workspace/$workspaceId",
+			params: { workspaceId },
+		}).catch(() => {});
+	};
+
+	return { creatingWithAgent, handleCreateWithAgent };
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/hooks/useCreatePageWithAgent/useCreatePageWithAgent.ts
@@ -11,12 +11,15 @@ import { PAGE_AGENT_PROMPT } from "./constants";
 export function useCreatePageWithAgent() {
 	const { t } = useLingui();
 	const navigate = useNavigate();
-	const { machineId, activeHostUrl } = useLocalHostService();
-	const { agents: agentChoices } = useV2AgentChoices(activeHostUrl);
+	const { machineId, activeHostUrl, hostServiceStatus } = useLocalHostService();
+	const { agents: agentChoices, isFetched: agentsFetched } =
+		useV2AgentChoices(activeHostUrl);
 	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
 	const [creatingWithAgent, setCreatingWithAgent] = useState(false);
+	const isReady =
+		!!activeHostUrl && hostServiceStatus === "running" && agentsFetched;
 	const handleCreateWithAgent = () => {
-		if (creatingWithAgent) return;
+		if (creatingWithAgent || !isReady) return;
 		if (!machineId) {
 			toast.error(
 				t({
@@ -52,8 +55,13 @@ export function useCreatePageWithAgent() {
 		navigate({
 			to: "/v2-workspace/$workspaceId",
 			params: { workspaceId },
-		}).catch(() => {});
+		}).catch((error) => {
+			console.error("[CreatePageWithAgent] failed to open workspace", error);
+		});
 	};
 
-	return { creatingWithAgent, handleCreateWithAgent };
+	return {
+		creatingWithAgent: creatingWithAgent || !isReady,
+		handleCreateWithAgent,
+	};
 }

--- a/apps/docs/content/docs/mcp-server.mdx
+++ b/apps/docs/content/docs/mcp-server.mdx
@@ -328,7 +328,7 @@ API keys grant full access to your organization. Keep them secret and never comm
 
 ### Pages
 
-A page is one self-contained HTML file published to a shareable URL. Every publish creates a new version; nothing is overwritten.
+[Superset Pages](/pages) lets agents present designs and reports to your team and act on feedback left directly on the page. The MCP publish tool accepts a self-contained HTML document and returns a shareable URL. Every publish creates a new version; nothing is overwritten.
 
 | Tool | Description |
 |------|-------------|

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -23,6 +23,7 @@
 		"ports",
 		"browser",
 		"computer",
+		"pages",
 		"agent-integration",
 		"agent-status",
 		"tasks",

--- a/apps/docs/content/docs/overview.mdx
+++ b/apps/docs/content/docs/overview.mdx
@@ -23,6 +23,7 @@ Superset is local-first: it works offline and syncs when connected. Your code ne
 - **Any agent**: Claude Code, Codex, Amp, Gemini, OpenCode, Cursor Agent, and [more](/agent-integration), or the built-in chat
 - **The whole loop in one place**: terminals, diffs, commits, PRs, ports, and dev servers per workspace
 - **Automations**: agent sessions on a schedule, with a real workspace as the output
+- **[Pages](/pages)**: share agent-created designs and reports with your team, and have an agent act on comments directly
 
 ## Next Steps
 

--- a/apps/docs/content/docs/pages.mdx
+++ b/apps/docs/content/docs/pages.mdx
@@ -1,0 +1,77 @@
+---
+title: Pages
+description: Share agent-created designs and reports with your team, and turn comments into updates
+---
+
+Superset Pages gives your agents a way to present designs, reports, and analysis to your team. Teammates comment directly on the page, and an agent picks up the feedback, makes changes, and publishes an updated version.
+
+Your teammates can talk directly to your agent. You no longer have to copy feedback from a review into an agent session and carry the result back.
+
+## The Design Loop
+
+1. **Create.** Ask an agent to build a design doc, report, or proposal and publish it as a Page.
+2. **Share.** Send the page's link to your team.
+3. **Comment.** Teammates pin feedback to the part of the page they want to discuss.
+4. **Iterate.** The agent watching the page receives new comments, updates the source, republishes, and replies to the threads it addressed.
+
+This is how we use Pages internally at Superset: someone creates a design doc, presents it to the team, and the doc evolves as teammates leave feedback. The discussion and the agent's updates stay together on the page.
+
+## Create Your First Page
+
+Open the **Pages** tab and click **Create with AI**. Superset starts an agent session that asks what you want to create, helps build the page, and publishes a link for your team. The help icon beside the **Pages** title opens this guide.
+
+You can also ask an agent in an existing Superset workspace:
+
+```text
+Create a design doc for our onboarding flow and publish it as a Superset Page
+so the team can review it and leave comments.
+```
+
+Or start with work the agent has already done:
+
+```text
+Turn your findings into a report and publish it as a Page for the team.
+```
+
+The Superset plugin includes a [Pages skill](/skills) that guides agents through building, publishing, and updating pages. A page can be a self-contained HTML file or a directory with an `index.html` and supporting assets.
+
+To publish from the CLI, keep the source inside your workspace and run:
+
+```bash
+superset pages publish design.html --title "Onboarding design" --label "First draft"
+```
+
+The command returns a shareable URL. New pages are visible to your organization by default. For a private draft, add `--visibility just_me` when you first publish.
+
+## Send Feedback Directly to an Agent
+
+Open the page, enter comment mode, and click an element to pin feedback to it. The agent receives the comment along with context identifying the element, so teammates can point to exactly what they want changed.
+
+Publishing from an agent's Superset terminal automatically sets that session to watch the page for new comments. In the workspace page pane, use the agent menu in the page header to see which agent is watching, select another running agent, or choose **Stop watching**.
+
+Keep the host and agent session running for automatic feedback delivery. If the menu says **Nothing is watching this page**, select a running agent. New comments are delivered when the agent is available to handle them.
+
+The agent can change the page, answer a question in the thread, or leave feedback open when it needs more discussion. When it makes a change, it republishes the page, replies with what changed, and resolves the feedback it addressed.
+
+## Keep Iterating on the Same Page
+
+Publish the same source path from the same workspace to create a new version of the existing page. Your team keeps using the same link, and earlier versions remain in version history.
+
+```bash
+superset pages publish design.html --label "Simplified onboarding after team review"
+```
+
+If the source moved or you're publishing from another workspace, pass the existing page ID explicitly:
+
+```bash
+superset pages publish design.html --page <page-id> --label "Updated onboarding flow"
+```
+
+Republishing preserves the page's visibility. You can also inspect version history or retrieve a published version:
+
+```bash
+superset pages versions <page-id-or-slug>
+superset pages pull <page-id-or-slug> --version 1 > original-design.html
+```
+
+Agents connecting through MCP can publish, retrieve versions, and reply to or resolve comments with the [Pages tools](/mcp-server#pages).

--- a/apps/docs/content/docs/skills.mdx
+++ b/apps/docs/content/docs/skills.mdx
@@ -30,6 +30,7 @@ Or, in Claude Code, via the plugin marketplace:
 | `superset:setup` | Makes a repo Superset-ready: authors `.superset/config.json` and project lifecycle scripts, then verifies with a real workspace |
 | `superset:orchestrate` | Turns the agent you're talking to into a coordinator of parallel agents; see [Agent Orchestration](/orchestration) |
 | `superset:automate` | Turns a recurring chore into a scheduled [automation](/automations) and reviews its first run with you |
+| `superset:page` | Builds and publishes shareable [Pages](/pages), then updates them in response to pinned team comments |
 | `superset:browser` | Drives a workspace's [in-app browser](/browser) panes — open, navigate, screenshot, eval, read console, and raw CDP for click/type automation — and routes to [Browser Use 3.0](/browser#browser-use-30) for browsers the panes can't reach |
 | `superset:computer` | Drives [native desktop apps](/computer) through an accessibility-first driver (Cua Driver by default) — inspect windows, click, type, use menus, and verify results with background interaction when the platform supports it |
 | `superset:standup` | Sweeps your workspaces, tasks, and agent terminals into a digest: what needs you, what's in flight, what's blocked |

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automatizace (selhává: {myFailedCount})"
 msgid "Automations & event triggers"
 msgstr "Automatizace a spouštěče událostí"
 
-msgid "Automations docs"
-msgstr "Dokumentace k automatizacím"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatizace, selhává: {myFailedCount}"
 
@@ -4248,9 +4245,6 @@ msgstr "Vytvoř na mém MacBooku pracovní prostor pro funkci auth"
 msgid "Create an account"
 msgstr "Vytvořit účet"
 
-msgid "Create an automation with an agent"
-msgstr "Vytvořit automatizaci s agentem"
-
 msgid "Create failed: {message}"
 msgstr "Vytvoření selhalo: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Každý agent běží ve vlastním git worktree, takže deset agentů m�
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Každá osa táhne na další úroveň. Udržte to a úroveň přijde sama."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Každý pátek v 16:00 sepiš poznámky k vydání ze sloučených PR za tento týden"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Každý pátek v 16:00 sepiš poznámky k vydání ze sloučených PR za tento týden."
 
@@ -5490,9 +5481,6 @@ msgstr "Každou středu v 9:00 projdi sloučené PR za tento týden a aktualizuj
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Každý všední den v 9:00 přečti nové GitHub issues, přiřaď štítky a připrav první odpověď ke kontrole."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Každý všední den v 9:00 roztřiď nové GitHub issues a připrav odpovědi ke kontrole"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Všichni se dohadují, jestli se to dá zobecnit. Právě ten spor je známkou toho, že úroveň byla dosažena."
@@ -8455,6 +8443,9 @@ msgstr "Další {kindLower} motivy"
 msgid "More actions"
 msgstr "Další akce"
 
+msgid "More options"
+msgstr "Další možnosti"
+
 msgid "More pages"
 msgstr "Další stránky"
 
@@ -8760,9 +8751,6 @@ msgstr "Další: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Super, až budeš mít hotovo, otevři PR."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Každou noc ve 2:00 najdi jednu malou chybu, oprav ji a otevři PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Veřejný"
 msgid "Public leaderboard"
 msgstr "Veřejný žebříček"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Zveřejněte stránku z agenta nebo z CLI a objeví se tady."
-
 msgid "Published"
 msgstr "Publikováno"
 
@@ -12628,6 +12613,9 @@ msgstr "Sytost barvy se vztahuje k nejrušnějšímu dni tohoto vývojáře"
 msgid "Share"
 msgstr "Sdílet"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Sdílejte návrhy a zprávy. Zpětnou vazbu nechte na svém agentovi."
+
 msgid "Share page"
 msgstr "Sdílet stránku"
 
@@ -13440,9 +13428,6 @@ msgstr "pro UI agentů a sdílené komponenty aplikace. Kliknutím na libovolnou
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Součet CPU využitého Supersetem a sledovanými stromy procesů terminálu. Přes 100 % znamená, že je vytíženo více jader. Dlouhodobě vysoké hodnoty obvykle způsobují sekání UI a rychlejší vybíjení baterie."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Každé ráno před standupem shrň neúspěšné běhy CI"
 
 msgid "Summary"
 msgstr "Souhrn"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automatisierungen ({myFailedCount} fehlgeschlagen)"
 msgid "Automations & event triggers"
 msgstr "Automatisierungen & Ereignis-Trigger"
 
-msgid "Automations docs"
-msgstr "Automatisierungs-Doku"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatisierungen, {myFailedCount} fehlgeschlagen"
 
@@ -4248,9 +4245,6 @@ msgstr "Erstelle einen Arbeitsbereich für das Auth-Feature auf meinem MacBook"
 msgid "Create an account"
 msgstr "Konto erstellen"
 
-msgid "Create an automation with an agent"
-msgstr "Automatisierung mit einem Agenten erstellen"
-
 msgid "Create failed: {message}"
 msgstr "Erstellen fehlgeschlagen: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Jeder Agent läuft in seinem eigenen Git-Worktree, sodass zehn Agenten a
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Jede Achse trägt ihren Teil zur nächsten Stufe bei. Halte dieses Niveau, und die Stufe folgt."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Jeden Freitag um 16 Uhr Release Notes aus den diese Woche gemergten PRs entwerfen"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Jeden Freitag um 16 Uhr Release Notes aus den diese Woche gemergten PRs entwerfen."
 
@@ -5490,9 +5481,6 @@ msgstr "Jeden Mittwoch um 9 Uhr die diese Woche gemergten PRs durchsehen und die
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Jeden Werktag um 9 Uhr neue GitHub-Issues lesen, Labels vergeben und eine erste Antwort für mein Review entwerfen."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Jeden Werktag um 9 Uhr neue GitHub-Issues triagieren und Antworten für mein Review entwerfen"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Alle streiten darüber, ob sich das verallgemeinern lässt. Genau dieser Streit ist das Zeichen, dass die Stufe erreicht wurde."
@@ -8455,6 +8443,9 @@ msgstr "Weitere {kindLower}e Themes"
 msgid "More actions"
 msgstr "Weitere Aktionen"
 
+msgid "More options"
+msgstr "Weitere Optionen"
+
 msgid "More pages"
 msgstr "Weitere Seiten"
 
@@ -8760,9 +8751,6 @@ msgstr "Weiter: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Super, öffne einen PR, wenn es so weit ist."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Nachts um 2 Uhr einen kleinen Bug finden, beheben und einen PR öffnen"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Öffentlich"
 msgid "Public leaderboard"
 msgstr "Öffentliches Leaderboard"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Veröffentliche eine Seite aus einem Agenten oder der CLI, dann erscheint sie hier."
-
 msgid "Published"
 msgstr "Veröffentlicht"
 
@@ -12628,6 +12613,9 @@ msgstr "Die Färbung bezieht sich auf den stärksten Tag dieses Entwicklers"
 msgid "Share"
 msgstr "Teilen"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Teile Entwürfe und Berichte. Lass deinen Agenten das Feedback bearbeiten."
+
 msgid "Share page"
 msgstr "Seite teilen"
 
@@ -13440,9 +13428,6 @@ msgstr "-Suite für Agenten-Oberflächen und gemeinsame App-Komponenten. Klicke 
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Summe der CPU-Last von Superset und den überwachten Terminal-Prozessbäumen. Über 100 % bedeutet, dass mehrere CPU-Kerne ausgelastet sind. Dauerhaft hohe Werte machen die Oberfläche meist träge und verbrauchen mehr Akku."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Jeden Morgen vor dem Standup fehlgeschlagene CI-Läufe zusammenfassen"
 
 msgid "Summary"
 msgstr "Übersicht"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automations ({myFailedCount} failing)"
 msgid "Automations & event triggers"
 msgstr "Automations & event triggers"
 
-msgid "Automations docs"
-msgstr "Automations docs"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automations, {myFailedCount} failing"
 
@@ -4248,9 +4245,6 @@ msgstr "Create a workspace for the auth feature on my MacBook"
 msgid "Create an account"
 msgstr "Create an account"
 
-msgid "Create an automation with an agent"
-msgstr "Create an automation with an agent"
-
 msgid "Create failed: {message}"
 msgstr "Create failed: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Every agent runs in its own Git worktree, so ten agents can work on ten 
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Every Friday at 4pm, draft release notes from this week's merged PRs"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Every Friday at 4pm, draft release notes from this week's merged PRs."
 
@@ -5490,9 +5481,6 @@ msgstr "Every Wednesday at 9am, review this week's merged PRs and update any doc
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
@@ -8455,6 +8443,9 @@ msgstr "More {kindLower} themes"
 msgid "More actions"
 msgstr "More actions"
 
+msgid "More options"
+msgstr "More options"
+
 msgid "More pages"
 msgstr "More pages"
 
@@ -8760,9 +8751,6 @@ msgstr "Next: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Nice, open a PR when ready."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Nightly at 2am, find one small bug, fix it, and open a PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Public"
 msgid "Public leaderboard"
 msgstr "Public leaderboard"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Publish a page from an agent or the CLI and it will show up here."
-
 msgid "Published"
 msgstr "Published"
 
@@ -12628,6 +12613,9 @@ msgstr "Shade is relative to this developer's busiest day"
 msgid "Share"
 msgstr "Share"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Share designs and reports. Let your agent handle the feedback."
+
 msgid "Share page"
 msgstr "Share page"
 
@@ -13440,9 +13428,6 @@ msgstr "suite for agent UIs, and shared app components. Click any import path to
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Summarize failed CI runs every morning before standup"
 
 msgid "Summary"
 msgstr "Summary"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automatizaciones ({myFailedCount} con errores)"
 msgid "Automations & event triggers"
 msgstr "Automatizaciones y disparadores por eventos"
 
-msgid "Automations docs"
-msgstr "Documentación de automatizaciones"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatizaciones, {myFailedCount} con errores"
 
@@ -4248,9 +4245,6 @@ msgstr "Crea un espacio de trabajo para la función de autenticación en mi MacB
 msgid "Create an account"
 msgstr "Crear una cuenta"
 
-msgid "Create an automation with an agent"
-msgstr "Crear una automatización con un agente"
-
 msgid "Create failed: {message}"
 msgstr "Error al crear: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Cada agente se ejecuta en su propio worktree de Git, así que diez agent
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Todos los ejes aportan su parte para el siguiente nivel. Mantenlo y el nivel llegará solo."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Cada viernes a las 16:00, redacta las notas de la versión a partir de los PR fusionados esta semana"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Cada viernes a las 16:00, redacta las notas de la versión a partir de los PR fusionados esta semana."
 
@@ -5490,9 +5481,6 @@ msgstr "Cada miércoles a las 9:00, revisa los PR fusionados esta semana y actua
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Cada día laborable a las 9:00, lee los issues nuevos de GitHub, aplica etiquetas y redacta una primera respuesta para que la revise."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Cada día laborable a las 9:00, clasifica los issues nuevos de GitHub y redacta respuestas para que las revise"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Todo el mundo discute si esto se generaliza. Esa discusión es la señal de que se alcanzó el nivel."
@@ -8455,6 +8443,9 @@ msgstr "Más temas {kindLower}"
 msgid "More actions"
 msgstr "Más acciones"
 
+msgid "More options"
+msgstr "Más opciones"
+
 msgid "More pages"
 msgstr "Más páginas"
 
@@ -8760,9 +8751,6 @@ msgstr "Siguiente: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Genial, abre un PR cuando esté listo."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Cada noche a las 2:00, busca un error pequeño, corrígelo y abre un PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Público"
 msgid "Public leaderboard"
 msgstr "Clasificación pública"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Publica una página desde un agente o la CLI y aparecerá aquí."
-
 msgid "Published"
 msgstr "Publicada"
 
@@ -12628,6 +12613,9 @@ msgstr "La intensidad es relativa al día más intenso de esta persona"
 msgid "Share"
 msgstr "Compartir"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Comparte diseños e informes. Deja que tu agente se encargue de los comentarios."
+
 msgid "Share page"
 msgstr "Compartir la página"
 
@@ -13440,9 +13428,6 @@ msgstr "para interfaces de agentes y los componentes compartidos de la app. Haz 
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Suma de la CPU que usan Superset y los árboles de procesos de terminal monitorizados. Más del 100 % significa que hay varios núcleos ocupados. Los valores altos sostenidos suelen provocar lentitud en la interfaz y más consumo de batería."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Resume las ejecuciones de CI fallidas cada mañana antes del standup"
 
 msgid "Summary"
 msgstr "Resumen"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automatisations ({myFailedCount} en échec)"
 msgid "Automations & event triggers"
 msgstr "Automatisations et déclencheurs d'événements"
 
-msgid "Automations docs"
-msgstr "Documentation des automatisations"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatisations, {myFailedCount} en échec"
 
@@ -4248,9 +4245,6 @@ msgstr "Crée un espace de travail pour la fonctionnalité d'authentification su
 msgid "Create an account"
 msgstr "Créer un compte"
 
-msgid "Create an automation with an agent"
-msgstr "Créer une automatisation avec un agent"
-
 msgid "Create failed: {message}"
 msgstr "Échec de la création : {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Chaque agent s'exécute dans son propre worktree Git : dix agents peuven
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Chaque axe tire son poids pour le palier suivant. Tenez-le et le palier suivra."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Chaque vendredi à 16 h, rédige les notes de version à partir des pull requests fusionnées cette semaine"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Chaque vendredi à 16 h, rédige les notes de version à partir des pull requests fusionnées cette semaine."
 
@@ -5490,9 +5481,6 @@ msgstr "Chaque mercredi à 9 h, passe en revue les pull requests fusionnées cet
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Chaque jour ouvré à 9 h, lis les nouvelles issues GitHub, applique des labels et rédige une première réponse pour ma revue."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Chaque jour ouvré à 9 h, trie les nouvelles issues GitHub et rédige des réponses pour ma revue"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Tout le monde débat de savoir si cela se généralise. Ce débat est le signe que le niveau est atteint."
@@ -8455,6 +8443,9 @@ msgstr "Plus de thèmes {kindLower}"
 msgid "More actions"
 msgstr "Plus d'actions"
 
+msgid "More options"
+msgstr "Plus d’options"
+
 msgid "More pages"
 msgstr "Plus de pages"
 
@@ -8760,9 +8751,6 @@ msgstr "Suivant : {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Parfait, ouvre une pull request quand c'est prêt."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Chaque nuit à 2 h, trouve un petit bug, corrige-le et ouvre une pull request"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Public"
 msgid "Public leaderboard"
 msgstr "Classement public"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Publiez une page depuis un agent ou la CLI et elle apparaîtra ici."
-
 msgid "Published"
 msgstr "Publiée"
 
@@ -12628,6 +12613,9 @@ msgstr "L'intensité est relative au jour le plus chargé de ce développeur"
 msgid "Share"
 msgstr "Partager"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Partagez des maquettes et des rapports. Laissez votre agent traiter les retours."
+
 msgid "Share page"
 msgstr "Partager la page"
 
@@ -13440,9 +13428,6 @@ msgstr "suite pour les interfaces d'agent, et les composants d'application parta
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Somme du CPU utilisé par Superset et par les arborescences de processus des terminaux surveillés. Au-delà de 100 %, plusieurs cœurs CPU sont occupés. Des valeurs élevées prolongées entraînent généralement une interface lente et une consommation de batterie accrue."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Résume les exécutions CI en échec chaque matin avant le point d'équipe"
 
 msgid "Summary"
 msgstr "Résumé"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Otomatisasi ({myFailedCount} gagal)"
 msgid "Automations & event triggers"
 msgstr "Otomatisasi & pemicu event"
 
-msgid "Automations docs"
-msgstr "Dokumentasi otomatisasi"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Otomatisasi, {myFailedCount} gagal"
 
@@ -4248,9 +4245,6 @@ msgstr "Buat workspace untuk fitur auth di MacBook saya"
 msgid "Create an account"
 msgstr "Buat akun"
 
-msgid "Create an automation with an agent"
-msgstr "Buat otomatisasi dengan agen"
-
 msgid "Create failed: {message}"
 msgstr "Gagal membuat: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Tiap agen berjalan di worktree Git-nya sendiri, jadi sepuluh agen bisa b
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Setiap sumbu sudah menopang untuk tingkat berikutnya. Pertahankan, tingkatnya akan menyusul."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Tiap Jumat jam 4 sore, susun draf catatan rilis dari PR yang di-merge minggu ini"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Tiap Jumat jam 4 sore, susun draf catatan rilis dari PR yang di-merge minggu ini."
 
@@ -5490,9 +5481,6 @@ msgstr "Tiap Rabu jam 9 pagi, tinjau PR yang di-merge minggu ini dan perbarui do
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Tiap hari kerja jam 9 pagi, baca issue GitHub baru, terapkan label, dan susun draf balasan pertama untuk saya review."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Tiap hari kerja jam 9 pagi, triase issue GitHub baru dan susun draf balasan untuk saya review"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Semua orang berdebat apakah ini bisa digeneralisasi. Perdebatan itu justru tanda bahwa levelnya sudah tercapai."
@@ -8455,6 +8443,9 @@ msgstr "Tema {kindLower} lainnya"
 msgid "More actions"
 msgstr "Aksi lainnya"
 
+msgid "More options"
+msgstr "Opsi lainnya"
+
 msgid "More pages"
 msgstr "Halaman lainnya"
 
@@ -8760,9 +8751,6 @@ msgstr "Berikutnya: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Bagus, buka PR kalau sudah siap."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Tiap malam jam 2, cari satu bug kecil, perbaiki, dan buka PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Publik"
 msgid "Public leaderboard"
 msgstr "Papan peringkat publik"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Publikasikan halaman dari agen atau CLI dan halaman itu akan muncul di sini."
-
 msgid "Published"
 msgstr "Diterbitkan"
 
@@ -12628,6 +12613,9 @@ msgstr "Kepekatan warna relatif terhadap hari tersibuk pengembang ini"
 msgid "Share"
 msgstr "Bagikan"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Bagikan desain dan laporan. Biarkan agen Anda menangani masukan."
+
 msgid "Share page"
 msgstr "Bagikan halaman"
 
@@ -13440,9 +13428,6 @@ msgstr "untuk UI agen, dan komponen aplikasi bersama. Klik path impor mana pun u
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Jumlah CPU yang dipakai Superset dan pohon proses terminal yang dipantau. Di atas 100% berarti beberapa inti CPU sedang sibuk. Nilai tinggi yang bertahan lama biasanya membuat UI terasa lambat dan baterai lebih boros."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Rangkum run CI yang gagal tiap pagi sebelum standup"
 
 msgid "Summary"
 msgstr "Ringkasan"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automazioni ({myFailedCount} in errore)"
 msgid "Automations & event triggers"
 msgstr "Automazioni e trigger da eventi"
 
-msgid "Automations docs"
-msgstr "Documentazione automazioni"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automazioni, {myFailedCount} in errore"
 
@@ -4248,9 +4245,6 @@ msgstr "Crea un workspace per la funzione di autenticazione sul mio MacBook"
 msgid "Create an account"
 msgstr "Crea un account"
 
-msgid "Create an automation with an agent"
-msgstr "Crea un'automazione con un agente"
-
 msgid "Create failed: {message}"
 msgstr "Creazione non riuscita: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Ogni agente gira nel proprio worktree Git, così dieci agenti possono la
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Ogni asse fa la sua parte per il livello successivo. Mantienilo e il livello arriva da sé."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Ogni venerdì alle 16, prepara le note di rilascio dalle PR unite questa settimana"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Ogni venerdì alle 16, prepara le note di rilascio dalle PR unite questa settimana."
 
@@ -5490,9 +5481,6 @@ msgstr "Ogni mercoledì alle 9, rivedi le PR unite questa settimana e aggiorna l
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Ogni giorno feriale alle 9, leggi le nuove issue GitHub, applica le etichette e prepara una prima risposta da rivedere."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Ogni giorno feriale alle 9, smista le nuove issue GitHub e prepara le risposte da rivedere"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Tutti discutono se questo sia generalizzabile. Quella discussione è il segno che il livello è stato raggiunto."
@@ -8455,6 +8443,9 @@ msgstr "Altri temi {kindLower}"
 msgid "More actions"
 msgstr "Altre azioni"
 
+msgid "More options"
+msgstr "Altre opzioni"
+
 msgid "More pages"
 msgstr "Altre pagine"
 
@@ -8760,9 +8751,6 @@ msgstr "Avanti: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Ottimo, apri una PR quando è pronta."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Ogni notte alle 2, trova un piccolo bug, correggilo e apri una PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Pubblico"
 msgid "Public leaderboard"
 msgstr "Classifica pubblica"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Pubblica una pagina da un agente o dalla CLI e comparirà qui."
-
 msgid "Published"
 msgstr "Pubblicato"
 
@@ -12628,6 +12613,9 @@ msgstr "L'intensità è relativa al giorno più intenso di questo sviluppatore"
 msgid "Share"
 msgstr "Condividi"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Condividi progetti e report. Lascia che il tuo agente gestisca i feedback."
+
 msgid "Share page"
 msgstr "Condividi la pagina"
 
@@ -13440,9 +13428,6 @@ msgstr "per le interfacce degli agenti e i componenti condivisi dell'app. Clicca
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Somma della CPU usata da Superset e dagli alberi di processi dei terminali monitorati. Oltre il 100% significa che più core della CPU sono occupati. Valori alti prolungati di solito causano lentezza dell'interfaccia e maggiore consumo della batteria."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Riassumi le esecuzioni CI fallite ogni mattina prima dello standup"
 
 msgid "Summary"
 msgstr "Riepilogo"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -12614,7 +12614,7 @@ msgid "Share"
 msgstr "Condividi"
 
 msgid "Share designs and reports. Let your agent handle the feedback."
-msgstr "Condividi progetti e report. Lascia che il tuo agente gestisca i feedback."
+msgstr "Condividi design e report. Lascia che il tuo agente gestisca il feedback."
 
 msgid "Share page"
 msgstr "Condividi la pagina"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -2220,9 +2220,6 @@ msgstr "オートメーション({myFailedCount}件失敗中)"
 msgid "Automations & event triggers"
 msgstr "オートメーションとイベントトリガー"
 
-msgid "Automations docs"
-msgstr "オートメーションのドキュメント"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "オートメーション、{myFailedCount}件が失敗中"
 
@@ -4248,9 +4245,6 @@ msgstr "MacBookに認証機能用のワークスペースを作って"
 msgid "Create an account"
 msgstr "アカウントを作成"
 
-msgid "Create an automation with an agent"
-msgstr "エージェントでオートメーションを作成"
-
 msgid "Create failed: {message}"
 msgstr "作成に失敗しました: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "各エージェントは専用のGitワークツリーで動くため、
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "すべての軸が次のティアのために働いています。これを維持すればティアは付いてきます。"
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "毎週金曜午後4時に、今週マージされたPRからリリースノートの下書きを作成する"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "毎週金曜午後4時に、今週マージされたPRからリリースノートの下書きを作成する。"
 
@@ -5490,9 +5481,6 @@ msgstr "毎週水曜午前9時に、今週マージされたPRを確認し、古
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "平日午前9時に、新しいGitHub issueを読み、ラベルを付け、レビュー用の返信を下書きする。"
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "平日午前9時に新しいGitHub issueをトリアージし、レビュー用の返信を下書きする"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "これが一般化するかどうかで議論が起きます。その議論こそ、このレベルに到達した証拠です。"
@@ -8455,6 +8443,9 @@ msgstr "他の{kindLower}テーマ"
 msgid "More actions"
 msgstr "その他の操作"
 
+msgid "More options"
+msgstr "その他のオプション"
+
 msgid "More pages"
 msgstr "その他のページ"
 
@@ -8760,9 +8751,6 @@ msgstr "次: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "いいですね。準備ができたらPRを作成してください。"
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "毎晩午前2時に小さなバグを1つ見つけて修正し、PRを作成する"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "パブリック"
 msgid "Public leaderboard"
 msgstr "公開リーダーボード"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "エージェントまたはCLIからページを公開すると、ここに表示されます。"
-
 msgid "Published"
 msgstr "公開日"
 
@@ -12628,6 +12613,9 @@ msgstr "濃さはこの開発者の最も活動量が多い日を基準にして
 msgid "Share"
 msgstr "共有"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "デザインやレポートを共有しましょう。フィードバックへの対応はエージェントに任せられます。"
+
 msgid "Share page"
 msgstr "ページを共有"
 
@@ -13440,9 +13428,6 @@ msgstr "スイート、そして共有アプリコンポーネントです。イ
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Supersetと監視対象のターミナルプロセスツリーが使用するCPUの合計。100%を超える場合は複数のCPUコアが動作しています。高い値が続くと、通常はUIの動作が重くなり、バッテリー消費も増えます。"
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "毎朝スタンドアップ前に失敗したCI実行をまとめる"
 
 msgid "Summary"
 msgstr "概要"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -2220,9 +2220,6 @@ msgstr "자동화 ({myFailedCount}개 실패)"
 msgid "Automations & event triggers"
 msgstr "자동화 및 이벤트 트리거"
 
-msgid "Automations docs"
-msgstr "자동화 문서"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "자동화, {myFailedCount}개 실패"
 
@@ -4248,9 +4245,6 @@ msgstr "내 MacBook에 인증 기능용 워크스페이스를 만들어 줘"
 msgid "Create an account"
 msgstr "계정 만들기"
 
-msgid "Create an automation with an agent"
-msgstr "에이전트로 자동화 만들기"
-
 msgid "Create failed: {message}"
 msgstr "생성 실패: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "모든 에이전트가 각자의 Git worktree에서 실행되므로, 에
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "모든 축이 다음 등급을 향해 제 몫을 하고 있습니다. 이대로 유지하면 등급은 따라옵니다."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "매주 금요일 오후 4시에 이번 주 머지된 PR로 릴리스 노트 초안 작성하기"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "매주 금요일 오후 4시에 이번 주 머지된 PR로 릴리스 노트 초안을 작성합니다."
 
@@ -5490,9 +5481,6 @@ msgstr "매주 수요일 오전 9시에 이번 주 머지된 PR을 검토하고,
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "평일 오전 9시마다 새 GitHub 이슈를 읽고, 라벨을 적용하고, 검토용 첫 답변 초안을 작성합니다."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "평일 오전 9시마다 새 GitHub 이슈를 분류하고 검토용 답변 초안 작성하기"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "이것이 일반화될 수 있는지를 두고 모두가 논쟁합니다. 그 논쟁 자체가 해당 단계에 도달했다는 신호입니다."
@@ -8455,6 +8443,9 @@ msgstr "{kindLower} 테마 더 보기"
 msgid "More actions"
 msgstr "추가 작업"
 
+msgid "More options"
+msgstr "추가 옵션"
+
 msgid "More pages"
 msgstr "더 많은 페이지"
 
@@ -8760,9 +8751,6 @@ msgstr "다음: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "좋아요, 준비되면 PR을 올려 주세요."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "매일 새벽 2시에 작은 버그 하나를 찾아 고치고 PR을 올리기"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "공개"
 msgid "Public leaderboard"
 msgstr "공개 리더보드"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "에이전트나 CLI에서 페이지를 게시하면 여기에 표시됩니다."
-
 msgid "Published"
 msgstr "게시일"
 
@@ -12628,6 +12613,9 @@ msgstr "색의 진하기는 이 개발자의 가장 바빴던 날을 기준으�
 msgid "Share"
 msgstr "공유"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "디자인과 보고서를 공유하세요. 피드백 처리는 에이전트에게 맡기세요."
+
 msgid "Share page"
 msgstr "페이지 공유"
 
@@ -13440,9 +13428,6 @@ msgstr "스위트, 그리고 공용 앱 컴포넌트입니다. import 경로를 
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Superset과 모니터링 중인 터미널 프로세스 트리가 사용하는 CPU의 합계입니다. 100%를 넘으면 여러 CPU 코어가 사용 중이라는 뜻입니다. 높은 값이 계속되면 보통 UI가 느려지고 배터리 소모가 커집니다."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "매일 아침 스탠드업 전에 실패한 CI 실행 요약하기"
 
 msgid "Summary"
 msgstr "요약"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automatiseringen ({myFailedCount} mislukt)"
 msgid "Automations & event triggers"
 msgstr "Automatiseringen en event-triggers"
 
-msgid "Automations docs"
-msgstr "Documentatie over automatiseringen"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatiseringen, {myFailedCount} mislukt"
 
@@ -4248,9 +4245,6 @@ msgstr "Maak een werkruimte voor de auth-feature op mijn MacBook"
 msgid "Create an account"
 msgstr "Een account aanmaken"
 
-msgid "Create an automation with an agent"
-msgstr "Een automatisering maken met een agent"
-
 msgid "Create failed: {message}"
 msgstr "Aanmaken mislukt: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Elke agent draait in zijn eigen Git-worktree, dus tien agents kunnen aan
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Elke as draagt zijn deel bij voor het volgende niveau. Houd dit vast en het niveau volgt."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Elke vrijdag om 16.00 uur: stel release notes op uit de gemergede PR's van deze week"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Elke vrijdag om 16.00 uur: stel release notes op uit de gemergede PR's van deze week."
 
@@ -5490,9 +5481,6 @@ msgstr "Elke woensdag om 9 uur: bekijk de gemergede PR's van deze week en werk d
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Elke werkdag om 9 uur: lees nieuwe GitHub-issues, plaats labels en stel een eerste antwoord op voor mijn review."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Elke werkdag om 9 uur: triageer nieuwe GitHub-issues en stel antwoorden op voor mijn review"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Iedereen discussieert over de vraag of dit generaliseert. Die discussie is het teken dat het niveau is bereikt."
@@ -8455,6 +8443,9 @@ msgstr "Meer {kindLower} thema's"
 msgid "More actions"
 msgstr "Meer acties"
 
+msgid "More options"
+msgstr "Meer opties"
+
 msgid "More pages"
 msgstr "Meer pagina's"
 
@@ -8760,9 +8751,6 @@ msgstr "Volgende: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Mooi, open een PR als het klaar is."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Elke nacht om 2 uur: zoek één kleine bug, fix die en open een PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Openbaar"
 msgid "Public leaderboard"
 msgstr "Openbare ranglijst"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Publiceer een pagina vanuit een agent of de CLI en die verschijnt hier."
-
 msgid "Published"
 msgstr "Gepubliceerd"
 
@@ -12628,6 +12613,9 @@ msgstr "De kleurintensiteit is relatief aan de drukste dag van deze ontwikkelaar
 msgid "Share"
 msgstr "Delen"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Deel ontwerpen en rapporten. Laat je agent de feedback verwerken."
+
 msgid "Share page"
 msgstr "Pagina delen"
 
@@ -13440,9 +13428,6 @@ msgstr "-suite voor agent-UI's en gedeelde app-componenten. Klik op een importpa
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Som van het CPU-gebruik van Superset en de gemonitorde terminalprocesbomen. Boven 100% betekent dat meerdere CPU-cores bezig zijn. Langdurig hoge waarden zorgen meestal voor een trage UI en meer batterijverbruik."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Vat elke ochtend voor de standup de mislukte CI-runs samen"
 
 msgid "Summary"
 msgstr "Samenvatting"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automatyzacje ({myFailedCount} nieudanych)"
 msgid "Automations & event triggers"
 msgstr "Automatyzacje i wyzwalacze zdarzeń"
 
-msgid "Automations docs"
-msgstr "Dokumentacja automatyzacji"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatyzacje, {myFailedCount} nieudanych"
 
@@ -4248,9 +4245,6 @@ msgstr "Utwórz obszar roboczy dla funkcji auth na moim MacBooku"
 msgid "Create an account"
 msgstr "Utwórz konto"
 
-msgid "Create an automation with an agent"
-msgstr "Utwórz automatyzację z agentem"
-
 msgid "Create failed: {message}"
 msgstr "Tworzenie nie powiodło się: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Każdy agent działa we własnym worktree gita, więc dziesięciu agent�
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Każda oś pracuje na następny poziom. Utrzymaj to, a poziom przyjdzie sam."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "W każdy piątek o 16:00 przygotuj notatki wydania z PR-ów scalonych w tym tygodniu"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "W każdy piątek o 16:00 przygotuj notatki wydania z PR-ów scalonych w tym tygodniu."
 
@@ -5490,9 +5481,6 @@ msgstr "W każdą środę o 9:00 przejrzyj scalone w tym tygodniu PR-y i zaktual
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "W każdy dzień roboczy o 9:00 przeczytaj nowe zgłoszenia GitHub, nadaj etykiety i przygotuj pierwszą odpowiedź do mojego przeglądu."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "W każdy dzień roboczy o 9:00 posegreguj nowe zgłoszenia GitHub i przygotuj odpowiedzi do mojego przeglądu"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Wszyscy spierają się, czy to się uogólnia. Ten spór jest znakiem, że poziom został osiągnięty."
@@ -8455,6 +8443,9 @@ msgstr "Więcej motywów {kindLower}"
 msgid "More actions"
 msgstr "Więcej akcji"
 
+msgid "More options"
+msgstr "Więcej opcji"
+
 msgid "More pages"
 msgstr "Więcej stron"
 
@@ -8760,9 +8751,6 @@ msgstr "Dalej: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Świetnie, otwórz PR, gdy będzie gotowy."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Co noc o 2:00 znajdź jeden mały błąd, napraw go i otwórz PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Publiczne"
 msgid "Public leaderboard"
 msgstr "Publiczny ranking"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Opublikuj stronę z agenta lub CLI, a pojawi się tutaj."
-
 msgid "Published"
 msgstr "Opublikowano"
 
@@ -12628,6 +12613,9 @@ msgstr "Nasycenie koloru odnosi się do najbardziej pracowitego dnia tego progra
 msgid "Share"
 msgstr "Udostępnij"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Udostępniaj projekty i raporty. Pozwól agentowi zająć się opiniami."
+
 msgid "Share page"
 msgstr "Udostępnij stronę"
 
@@ -13440,9 +13428,6 @@ msgstr "dla interfejsów agentów i wspólne komponenty aplikacji. Kliknij dowol
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Suma CPU zużywanego przez Superset i monitorowane drzewa procesów terminala. Ponad 100% oznacza, że pracuje wiele rdzeni. Utrzymujące się wysokie wartości zwykle powodują ociężałość interfejsu i szybsze rozładowanie baterii."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Podsumuj nieudane uruchomienia CI każdego ranka przed standupem"
 
 msgid "Summary"
 msgstr "Podsumowanie"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Automações ({myFailedCount} falhando)"
 msgid "Automations & event triggers"
 msgstr "Automações e gatilhos de evento"
 
-msgid "Automations docs"
-msgstr "Documentação de automações"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automações, {myFailedCount} falhando"
 
@@ -4248,9 +4245,6 @@ msgstr "Crie uma área de trabalho para a funcionalidade de autenticação no me
 msgid "Create an account"
 msgstr "Criar uma conta"
 
-msgid "Create an automation with an agent"
-msgstr "Criar uma automação com um agente"
-
 msgid "Create failed: {message}"
 msgstr "Falha ao criar: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Cada agente roda na própria worktree do Git, então dez agentes podem t
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Cada eixo está fazendo a sua parte para o próximo nível. Mantenha assim e o nível vem."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Toda sexta às 16h, escreva as notas de versão a partir dos PRs mesclados da semana"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Toda sexta às 16h, escreva as notas de versão a partir dos PRs mesclados da semana."
 
@@ -5490,9 +5481,6 @@ msgstr "Toda quarta às 9h, revise os PRs mesclados da semana e atualize a docum
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Todo dia útil às 9h, leia as novas issues do GitHub, aplique labels e escreva uma primeira resposta para eu revisar."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Todo dia útil às 9h, faça a triagem das novas issues do GitHub e escreva respostas para eu revisar"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Todo mundo discute se isso generaliza. Essa discussão é o sinal de que o nível foi alcançado."
@@ -8455,6 +8443,9 @@ msgstr "Mais temas {kindLower}s"
 msgid "More actions"
 msgstr "Mais ações"
 
+msgid "More options"
+msgstr "Mais opções"
+
 msgid "More pages"
 msgstr "Mais páginas"
 
@@ -8760,9 +8751,6 @@ msgstr "Próximo: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Boa, abre um PR quando estiver pronto."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Toda noite às 2h, ache um bug pequeno, corrija e abra um PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Público"
 msgid "Public leaderboard"
 msgstr "Ranking público"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Publique uma página por um agente ou pela CLI e ela aparecerá aqui."
-
 msgid "Published"
 msgstr "Publicado"
 
@@ -12628,6 +12613,9 @@ msgstr "A intensidade é relativa ao dia mais movimentado desta pessoa"
 msgid "Share"
 msgstr "Compartilhar"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Compartilhe designs e relatórios. Deixe seu agente cuidar do feedback."
+
 msgid "Share page"
 msgstr "Compartilhar página"
 
@@ -13440,9 +13428,6 @@ msgstr "para interfaces de agente e os componentes compartilhados do app. Clique
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Soma da CPU usada pelo Superset e pelas árvores de processos de terminal monitoradas. Acima de 100% significa que vários núcleos estão ocupados. Valores altos e constantes costumam deixar a interface lenta e consumir mais bateria."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Resuma as execuções de CI que falharam toda manhã antes da daily"
 
 msgid "Summary"
 msgstr "Resumo"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Автоматизации (с ошибкой: {myFailedCount})"
 msgid "Automations & event triggers"
 msgstr "Автоматизации и триггеры по событиям"
 
-msgid "Automations docs"
-msgstr "Документация по автоматизациям"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Автоматизации, с ошибкой: {myFailedCount}"
 
@@ -4248,9 +4245,6 @@ msgstr "Создай рабочую область для фичи автори�
 msgid "Create an account"
 msgstr "Создать аккаунт"
 
-msgid "Create an automation with an agent"
-msgstr "Создать автоматизацию с помощью агента"
-
 msgid "Create failed: {message}"
 msgstr "Не удалось создать: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Каждый агент работает в собственном Git w
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Каждая ось работает на следующий уровень. Удержите это — уровень придёт сам."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Каждую пятницу в 16:00 готовь черновик release notes по объединённым за неделю PR"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Каждую пятницу в 16:00 готовь черновик release notes по объединённым за неделю PR."
 
@@ -5490,9 +5481,6 @@ msgstr "Каждую среду в 9:00 просматривай объедин�
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Каждый будний день в 9:00 читай новые задачи GitHub, расставляй метки и готовь первый черновик ответа мне на проверку."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Каждый будний день в 9:00 разбирай новые задачи GitHub и готовь черновики ответов мне на проверку"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Все спорят, обобщается ли это. Сам спор — признак того, что уровень достигнут."
@@ -8455,6 +8443,9 @@ msgstr "Ещё {kindLower} темы"
 msgid "More actions"
 msgstr "Ещё действия"
 
+msgid "More options"
+msgstr "Другие варианты"
+
 msgid "More pages"
 msgstr "Ещё страницы"
 
@@ -8760,9 +8751,6 @@ msgstr "Далее: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Отлично, открой PR, когда будет готово."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Каждую ночь в 2:00 находи один мелкий баг, исправляй его и открывай PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Публичный"
 msgid "Public leaderboard"
 msgstr "Публичный рейтинг"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Опубликуйте страницу из агента или CLI, и она появится здесь."
-
 msgid "Published"
 msgstr "Опубликовано"
 
@@ -12628,6 +12613,9 @@ msgstr "Насыщенность цвета отсчитывается от са
 msgid "Share"
 msgstr "Поделиться"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Делитесь дизайнами и отчётами. Пусть ваш агент обработает отзывы."
+
 msgid "Share page"
 msgstr "Поделиться страницей"
 
@@ -13440,9 +13428,6 @@ msgstr "для интерфейсов агентов и общие компон�
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Суммарная загрузка CPU от Superset и отслеживаемых деревьев процессов терминала. Больше 100% означает, что заняты несколько ядер. Долго держащиеся высокие значения обычно вызывают подтормаживание интерфейса и ускоренный разряд батареи."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Каждое утро перед стендапом делай сводку упавших запусков CI"
 
 msgid "Summary"
 msgstr "Сводка"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Otomasyonlar ({myFailedCount} başarısız)"
 msgid "Automations & event triggers"
 msgstr "Otomasyonlar ve olay tetikleyicileri"
 
-msgid "Automations docs"
-msgstr "Otomasyon belgeleri"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Otomasyonlar, {myFailedCount} başarısız"
 
@@ -4248,9 +4245,6 @@ msgstr "MacBook'umda auth özelliği için bir çalışma alanı oluştur"
 msgid "Create an account"
 msgstr "Hesap oluşturun"
 
-msgid "Create an automation with an agent"
-msgstr "Bir ajanla otomasyon oluştur"
-
 msgid "Create failed: {message}"
 msgstr "Oluşturulamadı: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Her ajan kendi Git worktree'sinde çalışır, böylece on ajan tek bir 
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Her eksen bir sonraki katman için üzerine düşeni yapıyor. Bunu sürdür, katman kendiliğinden gelir."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Her cuma 16.00'da bu haftanın birleştirilen PR'larından sürüm notları taslağı hazırla"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Her cuma 16.00'da bu haftanın birleştirilen PR'larından sürüm notları taslağı hazırla."
 
@@ -5490,9 +5481,6 @@ msgstr "Her çarşamba 09.00'da bu haftanın birleştirilen PR'larını incele v
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Her hafta içi 09.00'da yeni GitHub issue'larını oku, etiket uygula ve incelemem için ilk yanıt taslağını hazırla."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Her hafta içi 09.00'da yeni GitHub issue'larını sınıflandır ve incelemem için yanıt taslakları hazırla"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Herkes bunun genellenebilir olup olmadığını tartışır. Bu tartışma, düzeye ulaşıldığının işaretidir."
@@ -8455,6 +8443,9 @@ msgstr "Daha fazla {kindLower} tema"
 msgid "More actions"
 msgstr "Diğer eylemler"
 
+msgid "More options"
+msgstr "Diğer seçenekler"
+
 msgid "More pages"
 msgstr "Daha fazla sayfa"
 
@@ -8760,9 +8751,6 @@ msgstr "Sonraki: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Güzel, hazır olduğunda bir PR aç."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Her gece 02.00'de küçük bir hata bul, düzelt ve PR aç"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Herkese açık"
 msgid "Public leaderboard"
 msgstr "Herkese açık lider tablosu"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Bir ajandan veya CLI'den sayfa yayımlayın, burada görünsün."
-
 msgid "Published"
 msgstr "Yayınlanma"
 
@@ -12628,6 +12613,9 @@ msgstr "Renk koyuluğu bu geliştiricinin en yoğun gününe göredir"
 msgid "Share"
 msgstr "Paylaş"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Tasarımları ve raporları paylaşın. Geri bildirimleri ajanınız ele alsın."
+
 msgid "Share page"
 msgstr "Sayfayı paylaş"
 
@@ -13440,9 +13428,6 @@ msgstr "paketi ve paylaşılan uygulama bileşenleri. Kopyalamak için herhangi 
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Superset ve izlenen terminal süreç ağaçlarının kullandığı CPU toplamı. %100'ün üzeri, birden fazla CPU çekirdeğinin meşgul olduğu anlamına gelir. Sürekli yüksek değerler genellikle arayüzde yavaşlığa ve daha hızlı pil tüketimine yol açar."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Her sabah standup'tan önce başarısız CI çalıştırmalarını özetle"
 
 msgid "Summary"
 msgstr "Özet"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -2220,9 +2220,6 @@ msgstr "Tự động hóa ({myFailedCount} đang lỗi)"
 msgid "Automations & event triggers"
 msgstr "Tự động hóa & trigger sự kiện"
 
-msgid "Automations docs"
-msgstr "Tài liệu tự động hóa"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "Tự động hóa, {myFailedCount} đang lỗi"
 
@@ -4248,9 +4245,6 @@ msgstr "Tạo một workspace cho tính năng xác thực trên MacBook của t�
 msgid "Create an account"
 msgstr "Tạo tài khoản"
 
-msgid "Create an automation with an agent"
-msgstr "Tạo tự động hóa với một agent"
-
 msgid "Create failed: {message}"
 msgstr "Tạo thất bại: {message}"
 
@@ -5467,9 +5461,6 @@ msgstr "Mỗi agent chạy trong git worktree riêng, nên mười agent có th�
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "Mọi trục đều đang góp sức cho hạng tiếp theo. Giữ được như vậy thì hạng sẽ tới."
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "Mỗi thứ Sáu lúc 4h chiều, soạn ghi chú phát hành từ các PR đã merge trong tuần"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "Mỗi thứ Sáu lúc 4h chiều, soạn ghi chú phát hành từ các PR đã merge trong tuần."
 
@@ -5490,9 +5481,6 @@ msgstr "Mỗi thứ Tư lúc 9h sáng, xem lại các PR đã merge trong tuần
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "Mỗi ngày trong tuần lúc 9h sáng, đọc issue GitHub mới, gán nhãn và soạn câu trả lời đầu tiên để tôi xem lại."
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "Mỗi ngày trong tuần lúc 9h sáng, phân loại issue GitHub mới và soạn câu trả lời để tôi xem lại"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "Ai cũng tranh cãi liệu điều này có khái quát được không. Chính cuộc tranh cãi đó là dấu hiệu mức này đã đạt được."
@@ -8455,6 +8443,9 @@ msgstr "Thêm chủ đề {kindLower}"
 msgid "More actions"
 msgstr "Thêm hành động"
 
+msgid "More options"
+msgstr "Tùy chọn khác"
+
 msgid "More pages"
 msgstr "Thêm trang"
 
@@ -8760,9 +8751,6 @@ msgstr "Tiếp: {nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "Tốt, mở PR khi sẵn sàng nhé."
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "Hằng đêm lúc 2h sáng, tìm một lỗi nhỏ, sửa nó và mở một PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "Công khai"
 msgid "Public leaderboard"
 msgstr "Bảng xếp hạng công khai"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "Xuất bản một trang từ agent hoặc CLI và nó sẽ xuất hiện ở đây."
-
 msgid "Published"
 msgstr "Phát hành"
 
@@ -12628,6 +12613,9 @@ msgstr "Độ đậm được tính theo ngày bận rộn nhất của nhà ph�
 msgid "Share"
 msgstr "Chia sẻ"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "Chia sẻ thiết kế và báo cáo. Để tác nhân của bạn xử lý phản hồi."
+
 msgid "Share page"
 msgstr "Chia sẻ trang"
 
@@ -13440,9 +13428,6 @@ msgstr "cho giao diện agent, và các component dùng chung của ứng dụng
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Tổng CPU mà Superset và các cây tiến trình terminal được theo dõi sử dụng. Trên 100% nghĩa là nhiều nhân CPU đang bận. Giá trị cao kéo dài thường làm giao diện chậm và hao pin hơn."
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "Tóm tắt các lần chạy CI thất bại mỗi sáng trước standup"
 
 msgid "Summary"
 msgstr "Tóm tắt"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -12614,7 +12614,7 @@ msgid "Share"
 msgstr "Chia sẻ"
 
 msgid "Share designs and reports. Let your agent handle the feedback."
-msgstr "Chia sẻ thiết kế và báo cáo. Để tác nhân của bạn xử lý phản hồi."
+msgstr "Chia sẻ thiết kế và báo cáo. Hãy để agent của bạn xử lý phản hồi."
 
 msgid "Share page"
 msgstr "Chia sẻ trang"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -2220,9 +2220,6 @@ msgstr "自动化（{myFailedCount}个失败）"
 msgid "Automations & event triggers"
 msgstr "自动化与事件触发"
 
-msgid "Automations docs"
-msgstr "自动化文档"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "自动化，{myFailedCount}个失败"
 
@@ -4248,9 +4245,6 @@ msgstr "在我的MacBook上为认证功能创建一个工作区"
 msgid "Create an account"
 msgstr "创建账户"
 
-msgid "Create an automation with an agent"
-msgstr "用智能体创建自动化"
-
 msgid "Create failed: {message}"
 msgstr "创建失败：{message}"
 
@@ -5467,9 +5461,6 @@ msgstr "每个智能体都跑在自己的Git worktree里，十个智能体可以
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "每个维度都在为下一等级出力。保持住，等级自然会来。"
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "每周五下午4点，根据本周合并的PR起草发布说明"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "每周五下午4点，根据本周合并的PR起草发布说明。"
 
@@ -5490,9 +5481,6 @@ msgstr "每周三上午9点，回顾本周合并的PR，更新被它们改过时
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "每个工作日上午9点，阅读新的GitHub议题，打上标签，并起草初步回复供我审阅。"
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "每个工作日上午9点，分类新的GitHub议题并起草回复供我审阅"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "所有人都在争论这能否推广。这场争论本身就说明这一级别已经达到了。"
@@ -8455,6 +8443,9 @@ msgstr "更多{kindLower}主题"
 msgid "More actions"
 msgstr "更多操作"
 
+msgid "More options"
+msgstr "更多选项"
+
 msgid "More pages"
 msgstr "更多页面"
 
@@ -8760,9 +8751,6 @@ msgstr "下一级：{nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "不错，准备好就开个PR。"
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "每晚2点，找一个小bug，修好它并提一个PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "公开"
 msgid "Public leaderboard"
 msgstr "公开排行榜"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "从智能体或CLI发布一个页面，它就会出现在这里。"
-
 msgid "Published"
 msgstr "发布时间"
 
@@ -12628,6 +12613,9 @@ msgstr "深浅以该开发者最忙的一天为基准"
 msgid "Share"
 msgstr "分享"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "分享设计和报告，让你的智能体处理反馈。"
+
 msgid "Share page"
 msgstr "分享页面"
 
@@ -13440,9 +13428,6 @@ msgstr "套件，以及共享应用组件。点击任意导入路径即可复制
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Superset与受监控的终端进程树占用的CPU总和。超过100%表示有多个CPU核心处于繁忙状态。持续偏高通常会导致界面卡顿和耗电增加。"
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "每天早上站会前总结失败的CI运行"
 
 msgid "Summary"
 msgstr "摘要"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -12614,7 +12614,7 @@ msgid "Share"
 msgstr "分享"
 
 msgid "Share designs and reports. Let your agent handle the feedback."
-msgstr "分享設計和報告，讓你的智慧體處理回饋。"
+msgstr "分享設計和報告，讓你的代理程式處理回饋。"
 
 msgid "Share page"
 msgstr "分享頁面"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -2220,9 +2220,6 @@ msgstr "自動化（{myFailedCount}個失敗）"
 msgid "Automations & event triggers"
 msgstr "自動化與事件觸發"
 
-msgid "Automations docs"
-msgstr "自動化文件"
-
 msgid "Automations, {myFailedCount} failing"
 msgstr "自動化，{myFailedCount}個失敗"
 
@@ -4248,9 +4245,6 @@ msgstr "在我的MacBook上為認證功能建立一個工作區"
 msgid "Create an account"
 msgstr "建立帳戶"
 
-msgid "Create an automation with an agent"
-msgstr "用代理程式建立自動化"
-
 msgid "Create failed: {message}"
 msgstr "建立失敗：{message}"
 
@@ -5467,9 +5461,6 @@ msgstr "每個代理程式都跑在自己的Git worktree裡，十個代理程式
 msgid "Every axis is carrying its weight for the next tier. Hold it and the tier follows."
 msgstr "每個維度都在為下一等級出力。保持住，等級自然會來。"
 
-msgid "Every Friday at 4pm, draft release notes from this week's merged PRs"
-msgstr "每週五下午4點，根據本週合併的PR起草釋出說明"
-
 msgid "Every Friday at 4pm, draft release notes from this week's merged PRs."
 msgstr "每週五下午4點，根據本週合併的PR起草釋出說明。"
 
@@ -5490,9 +5481,6 @@ msgstr "每週三上午9點，回顧本週合併的PR，更新被它們改過時
 
 msgid "Every weekday at 9am, read new GitHub issues, apply labels, and draft a first reply for my review."
 msgstr "每個工作日上午9點，閱讀新的GitHub議題，打上標籤，並起草初步回覆供我審閱。"
-
-msgid "Every weekday at 9am, triage new GitHub issues and draft replies for my review"
-msgstr "每個工作日上午9點，分類新的GitHub議題並起草回覆供我審閱"
 
 msgid "Everyone argues about whether this generalizes. That argument is the sign the level was reached."
 msgstr "所有人都在爭論這能否推廣。這場爭論本身就說明這一級別已經達到了。"
@@ -8455,6 +8443,9 @@ msgstr "更多{kindLower}主題"
 msgid "More actions"
 msgstr "更多操作"
 
+msgid "More options"
+msgstr "更多選項"
+
 msgid "More pages"
 msgstr "更多頁面"
 
@@ -8760,9 +8751,6 @@ msgstr "下一級：{nextLabel}"
 
 msgid "Nice, open a PR when ready."
 msgstr "不錯，準備好就開個PR。"
-
-msgid "Nightly at 2am, find one small bug, fix it, and open a PR"
-msgstr "每晚2點，找一個小bug，修好它並提一個PR"
 
 #. placeholder {0}: AGENT_LABELS[agent]
 msgid "No {0} logins on this host — sign in and usage appears here."
@@ -10883,9 +10871,6 @@ msgstr "公開"
 msgid "Public leaderboard"
 msgstr "公開排行榜"
 
-msgid "Publish a page from an agent or the CLI and it will show up here."
-msgstr "從代理程式或CLI釋出一個頁面，它就會出現在這裡。"
-
 msgid "Published"
 msgstr "發布時間"
 
@@ -12628,6 +12613,9 @@ msgstr "深淺以該開發者最忙的一天為基準"
 msgid "Share"
 msgstr "分享"
 
+msgid "Share designs and reports. Let your agent handle the feedback."
+msgstr "分享設計和報告，讓你的智慧體處理回饋。"
+
 msgid "Share page"
 msgstr "分享頁面"
 
@@ -13440,9 +13428,6 @@ msgstr "套件，以及共享應用元件。點選任意匯入路徑即可複製
 
 msgid "Sum of CPU used by Superset and monitored terminal process trees. Over 100% means multiple CPU cores are busy. Sustained high values usually cause UI sluggishness and higher battery drain."
 msgstr "Superset與受監控的終端處理程序樹佔用的CPU總和。超過100%表示有多個CPU核心處於繁忙狀態。持續偏高通常會導致介面卡頓和耗電增加。"
-
-msgid "Summarize failed CI runs every morning before standup"
-msgstr "每天早上站會前總結失敗的CI執行"
 
 msgid "Summary"
 msgstr "摘要"


### PR DESCRIPTION
## What & why

Pages now offers a Create with AI action that opens an agent workspace with explicit instructions to load the Pages skill, check CLI authentication, publish a real page, and verify comment watching. Add a Pages guide and an in-app documentation link, and simplify the Pages and Automations headers and empty states with clearer primary and manual actions. Includes translations for all 17 supported locales.

Related: [SUPER-2187 — Pages need onboarding](https://linear.app/superset-sh/issue/SUPER-2187/pages-need-onboarding).

## How I tested it

- Desktop typecheck, targeted Biome checks, `bun run check:i18n`, docs MDX generation, and `git diff --check` passed.
- Verified real desktop navigation, Create with AI workspace launch, and Automations manual creation. Removed the test automation afterward.
- A fresh agent launch visibly loaded `superset:page` and passed CLI support and authentication checks.
- [Before/after screenshots and walkthrough in Superset Pages](https://app.superset.sh/page/pages-create-with-ai-design-preview-l4czdr). First-use empty states are explicitly labeled fixtures; the launch screenshots are actual app behavior.

**Remaining verification:** dev publishing fails with `Unable to connect` because `R2_ENDPOINT` targets `localhost:9000` and no storage service is listening. Desktop and CLI use separate auth stores; the dev CLI login was repaired locally. The skill works in dev, but the publish → comment → agent update round trip still needs verification with working storage. The evidence page was published separately using the working production CLI; it does not prove the dev flow completed.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (targeted lint and desktop typecheck passed; full monorepo checks not run)
- [x] "Allow edits from maintainers" is checked on fork PRs (same-repository branch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Pages onboarding with a Create with AI action and simplifies the Pages and Automations headers and empty states. Related: [SUPER-2187](https://linear.app/superset-sh/issue/SUPER-2187/pages-need-onboarding).

- Create with AI opens an agent workspace seeded to load the Pages skill, check CLI authentication, publish a page, and verify comment watching.
- Adds a Pages guide to the docs and links it from the Pages header.
- Pages and Automations headers now use a shared `FeatureHeader` with Create with AI as the primary action and manual creation behind a dropdown.
- Empty states now offer Create with AI plus a manual action instead of rotating placeholder text.
- Updates translations in all 17 locales.

<sup>Written for commit ac6c37f011f2254fc775f17363def7efcb0be67c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Superset Pages documentation covering sharing, commenting, versioning, CLI publishing, and MCP support.
  - Added agent-assisted page creation with loading states and readiness checks.
  - Added manual and AI-assisted creation actions to page and automation empty states.
  - Added reusable headers with documentation links and creation actions.

- **UI Improvements**
  - Refined automation template cards and empty-state layouts.
  - Updated page controls based on organization state and active filters.

- **Documentation**
  - Added Pages to product navigation, overview content, and skills guidance.

- **Localization**
  - Added translations for new sharing and menu actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->