### PR TITLE
fix(automations): continue a pinned automation's agent instead of stacking a new session per run

### DIFF
--- a/packages/host-service/src/trpc/router/agents/agents.ts
+++ b/packages/host-service/src/trpc/router/agents/agents.ts
@@ -24,7 +24,10 @@ import { z } from "zod";
 import type { HostDb } from "../../../db";
 import { hostAgentConfigs, workspaces } from "../../../db/schema";
 import { hasHarnessSession } from "../../../terminal/harness-transcript";
-import { createTerminalSessionInternal } from "../../../terminal/terminal";
+import {
+	createTerminalSessionInternal,
+	writeFramedInputToSession,
+} from "../../../terminal/terminal";
 import type { HostServiceContext } from "../../../types";
 import { protectedProcedure, router } from "../../index";
 import { resolveAttachmentPath } from "../attachments/storage";
@@ -217,6 +220,13 @@ export interface AgentRunInput {
 	resumeSessionId?: string;
 	/** Session id to clone into a new provider-owned session. */
 	forkSessionId?: string;
+	/**
+	 * A terminal an earlier run of this same caller left behind. When it still
+	 * runs this agent, the prompt is delivered into that session instead of
+	 * starting a second one beside it. Anything else — terminal gone, agent
+	 * exited, a different agent now owns it — launches as usual.
+	 */
+	continueTerminalId?: string;
 }
 
 export type AgentRunResult = {
@@ -588,6 +598,72 @@ async function runTerminalAgent(
 	};
 }
 
+/**
+ * Deliver the prompt into the agent already running in `continueTerminalId`,
+ * or return null to let the caller launch a fresh session.
+ *
+ * For a caller that runs the same agent in the same workspace over and over —
+ * automation dispatch against a pinned workspace — every run used to leave
+ * another live agent behind: a five-minute schedule put 181 concurrent codex
+ * sessions in one worktree, all editing the same files and all spending
+ * tokens. Naming the previous run's terminal turns that into one session that
+ * keeps getting prompts.
+ *
+ * Every "no" here falls through to a normal launch rather than failing the
+ * run, so a caller can always name a terminal it is no longer sure about.
+ */
+async function continueTerminalAgent(
+	ctx: Pick<HostServiceContext, "db" | "eventBus" | "terminalAgentStore">,
+	input: AgentRunInput,
+): Promise<AgentRunResult | null> {
+	const terminalId = input.continueTerminalId;
+	if (!terminalId || input.prompt.trim().length === 0) return null;
+	// Launch-time-only options can't be applied to a process that is already
+	// running, so honour them with a launch instead of silently dropping them.
+	if (
+		input.model ||
+		input.effort ||
+		input.mode ||
+		input.resumeSessionId ||
+		input.forkSessionId ||
+		(input.attachmentIds?.length ?? 0) > 0
+	) {
+		return null;
+	}
+
+	const config = resolveHostAgentConfig(ctx.db, input.agent);
+	if (!config) return null;
+
+	// Live reads only: a binding whose terminal died or whose agent exited is
+	// not a continuation target. That is also what keeps the prompt out of a
+	// bare shell — the send below adopts but never respawns, so a terminal
+	// whose pty is gone errors instead of coming back as an empty shell.
+	const binding = ctx.terminalAgentStore
+		.listByWorkspace(input.workspaceId)
+		.find((candidate) => candidate.terminalId === terminalId);
+	if (!binding) return null;
+	// Resolve both sides: the caller may name a preset while the binding
+	// carries the custom definition that preset resolved to, or vice versa.
+	const bound = resolveHostAgentConfig(
+		ctx.db,
+		binding.definitionId ?? binding.agentId,
+	);
+	if (bound?.id !== config.id) return null;
+
+	const sent = await writeFramedInputToSession({
+		terminalId,
+		workspaceId: input.workspaceId,
+		text: input.prompt,
+		submit: true,
+		db: ctx.db,
+		eventBus: ctx.eventBus,
+	});
+	// Raced the session's death between the binding read and the write.
+	if ("error" in sent) return null;
+
+	return { kind: "terminal", sessionId: terminalId, label: config.label };
+}
+
 export async function runAgentInWorkspace(
 	ctx: HostServiceContext,
 	input: AgentRunInput,
@@ -603,6 +679,9 @@ export async function runAgentInWorkspace(
 			message: `Workspace ${input.workspaceId} not found on this host — it may have been deleted.`,
 		});
 	}
+	// Before any launch work: continuing costs no pty, no trust seeding.
+	const continued = await continueTerminalAgent(ctx, input);
+	if (continued) return continued;
 	// Session workspaces are standalone repos the host itself scaffolded, so
 	// agent CLIs can't inherit folder trust from anywhere — pre-trust the
 	// folder in the launching agent's own trust store so its first
