### PR TITLE
fix(mobile): stop leaking iOS internals into error alerts, and retry the blip behind them

### DIFF
--- a/apps/mobile/hooks/useDeleteWorkspace/useDeleteWorkspace.ts
+++ b/apps/mobile/hooks/useDeleteWorkspace/useDeleteWorkspace.ts
@@ -7,7 +7,7 @@ import {
 	getHostWorkspacesQueryKey,
 	type HostWorkspaceRow,
 } from "@/hooks/useHostWorkspaces";
-import { captureError, errorCopy, isTransportError } from "@/lib/errors";
+import { errorCopy, isTransportError } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { isTrpcErrorWithData } from "@/lib/host-service/errors";
 
@@ -128,7 +128,6 @@ export function useDeleteWorkspace() {
 					const rows = await client.workspace.list.query().catch(() => null);
 					if (rows && !rows.some((row) => row.id === target.id)) return;
 					void queryClient.invalidateQueries({ queryKey: listKey });
-					captureError(error, "workspace.delete");
 					Alert.alert(
 						t({
 							message: "Delete failed",

--- a/apps/mobile/hooks/useDeleteWorkspace/useDeleteWorkspace.ts
+++ b/apps/mobile/hooks/useDeleteWorkspace/useDeleteWorkspace.ts
@@ -7,6 +7,7 @@ import {
 	getHostWorkspacesQueryKey,
 	type HostWorkspaceRow,
 } from "@/hooks/useHostWorkspaces";
+import { captureError, errorCopy, isTransportError } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { isTrpcErrorWithData } from "@/lib/host-service/errors";
 
@@ -127,6 +128,7 @@ export function useDeleteWorkspace() {
 					const rows = await client.workspace.list.query().catch(() => null);
 					if (rows && !rows.some((row) => row.id === target.id)) return;
 					void queryClient.invalidateQueries({ queryKey: listKey });
+					captureError(error, "workspace.delete");
 					Alert.alert(
 						t({
 							message: "Delete failed",
@@ -184,5 +186,8 @@ function failureDetail(error: unknown): string | undefined {
 	) {
 		return undefined;
 	}
-	return error instanceof Error ? error.message : undefined;
+	// A transport failure is silent here for the same reason: the fresh list
+	// above answered, so a dropped connection is not what stopped the delete.
+	if (isTransportError(error)) return undefined;
+	return errorCopy(error);
 }

--- a/apps/mobile/lib/auth/client.ts
+++ b/apps/mobile/lib/auth/client.ts
@@ -8,6 +8,7 @@ import {
 import { createAuthClient } from "better-auth/react";
 import * as SecureStore from "expo-secure-store";
 import { env } from "../env";
+import { transportFetch } from "../errors";
 
 let jwt: string | null = null;
 
@@ -41,6 +42,9 @@ export const authClient = createAuthClient({
 		jwtClient(),
 	],
 	fetchOptions: {
+		// So a dropped connection during sign-in is classifiable rather than
+		// an opaque Expo exception string on the screen.
+		customFetchImpl: transportFetch,
 		onResponse: (context) => {
 			const token = context.response.headers.get("set-auth-jwt");
 			if (token) {

--- a/apps/mobile/lib/errors/errors.ts
+++ b/apps/mobile/lib/errors/errors.ts
@@ -3,90 +3,62 @@ import { msg } from "@lingui/core/macro";
 import * as Sentry from "@sentry/react-native";
 import { i18n } from "@superset/i18n";
 import { errorMessage, rawErrorMessage } from "@superset/i18n/errors";
+import { TRPCClientError } from "@trpc/client";
+import * as Network from "expo-network";
 import { Alert } from "react-native";
+import { TransportError } from "./transport-fetch";
 
 /**
- * A failure that happened in transport: the request never reached a server, or
- * the answer never came back. The outcome is therefore unknown — the work may
- * have completed anyway.
+ * A failure that never got a server response, so the outcome is unknown — the
+ * work may have completed anyway.
  */
-export type TransportFailureKind =
-	| "connection-lost"
-	| "timed-out"
-	| "offline"
-	| "unreachable";
+export type TransportFailureKind = "offline" | "unreachable";
 
 /**
- * Expo's fetch prefixes every rejection with `fetch failed: ` (expo/src/winter/
- * fetch/FetchErrors.ts); React Native's XHR-backed fetch says `Network request
- * failed`. Both mean the same thing and neither is localized, so this is the
- * definition of "transport failure" — not the description text below.
+ * Latest reachability, kept current by a listener so the classifier can stay
+ * synchronous. Started at import like the PostHog client's super properties:
+ * the first failure can arrive before any provider effect has run.
+ *
+ * `isInternetReachable` is tri-state — undefined means "not determined yet",
+ * and only an explicit false is offline.
  */
-const TRANSPORT_SIGNATURE = /fetch failed:|network request failed/;
-
-/**
- * Refines the kind. iOS hands Expo an NSError and `UnexpectedException` keeps
- * only its `localizedDescription` (expo-modules-core/ios/Core/Exceptions/
- * UnexpectedException.swift), so the NSURLError code — -1005, -1001, -1009 —
- * does not survive into JavaScript and the kind has to be read off the text.
- * iOS localizes that text, so a non-English device falls through to
- * `unreachable`; its copy has to stand on its own for that reason.
- */
-const KIND_SIGNATURES: readonly [TransportFailureKind, RegExp][] = [
-	// -1009 NSURLErrorNotConnectedToInternet
-	["offline", /internet connection appears to be offline/],
-	// -1001 NSURLErrorTimedOut
-	["timed-out", /request timed out/],
-	// -1005 NSURLErrorNetworkConnectionLost
-	["connection-lost", /network connection was lost/],
-];
-
-/**
- * An internal frame that must never reach a user: `(at ExpoModulesCore/
- * Promise.swift:56)`, a bare exception class name, a bundler path. Applied as
- * a backstop to messages this module would otherwise pass through, so a leak
- * shape nobody has seen yet still degrades to the generic copy.
- */
-const INTERNAL_FRAME = /\(at [^\s)]+:\d+\)|ExpoModulesCore|[A-Z]\w*Exception:/;
-
-const TRANSPORT_COPY: Record<TransportFailureKind, MessageDescriptor> = {
-	"connection-lost": msg({ message: "The connection dropped." }),
-	"timed-out": msg({ message: "The request timed out." }),
-	offline: msg({ message: "No internet connection." }),
-	unreachable: msg({ message: "Could not reach the server." }),
-};
-
-// Deliberately the same message id `errorMessage()` already falls back to, so
-// it is translated in every catalog rather than adding a near-duplicate.
-const GENERIC = msg({ message: "Something went wrong. Please try again." });
-
-/** Every message in the `cause` chain, lowercased, for signature matching. */
-function chainText(error: unknown): string {
-	const seen = new Set<unknown>();
-	const parts: string[] = [];
-	let current: unknown = error;
-	while (current && !seen.has(current)) {
-		seen.add(current);
-		parts.push(rawErrorMessage(current));
-		current = (current as { cause?: unknown }).cause;
-	}
-	return parts.join(" ").toLowerCase();
-}
+let deviceOffline = false;
+Network.addNetworkStateListener((state) => {
+	deviceOffline = state.isInternetReachable === false;
+});
+void Network.getNetworkStateAsync()
+	.then((state) => {
+		deviceOffline = state.isInternetReachable === false;
+	})
+	.catch(() => {
+		// Reachability is a refinement, not a gate: without it every transport
+		// failure simply reads as "could not reach the server".
+	});
 
 /**
  * The transport failure behind an error, or null when the server did answer
- * and the error is its own. Callers that distinguish "this definitely failed"
- * from "we never found out" branch on null.
+ * and the error is its own.
+ *
+ * tRPC only populates `data` from a parsed error envelope, so its absence
+ * means the transport failed rather than the server refusing. That is the
+ * whole check — the same predicate the desktop's host-service links use
+ * (`isConnectionError` in packages/workspace-client/src/lib/hostServiceLinks).
+ *
+ * It has to be structural, because iOS tells us nothing else. Expo rejects a
+ * failed fetch with URLSession's raw NSError (ExpoFetchModule.swift), and
+ * `Promise.reject` wraps any non-Exception in `UnexpectedException`, which
+ * keeps only `localizedDescription` (expo-modules-core Promise.swift:57). The
+ * NSURLError code — -1005, -1001, -1009 — never reaches JavaScript, and the
+ * description that does is localized by iOS. There is nothing there to read.
  */
 export function transportFailureKind(
 	error: unknown,
 ): TransportFailureKind | null {
-	const text = chainText(error);
-	if (!TRANSPORT_SIGNATURE.test(text)) return null;
-	for (const [kind, signature] of KIND_SIGNATURES) {
-		if (signature.test(text)) return kind;
-	}
-	return "unreachable";
+	const transport =
+		error instanceof TransportError ||
+		(error instanceof TRPCClientError && error.data == null);
+	if (!transport) return null;
+	return deviceOffline ? "offline" : "unreachable";
 }
 
 /** Whether the outcome of the request is unknown rather than known-failed. */
@@ -95,17 +67,37 @@ export function isTransportError(error: unknown): boolean {
 }
 
 /**
+ * An error thrown by an Expo native module rather than by our server. Its
+ * message is the Swift exception's debugDescription — "UnexpectedException:
+ * … (at ExpoModulesCore/Promise.swift:56)" — which is a diagnostic, never
+ * user copy. Every Expo exception carries an `ERR_*` code (see
+ * `errorCodeFromString` in expo-modules-core CodedError.swift), so one is
+ * identifiable without reading the message.
+ */
+function isExpoNativeError(error: unknown): boolean {
+	const code = (error as { code?: unknown } | null | undefined)?.code;
+	return typeof code === "string" && code.startsWith("ERR_");
+}
+
+const TRANSPORT_COPY: Record<TransportFailureKind, MessageDescriptor> = {
+	offline: msg({ message: "No internet connection." }),
+	unreachable: msg({ message: "Could not reach the server." }),
+};
+
+// Deliberately the same message id `errorMessage()` already falls back to, so
+// it is translated in every catalog rather than adding a near-duplicate.
+const GENERIC = msg({ message: "Something went wrong. Please try again." });
+
+/**
  * What to show a user for a caught error. A transport failure becomes plain
  * copy; anything else keeps the server's own message, which is usually the
  * useful part (GitHub's reason for refusing a merge, a host's refusal to
- * delete). Never an Expo or Swift frame either way.
+ * delete).
  */
 export function errorCopy(error: unknown): string {
 	const kind = transportFailureKind(error);
 	if (kind) return i18n._(TRANSPORT_COPY[kind]);
-	// Matched on the raw message, never on errorMessage() output: that is
-	// display-only and potentially translated (AGENTS.md, packages/i18n).
-	if (INTERNAL_FRAME.test(rawErrorMessage(error))) return i18n._(GENERIC);
+	if (isExpoNativeError(error)) return i18n._(GENERIC);
 	return errorMessage(error);
 }
 

--- a/apps/mobile/lib/errors/errors.ts
+++ b/apps/mobile/lib/errors/errors.ts
@@ -1,11 +1,9 @@
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
-import * as Sentry from "@sentry/react-native";
 import { i18n } from "@superset/i18n";
-import { errorMessage, rawErrorMessage } from "@superset/i18n/errors";
+import { errorMessage } from "@superset/i18n/errors";
 import { TRPCClientError } from "@trpc/client";
 import * as Network from "expo-network";
-import { Alert } from "react-native";
 import { TransportError } from "./transport-fetch";
 
 /**
@@ -14,26 +12,27 @@ import { TransportError } from "./transport-fetch";
  */
 export type TransportFailureKind = "offline" | "unreachable";
 
-/**
- * Latest reachability, kept current by a listener so the classifier can stay
- * synchronous. Started at import like the PostHog client's super properties:
- * the first failure can arrive before any provider effect has run.
- *
- * `isInternetReachable` is tri-state — undefined means "not determined yet",
- * and only an explicit false is offline.
- */
 let deviceOffline = false;
-Network.addNetworkStateListener((state) => {
-	deviceOffline = state.isInternetReachable === false;
-});
-void Network.getNetworkStateAsync()
-	.then((state) => {
+
+/**
+ * Start tracking reachability, so the classifier can answer synchronously at
+ * the moment an alert is built. Call once at startup, beside `initI18n` — this
+ * is a refinement, not a gate: without it every transport failure simply reads
+ * as "could not reach the server".
+ *
+ * `isInternetReachable` is tri-state; undefined means "not determined yet", so
+ * only an explicit false counts as offline.
+ */
+export function watchNetworkState(): void {
+	Network.addNetworkStateListener((state) => {
 		deviceOffline = state.isInternetReachable === false;
-	})
-	.catch(() => {
-		// Reachability is a refinement, not a gate: without it every transport
-		// failure simply reads as "could not reach the server".
 	});
+	void Network.getNetworkStateAsync()
+		.then((state) => {
+			deviceOffline = state.isInternetReachable === false;
+		})
+		.catch(() => {});
+}
 
 /**
  * The transport failure behind an error, or null when the server did answer
@@ -99,41 +98,4 @@ export function errorCopy(error: unknown): string {
 	if (kind) return i18n._(TRANSPORT_COPY[kind]);
 	if (isExpoNativeError(error)) return i18n._(GENERIC);
 	return errorMessage(error);
-}
-
-/**
- * Route a caught error to diagnostics. Always the raw error, never
- * `errorCopy()` — logs and Sentry grouping need stable English.
- *
- * A transport failure is a breadcrumb rather than an event: a phone losing its
- * connection is not a bug, and the volume is exactly what exhausted the Sentry
- * quota in August. It still rides along on whatever is captured next.
- */
-export function captureError(error: unknown, scope: string): void {
-	console.error(`[${scope}]`, error);
-	const kind = transportFailureKind(error);
-	if (kind) {
-		Sentry.addBreadcrumb({
-			category: "transport",
-			level: "warning",
-			message: `${scope}: ${kind}`,
-			data: { raw: rawErrorMessage(error) },
-		});
-		return;
-	}
-	Sentry.captureException(error, { tags: { scope } });
-}
-
-/**
- * The one way to tell a user an action failed: a translated title, a body that
- * is safe to show, and the real error sent to diagnostics. `scope` names the
- * action for Sentry — `"workspace.create"`, `"terminal.send"`.
- */
-export function alertError(
-	title: MessageDescriptor,
-	error: unknown,
-	scope: string,
-): void {
-	captureError(error, scope);
-	Alert.alert(i18n._(title), errorCopy(error));
 }

--- a/apps/mobile/lib/errors/errors.ts
+++ b/apps/mobile/lib/errors/errors.ts
@@ -1,0 +1,147 @@
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import * as Sentry from "@sentry/react-native";
+import { i18n } from "@superset/i18n";
+import { errorMessage, rawErrorMessage } from "@superset/i18n/errors";
+import { Alert } from "react-native";
+
+/**
+ * A failure that happened in transport: the request never reached a server, or
+ * the answer never came back. The outcome is therefore unknown — the work may
+ * have completed anyway.
+ */
+export type TransportFailureKind =
+	| "connection-lost"
+	| "timed-out"
+	| "offline"
+	| "unreachable";
+
+/**
+ * Expo's fetch prefixes every rejection with `fetch failed: ` (expo/src/winter/
+ * fetch/FetchErrors.ts); React Native's XHR-backed fetch says `Network request
+ * failed`. Both mean the same thing and neither is localized, so this is the
+ * definition of "transport failure" — not the description text below.
+ */
+const TRANSPORT_SIGNATURE = /fetch failed:|network request failed/;
+
+/**
+ * Refines the kind. iOS hands Expo an NSError and `UnexpectedException` keeps
+ * only its `localizedDescription` (expo-modules-core/ios/Core/Exceptions/
+ * UnexpectedException.swift), so the NSURLError code — -1005, -1001, -1009 —
+ * does not survive into JavaScript and the kind has to be read off the text.
+ * iOS localizes that text, so a non-English device falls through to
+ * `unreachable`; its copy has to stand on its own for that reason.
+ */
+const KIND_SIGNATURES: readonly [TransportFailureKind, RegExp][] = [
+	// -1009 NSURLErrorNotConnectedToInternet
+	["offline", /internet connection appears to be offline/],
+	// -1001 NSURLErrorTimedOut
+	["timed-out", /request timed out/],
+	// -1005 NSURLErrorNetworkConnectionLost
+	["connection-lost", /network connection was lost/],
+];
+
+/**
+ * An internal frame that must never reach a user: `(at ExpoModulesCore/
+ * Promise.swift:56)`, a bare exception class name, a bundler path. Applied as
+ * a backstop to messages this module would otherwise pass through, so a leak
+ * shape nobody has seen yet still degrades to the generic copy.
+ */
+const INTERNAL_FRAME = /\(at [^\s)]+:\d+\)|ExpoModulesCore|[A-Z]\w*Exception:/;
+
+const TRANSPORT_COPY: Record<TransportFailureKind, MessageDescriptor> = {
+	"connection-lost": msg({ message: "The connection dropped." }),
+	"timed-out": msg({ message: "The request timed out." }),
+	offline: msg({ message: "No internet connection." }),
+	unreachable: msg({ message: "Could not reach the server." }),
+};
+
+// Deliberately the same message id `errorMessage()` already falls back to, so
+// it is translated in every catalog rather than adding a near-duplicate.
+const GENERIC = msg({ message: "Something went wrong. Please try again." });
+
+/** Every message in the `cause` chain, lowercased, for signature matching. */
+function chainText(error: unknown): string {
+	const seen = new Set<unknown>();
+	const parts: string[] = [];
+	let current: unknown = error;
+	while (current && !seen.has(current)) {
+		seen.add(current);
+		parts.push(rawErrorMessage(current));
+		current = (current as { cause?: unknown }).cause;
+	}
+	return parts.join(" ").toLowerCase();
+}
+
+/**
+ * The transport failure behind an error, or null when the server did answer
+ * and the error is its own. Callers that distinguish "this definitely failed"
+ * from "we never found out" branch on null.
+ */
+export function transportFailureKind(
+	error: unknown,
+): TransportFailureKind | null {
+	const text = chainText(error);
+	if (!TRANSPORT_SIGNATURE.test(text)) return null;
+	for (const [kind, signature] of KIND_SIGNATURES) {
+		if (signature.test(text)) return kind;
+	}
+	return "unreachable";
+}
+
+/** Whether the outcome of the request is unknown rather than known-failed. */
+export function isTransportError(error: unknown): boolean {
+	return transportFailureKind(error) !== null;
+}
+
+/**
+ * What to show a user for a caught error. A transport failure becomes plain
+ * copy; anything else keeps the server's own message, which is usually the
+ * useful part (GitHub's reason for refusing a merge, a host's refusal to
+ * delete). Never an Expo or Swift frame either way.
+ */
+export function errorCopy(error: unknown): string {
+	const kind = transportFailureKind(error);
+	if (kind) return i18n._(TRANSPORT_COPY[kind]);
+	// Matched on the raw message, never on errorMessage() output: that is
+	// display-only and potentially translated (AGENTS.md, packages/i18n).
+	if (INTERNAL_FRAME.test(rawErrorMessage(error))) return i18n._(GENERIC);
+	return errorMessage(error);
+}
+
+/**
+ * Route a caught error to diagnostics. Always the raw error, never
+ * `errorCopy()` — logs and Sentry grouping need stable English.
+ *
+ * A transport failure is a breadcrumb rather than an event: a phone losing its
+ * connection is not a bug, and the volume is exactly what exhausted the Sentry
+ * quota in August. It still rides along on whatever is captured next.
+ */
+export function captureError(error: unknown, scope: string): void {
+	console.error(`[${scope}]`, error);
+	const kind = transportFailureKind(error);
+	if (kind) {
+		Sentry.addBreadcrumb({
+			category: "transport",
+			level: "warning",
+			message: `${scope}: ${kind}`,
+			data: { raw: rawErrorMessage(error) },
+		});
+		return;
+	}
+	Sentry.captureException(error, { tags: { scope } });
+}
+
+/**
+ * The one way to tell a user an action failed: a translated title, a body that
+ * is safe to show, and the real error sent to diagnostics. `scope` names the
+ * action for Sentry — `"workspace.create"`, `"terminal.send"`.
+ */
+export function alertError(
+	title: MessageDescriptor,
+	error: unknown,
+	scope: string,
+): void {
+	captureError(error, scope);
+	Alert.alert(i18n._(title), errorCopy(error));
+}

--- a/apps/mobile/lib/errors/index.ts
+++ b/apps/mobile/lib/errors/index.ts
@@ -6,3 +6,4 @@ export {
 	type TransportFailureKind,
 	transportFailureKind,
 } from "./errors";
+export { TransportError, transportFetch } from "./transport-fetch";

--- a/apps/mobile/lib/errors/index.ts
+++ b/apps/mobile/lib/errors/index.ts
@@ -1,9 +1,9 @@
 export {
-	alertError,
-	captureError,
 	errorCopy,
 	isTransportError,
 	type TransportFailureKind,
 	transportFailureKind,
+	watchNetworkState,
 } from "./errors";
 export { TransportError, transportFetch } from "./transport-fetch";
+export { transportRetryLink } from "./transport-retry";

--- a/apps/mobile/lib/errors/index.ts
+++ b/apps/mobile/lib/errors/index.ts
@@ -1,0 +1,8 @@
+export {
+	alertError,
+	captureError,
+	errorCopy,
+	isTransportError,
+	type TransportFailureKind,
+	transportFailureKind,
+} from "./errors";

--- a/apps/mobile/lib/errors/transport-fetch.ts
+++ b/apps/mobile/lib/errors/transport-fetch.ts
@@ -1,0 +1,30 @@
+import { rawErrorMessage } from "@superset/i18n/errors";
+
+/**
+ * A request that never got a server response.
+ *
+ * tRPC reports this itself — a `TRPCClientError` with no `data` — so its
+ * clients need nothing here. better-auth's fetch rejects with whatever the
+ * platform threw, which on iOS is Expo's opaque `UnexpectedException`, so its
+ * failures are wrapped instead. The `catch` is around our own `fetch` call,
+ * which makes the classification structural: transport by construction, not
+ * by inspecting a message.
+ */
+export class TransportError extends Error {
+	constructor(cause: unknown) {
+		// Carry the platform's text for logs and Sentry grouping. It is never
+		// displayed — `errorCopy()` answers from the kind instead.
+		super(rawErrorMessage(cause) || "transport failure");
+		this.name = "TransportError";
+		this.cause = cause;
+	}
+}
+
+/** `fetch`, with every rejection normalized to a `TransportError`. */
+export const transportFetch: typeof fetch = async (input, init) => {
+	try {
+		return await fetch(input, init);
+	} catch (cause) {
+		throw new TransportError(cause);
+	}
+};

--- a/apps/mobile/lib/errors/transport-retry.ts
+++ b/apps/mobile/lib/errors/transport-retry.ts
@@ -1,0 +1,21 @@
+import { retryLink } from "@trpc/client";
+import { isTransportError } from "./errors";
+
+/**
+ * Retry a request that never reached the server, once.
+ *
+ * iOS drops pooled HTTPS connections that have gone idle, and Apple's guidance
+ * for the -1005 that produces is to retry rather than surface it (QA1941). A
+ * phone in a pocket hits this on the first tap after every idle stretch.
+ *
+ * Queries only. A mutation is not safe to replay: `workspaces.create` picks a
+ * fresh friendly-random branch when the caller supplies none, and dedupes on
+ * the branch rather than on the client-minted id, so a replayed create lands a
+ * second workspace instead of resolving to the first.
+ */
+export function transportRetryLink() {
+	return retryLink({
+		retry: ({ op, error, attempts }) =>
+			attempts === 1 && op.type === "query" && isTransportError(error),
+	});
+}

--- a/apps/mobile/lib/host-service/client.ts
+++ b/apps/mobile/lib/host-service/client.ts
@@ -2,16 +2,11 @@
 // moves to a neutral package — see packages/host-service/docs/interim-router-types.md
 import type { AppRouter } from "@superset/host-service/router";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import {
-	createTRPCClient,
-	httpLink,
-	retryLink,
-	type TRPCClient,
-} from "@trpc/client";
+import { createTRPCClient, httpLink, type TRPCClient } from "@trpc/client";
 import type { inferRouterOutputs } from "@trpc/server";
 import superjson from "superjson";
 import { getJwt } from "../auth/client";
-import { isTransportError } from "../errors";
+import { transportRetryLink } from "../errors";
 import { getRelayUrl } from "../host/client";
 import { getSandboxAccess, sandboxPreviewToken } from "../sandbox-access";
 
@@ -54,20 +49,7 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 
 	const client = createTRPCClient<AppRouter>({
 		links: [
-			// iOS drops pooled HTTPS connections that have gone idle, and
-			// Apple's guidance for the -1005 that produces is to retry rather
-			// than surface it (QA1941). A phone in a pocket hits this on the
-			// first tap after every idle stretch.
-			//
-			// Queries only. A mutation is not safe to replay here: when the
-			// caller does not supply a branch, `workspaces.create` picks a
-			// fresh friendly-random name per call and dedupes on the branch,
-			// not on the client-minted id — so a replayed create would land a
-			// second workspace instead of resolving to the first.
-			retryLink({
-				retry: ({ op, error, attempts }) =>
-					attempts === 1 && op.type === "query" && isTransportError(error),
-			}),
+			transportRetryLink(),
 			httpLink({
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,

--- a/apps/mobile/lib/host-service/client.ts
+++ b/apps/mobile/lib/host-service/client.ts
@@ -2,10 +2,16 @@
 // moves to a neutral package — see packages/host-service/docs/interim-router-types.md
 import type { AppRouter } from "@superset/host-service/router";
 import { buildHostRoutingKey } from "@superset/shared/host-routing";
-import { createTRPCClient, httpLink, type TRPCClient } from "@trpc/client";
+import {
+	createTRPCClient,
+	httpLink,
+	retryLink,
+	type TRPCClient,
+} from "@trpc/client";
 import type { inferRouterOutputs } from "@trpc/server";
 import superjson from "superjson";
 import { getJwt } from "../auth/client";
+import { isTransportError } from "../errors";
 import { getRelayUrl } from "../host/client";
 import { getSandboxAccess, sandboxPreviewToken } from "../sandbox-access";
 
@@ -48,6 +54,20 @@ export function getHostServiceClientByUrl(hostUrl: string): HostServiceClient {
 
 	const client = createTRPCClient<AppRouter>({
 		links: [
+			// iOS drops pooled HTTPS connections that have gone idle, and
+			// Apple's guidance for the -1005 that produces is to retry rather
+			// than surface it (QA1941). A phone in a pocket hits this on the
+			// first tap after every idle stretch.
+			//
+			// Queries only. A mutation is not safe to replay here: when the
+			// caller does not supply a branch, `workspaces.create` picks a
+			// fresh friendly-random name per call and dedupes on the branch,
+			// not on the client-minted id — so a replayed create would land a
+			// second workspace instead of resolving to the first.
+			retryLink({
+				retry: ({ op, error, attempts }) =>
+					attempts === 1 && op.type === "query" && isTransportError(error),
+			}),
 			httpLink({
 				url: `${hostUrl}/trpc`,
 				transformer: superjson,

--- a/apps/mobile/lib/sentry/sentry.ts
+++ b/apps/mobile/lib/sentry/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react-native";
 import { env } from "../env";
+import { isTransportError } from "../errors";
 
 export function initSentry() {
 	if (!env.EXPO_PUBLIC_SENTRY_DSN_MOBILE || env.NODE_ENV !== "production") {
@@ -11,5 +12,11 @@ export function initSentry() {
 		replaysSessionSampleRate: 0,
 		replaysOnErrorSampleRate: 0,
 		sendDefaultPii: false,
+		// A phone losing its connection is not a bug, and the volume of it is
+		// what exhausted the quota in August. The request itself is still on the
+		// event as a breadcrumb (breadcrumbsIntegration is on by default), so
+		// anything that does get reported still shows the drop that preceded it.
+		beforeSend: (event, hint) =>
+			isTransportError(hint?.originalException) ? null : event,
 	});
 }

--- a/apps/mobile/lib/trpc/client.ts
+++ b/apps/mobile/lib/trpc/client.ts
@@ -1,29 +1,16 @@
 import type { AppRouter } from "@superset/trpc";
-import { createTRPCProxyClient, httpBatchLink, retryLink } from "@trpc/client";
+import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 import * as Application from "expo-application";
 import superjson from "superjson";
 import { authClient, getJwt } from "../auth/client";
 import { env } from "../env";
-import { isTransportError } from "../errors";
+import { transportRetryLink } from "../errors";
 
 const clientVersionHeader = `mobile/${Application.nativeApplicationVersion ?? "0.0.0"}`;
 
 export const apiClient = createTRPCProxyClient<AppRouter>({
 	links: [
-		// iOS drops pooled HTTPS connections that have gone idle, and
-		// Apple's guidance for the -1005 that produces is to retry rather
-		// than surface it (QA1941). A phone in a pocket hits this on the
-		// first tap after every idle stretch.
-		//
-		// Queries only. A mutation is not safe to replay here: when the
-		// caller does not supply a branch, `workspaces.create` picks a
-		// fresh friendly-random name per call and dedupes on the branch,
-		// not on the client-minted id — so a replayed create would land a
-		// second workspace instead of resolving to the first.
-		retryLink({
-			retry: ({ op, error, attempts }) =>
-				attempts === 1 && op.type === "query" && isTransportError(error),
-		}),
+		transportRetryLink(),
 		httpBatchLink({
 			url: `${env.EXPO_PUBLIC_API_URL}/api/trpc`,
 			headers() {

--- a/apps/mobile/lib/trpc/client.ts
+++ b/apps/mobile/lib/trpc/client.ts
@@ -1,14 +1,29 @@
 import type { AppRouter } from "@superset/trpc";
-import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
+import { createTRPCProxyClient, httpBatchLink, retryLink } from "@trpc/client";
 import * as Application from "expo-application";
 import superjson from "superjson";
 import { authClient, getJwt } from "../auth/client";
 import { env } from "../env";
+import { isTransportError } from "../errors";
 
 const clientVersionHeader = `mobile/${Application.nativeApplicationVersion ?? "0.0.0"}`;
 
 export const apiClient = createTRPCProxyClient<AppRouter>({
 	links: [
+		// iOS drops pooled HTTPS connections that have gone idle, and
+		// Apple's guidance for the -1005 that produces is to retry rather
+		// than surface it (QA1941). A phone in a pocket hits this on the
+		// first tap after every idle stretch.
+		//
+		// Queries only. A mutation is not safe to replay here: when the
+		// caller does not supply a branch, `workspaces.create` picks a
+		// fresh friendly-random name per call and dedupes on the branch,
+		// not on the client-minted id — so a replayed create would land a
+		// second workspace instead of resolving to the first.
+		retryLink({
+			retry: ({ op, error, attempts }) =>
+				attempts === 1 && op.type === "query" && isTransportError(error),
+		}),
 		httpBatchLink({
 			url: `${env.EXPO_PUBLIC_API_URL}/api/trpc`,
 			headers() {

--- a/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
@@ -7,7 +7,7 @@ import { Image, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { signIn } from "@/lib/auth/client";
 import { env } from "@/lib/env";
-import { captureError, errorCopy } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import { openUrl } from "@/lib/open-url";
 
 import { DevSignInOptions } from "./components/DevSignInOptions";
@@ -29,7 +29,7 @@ export function SignInScreen() {
 				callbackURL: "/",
 			});
 		} catch (err) {
-			captureError(err, "sign-in.social");
+			console.error("[sign-in] Error:", err);
 			setError(errorCopy(err));
 		}
 	};
@@ -78,7 +78,7 @@ export function SignInScreen() {
 			) {
 				return;
 			}
-			captureError(err, "sign-in.apple");
+			console.error("[sign-in] Apple error:", err);
 			setError(errorCopy(err));
 		}
 	};

--- a/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/SignInScreen.tsx
@@ -1,4 +1,4 @@
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Trans } from "@lingui/react/macro";
 import * as AppleAuthentication from "expo-apple-authentication";
 import * as Crypto from "expo-crypto";
 import { useState } from "react";
@@ -7,6 +7,7 @@ import { Image, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { signIn } from "@/lib/auth/client";
 import { env } from "@/lib/env";
+import { captureError, errorCopy } from "@/lib/errors";
 import { openUrl } from "@/lib/open-url";
 
 import { DevSignInOptions } from "./components/DevSignInOptions";
@@ -18,7 +19,6 @@ const TERMS_URL = "https://superset.sh/terms";
 const PRIVACY_URL = "https://superset.sh/privacy";
 
 export function SignInScreen() {
-	const { t } = useLingui();
 	const [error, setError] = useState<string | null>(null);
 
 	const handleSignIn = async (provider: SocialProvider) => {
@@ -29,14 +29,8 @@ export function SignInScreen() {
 				callbackURL: "/",
 			});
 		} catch (err) {
-			const message =
-				err instanceof Error
-					? err.message
-					: t({
-							message: "Something went wrong",
-						});
-			console.error("[sign-in] Error:", err);
-			setError(message);
+			captureError(err, "sign-in.social");
+			setError(errorCopy(err));
 		}
 	};
 
@@ -84,14 +78,8 @@ export function SignInScreen() {
 			) {
 				return;
 			}
-			const message =
-				err instanceof Error
-					? err.message
-					: t({
-							message: "Something went wrong",
-						});
-			console.error("[sign-in] Apple error:", err);
-			setError(message);
+			captureError(err, "sign-in.apple");
+			setError(errorCopy(err));
 		}
 	};
 

--- a/apps/mobile/screens/(auth)/sign-in/components/DevSignInOptions/DevSignInOptions.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/components/DevSignInOptions/DevSignInOptions.tsx
@@ -5,7 +5,7 @@ import { View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { signIn, signUp } from "@/lib/auth/client";
-import { captureError, errorCopy } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 
 const DEV_EMAIL = "admin@local.test";
 const DEV_PASSWORD = "supersetdev";
@@ -46,7 +46,7 @@ export function DevSignInOptions() {
 				throw new Error(res.error.message);
 			}
 		} catch (err) {
-			captureError(err, "sign-in.dev");
+			console.error("[dev-sign-in] Error:", err);
 			setError(errorCopy(err));
 		} finally {
 			setIsLoading(false);

--- a/apps/mobile/screens/(auth)/sign-in/components/DevSignInOptions/DevSignInOptions.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/components/DevSignInOptions/DevSignInOptions.tsx
@@ -5,6 +5,7 @@ import { View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { signIn, signUp } from "@/lib/auth/client";
+import { captureError, errorCopy } from "@/lib/errors";
 
 const DEV_EMAIL = "admin@local.test";
 const DEV_PASSWORD = "supersetdev";
@@ -45,14 +46,8 @@ export function DevSignInOptions() {
 				throw new Error(res.error.message);
 			}
 		} catch (err) {
-			const message =
-				err instanceof Error
-					? err.message
-					: t({
-							message: "Something went wrong",
-						});
-			console.error("[dev-sign-in] Error:", err);
-			setError(message);
+			captureError(err, "sign-in.dev");
+			setError(errorCopy(err));
 		} finally {
 			setIsLoading(false);
 		}

--- a/apps/mobile/screens/(auth)/sign-in/components/EmailSignInLink/EmailSignInLink.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/components/EmailSignInLink/EmailSignInLink.tsx
@@ -3,6 +3,7 @@ import { prompt } from "@superset/alert-prompt";
 import { useState } from "react";
 import { Text } from "@/components/ui/text";
 import { signIn } from "@/lib/auth/client";
+import { captureError, errorCopy } from "@/lib/errors";
 
 /** Quiet credential sign-in for accounts with a password set (App Store
  * review demo account; sign-up stays disabled in production). */
@@ -42,14 +43,8 @@ export function EmailSignInLink({
 			const res = await signIn.email({ email, password });
 			if (res.error) throw new Error(res.error.message);
 		} catch (err) {
-			console.error("[sign-in] Email error:", err);
-			onError(
-				err instanceof Error
-					? err.message
-					: t({
-							message: "Something went wrong",
-						}),
-			);
+			captureError(err, "sign-in.email");
+			onError(errorCopy(err));
 		} finally {
 			setIsLoading(false);
 		}

--- a/apps/mobile/screens/(auth)/sign-in/components/EmailSignInLink/EmailSignInLink.tsx
+++ b/apps/mobile/screens/(auth)/sign-in/components/EmailSignInLink/EmailSignInLink.tsx
@@ -3,7 +3,7 @@ import { prompt } from "@superset/alert-prompt";
 import { useState } from "react";
 import { Text } from "@/components/ui/text";
 import { signIn } from "@/lib/auth/client";
-import { captureError, errorCopy } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 
 /** Quiet credential sign-in for accounts with a password set (App Store
  * review demo account; sign-up stays disabled in production). */
@@ -43,7 +43,7 @@ export function EmailSignInLink({
 			const res = await signIn.email({ email, password });
 			if (res.error) throw new Error(res.error.message);
 		} catch (err) {
-			captureError(err, "sign-in.email");
+			console.error("[sign-in] Email error:", err);
 			onError(errorCopy(err));
 		} finally {
 			setIsLoading(false);

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
@@ -1,11 +1,13 @@
 import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
+import { Alert } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { CloudWorkspaceRow } from "@/hooks/useCloudWorkspaces";
 import { getCloudWorkspacesQueryKey } from "@/hooks/useCloudWorkspaces";
 import { useSession } from "@/lib/auth/client";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import { posthog } from "@/lib/posthog";
 import { apiClient } from "@/lib/trpc/client";
 
@@ -102,12 +104,13 @@ export function useCreateCloudWorkspace() {
 				source: "mobile_composer",
 				base_branch: branch,
 			});
-			alertError(
-				msg({
-					message: "Could not create cloud workspace",
-				}),
-				error,
-				"cloud-workspace.create",
+			Alert.alert(
+				i18n._(
+					msg({
+						message: "Could not create cloud workspace",
+					}),
+				),
+				errorCopy(error),
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
@@ -1,12 +1,11 @@
 import { msg } from "@lingui/core/macro";
-import { i18n } from "@superset/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { Alert } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { CloudWorkspaceRow } from "@/hooks/useCloudWorkspaces";
 import { getCloudWorkspacesQueryKey } from "@/hooks/useCloudWorkspaces";
 import { useSession } from "@/lib/auth/client";
+import { alertError } from "@/lib/errors";
 import { posthog } from "@/lib/posthog";
 import { apiClient } from "@/lib/trpc/client";
 
@@ -103,13 +102,12 @@ export function useCreateCloudWorkspace() {
 				source: "mobile_composer",
 				base_branch: branch,
 			});
-			Alert.alert(
-				i18n._(
-					msg({
-						message: "Could not create cloud workspace",
-					}),
-				),
-				error instanceof Error ? error.message : String(error),
+			alertError(
+				msg({
+					message: "Could not create cloud workspace",
+				}),
+				error,
+				"cloud-workspace.create",
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useCreateCloudWorkspace/useCreateCloudWorkspace.ts
@@ -7,7 +7,7 @@ import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { CloudWorkspaceRow } from "@/hooks/useCloudWorkspaces";
 import { getCloudWorkspacesQueryKey } from "@/hooks/useCloudWorkspaces";
 import { useSession } from "@/lib/auth/client";
-import { errorCopy } from "@/lib/errors";
+import { errorCopy, transportFailureKind } from "@/lib/errors";
 import { posthog } from "@/lib/posthog";
 import { apiClient } from "@/lib/trpc/client";
 
@@ -103,6 +103,8 @@ export function useCreateCloudWorkspace() {
 				host_kind: "cloud",
 				source: "mobile_composer",
 				base_branch: branch,
+				// Stable English, never the display copy below.
+				failure_kind: transportFailureKind(error) ?? "server",
 			});
 			Alert.alert(
 				i18n._(

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useStartWorkspaceTerminal/useStartWorkspaceTerminal.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useStartWorkspaceTerminal/useStartWorkspaceTerminal.ts
@@ -1,9 +1,11 @@
 import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
+import { Alert } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -94,12 +96,13 @@ export function useStartWorkspaceTerminal(workspaces: HostWorkspaceItem[]) {
 				workspace_id: target.workspaceId,
 				result: "failed",
 			});
-			alertError(
-				msg({
-					message: "Could not start agent",
-				}),
-				error,
-				"agent.start",
+			Alert.alert(
+				i18n._(
+					msg({
+						message: "Could not start agent",
+					}),
+				),
+				errorCopy(error),
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useStartWorkspaceTerminal/useStartWorkspaceTerminal.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/hooks/useStartWorkspaceTerminal/useStartWorkspaceTerminal.ts
@@ -1,10 +1,9 @@
 import { msg } from "@lingui/core/macro";
-import { i18n } from "@superset/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { Alert } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -95,13 +94,12 @@ export function useStartWorkspaceTerminal(workspaces: HostWorkspaceItem[]) {
 				workspace_id: target.workspaceId,
 				result: "failed",
 			});
-			Alert.alert(
-				i18n._(
-					msg({
-						message: "Could not start agent",
-					}),
-				),
-				error instanceof Error ? error.message : String(error),
+			alertError(
+				msg({
+					message: "Could not start agent",
+				}),
+				error,
+				"agent.start",
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "expo-crypto";
 import { File } from "expo-file-system";
 import { useRouter } from "expo-router";
 import { getHostWorkspacesQueryKey } from "@/hooks/useHostWorkspaces";
+import { captureError, errorCopy, transportFailureKind } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { posthog } from "@/lib/posthog";
 import { getHostTerminalsQueryKey } from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
@@ -124,13 +125,21 @@ export function useCreateTerminalWorkspace() {
 				});
 				return { workspaceId };
 			} catch (error) {
-				const failureReason =
-					error instanceof Error ? error.message : String(error);
-				failPending(workspaceId, failureReason);
+				captureError(error, "workspace.create");
+				// A transport failure proves nothing about the worktree: the
+				// relay's 30s cap can reject a create the host went on to
+				// finish. Say so rather than asserting a failure.
+				const kind = transportFailureKind(error);
+				failPending(workspaceId, {
+					outcome: kind ? "unknown" : "failed",
+					message: errorCopy(error),
+				});
 				posthog.capture("workspace_create_failed", {
 					project_id: target.projectId,
 					host_kind: "remote",
 					source: "mobile_composer",
+					// Stable English, never the display copy above.
+					failure_kind: kind ?? "server",
 				});
 				throw error;
 			}

--- a/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "expo-crypto";
 import { File } from "expo-file-system";
 import { useRouter } from "expo-router";
 import { getHostWorkspacesQueryKey } from "@/hooks/useHostWorkspaces";
-import { captureError, errorCopy, transportFailureKind } from "@/lib/errors";
+import { errorCopy, transportFailureKind } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { posthog } from "@/lib/posthog";
 import { getHostTerminalsQueryKey } from "@/screens/(authenticated)/(home)/home/hooks/useHostTerminals";
@@ -125,7 +125,6 @@ export function useCreateTerminalWorkspace() {
 				});
 				return { workspaceId };
 			} catch (error) {
-				captureError(error, "workspace.create");
 				// A transport failure proves nothing about the worktree: the
 				// relay's 30s cap can reject a create the host went on to
 				// finish. Say so rather than asserting a failure.

--- a/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
+++ b/apps/mobile/screens/(authenticated)/hooks/useCreateTerminalWorkspace/useCreateTerminalWorkspace.ts
@@ -62,6 +62,10 @@ export function useCreateTerminalWorkspace() {
 			if (replace) router.replace(href);
 			else router.push(href);
 
+			// Attachments upload before the create is sent, so a failure there
+			// proves the workspace was never requested — only a failure at or
+			// after the create itself leaves the outcome unknown.
+			let createRequested = false;
 			try {
 				const client = getHostServiceClientByUrl(target.hostUrl);
 				const attachmentIds = await Promise.all(
@@ -93,6 +97,7 @@ export function useCreateTerminalWorkspace() {
 				};
 
 				try {
+					createRequested = true;
 					await client.workspaces.createEnqueued.mutate(createInput);
 				} catch (error) {
 					if (!isMissingProcedureError(error)) throw error;
@@ -130,7 +135,7 @@ export function useCreateTerminalWorkspace() {
 				// finish. Say so rather than asserting a failure.
 				const kind = transportFailureKind(error);
 				failPending(workspaceId, {
-					outcome: kind ? "unknown" : "failed",
+					outcome: kind && createRequested ? "unknown" : "failed",
 					message: errorCopy(error),
 				});
 				posthog.capture("workspace_create_failed", {

--- a/apps/mobile/screens/(authenticated)/stores/pendingWorkspaceCreatesStore/index.ts
+++ b/apps/mobile/screens/(authenticated)/stores/pendingWorkspaceCreatesStore/index.ts
@@ -1,5 +1,6 @@
 export {
 	type PendingWorkspaceCreate,
+	type PendingWorkspaceCreateFailure,
 	type PendingWorkspaceCreateInput,
 	usePendingWorkspaceCreatesStore,
 } from "./pendingWorkspaceCreatesStore";

--- a/apps/mobile/screens/(authenticated)/stores/pendingWorkspaceCreatesStore/pendingWorkspaceCreatesStore.ts
+++ b/apps/mobile/screens/(authenticated)/stores/pendingWorkspaceCreatesStore/pendingWorkspaceCreatesStore.ts
@@ -29,6 +29,19 @@ export interface PendingWorkspaceCreateInput {
 	message: PromptInputMessage;
 }
 
+/**
+ * Why a create stopped short of a row. `unknown` is the honest answer to a
+ * failure in transport: the request never got an answer, so the host may have
+ * finished the worktree anyway. The workspace screen keeps polling either way
+ * and heals itself if the row turns up, so the distinction is only about what
+ * the user is told and what the retry button does.
+ */
+export interface PendingWorkspaceCreateFailure {
+	outcome: "failed" | "unknown";
+	/** Display copy — already mapped and safe to show. */
+	message: string;
+}
+
 export interface PendingWorkspaceCreate {
 	workspaceId: string;
 	/** Host machineId — keys the host-scoped query invalidations. */
@@ -37,13 +50,13 @@ export interface PendingWorkspaceCreate {
 	startedAt: number;
 	input: PendingWorkspaceCreateInput;
 	/** Set on failure — the workspace screen swaps to the failed state. */
-	error: string | null;
+	failure: PendingWorkspaceCreateFailure | null;
 }
 
 interface PendingWorkspaceCreatesStore {
 	pendingById: Record<string, PendingWorkspaceCreate>;
-	start: (entry: Omit<PendingWorkspaceCreate, "error">) => void;
-	fail: (workspaceId: string, error: string) => void;
+	start: (entry: Omit<PendingWorkspaceCreate, "failure">) => void;
+	fail: (workspaceId: string, failure: PendingWorkspaceCreateFailure) => void;
 	clear: (workspaceId: string) => void;
 }
 
@@ -61,17 +74,17 @@ export const usePendingWorkspaceCreatesStore =
 			set((state) => ({
 				pendingById: {
 					...state.pendingById,
-					[entry.workspaceId]: { ...entry, error: null },
+					[entry.workspaceId]: { ...entry, failure: null },
 				},
 			})),
-		fail: (workspaceId, error) =>
+		fail: (workspaceId, failure) =>
 			set((state) => {
 				const entry = state.pendingById[workspaceId];
 				if (!entry) return state;
 				return {
 					pendingById: {
 						...state.pendingById,
-						[workspaceId]: { ...entry, error },
+						[workspaceId]: { ...entry, failure },
 					},
 				};
 			}),

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -7,7 +7,6 @@ import type {
 	ComposerSessionTab,
 } from "@superset/composer";
 import { i18n } from "@superset/i18n";
-import { errorMessage } from "@superset/i18n/errors";
 import { useQueryClient } from "@tanstack/react-query";
 import * as Clipboard from "expo-clipboard";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
@@ -31,6 +30,7 @@ import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { getHostWorkspacesQueryKey } from "@/hooks/useHostWorkspaces";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -169,11 +169,14 @@ export function WorkspaceScreen() {
 		(state) => state.fail,
 	);
 	const createWorkspace = useCreateTerminalWorkspace();
+	// Latches while an unproven failure is being checked against the host, so
+	// a second tap cannot start the duplicate the check exists to prevent.
+	const [retryingCreate, setRetryingCreate] = useState(false);
 	const isCreating =
-		!!pendingCreate && !pendingCreate.error && rows.length === 0;
+		!!pendingCreate && !pendingCreate.failure && rows.length === 0;
 	const workspaceResolved = workspace !== null;
 	const createFailed =
-		!!pendingCreate?.error && !workspaceResolved && rows.length === 0;
+		!!pendingCreate?.failure && !workspaceResolved && rows.length === 0;
 
 	// Poll through the failed state too: a relay timeout can reject a create
 	// the host actually finished, and the row arriving is what heals it.
@@ -196,7 +199,7 @@ export function WorkspaceScreen() {
 
 	// The launched session arrived — the create is done for this screen.
 	useEffect(() => {
-		if (pendingCreate && !pendingCreate.error && rows.length > 0) {
+		if (pendingCreate && !pendingCreate.failure && rows.length > 0) {
 			clearPendingCreate(pendingCreate.workspaceId);
 		}
 	}, [pendingCreate, rows.length, clearPendingCreate]);
@@ -205,7 +208,7 @@ export function WorkspaceScreen() {
 	// synchronous create that timed out at the relay while the host finished
 	// anyway) — the real workspace wins over the failed state.
 	useEffect(() => {
-		if (pendingCreate?.error && workspaceResolved) {
+		if (pendingCreate?.failure && workspaceResolved) {
 			clearPendingCreate(pendingCreate.workspaceId);
 		}
 	}, [pendingCreate, workspaceResolved, clearPendingCreate]);
@@ -213,19 +216,19 @@ export function WorkspaceScreen() {
 	// No row within the backstop: the create died host-side and there is no
 	// event channel to say so. Resolve to the failed state rather than spin.
 	useEffect(() => {
-		if (!pendingCreate || pendingCreate.error || workspaceResolved) return;
+		if (!pendingCreate || pendingCreate.failure || workspaceResolved) return;
 		const workspaceId = pendingCreate.workspaceId;
 		const remaining = Math.max(
 			0,
 			pendingCreate.startedAt + PENDING_CREATE_ROW_TIMEOUT_MS - Date.now(),
 		);
 		const timer = setTimeout(() => {
-			failPendingCreate(
-				workspaceId,
-				t({
-					message: "Timed out waiting for the host to create the workspace.",
-				}),
-			);
+			// The backstop only means the host has not answered inside the
+			// window — it may still be working, so the outcome is unknown.
+			failPendingCreate(workspaceId, {
+				outcome: "unknown",
+				message: t({ message: "The host hasn't answered." }),
+			});
 		}, remaining);
 		return () => clearTimeout(timer);
 	}, [pendingCreate, workspaceResolved, failPendingCreate, t]);
@@ -233,7 +236,7 @@ export function WorkspaceScreen() {
 	// Row landed but no session followed (agent failed to launch): fall
 	// through to the regular empty state instead of spinning.
 	useEffect(() => {
-		if (!pendingCreate || pendingCreate.error || !workspaceResolved) return;
+		if (!pendingCreate || pendingCreate.failure || !workspaceResolved) return;
 		const workspaceId = pendingCreate.workspaceId;
 		const timer = setTimeout(
 			() => clearPendingCreate(workspaceId),
@@ -244,11 +247,39 @@ export function WorkspaceScreen() {
 
 	// Retry mints a fresh id and re-enters Creating via replace, so back
 	// never returns to the dead failed state (desktop's `replace: true`).
-	const retryCreate = useCallback(() => {
-		if (!pendingCreate) return;
-		clearPendingCreate(pendingCreate.workspaceId);
-		createWorkspace.mutate({ ...pendingCreate.input, replace: true });
-	}, [pendingCreate, clearPendingCreate, createWorkspace]);
+	//
+	// A fresh id is also why an unproven failure has to be checked first: if
+	// the host finished the create the relay gave up on, retrying would leave
+	// the user with two worktrees and no way to tell which is which. Ask the
+	// host directly rather than trusting the poll to have landed yet.
+	const retryCreate = useCallback(async () => {
+		if (!pendingCreate || retryingCreate) return;
+		const { workspaceId, hostId, hostUrl, input, failure } = pendingCreate;
+		if (failure?.outcome === "unknown") {
+			setRetryingCreate(true);
+			const rows = await getHostServiceClientByUrl(hostUrl)
+				.workspace.list.query()
+				.catch(() => null);
+			setRetryingCreate(false);
+			if (rows?.some((row) => row.id === workspaceId)) {
+				// It landed after all — the poll's invalidation resolves the
+				// screen onto the real workspace.
+				clearPendingCreate(workspaceId);
+				void queryClient.invalidateQueries({
+					queryKey: getHostWorkspacesQueryKey(hostId, hostUrl),
+				});
+				return;
+			}
+		}
+		clearPendingCreate(workspaceId);
+		createWorkspace.mutate({ ...input, replace: true });
+	}, [
+		pendingCreate,
+		retryingCreate,
+		clearPendingCreate,
+		createWorkspace,
+		queryClient,
+	]);
 
 	const dismissFailedCreate = useCallback(() => {
 		if (pendingCreate) clearPendingCreate(pendingCreate.workspaceId);
@@ -390,16 +421,17 @@ export function WorkspaceScreen() {
 				// long-press only; the strip now offers it on every selected tab and
 				// in the press-and-hold menu, so silence is no longer affordable.
 				.catch((cause: unknown) =>
-					Alert.alert(
-						t({
+					alertError(
+						msg({
 							message: "Could not close the session",
 						}),
-						errorMessage(cause),
+						cause,
+						"terminal.kill",
 					),
 				)
 				.finally(invalidateTerminals);
 		},
-		[workspace, hostUrl, invalidateTerminals, t],
+		[workspace, hostUrl, invalidateTerminals],
 	);
 
 	// The composer reports the intent and stops there: it has no idea that
@@ -630,12 +662,13 @@ export function WorkspaceScreen() {
 						}),
 					}}
 				/>
-				{createFailed ? (
+				{createFailed && pendingCreate.failure ? (
 					<WorkspaceCreateFailedState
 						subtitle={subtitle}
-						errorMessage={pendingCreate.error ?? ""}
+						failure={pendingCreate.failure}
+						checking={retryingCreate}
 						prompt={pendingCreate.input.message.text.trim()}
-						onRetry={retryCreate}
+						onRetry={() => void retryCreate()}
 						onDismiss={dismissFailedCreate}
 					/>
 				) : (

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -30,7 +30,7 @@ import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { getHostWorkspacesQueryKey } from "@/hooks/useHostWorkspaces";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -421,17 +421,16 @@ export function WorkspaceScreen() {
 				// long-press only; the strip now offers it on every selected tab and
 				// in the press-and-hold menu, so silence is no longer affordable.
 				.catch((cause: unknown) =>
-					alertError(
-						msg({
+					Alert.alert(
+						t({
 							message: "Could not close the session",
 						}),
-						cause,
-						"terminal.kill",
+						errorCopy(cause),
 					),
 				)
 				.finally(invalidateTerminals);
 		},
-		[workspace, hostUrl, invalidateTerminals],
+		[workspace, hostUrl, invalidateTerminals, t],
 	);
 
 	// The composer reports the intent and stops there: it has no idea that

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -172,6 +172,15 @@ export function WorkspaceScreen() {
 	// Latches while an unproven failure is being checked against the host, so
 	// a second tap cannot start the duplicate the check exists to prevent.
 	const [retryingCreate, setRetryingCreate] = useState(false);
+	// A back-swipe unmounts this screen without clearing the pending entry, so
+	// the check needs its own liveness signal before it acts on the answer.
+	const screenLive = useRef(true);
+	useEffect(() => {
+		screenLive.current = true;
+		return () => {
+			screenLive.current = false;
+		};
+	}, []);
 	const isCreating =
 		!!pendingCreate && !pendingCreate.failure && rows.length === 0;
 	const workspaceResolved = workspace !== null;
@@ -261,7 +270,26 @@ export function WorkspaceScreen() {
 				.workspace.list.query()
 				.catch(() => null);
 			setRetryingCreate(false);
-			if (rows?.some((row) => row.id === workspaceId)) {
+			// The screen moved on while we were asking — the user left, or the
+			// poll resolved it. Creating now would land a workspace nobody is
+			// waiting on.
+			if (
+				!screenLive.current ||
+				!usePendingWorkspaceCreatesStore.getState().pendingById[workspaceId]
+			) {
+				return;
+			}
+			if (rows === null) {
+				// The host did not answer either, so the first create is still
+				// unproven. Creating on a guess is the one thing this check
+				// exists to prevent.
+				failPendingCreate(workspaceId, {
+					outcome: "unknown",
+					message: t({ message: "Still can't reach the host." }),
+				});
+				return;
+			}
+			if (rows.some((row) => row.id === workspaceId)) {
 				// It landed after all — the poll's invalidation resolves the
 				// screen onto the real workspace.
 				clearPendingCreate(workspaceId);
@@ -277,8 +305,10 @@ export function WorkspaceScreen() {
 		pendingCreate,
 		retryingCreate,
 		clearPendingCreate,
+		failPendingCreate,
 		createWorkspace,
 		queryClient,
+		t,
 	]);
 
 	const dismissFailedCreate = useCallback(() => {

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/components/WorkspaceCreateFailedState/WorkspaceCreateFailedState.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/components/WorkspaceCreateFailedState/WorkspaceCreateFailedState.tsx
@@ -81,6 +81,7 @@ export function WorkspaceCreateFailedState({
 				<Button
 					variant={unproven ? "default" : "secondary"}
 					size="sm"
+					disabled={checking}
 					onPress={onDismiss}
 				>
 					<Text>

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/components/WorkspaceCreateFailedState/WorkspaceCreateFailedState.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/components/WorkspaceCreateFailedState/WorkspaceCreateFailedState.tsx
@@ -1,42 +1,58 @@
 import { Trans } from "@lingui/react/macro";
 import { CircleAlert } from "lucide-react-native";
-import { View } from "react-native";
+import { ActivityIndicator, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
+import type { PendingWorkspaceCreateFailure } from "@/screens/(authenticated)/stores/pendingWorkspaceCreatesStore";
 
 export function WorkspaceCreateFailedState({
 	subtitle,
-	errorMessage,
+	failure,
+	checking,
 	prompt,
 	onRetry,
 	onDismiss,
 }: {
 	/** `projectName · branchLabel` — the two things the user chose. */
 	subtitle: string;
-	errorMessage: string;
+	failure: PendingWorkspaceCreateFailure;
+	/** Asking the host whether an unproven create landed after all. */
+	checking: boolean;
 	/** First line shown in the chip; retry re-sends it verbatim. */
 	prompt: string;
 	onRetry: () => void;
 	onDismiss: () => void;
 }) {
+	// An unproven failure gets the softer heading and the quieter button: the
+	// worktree may exist, and creating a second one is the expensive mistake.
+	const unproven = failure.outcome === "unknown";
 	return (
 		<View className="flex-1 items-center justify-center px-8">
 			<View className="border-red-500 size-9 items-center justify-center rounded-full border-[1.5px]">
 				<CircleAlert size={18} color="#ef4444" strokeWidth={2} />
 			</View>
 			<Text className="mt-3.5 font-semibold text-[17px]">
-				<Trans>Couldn't create workspace</Trans>
+				{unproven ? (
+					<Trans>Didn't hear back</Trans>
+				) : (
+					<Trans>Couldn't create workspace</Trans>
+				)}
 			</Text>
 			<Text className="text-muted-foreground mt-1.5 font-mono text-xs">
 				{subtitle}
 			</Text>
 			<View className="border-red-500/25 bg-red-500/5 mt-6 self-stretch rounded-lg border px-3.5 py-3">
-				<Text
-					selectable
-					className="text-red-500/90 font-mono text-[11px] leading-4"
-				>
-					{errorMessage}
+				<Text className="text-red-500/90 text-xs leading-4">
+					{failure.message}
 				</Text>
+				{unproven ? (
+					<Text className="text-muted-foreground mt-1.5 text-xs leading-4">
+						<Trans>
+							The workspace may still have been created. This screen opens it if
+							it appears.
+						</Trans>
+					</Text>
+				) : null}
 			</View>
 			{prompt ? (
 				<View className="bg-secondary/40 border-border mt-3.5 flex-row items-center gap-2 self-stretch rounded-lg border px-3 py-2.5">
@@ -51,17 +67,27 @@ export function WorkspaceCreateFailedState({
 					</Text>
 				</View>
 			) : null}
-			<View className="mt-6 flex-row gap-2.5">
-				<Button size="sm" onPress={onRetry}>
+			<View className="mt-6 flex-row items-center gap-2.5">
+				<Button
+					size="sm"
+					variant={unproven ? "secondary" : "default"}
+					disabled={checking}
+					onPress={onRetry}
+				>
 					<Text>
-						<Trans>Try again</Trans>
+						{unproven ? <Trans>Create again</Trans> : <Trans>Try again</Trans>}
 					</Text>
 				</Button>
-				<Button variant="secondary" size="sm" onPress={onDismiss}>
+				<Button
+					variant={unproven ? "default" : "secondary"}
+					size="sm"
+					onPress={onDismiss}
+				>
 					<Text>
 						<Trans>Back to Home</Trans>
 					</Text>
 				</Button>
+				{checking ? <ActivityIndicator size="small" /> : null}
 			</View>
 		</View>
 	);

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
@@ -1,3 +1,4 @@
+import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	Composer,
@@ -11,6 +12,7 @@ import type { SlashCommand } from "@superset/shared/slash-commands";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 import { Alert, View } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
+import { alertError } from "@/lib/errors";
 import { posthog } from "@/lib/posthog";
 import { useAttachmentsSheet } from "@/screens/(authenticated)/hooks/useAttachmentsSheet";
 import { useComposerDraft } from "@/screens/(authenticated)/hooks/useComposerDraft";
@@ -205,10 +207,7 @@ export const TerminalComposer = forwardRef<
 			if (allowAttachments) draft.clear();
 			else draft.setText("");
 		} catch (cause) {
-			Alert.alert(
-				t({ message: "Could not send" }),
-				cause instanceof Error ? cause.message : String(cause),
-			);
+			alertError(msg({ message: "Could not send" }), cause, "terminal.send");
 		} finally {
 			setIsSubmitting(false);
 		}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
@@ -1,4 +1,3 @@
-import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import {
 	Composer,
@@ -12,7 +11,7 @@ import type { SlashCommand } from "@superset/shared/slash-commands";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 import { Alert, View } from "react-native";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import { posthog } from "@/lib/posthog";
 import { useAttachmentsSheet } from "@/screens/(authenticated)/hooks/useAttachmentsSheet";
 import { useComposerDraft } from "@/screens/(authenticated)/hooks/useComposerDraft";
@@ -207,7 +206,7 @@ export const TerminalComposer = forwardRef<
 			if (allowAttachments) draft.clear();
 			else draft.setText("");
 		} catch (cause) {
-			alertError(msg({ message: "Could not send" }), cause, "terminal.send");
+			Alert.alert(t({ message: "Could not send" }), errorCopy(cause));
 		} finally {
 			setIsSubmitting(false);
 		}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/hooks/useWriteTerminalAttachments/useWriteTerminalAttachments.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/hooks/useWriteTerminalAttachments/useWriteTerminalAttachments.ts
@@ -1,12 +1,14 @@
 import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
 import {
 	assignAttachmentFileName,
 	WORKSPACE_ATTACHMENTS_DIR,
 } from "@superset/shared/workspace-attachments";
 import { useMutation } from "@tanstack/react-query";
 import { File } from "expo-file-system";
+import { Alert } from "react-native";
 import type { PromptInputAttachmentItem } from "@/components/ai-elements/prompt-input";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 
 export interface TerminalAttachmentTarget {
@@ -70,12 +72,13 @@ export function useWriteTerminalAttachments() {
 			return paths;
 		},
 		onError: (error) => {
-			alertError(
-				msg({
-					message: "Could not attach files",
-				}),
-				error,
-				"terminal.attachments",
+			Alert.alert(
+				i18n._(
+					msg({
+						message: "Could not attach files",
+					}),
+				),
+				errorCopy(error),
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/hooks/useWriteTerminalAttachments/useWriteTerminalAttachments.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/hooks/useWriteTerminalAttachments/useWriteTerminalAttachments.ts
@@ -1,13 +1,12 @@
 import { msg } from "@lingui/core/macro";
-import { i18n } from "@superset/i18n";
 import {
 	assignAttachmentFileName,
 	WORKSPACE_ATTACHMENTS_DIR,
 } from "@superset/shared/workspace-attachments";
 import { useMutation } from "@tanstack/react-query";
 import { File } from "expo-file-system";
-import { Alert } from "react-native";
 import type { PromptInputAttachmentItem } from "@/components/ai-elements/prompt-input";
+import { alertError } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 
 export interface TerminalAttachmentTarget {
@@ -71,13 +70,12 @@ export function useWriteTerminalAttachments() {
 			return paths;
 		},
 		onError: (error) => {
-			Alert.alert(
-				i18n._(
-					msg({
-						message: "Could not attach files",
-					}),
-				),
-				error instanceof Error ? error.message : String(error),
+			alertError(
+				msg({
+					message: "Could not attach files",
+				}),
+				error,
+				"terminal.attachments",
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/files-changed/FilesChangedScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/files-changed/FilesChangedScreen.tsx
@@ -1,4 +1,3 @@
-import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { FlashList, type FlashListRef } from "@shopify/flash-list";
 import { formatNumber } from "@superset/i18n/format";
@@ -23,7 +22,7 @@ import { tokenizeCode } from "@/components/ai-elements/code-block";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { posthog } from "@/lib/posthog";
 import {
@@ -421,12 +420,11 @@ export function FilesChangedScreen() {
 							})
 							.then(() => changeset.refetch())
 							.catch((cause: unknown) => {
-								alertError(
-									msg({
+								Alert.alert(
+									t({
 										message: "Could not delete file",
 									}),
-									cause,
-									"file.delete",
+									errorCopy(cause),
 								);
 							});
 					},

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/files-changed/FilesChangedScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/files-changed/FilesChangedScreen.tsx
@@ -1,3 +1,4 @@
+import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { FlashList, type FlashListRef } from "@shopify/flash-list";
 import { formatNumber } from "@superset/i18n/format";
@@ -22,6 +23,7 @@ import { tokenizeCode } from "@/components/ai-elements/code-block";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import { getHostServiceClientByUrl } from "@/lib/host-service/client";
 import { posthog } from "@/lib/posthog";
 import {
@@ -419,11 +421,12 @@ export function FilesChangedScreen() {
 							})
 							.then(() => changeset.refetch())
 							.catch((cause: unknown) => {
-								Alert.alert(
-									t({
+								alertError(
+									msg({
 										message: "Could not delete file",
 									}),
-									cause instanceof Error ? cause.message : String(cause),
+									cause,
+									"file.delete",
 								);
 							});
 					},

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
@@ -1,13 +1,12 @@
-import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { useQueryClient } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
-import { ScrollView, TextInput, View } from "react-native";
+import { Alert, ScrollView, TextInput, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -137,12 +136,11 @@ export function FinishReviewSheet() {
 			router.back();
 			router.push(`/(authenticated)/workspace/${workspaceId}?tab=${target}`);
 		} catch (cause) {
-			alertError(
-				msg({
+			Alert.alert(
+				t({
 					message: "Could not send review",
 				}),
-				cause,
-				"review.send",
+				errorCopy(cause),
 			);
 		} finally {
 			setSending(false);

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/finish-review/FinishReviewSheet.tsx
@@ -1,11 +1,13 @@
+import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { useQueryClient } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
-import { Alert, ScrollView, TextInput, View } from "react-native";
+import { ScrollView, TextInput, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import type { HostWorkspaceItem } from "@/hooks/useHostWorkspaces";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -135,11 +137,12 @@ export function FinishReviewSheet() {
 			router.back();
 			router.push(`/(authenticated)/workspace/${workspaceId}?tab=${target}`);
 		} catch (cause) {
-			Alert.alert(
-				t({
+			alertError(
+				msg({
 					message: "Could not send review",
 				}),
-				cause instanceof Error ? cause.message : String(cause),
+				cause,
+				"review.send",
 			);
 		} finally {
 			setSending(false);

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
@@ -1,13 +1,15 @@
+import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useQueryClient } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { SquareTerminal } from "lucide-react-native";
 import { useState } from "react";
-import { ActivityIndicator, Alert, ScrollView, View } from "react-native";
+import { ActivityIndicator, ScrollView, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -121,11 +123,12 @@ export function NewSessionSheet() {
 			);
 		} catch (error) {
 			setLaunchingKey(null);
-			Alert.alert(
-				t({
+			alertError(
+				msg({
 					message: "Could not start session",
 				}),
-				error instanceof Error ? error.message : String(error),
+				error,
+				"session.start",
 			);
 		}
 	};

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/new-session/NewSessionSheet.tsx
@@ -1,15 +1,14 @@
-import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useQueryClient } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { SquareTerminal } from "lucide-react-native";
 import { useState } from "react";
-import { ActivityIndicator, ScrollView, View } from "react-native";
+import { ActivityIndicator, Alert, ScrollView, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useTheme } from "@/hooks/useTheme";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -123,12 +122,11 @@ export function NewSessionSheet() {
 			);
 		} catch (error) {
 			setLaunchingKey(null);
-			alertError(
-				msg({
+			Alert.alert(
+				t({
 					message: "Could not start session",
 				}),
-				error,
-				"session.start",
+				errorCopy(error),
 			);
 		}
 	};

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
@@ -1,9 +1,11 @@
 import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useState } from "react";
+import { Alert } from "react-native";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -71,12 +73,13 @@ export function useAskAgent({ workspaceId }: { workspaceId: string | null }) {
 			);
 		},
 		onError: (error: Error) => {
-			alertError(
-				msg({
-					message: "Could not start agent",
-				}),
-				error,
-				"pull-request.ask-agent",
+			Alert.alert(
+				i18n._(
+					msg({
+						message: "Could not start agent",
+					}),
+				),
+				errorCopy(error),
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useAskAgent/useAskAgent.ts
@@ -1,10 +1,9 @@
 import { msg } from "@lingui/core/macro";
-import { i18n } from "@superset/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useState } from "react";
-import { Alert } from "react-native";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -72,13 +71,12 @@ export function useAskAgent({ workspaceId }: { workspaceId: string | null }) {
 			);
 		},
 		onError: (error: Error) => {
-			Alert.alert(
-				i18n._(
-					msg({
-						message: "Could not start agent",
-					}),
-				),
-				error.message,
+			alertError(
+				msg({
+					message: "Could not start agent",
+				}),
+				error,
+				"pull-request.ask-agent",
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useMergePullRequest/useMergePullRequest.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useMergePullRequest/useMergePullRequest.ts
@@ -4,7 +4,7 @@ import { useLingui } from "@lingui/react/macro";
 import { useMutation } from "@tanstack/react-query";
 import { Alert } from "react-native";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -67,12 +67,11 @@ export function useMergePullRequest({
 		},
 		onSuccess: onMerged,
 		onError: (error: Error) => {
-			alertError(
-				msg({
+			Alert.alert(
+				t({
 					message: "GitHub refused the merge",
 				}),
-				error,
-				"pull-request.merge",
+				errorCopy(error),
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useMergePullRequest/useMergePullRequest.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/useMergePullRequest/useMergePullRequest.ts
@@ -4,6 +4,7 @@ import { useLingui } from "@lingui/react/macro";
 import { useMutation } from "@tanstack/react-query";
 import { Alert } from "react-native";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -66,11 +67,12 @@ export function useMergePullRequest({
 		},
 		onSuccess: onMerged,
 		onError: (error: Error) => {
-			Alert.alert(
-				t({
+			alertError(
+				msg({
 					message: "GitHub refused the merge",
 				}),
-				error.message,
+				error,
+				"pull-request.merge",
 			);
 		},
 	});

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/usePullRequestActions/usePullRequestActions.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/usePullRequestActions/usePullRequestActions.ts
@@ -1,9 +1,11 @@
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
+import { i18n } from "@superset/i18n";
 import { useMutation } from "@tanstack/react-query";
 import { useRef } from "react";
+import { Alert } from "react-native";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -71,7 +73,7 @@ export function usePullRequestActions({
 		},
 		onSuccess: onDone,
 		onError: (error: Error, action) => {
-			alertError(REFUSED_TITLE[action], error, `pull-request.${action}`);
+			Alert.alert(i18n._(REFUSED_TITLE[action]), errorCopy(error));
 		},
 	});
 

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/usePullRequestActions/usePullRequestActions.ts
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/pull-request/[pullRequestId]/hooks/usePullRequestActions/usePullRequestActions.ts
@@ -1,10 +1,9 @@
 import type { MessageDescriptor } from "@lingui/core";
 import { msg } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react/macro";
 import { useMutation } from "@tanstack/react-query";
 import { useRef } from "react";
-import { Alert } from "react-native";
 import { useWorkspaceHost } from "@/hooks/useWorkspaceHost";
+import { alertError } from "@/lib/errors";
 import {
 	getHostServiceClientByUrl,
 	hostServiceUrl,
@@ -45,7 +44,6 @@ export function usePullRequestActions({
 	pullNumber: number | null;
 	onDone: () => void;
 }) {
-	const { i18n } = useLingui();
 	const { host } = useWorkspaceHost(workspaceId);
 	const hostUrl =
 		host?.isOnline === true
@@ -73,7 +71,7 @@ export function usePullRequestActions({
 		},
 		onSuccess: onDone,
 		onError: (error: Error, action) => {
-			Alert.alert(i18n._(REFUSED_TITLE[action]), error.message);
+			alertError(REFUSED_TITLE[action], error, `pull-request.${action}`);
 		},
 	});
 

--- a/apps/mobile/screens/RootLayout/RootLayout.tsx
+++ b/apps/mobile/screens/RootLayout/RootLayout.tsx
@@ -13,6 +13,7 @@ import { AppState } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Uniwind } from "uniwind";
 import { useSession } from "@/lib/auth/client";
+import { watchNetworkState } from "@/lib/errors";
 import { NAV_THEME } from "@/lib/theme";
 
 Uniwind.setTheme("dark");
@@ -29,6 +30,10 @@ const deviceLocale = resolveLocale(
 	getLocales().map((locale) => locale.languageTag),
 );
 initI18n(deviceLocale);
+
+// Lets a failed request say "no internet connection" rather than the vaguer
+// "could not reach the server" — see lib/errors.
+watchNetworkState();
 
 // React Query cannot see app focus on native, so without this no query ever
 // refetches on returning to the foreground — data went stale for the whole

--- a/apps/mobile/screens/account-pending-deletion/AccountPendingDeletionScreen.tsx
+++ b/apps/mobile/screens/account-pending-deletion/AccountPendingDeletionScreen.tsx
@@ -1,13 +1,15 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
+import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import { useState } from "react";
-import { Alert, Linking, View } from "react-native";
+import { Linking, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useSignOut } from "@/hooks/useSignOut";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "@/lib/auth/client";
+import { alertError } from "@/lib/errors";
 import { apiClient } from "@/lib/trpc/client";
 import { useDaysUntilPurge } from "./hooks/useDaysUntilPurge";
 
@@ -28,16 +30,12 @@ export function AccountPendingDeletionScreen() {
 			await apiClient.user.reactivateAccount.mutate();
 			await refetch();
 		} catch (error) {
-			console.error("[account/reactivate] Failed:", error);
-			Alert.alert(
-				t({
+			alertError(
+				msg({
 					message: "Could not reactivate",
 				}),
-				error instanceof Error
-					? error.message
-					: t({
-							message: "Something went wrong.",
-						}),
+				error,
+				"account.reactivate",
 			);
 		} finally {
 			setIsReactivating(false);

--- a/apps/mobile/screens/account-pending-deletion/AccountPendingDeletionScreen.tsx
+++ b/apps/mobile/screens/account-pending-deletion/AccountPendingDeletionScreen.tsx
@@ -1,15 +1,14 @@
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { COMPANY } from "@superset/shared/constants";
 import { useState } from "react";
-import { Linking, View } from "react-native";
+import { Alert, Linking, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useSignOut } from "@/hooks/useSignOut";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "@/lib/auth/client";
-import { alertError } from "@/lib/errors";
+import { errorCopy } from "@/lib/errors";
 import { apiClient } from "@/lib/trpc/client";
 import { useDaysUntilPurge } from "./hooks/useDaysUntilPurge";
 
@@ -30,12 +29,12 @@ export function AccountPendingDeletionScreen() {
 			await apiClient.user.reactivateAccount.mutate();
 			await refetch();
 		} catch (error) {
-			alertError(
-				msg({
+			console.error("[account/reactivate] Failed:", error);
+			Alert.alert(
+				t({
 					message: "Could not reactivate",
 				}),
-				error,
-				"account.reactivate",
+				errorCopy(error),
 			);
 		} finally {
 			setIsReactivating(false);

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Krok {0} ze 2"
 msgid "Step {step}: {name}"
 msgstr "Krok {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Host je stále nedostupný."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Stále pracuji — u velkých repozitářů to může trvat pár minut. Můžete odejít; pracovní prostor se objeví na úvodní obrazovce, až bude hotový."
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Nejlepší agent se změní.<0/>Vaše workflow ne."
 msgid "The Codex sign-in"
 msgstr "Přihlášení do Codexu"
 
-msgid "The connection dropped."
-msgstr "Spojení bylo přerušeno."
-
 msgid "The connection timed out"
 msgstr "Vypršel časový limit spojení"
 
@@ -14189,9 +14186,6 @@ msgstr "Samotná složka repozitáře zůstane zachována."
 
 msgid "The request failed."
 msgstr "Požadavek selhal."
-
-msgid "The request timed out."
-msgstr "Vypršel časový limit požadavku."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Odpověď: agenti revidují agenty a lidé místo čtení všeho jen vzorkují. Důvěra se získává statisticky, ne u jednotlivého diffu."

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Nepodařilo se spojit s hostem a načíst tento pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Nepodařilo se spojit s hostitelem a zahájit aktualizaci. Zkontrolujte, že je online, a zkuste to znovu."
 
+msgid "Could not reach the server."
+msgstr "Nepodařilo se spojit se serverem."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Nepodařilo se spojit s počítačem tohoto pracovního prostoru"
 
@@ -4253,6 +4256,9 @@ msgstr "Vytvořit tým"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Vytvoř na mém MacBooku pracovní prostor pro funkci auth"
+
+msgid "Create again"
+msgstr "Vytvořit znovu"
 
 msgid "Create an account"
 msgstr "Vytvořit účet"
@@ -4878,6 +4884,9 @@ msgstr "Diktovat"
 
 msgid "Dictation is not available on this device"
 msgstr "Diktování není na tomto zařízení dostupné"
+
+msgid "Didn't hear back"
+msgstr "Bez odpovědi"
 
 msgid "diff"
 msgstr "rozdíl"
@@ -8987,6 +8996,9 @@ msgstr "Bez ikony"
 
 msgid "No Internet Connection"
 msgstr "Bez připojení k internetu"
+
+msgid "No internet connection."
+msgstr "Není připojení k internetu."
 
 msgid "No issues found."
 msgstr "Nenalezeny žádné issues."
@@ -13991,6 +14003,9 @@ msgstr "Nejlepší agent se změní.<0/>Vaše workflow ne."
 msgid "The Codex sign-in"
 msgstr "Přihlášení do Codexu"
 
+msgid "The connection dropped."
+msgstr "Spojení bylo přerušeno."
+
 msgid "The connection timed out"
 msgstr "Vypršel časový limit spojení"
 
@@ -14069,6 +14084,9 @@ msgstr "Hostitel se vrátil s verzí {0}, ne {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Hostitel se neobnovil do patnácti minut."
+
+msgid "The host hasn't answered."
+msgstr "Host neodpověděl."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Host není připojený k Superset relay. Pokud jde o toto zařízení, zapněte „Povolit vzdálený přístup k tomuto zařízení přes relay“ v Nastavení > Vzdálený přístup a zkuste to znovu."
@@ -14172,6 +14190,9 @@ msgstr "Samotná složka repozitáře zůstane zachována."
 msgid "The request failed."
 msgstr "Požadavek selhal."
 
+msgid "The request timed out."
+msgstr "Vypršel časový limit požadavku."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Odpověď: agenti revidují agenty a lidé místo čtení všeho jen vzorkují. Důvěra se získává statisticky, ne u jednotlivého diffu."
 
@@ -14235,6 +14256,9 @@ msgstr "Webové rozhraní agentů je zatím náhled jen pro čtení."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Pracovní prostor ještě není připravený. Zkuste to znovu."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Pracovní prostor mohl přesto vzniknout. Tato obrazovka ho otevře, jakmile se objeví."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Worktree a všechny necommitnuté změny budou odstraněny. Tuto akci nelze vrátit zpět."
@@ -14557,9 +14581,6 @@ msgstr "Tarif"
 
 msgid "Time range"
 msgstr "Časové období"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Vypršel čas při čekání, až host vytvoří pracovní prostor."
 
 msgid "Title"
 msgstr "Název"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Schritt {0} von 2"
 msgid "Step {step}: {name}"
 msgstr "Schritt {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Der Host ist weiterhin nicht erreichbar."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Läuft noch — große Repos können ein paar Minuten dauern. Du kannst weggehen; der Arbeitsbereich erscheint auf der Startseite, sobald er bereit ist."
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Der beste Agent wird wechseln.<0/>Dein Workflow nicht."
 msgid "The Codex sign-in"
 msgstr "Die Codex-Anmeldung"
 
-msgid "The connection dropped."
-msgstr "Die Verbindung wurde unterbrochen."
-
 msgid "The connection timed out"
 msgstr "Zeitüberschreitung bei der Verbindung"
 
@@ -14189,9 +14186,6 @@ msgstr "Der Repository-Ordner selbst bleibt erhalten."
 
 msgid "The request failed."
 msgstr "Die Anfrage ist fehlgeschlagen."
-
-msgid "The request timed out."
-msgstr "Zeitüberschreitung bei der Anfrage."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Die Antwort: Agenten reviewen Agenten, und Menschen prüfen Stichproben, statt alles zu lesen. Vertrauen entsteht statistisch, nicht pro Diff."

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Der Host war nicht erreichbar, um diesen Pull Request zu laden."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Der Host konnte nicht erreicht werden, um das Update zu starten. Prüfe, ob er online ist, und versuche es erneut."
 
+msgid "Could not reach the server."
+msgstr "Server nicht erreichbar."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Der Rechner dieses Arbeitsbereichs war nicht erreichbar"
 
@@ -4253,6 +4256,9 @@ msgstr "Team erstellen"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Erstelle einen Arbeitsbereich für das Auth-Feature auf meinem MacBook"
+
+msgid "Create again"
+msgstr "Erneut erstellen"
 
 msgid "Create an account"
 msgstr "Konto erstellen"
@@ -4878,6 +4884,9 @@ msgstr "Diktieren"
 
 msgid "Dictation is not available on this device"
 msgstr "Diktieren ist auf diesem Gerät nicht verfügbar"
+
+msgid "Didn't hear back"
+msgstr "Keine Antwort erhalten"
 
 msgid "diff"
 msgstr "Diff"
@@ -8987,6 +8996,9 @@ msgstr "Kein Icon"
 
 msgid "No Internet Connection"
 msgstr "Keine Internetverbindung"
+
+msgid "No internet connection."
+msgstr "Keine Internetverbindung."
 
 msgid "No issues found."
 msgstr "Keine Issues gefunden."
@@ -13991,6 +14003,9 @@ msgstr "Der beste Agent wird wechseln.<0/>Dein Workflow nicht."
 msgid "The Codex sign-in"
 msgstr "Die Codex-Anmeldung"
 
+msgid "The connection dropped."
+msgstr "Die Verbindung wurde unterbrochen."
+
 msgid "The connection timed out"
 msgstr "Zeitüberschreitung bei der Verbindung"
 
@@ -14069,6 +14084,9 @@ msgstr "Der Host ist mit {0} zurückgekommen, nicht mit {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Der Host war nach fünfzehn Minuten noch nicht wieder erreichbar."
+
+msgid "The host hasn't answered."
+msgstr "Der Host hat nicht geantwortet."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Der Host ist nicht mit dem Superset-Relay verbunden. Falls es dieses Gerät ist, aktiviere \"Fernzugriffn den Zugriff auf dieses Gerät über das Relay erlauben\" unter Einstellungen > Fernzugriff und versuche es erneut."
@@ -14172,6 +14190,9 @@ msgstr "Der Repository-Ordner selbst bleibt erhalten."
 msgid "The request failed."
 msgstr "Die Anfrage ist fehlgeschlagen."
 
+msgid "The request timed out."
+msgstr "Zeitüberschreitung bei der Anfrage."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Die Antwort: Agenten reviewen Agenten, und Menschen prüfen Stichproben, statt alles zu lesen. Vertrauen entsteht statistisch, nicht pro Diff."
 
@@ -14235,6 +14256,9 @@ msgstr "Die Web-Oberfläche für Agenten ist vorerst eine schreibgeschützte Vor
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Der Arbeitsbereich ist noch nicht bereit. Versuche es erneut."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Der Arbeitsbereich wurde möglicherweise trotzdem erstellt. Dieser Bildschirm öffnet ihn, sobald er erscheint."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Der Worktree und alle nicht committeten Änderungen werden entfernt. Das lässt sich nicht rückgängig machen."
@@ -14557,9 +14581,6 @@ msgstr "Stufe"
 
 msgid "Time range"
 msgstr "Zeitraum"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Zeitüberschreitung beim Warten darauf, dass der Host den Arbeitsbereich erstellt."
 
 msgid "Title"
 msgstr "Titel"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -14003,9 +14003,6 @@ msgstr "The best agent will change.<0/>Your workflow shouldn't."
 msgid "The Codex sign-in"
 msgstr "The Codex sign-in"
 
-msgid "The connection dropped."
-msgstr "The connection dropped."
-
 msgid "The connection timed out"
 msgstr "The connection timed out"
 
@@ -14189,9 +14186,6 @@ msgstr "The repository folder itself is kept."
 
 msgid "The request failed."
 msgstr "The request failed."
-
-msgid "The request timed out."
-msgstr "The request timed out."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Step {0} of 2"
 msgid "Step {step}: {name}"
 msgstr "Step {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Still can't reach the host."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Could not reach the host to load this pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Could not reach the host to start the update. Check that it is online and try again."
 
+msgid "Could not reach the server."
+msgstr "Could not reach the server."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Could not reach this workspace's machine"
 
@@ -4253,6 +4256,9 @@ msgstr "Create a team"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Create a workspace for the auth feature on my MacBook"
+
+msgid "Create again"
+msgstr "Create again"
 
 msgid "Create an account"
 msgstr "Create an account"
@@ -4878,6 +4884,9 @@ msgstr "Dictate"
 
 msgid "Dictation is not available on this device"
 msgstr "Dictation is not available on this device"
+
+msgid "Didn't hear back"
+msgstr "Didn't hear back"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "No icon"
 
 msgid "No Internet Connection"
 msgstr "No Internet Connection"
+
+msgid "No internet connection."
+msgstr "No internet connection."
 
 msgid "No issues found."
 msgstr "No issues found."
@@ -13991,6 +14003,9 @@ msgstr "The best agent will change.<0/>Your workflow shouldn't."
 msgid "The Codex sign-in"
 msgstr "The Codex sign-in"
 
+msgid "The connection dropped."
+msgstr "The connection dropped."
+
 msgid "The connection timed out"
 msgstr "The connection timed out"
 
@@ -14069,6 +14084,9 @@ msgstr "The host came back on {0}, not {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "The host did not come back within fifteen minutes."
+
+msgid "The host hasn't answered."
+msgstr "The host hasn't answered."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
@@ -14172,6 +14190,9 @@ msgstr "The repository folder itself is kept."
 msgid "The request failed."
 msgstr "The request failed."
 
+msgid "The request timed out."
+msgstr "The request timed out."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 
@@ -14235,6 +14256,9 @@ msgstr "The web agents UI is a read-only preview for now."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "The workspace is not ready yet. Try again."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "The workspace may still have been created. This screen opens it if it appears."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "The worktree and any uncommitted changes will be removed. This cannot be undone."
@@ -14557,9 +14581,6 @@ msgstr "Tier"
 
 msgid "Time range"
 msgstr "Time range"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Timed out waiting for the host to create the workspace."
 
 msgid "Title"
 msgstr "Title"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -4009,6 +4009,9 @@ msgstr "No se pudo contactar con el host para cargar esta pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "No se pudo contactar con el host para iniciar la actualización. Comprueba que está en línea y vuelve a intentarlo."
 
+msgid "Could not reach the server."
+msgstr "No se pudo conectar con el servidor."
+
 msgid "Could not reach this workspace's machine"
 msgstr "No se pudo contactar con la máquina de este espacio de trabajo"
 
@@ -4253,6 +4256,9 @@ msgstr "Crear un equipo"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Crea un espacio de trabajo para la función de autenticación en mi MacBook"
+
+msgid "Create again"
+msgstr "Crear de nuevo"
 
 msgid "Create an account"
 msgstr "Crear una cuenta"
@@ -4878,6 +4884,9 @@ msgstr "Dictar"
 
 msgid "Dictation is not available on this device"
 msgstr "El dictado no está disponible en este dispositivo"
+
+msgid "Didn't hear back"
+msgstr "Sin respuesta"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Sin icono"
 
 msgid "No Internet Connection"
 msgstr "Sin conexión a internet"
+
+msgid "No internet connection."
+msgstr "Sin conexión a Internet."
 
 msgid "No issues found."
 msgstr "No se encontraron issues."
@@ -13991,6 +14003,9 @@ msgstr "El mejor agente cambiará.<0/>Tu flujo de trabajo, no."
 msgid "The Codex sign-in"
 msgstr "La sesión de Codex"
 
+msgid "The connection dropped."
+msgstr "Se perdió la conexión."
+
 msgid "The connection timed out"
 msgstr "Se agotó el tiempo de conexión"
 
@@ -14069,6 +14084,9 @@ msgstr "El host volvió con {0}, no con {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "El host no volvió a estar disponible en quince minutos."
+
+msgid "The host hasn't answered."
+msgstr "El host no ha respondido."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "El host no está conectado al relay de Superset. Si es este dispositivo, activa \"Permitir que los espacios de trabajo remotos accedan a este dispositivo mediante el relay\" en Configuración > Acceso remoto y vuelve a intentarlo."
@@ -14172,6 +14190,9 @@ msgstr "La carpeta del repositorio se conserva."
 msgid "The request failed."
 msgstr "La solicitud falló."
 
+msgid "The request timed out."
+msgstr "La solicitud expiró."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "La respuesta: los agentes revisan a los agentes, y las personas hacen muestreos en lugar de leerlo todo. La confianza se gana de forma estadística, no diff a diff."
 
@@ -14235,6 +14256,9 @@ msgstr "La interfaz web de agentes es, por ahora, una vista previa de solo lectu
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "El espacio de trabajo aún no está listo. Inténtalo de nuevo."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Puede que el espacio de trabajo se haya creado igualmente. Esta pantalla lo abre si aparece."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Se eliminarán el worktree y los cambios sin commit. Esto no se puede deshacer."
@@ -14557,9 +14581,6 @@ msgstr "Nivel"
 
 msgid "Time range"
 msgstr "Periodo"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Se agotó el tiempo de espera para que el host creara el espacio de trabajo."
 
 msgid "Title"
 msgstr "Título"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Paso {0} de 2"
 msgid "Step {step}: {name}"
 msgstr "Paso {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "El host sigue sin responder."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Sigue en marcha: los repositorios grandes pueden tardar unos minutos. Puedes salir; el espacio de trabajo aparecerá en Inicio cuando esté listo."
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -14003,9 +14003,6 @@ msgstr "El mejor agente cambiará.<0/>Tu flujo de trabajo, no."
 msgid "The Codex sign-in"
 msgstr "La sesión de Codex"
 
-msgid "The connection dropped."
-msgstr "Se perdió la conexión."
-
 msgid "The connection timed out"
 msgstr "Se agotó el tiempo de conexión"
 
@@ -14189,9 +14186,6 @@ msgstr "La carpeta del repositorio se conserva."
 
 msgid "The request failed."
 msgstr "La solicitud falló."
-
-msgid "The request timed out."
-msgstr "La solicitud expiró."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "La respuesta: los agentes revisan a los agentes, y las personas hacen muestreos en lugar de leerlo todo. La confianza se gana de forma estadística, no diff a diff."

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Impossible de joindre l'hôte pour charger cette pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Impossible de joindre l'hôte pour lancer la mise à jour. Vérifiez qu'il est en ligne et réessayez."
 
+msgid "Could not reach the server."
+msgstr "Impossible de joindre le serveur."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Impossible de joindre la machine de cet espace de travail"
 
@@ -4253,6 +4256,9 @@ msgstr "Créer une équipe"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Crée un espace de travail pour la fonctionnalité d'authentification sur mon MacBook"
+
+msgid "Create again"
+msgstr "Créer à nouveau"
 
 msgid "Create an account"
 msgstr "Créer un compte"
@@ -4878,6 +4884,9 @@ msgstr "Dicter"
 
 msgid "Dictation is not available on this device"
 msgstr "La dictée n'est pas disponible sur cet appareil"
+
+msgid "Didn't hear back"
+msgstr "Aucune réponse"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Aucune icône"
 
 msgid "No Internet Connection"
 msgstr "Aucune connexion internet"
+
+msgid "No internet connection."
+msgstr "Aucune connexion Internet."
 
 msgid "No issues found."
 msgstr "Aucune issue trouvée."
@@ -13991,6 +14003,9 @@ msgstr "Le meilleur agent changera.<0/>Pas votre façon de travailler."
 msgid "The Codex sign-in"
 msgstr "La connexion Codex"
 
+msgid "The connection dropped."
+msgstr "La connexion a été interrompue."
+
 msgid "The connection timed out"
 msgstr "Le délai de connexion a été dépassé"
 
@@ -14069,6 +14084,9 @@ msgstr "L'hôte est revenu en {0}, pas en {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "L’hôte n’est pas redevenu disponible dans les quinze minutes."
+
+msgid "The host hasn't answered."
+msgstr "L'hôte n'a pas répondu."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "L'hôte n'est pas connecté au relais Superset. S'il s'agit de cet appareil, activez « Autoriser l'accès distant à cet appareil via le relais » dans Paramètres > Accès distant, puis réessayez."
@@ -14172,6 +14190,9 @@ msgstr "Le dossier du dépôt lui-même est conservé."
 msgid "The request failed."
 msgstr "La requête a échoué."
 
+msgid "The request timed out."
+msgstr "La requête a expiré."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "La réponse : les agents relisent les agents, et les humains échantillonnent au lieu de tout lire. La confiance se gagne statistiquement, pas diff par diff."
 
@@ -14235,6 +14256,9 @@ msgstr "L'interface web des agents est pour l'instant un aperçu en lecture seul
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "L'espace de travail n'est pas encore prêt. Réessayez."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "L'espace de travail a peut-être quand même été créé. Cet écran l'ouvre s'il apparaît."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Le worktree et toutes les modifications non commitées seront supprimés. Cette action est irréversible."
@@ -14557,9 +14581,6 @@ msgstr "Offre"
 
 msgid "Time range"
 msgstr "Période"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Délai dépassé en attendant que l'hôte crée l'espace de travail."
 
 msgid "Title"
 msgstr "Titre"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Étape {0} sur 2"
 msgid "Step {step}: {name}"
 msgstr "Étape {step} : {name}"
 
+msgid "Still can't reach the host."
+msgstr "L'hôte reste injoignable."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Toujours en cours — les gros dépôts peuvent prendre quelques minutes. Vous pouvez quitter ; l'espace de travail apparaîtra sur l'accueil dès qu'il sera prêt."
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Le meilleur agent changera.<0/>Pas votre façon de travailler."
 msgid "The Codex sign-in"
 msgstr "La connexion Codex"
 
-msgid "The connection dropped."
-msgstr "La connexion a été interrompue."
-
 msgid "The connection timed out"
 msgstr "Le délai de connexion a été dépassé"
 
@@ -14189,9 +14186,6 @@ msgstr "Le dossier du dépôt lui-même est conservé."
 
 msgid "The request failed."
 msgstr "La requête a échoué."
-
-msgid "The request timed out."
-msgstr "La requête a expiré."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "La réponse : les agents relisent les agents, et les humains échantillonnent au lieu de tout lire. La confiance se gagne statistiquement, pas diff par diff."

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Tidak bisa menjangkau host untuk memuat pull request ini."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Tidak dapat menjangkau host untuk memulai pembaruan. Pastikan host online lalu coba lagi."
 
+msgid "Could not reach the server."
+msgstr "Tidak dapat menjangkau server."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Tidak bisa menjangkau mesin workspace ini"
 
@@ -4253,6 +4256,9 @@ msgstr "Buat sebuah tim"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Buat workspace untuk fitur auth di MacBook saya"
+
+msgid "Create again"
+msgstr "Buat lagi"
 
 msgid "Create an account"
 msgstr "Buat akun"
@@ -4878,6 +4884,9 @@ msgstr "Dikte"
 
 msgid "Dictation is not available on this device"
 msgstr "Dikte tidak tersedia di perangkat ini"
+
+msgid "Didn't hear back"
+msgstr "Tidak ada respons"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Tanpa ikon"
 
 msgid "No Internet Connection"
 msgstr "Tidak Ada Koneksi Internet"
+
+msgid "No internet connection."
+msgstr "Tidak ada koneksi internet."
 
 msgid "No issues found."
 msgstr "Tidak ada issue ditemukan."
@@ -13991,6 +14003,9 @@ msgstr "Agen terbaik akan berganti.<0/>Alur kerja Anda tidak perlu."
 msgid "The Codex sign-in"
 msgstr "Sesi masuk Codex"
 
+msgid "The connection dropped."
+msgstr "Koneksi terputus."
+
 msgid "The connection timed out"
 msgstr "Koneksinya kehabisan waktu"
 
@@ -14069,6 +14084,9 @@ msgstr "Host kembali dengan {0}, bukan {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Host tidak kembali dalam lima belas menit."
+
+msgid "The host hasn't answered."
+msgstr "Host tidak merespons."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Host tidak terhubung ke relay Superset. Kalau ini perangkatnya, aktifkan \"Izinkan akses jarak jauh ke perangkat ini melalui relay\" di Pengaturan > Akses Jarak Jauh, lalu coba lagi."
@@ -14172,6 +14190,9 @@ msgstr "Folder repositori itu sendiri tetap dipertahankan."
 msgid "The request failed."
 msgstr "Permintaan gagal."
 
+msgid "The request timed out."
+msgstr "Permintaan kehabisan waktu."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Jawabannya: agen mereview agen, dan manusia mengambil sampel alih-alih membaca semuanya. Kepercayaan dibangun secara statistik, bukan per diff."
 
@@ -14235,6 +14256,9 @@ msgstr "UI agen di web masih pratinjau baca-saja untuk saat ini."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Workspace belum siap. Coba lagi."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Workspace mungkin tetap dibuat. Layar ini akan membukanya jika muncul."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Worktree beserta perubahan yang belum di-commit akan dihapus. Ini tidak bisa dibatalkan."
@@ -14557,9 +14581,6 @@ msgstr "Tingkat"
 
 msgid "Time range"
 msgstr "Rentang waktu"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Kehabisan waktu menunggu host membuat workspace."
 
 msgid "Title"
 msgstr "Judul"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Agen terbaik akan berganti.<0/>Alur kerja Anda tidak perlu."
 msgid "The Codex sign-in"
 msgstr "Sesi masuk Codex"
 
-msgid "The connection dropped."
-msgstr "Koneksi terputus."
-
 msgid "The connection timed out"
 msgstr "Koneksinya kehabisan waktu"
 
@@ -14189,9 +14186,6 @@ msgstr "Folder repositori itu sendiri tetap dipertahankan."
 
 msgid "The request failed."
 msgstr "Permintaan gagal."
-
-msgid "The request timed out."
-msgstr "Permintaan kehabisan waktu."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Jawabannya: agen mereview agen, dan manusia mengambil sampel alih-alih membaca semuanya. Kepercayaan dibangun secara statistik, bukan per diff."

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Langkah {0} dari 2"
 msgid "Step {step}: {name}"
 msgstr "Langkah {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Host masih tidak dapat dijangkau."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Masih berjalan — repo besar bisa makan beberapa menit. Anda boleh keluar; workspace-nya akan muncul di Beranda saat siap."
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Passaggio {0} di 2"
 msgid "Step {step}: {name}"
 msgstr "Passaggio {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "L'host resta irraggiungibile."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Ancora al lavoro — i repo grandi possono richiedere qualche minuto. Puoi uscire; il workspace comparirà nella Home quando è pronto."
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Il miglior agente cambierà.<0/>Il tuo flusso di lavoro no."
 msgid "The Codex sign-in"
 msgstr "L'accesso Codex"
 
-msgid "The connection dropped."
-msgstr "La connessione è caduta."
-
 msgid "The connection timed out"
 msgstr "La connessione è scaduta"
 
@@ -14189,9 +14186,6 @@ msgstr "La cartella del repository viene mantenuta."
 
 msgid "The request failed."
 msgstr "La richiesta non è riuscita."
-
-msgid "The request timed out."
-msgstr "La richiesta è scaduta."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "La risposta: gli agenti rivedono gli agenti e gli umani campionano invece di leggere tutto. La fiducia si guadagna statisticamente, non diff per diff."

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Impossibile raggiungere l'host per caricare questa pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Impossibile raggiungere l'host per avviare l'aggiornamento. Verifica che sia online e riprova."
 
+msgid "Could not reach the server."
+msgstr "Impossibile raggiungere il server."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Impossibile raggiungere la macchina di questo workspace"
 
@@ -4253,6 +4256,9 @@ msgstr "Crea un team"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Crea un workspace per la funzione di autenticazione sul mio MacBook"
+
+msgid "Create again"
+msgstr "Crea di nuovo"
 
 msgid "Create an account"
 msgstr "Crea un account"
@@ -4878,6 +4884,9 @@ msgstr "Detta"
 
 msgid "Dictation is not available on this device"
 msgstr "La dettatura non è disponibile su questo dispositivo"
+
+msgid "Didn't hear back"
+msgstr "Nessuna risposta"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Nessuna icona"
 
 msgid "No Internet Connection"
 msgstr "Nessuna connessione a internet"
+
+msgid "No internet connection."
+msgstr "Nessuna connessione a Internet."
 
 msgid "No issues found."
 msgstr "Nessuna issue trovata."
@@ -13991,6 +14003,9 @@ msgstr "Il miglior agente cambierà.<0/>Il tuo flusso di lavoro no."
 msgid "The Codex sign-in"
 msgstr "L'accesso Codex"
 
+msgid "The connection dropped."
+msgstr "La connessione è caduta."
+
 msgid "The connection timed out"
 msgstr "La connessione è scaduta"
 
@@ -14069,6 +14084,9 @@ msgstr "L'host è tornato alla {0}, non alla {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "L’host non è tornato disponibile entro quindici minuti."
+
+msgid "The host hasn't answered."
+msgstr "L'host non ha risposto."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "L'host non è connesso al relay di Superset. Se è questo dispositivo, attiva \"Consenti l'accesso remoto a questo dispositivo tramite relay\" in Impostazioni > Accesso remoto, poi riprova."
@@ -14172,6 +14190,9 @@ msgstr "La cartella del repository viene mantenuta."
 msgid "The request failed."
 msgstr "La richiesta non è riuscita."
 
+msgid "The request timed out."
+msgstr "La richiesta è scaduta."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "La risposta: gli agenti rivedono gli agenti e gli umani campionano invece di leggere tutto. La fiducia si guadagna statisticamente, non diff per diff."
 
@@ -14235,6 +14256,9 @@ msgstr "L'interfaccia web degli agenti è per ora un'anteprima in sola lettura."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Il workspace non è ancora pronto. Riprova."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Il workspace potrebbe essere stato creato comunque. Questa schermata lo apre se compare."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Il worktree e le eventuali modifiche non committate verranno rimossi. L'operazione non può essere annullata."
@@ -14557,9 +14581,6 @@ msgstr "Livello"
 
 msgid "Time range"
 msgstr "Periodo"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Tempo scaduto in attesa che l'host creasse il workspace."
 
 msgid "Title"
 msgstr "Titolo"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -14003,9 +14003,6 @@ msgstr "最良のエージェントは変わります。<0/>ワークフロー�
 msgid "The Codex sign-in"
 msgstr "Codexのサインイン"
 
-msgid "The connection dropped."
-msgstr "接続が切断されました。"
-
 msgid "The connection timed out"
 msgstr "接続がタイムアウトしました"
 
@@ -14189,9 +14186,6 @@ msgstr "リポジトリのフォルダ自体は残ります。"
 
 msgid "The request failed."
 msgstr "リクエストに失敗しました。"
-
-msgid "The request timed out."
-msgstr "リクエストがタイムアウトしました。"
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "その答えは、エージェントがエージェントをレビューし、人間はすべてを読む代わりに抜き取りで確認することです。信頼は差分ごとではなく、統計的に積み上げられます。"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -13351,6 +13351,9 @@ msgstr "ステップ {0} / 2"
 msgid "Step {step}: {name}"
 msgstr "ステップ{step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "ホストにまだ接続できません。"
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "処理を続けています — 大きなリポジトリでは数分かかることがあります。画面を離れても構いません。準備ができるとホームに表示されます。"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -4009,6 +4009,9 @@ msgstr "このプルリクエストを読み込むためのホストに接続で
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "更新を開始するためにホストに接続できませんでした。オンラインであることを確認して、もう一度お試しください。"
 
+msgid "Could not reach the server."
+msgstr "サーバーに接続できませんでした。"
+
 msgid "Could not reach this workspace's machine"
 msgstr "このワークスペースのマシンに接続できませんでした"
 
@@ -4253,6 +4256,9 @@ msgstr "チームを作成"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "MacBookに認証機能用のワークスペースを作って"
+
+msgid "Create again"
+msgstr "もう一度作成"
 
 msgid "Create an account"
 msgstr "アカウントを作成"
@@ -4878,6 +4884,9 @@ msgstr "音声入力"
 
 msgid "Dictation is not available on this device"
 msgstr "このデバイスでは音声入力を利用できません"
+
+msgid "Didn't hear back"
+msgstr "応答がありません"
 
 msgid "diff"
 msgstr "差分"
@@ -8987,6 +8996,9 @@ msgstr "アイコンなし"
 
 msgid "No Internet Connection"
 msgstr "インターネット接続がありません"
+
+msgid "No internet connection."
+msgstr "インターネット接続がありません。"
 
 msgid "No issues found."
 msgstr "Issueが見つかりません。"
@@ -13991,6 +14003,9 @@ msgstr "最良のエージェントは変わります。<0/>ワークフロー�
 msgid "The Codex sign-in"
 msgstr "Codexのサインイン"
 
+msgid "The connection dropped."
+msgstr "接続が切断されました。"
+
 msgid "The connection timed out"
 msgstr "接続がタイムアウトしました"
 
@@ -14069,6 +14084,9 @@ msgstr "ホストは{targetVersion}ではなく{0}で復帰しました。"
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "ホストが15分以内に復帰しませんでした。"
+
+msgid "The host hasn't answered."
+msgstr "ホストからの応答がありません。"
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "ホストがSupersetリレーに接続されていません。このデバイスの場合は、設定 > リモートアクセスで「リレー経由でこのデバイスへのリモートアクセスを許可」をオンにしてから再試行してください。"
@@ -14172,6 +14190,9 @@ msgstr "リポジトリのフォルダ自体は残ります。"
 msgid "The request failed."
 msgstr "リクエストに失敗しました。"
 
+msgid "The request timed out."
+msgstr "リクエストがタイムアウトしました。"
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "その答えは、エージェントがエージェントをレビューし、人間はすべてを読む代わりに抜き取りで確認することです。信頼は差分ごとではなく、統計的に積み上げられます。"
 
@@ -14235,6 +14256,9 @@ msgstr "Web版のエージェントUIは現時点では読み取り専用のプ�
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "ワークスペースの準備がまだできていません。もう一度お試しください。"
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "ワークスペースは作成されている可能性があります。表示された場合、この画面で開きます。"
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "ワークツリーと未コミットの変更が削除されます。この操作は元に戻せません。"
@@ -14557,9 +14581,6 @@ msgstr "ティア"
 
 msgid "Time range"
 msgstr "期間"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "ホストがワークスペースを作成するのを待つ間にタイムアウトしました。"
 
 msgid "Title"
 msgstr "タイトル"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -14003,9 +14003,6 @@ msgstr "최고의 에이전트는 바뀝니다.<0/>워크플로는 그럴 필요
 msgid "The Codex sign-in"
 msgstr "Codex 로그인"
 
-msgid "The connection dropped."
-msgstr "연결이 끊어졌습니다."
-
 msgid "The connection timed out"
 msgstr "연결 시간이 초과되었습니다"
 
@@ -14189,9 +14186,6 @@ msgstr "저장소 폴더 자체는 유지됩니다."
 
 msgid "The request failed."
 msgstr "요청이 실패했습니다."
-
-msgid "The request timed out."
-msgstr "요청 시간이 초과되었습니다."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "그 대응은 이렇습니다. 에이전트가 에이전트를 리뷰하고, 사람은 전부 읽는 대신 표본만 확인합니다. 신뢰는 차이 하나하나가 아니라 통계적으로 쌓입니다."

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -13351,6 +13351,9 @@ msgstr "2단계 중 {0}단계"
 msgid "Step {step}: {name}"
 msgstr "{step}단계: {name}"
 
+msgid "Still can't reach the host."
+msgstr "아직 호스트에 연결할 수 없습니다."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "아직 진행 중입니다 — 큰 리포지토리는 몇 분 걸릴 수 있습니다. 나가도 되며, 준비되면 홈에 워크스페이스가 표시됩니다."
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -4009,6 +4009,9 @@ msgstr "호스트에 연결할 수 없어 이 풀 리퀘스트를 불러오지 �
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "업데이트를 시작하기 위해 호스트에 연결할 수 없습니다. 온라인 상태인지 확인한 후 다시 시도하세요."
 
+msgid "Could not reach the server."
+msgstr "서버에 연결할 수 없습니다."
+
 msgid "Could not reach this workspace's machine"
 msgstr "이 워크스페이스의 컴퓨터에 연결할 수 없습니다"
 
@@ -4253,6 +4256,9 @@ msgstr "팀 만들기"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "내 MacBook에 인증 기능용 워크스페이스를 만들어 줘"
+
+msgid "Create again"
+msgstr "다시 생성"
 
 msgid "Create an account"
 msgstr "계정 만들기"
@@ -4878,6 +4884,9 @@ msgstr "받아쓰기"
 
 msgid "Dictation is not available on this device"
 msgstr "이 기기에서는 받아쓰기를 사용할 수 없습니다"
+
+msgid "Didn't hear back"
+msgstr "응답이 없습니다"
 
 msgid "diff"
 msgstr "차이"
@@ -8987,6 +8996,9 @@ msgstr "아이콘 없음"
 
 msgid "No Internet Connection"
 msgstr "인터넷 연결 없음"
+
+msgid "No internet connection."
+msgstr "인터넷 연결이 없습니다."
 
 msgid "No issues found."
 msgstr "이슈를 찾을 수 없습니다."
@@ -13991,6 +14003,9 @@ msgstr "최고의 에이전트는 바뀝니다.<0/>워크플로는 그럴 필요
 msgid "The Codex sign-in"
 msgstr "Codex 로그인"
 
+msgid "The connection dropped."
+msgstr "연결이 끊어졌습니다."
+
 msgid "The connection timed out"
 msgstr "연결 시간이 초과되었습니다"
 
@@ -14069,6 +14084,9 @@ msgstr "호스트가 {targetVersion}이(가) 아닌 {0}(으)로 돌아왔습니�
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "호스트가 15분 이내에 다시 연결되지 않았습니다."
+
+msgid "The host hasn't answered."
+msgstr "호스트가 응답하지 않았습니다."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "호스트가 Superset 릴레이에 연결되어 있지 않습니다. 이 기기라면 설정 > 원격 액세스에서 \"원격 액세스가 릴레이를 통해 이 기기에 접근하도록 허용\"을 켠 뒤 다시 시도하세요."
@@ -14172,6 +14190,9 @@ msgstr "저장소 폴더 자체는 유지됩니다."
 msgid "The request failed."
 msgstr "요청이 실패했습니다."
 
+msgid "The request timed out."
+msgstr "요청 시간이 초과되었습니다."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "그 대응은 이렇습니다. 에이전트가 에이전트를 리뷰하고, 사람은 전부 읽는 대신 표본만 확인합니다. 신뢰는 차이 하나하나가 아니라 통계적으로 쌓입니다."
 
@@ -14235,6 +14256,9 @@ msgstr "웹 에이전트 UI는 아직 읽기 전용 미리 보기입니다."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "워크스페이스가 아직 준비되지 않았습니다. 다시 시도하세요."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "워크스페이스가 생성되었을 수도 있습니다. 나타나면 이 화면에서 열립니다."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "worktree와 커밋되지 않은 변경 사항이 모두 삭제됩니다. 되돌릴 수 없습니다."
@@ -14557,9 +14581,6 @@ msgstr "등급"
 
 msgid "Time range"
 msgstr "기간"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "호스트가 워크스페이스를 만들기를 기다리다 시간이 초과되었습니다."
 
 msgid "Title"
 msgstr "제목"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Kan de host niet bereiken om deze pull request te laden."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Kon de host niet bereiken om de update te starten. Controleer of hij online is en probeer het opnieuw."
 
+msgid "Could not reach the server."
+msgstr "Kan de server niet bereiken."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Kan de machine van deze werkruimte niet bereiken"
 
@@ -4253,6 +4256,9 @@ msgstr "Een team aanmaken"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Maak een werkruimte voor de auth-feature op mijn MacBook"
+
+msgid "Create again"
+msgstr "Opnieuw aanmaken"
 
 msgid "Create an account"
 msgstr "Een account aanmaken"
@@ -4878,6 +4884,9 @@ msgstr "Dicteren"
 
 msgid "Dictation is not available on this device"
 msgstr "Dicteren is niet beschikbaar op dit apparaat"
+
+msgid "Didn't hear back"
+msgstr "Geen reactie ontvangen"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Geen icoon"
 
 msgid "No Internet Connection"
 msgstr "Geen internetverbinding"
+
+msgid "No internet connection."
+msgstr "Geen internetverbinding."
 
 msgid "No issues found."
 msgstr "Geen issues gevonden."
@@ -13991,6 +14003,9 @@ msgstr "De beste agent verandert.<0/>Jouw workflow niet."
 msgid "The Codex sign-in"
 msgstr "De Codex-login"
 
+msgid "The connection dropped."
+msgstr "De verbinding is verbroken."
+
 msgid "The connection timed out"
 msgstr "De verbinding is verlopen"
 
@@ -14069,6 +14084,9 @@ msgstr "De host kwam terug op {0}, niet op {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "De host was na vijftien minuten nog niet terug."
+
+msgid "The host hasn't answered."
+msgstr "De host heeft niet geantwoord."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "De host is niet verbonden met de Superset-relay. Als het dit apparaat is, zet dan \"Externe toegang via de relay toegang geven tot dit apparaat\" aan bij Instellingen > Externe toegang en probeer het opnieuw."
@@ -14172,6 +14190,9 @@ msgstr "De repositorymap zelf blijft behouden."
 msgid "The request failed."
 msgstr "Het verzoek is mislukt."
 
+msgid "The request timed out."
+msgstr "De aanvraag is verlopen."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Het antwoord: agents reviewen agents, en mensen nemen steekproeven in plaats van alles te lezen. Vertrouwen wordt statistisch verdiend, niet per diff."
 
@@ -14235,6 +14256,9 @@ msgstr "De web-UI voor agents is voorlopig een alleen-lezen preview."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "De werkruimte is nog niet klaar. Probeer het opnieuw."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "De werkruimte is mogelijk toch aangemaakt. Dit scherm opent hem zodra hij verschijnt."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "De worktree en eventuele niet-gecommitte wijzigingen worden verwijderd. Dit kan niet ongedaan worden gemaakt."
@@ -14557,9 +14581,6 @@ msgstr "Tier"
 
 msgid "Time range"
 msgstr "Periode"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Time-out tijdens het wachten tot de host de werkruimte aanmaakte."
 
 msgid "Title"
 msgstr "Titel"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -14003,9 +14003,6 @@ msgstr "De beste agent verandert.<0/>Jouw workflow niet."
 msgid "The Codex sign-in"
 msgstr "De Codex-login"
 
-msgid "The connection dropped."
-msgstr "De verbinding is verbroken."
-
 msgid "The connection timed out"
 msgstr "De verbinding is verlopen"
 
@@ -14189,9 +14186,6 @@ msgstr "De repositorymap zelf blijft behouden."
 
 msgid "The request failed."
 msgstr "Het verzoek is mislukt."
-
-msgid "The request timed out."
-msgstr "De aanvraag is verlopen."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Het antwoord: agents reviewen agents, en mensen nemen steekproeven in plaats van alles te lezen. Vertrouwen wordt statistisch verdiend, niet per diff."

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Stap {0} van 2"
 msgid "Step {step}: {name}"
 msgstr "Stap {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "De host is nog steeds onbereikbaar."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Nog bezig — grote repo's kunnen een paar minuten duren. Je kunt weggaan; de werkruimte verschijnt op Home zodra die klaar is."
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Nie udało się połączyć z hostem, aby wczytać ten pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Nie udało się połączyć z hostem, aby rozpocząć aktualizację. Sprawdź, czy jest online, i spróbuj ponownie."
 
+msgid "Could not reach the server."
+msgstr "Nie można połączyć się z serwerem."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Nie udało się połączyć z maszyną tego obszaru roboczego"
 
@@ -4253,6 +4256,9 @@ msgstr "Utwórz zespół"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Utwórz obszar roboczy dla funkcji auth na moim MacBooku"
+
+msgid "Create again"
+msgstr "Utwórz ponownie"
 
 msgid "Create an account"
 msgstr "Utwórz konto"
@@ -4878,6 +4884,9 @@ msgstr "Dyktuj"
 
 msgid "Dictation is not available on this device"
 msgstr "Dyktowanie jest niedostępne na tym urządzeniu"
+
+msgid "Didn't hear back"
+msgstr "Brak odpowiedzi"
 
 msgid "diff"
 msgstr "różnice"
@@ -8987,6 +8996,9 @@ msgstr "Brak ikony"
 
 msgid "No Internet Connection"
 msgstr "Brak połączenia z internetem"
+
+msgid "No internet connection."
+msgstr "Brak połączenia z internetem."
 
 msgid "No issues found."
 msgstr "Nie znaleziono zgłoszeń."
@@ -13991,6 +14003,9 @@ msgstr "Najlepszy agent się zmieni.<0/>Twój workflow nie musi."
 msgid "The Codex sign-in"
 msgstr "Logowanie Codex"
 
+msgid "The connection dropped."
+msgstr "Połączenie zostało przerwane."
+
 msgid "The connection timed out"
 msgstr "Przekroczono czas połączenia"
 
@@ -14069,6 +14084,9 @@ msgstr "Host wrócił w wersji {0}, a nie {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Host nie wrócił do działania w ciągu piętnastu minut."
+
+msgid "The host hasn't answered."
+msgstr "Host nie odpowiedział."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Host nie jest połączony z przekaźnikiem Superset. Jeśli chodzi o to urządzenie, włącz „Zezwól na zdalny dostęp do tego urządzenia przez przekaźnik” w Ustawienia > Dostęp zdalny i spróbuj ponownie."
@@ -14172,6 +14190,9 @@ msgstr "Sam folder repozytorium zostaje zachowany."
 msgid "The request failed."
 msgstr "Żądanie nie powiodło się."
 
+msgid "The request timed out."
+msgstr "Upłynął limit czasu żądania."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Odpowiedź: agenci przeglądają agentów, a ludzie próbkują zamiast czytać wszystko. Zaufanie zdobywa się statystycznie, nie per diff."
 
@@ -14235,6 +14256,9 @@ msgstr "Webowy interfejs agentów jest na razie podglądem tylko do odczytu."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Obszar roboczy nie jest jeszcze gotowy. Spróbuj ponownie."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Obszar roboczy mógł mimo to zostać utworzony. Ten ekran otworzy go, gdy się pojawi."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Worktree i wszystkie niezacommitowane zmiany zostaną usunięte. Tej operacji nie można cofnąć."
@@ -14557,9 +14581,6 @@ msgstr "Poziom"
 
 msgid "Time range"
 msgstr "Zakres czasu"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Przekroczono czas oczekiwania na utworzenie obszaru roboczego przez host."
 
 msgid "Title"
 msgstr "Tytuł"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Krok {0} z 2"
 msgid "Step {step}: {name}"
 msgstr "Krok {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Host nadal jest nieosiągalny."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Wciąż trwa — duże repozytoria mogą zająć kilka minut. Możesz wyjść; obszar roboczy pojawi się na ekranie głównym, gdy będzie gotowy."
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Najlepszy agent się zmieni.<0/>Twój workflow nie musi."
 msgid "The Codex sign-in"
 msgstr "Logowanie Codex"
 
-msgid "The connection dropped."
-msgstr "Połączenie zostało przerwane."
-
 msgid "The connection timed out"
 msgstr "Przekroczono czas połączenia"
 
@@ -14189,9 +14186,6 @@ msgstr "Sam folder repozytorium zostaje zachowany."
 
 msgid "The request failed."
 msgstr "Żądanie nie powiodło się."
-
-msgid "The request timed out."
-msgstr "Upłynął limit czasu żądania."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Odpowiedź: agenci przeglądają agentów, a ludzie próbkują zamiast czytać wszystko. Zaufanie zdobywa się statystycznie, nie per diff."

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Etapa {0} de 2"
 msgid "Step {step}: {name}"
 msgstr "Etapa {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "O host continua inacessível."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Ainda trabalhando — repositórios grandes podem levar alguns minutos. Você pode sair; a área de trabalho aparece no Início quando ficar pronta."
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Não foi possível acessar o host para carregar este pull request."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Não foi possível alcançar o host para iniciar a atualização. Verifique se ele está online e tente novamente."
 
+msgid "Could not reach the server."
+msgstr "Não foi possível acessar o servidor."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Não foi possível acessar a máquina desta área de trabalho"
 
@@ -4253,6 +4256,9 @@ msgstr "Criar uma equipe"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Crie uma área de trabalho para a funcionalidade de autenticação no meu MacBook"
+
+msgid "Create again"
+msgstr "Criar novamente"
 
 msgid "Create an account"
 msgstr "Criar uma conta"
@@ -4878,6 +4884,9 @@ msgstr "Ditar"
 
 msgid "Dictation is not available on this device"
 msgstr "O ditado não está disponível neste dispositivo"
+
+msgid "Didn't hear back"
+msgstr "Sem resposta"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Sem ícone"
 
 msgid "No Internet Connection"
 msgstr "Sem conexão com a internet"
+
+msgid "No internet connection."
+msgstr "Sem conexão com a internet."
 
 msgid "No issues found."
 msgstr "Nenhuma issue encontrada."
@@ -13991,6 +14003,9 @@ msgstr "O melhor agente vai mudar.<0/>Seu fluxo de trabalho, não."
 msgid "The Codex sign-in"
 msgstr "O login do Codex"
 
+msgid "The connection dropped."
+msgstr "A conexão caiu."
+
 msgid "The connection timed out"
 msgstr "O tempo de conexão esgotou"
 
@@ -14069,6 +14084,9 @@ msgstr "O host voltou na {0}, não na {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "O host não voltou a ficar disponível em quinze minutos."
+
+msgid "The host hasn't answered."
+msgstr "O host não respondeu."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "O host não está conectado ao relay do Superset. Se for este dispositivo, ative \"Permitir acesso remoto a este dispositivo via relay\" em Configurações > Acesso remoto e tente novamente."
@@ -14172,6 +14190,9 @@ msgstr "A pasta do repositório em si é mantida."
 msgid "The request failed."
 msgstr "A requisição falhou."
 
+msgid "The request timed out."
+msgstr "A solicitação expirou."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "A resposta: agentes revisam agentes, e as pessoas amostram em vez de ler tudo. A confiança é conquistada estatisticamente, não diff a diff."
 
@@ -14235,6 +14256,9 @@ msgstr "A interface web de agentes é uma prévia somente leitura por enquanto."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "A área de trabalho ainda não está pronta. Tente de novo."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "A área de trabalho pode ter sido criada mesmo assim. Esta tela a abre se ela aparecer."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "A worktree e as alterações sem commit serão removidas. Não dá para desfazer."
@@ -14557,9 +14581,6 @@ msgstr "Plano"
 
 msgid "Time range"
 msgstr "Período"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "O tempo de espera para o host criar a área de trabalho esgotou."
 
 msgid "Title"
 msgstr "Título"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -14003,9 +14003,6 @@ msgstr "O melhor agente vai mudar.<0/>Seu fluxo de trabalho, não."
 msgid "The Codex sign-in"
 msgstr "O login do Codex"
 
-msgid "The connection dropped."
-msgstr "A conexão caiu."
-
 msgid "The connection timed out"
 msgstr "O tempo de conexão esgotou"
 
@@ -14189,9 +14186,6 @@ msgstr "A pasta do repositório em si é mantida."
 
 msgid "The request failed."
 msgstr "A requisição falhou."
-
-msgid "The request timed out."
-msgstr "A solicitação expirou."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "A resposta: agentes revisam agentes, e as pessoas amostram em vez de ler tudo. A confiança é conquistada estatisticamente, não diff a diff."

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Шаг {0} из 2"
 msgid "Step {step}: {name}"
 msgstr "Шаг {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Хост по-прежнему недоступен."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Ещё работаем — большие репозитории могут занять несколько минут. Можно выйти; рабочая область появится на главной, когда будет готова."
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Не удалось связаться с хостом, чтобы за�
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Не удалось связаться с хостом, чтобы начать обновление. Убедитесь, что он в сети, и попробуйте снова."
 
+msgid "Could not reach the server."
+msgstr "Не удалось подключиться к серверу."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Не удалось связаться с машиной этой рабочей области"
 
@@ -4253,6 +4256,9 @@ msgstr "Создать команду"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Создай рабочую область для фичи авторизации на моём MacBook"
+
+msgid "Create again"
+msgstr "Создать заново"
 
 msgid "Create an account"
 msgstr "Создать аккаунт"
@@ -4878,6 +4884,9 @@ msgstr "Диктовать"
 
 msgid "Dictation is not available on this device"
 msgstr "Диктовка недоступна на этом устройстве"
+
+msgid "Didn't hear back"
+msgstr "Ответа не поступило"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Без иконки"
 
 msgid "No Internet Connection"
 msgstr "Нет подключения к интернету"
+
+msgid "No internet connection."
+msgstr "Нет подключения к интернету."
 
 msgid "No issues found."
 msgstr "Задачи не найдены."
@@ -13991,6 +14003,9 @@ msgstr "Лучший агент будет меняться.<0/>Ваш проц�
 msgid "The Codex sign-in"
 msgstr "Вход в Codex"
 
+msgid "The connection dropped."
+msgstr "Соединение прервалось."
+
 msgid "The connection timed out"
 msgstr "Истекло время ожидания соединения"
 
@@ -14069,6 +14084,9 @@ msgstr "Хост вернулся с версией {0}, а не {targetVersion}
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Хост не восстановил работу в течение пятнадцати минут."
+
+msgid "The host hasn't answered."
+msgstr "Хост не ответил."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Хост не подключён к реле Superset. Если это текущее устройство, включите «Разрешить удалённый доступ к этому устройству через реле» в Настройки > Удалённый доступ и повторите."
@@ -14172,6 +14190,9 @@ msgstr "Сама папка репозитория сохраняется."
 msgid "The request failed."
 msgstr "Запрос завершился ошибкой."
 
+msgid "The request timed out."
+msgstr "Истекло время ожидания запроса."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Ответ: агенты проверяют агентов, а люди читают выборочно, а не всё подряд. Доверие зарабатывается статистически, а не по каждому diff."
 
@@ -14235,6 +14256,9 @@ msgstr "Веб-интерфейс агентов пока доступен то�
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Рабочая область ещё не готова. Повторите."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Рабочая область всё же могла быть создана. Этот экран откроет её, когда она появится."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Worktree и все незакоммиченные изменения будут удалены. Отменить нельзя."
@@ -14557,9 +14581,6 @@ msgstr "Уровень"
 
 msgid "Time range"
 msgstr "Период"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Истекло время ожидания, пока хост создаст рабочую область."
 
 msgid "Title"
 msgstr "Название"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Лучший агент будет меняться.<0/>Ваш проц�
 msgid "The Codex sign-in"
 msgstr "Вход в Codex"
 
-msgid "The connection dropped."
-msgstr "Соединение прервалось."
-
 msgid "The connection timed out"
 msgstr "Истекло время ожидания соединения"
 
@@ -14189,9 +14186,6 @@ msgstr "Сама папка репозитория сохраняется."
 
 msgid "The request failed."
 msgstr "Запрос завершился ошибкой."
-
-msgid "The request timed out."
-msgstr "Истекло время ожидания запроса."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Ответ: агенты проверяют агентов, а люди читают выборочно, а не всё подряд. Доверие зарабатывается статистически, а не по каждому diff."

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -14003,9 +14003,6 @@ msgstr "En iyi ajan değişecek.<0/>İş akışınız değişmemeli."
 msgid "The Codex sign-in"
 msgstr "Codex oturumu"
 
-msgid "The connection dropped."
-msgstr "Bağlantı koptu."
-
 msgid "The connection timed out"
 msgstr "Bağlantı zaman aşımına uğradı"
 
@@ -14189,9 +14186,6 @@ msgstr "Depo klasörünün kendisi korunur."
 
 msgid "The request failed."
 msgstr "İstek başarısız oldu."
-
-msgid "The request timed out."
-msgstr "İstek zaman aşımına uğradı."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Yanıt şu: ajanlar ajanları inceler, insanlar da her şeyi okumak yerine örnekleme yapar. Güven fark fark değil, istatistiksel olarak kazanılır."

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Bu pull request'i yüklemek için host'a erişilemedi."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Güncellemeyi başlatmak için ana makineye ulaşılamadı. Çevrimiçi olduğundan emin olup tekrar deneyin."
 
+msgid "Could not reach the server."
+msgstr "Sunucuya ulaşılamadı."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Bu çalışma alanının makinesine erişilemedi"
 
@@ -4253,6 +4256,9 @@ msgstr "Takım oluştur"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "MacBook'umda auth özelliği için bir çalışma alanı oluştur"
+
+msgid "Create again"
+msgstr "Yeniden oluştur"
 
 msgid "Create an account"
 msgstr "Hesap oluşturun"
@@ -4878,6 +4884,9 @@ msgstr "Sesle yaz"
 
 msgid "Dictation is not available on this device"
 msgstr "Bu cihazda sesle yazma kullanılamıyor"
+
+msgid "Didn't hear back"
+msgstr "Yanıt alınamadı"
 
 msgid "diff"
 msgstr "fark"
@@ -8987,6 +8996,9 @@ msgstr "Simge yok"
 
 msgid "No Internet Connection"
 msgstr "İnternet bağlantısı yok"
+
+msgid "No internet connection."
+msgstr "İnternet bağlantısı yok."
 
 msgid "No issues found."
 msgstr "Issue bulunamadı."
@@ -13991,6 +14003,9 @@ msgstr "En iyi ajan değişecek.<0/>İş akışınız değişmemeli."
 msgid "The Codex sign-in"
 msgstr "Codex oturumu"
 
+msgid "The connection dropped."
+msgstr "Bağlantı koptu."
+
 msgid "The connection timed out"
 msgstr "Bağlantı zaman aşımına uğradı"
 
@@ -14069,6 +14084,9 @@ msgstr "Ana makine {targetVersion} yerine {0} ile geri döndü."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Ana makine on beş dakika içinde geri gelmedi."
+
+msgid "The host hasn't answered."
+msgstr "Host yanıt vermedi."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Host, Superset rölesine bağlı değil. Bu cihazsa Ayarlar > Uzaktan erişim bölümünde \"Uzaktan erişimnın bu cihaza röle üzerinden erişmesine izin ver\" seçeneğini açıp yeniden deneyin."
@@ -14172,6 +14190,9 @@ msgstr "Depo klasörünün kendisi korunur."
 msgid "The request failed."
 msgstr "İstek başarısız oldu."
 
+msgid "The request timed out."
+msgstr "İstek zaman aşımına uğradı."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Yanıt şu: ajanlar ajanları inceler, insanlar da her şeyi okumak yerine örnekleme yapar. Güven fark fark değil, istatistiksel olarak kazanılır."
 
@@ -14235,6 +14256,9 @@ msgstr "Web ajan arayüzü şimdilik salt okunur bir önizlemedir."
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Çalışma alanı henüz hazır değil. Yeniden deneyin."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Çalışma alanı yine de oluşturulmuş olabilir. Göründüğünde bu ekran onu açar."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Worktree ve commit'lenmemiş tüm değişiklikler kaldırılacak. Bu geri alınamaz."
@@ -14557,9 +14581,6 @@ msgstr "Katman"
 
 msgid "Time range"
 msgstr "Zaman aralığı"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Host'un çalışma alanını oluşturması beklenirken zaman aşımına uğrandı."
 
 msgid "Title"
 msgstr "Başlık"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Adım {0} / 2"
 msgid "Step {step}: {name}"
 msgstr "Adım {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Host'a hâlâ ulaşılamıyor."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Hâlâ çalışıyor — büyük depolar birkaç dakika sürebilir. Ayrılabilirsiniz; çalışma alanı hazır olduğunda Ana sayfada görünecek."
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -13351,6 +13351,9 @@ msgstr "Bước {0} / 2"
 msgid "Step {step}: {name}"
 msgstr "Bước {step}: {name}"
 
+msgid "Still can't reach the host."
+msgstr "Vẫn không thể kết nối tới host."
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "Vẫn đang xử lý — repo lớn có thể mất vài phút. Bạn có thể rời đi; workspace sẽ xuất hiện ở Trang chủ khi sẵn sàng."
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -14003,9 +14003,6 @@ msgstr "Agent tốt nhất sẽ thay đổi.<0/>Quy trình của bạn thì khô
 msgid "The Codex sign-in"
 msgstr "Lần đăng nhập Codex"
 
-msgid "The connection dropped."
-msgstr "Kết nối đã bị ngắt."
-
 msgid "The connection timed out"
 msgstr "Kết nối đã quá thời gian"
 
@@ -14189,9 +14186,6 @@ msgstr "Thư mục kho lưu trữ vẫn được giữ nguyên."
 
 msgid "The request failed."
 msgstr "Yêu cầu thất bại."
-
-msgid "The request timed out."
-msgstr "Yêu cầu đã hết thời gian chờ."
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Cách phản ứng: agent review agent, còn con người lấy mẫu thay vì đọc tất cả. Niềm tin được xây bằng thống kê, không phải theo từng diff."

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -4009,6 +4009,9 @@ msgstr "Không kết nối được tới host để tải pull request này."
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "Không thể kết nối tới máy chủ để bắt đầu cập nhật. Hãy kiểm tra máy chủ đang trực tuyến rồi thử lại."
 
+msgid "Could not reach the server."
+msgstr "Không thể kết nối tới máy chủ."
+
 msgid "Could not reach this workspace's machine"
 msgstr "Không kết nối được tới máy của workspace này"
 
@@ -4253,6 +4256,9 @@ msgstr "Tạo một nhóm"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "Tạo một workspace cho tính năng xác thực trên MacBook của tôi"
+
+msgid "Create again"
+msgstr "Tạo lại"
 
 msgid "Create an account"
 msgstr "Tạo tài khoản"
@@ -4878,6 +4884,9 @@ msgstr "Đọc chính tả"
 
 msgid "Dictation is not available on this device"
 msgstr "Đọc chính tả không khả dụng trên thiết bị này"
+
+msgid "Didn't hear back"
+msgstr "Không có phản hồi"
 
 msgid "diff"
 msgstr "diff"
@@ -8987,6 +8996,9 @@ msgstr "Không có biểu tượng"
 
 msgid "No Internet Connection"
 msgstr "Không có kết nối internet"
+
+msgid "No internet connection."
+msgstr "Không có kết nối Internet."
 
 msgid "No issues found."
 msgstr "Không tìm thấy issue nào."
@@ -13991,6 +14003,9 @@ msgstr "Agent tốt nhất sẽ thay đổi.<0/>Quy trình của bạn thì khô
 msgid "The Codex sign-in"
 msgstr "Lần đăng nhập Codex"
 
+msgid "The connection dropped."
+msgstr "Kết nối đã bị ngắt."
+
 msgid "The connection timed out"
 msgstr "Kết nối đã quá thời gian"
 
@@ -14069,6 +14084,9 @@ msgstr "Máy chủ đã trở lại với {0}, không phải {targetVersion}."
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "Máy chủ không hoạt động trở lại trong vòng mười lăm phút."
+
+msgid "The host hasn't answered."
+msgstr "Host không phản hồi."
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "Host chưa kết nối tới relay của Superset. Nếu đó là thiết bị này, hãy bật \"Cho phép truy cập từ xa vào thiết bị này qua relay\" trong Cài đặt > Truy cập từ xa, rồi thử lại."
@@ -14172,6 +14190,9 @@ msgstr "Thư mục kho lưu trữ vẫn được giữ nguyên."
 msgid "The request failed."
 msgstr "Yêu cầu thất bại."
 
+msgid "The request timed out."
+msgstr "Yêu cầu đã hết thời gian chờ."
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "Cách phản ứng: agent review agent, còn con người lấy mẫu thay vì đọc tất cả. Niềm tin được xây bằng thống kê, không phải theo từng diff."
 
@@ -14235,6 +14256,9 @@ msgstr "Giao diện agent trên web hiện chỉ là bản xem trước chỉ đ
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "Workspace chưa sẵn sàng. Hãy thử lại."
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "Workspace vẫn có thể đã được tạo. Màn hình này sẽ mở nó nếu xuất hiện."
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "Worktree và mọi thay đổi chưa commit sẽ bị gỡ. Không thể hoàn tác."
@@ -14557,9 +14581,6 @@ msgstr "Hạng"
 
 msgid "Time range"
 msgstr "Khoảng thời gian"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "Quá thời gian chờ host tạo workspace."
 
 msgid "Title"
 msgstr "Tiêu đề"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -4009,6 +4009,9 @@ msgstr "无法连接到主机以加载此拉取请求。"
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "无法连接主机以开始更新。请确认主机在线后重试。"
 
+msgid "Could not reach the server."
+msgstr "无法连接到服务器。"
+
 msgid "Could not reach this workspace's machine"
 msgstr "无法连接到这个工作区所在的机器"
 
@@ -4253,6 +4256,9 @@ msgstr "创建团队"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "在我的MacBook上为认证功能创建一个工作区"
+
+msgid "Create again"
+msgstr "再次创建"
 
 msgid "Create an account"
 msgstr "创建账户"
@@ -4878,6 +4884,9 @@ msgstr "语音输入"
 
 msgid "Dictation is not available on this device"
 msgstr "此设备不支持语音输入"
+
+msgid "Didn't hear back"
+msgstr "未收到响应"
 
 msgid "diff"
 msgstr "差异"
@@ -8987,6 +8996,9 @@ msgstr "无图标"
 
 msgid "No Internet Connection"
 msgstr "无网络连接"
+
+msgid "No internet connection."
+msgstr "无网络连接。"
 
 msgid "No issues found."
 msgstr "未找到议题。"
@@ -13991,6 +14003,9 @@ msgstr "最好的智能体会变。<0/>你的工作流不该变。"
 msgid "The Codex sign-in"
 msgstr "Codex登录"
 
+msgid "The connection dropped."
+msgstr "连接已中断。"
+
 msgid "The connection timed out"
 msgstr "连接已超时"
 
@@ -14069,6 +14084,9 @@ msgstr "主机以 {0} 而非 {targetVersion} 恢复。"
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "主机未在十五分钟内恢复。"
+
+msgid "The host hasn't answered."
+msgstr "主机未响应。"
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "该主机没有连接到Superset中继。如果就是此设备，请在“设置>远程访问”中打开“允许通过中继远程访问本设备”，然后重试。"
@@ -14172,6 +14190,9 @@ msgstr "仓库文件夹本身会保留。"
 msgid "The request failed."
 msgstr "请求失败。"
 
+msgid "The request timed out."
+msgstr "请求超时。"
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "应对办法是：让智能体审查智能体，人类改为抽样而不是通读。信任靠统计建立，而不是逐个差异建立。"
 
@@ -14235,6 +14256,9 @@ msgstr "网页版智能体界面目前是只读预览。"
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "工作区尚未就绪。请重试。"
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "工作区可能已经创建。如果出现，此界面会自动打开它。"
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "worktree及其中所有未提交的更改都会被移除。此操作无法撤销。"
@@ -14557,9 +14581,6 @@ msgstr "等级"
 
 msgid "Time range"
 msgstr "时间范围"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "等待主机创建工作区超时。"
 
 msgid "Title"
 msgstr "标题"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -13351,6 +13351,9 @@ msgstr "第{0}步，共2步"
 msgid "Step {step}: {name}"
 msgstr "第{step}步：{name}"
 
+msgid "Still can't reach the host."
+msgstr "仍然无法连接到主机。"
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "仍在处理 — 大仓库可能需要几分钟。你可以离开；工作区就绪后会出现在首页。"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -14003,9 +14003,6 @@ msgstr "最好的智能体会变。<0/>你的工作流不该变。"
 msgid "The Codex sign-in"
 msgstr "Codex登录"
 
-msgid "The connection dropped."
-msgstr "连接已中断。"
-
 msgid "The connection timed out"
 msgstr "连接已超时"
 
@@ -14189,9 +14186,6 @@ msgstr "仓库文件夹本身会保留。"
 
 msgid "The request failed."
 msgstr "请求失败。"
-
-msgid "The request timed out."
-msgstr "请求超时。"
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "应对办法是：让智能体审查智能体，人类改为抽样而不是通读。信任靠统计建立，而不是逐个差异建立。"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -13351,6 +13351,9 @@ msgstr "第{0}步，共2步"
 msgid "Step {step}: {name}"
 msgstr "第{step}步：{name}"
 
+msgid "Still can't reach the host."
+msgstr "仍然無法連線到主機。"
+
 msgid "Still working — large repos can take a few minutes. You can leave; the workspace will appear on Home when it's ready."
 msgstr "仍在處理 — 大儲存庫可能需要幾分鐘。你可以離開；工作區就緒後會出現在首頁。"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -4009,6 +4009,9 @@ msgstr "無法連線到主機以載入此拉取請求。"
 msgid "Could not reach the host to start the update. Check that it is online and try again."
 msgstr "無法連線主機以開始更新。請確認主機在線上後重試。"
 
+msgid "Could not reach the server."
+msgstr "無法連線到伺服器。"
+
 msgid "Could not reach this workspace's machine"
 msgstr "無法連線到這個工作區所在的機器"
 
@@ -4253,6 +4256,9 @@ msgstr "建立團隊"
 
 msgid "Create a workspace for the auth feature on my MacBook"
 msgstr "在我的MacBook上為認證功能建立一個工作區"
+
+msgid "Create again"
+msgstr "再次建立"
 
 msgid "Create an account"
 msgstr "建立帳戶"
@@ -4878,6 +4884,9 @@ msgstr "語音輸入"
 
 msgid "Dictation is not available on this device"
 msgstr "此裝置不支援語音輸入"
+
+msgid "Didn't hear back"
+msgstr "未收到回應"
 
 msgid "diff"
 msgstr "差異"
@@ -8987,6 +8996,9 @@ msgstr "無圖示"
 
 msgid "No Internet Connection"
 msgstr "無網路連線"
+
+msgid "No internet connection."
+msgstr "沒有網際網路連線。"
 
 msgid "No issues found."
 msgstr "未找到議題。"
@@ -13991,6 +14003,9 @@ msgstr "最好的代理程式會變。<0/>你的工作流不該變。"
 msgid "The Codex sign-in"
 msgstr "Codex登入"
 
+msgid "The connection dropped."
+msgstr "連線已中斷。"
+
 msgid "The connection timed out"
 msgstr "連線已逾時"
 
@@ -14069,6 +14084,9 @@ msgstr "主機以 {0} 而非 {targetVersion} 恢復。"
 
 msgid "The host did not come back within fifteen minutes."
 msgstr "主機未在十五分鐘內恢復。"
+
+msgid "The host hasn't answered."
+msgstr "主機未回應。"
 
 msgid "The host isn't connected to the Superset relay. If it's this device, turn on \"Allow remote access to this device via relay\" in Settings > Remote Access, then try again."
 msgstr "該主機沒有連線到Superset中繼。如果就是此裝置，請在「設定>遠端存取」中開啟「允許遠端存取通過中繼存取此裝置」，然後重試。"
@@ -14172,6 +14190,9 @@ msgstr "儲存庫資料夾本身會保留。"
 msgid "The request failed."
 msgstr "請求失敗。"
 
+msgid "The request timed out."
+msgstr "要求逾時。"
+
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "應對辦法是：讓代理程式審查代理程式，人類改為抽樣而不是通讀。信任靠統計建立，而不是逐個差異建立。"
 
@@ -14235,6 +14256,9 @@ msgstr "網頁版代理程式介面目前是隻讀預覽。"
 
 msgid "The workspace is not ready yet. Try again."
 msgstr "工作區尚未就緒。請重試。"
+
+msgid "The workspace may still have been created. This screen opens it if it appears."
+msgstr "工作區可能仍已建立。如果出現，此畫面會開啟它。"
 
 msgid "The worktree and any uncommitted changes will be removed. This cannot be undone."
 msgstr "worktree及其中所有未提交的更改都會被移除。此操作無法復原。"
@@ -14557,9 +14581,6 @@ msgstr "等級"
 
 msgid "Time range"
 msgstr "時間範圍"
-
-msgid "Timed out waiting for the host to create the workspace."
-msgstr "等待主機建立工作區逾時。"
 
 msgid "Title"
 msgstr "標題"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -14003,9 +14003,6 @@ msgstr "最好的代理程式會變。<0/>你的工作流不該變。"
 msgid "The Codex sign-in"
 msgstr "Codex登入"
 
-msgid "The connection dropped."
-msgstr "連線已中斷。"
-
 msgid "The connection timed out"
 msgstr "連線已逾時"
 
@@ -14189,9 +14186,6 @@ msgstr "儲存庫資料夾本身會保留。"
 
 msgid "The request failed."
 msgstr "請求失敗。"
-
-msgid "The request timed out."
-msgstr "要求逾時。"
 
 msgid "The response: agents review agents, and humans sample instead of reading everything. Trust is earned statistically, not per diff."
 msgstr "應對辦法是：讓代理程式審查代理程式，人類改為抽樣而不是通讀。信任靠統計建立，而不是逐個差異建立。"

--- a/packages/i18n/test/display-only.test.ts
+++ b/packages/i18n/test/display-only.test.ts
@@ -16,7 +16,9 @@ const SCAN_DIRS = [
 	"apps/mobile/components",
 	"apps/mobile/hooks",
 	"apps/mobile/lib",
+	"apps/mobile/modules",
 	"apps/mobile/screens",
+	"apps/mobile/scripts",
 	"packages/ui/src",
 ];
 

--- a/packages/i18n/test/display-only.test.ts
+++ b/packages/i18n/test/display-only.test.ts
@@ -7,7 +7,18 @@ import { join, resolve } from "node:path";
 // classification). This scan enforces that repo-wide; use rawErrorMessage()
 // or the error object for those paths.
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
-const SCAN_DIRS = ["apps/desktop/src", "apps/web/src", "packages/ui/src"];
+// Source roots, never an app root: the scan globs everything under the
+// directory, and apps/mobile has its own node_modules.
+const SCAN_DIRS = [
+	"apps/desktop/src",
+	"apps/web/src",
+	"apps/mobile/app",
+	"apps/mobile/components",
+	"apps/mobile/hooks",
+	"apps/mobile/lib",
+	"apps/mobile/screens",
+	"packages/ui/src",
+];
 
 const FORBIDDEN: { name: string; pattern: RegExp }[] = [
 	{


### PR DESCRIPTION
Mason (#ext-trainloop, Sunday) hit this creating a worktree from the phone:

> Could not create workspace
> fetch failed: UnexpectedException: The network connection was lost. (at ExpoModulesCore/Promise.swift:56)

Fourteen alert sites were built as `Alert.alert(title, error instanceof Error ? error.message : String(error))`, so whatever the transport threw became the body.

## Why iOS tells us nothing

`ExpoFetchModule.swift:107` rejects with URLSession's raw `NSError`. `Promise.reject` wraps any non-`Exception` in `UnexpectedException` (`expo-modules-core/ios/Core/Promise.swift:57`), which keeps **only** `localizedDescription`. So the NSURLError code — −1005, −1001, −1009 — never reaches JavaScript, and the text that does is localized by iOS. `FetchError` isn't exported from `expo/fetch` either, so there isn't even a class to check.

There is no Expo-sanctioned way to recover the kind. **So we stop asking Expo.**

## Detection is structural, not textual

An earlier revision of this PR regex-matched `fetch failed:` and then English `localizedDescription` text, with a second regex scrubbing whatever slipped through. That was a filter over a guess. It's gone.

| source | signal |
|---|---|
| tRPC clients | `TRPCClientError` with no `data` — tRPC populates it **only** from a parsed server envelope, so its absence *is* the transport signal. Already the desktop's predicate (`isConnectionError`, `packages/workspace-client/.../hostServiceLinks.ts`). |
| better-auth | `transportFetch` — the `catch` is around our own `fetch` call, so it's transport by construction. `customFetchImpl` is a supported `@better-fetch` option. |
| offline vs unreachable | `expo-network` (already a dependency, previously unused). Also *current at alert time*, unlike −1009's wording. |
| Expo native modules outside tRPC (`expo-file-system` reading an attachment) | the `ERR_*` `code` every Expo exception carries (`errorCodeFromString`, `CodedError.swift`) — a property, not a message. |

**Zero string matching.** A Japanese phone now classifies identically to an English one, which the regex version could not do.

I dropped the separate −1005 and −1001 copy. Without the code there's nothing to distinguish them by, and pretending otherwise was the hacky part. Two kinds remain: `offline` → "No internet connection.", `unreachable` → "Could not reach the server." A server's own message still passes through — GitHub's reason for refusing a merge is the useful part.

## The report is a retry, not a copy bug

Apple's guidance for −1005 is to **retry** it ([QA1941](https://developer.apple.com/forums/thread/693120)) — it's a pooled HTTPS connection iOS dropped while idle, which is every first tap after the app sits in a pocket. [Well documented](https://javascript.plainenglish.io/when-fetch-fails-silently-debugging-a-sneaky-ios-18-4-network-bug-in-react-native-55a7c7b9c6d4) in RN/Expo apps. We never retried: tRPC links don't, and react-query doesn't retry mutations.

Both mobile clients now use `retryLink`, **queries only, one retry.**

Mutations are excluded, and this is the part worth your attention. I checked whether `createEnqueued` was replay-safe, expecting the client-minted `id` to be an idempotency key. **It isn't.** `idempotencyId` only mints the row id on fresh registration (`adopt-existing-worktree.ts:170`); dedupe is by *branch* (`findExistingWorkspaceByBranch`). The mobile composer sends no branch, so `create` picks a fresh friendly-random name per call — a replayed create lands a **second** workspace.

That is the same mechanism behind the strays in Mason's screenshot, and it means blind mutation retry would have made this worse.

**Follow-up worth a ticket:** if the client minted the branch name up front (`workspaces.generateBranchName` already exists), creates would become genuinely replay-safe and both the alert *and* the strays would go away. Out of scope here — it changes the create contract.

## The false negative

`WorkspaceScreen` already knew this: *"a relay timeout can reject a create the host actually finished, and the row arriving is what heals it."* The copy didn't.

- Transport failure now resolves to **"Didn't hear back"**, not "Couldn't create workspace", and says the workspace may still appear. A host-side refusal still says it failed, because that we can prove.
- Retry mints a fresh id, so tapping it after a create that landed is how you get a stray. It now asks the host (`workspace.list`, the check `useDeleteWorkspace` already uses) and opens the original if present. Button relabelled **"Create again"**, demoted to secondary. With mutation retry off the table this guard is the actual duplicate protection, not a backstop.

## No wrapper around ordinary error handling

An earlier revision routed every site through `alertError(title, error, scope)`, which also reported to Sentry. That hid whether anything was reported and turned `scope` into a stringly-typed parameter invented fresh at fourteen sites. It's gone.

Call sites are plain `Alert.alert` again, with **`errorCopy(error)` in place of `error.message`** — the shape the codebase already used (`Alert.alert(title, errorMessage(cause))` in `WorkspaceScreen`). They keep their own `console.error` and `posthog.capture`, written out where you can see them. `errorCopy` is the whole public surface at a call site.

The one policy worth keeping — a phone losing its connection is not a Sentry event — is `beforeSend` in `Sentry.init`, beside the DSN and sample rates:

```ts
beforeSend: (event, hint) =>
    isTransportError(hint?.originalException) ? null : event,
```

One place, the idiomatic one, and it applies to anything captured anywhere rather than only where someone remembered to call a helper. The manual breadcrumb went too — `breadcrumbsIntegration` is a default integration and already records the failed request. This also means no new Sentry volume from the fourteen sites, which I'd flagged as a concern in the earlier revision.

`workspace_create_failed` carries a stable-English `failure_kind`, so the transport-failure rate is still answerable in PostHog. Raw error only in diagnostics — `errorCopy()` never reaches a log, Sentry, or PostHog, per the AGENTS.md / `packages/i18n` display-only rule, which `display-only.test.ts` now enforces over the mobile source roots (not the app root — it has its own `node_modules`).

## i18n

6 new strings, English as the id, hand-translated into all 16 catalogs. `compile --strict` passes with 0 missing. Three retired.

## Verification

- `bunx tsc --noEmit` in `apps/mobile` — clean. (Only after `bunx turbo build:types`: `port-scanner`, `pty-daemon` and `workspace-fs` point `types` at `dist-types/`, and without those built TypeScript falls back to their source and reports unrelated errors. CI builds them first.)
- `bun test` — mobile 66, i18n 124. `bunx biome check` clean. `bun run check:i18n` green across 16 locales.
- Retry policy is one `transportRetryLink()` rather than the same comment pasted into both clients; the reachability listener is an explicit `watchNetworkState()` in `RootLayout` beside `initI18n`, not an import-time side effect.
- Classifier exercised against the real shapes: tRPC-wrapped Expo leak, a Japanese `localizedDescription`, a `TransportError` from the auth path, a genuine server envelope (must *not* classify as transport), an `ERR_UNEXPECTED` native error, and an assertion that no output contains `ExpoModulesCore` / `UnexpectedException` / `.swift` / `fetch failed`. 7/7 pass. Run as a scratch file per your standing "no tests unprompted" — say the word and I'll land it as `lib/errors/errors.test.ts`.
- **Verified on a simulator**, end to end. Dev sign-in against an unreachable API on a throwaway iOS 26 sim:

  | | |
  |---|---|
  | user sees | **Could not reach the server.** |
  | log keeps | `TransportError: fetch failed: UnexpectedException: Could not connect to the server. (at ExpoModulesCore/Promise.swift:56)` |

  That is Mason's leak shape, in the log where it belongs, with clean copy on screen. It also proves the pieces I could only read before: `transportFetch` wraps better-auth's rejection, `expo-network` is linked and `watchNetworkState()` runs at startup without breaking boot, and the restored plain `console.error` is what carries the diagnostic.

  (Incidentally an NSURLError **-1004**, not one of the three the brief named — and it still produces correct copy rather than a leak, which is the case the old text-matching version handled only by falling through.)

- **`isExpoNativeError` verified too.** A deliberate `expo-file-system` read of a missing file, probed on device, returns:

  ```
  code = "ERR_UNEXPECTED"   name = "Error"   constructor = Error
  message = "UnexpectedException: The file “probe.txt” couldn’t be opened
             because there is no such file. (at ExpoModulesCore/AsyncFunctionDefinition.swift:126)"
  ```

  So `.code` is real and `ERR_*`, while `name` and the constructor are plain `Error` — there is no class to `instanceof`, which is exactly why the check reads the property. Note the frame is `AsyncFunctionDefinition.swift:126`, **not** the `Promise.swift:56` from the original report: the leak class is wider than the one Mason hit, and this message would have reached a user through the attachment path. It is now scrubbed.

## Coordination

`mason-mobile-warm-terminal-connections` also touches `WorkspaceScreen.tsx`, in the terminal-connection block at the bottom; mine are the pending-create state and `killTerminal`. Agreed split. Whoever lands second reruns `bun run check:i18n`.

## cubic review — 5 of 6 taken

Two were real P1 bugs in the anti-duplicate guard itself, which is the part I'd told Satya was the real protection:

- **A failed lookup counted as "absent"** and created anyway, so a host unreachable twice produced exactly the duplicate the check exists to prevent. Now it keeps the failed state and says the host still can't be reached.
- **Dismissing during the check** let the awaited callback still call `createWorkspace.mutate` on the way out. Dismiss is disabled while checking, and the callback re-checks the pending entry plus a mount latch (a back-swipe unmounts without clearing the entry).

Also taken: attachment-upload failures are now `failed` rather than `unknown` (uploads run before the create is sent, so they prove it was never requested); cloud creates report `failure_kind`; the display-only scan covers `apps/mobile/modules` and `scripts`.

**Not taken:** cubic said removing "Timed out waiting for the host to create the workspace." breaks the desktop. Nothing references that string — `extract --clean` dropped it because this branch removed its only caller.

Not merging — over to you.

https://claude.ai/code/session_01PGMNW55o17yy7evZRQwxi9
