### PR TITLE
feat(desktop): copy a shareable link to an automation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
@@ -16,10 +16,11 @@ import {
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { Link } from "@tanstack/react-router";
-import { LuClock, LuEllipsis, LuPlay, LuTrash2 } from "react-icons/lu";
+import { LuClock, LuEllipsis, LuLink, LuPlay, LuTrash2 } from "react-icons/lu";
 
 interface AutomationDetailHeaderProps {
 	name: string;
+	onCopyLink: () => void;
 	onDelete: () => void;
 	onRunNow: () => void;
 	onOpenHistory: () => void;
@@ -31,6 +32,7 @@ interface AutomationDetailHeaderProps {
 
 export function AutomationDetailHeader({
 	name,
+	onCopyLink,
 	onDelete,
 	onRunNow,
 	onOpenHistory,
@@ -92,7 +94,6 @@ export function AutomationDetailHeader({
 						<Button
 							variant="ghost"
 							size="icon-sm"
-							disabled={readOnly}
 							aria-label={t({
 								message: "More actions",
 							})}
@@ -101,9 +102,13 @@ export function AutomationDetailHeader({
 						</Button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="end">
+						<DropdownMenuItem onSelect={onCopyLink}>
+							<LuLink className="size-4" />
+							<Trans>Copy link</Trans>
+						</DropdownMenuItem>
 						<DropdownMenuItem
 							variant="destructive"
-							disabled={deleteDisabled}
+							disabled={readOnly || deleteDisabled}
 							onSelect={onDelete}
 						>
 							<LuTrash2 className="size-4" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -11,6 +11,7 @@ import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { HostOfflineRunDialog } from "../components/HostOfflineRunDialog";
+import { useCopyAutomationLink } from "../hooks/useCopyAutomationLink";
 import { isHostOfflineError } from "../utils/hostOfflineError";
 import { isStaleAgentError, STALE_AGENT_HELP } from "../utils/staleAgentError";
 import { AutomationBody } from "./components/AutomationBody";
@@ -43,6 +44,7 @@ function AutomationDetailPage() {
 	const currentUserId = session?.user?.id;
 	const [historyOpen, setHistoryOpen] = useState(history ?? false);
 	const [hostOfflineOpen, setHostOfflineOpen] = useState(false);
+	const copyAutomationLink = useCopyAutomationLink();
 
 	// The prompt body rides its own procedure — `get` omits it.
 	const automationQuery = cloudTrpc.automation.get.useQuery(
@@ -160,6 +162,7 @@ function AutomationDetailPage() {
 			<div className="flex flex-1 flex-col overflow-hidden">
 				<AutomationDetailHeader
 					name={automation.name}
+					onCopyLink={() => copyAutomationLink(automation.id)}
 					onDelete={() => {
 						alert({
 							title: t({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/AutomationRow.tsx
@@ -28,6 +28,7 @@ import { LuEllipsis, LuPlay, LuRotateCw } from "react-icons/lu";
 import type { AutomationLastRun } from "renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations";
 import type { ProjectOption } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/types";
 import { ProjectThumbnail } from "renderer/routes/_authenticated/components/ProjectThumbnail";
+import { useCopyAutomationLink } from "../../hooks/useCopyAutomationLink";
 import { AutomationActionsMenuItems } from "./components/AutomationActionsMenuItems";
 
 type AutomationListItem = RouterOutputs["automation"]["list"][number];
@@ -131,6 +132,7 @@ export function AutomationRow({
 }: AutomationRowProps) {
 	const { t } = useLingui();
 	const navigate = useNavigate();
+	const copyAutomationLink = useCopyAutomationLink();
 	// No rrule but some trigger means the automation is driven by events
 	// rather than a clock; no triggers at all means it never fires.
 	const scheduleLabel = automation.rrule
@@ -172,6 +174,7 @@ export function AutomationRow({
 			isOwner={isOwner}
 			enabled={automation.enabled}
 			onEdit={openDetail}
+			onCopyLink={() => copyAutomationLink(automation.id)}
 			onRunNow={() => onRunNow(automation)}
 			onToggleEnabled={() => onToggleEnabled(automation)}
 			onHistory={openHistory}
@@ -378,29 +381,27 @@ export function AutomationRow({
 									</TooltipContent>
 								</Tooltip>
 							)}
-							{isOwner && (
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<Button
-											variant="ghost"
-											size="icon-sm"
-											onClick={(e) => e.stopPropagation()}
-											aria-label={t({
-												message: "Row actions",
-											})}
-											className="opacity-0 group-hover/row:opacity-100 data-[state=open]:opacity-100 focus-visible:opacity-100"
-										>
-											<LuEllipsis className="size-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent
-										align="end"
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										size="icon-sm"
 										onClick={(e) => e.stopPropagation()}
+										aria-label={t({
+											message: "Row actions",
+										})}
+										className="opacity-0 group-hover/row:opacity-100 data-[state=open]:opacity-100 focus-visible:opacity-100"
 									>
-										{actionsMenuItems("dropdown")}
-									</DropdownMenuContent>
-								</DropdownMenu>
-							)}
+										<LuEllipsis className="size-4" />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent
+									align="end"
+									onClick={(e) => e.stopPropagation()}
+								>
+									{actionsMenuItems("dropdown")}
+								</DropdownMenuContent>
+							</DropdownMenu>
 						</span>
 					</TableCell>
 				</TableRow>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/components/AutomationActionsMenuItems/AutomationActionsMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationRow/components/AutomationActionsMenuItems/AutomationActionsMenuItems.tsx
@@ -8,13 +8,21 @@ import {
 	DropdownMenuSeparator,
 } from "@superset/ui/dropdown-menu";
 import type { ReactNode } from "react";
-import { LuClock, LuPause, LuPencil, LuPlay, LuTrash2 } from "react-icons/lu";
+import {
+	LuClock,
+	LuLink,
+	LuPause,
+	LuPencil,
+	LuPlay,
+	LuTrash2,
+} from "react-icons/lu";
 
 interface AutomationActionsMenuItemsProps {
 	kind: "context" | "dropdown";
 	isOwner: boolean;
 	enabled: boolean;
 	onEdit: () => void;
+	onCopyLink: () => void;
 	onRunNow: () => void;
 	onToggleEnabled: () => void;
 	onHistory: () => void;
@@ -26,6 +34,7 @@ export function AutomationActionsMenuItems({
 	isOwner,
 	enabled,
 	onEdit,
+	onCopyLink,
 	onRunNow,
 	onToggleEnabled,
 	onHistory,
@@ -59,6 +68,15 @@ export function AutomationActionsMenuItems({
 					<>
 						<LuPencil className="size-4" />
 						{isOwner ? <Trans>Edit</Trans> : <Trans>View</Trans>}
+					</>
+				),
+			})}
+			{renderItem({
+				onSelect: onCopyLink,
+				children: (
+					<>
+						<LuLink className="size-4" />
+						<Trans>Copy link</Trans>
 					</>
 				),
 			})}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/hooks/useCopyAutomationLink/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/hooks/useCopyAutomationLink/index.ts
@@ -1,0 +1,1 @@
+export { useCopyAutomationLink } from "./useCopyAutomationLink";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/hooks/useCopyAutomationLink/useCopyAutomationLink.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/hooks/useCopyAutomationLink/useCopyAutomationLink.ts
@@ -1,0 +1,33 @@
+import { useLingui } from "@lingui/react/macro";
+import { toast } from "@superset/ui/sonner";
+import { useCallback } from "react";
+import { env } from "renderer/env.renderer";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+
+/**
+ * Shareable URL for an automation. Automations have no web UI, so the link
+ * points at the web passthrough route (apps/web/src/app/automations) that
+ * bounces back into the desktop app.
+ */
+function automationShareUrl(automationId: string): string {
+	return `${env.NEXT_PUBLIC_WEB_URL}/automations/${automationId}`;
+}
+
+export function useCopyAutomationLink() {
+	const { t } = useLingui();
+	const { copyToClipboard } = useCopyToClipboard();
+
+	return useCallback(
+		(automationId: string) => {
+			toast.promise(copyToClipboard(automationShareUrl(automationId)), {
+				success: t({
+					message: "Link copied",
+				}),
+				error: t({
+					message: "Could not copy the link",
+				}),
+			});
+		},
+		[copyToClipboard, t],
+	);
+}

--- a/apps/web/src/app/automations/[automationId]/page.tsx
+++ b/apps/web/src/app/automations/[automationId]/page.tsx
@@ -1,0 +1,14 @@
+import { DeepLinkRedirect } from "@/components/DeepLinkRedirect";
+
+interface PageProps {
+	params: Promise<{ automationId: string }>;
+}
+
+export default async function AutomationDeepLinkPage({ params }: PageProps) {
+	const { automationId } = await params;
+	return (
+		<DeepLinkRedirect
+			path={`automations/${encodeURIComponent(automationId)}`}
+		/>
+	);
+}

--- a/apps/web/src/app/tasks/[slug]/page.tsx
+++ b/apps/web/src/app/tasks/[slug]/page.tsx
@@ -1,44 +1,10 @@
-"use client";
+import { DeepLinkRedirect } from "@/components/DeepLinkRedirect";
 
-import { Trans } from "@lingui/react/macro";
-import Image from "next/image";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useEffect } from "react";
+interface PageProps {
+	params: Promise<{ slug: string }>;
+}
 
-/**
- * Deep link passthrough page for tasks.
- * Attempts to open the Superset desktop app, falls back to dashboard.
- */
-export default function TaskDeepLinkPage() {
-	const params = useParams<{ slug: string }>();
-	const slug = params.slug;
-	const deepLink = `superset://tasks/${slug}`;
-
-	useEffect(() => {
-		window.location.href = deepLink;
-	}, [deepLink]);
-
-	return (
-		<div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
-			<div className="flex flex-col items-center gap-6">
-				<Image
-					src="/title.svg"
-					alt="Superset"
-					width={280}
-					height={86}
-					priority
-				/>
-				<p className="text-xl text-muted-foreground">
-					<Trans>Redirecting to desktop app...</Trans>
-				</p>
-				<Link
-					href={deepLink}
-					className="text-sm text-muted-foreground/70 underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-muted-foreground"
-				>
-					<Trans>Click here if not redirected</Trans>
-				</Link>
-			</div>
-		</div>
-	);
+export default async function TaskDeepLinkPage({ params }: PageProps) {
+	const { slug } = await params;
+	return <DeepLinkRedirect path={`tasks/${encodeURIComponent(slug)}`} />;
 }

--- a/apps/web/src/components/DeepLinkRedirect/DeepLinkRedirect.tsx
+++ b/apps/web/src/components/DeepLinkRedirect/DeepLinkRedirect.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { PROTOCOL_SCHEMES } from "@superset/shared/constants";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect } from "react";
+
+interface DeepLinkRedirectProps {
+	/** Desktop route to open, without a leading slash — e.g. `tasks/my-slug`. */
+	path: string;
+}
+
+/**
+ * Passthrough screen for web routes that only exist to hand a destination to
+ * the desktop app. Shareable links point here so a recipient gets a real URL
+ * instead of a `superset://` one their chat client won't render.
+ */
+export function DeepLinkRedirect({ path }: DeepLinkRedirectProps) {
+	const deepLink = `${PROTOCOL_SCHEMES.PROD}://${path}`;
+
+	useEffect(() => {
+		window.location.href = deepLink;
+	}, [deepLink]);
+
+	return (
+		<div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
+			<div className="flex flex-col items-center gap-6">
+				<Image
+					src="/title.svg"
+					alt="Superset"
+					width={280}
+					height={86}
+					priority
+				/>
+				<p className="text-xl text-muted-foreground">
+					<Trans>Redirecting to desktop app...</Trans>
+				</p>
+				<Link
+					href={deepLink}
+					className="text-sm text-muted-foreground/70 underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-muted-foreground"
+				>
+					<Trans>Click here if not redirected</Trans>
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/DeepLinkRedirect/index.ts
+++ b/apps/web/src/components/DeepLinkRedirect/index.ts
@@ -1,0 +1,1 @@
+export { DeepLinkRedirect } from "./DeepLinkRedirect";

--- a/apps/web/src/proxy-routes.test.ts
+++ b/apps/web/src/proxy-routes.test.ts
@@ -19,6 +19,8 @@ describe("isPublicRoute", () => {
 		"/accept-invitation/invitation-123",
 		"/cli/auth/code",
 		"/cli/auth/code/success",
+		"/tasks/my-slug",
+		"/automations/automation-123",
 	])("allows the exact public route or its children: %s", (pathname: string) => {
 		expect(isPublicRoute(pathname)).toBe(true);
 	});
@@ -33,6 +35,8 @@ describe("isPublicRoute", () => {
 		"/api/auth/desktopish",
 		"/accept-invitation-list",
 		"/cli/auth/codegen",
+		"/tasksy",
+		"/automations-overview",
 	])("keeps sibling routes protected: %s", (pathname: string) => {
 		expect(isPublicRoute(pathname)).toBe(false);
 	});

--- a/apps/web/src/proxy-routes.ts
+++ b/apps/web/src/proxy-routes.ts
@@ -5,6 +5,10 @@ const otherPublicRoutes = [
 	"/api/auth/desktop",
 	"/accept-invitation",
 	"/cli/auth/code",
+	// Deep link passthroughs: they render nothing but a bounce into the desktop
+	// app, so a sign-in wall only strands the recipient of a shared link.
+	"/tasks",
+	"/automations",
 ] as const;
 
 const publicRoutes = [...authPageRoutes, ...otherPublicRoutes] as const;


### PR DESCRIPTION
Automations had no way to hand one to a teammate. They also have no web UI, so a shared link points at a passthrough page on the web app that bounces straight into desktop — the shape `/tasks/<slug>` already used.

**Copy link** → `https://app.superset.sh/automations/<id>` → the page hands `superset://automations/<id>` to the OS → desktop focuses and navigates to that automation.

## Notes

- **Copying is not owner-gated** — anyone who can see an automation can share it. Two gates had to open for that to be reachable on a teammate's automation: the row's `…` button rendered for owners only, and the detail header's overflow trigger was `disabled={readOnly}` outright. `readOnly` now sits on the Delete item instead, so the menu opens with Delete dimmed.
- **Both passthrough routes are now public.** `/tasks` and `/automations` render nothing but the redirect, and the sign-in wall only stranded the recipient of a shared link. Extended the existing `proxy-routes.test.ts` cases.
- **`DeepLinkRedirect`** extracts the redirect screen `/tasks/[slug]` already had, rather than copy-pasting it.
- **No new strings.** "Copy link", "Link copied", "Could not copy the link" and the passthrough's two are all already in the catalogs, so all 17 locales stay at 0 missing.

## Verification

Driven over CDP against a dev build, and the last leg against the installed app:

| Leg | Result |
| --- | --- |
| Copy link → clipboard | URL id matches the open route exactly |
| Owner row menu | Edit · **Copy link** · Run now · Pause · Prompt history · Delete |
| Teammate's row menu | View · **Copy link** — nothing else |
| Teammate's detail menu | Copy link enabled, Delete automation disabled |
| Web page signed-out | 200; `/settings/billing` still 307s to `/sign-in` |
| Dev build, running on another route | `superset-<workspace>://automations/<id>` → landed on the detail page |
| Installed app, prod scheme | `superset://automations/<id>` → landed on the automation |

Screenshots: https://app.superset.sh/page/copy-link-to-an-automation-chmexp

Not covered: a cross-organization link. `automation.get` is org-gated server-side, so someone outside the org gets an error page rather than a graceful "no access" screen.

https://claude.ai/code/session_012i4sML8GdjiCrKypTanYLS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Copy link" action to automations so they can be shared with teammates. Automations have no web UI, so the link points at a public web passthrough page that bounces into the desktop app — the same shape `/tasks/<slug>` already uses.

**Notes**
- Copying is not owner-gated: anyone who can see an automation can copy its link.
- The row overflow button now renders for non-owners, and the detail header's overflow trigger is always enabled; Delete is dimmed for read-only users instead.
- Both `/tasks` and `/automations` passthrough routes are now public so shared links don't hit the sign-in wall.
- Extracted the passthrough redirect into a shared `DeepLinkRedirect` component.
- No new translation strings; all locales stay at 0 missing.

<sup>Written for commit 87563b1f41864cc4b5ad359c1396f5000649f989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Copy link” action for automations in detail views and action menus.
  - Added success and error notifications when copying automation links.
  - Added web deep links for automations that redirect to the desktop app.
  - Made automation action menus accessible to non-owners while keeping deletion restricted appropriately.

- **Improvements**
  - Updated task deep links to use the shared desktop-app redirection experience.
  - Allowed task and automation deep-link routes to load without sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->