### PR TITLE
fix(desktop): keep a stale diff from crashing the reviewer pane

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -2,6 +2,7 @@ import { useLingui } from "@lingui/react/macro";
 import type {
 	CodeViewItem,
 	DiffLineAnnotation,
+	FileDiffLoadedFiles,
 	FileDiffMetadata,
 	LineAnnotation,
 	FileContents as PierreFileContents,
@@ -57,7 +58,10 @@ import { useDiffCommentComposer } from "./hooks/useDiffCommentComposer";
 import { useDiffCommentNavigation } from "./hooks/useDiffCommentNavigation";
 import { useDiffPaneSearch } from "./hooks/useDiffPaneSearch";
 import { createGetDiffInput } from "./utils/createGetDiffInput";
-import { isDiffContentTooLarge } from "./utils/diffLoadingGuards";
+import {
+	isDiffContentStale,
+	isDiffContentTooLarge,
+} from "./utils/diffLoadingGuards";
 import { getCharacterOffsetAtClientX } from "./utils/getCharacterOffsetAtClientX";
 
 interface CreateNewAgentSessionInput {
@@ -466,9 +470,19 @@ export function DiffPane({
 				// hunks we already have.
 				throw new Error(`${file.path} is too large to expand`);
 			}
-			return fileDiff.type === "rename-pure"
-				? { oldFile: null, newFile }
-				: { oldFile, newFile };
+			const loaded: FileDiffLoadedFiles =
+				fileDiff.type === "rename-pure"
+					? { oldFile: null, newFile }
+					: { oldFile, newFile };
+			if (isDiffContentStale(fileDiff, loaded)) {
+				// The file moved on after its patch was cached, so these lines
+				// don't line up with the hunks they'd be hydrated into.
+				// Staying partial keeps the patch's hunks on screen instead of
+				// tearing the pane down; the `git:changed` that follows the
+				// write refetches the patch, and expanding works again.
+				throw new Error(`${file.path} changed since its diff was loaded`);
+			}
+			return loaded;
 		},
 		[files, trpcClient, workspaceId],
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.test.ts
@@ -1,8 +1,87 @@
 import { describe, expect, test } from "bun:test";
+import type { FileContents, FileDiffMetadata } from "@pierre/diffs";
+import { parsePatchFiles } from "@pierre/diffs";
 import {
+	isDiffContentStale,
 	isDiffContentTooLarge,
 	isGeneratedDiffFile,
 } from "./diffLoadingGuards";
+
+const FILE_PATH =
+	"front_porch/modules/delinquency/liquidation/proceeds/internals/liquidation_proceeds_apply_state_machine.py";
+
+/** The file as its patch was generated against: twelve numbered lines. */
+const COMMITTED_LINES = Array.from(
+	{ length: 12 },
+	(_, index) => `committed_line_${String(index + 1).padStart(2, "0")}`,
+);
+
+function parsePatch(hunkHeader: string, hunkBody: string[]): FileDiffMetadata {
+	const patch = [
+		`diff --git a/${FILE_PATH} b/${FILE_PATH}`,
+		`--- a/${FILE_PATH}`,
+		`+++ b/${FILE_PATH}`,
+		hunkHeader,
+		...hunkBody,
+		"",
+	].join("\n");
+	const fileDiff = parsePatchFiles(patch, "diff-loading-guards-test")[0]
+		?.files[0];
+	if (!fileDiff) throw new Error("fixture patch parsed into no file diff");
+	return fileDiff;
+}
+
+function fileContents(lines: string[]): FileContents {
+	return { name: FILE_PATH, contents: `${lines.join("\n")}\n` };
+}
+
+/** A hunk that rewrites the last three lines, so it runs to end-of-file on
+ * both sides and leaves no trailing context. */
+const REWRITES_TO_END_OF_FILE = parsePatch("@@ -7,6 +7,6 @@", [
+	...COMMITTED_LINES.slice(6, 9).map((line) => ` ${line}`),
+	...COMMITTED_LINES.slice(9).map((line) => `-${line}`),
+	"+rewritten_line_10",
+	"+rewritten_line_11",
+	"+rewritten_line_12",
+]);
+const REWRITTEN_LINES = [
+	...COMMITTED_LINES.slice(0, 9),
+	"rewritten_line_10",
+	"rewritten_line_11",
+	"rewritten_line_12",
+];
+
+/** A pure-addition hunk appending three lines at end-of-file — the shape the
+ * crash was reported against. */
+const APPENDS_AT_END_OF_FILE = parsePatch("@@ -10,3 +10,6 @@", [
+	...COMMITTED_LINES.slice(9).map((line) => ` ${line}`),
+	"+appended_line_13",
+	"+appended_line_14",
+	"+appended_line_15",
+]);
+const APPENDED_LINES = [
+	...COMMITTED_LINES,
+	"appended_line_13",
+	"appended_line_14",
+	"appended_line_15",
+];
+
+/** A hunk in the middle of the file, leaving three lines of trailing context
+ * on both sides — the region "expand hidden context" actually expands. */
+const REWRITES_MIDDLE = parsePatch("@@ -4,6 +4,6 @@", [
+	...COMMITTED_LINES.slice(3, 6).map((line) => ` ${line}`),
+	...COMMITTED_LINES.slice(6, 9).map((line) => `-${line}`),
+	"+rewritten_line_07",
+	"+rewritten_line_08",
+	"+rewritten_line_09",
+]);
+const MIDDLE_REWRITTEN_LINES = [
+	...COMMITTED_LINES.slice(0, 6),
+	"rewritten_line_07",
+	"rewritten_line_08",
+	"rewritten_line_09",
+	...COMMITTED_LINES.slice(9),
+];
 
 describe("diff loading guards", () => {
 	test("treats lockfiles and compiled artifacts as generated", () => {
@@ -35,5 +114,84 @@ describe("diff loading guards", () => {
 		expect(
 			isDiffContentTooLarge("a".repeat(250_000), "b".repeat(250_000)),
 		).toBe(false);
+	});
+
+	test("accepts contents read at the revision the patch was generated from", () => {
+		for (const [fileDiff, newLines] of [
+			[REWRITES_TO_END_OF_FILE, REWRITTEN_LINES],
+			[APPENDS_AT_END_OF_FILE, APPENDED_LINES],
+			[REWRITES_MIDDLE, MIDDLE_REWRITTEN_LINES],
+		] as const) {
+			expect(
+				isDiffContentStale(fileDiff, {
+					oldFile: fileContents(COMMITTED_LINES),
+					newFile: fileContents(newLines),
+				}),
+			).toBe(false);
+		}
+	});
+
+	test("rejects contents read after the file grew past its patch", () => {
+		// Three lines appended to the working tree after the patch was cached:
+		// the new side runs three lines past the last hunk while the old side
+		// ends exactly on it, which is the (additions=3, deletions=0) trailing
+		// context mismatch @pierre/diffs throws on mid-layout.
+		expect(
+			isDiffContentStale(APPENDS_AT_END_OF_FILE, {
+				oldFile: fileContents(COMMITTED_LINES),
+				newFile: fileContents([
+					...APPENDED_LINES,
+					"written_after_the_patch_1",
+					"written_after_the_patch_2",
+					"written_after_the_patch_3",
+				]),
+			}),
+		).toBe(true);
+		expect(
+			isDiffContentStale(REWRITES_TO_END_OF_FILE, {
+				oldFile: fileContents(COMMITTED_LINES),
+				newFile: fileContents([
+					...REWRITTEN_LINES,
+					"written_after_the_patch_1",
+					"written_after_the_patch_2",
+					"written_after_the_patch_3",
+				]),
+			}),
+		).toBe(true);
+	});
+
+	test("rejects contents whose trailing context shrank past its patch", () => {
+		expect(
+			isDiffContentStale(REWRITES_MIDDLE, {
+				oldFile: fileContents(COMMITTED_LINES),
+				newFile: fileContents(MIDDLE_REWRITTEN_LINES.slice(0, -2)),
+			}),
+		).toBe(true);
+	});
+
+	test("rejects contents missing a side the diff needs", () => {
+		expect(
+			isDiffContentStale(REWRITES_TO_END_OF_FILE, {
+				oldFile: null,
+				newFile: fileContents(REWRITTEN_LINES),
+			}),
+		).toBe(true);
+	});
+
+	test("leaves the metadata partial so a rejected load keeps its patch hunks", () => {
+		const fileDiff = parsePatch("@@ -10,3 +10,6 @@", [
+			...COMMITTED_LINES.slice(9).map((line) => ` ${line}`),
+			"+appended_line_13",
+			"+appended_line_14",
+			"+appended_line_15",
+		]);
+		const hunksBefore = fileDiff.hunks.length;
+		isDiffContentStale(fileDiff, {
+			oldFile: fileContents(COMMITTED_LINES),
+			newFile: fileContents([...APPENDED_LINES, "written_after_the_patch"]),
+		});
+		expect(fileDiff.isPartial).toBe(true);
+		expect(fileDiff.additionLines.length).toBeLessThan(APPENDED_LINES.length);
+		expect(fileDiff.hunks).toHaveLength(hunksBefore);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.ts
@@ -2,6 +2,12 @@
  * hook that uses them pulls in the renderer's tRPC client, which other test
  * files partially mock — and `mock.module` is process-global in Bun. */
 
+import {
+	type FileDiffLoadedFiles,
+	type FileDiffMetadata,
+	hydratePartialDiff,
+} from "@pierre/diffs";
+
 /** Ceiling on the file contents `loadDiffFiles` will pull in to expand a
  * partial diff. Parsing more than this on the main thread is the freeze the
  * Changes pane exists to avoid. */
@@ -41,4 +47,50 @@ export function isDiffContentTooLarge(
 	return (
 		oldContents.length + newContents.length > MAX_RENDERED_DIFF_CONTENT_CHARS
 	);
+}
+
+/** Whether `files` was read at a different revision than the patch `fileDiff`
+ * was parsed from. Hydration keeps the patch's hunks and swaps in whole-file
+ * line arrays, so contents fetched after the file moved on leave the lines past
+ * the last hunk uneven between the two sides. @pierre/diffs asserts they match
+ * while it measures layout, and throws from a layout effect — which no boundary
+ * inside the pane can catch, so the whole view goes down. Measured on a
+ * throwaway clone: rejecting the load leaves the real metadata partial, still
+ * rendering the hunks the patch already gave us. */
+export function isDiffContentStale(
+	fileDiff: FileDiffMetadata,
+	files: FileDiffLoadedFiles,
+): boolean {
+	if (!fileDiff.isPartial) return false;
+	let hydrated: FileDiffMetadata;
+	try {
+		hydrated = hydratePartialDiff("clone", fileDiff, files);
+	} catch {
+		// Contents this diff can't be hydrated from at all — a missing side for
+		// its change type — are just as unusable as mismatched ones.
+		return true;
+	}
+	const lastHunk = hydrated.hunks.at(-1);
+	// Mirrors the cases @pierre/diffs itself skips before comparing.
+	if (
+		lastHunk == null ||
+		hydrated.additionLines.length === 0 ||
+		hydrated.deletionLines.length === 0
+	) {
+		return false;
+	}
+	const additionRemaining =
+		hydrated.additionLines.length -
+		getHunkSideEndBoundary(lastHunk.additionStart, lastHunk.additionCount);
+	const deletionRemaining =
+		hydrated.deletionLines.length -
+		getHunkSideEndBoundary(lastHunk.deletionStart, lastHunk.deletionCount);
+	if (additionRemaining <= 0 && deletionRemaining <= 0) return false;
+	return additionRemaining !== deletionRemaining;
+}
+
+/** @pierre/diffs' own unified-hunk boundary math, which it doesn't export: a
+ * zero-count side sits between two lines and consumes none of them. */
+function getHunkSideEndBoundary(start: number, count: number): number {
+	return start - (count === 0 ? 0 : 1) + count;
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/index.ts
@@ -1,4 +1,5 @@
 export {
+	isDiffContentStale,
 	isDiffContentTooLarge,
 	isGeneratedDiffFile,
 } from "./diffLoadingGuards";


### PR DESCRIPTION
Clicking "expand hidden context" in the reviewer drops the whole view to
"This view hit an error":

```
VirtualizedFileDiff: trailing context mismatch (additions=3, deletions=0)
for front_porch/.../liquidation_proceeds_apply_state_machine.py
```

94 events across releases 1.25.1, 1.26.0 and 1.27.0 — reported from Slack
against 1.26.0, still firing on current.

## Root cause

`VirtualizedFileDiff` isn't ours — the string appears nowhere in the tree or in
`git log --all -S`. It's `@pierre/diffs@1.3.6`
(`dist/utils/virtualDiffLayout.js`), and `additions=3, deletions=0` are trailing
*remainders*, not hunk counts: 3 lines past the last hunk on the new side, 0 on
the old.

`DiffPane` fetches a **patch** (`git.getDiffPatch`, `staleTime: Infinity`), which
parses to `isPartial: true`. Expanding makes the library call our `loadDiffFiles`,
which reads the file **as it is right now** via `git.getDiff`. `hydratePartialDiff`
then keeps the **patch's hunks** and swaps in whole-file line arrays — it never
re-diffs. Anything written between those two reads leaves the new side running
past the last hunk while the immutable old side doesn't, and the invariant blows
up.

Agents write files while a review is open, which is why this fires steadily.
`useGitStatus.ts:70` already documents the skew: *"leaves the cached hunks stale
while `loadDiffFiles` reads the file as it is now."*

It takes down the whole view because the throw lands in a React **layout effect**
(`CodeView.setItems` → `reconcileItems` → `getScrollAnchor` →
`approximateLayoutCheckpoints`), which no boundary inside the pane can catch.

Upgrading doesn't help: 1.4.1's `getTrailingContextRangeSize` is byte-identical
to 1.3.6's.

## Fix

`FileDiff.loadFilesForDiff` wraps the loader in try/catch and just `console.error`s
a rejection, leaving the diff partial (we never set `disableErrorHandling`) — the
same graceful path the existing `isDiffContentTooLarge` guard uses. So the bad load
is rejected rather than let through:

- `isDiffContentStale(fileDiff, files)` validates on a throwaway clone via
  `hydratePartialDiff("clone", …)`, so the real metadata stays partial. Reusing the
  library's own hydration avoids reimplementing its line-splitting; only the 1-line
  boundary formula is mirrored, because the package `exports` map blocks importing
  its internals.
- `DiffPane` checks before returning. On skew the pane keeps rendering the patch's
  hunks; the `git:changed` that follows the write refetches the patch and expanding
  works again.

**Closes the whole class.** All 14 throw sites need a non-partial diff, and
hydration is the only path pairing foreign hunks with file contents
(`parseDiffFromFile` builds hunks *from* the contents). One guard covers all four
Sentry issues.

## Testing

- 8 unit tests on real `parsePatchFiles` output, fixtures shaped like the report
  (pure-addition hunk at EOF, hunk rewriting to EOF, mid-file hunk with real
  trailing context). Mutation-checked: neutering the guard kills all 3 "rejects"
  tests.
- Verified against the real library that the fixture reproduces the exact
  production message, and that clone mode leaves the original partial.
- Typecheck + biome clean. Full desktop suite 3712 pass / 1 fail; that failure
  (`useSidebarDnd.test.ts`, `@dnd-kit/core` React interop) reproduces identically
  on a clean tree at 3707 pass / 1 fail — pre-existing and unrelated.

## Deliberately not done

No auto-refetch on skew: `getDiffPatch.invalidate` matches all patch groups,
rebuilding every `FileDiffMetadata` and discarding every open expansion in the
pane — exactly when an agent is writing. Existing `git:changed` invalidation
already covers recovery.

Structural follow-up worth considering separately: the patch and the contents are
two independently-cached reads. Having `getDiffPatch` return contents (or accept a
revision token) would eliminate the skew rather than detect it — a host-service API
change.

https://claude.ai/code/session_016zA1KiWj2ok4E6jMMpd4XE


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the reviewer pane crashing when expanding hidden context on a diff whose file changed after the patch was cached. The pane previously threw `VirtualizedFileDiff: trailing context mismatch` from a layout effect no error boundary could catch; it now keeps rendering the patch's hunks and recovers on the next `git:changed` refetch.

**Root cause**

- `@pierre/diffs` hydrates a partial diff by keeping the patch's hunks and swapping in whole-file line arrays read at a different time — it never re-diffs.
- The patch is cached indefinitely while file contents are read on expand, so anything written in between leaves the new side running past the last hunk.

**Fix**

- Adds `isDiffContentStale`, which validates loaded contents against the patch's hunks using the library's own hydration on a throwaway clone, so the real metadata stays partial.
- `DiffPane` rejects a stale load; the existing graceful path handles it, and the `git:changed` that follows the write refetches the patch.
- One guard covers all 14 throw sites since hydration is the only path pairing foreign hunks with file contents.
- 8 unit tests cover hunks appending to EOF, rewriting to EOF, and mid-file with trailing context.

<sup>Written for commit dbab0104e2408173455ab5fa5a716b0fcb61b1f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diff reliability by detecting when loaded file contents no longer match the cached patch.
  - Prevented mismatched or stale hunks from being hydrated into the diff view.
  - Diff panes now remain partially loaded when file contents have changed, preserving available patch information.

- **Tests**
  - Added coverage for unchanged, modified, expanded, truncated, and missing file contents during diff loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->