### PR TITLE
fix(automations): name the organization instead of a dead-end 404

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBreadcrumbBar/AutomationBreadcrumbBar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBreadcrumbBar/AutomationBreadcrumbBar.tsx
@@ -1,0 +1,56 @@
+import { Trans } from "@lingui/react/macro";
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from "@superset/ui/breadcrumb";
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+interface AutomationBreadcrumbBarProps {
+	/** Omitted when the automation could not be loaded — the crumb stops at the list. */
+	name?: string;
+	/** The header's right-hand actions, if there are any. */
+	children?: ReactNode;
+}
+
+/**
+ * The detail route's top bar. Error states render it without a name so a
+ * deep link that lands somewhere unusable still offers the way back.
+ */
+export function AutomationBreadcrumbBar({
+	name,
+	children,
+}: AutomationBreadcrumbBarProps) {
+	return (
+		<header className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
+			<Breadcrumb>
+				<BreadcrumbList className="text-sm">
+					<BreadcrumbItem>
+						<BreadcrumbLink asChild>
+							<Link to="/automations">
+								<Trans>Automations</Trans>
+							</Link>
+						</BreadcrumbLink>
+					</BreadcrumbItem>
+					{name !== undefined && (
+						<>
+							<BreadcrumbSeparator />
+							<BreadcrumbItem>
+								<BreadcrumbPage className="font-medium">{name}</BreadcrumbPage>
+							</BreadcrumbItem>
+						</>
+					)}
+				</BreadcrumbList>
+			</Breadcrumb>
+
+			{/* Window-drag leaf standing in for the hidden TopBar. */}
+			<div className="drag h-full min-w-0 flex-1" />
+
+			{children && <div className="flex items-center gap-1">{children}</div>}
+		</header>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBreadcrumbBar/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationBreadcrumbBar/index.ts
@@ -1,0 +1,1 @@
+export { AutomationBreadcrumbBar } from "./AutomationBreadcrumbBar";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/AutomationDetailHeader/AutomationDetailHeader.tsx
@@ -1,12 +1,4 @@
 import { Trans, useLingui } from "@lingui/react/macro";
-import {
-	Breadcrumb,
-	BreadcrumbItem,
-	BreadcrumbLink,
-	BreadcrumbList,
-	BreadcrumbPage,
-	BreadcrumbSeparator,
-} from "@superset/ui/breadcrumb";
 import { Button } from "@superset/ui/button";
 import {
 	DropdownMenu,
@@ -15,8 +7,8 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
-import { Link } from "@tanstack/react-router";
 import { LuClock, LuEllipsis, LuLink, LuPlay, LuTrash2 } from "react-icons/lu";
+import { AutomationBreadcrumbBar } from "../AutomationBreadcrumbBar";
 
 interface AutomationDetailHeaderProps {
 	name: string;
@@ -42,105 +34,84 @@ export function AutomationDetailHeader({
 }: AutomationDetailHeaderProps) {
 	const { t } = useLingui();
 	return (
-		<header className="flex h-11 shrink-0 items-center justify-between border-b border-border px-4">
-			<Breadcrumb>
-				<BreadcrumbList className="text-sm">
-					<BreadcrumbItem>
-						<BreadcrumbLink asChild>
-							<Link to="/automations">
-								<Trans>Automations</Trans>
-							</Link>
-						</BreadcrumbLink>
-					</BreadcrumbItem>
-					<BreadcrumbSeparator />
-					<BreadcrumbItem>
-						<BreadcrumbPage className="font-medium">{name}</BreadcrumbPage>
-					</BreadcrumbItem>
-				</BreadcrumbList>
-			</Breadcrumb>
-
-			{/* Window-drag leaf standing in for the hidden TopBar. */}
-			<div className="drag h-full min-w-0 flex-1" />
-
-			<div className="flex items-center gap-1">
-				<Tooltip>
-					{/* Disabled buttons swallow hover events, so the trigger is a
+		<AutomationBreadcrumbBar name={name}>
+			<Tooltip>
+				{/* Disabled buttons swallow hover events, so the trigger is a
 					    span — otherwise the read-only explanation never shows. */}
-					<TooltipTrigger asChild>
-						<span className="inline-flex">
-							<Button
-								variant="ghost"
-								size="icon-sm"
-								onClick={onOpenHistory}
-								disabled={readOnly}
-								aria-label={t({
-									message: "Prompt history",
-								})}
-							>
-								<LuClock className="size-4" />
-							</Button>
-						</span>
-					</TooltipTrigger>
-					<TooltipContent>
-						{readOnly ? (
-							<Trans>Only the owner can view prompt history</Trans>
-						) : (
-							<Trans>Prompt history</Trans>
-						)}
-					</TooltipContent>
-				</Tooltip>
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
+				<TooltipTrigger asChild>
+					<span className="inline-flex">
 						<Button
 							variant="ghost"
 							size="icon-sm"
+							onClick={onOpenHistory}
+							disabled={readOnly}
 							aria-label={t({
-								message: "More actions",
+								message: "Prompt history",
 							})}
 						>
-							<LuEllipsis className="size-4" />
+							<LuClock className="size-4" />
 						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end">
-						<DropdownMenuItem onSelect={onCopyLink}>
-							<LuLink className="size-4" />
-							<Trans>Copy link</Trans>
-						</DropdownMenuItem>
-						<DropdownMenuItem
-							variant="destructive"
-							disabled={readOnly || deleteDisabled}
-							onSelect={onDelete}
-						>
-							<LuTrash2 className="size-4" />
-							<Trans>Delete automation</Trans>
-						</DropdownMenuItem>
-					</DropdownMenuContent>
-				</DropdownMenu>
-				<div className="mx-1 h-4 w-px bg-border" />
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="inline-flex">
-							<Button
-								variant="outline"
-								size="sm"
-								className="h-8 gap-1.5 px-3"
-								onClick={onRunNow}
-								disabled={readOnly || runNowDisabled}
-							>
-								<LuPlay className="size-4" />
-								<span>
-									<Trans>Run now</Trans>
-								</span>
-							</Button>
-						</span>
-					</TooltipTrigger>
-					{readOnly && (
-						<TooltipContent>
-							<Trans>Only the owner can run this automation</Trans>
-						</TooltipContent>
+					</span>
+				</TooltipTrigger>
+				<TooltipContent>
+					{readOnly ? (
+						<Trans>Only the owner can view prompt history</Trans>
+					) : (
+						<Trans>Prompt history</Trans>
 					)}
-				</Tooltip>
-			</div>
-		</header>
+				</TooltipContent>
+			</Tooltip>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						aria-label={t({
+							message: "More actions",
+						})}
+					>
+						<LuEllipsis className="size-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem onSelect={onCopyLink}>
+						<LuLink className="size-4" />
+						<Trans>Copy link</Trans>
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						variant="destructive"
+						disabled={readOnly || deleteDisabled}
+						onSelect={onDelete}
+					>
+						<LuTrash2 className="size-4" />
+						<Trans>Delete automation</Trans>
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<div className="mx-1 h-4 w-px bg-border" />
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span className="inline-flex">
+						<Button
+							variant="outline"
+							size="sm"
+							className="h-8 gap-1.5 px-3"
+							onClick={onRunNow}
+							disabled={readOnly || runNowDisabled}
+						>
+							<LuPlay className="size-4" />
+							<span>
+								<Trans>Run now</Trans>
+							</span>
+						</Button>
+					</span>
+				</TooltipTrigger>
+				{readOnly && (
+					<TooltipContent>
+						<Trans>Only the owner can run this automation</Trans>
+					</TooltipContent>
+				)}
+			</Tooltip>
+		</AutomationBreadcrumbBar>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/WrongOrganizationNotice/WrongOrganizationNotice.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/WrongOrganizationNotice/WrongOrganizationNotice.tsx
@@ -1,0 +1,42 @@
+import { Trans } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
+import { LuBuilding } from "react-icons/lu";
+
+interface WrongOrganizationNoticeProps {
+	/** The server's explanation, which names the organization. */
+	description: string;
+	/** Absent when the server named an organization but not its id. */
+	onSwitch: (() => void) | undefined;
+}
+
+/**
+ * A shared link opened while a different organization is active. The row
+ * exists and the viewer can reach it — they are just looking at the wrong
+ * organization — so this offers the switch rather than reading as a 404.
+ * Mirrors WrongOrganization in apps/web's page route.
+ */
+export function WrongOrganizationNotice({
+	description,
+	onSwitch,
+}: WrongOrganizationNoticeProps) {
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+			<div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+				<LuBuilding className="size-5" />
+			</div>
+			<div className="space-y-2">
+				<h2 className="font-semibold text-lg tracking-tight">
+					<Trans>This automation is in another organization</Trans>
+				</h2>
+				<p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+					{description}
+				</p>
+			</div>
+			{onSwitch && (
+				<Button size="sm" onClick={onSwitch}>
+					<Trans>Switch organization</Trans>
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/WrongOrganizationNotice/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/components/WrongOrganizationNotice/index.ts
@@ -1,0 +1,1 @@
+export { WrongOrganizationNotice } from "./WrongOrganizationNotice";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -10,13 +10,16 @@ import { useMemo, useState } from "react";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { HostOfflineRunDialog } from "../components/HostOfflineRunDialog";
 import { useCopyAutomationLink } from "../hooks/useCopyAutomationLink";
 import { isHostOfflineError } from "../utils/hostOfflineError";
 import { isStaleAgentError, STALE_AGENT_HELP } from "../utils/staleAgentError";
 import { AutomationBody } from "./components/AutomationBody";
+import { AutomationBreadcrumbBar } from "./components/AutomationBreadcrumbBar";
 import { AutomationDetailHeader } from "./components/AutomationDetailHeader";
 import { VersionHistorySheet } from "./components/VersionHistorySheet";
+import { WrongOrganizationNotice } from "./components/WrongOrganizationNotice";
 
 type AutomationDetailSearch = {
 	history?: boolean;
@@ -33,6 +36,19 @@ export const Route = createFileRoute(
 	}),
 });
 
+/** Reads the organization the server named on a wrong-active-org FORBIDDEN. */
+function organizationFromError(params: unknown): { id: string | null } | null {
+	if (typeof params !== "object" || params === null) return null;
+	const { organizationName, organizationId } = params as Record<
+		string,
+		unknown
+	>;
+	// organizationName is what identifies this particular FORBIDDEN; the id is
+	// only there to offer the switch.
+	if (typeof organizationName !== "string" || !organizationName) return null;
+	return { id: typeof organizationId === "string" ? organizationId : null };
+}
+
 const RECENT_RUNS_LIMIT = 10;
 
 function AutomationDetailPage() {
@@ -45,6 +61,7 @@ function AutomationDetailPage() {
 	const [historyOpen, setHistoryOpen] = useState(history ?? false);
 	const [hostOfflineOpen, setHostOfflineOpen] = useState(false);
 	const copyAutomationLink = useCopyAutomationLink();
+	const { switchOrganization } = useCollections();
 
 	// The prompt body rides its own procedure — `get` omits it.
 	const automationQuery = cloudTrpc.automation.get.useQuery(
@@ -137,15 +154,37 @@ function AutomationDetailPage() {
 		// A deleted automation is a NOT_FOUND from the server; anything else is a
 		// failed read and must not be reported as a missing automation.
 		const loadError = automationQuery.error ?? promptQuery.error;
+		// A member looking at the wrong active organization, not a missing row —
+		// the server resolves that case to FORBIDDEN and names the organization.
+		const elsewhere =
+			loadError instanceof TRPCClientError &&
+			loadError.data?.code === "FORBIDDEN"
+				? organizationFromError(loadError.data?.i18nParams)
+				: null;
 		const isMissing =
 			loadError instanceof TRPCClientError &&
 			loadError.data?.code === "NOT_FOUND";
+		const switchTo = elsewhere?.id;
+		// Keep the breadcrumb: a deep link is how people land here, so without it
+		// there is no way back to the list.
 		return (
-			<div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground select-text cursor-text">
-				{loadError && !isMissing ? (
-					<Trans>Couldn't load automation: {loadError.message}</Trans>
+			<div className="flex h-full w-full flex-col overflow-hidden">
+				<AutomationBreadcrumbBar />
+				{elsewhere ? (
+					<WrongOrganizationNotice
+						description={errorMessage(loadError)}
+						onSwitch={
+							switchTo ? () => void switchOrganization(switchTo) : undefined
+						}
+					/>
 				) : (
-					<Trans>Automation not found.</Trans>
+					<div className="flex flex-1 items-center justify-center text-sm text-muted-foreground select-text cursor-text">
+						{loadError && !isMissing ? (
+							<Trans>Couldn't load automation: {loadError.message}</Trans>
+						) : (
+							<Trans>Automation not found.</Trans>
+						)}
+					</div>
 				)}
 			</div>
 		);

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Tato aplikace bude moci:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Tato aplikace bude mít přístup k datům ve vybrané organizaci."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Tato automatizace patří organizaci {0}. Přepněte na tuto organizaci, abyste ji otevřeli."
+
+msgid "This automation is in another organization"
+msgstr "Tato automatizace je v jiné organizaci"
+
 msgid "This cannot be undone."
 msgstr "Nelze vrátit zpět."
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -14325,7 +14325,7 @@ msgstr "Diese Anwendung erhält Zugriff auf die Daten der gewählten Organisatio
 
 #. placeholder {0}: params?.organizationName
 msgid "This automation belongs to {0}. Switch to that organization to open it."
-msgstr "Diese Automatisierung gehört zu {0}. Wechseln Sie zu dieser Organisation, um sie zu öffnen."
+msgstr "Diese Automatisierung gehört zu {0}. Wechsle zu dieser Organisation, um sie zu öffnen."
 
 msgid "This automation is in another organization"
 msgstr "Diese Automatisierung befindet sich in einer anderen Organisation"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Diese Anwendung wird Folgendes können:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Diese Anwendung erhält Zugriff auf die Daten der gewählten Organisation."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Diese Automatisierung gehört zu {0}. Wechseln Sie zu dieser Organisation, um sie zu öffnen."
+
+msgid "This automation is in another organization"
+msgstr "Diese Automatisierung befindet sich in einer anderen Organisation"
+
 msgid "This cannot be undone."
 msgstr "Das lässt sich nicht rückgängig machen."
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -14323,6 +14323,13 @@ msgstr "This application will be able to:"
 msgid "This application will have access to data in the selected organization."
 msgstr "This application will have access to data in the selected organization."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "This automation belongs to {0}. Switch to that organization to open it."
+
+msgid "This automation is in another organization"
+msgstr "This automation is in another organization"
+
 msgid "This cannot be undone."
 msgstr "This cannot be undone."
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Esta aplicación podrá:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Esta aplicación tendrá acceso a los datos de la organización seleccionada."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Esta automatización pertenece a {0}. Cambia a esa organización para abrirla."
+
+msgid "This automation is in another organization"
+msgstr "Esta automatización está en otra organización"
+
 msgid "This cannot be undone."
 msgstr "Esto no se puede deshacer."
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Cette application pourra :"
 msgid "This application will have access to data in the selected organization."
 msgstr "Cette application aura accès aux données de l'organisation sélectionnée."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Cette automatisation appartient à {0}. Basculez vers cette organisation pour l'ouvrir."
+
+msgid "This automation is in another organization"
+msgstr "Cette automatisation se trouve dans une autre organisation"
+
 msgid "This cannot be undone."
 msgstr "Cette action est irréversible."
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Aplikasi ini akan bisa:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Aplikasi ini akan punya akses ke data di organisasi yang dipilih."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Otomatisasi ini milik {0}. Ganti ke organisasi tersebut untuk membukanya."
+
+msgid "This automation is in another organization"
+msgstr "Otomatisasi ini berada di organisasi lain"
+
 msgid "This cannot be undone."
 msgstr "Ini tidak bisa dibatalkan."
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Questa applicazione potrà:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Questa applicazione avrà accesso ai dati dell'organizzazione selezionata."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Questa automazione appartiene a {0}. Passa a quell'organizzazione per aprirla."
+
+msgid "This automation is in another organization"
+msgstr "Questa automazione si trova in un'altra organizzazione"
+
 msgid "This cannot be undone."
 msgstr "L'operazione non può essere annullata."
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -14323,6 +14323,13 @@ msgstr "このアプリケーションは次のことができます:"
 msgid "This application will have access to data in the selected organization."
 msgstr "このアプリケーションは選択した組織のデータにアクセスできます。"
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "このオートメーションは {0} に属しています。開くにはその組織に切り替えてください。"
+
+msgid "This automation is in another organization"
+msgstr "このオートメーションは別の組織にあります"
+
 msgid "This cannot be undone."
 msgstr "この操作は元に戻せません。"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -14323,6 +14323,13 @@ msgstr "이 애플리케이션은 다음을 할 수 있습니다:"
 msgid "This application will have access to data in the selected organization."
 msgstr "이 애플리케이션은 선택한 조직의 데이터에 접근할 수 있습니다."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "이 자동화는 {0}에 속해 있습니다. 열려면 해당 조직으로 전환하세요."
+
+msgid "This automation is in another organization"
+msgstr "이 자동화는 다른 조직에 있습니다"
+
 msgid "This cannot be undone."
 msgstr "되돌릴 수 없습니다."
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Deze applicatie kan:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Deze applicatie krijgt toegang tot gegevens in de gekozen organisatie."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Deze automatisering hoort bij {0}. Wissel naar die organisatie om hem te openen."
+
+msgid "This automation is in another organization"
+msgstr "Deze automatisering staat in een andere organisatie"
+
 msgid "This cannot be undone."
 msgstr "Dit kan niet ongedaan worden gemaakt."
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Ta aplikacja będzie mogła:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Ta aplikacja uzyska dostęp do danych w wybranej organizacji."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Ta automatyzacja należy do organizacji {0}. Przełącz się na tę organizację, aby ją otworzyć."
+
+msgid "This automation is in another organization"
+msgstr "Ta automatyzacja znajduje się w innej organizacji"
+
 msgid "This cannot be undone."
 msgstr "Tej operacji nie można cofnąć."
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Este aplicativo vai poder:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Este aplicativo terá acesso aos dados da organização selecionada."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Esta automação pertence a {0}. Troque para essa organização para abri-la."
+
+msgid "This automation is in another organization"
+msgstr "Esta automação está em outra organização"
+
 msgid "This cannot be undone."
 msgstr "Não dá para desfazer."
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Это приложение сможет:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Это приложение получит доступ к данным выбранной организации."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Эта автоматизация принадлежит организации {0}. Смените организацию, чтобы открыть её."
+
+msgid "This automation is in another organization"
+msgstr "Эта автоматизация находится в другой организации"
+
 msgid "This cannot be undone."
 msgstr "Это нельзя отменить."
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Bu uygulama şunları yapabilecek:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Bu uygulama, seçili kuruluştaki verilere erişebilecek."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Bu otomasyon {0} kuruluşuna ait. Açmak için o kuruluşa geçin."
+
+msgid "This automation is in another organization"
+msgstr "Bu otomasyon başka bir kuruluşta"
+
 msgid "This cannot be undone."
 msgstr "Bu geri alınamaz."
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -14323,6 +14323,13 @@ msgstr "Ứng dụng này sẽ có thể:"
 msgid "This application will have access to data in the selected organization."
 msgstr "Ứng dụng này sẽ truy cập được dữ liệu trong tổ chức đã chọn."
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "Tự động hóa này thuộc về {0}. Chuyển sang tổ chức đó để mở."
+
+msgid "This automation is in another organization"
+msgstr "Tự động hóa này nằm trong một tổ chức khác"
+
 msgid "This cannot be undone."
 msgstr "Không thể hoàn tác."
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -14323,6 +14323,13 @@ msgstr "该应用将能够："
 msgid "This application will have access to data in the selected organization."
 msgstr "该应用将可以访问所选组织中的数据。"
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "此自动化属于 {0}。请切换到该组织后打开。"
+
+msgid "This automation is in another organization"
+msgstr "此自动化位于其他组织"
+
 msgid "This cannot be undone."
 msgstr "此操作无法撤销。"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -14323,6 +14323,13 @@ msgstr "該應用程式將能夠："
 msgid "This application will have access to data in the selected organization."
 msgstr "該應用程式將可以存取所選組織中的資料。"
 
+#. placeholder {0}: params?.organizationName
+msgid "This automation belongs to {0}. Switch to that organization to open it."
+msgstr "此自動化屬於 {0}。請切換到該組織後開啟。"
+
+msgid "This automation is in another organization"
+msgstr "此自動化位於其他組織"
+
 msgid "This cannot be undone."
 msgstr "此操作無法復原。"
 

--- a/packages/i18n/src/server-errors.ts
+++ b/packages/i18n/src/server-errors.ts
@@ -31,6 +31,12 @@ export const serverErrorMessages: Record<
 				message: "Automation has no instructions",
 			}),
 		),
+	"serverError.automation.automationInAnotherOrganization": (params) =>
+		i18n._(
+			msg({
+				message: `This automation belongs to ${params?.organizationName}. Switch to that organization to open it.`,
+			}),
+		),
 	"serverError.automation.automationNotFound": () =>
 		i18n._(
 			msg({

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -24,6 +24,7 @@ import { requireActiveOrgMembership } from "../utils/active-org";
 import { dispatchAutomation } from "./dispatch";
 import {
 	automationBaseColumns,
+	automationNotFound,
 	getAutomationForUser,
 	NO_SCHEDULE,
 	promptSourceFromSession,
@@ -254,11 +255,7 @@ export const automationRouter = {
 			// Reads are org-scoped (Team tab links to any member's automation);
 			// mutations stay owner-scoped via getAutomationForUser.
 			if (!row) {
-				throw userError({
-					code: "NOT_FOUND",
-					message: "Automation not found",
-					i18nKey: "serverError.automation.automationNotFound",
-				});
+				throw await automationNotFound(input.id, ctx.session.user.id);
 			}
 
 			// The whole set, since the editor saves it as one and needs the ids to
@@ -634,11 +631,7 @@ export const automationRouter = {
 				)
 				.limit(1);
 			if (!existing) {
-				throw userError({
-					code: "NOT_FOUND",
-					message: "Automation not found",
-					i18nKey: "serverError.automation.automationNotFound",
-				});
+				throw await automationNotFound(input.id, ctx.session.user.id);
 			}
 			return existing;
 		}),

--- a/packages/trpc/src/router/automation/helpers.ts
+++ b/packages/trpc/src/router/automation/helpers.ts
@@ -5,6 +5,8 @@ import {
 	automationPromptVersions,
 	automations,
 	automationTriggers,
+	members,
+	organizations,
 	type ScheduleTriggerConfig,
 	type TriggerConfig,
 } from "@superset/db/schema";
@@ -311,6 +313,55 @@ export const automationBaseColumns = {
 	createdAt: automations.createdAt,
 	updatedAt: automations.updatedAt,
 };
+
+/**
+ * The miss for an org-scoped automation read. An automation the caller can
+ * reach from another organization is a wrong-active-org, not a missing row —
+ * deep links land people here — so name that organization instead of a dead
+ * end. The members join is what keeps it from leaking: it can only ever
+ * resolve an organization the caller already belongs to. Mirrors pageNotFound
+ * in ../page/page.ts.
+ */
+export async function automationNotFound(
+	id: string,
+	userId: string,
+): Promise<Error> {
+	const [elsewhere] = await db
+		.select({
+			organizationId: organizations.id,
+			organizationName: organizations.name,
+		})
+		.from(automations)
+		.innerJoin(
+			members,
+			and(
+				eq(members.organizationId, automations.organizationId),
+				eq(members.userId, userId),
+			),
+		)
+		.innerJoin(organizations, eq(organizations.id, automations.organizationId))
+		.where(eq(automations.id, id))
+		.limit(1);
+
+	if (!elsewhere) {
+		return userError({
+			code: "NOT_FOUND",
+			message: "Automation not found",
+			i18nKey: "serverError.automation.automationNotFound",
+		});
+	}
+	return userError({
+		code: "FORBIDDEN",
+		message: `This automation belongs to ${elsewhere.organizationName}. Switch to that organization to open it.`,
+		i18nKey: "serverError.automation.automationInAnotherOrganization",
+		// organizationId rides along unused by the message so the client can
+		// offer a one-click switch rather than only naming the organization.
+		params: {
+			organizationName: elsewhere.organizationName,
+			organizationId: elsewhere.organizationId,
+		},
+	});
+}
 
 export async function getAutomationForUser(
 	userId: string,


### PR DESCRIPTION
Follow-up to #7347. Automation reads are scoped to the **active** organization and threw `NOT_FOUND` for everything, so a member who opened a shared link while a different organization was active saw "Automation not found." — indistinguishable from a deleted row, with no hint that switching would show it. Deep links make that the likelier of the two failures, since you no longer have to already be in the organization that lists it.

## The rule

`automationNotFound(id, userId)` mirrors `pageNotFound` in `router/page/page.ts`: on a miss, re-query by id `innerJoin`ed to `members` on the caller's own userId.

- caller is a member of the owning organization → `FORBIDDEN`, naming it
- otherwise → `NOT_FOUND`, unchanged

The join is the leak guard — it can only ever name an organization the caller already belongs to. Used by `get` and `getPrompt`, the two reads behind the detail route.

## Notes

- **One-click switch.** The organization id rides along in `i18nParams` so the client can call `switchOrganization` directly instead of only naming the organization and leaving you to find the picker. Commented at the throw site so it doesn't get tidied away as unused.
- **First parameterised server error.** `userError`'s `params` and the `i18nParams` plumbing through `formatError` → `errorMessage()` already existed but had no callers; this is the first, so the catalog entry takes `params`.
- **Every error state keeps the breadcrumb.** They used to replace the whole pane, so a deep-linked visitor had no way back to the list — true of the existing not-found branch too. `AutomationBreadcrumbBar` is extracted from `AutomationDetailHeader` (which now composes it) and rendered on its own by the error branch.
- 2 new messages, 32 translations written; all 17 locales at 0 missing.

## Verification

Driven over CDP against a dev build, using a real 4-organization membership:

| Case | Server | UI |
| --- | --- | --- |
| Own automation, right organization active | 200 | detail page |
| Own automation, **wrong organization active** | `FORBIDDEN` naming it | notice + switch button |
| Automation in an organization the caller is **not** in | `NOT_FOUND` | "Automation not found." |
| Nonexistent id | `NOT_FOUND` | "Automation not found." |

Clicking **Switch organization** flipped the active organization and rendered the automation in one click.

Worth recording: the first UI pass on the two no-leak rows *looked* like it showed the wrong-organization notice. That was a stale render — `window.location.hash` does not remount the route, and a reload is overridden by the persisted history. Reading the raw tRPC codes through the app's authed client, then re-testing via the deep link, produced the table above.

https://claude.ai/code/session_012i4sML8GdjiCrKypTanYLS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opening a shared automation link under the wrong active organization now shows that organization's name and a one-click switch, instead of a dead-end "Automation not found." The server returns `FORBIDDEN` naming the organization only when the caller is a member of it; otherwise it stays `NOT_FOUND`. Error states keep the breadcrumb so deep-linked visitors can get back to the list. Translations cover all 17 locales, with German using the catalog's informal address.

<sup>Written for commit d9ecd509c2e735b889d46a193b1066463cb1abbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automation detail pages now include breadcrumb navigation with contextual actions.
  - Shared automation links identify when an automation belongs to another organization and offer an option to switch organizations.

- **Bug Fixes**
  - Automation access errors now distinguish unavailable automations from those belonging to another organization.

- **Localization**
  - Added translated cross-organization automation messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->