### PR TITLE
feat(desktop): create a cloud workspace from the sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -1,11 +1,17 @@
-import { useLingui } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { FEATURE_FLAGS } from "@superset/shared/constants";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useLiveQuery } from "@tanstack/react-db";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo } from "react";
+import { LuPlus } from "react-icons/lu";
 import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId";
 import { useCloudWorkspaces } from "renderer/hooks/useCloudWorkspaces";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { CLOUD_HOST_ID } from "renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/DevicePicker";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { useOpenNewWorkspaceModalForHost } from "renderer/stores/new-workspace-modal";
 import { useSidebarSectionsCollapseStore } from "renderer/stores/sidebar-sections-collapse";
 import {
 	type CloudPullRequestRef,
@@ -39,6 +45,12 @@ export function DashboardSidebarCloudSection({
 	const { t } = useLingui();
 	const { workspaces: cloudWorkspaces } = useCloudWorkspaces();
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
+	// The same flag that offers Cloud in the device picker, and the same
+	// audience the API allows (`assertInternal`). Undefined means the flags
+	// haven't resolved, which is not a yes.
+	const isCloudEnabled =
+		useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES) === true;
+	const openNewWorkspaceModalForHost = useOpenNewWorkspaceModalForHost();
 	const isSectionCollapsed = useSidebarSectionsCollapseStore(
 		(s) => s.collapsed.cloud,
 	);
@@ -178,7 +190,11 @@ export function DashboardSidebarCloudSection({
 		localStateRows,
 	]);
 
-	if (rows.length === 0) return null;
+	// The header carries the only way to create a cloud workspace, so it stays
+	// at zero rows like the Sessions header does — a user with no cloud
+	// workspaces is exactly who needs the "+". The collapsed rail has no
+	// headers, so there it is still rows or nothing.
+	if (rows.length === 0 && (isCollapsed || !isCloudEnabled)) return null;
 
 	if (isCollapsed) {
 		return (
@@ -201,7 +217,29 @@ export function DashboardSidebarCloudSection({
 			<DashboardSidebarSectionHeader
 				label={t({ message: "Cloud" })}
 				section="cloud"
-			/>
+			>
+				{isCloudEnabled && (
+					<Tooltip delayDuration={700}>
+						<TooltipTrigger asChild>
+							<button
+								type="button"
+								aria-label={t({ message: "New cloud workspace" })}
+								onClick={(event) => {
+									event.stopPropagation();
+									openNewWorkspaceModalForHost(CLOUD_HOST_ID);
+								}}
+								onKeyDown={(event) => event.stopPropagation()}
+								className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground"
+							>
+								<LuPlus className="size-3.5" />
+							</button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">
+							<Trans>New cloud workspace</Trans>
+						</TooltipContent>
+					</Tooltip>
+				)}
+			</DashboardSidebarSectionHeader>
 			{!isSectionCollapsed &&
 				rows.map((workspace) => (
 					<DashboardSidebarWorkspaceItem

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarCloudSection/DashboardSidebarCloudSection.tsx
@@ -47,9 +47,9 @@ export function DashboardSidebarCloudSection({
 	const { workspaces: hostWorkspaces } = useHostWorkspaces();
 	// The same flag that offers Cloud in the device picker, and the same
 	// audience the API allows (`assertInternal`). Undefined means the flags
-	// haven't resolved, which is not a yes.
-	const isCloudEnabled =
-		useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES) === true;
+	// haven't resolved, which is neither a yes nor a no.
+	const cloudFlag = useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES);
+	const isCloudEnabled = cloudFlag === true;
 	const openNewWorkspaceModalForHost = useOpenNewWorkspaceModalForHost();
 	const isSectionCollapsed = useSidebarSectionsCollapseStore(
 		(s) => s.collapsed.cloud,
@@ -190,10 +190,16 @@ export function DashboardSidebarCloudSection({
 		localStateRows,
 	]);
 
+	// A definite no takes the rows with it. The list query is gated on the same
+	// flag, but react-query keeps what it already fetched when a query is
+	// disabled, so a flag that flips off mid-session would otherwise leave the
+	// section it gates on screen.
+	if (cloudFlag === false) return null;
 	// The header carries the only way to create a cloud workspace, so it stays
 	// at zero rows like the Sessions header does — a user with no cloud
-	// workspaces is exactly who needs the "+". The collapsed rail has no
-	// headers, so there it is still rows or nothing.
+	// workspaces is exactly who needs the "+". Only on a definite yes, so
+	// unresolved flags don't leave an empty Cloud section behind; the
+	// collapsed rail has no headers, so there it is still rows or nothing.
 	if (rows.length === 0 && (isCollapsed || !isCloudEnabled)) return null;
 
 	if (isCollapsed) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/new-workspace/page.tsx
@@ -9,10 +9,11 @@ export const Route = createFileRoute(
 )({
 	validateSearch: (
 		search: Record<string, unknown>,
-	): { projectId?: string; session?: boolean } => ({
+	): { projectId?: string; session?: boolean; host?: string } => ({
 		projectId:
 			typeof search.projectId === "string" ? search.projectId : undefined,
 		session: search.session === true ? true : undefined,
+		host: typeof search.host === "string" ? search.host : undefined,
 	}),
 	component: NewWorkspacePage,
 });
@@ -22,7 +23,7 @@ export const Route = createFileRoute(
  * route. Store opens are redirected here by DashboardNewWorkspaceModal.
  */
 function NewWorkspacePage() {
-	const { projectId, session } = Route.useSearch();
+	const { projectId, session, host } = Route.useSearch();
 	return (
 		<DashboardNewWorkspaceDraftProvider onClose={() => {}}>
 			<PromptInputProvider attachmentsStore={newWorkspaceAttachmentsStore}>
@@ -30,6 +31,7 @@ function NewWorkspacePage() {
 					isOpen
 					preSelectedProjectId={projectId ?? null}
 					preSelectedSession={session === true}
+					preSelectedHostId={host ?? null}
 				/>
 				{/* Window-drag surface replacing the hidden TopBar's drag region.
 				    Stops short of the top-right corner so the screen's naming

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/DashboardNewWorkspaceModal.tsx
@@ -16,6 +16,7 @@ import { newWorkspaceAttachmentsStore } from "renderer/stores/new-workspace-atta
 import {
 	useCloseNewWorkspaceModal,
 	useNewWorkspaceModalOpen,
+	usePreSelectedHostId,
 	usePreSelectedProjectId,
 	usePreSelectedSession,
 } from "renderer/stores/new-workspace-modal";
@@ -48,6 +49,7 @@ export function DashboardNewWorkspaceModal() {
 	const closeModal = useCloseNewWorkspaceModal();
 	const preSelectedProjectId = usePreSelectedProjectId();
 	const preSelectedSession = usePreSelectedSession();
+	const preSelectedHostId = usePreSelectedHostId();
 	const navigate = useNavigate();
 	const variant = useNewWorkspaceScreenVariant(isOpen);
 	const isScreen = variant === "test";
@@ -59,17 +61,20 @@ export function DashboardNewWorkspaceModal() {
 		closeModal();
 		void navigate({
 			to: "/new-workspace",
-			search: preSelectedSession
-				? { session: true }
-				: preSelectedProjectId
-					? { projectId: preSelectedProjectId }
-					: undefined,
+			search: {
+				session: preSelectedSession ? true : undefined,
+				projectId: preSelectedSession
+					? undefined
+					: (preSelectedProjectId ?? undefined),
+				host: preSelectedHostId ?? undefined,
+			},
 		});
 	}, [
 		isScreen,
 		isOpen,
 		closeModal,
 		navigate,
+		preSelectedHostId,
 		preSelectedProjectId,
 		preSelectedSession,
 	]);
@@ -103,6 +108,7 @@ export function DashboardNewWorkspaceModal() {
 							isOpen={isOpen}
 							preSelectedProjectId={preSelectedProjectId}
 							preSelectedSession={preSelectedSession}
+							preSelectedHostId={preSelectedHostId}
 						/>
 					</DialogContent>
 				</Dialog>

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/PromptGroup.tsx
@@ -360,14 +360,15 @@ export function PromptGroup({
 	// fall into a toast.
 	const { otherHosts } = useWorkspaceHostOptions();
 	const submitBlocker = useMemo<string | null>(() => {
+		const selectedHostId = draft.hostId ?? machineId;
+		// A cloud workspace is provisioned by the API from the one cloud repo:
+		// no host whose readiness could block it, and no project either — the
+		// picker is hidden for cloud, so requiring one is unanswerable.
+		if (selectedHostId === CLOUD_HOST_ID) return null;
 		if (!projectId && !draft.isSession)
 			return t({
 				message: "Select a project",
 			});
-		const selectedHostId = draft.hostId ?? machineId;
-		// A cloud workspace is provisioned on submit, so there is no host whose
-		// readiness could block it.
-		if (selectedHostId === CLOUD_HOST_ID) return null;
 		if (!selectedHostId)
 			return t({
 				message: "No active host",

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/PromptGroup/hooks/useSubmitWorkspace/useSubmitWorkspace.ts
@@ -42,7 +42,12 @@ export function useSubmitWorkspace(
 	const isSession = draft.isSession;
 
 	const submitWorkspace = useCallback(async () => {
-		if (!projectId && !isSession) {
+		const hostId = draft.hostId ?? machineId;
+		const isCloud = hostId === CLOUD_HOST_ID;
+		// A cloud workspace clones the one cloud repo, so it has no use for a
+		// project — and the create surface hides the project picker when cloud
+		// is the target, which would make this an unanswerable error.
+		if (!projectId && !isSession && !isCloud) {
 			toast.error(
 				t({
 					message: "Select a project first",
@@ -67,7 +72,6 @@ export function useSubmitWorkspace(
 			return;
 		}
 
-		const hostId = draft.hostId ?? machineId;
 		if (!hostId) {
 			toast.error(
 				t({
@@ -97,7 +101,7 @@ export function useSubmitWorkspace(
 
 		// Cloud workspaces are provisioned by the API, not the local host, so
 		// they bypass the host `workspaces.create` path entirely.
-		if (hostId === CLOUD_HOST_ID) {
+		if (isCloud) {
 			const environments = await cloudTrpcClient.environment.list.query({
 				organizationId: activeOrganizationId,
 			});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/DashboardNewWorkspaceModalContent.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceModalContent/DashboardNewWorkspaceModalContent.tsx
@@ -11,6 +11,8 @@ interface DashboardNewWorkspaceModalContentProps {
 	preSelectedProjectId: string | null;
 	/** Open with "No project" (session) preselected. */
 	preSelectedSession?: boolean;
+	/** Open targeting this host instead of the remembered one. */
+	preSelectedHostId?: string | null;
 }
 
 /**
@@ -24,6 +26,7 @@ export function DashboardNewWorkspaceModalContent({
 	isOpen,
 	preSelectedProjectId,
 	preSelectedSession = false,
+	preSelectedHostId = null,
 }: DashboardNewWorkspaceModalContentProps) {
 	const { draft, updateDraft, selectProject, selectSession } =
 		useDashboardNewWorkspaceDraft();
@@ -63,12 +66,15 @@ export function DashboardNewWorkspaceModalContent({
 		}
 		if (appliedHostIdRef.current) return;
 		appliedHostIdRef.current = true;
-		const persistedHostId =
+		// An opener that named a host (the sidebar's Cloud "+") outranks the
+		// remembered one — the target is the whole point of that button.
+		const hostId =
+			preSelectedHostId ??
 			useV2WorkspaceCreateDefaultsStore.getState().lastHostId;
-		if (typeof persistedHostId === "string") {
-			updateDraft({ hostId: persistedHostId });
+		if (typeof hostId === "string") {
+			updateDraft({ hostId });
 		}
-	}, [isOpen, updateDraft]);
+	}, [isOpen, preSelectedHostId, updateDraft]);
 
 	useEffect(() => {
 		if (!isOpen) return;

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -119,6 +119,8 @@ interface NewWorkspaceScreenProps {
 	preSelectedProjectId: string | null;
 	/** Open with "No project" (session) preselected. */
 	preSelectedSession?: boolean;
+	/** Open targeting this host instead of the remembered one. */
+	preSelectedHostId?: string | null;
 }
 
 /**
@@ -131,6 +133,7 @@ export function NewWorkspaceScreen({
 	isOpen,
 	preSelectedProjectId,
 	preSelectedSession = false,
+	preSelectedHostId = null,
 }: NewWorkspaceScreenProps) {
 	const { t } = useLingui();
 	const navigate = useNavigate();
@@ -368,16 +371,30 @@ export function NewWorkspaceScreen({
 	} = useLinkedContext(draft.linkedIssues, updateDraft);
 
 	// Restore the last-used launch host once per mount, like the modal does.
+	// A host named in the URL (the sidebar's Cloud "+") wins, and applies when
+	// it arrives rather than only at mount — this screen stays mounted across
+	// navigations to it.
 	const appliedPersistedHostRef = useRef(false);
+	const appliedPreSelectedHostRef = useRef<string | null>(null);
 	useEffect(() => {
-		if (!isOpen || appliedPersistedHostRef.current) return;
+		if (!isOpen) return;
+		if (
+			preSelectedHostId &&
+			preSelectedHostId !== appliedPreSelectedHostRef.current
+		) {
+			appliedPreSelectedHostRef.current = preSelectedHostId;
+			appliedPersistedHostRef.current = true;
+			updateDraft({ hostId: preSelectedHostId });
+			return;
+		}
+		if (appliedPersistedHostRef.current) return;
 		appliedPersistedHostRef.current = true;
 		const persistedHostId =
 			useV2WorkspaceCreateDefaultsStore.getState().lastHostId;
 		if (typeof persistedHostId === "string") {
 			updateDraft({ hostId: persistedHostId });
 		}
-	}, [isOpen, updateDraft]);
+	}, [isOpen, preSelectedHostId, updateDraft]);
 
 	// Reset baseBranch on project or host change, defaulting to the user's
 	// last selected branch for that project — the draft store is global, so a
@@ -576,14 +593,15 @@ export function NewWorkspaceScreen({
 
 	const { otherHosts } = useWorkspaceHostOptions();
 	const submitBlocker = useMemo<string | null>(() => {
+		const selectedHostId = draft.hostId ?? machineId;
+		// A cloud workspace is provisioned by the API from the one cloud repo:
+		// no host whose readiness could block it, and no project either — the
+		// picker is hidden for cloud, so requiring one is unanswerable.
+		if (selectedHostId === CLOUD_HOST_ID) return null;
 		if (!projectId && !draft.isSession)
 			return t({
 				message: "Select a project",
 			});
-		const selectedHostId = draft.hostId ?? machineId;
-		// A cloud workspace is provisioned on submit, so there is no host whose
-		// readiness could block it.
-		if (selectedHostId === CLOUD_HOST_ID) return null;
 		if (!selectedHostId)
 			return t({
 				message: "No active host",

--- a/apps/desktop/src/renderer/stores/new-workspace-modal.ts
+++ b/apps/desktop/src/renderer/stores/new-workspace-modal.ts
@@ -29,10 +29,16 @@ interface NewWorkspaceModalState {
 	preSelectedProjectId: string | null;
 	/** Open with "No project" (session) preselected. */
 	preSelectedSession: boolean;
+	/**
+	 * Open targeting this host instead of the last-used one. Null leaves the
+	 * remembered target alone, which is what every other open does.
+	 */
+	preSelectedHostId: string | null;
 	pendingWorkspace: PendingWorkspace | null;
 	stashedDraft: StashedDraft | null;
 	openModal: (projectId?: string) => void;
 	openSessionModal: () => void;
+	openHostModal: (hostId: string) => void;
 	closeModal: () => void;
 	setPendingWorkspace: (workspace: PendingWorkspace | null) => void;
 	clearPendingWorkspace: (id: string) => void;
@@ -51,6 +57,7 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 			isOpen: false,
 			preSelectedProjectId: null,
 			preSelectedSession: false,
+			preSelectedHostId: null,
 			pendingWorkspace: null,
 			stashedDraft: null,
 
@@ -59,6 +66,7 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 					isOpen: true,
 					preSelectedProjectId: projectId ?? null,
 					preSelectedSession: false,
+					preSelectedHostId: null,
 				});
 			},
 
@@ -67,6 +75,21 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 					isOpen: true,
 					preSelectedProjectId: null,
 					preSelectedSession: true,
+					preSelectedHostId: null,
+				});
+			},
+
+			/**
+			 * Open aimed at one host — the Cloud section's "+", whose whole point
+			 * is the target. Project selection is left to the usual default so
+			 * this stays a host preference, not a second create surface.
+			 */
+			openHostModal: (hostId: string) => {
+				set({
+					isOpen: true,
+					preSelectedProjectId: null,
+					preSelectedSession: false,
+					preSelectedHostId: hostId,
 				});
 			},
 
@@ -75,6 +98,7 @@ export const useNewWorkspaceModalStore = create<NewWorkspaceModalState>()(
 					isOpen: false,
 					preSelectedProjectId: null,
 					preSelectedSession: false,
+					preSelectedHostId: null,
 				});
 			},
 
@@ -130,6 +154,10 @@ export const useOpenNewWorkspaceModal = () =>
 	useNewWorkspaceModalStore((state) => state.openModal);
 export const useOpenNewSessionModal = () =>
 	useNewWorkspaceModalStore((state) => state.openSessionModal);
+export const useOpenNewWorkspaceModalForHost = () =>
+	useNewWorkspaceModalStore((state) => state.openHostModal);
+export const usePreSelectedHostId = () =>
+	useNewWorkspaceModalStore((state) => state.preSelectedHostId);
 export const usePreSelectedSession = () =>
 	useNewWorkspaceModalStore((state) => state.preSelectedSession);
 export const useCloseNewWorkspaceModal = () =>

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -8619,6 +8619,9 @@ msgstr "noví vyzyvatelé"
 msgid "New chat"
 msgstr "Nový chat"
 
+msgid "New cloud workspace"
+msgstr "Nový cloudový pracovní prostor"
+
 msgid "New environment"
 msgstr "Nové prostředí"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -8619,6 +8619,9 @@ msgstr "neue Herausforderer"
 msgid "New chat"
 msgstr "Neuer Chat"
 
+msgid "New cloud workspace"
+msgstr "Neuer Cloud-Arbeitsbereich"
+
 msgid "New environment"
 msgstr "Neue Umgebung"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -8619,6 +8619,9 @@ msgstr "new challengers"
 msgid "New chat"
 msgstr "New chat"
 
+msgid "New cloud workspace"
+msgstr "New cloud workspace"
+
 msgid "New environment"
 msgstr "New environment"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -8619,6 +8619,9 @@ msgstr "nuevos rivales"
 msgid "New chat"
 msgstr "Chat nuevo"
 
+msgid "New cloud workspace"
+msgstr "Nuevo espacio de trabajo en la nube"
+
 msgid "New environment"
 msgstr "Nuevo entorno"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -8619,6 +8619,9 @@ msgstr "nouveaux adversaires"
 msgid "New chat"
 msgstr "Nouvelle discussion"
 
+msgid "New cloud workspace"
+msgstr "Nouvel espace de travail cloud"
+
 msgid "New environment"
 msgstr "Nouvel environnement"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -8619,6 +8619,9 @@ msgstr "penantang baru"
 msgid "New chat"
 msgstr "Chat baru"
 
+msgid "New cloud workspace"
+msgstr "Workspace cloud baru"
+
 msgid "New environment"
 msgstr "Environment baru"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -8619,6 +8619,9 @@ msgstr "nuovi sfidanti"
 msgid "New chat"
 msgstr "Nuova chat"
 
+msgid "New cloud workspace"
+msgstr "Nuovo workspace cloud"
+
 msgid "New environment"
 msgstr "Nuovo ambiente"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -8619,6 +8619,9 @@ msgstr "別の対戦相手"
 msgid "New chat"
 msgstr "新しいチャット"
 
+msgid "New cloud workspace"
+msgstr "新規クラウドワークスペース"
+
 msgid "New environment"
 msgstr "新しい環境"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -8619,6 +8619,9 @@ msgstr "새 도전자"
 msgid "New chat"
 msgstr "새 채팅"
 
+msgid "New cloud workspace"
+msgstr "새 클라우드 워크스페이스"
+
 msgid "New environment"
 msgstr "새 환경"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -8620,7 +8620,7 @@ msgid "New chat"
 msgstr "Nieuwe chat"
 
 msgid "New cloud workspace"
-msgstr "Nieuwe cloud-werkruimte"
+msgstr "Nieuwe cloudwerkruimte"
 
 msgid "New environment"
 msgstr "Nieuwe omgeving"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -8619,6 +8619,9 @@ msgstr "nieuwe uitdagers"
 msgid "New chat"
 msgstr "Nieuwe chat"
 
+msgid "New cloud workspace"
+msgstr "Nieuwe cloud-werkruimte"
+
 msgid "New environment"
 msgstr "Nieuwe omgeving"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -8619,6 +8619,9 @@ msgstr "nowi przeciwnicy"
 msgid "New chat"
 msgstr "Nowy czat"
 
+msgid "New cloud workspace"
+msgstr "Nowy obszar roboczy w chmurze"
+
 msgid "New environment"
 msgstr "Nowe środowisko"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -8619,6 +8619,9 @@ msgstr "novos desafiantes"
 msgid "New chat"
 msgstr "Novo chat"
 
+msgid "New cloud workspace"
+msgstr "Nova área de trabalho na nuvem"
+
 msgid "New environment"
 msgstr "Novo ambiente"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -8619,6 +8619,9 @@ msgstr "другие соперники"
 msgid "New chat"
 msgstr "Новый чат"
 
+msgid "New cloud workspace"
+msgstr "Новая облачная рабочая область"
+
 msgid "New environment"
 msgstr "Новое окружение"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -8619,6 +8619,9 @@ msgstr "yeni rakipler"
 msgid "New chat"
 msgstr "Yeni sohbet"
 
+msgid "New cloud workspace"
+msgstr "Yeni bulut çalışma alanı"
+
 msgid "New environment"
 msgstr "Yeni ortam"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -8619,6 +8619,9 @@ msgstr "đối thủ mới"
 msgid "New chat"
 msgstr "Chat mới"
 
+msgid "New cloud workspace"
+msgstr "Workspace cloud mới"
+
 msgid "New environment"
 msgstr "Environment mới"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -8619,6 +8619,9 @@ msgstr "换对手"
 msgid "New chat"
 msgstr "新建聊天"
 
+msgid "New cloud workspace"
+msgstr "新建云端工作区"
+
 msgid "New environment"
 msgstr "新建环境"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -8619,6 +8619,9 @@ msgstr "換對手"
 msgid "New chat"
 msgstr "新建聊天"
 
+msgid "New cloud workspace"
+msgstr "新建雲端工作區"
+
 msgid "New environment"
 msgstr "新增環境"
 


### PR DESCRIPTION
## What

The Cloud section header gets a "+", so there is finally a UI entry point for creating a cloud workspace. Today the only way in is to open the create surface and switch the device picker to Cloud — nobody finds that, and it came up in team chat.

The button is the Sessions header's button, verbatim: same icon, size, hover treatment, 700ms tooltip, and `stopPropagation` so it doesn't toggle the section's collapse. The section header also renders at zero rows now, again like Sessions — a "+" that only appears once you already have a cloud workspace helps nobody.

## How it's wired

It opens the existing create surface (`cloudTrpc.cloudWorkspace.create` via `useSubmitWorkspace`), aimed at the cloud target — no new create path.

Aiming it needed a preselected host. The modal seeds its draft from the persisted `lastHostId` when it opens, so a host written onto the draft store by the opener is overwritten a frame later. `preSelectedHostId` mirrors the existing `preSelectedSession`; the new-workspace-screen experiment arm takes the same thing through a `?host=` search param.

Both submit gates ("Select a project") also demanded a project when the target was cloud — where the project picker is hidden and `projectId` is unused by the cloud branch. That is an error you cannot answer if you have no local projects, which is exactly the person reaching for a cloud workspace. The cloud short-circuit moves above that check.

## Gate

`useFeatureFlagEnabled(FEATURE_FLAGS.CLOUD_WORKSPACES)` — the same call the device picker makes before offering Cloud. Hidden, not disabled. The flag is a single 100% release condition on `email icontains @superset.sh`, i.e. the same audience `assertInternal` allows on the API, and its own description says it gates the picker option and the sidebar section. Unresolved flags count as "no", so nobody gets a flash of an empty Cloud section.

## Verification

Drove the dev app over CDP with real mouse input, both experiment arms:

- **Screen arm:** clicking "+" moved the route to `/new-workspace?host=cloud`, the picker flipped `Device: satyas-mbp` → `Device: Cloud`, the project pill was replaced by the environment pill, no submit blocker, no console errors.
- **Control (modal) arm:** picked Local Device in the picker, reopened via the sidebar's generic "New Workspace" → still local; clicked the Cloud "+" → dialog opened at `Device: Cloud`, `Cloud · Default · main`.

Did not press create — that provisions a real sandbox; the create mutation itself is untouched.

`tsc --noEmit`, `biome check` and `check:i18n` clean (new string translated into all 16 locales). Full `apps/desktop` suite: 3707 pass, 1 fail — `useSidebarDnd.test.ts`, a `@dnd-kit`/React interop error in full-suite runs that reproduces identically with these changes reverted.

https://claude.ai/code/session_019sE8zWkxLsCSayWfNRkjHd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "+" button to the Cloud section header that opens the existing create surface aimed at the cloud target. Previously, creating a cloud workspace required opening the create surface and switching the device picker to Cloud.

**New Features**
- The Cloud section header now renders even with zero workspaces, so users who need a cloud workspace can find the button.
- The create surface accepts a preselected host through a new store field and a `?host=` search param for the screen arm.
- A definite "off" from the cloud-workspaces flag hides the whole section; an unresolved flag still shows rows already fetched.

**Bug Fixes**
- Cloud submits no longer require a project, which was an unanswerable error for users without local projects.

<sup>Written for commit 20f44ccb097b8a00df3af78d43262b95c82a8f1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a feature-flagged Cloud workspaces section to the dashboard sidebar.
  - Added a shortcut for creating a new cloud workspace.
  - New workspace flows can open with a specific host preselected.
  - Cloud workspaces can be created without selecting a project.
- **Localization**
  - Added “New cloud workspace” translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->