### PR TITLE
fix(marketing): match cloud page icon to banner

### DIFF
--- a/apps/marketing/src/app/[lang]/cloud/page.tsx
+++ b/apps/marketing/src/app/[lang]/cloud/page.tsx
@@ -1,8 +1,8 @@
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { i18n } from "@superset/i18n";
-import { Cloud } from "lucide-react";
 import type { Metadata } from "next";
+import { FaCloud } from "react-icons/fa";
 import { ContactForm } from "@/app/[lang]/components/ContactForm";
 import { localizedAlternates } from "@/app/[lang]/metadata";
 import { initServerI18n } from "@/app/i18n-server";
@@ -27,7 +27,7 @@ export default async function CloudPage() {
 			<header className="border-b border-border">
 				<div className="max-w-3xl mx-auto px-6 pt-16 pb-10 md:pt-20 md:pb-12">
 					<div className="inline-flex items-center gap-2 text-sm font-mono text-muted-foreground">
-						<Cloud aria-hidden="true" className="size-4 text-brand" />
+						<FaCloud aria-hidden="true" className="size-4 text-brand" />
 						<Trans>Cloud</Trans>
 						<span className="border border-border px-2 py-0.5 text-xs">
 							<Trans>Coming soon</Trans>


### PR DESCRIPTION
## What & why

Use the same filled FaCloud icon on the cloud design partner page as the homepage banner for visual consistency.

## How I tested it

- `bunx biome check 'apps/marketing/src/app/[lang]/cloud/page.tsx'` passed.
- `git diff --check` passed.
- `bun run check:plugins` passed.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses the filled `FaCloud` icon from `react-icons` on the cloud page instead of the outline `Cloud` from `lucide-react` so the icon matches the homepage banner.

<sup>Written for commit 924c57d23faf58d52789ba9cc8c75ef5dc2ff1ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Cloud page’s cloud icon to use a different visual design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->