@@ -632,6 +711,7 @@ export const agentsRouter = router({
 				mode: z.string().min(1).optional(),
 				resumeSessionId: z.string().min(1).optional(),
 				forkSessionId: z.string().min(1).optional(),
+				continueTerminalId: z.string().min(1).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => runAgentInWorkspace(ctx, input)),

--- a/packages/trpc/src/router/automation/dispatch.ts
+++ b/packages/trpc/src/router/automation/dispatch.ts
@@ -18,7 +18,7 @@ import {
 	sanitizeBranchNameWithMaxLength,
 	slugifyForBranch,
 } from "@superset/shared/workspace-launch";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
 import { fetchRelayPresence } from "../../lib/relay-presence";
 import { RelayDispatchError, relayMutation } from "./relay-client";
 import { promptWithTriggerContext } from "./triggerContext";
@@ -223,6 +223,10 @@ export async function dispatchAutomation(
 			event,
 		);
 
+		const continueTerminalId = automation.v2WorkspaceId
+			? await previousRunTerminal(automation.id, automation.v2WorkspaceId)
+			: undefined;
+
 		const runAgent = (targetWorkspaceId: string) =>
 			runAgentOnHost({
 				relayUrl,
@@ -231,6 +235,11 @@ export async function dispatchAutomation(
 				workspaceId: targetWorkspaceId,
 				agent: automation.agent,
 				prompt,
+				// Only the pinned workspace holds a session worth continuing; the
+				// stale-pin fallback below branches a fresh one, which has none.
+				...(continueTerminalId && targetWorkspaceId === automation.v2WorkspaceId
+					? { continueTerminalId }
+					: {}),
 			});
 
 		workspaceId = automation.v2WorkspaceId ?? (await createFreshWorkspace());
@@ -613,12 +622,15 @@ async function runAgentOnHost(args: {
 	workspaceId: string;
 	agent: string;
 	prompt: string;
+	/** See {@link previousRunTerminal}. */
+	continueTerminalId?: string;
 }): Promise<AgentRunResult> {
 	return relayMutation<
 		{
 			workspaceId: string;
 			agent: string;
 			prompt: string;
+			continueTerminalId?: string;
 		},
 		AgentRunResult
 	>(
@@ -628,8 +640,50 @@ async function runAgentOnHost(args: {
 			workspaceId: args.workspaceId,
 			agent: args.agent,
 			prompt: args.prompt,
+			// An older host's run schema simply strips the unknown key and
+			// launches, which is what every host did before this existed.
+			...(args.continueTerminalId
+				? { continueTerminalId: args.continueTerminalId }
+				: {}),
 		},
 	);
+}
+
+/**
+ * The terminal this automation's last run left in its pinned workspace, for
+ * the host to deliver into instead of launching beside it.
+ *
+ * A workspace pin means "reuse this workspace every run", but only the
+ * directory was ever reused: each run started another agent next to the last
+ * one, none of which ever exits — a TUI agent sits at its prompt after
+ * finishing a turn. A five-minute schedule pinned to one workspace therefore
+ * accumulated a live agent per tick (181 codex sessions in 18 hours, all on
+ * the same worktree, all billing tokens) until the owner paused it.
+ *
+ * Unpinned automations branch a fresh workspace per run, so they have no
+ * previous session to continue and are left alone. The host makes the final
+ * call — this only names a candidate, and a stale one costs nothing.
+ */
+async function previousRunTerminal(
+	automationId: string,
+	workspaceId: string,
+): Promise<string | undefined> {
+	const [previous] = await db
+		.select({ terminalSessionId: automationRuns.terminalSessionId })
+		.from(automationRuns)
+		.where(
+			and(
+				eq(automationRuns.automationId, automationId),
+				eq(automationRuns.v2WorkspaceId, workspaceId),
+				eq(automationRuns.status, "dispatched"),
+				eq(automationRuns.sessionKind, "terminal"),
+				isNotNull(automationRuns.terminalSessionId),
+			),
+		)
+		// createdAt, not dispatchedAt: it matches automation_runs_history_idx.
+		.orderBy(desc(automationRuns.createdAt))
+		.limit(1);
+	return previous?.terminalSessionId ?? undefined;
 }
 
 function describeError(err: unknown, context: string): string {


### PR DESCRIPTION
## Problem

A user reported that opening a workspace on mobile "duplicates the same agent a bunch of times" — 6 agent marks on the home row, then 13 forty minutes later. It is not the mobile app, and it is not reconnecting: the count grows on a wall clock, not on taps.

They had a scheduled automation (`FREQ=MINUTELY;INTERVAL=5`) **pinned to a workspace**. Every duplicate was a real PTY running a real agent, spending real tokens.

## Root cause

A workspace pin means "reuse this workspace every run" — the `--workspace` flag is documented as *"existing v2 workspace id — reuses it every run"*. Only the directory was ever reused.

- `packages/trpc/src/router/automation/dispatch.ts:249` — `runAgent(workspaceId)` fires unconditionally on every tick
- `packages/host-service/src/trpc/router/agents/agents.ts:580` — `runTerminalAgent` mints a fresh `crypto.randomUUID()` terminal on every call

A TUI agent never exits; it sits at its prompt after finishing a turn. So each tick left another live agent behind, forever:

```
schedule tick → dispatchAutomation → agents.run(workspaceId: <pinned>)
              → runTerminalAgent → new terminalId → new pty → another live agent
```

### Evidence

From `automation_runs` for the affected automation (read-only query against a branch copy):

| status | runs | with a session | **distinct sessions** |
|---|---|---|---|
| dispatched | 181 | 181 | **181** |
| skipped_offline | 23 | 0 | 0 |
| dispatch_failed | 13 | 0 | 0 |

One session per successful run — **181 of them, all in a single `v2_workspace_id`**, over 18 hours until the owner paused the automation. The counts match the two user reports exactly: **5** runs dispatched by the time of the first screenshot (plus the workspace's own original session = the 6 shown), and **13** forty minutes later.

Failed runs produced **zero** sessions, so this is not the retry-storm class of #7284 / #7280 — it is one session per *successful* run, by construction.

## Fix

`agents.run` takes an optional `continueTerminalId`. When that terminal still holds a **live binding for the same agent**, the prompt is delivered into it via `writeFramedInputToSession` — the same path `terminal.send` already uses — instead of launching beside it. Automation dispatch names the terminal its own previous run reported, and only for a pinned workspace.

The host makes the decision, in one round trip. Every "no" falls through to a normal launch rather than failing the run:

- the terminal is gone, or its agent exited (a bare shell must never be typed into — the send adopts but never respawns, so a dead pty errors instead of returning as an empty shell)
- a different agent now owns it
- launch-only options are set (`model` / `effort` / `mode` / attachments / resume / fork), which cannot be applied to a running process
- the send raced the session's death

The candidate is always the automation's **own** previous session, never "any agent of this kind in the workspace", so it can never hijack a session the user started. Two automations pinned to one workspace keep their own sessions.

**Unchanged:** create-on-attach (the desktop still inserts panes optimistically), resume, `restartAccountSessions`, and unpinned automations — those branch a fresh workspace per run, so they have no previous session to continue. An older host simply strips the unknown key and launches, exactly as before.

**No host-side cap.** Parallel agents in one workspace are legitimate and deliberate; the host is not where the unwanted repetition originates. The dispatcher is.

**Trade-off, stated plainly:** a pinned recurring automation now accumulates turns in one conversation instead of accumulating sessions. That is the right side of the trade against N concurrent processes on one worktree, and it also gives a recurring monitor the continuity it would otherwise hand-roll through a state file.

## Verification

End to end against a real host-service and pty daemon (`createProjectScenario` + `agents.run` + the real `notifications.hook` agent lifecycle hook), 4 cases:

1. **the bug** — 4 runs without the field → 4 live ptys
2. **the fix** — 6 ticks with `continueTerminalId` → exactly **1** live pty
3. an unknown terminal → falls through to a launch
4. an agent that ended (pty still alive as a bare shell) → falls through; the prompt is never typed into the shell

```
 4 pass
 0 fail
Ran 4 tests across 1 file.
```

Across three repeat runs on a loaded machine, cases 2–4 passed every time; the reproduction case flaked twice on git-fixture setup (`fatal: not a git repository` in the temp worktree), unrelated to this change.

The test is not in this commit, per the usual "no tests unprompted" rule — it is written and green, say the word and I will add it.

```
$ bunx biome check packages/host-service/src/trpc/router/agents/agents.ts packages/trpc/src/router/automation/dispatch.ts
Checked 2 files in 40ms. No fixes applied.

$ bunx tsc --noEmit -p packages/host-service/tsconfig.json && bunx tsc --noEmit -p packages/trpc/tsconfig.json
TYPECHECK OK

$ cd packages/host-service && bun test src/trpc/router/agents src/trpc/router/terminal-agents src/terminal-agents src/trpc/router/terminal
 148 pass
 0 fail
Ran 148 tests across 9 files.
```

`packages/trpc` has 4 pre-existing failures (growth sitemap, search-console, github, plugins oauth) that fail identically with `origin/main`'s `dispatch.ts` — missing env vars in the worktree, unrelated. The wider `host-service` suite timed out on `workspaceCleanup` and `host-worker-pool` under load; both pass when run alone.

## Not fixed here

The sessions already accumulated on an affected machine. Reaping them is a user action, not a migration.

https://claude.ai/code/session_01HqtqS723QGrk6esbZ3gpA5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pinned automations leaving one live agent session behind per run by continuing the previous run's terminal instead of launching a new one.

**Notes**
- Applies only to pinned workspaces; unpinned automations branch fresh workspaces and are unchanged.
- Any mismatch falls back to a fresh launch — no run fails.
- Already-accumulated sessions on affected machines aren't cleaned up here.
- Older hosts ignore `continueTerminalId` and launch as before.

<sup>Written for commit fd90817ad0f07d2754aeaa140616fa5277a5399b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automation runs can now continue an agent session already active in the relevant terminal.
  * Prompts are delivered to an existing session when compatible; otherwise, a new session starts automatically.
  * Automation dispatch can preserve continuity for runs associated with a pinned workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->