### PR TITLE
feat(mobile): remember the last session tab per workspace

### DIFF
--- a/apps/mobile/screens/(authenticated)/stores/lastSessionTabStore/index.ts
+++ b/apps/mobile/screens/(authenticated)/stores/lastSessionTabStore/index.ts
@@ -1,0 +1,1 @@
+export { useLastSessionTabStore } from "./lastSessionTabStore";

--- a/apps/mobile/screens/(authenticated)/stores/lastSessionTabStore/lastSessionTabStore.ts
+++ b/apps/mobile/screens/(authenticated)/stores/lastSessionTabStore/lastSessionTabStore.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+/**
+ * Same bound as desktop's v2 pane selection: past any number of workspaces a
+ * phone opens, but finite, so ids for workspaces deleted on some other machine
+ * cannot pile up here forever. Nothing else tells this device that a workspace
+ * is gone — the home list only ever names one host's.
+ */
+const MAX_REMEMBERED_WORKSPACES = 100;
+
+/**
+ * Device-local last active tab: workspaceId → the session that was attached
+ * when the user last left the workspace, so reopening it lands where they
+ * were rather than on the first tab. Only a hint — a session that has since
+ * exited is no longer in the strip, and the screen falls back to the first
+ * row.
+ */
+interface LastSessionTabStore {
+	tabByWorkspace: Record<string, string>;
+	/** False until AsyncStorage answers — the first tab would win the race. */
+	hasHydrated: boolean;
+	setLastSessionTab: (workspaceId: string, terminalId: string) => void;
+}
+
+export const useLastSessionTabStore = create<LastSessionTabStore>()(
+	persist(
+		(set) => ({
+			tabByWorkspace: {},
+			hasHydrated: false,
+			setLastSessionTab: (workspaceId, terminalId) => {
+				set((state) => {
+					// Re-inserted rather than assigned in place, so key order stays
+					// least-recently-opened first (JSON round-trips it) and the
+					// eviction below drops a workspace this device stopped opening
+					// rather than whichever one it happens to reach.
+					const { [workspaceId]: _previous, ...rest } = state.tabByWorkspace;
+					const tabByWorkspace = { ...rest, [workspaceId]: terminalId };
+					const overflow = Object.keys(tabByWorkspace).slice(
+						0,
+						-MAX_REMEMBERED_WORKSPACES,
+					);
+					for (const stale of overflow) delete tabByWorkspace[stale];
+					return { tabByWorkspace };
+				});
+			},
+		}),
+		{
+			name: "last-session-tab-v1",
+			storage: createJSONStorage(() => AsyncStorage),
+			partialize: ({ tabByWorkspace }) => ({ tabByWorkspace }),
+			// Flips on storage errors too, so a failed read falls back to the
+			// first tab rather than leaving the screen on its spinner.
+			onRehydrateStorage: () => () =>
+				useLastSessionTabStore.setState({ hasHydrated: true }),
+		},
+	),
+);

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -46,6 +46,7 @@ import { useAgentIconUris } from "@/screens/(authenticated)/hooks/useAgentIconUr
 import { useAppReviewPrompt } from "@/screens/(authenticated)/hooks/useAppReviewPrompt";
 import { useCreateTerminalWorkspace } from "@/screens/(authenticated)/hooks/useCreateTerminalWorkspace";
 import { useSlashCommands } from "@/screens/(authenticated)/hooks/useSlashCommands";
+import { useLastSessionTabStore } from "@/screens/(authenticated)/stores/lastSessionTabStore";
 import { usePendingWorkspaceCreatesStore } from "@/screens/(authenticated)/stores/pendingWorkspaceCreatesStore";
 import { useTerminalSeenStore } from "@/screens/(authenticated)/stores/terminalSeenStore";
 import { useTerminalTabOrderStore } from "@/screens/(authenticated)/stores/terminalTabOrderStore";
@@ -144,17 +145,42 @@ export function WorkspaceScreen() {
 		[terminalsByWorkspace, id, savedOrder],
 	);
 
-	// Active tab: the deep-linked ?tab= until the user switches, else the
-	// first session. Falls back gracefully when the active terminal dies.
+	// Active tab: the deep-linked ?tab= until the user switches, then the tab
+	// this workspace was left on, else the first session. A deep link names a
+	// session on purpose — a notification has to win over what the device
+	// remembers. Falls back gracefully when a candidate's terminal has died.
 	const [pickedTerminalId, setPickedTerminalId] = useState<string | null>(null);
+	const rememberedTerminalId = useLastSessionTabStore((state) =>
+		id ? state.tabByWorkspace[id] : undefined,
+	);
+	const tabsHydrated = useLastSessionTabStore((state) => state.hasHydrated);
 	const activeTerminalId = useMemo(() => {
-		for (const candidate of [pickedTerminalId, params.tab]) {
+		// Nothing to resolve against until AsyncStorage answers (~165ms cold):
+		// picking the first row now attaches a stream to the wrong session and
+		// swaps it out from under the user when the remembered tab lands.
+		if (!tabsHydrated) return null;
+		for (const candidate of [
+			pickedTerminalId,
+			params.tab,
+			rememberedTerminalId,
+		]) {
 			if (candidate && rows.some((row) => row.terminalId === candidate)) {
 				return candidate;
 			}
 		}
 		return rows[0]?.terminalId ?? null;
-	}, [pickedTerminalId, params.tab, rows]);
+	}, [tabsHydrated, pickedTerminalId, params.tab, rememberedTerminalId, rows]);
+
+	// Remembered here rather than in the tab-strip handler: every route into a
+	// session ends at this value — the strip, the sessions sheet, a new
+	// session's ?tab=, the fallback when the one you were on exits — and the
+	// effect writes once per change instead of once per render.
+	const setLastSessionTab = useLastSessionTabStore(
+		(state) => state.setLastSessionTab,
+	);
+	useEffect(() => {
+		if (id && activeTerminalId) setLastSessionTab(id, activeTerminalId);
+	}, [id, activeTerminalId, setLastSessionTab]);
 
 	// --- pending create (enqueued via `workspaces.createEnqueued`) ---
 	// The settled event only exists on the desktop's event bus, so poll the
@@ -784,7 +810,7 @@ export function WorkspaceScreen() {
 					</>
 				) : cloud && !workspace ? (
 					<CloudWorkspaceProvisioningState cloud={cloud} />
-				) : isResolving || (!isReady && host) ? (
+				) : isResolving || ((!isReady || !tabsHydrated) && host) ? (
 					<Centered>
 						<ActivityIndicator />
 					</Centered>


### PR DESCRIPTION
Reported by Mason Pierce in #ext-trainloop: *"it would be cool if you remembered my tab from the last time I opened it. Currently always defaults to first."*

He's right — the active tab lived in `pickedTerminalId`, component state that dies with the screen, so every reopen fell through to `rows[0]`.

## The change

A persisted `lastSessionTabStore` beside `terminalTabOrderStore`, same shape and same key (`tabByWorkspace[workspaceId]`), written whenever the active tab changes rather than from the tab-strip handler — every route into a session (the strip, the sessions sheet, a new session's `?tab=`, the fallback when one exits) ends at that one value, and the effect fires once per switch instead of once per render.

Precedence is now **explicit `?tab=` > remembered tab > first row**. A deep link names a session on purpose — a notification or a shared URL has to beat what the device remembers — so it stays ahead of the memory. The existing `rows.some(...)` guard already covers a remembered session that has since exited; it just falls through to the next candidate.

Two details worth a look in review:

- **Hydration gate.** AsyncStorage answers in ~165ms cold (the number `workspacesFilterStore` measured), and the effect that pins the resolved tab would latch the first row before the remembered one arrived. So `activeTerminalId` stays `null` until `hasHydrated`, and the screen's existing "still resolving" branch covers that window — same `hasHydrated` pattern `collapsedProjectsStore` and `workspacesFilterStore` use. Without it you'd attach a stream to the wrong session and visibly swap.
- **Bounded at 100 workspaces**, least-recently-opened evicted, matching desktop's `v2-pane-selection`. Nothing on the phone is told when a workspace is deleted elsewhere, and pruning against the home list would be wrong — it only ever names one host's workspaces, so an offline host would wipe its remembered tabs.

## Verified on a simulator

Dedicated iOS 26 sim against prod, a fixture workspace with three labelled sessions (ALPHA / BRAVO / CHARLIE):

| Scenario | Result |
| --- | --- |
| First open, nothing remembered | ALPHA (first row) — unchanged |
| Tab-strip switch to BRAVO → home → reopen with no `?tab=` | BRAVO |
| Deep link `?tab=CHARLIE` while BRAVO is remembered | CHARLIE — the link wins |
| Kill the app, relaunch, reopen | CHARLIE — survives AsyncStorage |
| Close CHARLIE, reopen | ALPHA — clean fallback |

`bun test` in apps/mobile: 66 pass. Typecheck error count unchanged against HEAD (24 pre-existing, all in `packages/port-scanner`, `pty-daemon`, `workspace-fs`; none in the touched files). Biome clean. No new strings, so no catalog changes.

https://claude.ai/code/session_011vfbtLKqJKzBxVHkV1tpcV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remembers the last session tab per workspace on mobile, so reopening a workspace lands where you left off instead of always on the first tab.

**Details**
- Explicit `?tab=` deep links still win over the remembered tab.
- The remembered session is validated against the current tab list; if it's gone, falls back to the first row.
- The store is capped at 100 workspaces, least-recently-opened evicted, matching desktop's v2 pane selection.
- A hydration gate keeps the screen on its loading state until AsyncStorage answers, preventing a brief attach to the wrong session.

<sup>Written for commit aa61addacaa9e00c45cf23cb31b759cd4ff164bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace screens now remember the last active session tab for each workspace.
  * Returning to a workspace restores the previously selected tab when available.
  * Deep-linked tabs continue to take priority over remembered selections.
* **Bug Fixes**
  * Improved tab loading behavior while saved session preferences are being restored.
  * Added a fallback to the first available tab if saved preferences cannot be restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->