### PR TITLE
feat(mobile): agent status on the Lock Screen and Dynamic Island

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -26,10 +26,18 @@ export default ({ config }: ConfigContext) => ({
 	},
 	ios: {
 		supportsTablet: false,
+		appleTeamId: "NV9657CS5A",
+		// Shared with the AgentActivity widget extension: the Live Activity
+		// sandbox has no network, so project icons are cached here by the app
+		// and read back by the extension from disk.
+		entitlements: {
+			"com.apple.security.application-groups": ["group.sh.superset.mobile"],
+		},
 		bundleIdentifier: "sh.superset.mobile",
 		usesAppleSignIn: true,
 		infoPlist: {
 			ITSAppUsesNonExemptEncryption: false,
+			NSSupportsLiveActivities: true,
 			// Dictation is native now (`modules/composer`), so no config plugin
 			// contributes this any more — `expo-speech-recognition` used to, and
 			// went with `GlassComposer`. Without it `SFSpeechRecognizer`'s
@@ -52,6 +60,7 @@ export default ({ config }: ConfigContext) => ({
 	},
 	plugins: [
 		[withIosAccentColor, { color: "#FFFFFF" }],
+		"@bacons/apple-targets",
 		"expo-router",
 		[
 			"@sentry/react-native/expo",

--- a/apps/mobile/modules/live-activity/expo-module.config.json
+++ b/apps/mobile/modules/live-activity/expo-module.config.json
@@ -1,0 +1,4 @@
+{
+	"platforms": ["apple"],
+	"apple": { "modules": ["LiveActivityModule"] }
+}

--- a/apps/mobile/modules/live-activity/ios/AgentActivityAttributes.swift
+++ b/apps/mobile/modules/live-activity/ios/AgentActivityAttributes.swift
@@ -47,6 +47,9 @@ struct AgentActivityAttributes: ActivityAttributes {
 		var rows: [AgentRow]
 		/// "+6 more working", or nil when nothing was dropped.
 		var more: String?
+		/// Every agent, not just the rows that fit. `rows` is capped at four,
+		/// so the Dynamic Island would otherwise say "4" for a fleet of nine.
+		var totalCount: Int
 		/// Most urgent state in the fleet — tints the Dynamic Island.
 		var topState: String
 		/// Shown instead of the headline once ActivityKit marks the activity

--- a/apps/mobile/modules/live-activity/ios/AgentActivityAttributes.swift
+++ b/apps/mobile/modules/live-activity/ios/AgentActivityAttributes.swift
@@ -49,7 +49,10 @@ struct AgentActivityAttributes: ActivityAttributes {
 		var more: String?
 		/// Most urgent state in the fleet — tints the Dynamic Island.
 		var topState: String
-		var isStale: Bool
+		/// Shown instead of the headline once ActivityKit marks the activity
+		/// stale. The flag itself is ActivityKit's (`context.isStale`), driven
+		/// by the staleDate we pass on every update — a field of our own could
+		/// never be set, because by definition nothing is updating us.
 		var staleDetail: String
 	}
 

--- a/apps/mobile/modules/live-activity/ios/AgentActivityAttributes.swift
+++ b/apps/mobile/modules/live-activity/ios/AgentActivityAttributes.swift
@@ -1,0 +1,57 @@
+import ActivityKit
+import Foundation
+
+/// Shared with the app target. ActivityKit matches the app's
+/// `Activity<AgentActivityAttributes>` to the widget's `ActivityConfiguration`
+/// by type name, so both targets carry their own copy of this declaration.
+struct AgentActivityAttributes: ActivityAttributes {
+	/// The App Group both targets read and write. The Live Activity sandbox
+	/// has no network, so project icons arrive as files, never as URLs.
+	static let appGroup = "group.sh.superset.mobile"
+
+	struct AgentRow: Codable, Hashable, Identifiable {
+		/// Terminal id. Identity for ForEach, and the tab the link selects.
+		var id: String
+		/// The workspace the terminal belongs to. The app has no /terminal
+		/// route — a session is reached as /workspace/<id>?tab=<terminalId>.
+		var workspaceId: String
+		var branch: String
+		/// Only used to draw the initial when there is no cached icon.
+		var project: String
+		/// Filename inside the App Group container, or nil to draw the initial.
+		/// ~40% of projects have no icon at all, so the fallback is the common
+		/// path, not an error path.
+		var iconFile: String?
+		/// Pre-translated status word — "Needs you", "Working", "Review".
+		/// Never a bare colour: at this size yellow-500 and amber-500 are
+		/// the same colour, which is what the first build got wrong.
+		var status: String
+		/// permission | working | failed | review — tint only.
+		var state: String
+		/// Time in the current state, already formatted — "12m", "1h", "3d".
+		/// Not a Date: SwiftUI's free-ticking `Text(style: .timer)` can only
+		/// render mm:ss, and the app's own compact format is what people read
+		/// everywhere else. Formatting in JS also keeps it inside Lingui's
+		/// catalogs rather than hardcoding units in Swift.
+		var elapsed: String
+		/// This row's host has stopped reporting. Per row, not per card —
+		/// one Mac sleeping says nothing about the cloud agents.
+		var isQuiet: Bool
+	}
+
+	struct ContentState: Codable, Hashable {
+		/// "1 needs you · 4 agents". Pre-translated.
+		var headline: String
+		/// Ranked by the shared STATUS_PRIORITY, then recency. Attention
+		/// states are never truncated; only `working` rows are.
+		var rows: [AgentRow]
+		/// "+6 more working", or nil when nothing was dropped.
+		var more: String?
+		/// Most urgent state in the fleet — tints the Dynamic Island.
+		var topState: String
+		var isStale: Bool
+		var staleDetail: String
+	}
+
+	var machineName: String
+}

--- a/apps/mobile/modules/live-activity/ios/LiveActivity.podspec
+++ b/apps/mobile/modules/live-activity/ios/LiveActivity.podspec
@@ -1,0 +1,25 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'LiveActivity'
+  s.version        = package['version']
+  s.summary        = 'ActivityKit bridge for Superset'
+  s.description    = 'Starts, updates and ends the agent-status Live Activity'
+  s.license        = 'MIT'
+  s.author         = 'Superset'
+  s.homepage       = 'https://superset.sh'
+  s.platforms      = { :ios => '26.0' }
+  s.swift_version  = '5.9'
+  s.source         = { git: 'https://github.com/nicksupersetsh/superset.git' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES'
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -19,6 +19,7 @@ struct AgentSnapshotRecord: Record {
   @Field var headline: String = ""
   @Field var rows: [AgentRowRecord] = []
   @Field var more: String? = nil
+  @Field var totalCount: Int = 0
   @Field var topState: String = "working"
   @Field var staleDetail: String = ""
   @Field var machineName: String = ""
@@ -37,6 +38,7 @@ private func contentState(
         status: $0.status, state: $0.state, elapsed: $0.elapsed, isQuiet: $0.isQuiet)
     },
     more: snapshot.more,
+    totalCount: snapshot.totalCount,
     topState: snapshot.topState,
     staleDetail: snapshot.staleDetail
   )

--- a/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -1,0 +1,136 @@
+import ActivityKit
+import ExpoModulesCore
+import UIKit
+
+struct AgentRowRecord: Record {
+  @Field var id: String = ""
+  @Field var workspaceId: String = ""
+  @Field var branch: String = ""
+  @Field var project: String = ""
+  @Field var iconFile: String? = nil
+  @Field var status: String = ""
+  @Field var state: String = "working"
+  /// Pre-formatted time in state — "12m", "1h". See AgentRow.elapsed.
+  @Field var elapsed: String = ""
+  @Field var isQuiet: Bool = false
+}
+
+struct AgentSnapshotRecord: Record {
+  @Field var headline: String = ""
+  @Field var rows: [AgentRowRecord] = []
+  @Field var more: String? = nil
+  @Field var topState: String = "working"
+  @Field var isStale: Bool = false
+  @Field var staleDetail: String = ""
+  @Field var machineName: String = ""
+  /// Seconds until the card should call itself out of date. 0 = never.
+  @Field var staleAfterSeconds: Double = 0
+}
+
+private func contentState(
+  from snapshot: AgentSnapshotRecord
+) -> AgentActivityAttributes.ContentState {
+  AgentActivityAttributes.ContentState(
+    headline: snapshot.headline,
+    rows: snapshot.rows.map {
+      AgentActivityAttributes.AgentRow(
+        id: $0.id, workspaceId: $0.workspaceId, branch: $0.branch, project: $0.project, iconFile: $0.iconFile,
+        status: $0.status, state: $0.state, elapsed: $0.elapsed, isQuiet: $0.isQuiet)
+    },
+    more: snapshot.more,
+    topState: snapshot.topState,
+    isStale: snapshot.isStale,
+    staleDetail: snapshot.staleDetail
+  )
+}
+
+private func iconsDirectory() throws -> URL {
+  guard
+    let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: AgentActivityAttributes.appGroup)
+  else {
+    throw Exception(name: "ERR_NO_APP_GROUP", description: "App Group unavailable")
+  }
+  let dir = container.appendingPathComponent("icons", isDirectory: true)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  return dir
+}
+
+public final class LiveActivityModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("LiveActivity")
+
+    Function("areActivitiesEnabled") { () -> Bool in
+      ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+
+    Function("activeIds") { () -> [String] in
+      Activity<AgentActivityAttributes>.activities.map(\.id)
+    }
+
+    /// Downloads a project icon, downscales it, and writes it into the App
+    /// Group so the widget extension can read it off disk. The extension has
+    /// no network of its own, and a 54pt PNG is 35-76% of the entire 4KB
+    /// ContentState budget, so it cannot travel in the payload either.
+    AsyncFunction("cacheIcon") { (key: String, url: String) -> String in
+      let file = "\(key).png"
+      let target = try iconsDirectory().appendingPathComponent(file)
+      if FileManager.default.fileExists(atPath: target.path) { return file }
+      guard let source = URL(string: url) else {
+        throw Exception(name: "ERR_BAD_URL", description: url)
+      }
+      let (data, _) = try await URLSession.shared.data(from: source)
+      guard let image = UIImage(data: data) else {
+        throw Exception(name: "ERR_DECODE", description: "not an image")
+      }
+      // Apple: an asset larger than the presentation "might fail to start the
+      // Live Activity", so never cache at source resolution.
+      let side: CGFloat = 54
+      let renderer = UIGraphicsImageRenderer(size: CGSize(width: side, height: side))
+      let scaled = renderer.image { _ in
+        image.draw(in: CGRect(x: 0, y: 0, width: side, height: side))
+      }
+      guard let png = scaled.pngData() else {
+        throw Exception(name: "ERR_ENCODE", description: "png encode failed")
+      }
+      try png.write(to: target, options: .atomic)
+      return file
+    }
+
+    AsyncFunction("start") { (snapshot: AgentSnapshotRecord) -> String in
+      guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+        throw Exception(name: "ERR_DISABLED", description: "Live Activities are off")
+      }
+      let stale = snapshot.staleAfterSeconds > 0
+        ? Date().addingTimeInterval(snapshot.staleAfterSeconds) : nil
+      let activity = try Activity.request(
+        attributes: AgentActivityAttributes(machineName: snapshot.machineName),
+        content: .init(state: contentState(from: snapshot), staleDate: stale),
+        pushType: nil
+      )
+      return activity.id
+    }
+
+    AsyncFunction("update") { (id: String, snapshot: AgentSnapshotRecord, alert: String?) in
+      guard let activity = Activity<AgentActivityAttributes>.activities.first(where: { $0.id == id })
+      else { return }
+      let stale = snapshot.staleAfterSeconds > 0
+        ? Date().addingTimeInterval(snapshot.staleAfterSeconds) : nil
+      let content = ActivityContent(state: contentState(from: snapshot), staleDate: stale)
+      if let alert {
+        await activity.update(
+          content,
+          alertConfiguration: AlertConfiguration(
+            title: "\(alert)", body: "\(snapshot.headline)", sound: .default))
+      } else {
+        await activity.update(content)
+      }
+    }
+
+    AsyncFunction("endAll") {
+      for activity in Activity<AgentActivityAttributes>.activities {
+        await activity.end(nil, dismissalPolicy: .immediate)
+      }
+    }
+  }
+}

--- a/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
+++ b/apps/mobile/modules/live-activity/ios/LiveActivityModule.swift
@@ -20,7 +20,6 @@ struct AgentSnapshotRecord: Record {
   @Field var rows: [AgentRowRecord] = []
   @Field var more: String? = nil
   @Field var topState: String = "working"
-  @Field var isStale: Bool = false
   @Field var staleDetail: String = ""
   @Field var machineName: String = ""
   /// Seconds until the card should call itself out of date. 0 = never.
@@ -39,7 +38,6 @@ private func contentState(
     },
     more: snapshot.more,
     topState: snapshot.topState,
-    isStale: snapshot.isStale,
     staleDetail: snapshot.staleDetail
   )
 }
@@ -73,7 +71,14 @@ public final class LiveActivityModule: Module {
     /// no network of its own, and a 54pt PNG is 35-76% of the entire 4KB
     /// ContentState budget, so it cannot travel in the payload either.
     AsyncFunction("cacheIcon") { (key: String, url: String) -> String in
-      let file = "\(key).png"
+      // The key is a project id, but it arrives from JS: a separator or a
+      // traversal component would write outside the icons directory.
+      let safe = key.replacingOccurrences(
+        of: "[^A-Za-z0-9._-]", with: "_", options: .regularExpression)
+      guard !safe.isEmpty, safe != ".", safe != ".." else {
+        throw Exception(name: "ERR_BAD_KEY", description: key)
+      }
+      let file = "\(safe).png"
       let target = try iconsDirectory().appendingPathComponent(file)
       if FileManager.default.fileExists(atPath: target.path) { return file }
       guard let source = URL(string: url) else {

--- a/apps/mobile/modules/live-activity/package.json
+++ b/apps/mobile/modules/live-activity/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "@superset/live-activity",
+	"version": "0.0.1",
+	"main": "src/index.ts",
+	"private": true,
+	"peerDependencies": {
+		"expo": "*",
+		"react": "*",
+		"react-native": "*"
+	}
+}

--- a/apps/mobile/modules/live-activity/src/index.ts
+++ b/apps/mobile/modules/live-activity/src/index.ts
@@ -25,6 +25,8 @@ export interface AgentSnapshot {
 	headline: string;
 	rows: AgentRow[];
 	more?: string;
+	/** Every agent, not just the rows that fit on the card. */
+	totalCount: number;
 	topState: AgentRow["state"];
 	staleDetail?: string;
 	machineName: string;

--- a/apps/mobile/modules/live-activity/src/index.ts
+++ b/apps/mobile/modules/live-activity/src/index.ts
@@ -1,0 +1,70 @@
+import { requireNativeModule } from "expo";
+
+export interface AgentRow {
+	/** Terminal id — selected as `?tab=` on the workspace route. */
+	id: string;
+	/** Workspace the terminal belongs to; the deep link's real target. */
+	workspaceId: string;
+	branch: string;
+	project: string;
+	/** Filename returned by `cacheIcon`, or omitted to draw the initial. */
+	iconFile?: string;
+	/** Pre-translated status word, e.g. "Needs you". */
+	status: string;
+	state: "permission" | "working" | "failed" | "review";
+	/**
+	 * Time in the current state, already formatted — "12m", "1h", "3d".
+	 * Formatted here rather than in Swift: SwiftUI's free-ticking timer can
+	 * only render mm:ss, and units belong in Lingui's catalogs.
+	 */
+	elapsed: string;
+	isQuiet?: boolean;
+}
+
+export interface AgentSnapshot {
+	headline: string;
+	rows: AgentRow[];
+	more?: string;
+	topState: AgentRow["state"];
+	isStale?: boolean;
+	staleDetail?: string;
+	machineName: string;
+	staleAfterSeconds?: number;
+}
+
+/**
+ * Row order for the card, most urgent first.
+ *
+ * Deliberately NOT desktop's `STATUS_PRIORITY`, which ranks `working` above
+ * `review`. On a glanceable card the question is "what wants me?", and a
+ * finished session waiting to be read wants you more than a busy one that
+ * does not. Rows are sorted by this, then by recency.
+ */
+export const CARD_PRIORITY: Record<AgentRow["state"], number> = {
+	permission: 4,
+	failed: 3,
+	review: 2,
+	working: 1,
+};
+
+export function orderRows(rows: AgentRow[]): AgentRow[] {
+	return [...rows].sort(
+		(a, b) => CARD_PRIORITY[b.state] - CARD_PRIORITY[a.state],
+	);
+}
+
+interface LiveActivityModule {
+	areActivitiesEnabled: () => boolean;
+	activeIds: () => string[];
+	/** Downloads, downscales and caches a project icon into the App Group. */
+	cacheIcon: (key: string, url: string) => Promise<string>;
+	start: (snapshot: AgentSnapshot) => Promise<string>;
+	update: (
+		id: string,
+		snapshot: AgentSnapshot,
+		alert?: string | null,
+	) => Promise<void>;
+	endAll: () => Promise<void>;
+}
+
+export default requireNativeModule<LiveActivityModule>("LiveActivity");

--- a/apps/mobile/modules/live-activity/src/index.ts
+++ b/apps/mobile/modules/live-activity/src/index.ts
@@ -26,7 +26,6 @@ export interface AgentSnapshot {
 	rows: AgentRow[];
 	more?: string;
 	topState: AgentRow["state"];
-	isStale?: boolean;
 	staleDetail?: string;
 	machineName: string;
 	staleAfterSeconds?: number;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -132,6 +132,7 @@
 	},
 	"devDependencies": {
 		"@babel/preset-typescript": "7.29.7",
+		"@bacons/apple-targets": "5.0.0",
 		"@lingui/babel-plugin-lingui-macro": "6.6.0",
 		"@storybook/addon-ondevice-actions": "10.4.2",
 		"@storybook/addon-ondevice-controls": "10.4.2",

--- a/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/HomeScreen.tsx
@@ -36,6 +36,7 @@ import { OrganizationHeaderButton } from "./components/OrganizationHeaderButton"
 import { ProjectSectionHeader } from "./components/ProjectSectionHeader";
 import { ScopeBar } from "./components/ScopeBar";
 import { WorkspaceRow } from "./components/WorkspaceRow";
+import { useAgentLiveActivity } from "./hooks/useAgentLiveActivity";
 import { useCloudRepoPrefix } from "./hooks/useCloudRepoPrefixes";
 import {
 	type TerminalsHost,
@@ -151,6 +152,16 @@ export function HomeScreen() {
 
 	// Projects are fully local — served by the selected host, not the cloud.
 	const { projects } = useHostProjects(selectedHost);
+
+	// Mirrors the rows above onto the Lock Screen and Dynamic Island while the
+	// app is open. Foreground-only for now: nothing server-side knows an agent
+	// needs attention yet, so the card goes stale (and says so) once the app
+	// closes. ActivityKit push updates are the follow-up that fixes that.
+	useAgentLiveActivity({
+		terminalsByWorkspace,
+		workspaces,
+		projects,
+	});
 	const pullRequests = usePullRequests();
 
 	const collapsed = useCollapsedProjectsStore((state) => state.collapsed);

--- a/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/index.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/index.ts
@@ -1,0 +1,5 @@
+export type {
+	LiveActivityProject,
+	LiveActivityWorkspace,
+} from "./useAgentLiveActivity";
+export { useAgentLiveActivity } from "./useAgentLiveActivity";

--- a/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/useAgentLiveActivity.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/useAgentLiveActivity.ts
@@ -58,6 +58,10 @@ export function useAgentLiveActivity({
 	// Bumped on every run so a slow icon download cannot post a snapshot the
 	// hook has already moved past — or resurrect one after unmount.
 	const runId = useRef(0);
+	// One delivery at a time. Two effect runs could otherwise both find no
+	// activity mid-await and each start one, leaving a second card behind.
+	const inFlight = useRef(false);
+	const queued = useRef<(() => Promise<void>) | null>(null);
 	// Icons are cached once per project per launch: the file already on disk
 	// is reused, so this only ever pays for projects newly on the card.
 	const cachedIcons = useRef<Map<string, string>>(new Map());
@@ -130,6 +134,7 @@ export function useAgentLiveActivity({
 						other: "# agents working",
 					}),
 			rows: shown,
+			totalCount: total,
 			topState: shown[0]?.state ?? "working",
 			machineName: "",
 			staleDetail: t({ message: "Not updating", context: "agent status" }),
@@ -144,11 +149,10 @@ export function useAgentLiveActivity({
 		// The card is only worth waking for when something it shows changed.
 		const payload = JSON.stringify(snapshot);
 		if (payload === lastPayload.current) return;
-		lastPayload.current = payload;
 
 		runId.current += 1;
 		const generation = runId.current;
-		void (async () => {
+		const deliver = async () => {
 			for (const row of shown) {
 				const project = workspaceById.get(row.workspaceId)?.projectId;
 				const icon = project ? projectById.get(project) : undefined;
@@ -192,10 +196,32 @@ export function useAgentLiveActivity({
 				} else {
 					activityId.current = await LiveActivity.start(withIcons);
 				}
+				// Only now is the payload really delivered: marking it earlier
+				// would swallow the retry after a failure.
+				lastPayload.current = payload;
 			} catch {
 				// Denied, or the device is at its concurrent-activity limit.
 				activityId.current = null;
 				lastPayload.current = null;
+			}
+		};
+
+		if (inFlight.current) {
+			// Keep only the newest — intermediate states are not worth showing.
+			queued.current = deliver;
+			return;
+		}
+		void (async () => {
+			inFlight.current = true;
+			try {
+				let next: (() => Promise<void>) | null = deliver;
+				while (next) {
+					await next();
+					next = queued.current;
+					queued.current = null;
+				}
+			} finally {
+				inFlight.current = false;
 			}
 		})();
 	}, [terminalsByWorkspace, workspaces, projects, enabled, t]);

--- a/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/useAgentLiveActivity.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/useAgentLiveActivity.ts
@@ -1,0 +1,181 @@
+import { useLingui } from "@lingui/react/macro";
+import LiveActivity, {
+	type AgentRow,
+	type AgentSnapshot,
+	orderRows,
+} from "@superset/live-activity";
+import { useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import type { TerminalAttention, TerminalRowData } from "../useHostTerminals";
+
+/**
+ * Rows the Lock Screen card can actually show. Four is the measured ceiling:
+ * a fifth pushes the card past the 160pt height at which the system truncates
+ * it. Everything beyond becomes the "+N more" line.
+ */
+const MAX_ROWS = 4;
+
+export interface LiveActivityProject {
+	id: string;
+	name: string;
+	iconUrl?: string | null;
+}
+
+/**
+ * Structural, not `HostWorkspaceItem`: the hook needs four fields and binding
+ * it to the host row would couple this surface to the whole schema for no gain.
+ */
+export interface LiveActivityWorkspace {
+	id: string;
+	name: string;
+	branch?: string | null;
+	projectId?: string | null;
+}
+
+/** "12m", "1h", "3d" — the app's compact style without the "ago" suffix. */
+function elapsedLabel(since: number, now: number): string {
+	const minutes = Math.max(1, Math.round((now - since) / 60_000));
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	return hours < 24 ? `${hours}h` : `${Math.round(hours / 24)}d`;
+}
+
+export function useAgentLiveActivity({
+	terminalsByWorkspace,
+	workspaces,
+	projects,
+	enabled = true,
+}: {
+	terminalsByWorkspace: ReadonlyMap<string, TerminalRowData[]>;
+	workspaces: readonly LiveActivityWorkspace[];
+	projects: readonly LiveActivityProject[];
+	enabled?: boolean;
+}): void {
+	const { t } = useLingui();
+	const activityId = useRef<string | null>(null);
+	const lastPayload = useRef<string | null>(null);
+	// Icons are cached once per project per launch: the file already on disk
+	// is reused, so this only ever pays for projects newly on the card.
+	const cachedIcons = useRef<Map<string, string>>(new Map());
+
+	useEffect(() => {
+		if (!enabled) return;
+		if (!LiveActivity.areActivitiesEnabled()) return;
+		// A Live Activity can only be started from the foreground —
+		// `ActivityAuthorizationError.visibility` otherwise.
+		if (AppState.currentState !== "active") return;
+
+		const projectById = new Map(projects.map((p) => [p.id, p]));
+		const workspaceById = new Map(workspaces.map((w) => [w.id, w]));
+		const now = Date.now();
+
+		const statusWord: Record<TerminalAttention, string> = {
+			permission: t({ message: "Needs you", context: "agent status" }),
+			failed: t({ message: "Failed", context: "agent status" }),
+			review: t({ message: "Review", context: "agent status" }),
+			working: t({ message: "Working", context: "agent status" }),
+		};
+
+		const all: AgentRow[] = [];
+		for (const [workspaceId, terminals] of terminalsByWorkspace) {
+			const workspace = workspaceById.get(workspaceId);
+			if (!workspace) continue;
+			const project = workspace.projectId
+				? projectById.get(workspace.projectId)
+				: undefined;
+			for (const terminal of terminals) {
+				if (!terminal.attention) continue;
+				all.push({
+					id: terminal.terminalId,
+					workspaceId,
+					branch: workspace.branch ?? workspace.name,
+					project: project?.name ?? "",
+					status: statusWord[terminal.attention],
+					state: terminal.attention,
+					elapsed: elapsedLabel(terminal.lastEventAt ?? terminal.ts, now),
+				});
+			}
+		}
+
+		if (all.length === 0) {
+			if (activityId.current) {
+				void LiveActivity.endAll();
+				activityId.current = null;
+				lastPayload.current = null;
+			}
+			return;
+		}
+
+		const total = all.length;
+		const ranked = orderRows(all);
+		const shown = ranked.slice(0, MAX_ROWS);
+		const hidden = ranked.length - shown.length;
+		const needing = all.filter((row) => row.state === "permission").length;
+
+		const snapshot: AgentSnapshot = {
+			headline: needing
+				? t`${needing} needs you · ${total} agents`
+				: t`${total} agents working`,
+			rows: shown,
+			topState: shown[0]?.state ?? "working",
+			machineName: "",
+			staleDetail: t({ message: "Not updating", context: "agent status" }),
+			// Updates only arrive while the app is in the foreground, so the card
+			// has to admit when it has stopped hearing anything rather than leave
+			// a stale "Working" on the Lock Screen. Two minutes is well past the
+			// 5s poll that feeds it.
+			staleAfterSeconds: 120,
+			...(hidden > 0 ? { more: t`+${hidden} more` } : {}),
+		};
+
+		// The card is only worth waking for when something it shows changed.
+		const payload = JSON.stringify(snapshot);
+		if (payload === lastPayload.current) return;
+		lastPayload.current = payload;
+
+		void (async () => {
+			for (const row of shown) {
+				const project = workspaceById.get(row.workspaceId)?.projectId;
+				const icon = project ? projectById.get(project) : undefined;
+				if (!icon?.iconUrl || cachedIcons.current.has(icon.id)) continue;
+				try {
+					// The extension has no network of its own, so the app writes
+					// icons into the shared App Group container for it to read.
+					cachedIcons.current.set(
+						icon.id,
+						await LiveActivity.cacheIcon(icon.id, icon.iconUrl),
+					);
+				} catch {
+					// A missing icon falls back to the project's initial, which is
+					// what ProjectAvatar draws everywhere else.
+				}
+			}
+			const withIcons: AgentSnapshot = {
+				...snapshot,
+				rows: shown.map((row) => {
+					const projectId = workspaceById.get(row.workspaceId)?.projectId;
+					const file = projectId
+						? cachedIcons.current.get(projectId)
+						: undefined;
+					return file ? { ...row, iconFile: file } : row;
+				}),
+			};
+			try {
+				if (activityId.current) {
+					await LiveActivity.update(activityId.current, withIcons);
+				} else {
+					activityId.current = await LiveActivity.start(withIcons);
+				}
+			} catch {
+				// Denied, or the device is at its concurrent-activity limit.
+				activityId.current = null;
+			}
+		})();
+	}, [terminalsByWorkspace, workspaces, projects, enabled, t]);
+
+	useEffect(() => {
+		return () => {
+			if (activityId.current) void LiveActivity.endAll();
+		};
+	}, []);
+}

--- a/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/useAgentLiveActivity.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/hooks/useAgentLiveActivity/useAgentLiveActivity.ts
@@ -1,3 +1,4 @@
+import { plural } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import LiveActivity, {
 	type AgentRow,
@@ -54,6 +55,9 @@ export function useAgentLiveActivity({
 	const { t } = useLingui();
 	const activityId = useRef<string | null>(null);
 	const lastPayload = useRef<string | null>(null);
+	// Bumped on every run so a slow icon download cannot post a snapshot the
+	// hook has already moved past — or resurrect one after unmount.
+	const runId = useRef(0);
 	// Icons are cached once per project per launch: the file already on disk
 	// is reused, so this only ever pays for projects newly on the card.
 	const cachedIcons = useRef<Map<string, string>>(new Map());
@@ -98,7 +102,8 @@ export function useAgentLiveActivity({
 		}
 
 		if (all.length === 0) {
-			if (activityId.current) {
+			runId.current += 1;
+			if (activityId.current || LiveActivity.activeIds().length > 0) {
 				void LiveActivity.endAll();
 				activityId.current = null;
 				lastPayload.current = null;
@@ -113,9 +118,17 @@ export function useAgentLiveActivity({
 		const needing = all.filter((row) => row.state === "permission").length;
 
 		const snapshot: AgentSnapshot = {
+			// The card renders these verbatim — no pluralisation layer sits below
+			// a pre-formatted string, so "1 agents working" would ship as-is.
 			headline: needing
-				? t`${needing} needs you · ${total} agents`
-				: t`${total} agents working`,
+				? `${plural(needing, { one: "# needs you", other: "# need you" })} · ${plural(
+						total,
+						{ one: "# agent", other: "# agents" },
+					)}`
+				: plural(total, {
+						one: "# agent working",
+						other: "# agents working",
+					}),
 			rows: shown,
 			topState: shown[0]?.state ?? "working",
 			machineName: "",
@@ -133,6 +146,8 @@ export function useAgentLiveActivity({
 		if (payload === lastPayload.current) return;
 		lastPayload.current = payload;
 
+		runId.current += 1;
+		const generation = runId.current;
 		void (async () => {
 			for (const row of shown) {
 				const project = workspaceById.get(row.workspaceId)?.projectId;
@@ -160,21 +175,34 @@ export function useAgentLiveActivity({
 					return file ? { ...row, iconFile: file } : row;
 				}),
 			};
+			if (generation !== runId.current) return;
 			try {
-				if (activityId.current) {
-					await LiveActivity.update(activityId.current, withIcons);
+				// ActivityKit is the source of truth, not our ref: an activity can
+				// outlive the JS context (relaunch) or be dismissed by the user,
+				// and either way a stale ref would silently no-op every update or
+				// start a second card.
+				const live = LiveActivity.activeIds();
+				const existing =
+					activityId.current && live.includes(activityId.current)
+						? activityId.current
+						: (live[0] ?? null);
+				if (existing) {
+					activityId.current = existing;
+					await LiveActivity.update(existing, withIcons);
 				} else {
 					activityId.current = await LiveActivity.start(withIcons);
 				}
 			} catch {
 				// Denied, or the device is at its concurrent-activity limit.
 				activityId.current = null;
+				lastPayload.current = null;
 			}
 		})();
 	}, [terminalsByWorkspace, workspaces, projects, enabled, t]);
 
 	useEffect(() => {
 		return () => {
+			runId.current += 1;
 			if (activityId.current) void LiveActivity.endAll();
 		};
 	}, []);

--- a/apps/mobile/targets/agentactivity/AgentActivityAttributes.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityAttributes.swift
@@ -47,6 +47,9 @@ struct AgentActivityAttributes: ActivityAttributes {
 		var rows: [AgentRow]
 		/// "+6 more working", or nil when nothing was dropped.
 		var more: String?
+		/// Every agent, not just the rows that fit. `rows` is capped at four,
+		/// so the Dynamic Island would otherwise say "4" for a fleet of nine.
+		var totalCount: Int
 		/// Most urgent state in the fleet — tints the Dynamic Island.
 		var topState: String
 		/// Shown instead of the headline once ActivityKit marks the activity

--- a/apps/mobile/targets/agentactivity/AgentActivityAttributes.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityAttributes.swift
@@ -49,7 +49,10 @@ struct AgentActivityAttributes: ActivityAttributes {
 		var more: String?
 		/// Most urgent state in the fleet — tints the Dynamic Island.
 		var topState: String
-		var isStale: Bool
+		/// Shown instead of the headline once ActivityKit marks the activity
+		/// stale. The flag itself is ActivityKit's (`context.isStale`), driven
+		/// by the staleDate we pass on every update — a field of our own could
+		/// never be set, because by definition nothing is updating us.
 		var staleDetail: String
 	}
 

--- a/apps/mobile/targets/agentactivity/AgentActivityAttributes.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityAttributes.swift
@@ -1,0 +1,57 @@
+import ActivityKit
+import Foundation
+
+/// Shared with the app target. ActivityKit matches the app's
+/// `Activity<AgentActivityAttributes>` to the widget's `ActivityConfiguration`
+/// by type name, so both targets carry their own copy of this declaration.
+struct AgentActivityAttributes: ActivityAttributes {
+	/// The App Group both targets read and write. The Live Activity sandbox
+	/// has no network, so project icons arrive as files, never as URLs.
+	static let appGroup = "group.sh.superset.mobile"
+
+	struct AgentRow: Codable, Hashable, Identifiable {
+		/// Terminal id. Identity for ForEach, and the tab the link selects.
+		var id: String
+		/// The workspace the terminal belongs to. The app has no /terminal
+		/// route — a session is reached as /workspace/<id>?tab=<terminalId>.
+		var workspaceId: String
+		var branch: String
+		/// Only used to draw the initial when there is no cached icon.
+		var project: String
+		/// Filename inside the App Group container, or nil to draw the initial.
+		/// ~40% of projects have no icon at all, so the fallback is the common
+		/// path, not an error path.
+		var iconFile: String?
+		/// Pre-translated status word — "Needs you", "Working", "Review".
+		/// Never a bare colour: at this size yellow-500 and amber-500 are
+		/// the same colour, which is what the first build got wrong.
+		var status: String
+		/// permission | working | failed | review — tint only.
+		var state: String
+		/// Time in the current state, already formatted — "12m", "1h", "3d".
+		/// Not a Date: SwiftUI's free-ticking `Text(style: .timer)` can only
+		/// render mm:ss, and the app's own compact format is what people read
+		/// everywhere else. Formatting in JS also keeps it inside Lingui's
+		/// catalogs rather than hardcoding units in Swift.
+		var elapsed: String
+		/// This row's host has stopped reporting. Per row, not per card —
+		/// one Mac sleeping says nothing about the cloud agents.
+		var isQuiet: Bool
+	}
+
+	struct ContentState: Codable, Hashable {
+		/// "1 needs you · 4 agents". Pre-translated.
+		var headline: String
+		/// Ranked by the shared STATUS_PRIORITY, then recency. Attention
+		/// states are never truncated; only `working` rows are.
+		var rows: [AgentRow]
+		/// "+6 more working", or nil when nothing was dropped.
+		var more: String?
+		/// Most urgent state in the fleet — tints the Dynamic Island.
+		var topState: String
+		var isStale: Bool
+		var staleDetail: String
+	}
+
+	var machineName: String
+}

--- a/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
@@ -1,0 +1,199 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// Measured off the reference card, then tightened until four rows with icons
+/// fit under the 160pt truncation limit. Values in points.
+private enum Metrics {
+	static let hPadding: CGFloat = 16
+	static let topPadding: CGFloat = 19
+	static let bottomPadding: CGFloat = 13
+	static let headToRows: CGFloat = 13
+	static let rowGap: CGFloat = 5
+	/// 16, not 18: an 18pt icon grows the row past the 19.2pt text line and
+	/// four rows then overrun the card by 5pt.
+	static let icon: CGFloat = 16
+	static let headSize: CGFloat = 14
+	static let branchSize: CGFloat = 16
+	static let metaSize: CGFloat = 13
+	static let timeWidth: CGFloat = 36
+}
+
+/// The app has no /terminal route: a session is a tab within its workspace.
+private func rowURL(_ row: AgentActivityAttributes.AgentRow) -> URL {
+	// Route groups like (authenticated) are an expo-router organisational
+	// device and never appear in a URL. Triple slash = empty host, so the
+	// whole thing parses as a path rather than workspace becoming the host.
+	URL(string: "superset:///workspace/\(row.workspaceId)?tab=\(row.id)")
+		?? URL(string: "superset:///")!
+}
+
+/// The card inherits the Lock Screen's appearance, which can be light. The
+/// 500-weight tokens are tuned for our dark UI and wash out on white, so each
+/// state carries a darker light-mode partner.
+private func adaptive(dark: (Double, Double, Double), light: (Double, Double, Double)) -> Color {
+	Color(UIColor { traits in
+		let c = traits.userInterfaceStyle == .light ? light : dark
+		return UIColor(red: c.0, green: c.1, blue: c.2, alpha: 1)
+	})
+}
+
+private func stateColor(_ state: String) -> Color {
+	switch state {
+	// yellow-500 / yellow-700
+	case "permission": return adaptive(dark: (0.918, 0.702, 0.031), light: (0.631, 0.443, 0.012))
+	// red-500 / red-700
+	case "failed": return adaptive(dark: (0.937, 0.267, 0.267), light: (0.729, 0.11, 0.11))
+	// green-500 / green-700
+	case "review": return adaptive(dark: (0.133, 0.773, 0.369), light: (0.082, 0.502, 0.239))
+	default: return .secondary
+	}
+}
+
+/// Icons live in the App Group container because the Live Activity sandbox
+/// cannot reach the network. The app downscales and writes them; we only read.
+private func cachedIcon(_ file: String?) -> UIImage? {
+	guard let file,
+		let dir = FileManager.default.containerURL(
+			forSecurityApplicationGroupIdentifier: AgentActivityAttributes.appGroup)
+	else { return nil }
+	return UIImage(contentsOfFile: dir.appendingPathComponent("icons/\(file)").path)
+}
+
+private struct ProjectIcon: View {
+	let row: AgentActivityAttributes.AgentRow
+
+	var body: some View {
+		Group {
+			if let image = cachedIcon(row.iconFile) {
+				Image(uiImage: image)
+					.resizable()
+					.aspectRatio(contentMode: .fill)
+			} else {
+				// The same fallback ProjectAvatar draws everywhere else in the
+				// app, so a project with no icon reads as familiar, not broken.
+				ZStack {
+					Rectangle().fill(.quaternary)
+					Text(String(row.project.prefix(1)).uppercased())
+						.font(.system(size: Metrics.icon * 0.55, weight: .semibold))
+						.foregroundStyle(.secondary)
+				}
+			}
+		}
+		.frame(width: Metrics.icon, height: Metrics.icon)
+		.clipShape(RoundedRectangle(cornerRadius: Metrics.icon * 0.28, style: .continuous))
+	}
+}
+
+private struct Row: View {
+	let row: AgentActivityAttributes.AgentRow
+
+	var body: some View {
+		HStack(spacing: 9) {
+			ProjectIcon(row: row)
+			Text(row.branch)
+				.font(.system(size: Metrics.branchSize))
+				.foregroundStyle(.primary)
+				.lineLimit(1)
+				.truncationMode(.tail)
+			Spacer(minLength: 8)
+			Text(row.status)
+				.font(.system(size: Metrics.metaSize))
+				.foregroundStyle(stateColor(row.state))
+				.lineLimit(1)
+				.fixedSize()
+			Text(row.elapsed)
+				.font(.system(size: Metrics.metaSize))
+				.monospacedDigit()
+				.foregroundStyle(.tertiary)
+				.multilineTextAlignment(.trailing)
+				.frame(width: Metrics.timeWidth, alignment: .trailing)
+		}
+		.opacity(row.isQuiet ? 0.42 : 1)
+	}
+}
+
+private struct CardBody: View {
+	let context: ActivityViewContext<AgentActivityAttributes>
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 0) {
+			Text(context.state.isStale ? context.state.staleDetail : context.state.headline)
+				.font(.system(size: Metrics.headSize))
+				.foregroundStyle(
+					context.state.isStale
+						? AnyShapeStyle(.secondary) : AnyShapeStyle(stateColor(context.state.topState))
+				)
+				.lineLimit(1)
+			Spacer().frame(height: Metrics.headToRows)
+			VStack(alignment: .leading, spacing: Metrics.rowGap) {
+				ForEach(context.state.rows) { row in
+					// Each row is its own tap target: one Link per agent, with
+					// the card-wide widgetURL below as the fallback.
+					Link(destination: rowURL(row)) {
+						Row(row: row)
+					}
+				}
+			}
+			if let more = context.state.more, !more.isEmpty {
+				Spacer().frame(height: 8)
+				Text(more)
+					.font(.system(size: Metrics.metaSize))
+					.foregroundStyle(.tertiary)
+			}
+		}
+		.opacity(context.state.isStale ? 0.55 : 1)
+	}
+}
+
+struct AgentActivityWidget: Widget {
+	var body: some WidgetConfiguration {
+		ActivityConfiguration(for: AgentActivityAttributes.self) { context in
+			CardBody(context: context)
+				.padding(.horizontal, Metrics.hPadding)
+				.padding(.top, Metrics.topPadding)
+				.padding(.bottom, Metrics.bottomPadding)
+				.widgetURL(URL(string: "superset:///"))
+		} dynamicIsland: { context in
+			DynamicIsland {
+				DynamicIslandExpandedRegion(.leading) {
+					Text(context.state.headline)
+						.font(.system(size: 13))
+						.foregroundStyle(stateColor(context.state.topState))
+						.lineLimit(1)
+						.padding(.leading, 4)
+				}
+				DynamicIslandExpandedRegion(.bottom) {
+					VStack(alignment: .leading, spacing: Metrics.rowGap) {
+						ForEach(context.state.rows.prefix(3)) { row in
+							Link(destination: rowURL(row)) {
+								Row(row: row)
+							}
+						}
+					}
+					.padding(.horizontal, 4)
+				}
+			} compactLeading: {
+				Image(systemName: context.state.topState == "permission"
+					? "person.wave.2.fill" : "terminal.fill")
+					.foregroundStyle(stateColor(context.state.topState))
+			} compactTrailing: {
+				// The island is a single tap target by design, so it shows the
+				// count rather than pretending to be a list.
+				Text("\(context.state.rows.count)")
+					.font(.system(size: 14, weight: .medium))
+					.monospacedDigit()
+			} minimal: {
+				Image(systemName: "terminal.fill")
+					.foregroundStyle(stateColor(context.state.topState))
+			}
+		}
+	}
+}
+
+@main
+struct AgentActivityBundle: WidgetBundle {
+	var body: some Widget {
+		AgentActivityWidget()
+	}
+}

--- a/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
@@ -180,7 +180,7 @@ struct AgentActivityWidget: Widget {
 			} compactTrailing: {
 				// The island is a single tap target by design, so it shows the
 				// count rather than pretending to be a list.
-				Text("\(context.state.rows.count)")
+				Text("\(context.state.totalCount)")
 					.font(.system(size: 14, weight: .medium))
 					.monospacedDigit()
 			} minimal: {

--- a/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
@@ -118,10 +118,10 @@ private struct CardBody: View {
 
 	var body: some View {
 		VStack(alignment: .leading, spacing: 0) {
-			Text(context.state.isStale ? context.state.staleDetail : context.state.headline)
+			Text(context.isStale ? context.state.staleDetail : context.state.headline)
 				.font(.system(size: Metrics.headSize))
 				.foregroundStyle(
-					context.state.isStale
+					context.isStale
 						? AnyShapeStyle(.secondary) : AnyShapeStyle(stateColor(context.state.topState))
 				)
 				.lineLimit(1)
@@ -142,7 +142,7 @@ private struct CardBody: View {
 					.foregroundStyle(.tertiary)
 			}
 		}
-		.opacity(context.state.isStale ? 0.55 : 1)
+		.opacity(context.isStale ? 0.55 : 1)
 	}
 }
 

--- a/apps/mobile/targets/agentactivity/Info.plist
+++ b/apps/mobile/targets/agentactivity/Info.plist
@@ -10,10 +10,13 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<!-- Must match the container app exactly or App Store Connect rejects the
+	     upload. Both come from the target's build settings, which the config
+	     plugin derives from app.config.ts, so an EAS version bump carries. -->
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/apps/mobile/targets/agentactivity/Info.plist
+++ b/apps/mobile/targets/agentactivity/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Agent Activity</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/mobile/targets/agentactivity/expo-target.config.js
+++ b/apps/mobile/targets/agentactivity/expo-target.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = (config) => ({
+	type: "widget",
+	name: "AgentActivity",
+	displayName: "Agent Activity",
+	deploymentTarget: "26.0",
+	frameworks: ["SwiftUI", "WidgetKit", "ActivityKit"],
+	entitlements: {
+		"com.apple.security.application-groups":
+			config.ios.entitlements["com.apple.security.application-groups"],
+	},
+});

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -9,7 +9,8 @@
 			"@superset/attachments-sheet": [
 				"./modules/attachments-sheet/src/index.ts"
 			],
-			"@superset/composer": ["./modules/composer/src/index.tsx"]
+			"@superset/composer": ["./modules/composer/src/index.tsx"],
+			"@superset/live-activity": ["./modules/live-activity/src/index.ts"]
 		}
 	},
 	"include": ["**/*.ts", "**/*.tsx", "uniwind-env.d.ts", "uniwind-types.d.ts"],

--- a/bun.lock
+++ b/bun.lock
@@ -610,6 +610,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "7.29.7",
+        "@bacons/apple-targets": "5.0.0",
         "@lingui/babel-plugin-lingui-macro": "6.6.0",
         "@storybook/addon-ondevice-actions": "10.4.2",
         "@storybook/addon-ondevice-controls": "10.4.2",
@@ -1535,6 +1536,8 @@
 
     "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
 
+    "@babel/highlight": ["@babel/highlight@7.25.9", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "chalk": "^2.4.2", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw=="],
+
     "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
 
     "@babel/plugin-proposal-decorators": ["@babel/plugin-proposal-decorators@7.29.7", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7", "@babel/plugin-syntax-decorators": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg=="],
@@ -1632,6 +1635,10 @@
     "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
 
     "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@bacons/apple-targets": ["@bacons/apple-targets@5.0.0", "", { "dependencies": { "@bacons/xcode": "1.0.0-alpha.32", "@expo/prebuild-config": "~55.0.6", "@react-native/normalize-colors": "^0.79.2", "debug": "^4.3.4", "glob": "^10.4.2" }, "peerDependencies": { "expo": ">=52" } }, "sha512-03LEidnuAAccH5ueL03sOaauQMnpJ7ZGwrVUlzNc5K3BrlfGE9SDUJs1ITkXC7YLKfFPJyiB7VzoZYiRxJmUdA=="],
+
+    "@bacons/xcode": ["@bacons/xcode@1.0.0-alpha.32", "", { "dependencies": { "@expo/plist": "^0.0.18", "debug": "^4.3.4", "uuid": "^8.3.2" } }, "sha512-OGpH7+yMbWC2cgYZon5B+VVadH9HsB2V/abtEiplA65XnSuV4GAYAVixOCDc5k182WkfoakfdM0zW6U9cbcsbw=="],
 
     "@better-auth/api-key": ["@better-auth/api-key@1.6.22", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.22", "@better-auth/utils": "0.4.2", "better-auth": "^1.6.22", "better-call": "1.3.7" } }, "sha512-HDiiLYF0ov0zqhKv4CMTyLwpjTZ3UWl2dug451uTw40VM9zGxWSNxwILDcMDZ6hS5evaTHmmk7R5gciskEk2nQ=="],
 
@@ -1891,7 +1898,7 @@
 
     "@expo/config-plugins": ["@expo/config-plugins@57.0.8", "", { "dependencies": { "@expo/config-types": "^57.0.2", "@expo/json-file": "~11.0.1", "@expo/plist": "^0.8.1", "@expo/require-utils": "^57.0.4", "@expo/sdk-runtime-versions": "^1.0.0", "chalk": "^4.1.2", "debug": "^4.3.5", "getenv": "^2.0.0", "glob": "^13.0.0", "semver": "^7.5.4", "slugify": "^1.6.6", "xcode": "^3.0.1", "xml2js": "0.6.0" } }, "sha512-x6lx4s/19i39/+1dMPwb9tFCc4WR843dG5Yi+C64lhKL3YHX+6oKrT2Kv72PCEalnUY+usQDkB3NrLSrYOWtDg=="],
 
-    "@expo/config-types": ["@expo/config-types@57.0.2", "", {}, "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g=="],
+    "@expo/config-types": ["@expo/config-types@55.0.6", "", {}, "sha512-S+GJKYoIjnWlert/9vXuTohaTsMbyOLSVxdIgPgoq3P4N1p4CWrfyZLnz6qRug8wYSO5fcYcS9mFleyEP8wRLg=="],
 
     "@expo/devcert": ["@expo/devcert@1.2.1", "", { "dependencies": { "@expo/sudo-prompt": "^9.3.1", "debug": "^3.1.0" } }, "sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA=="],
 
@@ -1909,7 +1916,7 @@
 
     "@expo/inline-modules": ["@expo/inline-modules@0.1.6", "", { "dependencies": { "@expo/config-plugins": "~57.0.8" } }, "sha512-5f6EiOIKsFj9zlrCBet4ZIQRPEa9dBUdQgTzpjYwdZ8Z/M8W5lqMVL9dEs4HYKvEmDnqv0dQuDkFLyRSwu/DAQ=="],
 
-    "@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
+    "@expo/json-file": ["@expo/json-file@10.2.0", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ=="],
 
     "@expo/local-build-cache-provider": ["@expo/local-build-cache-provider@57.0.7", "", { "dependencies": { "@expo/config": "~57.0.8", "chalk": "^4.1.2" } }, "sha512-Hq5xWhXJWuyH3CWh3uqDWoHtxM0XYqLs9h2OzRWImBJahCPfePOo4kmw2uTEB6qHT5T47eqO4jtDG3MRGGZCpw=="],
 
@@ -1929,9 +1936,9 @@
 
     "@expo/package-manager": ["@expo/package-manager@1.13.1", "", { "dependencies": { "@expo/json-file": "^11.0.1", "@expo/spawn-async": "^1.8.0", "chalk": "^4.0.0", "npm-package-arg": "^11.0.0", "ora": "^3.4.0", "resolve-workspace-root": "^2.0.0" } }, "sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg=="],
 
-    "@expo/plist": ["@expo/plist@0.8.1", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw=="],
+    "@expo/plist": ["@expo/plist@0.0.18", "", { "dependencies": { "@xmldom/xmldom": "~0.7.0", "base64-js": "^1.2.3", "xmlbuilder": "^14.0.0" } }, "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w=="],
 
-    "@expo/prebuild-config": ["@expo/prebuild-config@57.0.13", "", { "dependencies": { "@expo/config": "~57.0.8", "@expo/config-plugins": "~57.0.8", "@expo/config-types": "^57.0.2", "@expo/image-utils": "^0.11.4", "@expo/json-file": "^11.0.1", "@react-native/normalize-colors": "0.86.2", "debug": "^4.3.1", "expo-modules-autolinking": "~57.0.10", "resolve-from": "^5.0.0", "semver": "^7.6.0" } }, "sha512-VhSySuXqOwK4fIc+9rgms7zN+c1Khj2xpuIgpVLPNyWRtpS8wB+eyV5CSohjSUBa3h+NsFdPk/VG6p0ZwlMDrg=="],
+    "@expo/prebuild-config": ["@expo/prebuild-config@55.0.22", "", { "dependencies": { "@expo/config": "~55.0.21", "@expo/config-plugins": "~55.0.11", "@expo/config-types": "^55.0.6", "@expo/image-utils": "^0.8.17", "@expo/json-file": "^10.0.15", "@react-native/normalize-colors": "0.83.10", "debug": "^4.3.1", "resolve-from": "^5.0.0", "semver": "^7.6.0", "xml2js": "0.6.0" }, "peerDependencies": { "expo": "*" } }, "sha512-2p1lE2hOCy9HUV9qxbEqmetxUgcBnVY8jR+j/SYRXgaBeHalyQ5d09Ol5XL36/HO2fViK8VmSnTbS7C3t8eFGg=="],
 
     "@expo/require-utils": ["@expo/require-utils@57.0.4", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "@babel/core": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8" }, "peerDependencies": { "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["typescript"] }, "sha512-e7xbg/9BTQcsZE/oErafZXtI7kh5IgfasLJ97J5sFSzX2cA74pDvdlhW1KHVSaDkQyQv6h1LSLhsY7dEeOk7hw=="],
 
@@ -2709,7 +2716,7 @@
 
     "@react-native/metro-config": ["@react-native/metro-config@0.87.0", "", { "dependencies": { "@react-native/js-polyfills": "0.87.0", "@react-native/metro-babel-transformer": "0.87.0", "metro-config": "^0.87.0", "metro-runtime": "^0.87.0" } }, "sha512-Pg0DmsJ/DbLP8JuxnRSDmrIaQjKhpzd2uYAZRyB2A8fJQzJWpAFLr7TUAXhiGD5025F6+PVPAnJL3HXaeMfZqQ=="],
 
-    "@react-native/normalize-colors": ["@react-native/normalize-colors@0.86.2", "", {}, "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg=="],
+    "@react-native/normalize-colors": ["@react-native/normalize-colors@0.79.7", "", {}, "sha512-RrvewhdanEWhlyrHNWGXGZCc6MY0JGpNgRzA8y6OomDz0JmlnlIsbBHbNpPnIrt9Jh2KaV10KTscD1Ry8xU9gQ=="],
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.86.2", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.2.0", "react": "*", "react-native": "0.86.2" }, "optionalPeers": ["@types/react"] }, "sha512-uO0J72gh3EvE+1/GHRk18QRyBDTRHRB0AraAfojsRjbT7VMuJwKrZYaKGshavoaEud6aw00ZB9/8mTMIKjjcAw=="],
 
@@ -6691,7 +6698,13 @@
 
     "@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
+
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@bacons/apple-targets/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "@bacons/xcode/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "@blaxel/core/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
@@ -6761,6 +6774,12 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@expo/cli/@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
+
+    "@expo/cli/@expo/plist": ["@expo/plist@0.8.1", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw=="],
+
+    "@expo/cli/@expo/prebuild-config": ["@expo/prebuild-config@57.0.13", "", { "dependencies": { "@expo/config": "~57.0.8", "@expo/config-plugins": "~57.0.8", "@expo/config-types": "^57.0.2", "@expo/image-utils": "^0.11.4", "@expo/json-file": "^11.0.1", "@react-native/normalize-colors": "0.86.2", "debug": "^4.3.1", "expo-modules-autolinking": "~57.0.10", "resolve-from": "^5.0.0", "semver": "^7.6.0" } }, "sha512-VhSySuXqOwK4fIc+9rgms7zN+c1Khj2xpuIgpVLPNyWRtpS8wB+eyV5CSohjSUBa3h+NsFdPk/VG6p0ZwlMDrg=="],
+
     "@expo/cli/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "@expo/cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -6779,7 +6798,17 @@
 
     "@expo/cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@expo/config/@expo/config-types": ["@expo/config-types@57.0.2", "", {}, "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g=="],
+
+    "@expo/config/@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
+
     "@expo/config/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "@expo/config-plugins/@expo/config-types": ["@expo/config-types@57.0.2", "", {}, "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g=="],
+
+    "@expo/config-plugins/@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
+
+    "@expo/config-plugins/@expo/plist": ["@expo/plist@0.8.1", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-3gTReGIUm0oRaMClsAJYxBnVPCl6fVpsl8HS+DTVxDhW4GyVyxg9E/Znm3BvcHtUJ51RJJI14pC1wvrNilCRHw=="],
 
     "@expo/config-plugins/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -6805,6 +6834,8 @@
 
     "@expo/mcp-tunnel/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@expo/metro-config/@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
+
     "@expo/metro-config/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/metro-config/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -6813,13 +6844,27 @@
 
     "@expo/metro-runtime/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
+    "@expo/package-manager/@expo/json-file": ["@expo/json-file@11.0.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ=="],
+
     "@expo/package-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/package-manager/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
-    "@expo/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+    "@expo/plist/@xmldom/xmldom": ["@xmldom/xmldom@0.7.13", "", {}, "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g=="],
+
+    "@expo/plist/xmlbuilder": ["xmlbuilder@14.0.0", "", {}, "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg=="],
+
+    "@expo/prebuild-config/@expo/config": ["@expo/config@55.0.21", "", { "dependencies": { "@expo/config-plugins": "~55.0.11", "@expo/config-types": "^55.0.6", "@expo/json-file": "^10.0.15", "@expo/require-utils": "^55.0.8", "deepmerge": "^4.3.1", "getenv": "^2.0.0", "glob": "^13.0.0", "resolve-workspace-root": "^2.0.0", "semver": "^7.6.0", "slugify": "^1.3.4" } }, "sha512-yHmSSnBrm2ecB1DNsCrZZrScVnvXrtg3+PAMwI3ocxEtD9YK8yX5xV2xi2pmor9TYitAO+udFWxo+XDEGibznw=="],
+
+    "@expo/prebuild-config/@expo/config-plugins": ["@expo/config-plugins@55.0.11", "", { "dependencies": { "@expo/config-types": "^55.0.6", "@expo/json-file": "~10.0.15", "@expo/plist": "^0.5.4", "@expo/sdk-runtime-versions": "^1.0.0", "chalk": "^4.1.2", "debug": "^4.3.5", "getenv": "^2.0.0", "glob": "^13.0.0", "resolve-from": "^5.0.0", "semver": "^7.5.4", "slugify": "^1.6.6", "xcode": "^3.0.1", "xml2js": "0.6.0" } }, "sha512-85ZSmIK8rMfvYbG/2IHtwnykVdb6LI0ZavduM3ZwUMThyyVegYjVsO5Zek2ec8xzPhCmYX0ar5onnFEcwUDUlw=="],
+
+    "@expo/prebuild-config/@expo/image-utils": ["@expo/image-utils@0.8.17", "", { "dependencies": { "@expo/require-utils": "^55.0.8", "@expo/spawn-async": "^1.7.2", "chalk": "^4.0.0", "getenv": "^2.0.0", "jimp-compact": "0.16.1", "parse-png": "^2.1.0", "semver": "^7.6.0" } }, "sha512-1eVrX6FFkPNl9DJNiw3Gjsf6PtG7HttbapEVvcROVrA9PCMikujOJWWHDYKGptmKoVIIVajFZE8UHGHUb3mPug=="],
+
+    "@expo/prebuild-config/@react-native/normalize-colors": ["@react-native/normalize-colors@0.83.10", "", {}, "sha512-dWgqcxaBy27oLx9tndcTF0917vbLOOstyNjYD58J6Z7YxkEZSaKG6+A+3I1KV6O1Xg2D69QThp4t6ezoC3NiGA=="],
 
     "@expo/prebuild-config/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "@expo/prebuild-config/xml2js": ["xml2js@0.6.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w=="],
 
     "@expo/xcpretty/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -7315,6 +7360,8 @@
 
     "expo-router/react-is": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
 
+    "expo-system-ui/@react-native/normalize-colors": ["@react-native/normalize-colors@0.86.2", "", {}, "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg=="],
+
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -7537,6 +7584,8 @@
 
     "react-mosaic-component/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
+    "react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.86.2", "", {}, "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg=="],
+
     "react-native/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "react-native/babel-plugin-syntax-hermes-parser": ["babel-plugin-syntax-hermes-parser@0.36.0", "", { "dependencies": { "hermes-parser": "0.36.0" } }, "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q=="],
@@ -7689,6 +7738,18 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "@babel/highlight/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
+
+    "@babel/highlight/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "@bacons/apple-targets/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "@bacons/apple-targets/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "@bacons/apple-targets/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
     "@code-inspector/core/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@code-inspector/vite/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -7775,6 +7836,12 @@
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
+    "@expo/cli/@expo/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
+    "@expo/cli/@expo/prebuild-config/@expo/config-types": ["@expo/config-types@57.0.2", "", {}, "sha512-ewW08OonrcRIsRKIlFvvcmmafE5zemb1ocu3HkNwtVPyRtj2w42pZCAkMIROYpcVBaPnc3mDT9UZDzwXWC3i6g=="],
+
+    "@expo/cli/@expo/prebuild-config/@react-native/normalize-colors": ["@react-native/normalize-colors@0.86.2", "", {}, "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg=="],
+
     "@expo/cli/accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "@expo/cli/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
@@ -7804,6 +7871,8 @@
     "@expo/cli/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@expo/cli/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@expo/config-plugins/@expo/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "@expo/config-plugins/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -7852,6 +7921,18 @@
     "@expo/package-manager/ora/log-symbols": ["log-symbols@2.2.0", "", { "dependencies": { "chalk": "^2.0.1" } }, "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg=="],
 
     "@expo/package-manager/ora/strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
+
+    "@expo/prebuild-config/@expo/config/@expo/require-utils": ["@expo/require-utils@55.0.8", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "@babel/core": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8" }, "peerDependencies": { "typescript": "^5.0.0 || ^5.0.0-0" }, "optionalPeers": ["typescript"] }, "sha512-DDS5R67iz2SJwncbpcUMHtnsq31dSfllhaEncKxGlK0/ewgc2CaXUCkDA2AumfT7ubnSXiPkU9Gn8v2xCrvj+A=="],
+
+    "@expo/prebuild-config/@expo/config-plugins/@expo/json-file": ["@expo/json-file@10.0.16", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "json5": "^2.2.3" } }, "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw=="],
+
+    "@expo/prebuild-config/@expo/config-plugins/@expo/plist": ["@expo/plist@0.5.4", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-Jqppj0FULNq6Zp5JtQrFICl8TtpMjwwUbxEcEC2T3z7m+TOrTQEHZXz3D3Ay7vhbmvD+VMgfWJ4ARclJXeN8Eg=="],
+
+    "@expo/prebuild-config/@expo/config-plugins/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@expo/prebuild-config/@expo/image-utils/@expo/require-utils": ["@expo/require-utils@55.0.8", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "@babel/core": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8" }, "peerDependencies": { "typescript": "^5.0.0 || ^5.0.0-0" }, "optionalPeers": ["typescript"] }, "sha512-DDS5R67iz2SJwncbpcUMHtnsq31dSfllhaEncKxGlK0/ewgc2CaXUCkDA2AumfT7ubnSXiPkU9Gn8v2xCrvj+A=="],
+
+    "@expo/prebuild-config/@expo/image-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/xcpretty/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -8943,6 +9024,16 @@
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@babel/highlight/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
+    "@babel/highlight/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "@bacons/apple-targets/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@bacons/apple-targets/glob/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
+
+    "@bacons/apple-targets/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "@dotenvx/dotenvx/conf/debounce-fn/mimic-fn": ["mimic-fn@3.1.0", "", {}, "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="],
 
     "@dotenvx/dotenvx/conf/dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
@@ -8980,6 +9071,14 @@
     "@expo/package-manager/ora/cli-cursor/restore-cursor": ["restore-cursor@2.0.0", "", { "dependencies": { "onetime": "^2.0.0", "signal-exit": "^3.0.2" } }, "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q=="],
 
     "@expo/package-manager/ora/strip-ansi/ansi-regex": ["ansi-regex@4.1.1", "", {}, "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="],
+
+    "@expo/prebuild-config/@expo/config-plugins/@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
+    "@expo/prebuild-config/@expo/config-plugins/@expo/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
+    "@expo/prebuild-config/@expo/config-plugins/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@expo/prebuild-config/@expo/image-utils/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@lingui/cli/ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
@@ -9329,6 +9428,14 @@
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "@babel/highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
+
+    "@bacons/apple-targets/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@bacons/apple-targets/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@bacons/apple-targets/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
     "@expo/cli/ora/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "@expo/cli/ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
@@ -9384,6 +9491,8 @@
     "pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "temp/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
+    "@bacons/apple-targets/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@expo/cli/ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} je vestavěný a nelze jej nahradit"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} není přidán"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} čeká na tebe · {total} agentů"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} kliknutí"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} přerušeno"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Kontrola prošla} few {Všechny # kontroly prošly} many {Všech # kontroly prošlo} other {Všech # kontrol prošlo}}"
 
+msgid "{total} agents working"
+msgstr "Pracuje {total} agentů"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} few {GitHub issues} many {GitHub issues} other {GitHub issues}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ kliknutí"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# soubor} few {# soubory} many {# souboru} other {# souborů}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} dalších"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} dřívějších"
@@ -5653,6 +5662,10 @@ msgstr "selhalo"
 msgid "Failed"
 msgstr "Selhalo"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Selhalo"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Selhalo <0>· 7 d</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "vyžaduje aktualizaci"
 msgid "Needs update"
 msgstr "Vyžaduje aktualizaci"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Čeká na tebe"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Na tomto hostu není nastaveno"
 
 msgid "not sorted"
 msgstr "neseřazeno"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Bez aktualizací"
 
 msgid "Notes"
 msgstr "Poznámky"
@@ -11756,6 +11777,10 @@ msgstr "Odhalit mou pozici"
 
 msgid "Review"
 msgstr "Revize"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Ke kontrole"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Fronty revizí a CI spolykají zisky, které agenti vytvoří."
@@ -15719,6 +15744,10 @@ msgstr "Dokončen běh workflow…"
 msgid "Workflow Tutorials"
 msgstr "Návody k workflow"
 
+msgid "Working"
+msgstr "Pracuje"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Pracuje"
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} je vestavěný a nelze jej nahradit"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} není přidán"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} čeká na tebe · {total} agentů"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# čeká na tebe} few {# čekají na tebe} many {# čeká na tebe} other {# čeká na tebe}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} kliknutí"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {sloučen # PR agenta} few {sloučeny # PR agent
 msgid "{toolName} interrupted"
 msgstr "{toolName} přerušeno"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agent pracuje} few {# agenti pracují} many {# agenta pracuje} other {# agentů pracuje}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agent} few {# agenti} many {# agenta} other {# agentů}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Kontrola prošla} few {Všechny # kontroly prošly} many {Všech # kontroly prošlo} other {Všech # kontrol prošlo}}"
-
-msgid "{total} agents working"
-msgstr "Pracuje {total} agentů"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} few {GitHub issues} many {GitHub issues} other {GitHub issues}}"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} ist integriert und kann nicht ersetzt werden"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} ist nicht hinzugefügt"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} wartet auf dich · {total} Agenten"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# wartet auf dich} other {# warten auf dich}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} der Klicks"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# Agenten-PR gemergt} other {# Agenten-PRs geme
 msgid "{toolName} interrupted"
 msgstr "{toolName} unterbrochen"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# Agent arbeitet} other {# Agenten arbeiten}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# Agent} other {# Agenten}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Die Prüfung wurde bestanden} other {Alle # Prüfungen bestanden}}"
-
-msgid "{total} agents working"
-msgstr "{total} Agenten arbeiten"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub-Issue} other {GitHub-Issues}}"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} ist integriert und kann nicht ersetzt werden"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} ist nicht hinzugefügt"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} wartet auf dich · {total} Agenten"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} der Klicks"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} unterbrochen"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Die Prüfung wurde bestanden} other {Alle # Prüfungen bestanden}}"
 
+msgid "{total} agents working"
+msgstr "{total} Agenten arbeiten"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub-Issue} other {GitHub-Issues}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ Klick"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# Datei} other {# Dateien}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} weitere"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} früher"
@@ -5653,6 +5662,10 @@ msgstr "fehlgeschlagen"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Fehlgeschlagen"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Fehlgeschlagen <0>· 7 T.</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "Update nötig"
 msgid "Needs update"
 msgstr "Update nötig"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Wartet auf dich"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Auf diesem Host nicht eingerichtet"
 
 msgid "not sorted"
 msgstr "nicht sortiert"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Keine Updates"
 
 msgid "Notes"
 msgstr "Notizen"
@@ -11756,6 +11777,10 @@ msgstr "Meinen Rang anzeigen"
 
 msgid "Review"
 msgstr "Review"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Prüfen"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Review- und CI-Warteschlangen fressen die Gewinne der Agenten auf."
@@ -15719,6 +15744,10 @@ msgstr "Workflow-Lauf abgeschlossen…"
 msgid "Workflow Tutorials"
 msgstr "Workflow-Tutorials"
 
+msgid "Working"
+msgstr "Arbeitet"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Arbeitet"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} is built in and cannot be replaced"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} is not added"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} needs you · {total} agents"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# needs you} other {# need you}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} of clicks"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# agent PR merged} other {# agent PRs merged}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName} interrupted"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agent working} other {# agents working}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agent} other {# agents}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {The check passed} other {All # checks passed}}"
-
-msgid "{total} agents working"
-msgstr "{total} agents working"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} is built in and cannot be replaced"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} is not added"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} needs you · {total} agents"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} of clicks"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} interrupted"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {The check passed} other {All # checks passed}}"
 
+msgid "{total} agents working"
+msgstr "{total} agents working"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ click"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# file} other {# files}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} more"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} earlier"
@@ -5653,6 +5662,10 @@ msgstr "failed"
 msgid "Failed"
 msgstr "Failed"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Failed"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Failed <0>· 7d</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "needs update"
 msgid "Needs update"
 msgstr "Needs update"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Needs you"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Not set up on this host"
 
 msgid "not sorted"
 msgstr "not sorted"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Not updating"
 
 msgid "Notes"
 msgstr "Notes"
@@ -11754,6 +11775,10 @@ msgstr "Reveal in sidebar"
 msgid "Reveal my rank"
 msgstr "Reveal my rank"
 
+msgid "Review"
+msgstr "Review"
+
+msgctxt "agent status"
 msgid "Review"
 msgstr "Review"
 
@@ -15719,6 +15744,10 @@ msgstr "Workflow run completed…"
 msgid "Workflow Tutorials"
 msgstr "Workflow Tutorials"
 
+msgid "Working"
+msgstr "Working"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Working"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} es integrado y no se puede reemplazar"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} no está añadido"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} te necesita · {total} agentes"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} de los clics"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} interrumpido"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {La comprobación se superó} other {Las # comprobaciones se superaron}}"
 
+msgid "{total} agents working"
+msgstr "{total} agentes trabajando"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue de GitHub} other {issues de GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ clic"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# archivo} other {# archivos}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} más"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} anteriores"
@@ -5653,6 +5662,10 @@ msgstr "fallida"
 msgid "Failed"
 msgstr "Fallida"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Falló"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Fallidas <0>· 7 d</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "requiere actualización"
 msgid "Needs update"
 msgstr "Requiere actualización"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Te necesita"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "No configurado en este host"
 
 msgid "not sorted"
 msgstr "sin ordenar"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Sin actualizar"
 
 msgid "Notes"
 msgstr "Notas"
@@ -11756,6 +11777,10 @@ msgstr "Mostrar mi puesto"
 
 msgid "Review"
 msgstr "Revisión"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Revisar"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Las colas de revisión y de CI se comen las ganancias que crean los agentes."
@@ -15719,6 +15744,10 @@ msgstr "Ejecución de workflow completada…"
 msgid "Workflow Tutorials"
 msgstr "Tutoriales de flujo de trabajo"
 
+msgid "Working"
+msgstr "Trabajando"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Trabajando"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} es integrado y no se puede reemplazar"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} no está añadido"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} te necesita · {total} agentes"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# te necesita} other {# te necesitan}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} de los clics"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# PR de agente fusionada} other {# PR de agente
 msgid "{toolName} interrupted"
 msgstr "{toolName} interrumpido"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agente trabajando} other {# agentes trabajando}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agente} other {# agentes}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {La comprobación se superó} other {Las # comprobaciones se superaron}}"
-
-msgid "{total} agents working"
-msgstr "{total} agentes trabajando"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue de GitHub} other {issues de GitHub}}"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} est intégré et ne peut pas être remplacé"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} n'est pas ajouté"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} vous attend · {total} agents"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} des clics"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} interrompu"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {La vérification a réussi} other {Les # vérifications ont toutes réussi}}"
 
+msgid "{total} agents working"
+msgstr "{total} agents en cours"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issues GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ clic"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# fichier} other {# fichiers}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} de plus"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} précédents"
@@ -5653,6 +5662,10 @@ msgstr "échouée"
 msgid "Failed"
 msgstr "Échouée"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Échec"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Échecs <0>· 7 j</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "mise à jour requise"
 msgid "Needs update"
 msgstr "Mise à jour requise"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Vous attend"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Non configuré sur cet hôte"
 
 msgid "not sorted"
 msgstr "non trié"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Pas de mise à jour"
 
 msgid "Notes"
 msgstr "Notes"
@@ -11756,6 +11777,10 @@ msgstr "Révéler mon rang"
 
 msgid "Review"
 msgstr "Revue"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "À relire"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Les files d'attente de revue et de CI absorbent les gains créés par les agents."
@@ -15719,6 +15744,10 @@ msgstr "Exécution de workflow terminée…"
 msgid "Workflow Tutorials"
 msgstr "Tutoriels de workflow"
 
+msgid "Working"
+msgstr "En cours"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "En cours"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} est intégré et ne peut pas être remplacé"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} n'est pas ajouté"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} vous attend · {total} agents"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# vous attend} other {# vous attendent}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} des clics"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# PR d'agent fusionnée} other {# PR d'agent fu
 msgid "{toolName} interrupted"
 msgstr "{toolName} interrompu"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agent en cours} other {# agents en cours}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agent} other {# agents}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {La vérification a réussi} other {Les # vérifications ont toutes réussi}}"
-
-msgid "{total} agents working"
-msgstr "{total} agents en cours"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issues GitHub}}"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} bawaan dan tidak dapat diganti"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} belum ditambahkan"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} butuh Anda · {total} agen"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} dari klik"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} dihentikan"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Semua # check lulus} other {Semua # check lulus}}"
 
+msgid "{total} agents working"
+msgstr "{total} agen bekerja"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issue GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ klik"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# file} other {# file}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} lagi"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} sebelumnya"
@@ -5653,6 +5662,10 @@ msgstr "gagal"
 msgid "Failed"
 msgstr "Gagal"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Gagal"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Gagal <0>· 7h</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "perlu diperbarui"
 msgid "Needs update"
 msgstr "Perlu diperbarui"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Butuh Anda"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Belum disiapkan di host ini"
 
 msgid "not sorted"
 msgstr "tidak diurutkan"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Tidak diperbarui"
 
 msgid "Notes"
 msgstr "Catatan"
@@ -11756,6 +11777,10 @@ msgstr "Tampilkan peringkat saya"
 
 msgid "Review"
 msgstr "Review"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Tinjau"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Antrean review dan CI memakan keuntungan yang dihasilkan agen."
@@ -15719,6 +15744,10 @@ msgstr "Run workflow selesai…"
 msgid "Workflow Tutorials"
 msgstr "Tutorial Alur Kerja"
 
+msgid "Working"
+msgstr "Bekerja"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Bekerja"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} bawaan dan tidak dapat diganti"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} belum ditambahkan"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} butuh Anda · {total} agen"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, other {# butuh Anda}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} dari klik"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, other {# PR agen digabungkan}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName} dihentikan"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, other {# agen bekerja}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, other {# agen}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Semua # check lulus} other {Semua # check lulus}}"
-
-msgid "{total} agents working"
-msgstr "{total} agen bekerja"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issue GitHub}}"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} è integrato e non può essere sostituito"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} non è aggiunto"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} ti aspetta · {total} agenti"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# ti aspetta} other {# ti aspettano}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} dei clic"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# PR dell'agente unita} other {# PR dell'agente
 msgid "{toolName} interrupted"
 msgstr "{toolName} interrotto"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agente in corso} other {# agenti in corso}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agente} other {# agenti}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Il controllo è passato} other {Tutti i # controlli sono passati}}"
-
-msgid "{total} agents working"
-msgstr "{total} agenti in corso"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issue GitHub}}"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} è integrato e non può essere sostituito"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} non è aggiunto"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} ti aspetta · {total} agenti"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} dei clic"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} interrotto"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Il controllo è passato} other {Tutti i # controlli sono passati}}"
 
+msgid "{total} agents working"
+msgstr "{total} agenti in corso"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issue GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ clic"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# file} other {# file}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} altri"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} precedenti"
@@ -5653,6 +5662,10 @@ msgstr "fallita"
 msgid "Failed"
 msgstr "Fallito"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Non riuscito"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Falliti <0>· 7g</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "da aggiornare"
 msgid "Needs update"
 msgstr "Da aggiornare"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Ti aspetta"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Non configurato su questo host"
 
 msgid "not sorted"
 msgstr "non ordinato"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Nessun aggiornamento"
 
 msgid "Notes"
 msgstr "Note"
@@ -11756,6 +11777,10 @@ msgstr "Mostra la mia posizione"
 
 msgid "Review"
 msgstr "Revisione"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Da rivedere"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Le code di revisione e di CI si mangiano i guadagni creati dagli agenti."
@@ -15721,6 +15746,10 @@ msgstr "Tutorial sui flussi di lavoro"
 
 msgid "Working"
 msgstr "Al lavoro"
+
+msgctxt "agent status"
+msgid "Working"
+msgstr "In corso"
 
 msgid "Works when environments are clean. Environments are rarely clean."
 msgstr "Funziona quando gli ambienti sono puliti. Gli ambienti sono raramente puliti."

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} は組み込みのため置き換えられません"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} は追加されていません"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} 件が要対応 · エージェント {total} 件"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, other {# 件が要対応}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "クリックの {nonBrandPct}"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, other {#件のエージェントPRをマージ}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName}が中断されました"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, other {エージェント # 件が実行中}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, other {エージェント # 件}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#件のチェックにすべて成功しました} other {#件のチェックにすべて成功しました}}"
-
-msgid "{total} agents working"
-msgstr "{total} 件のエージェントが実行中"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} other {GitHub issue}}"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} は組み込みのため置き換えられません"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} は追加されていません"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} 件が要対応 · エージェント {total} 件"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "クリックの {nonBrandPct}"
 
@@ -877,6 +880,9 @@ msgstr "{toolName}が中断されました"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#件のチェックにすべて成功しました} other {#件のチェックにすべて成功しました}}"
 
+msgid "{total} agents working"
+msgstr "{total} 件のエージェントが実行中"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} other {GitHub issue}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧クリック"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {#ファイル} other {#ファイル}}"
+
+msgid "+{hidden} more"
+msgstr "他 {hidden} 件"
 
 msgid "+{hiddenCount} earlier"
 msgstr "以前の{hiddenCount}件"
@@ -5653,6 +5662,10 @@ msgstr "失敗"
 msgid "Failed"
 msgstr "失敗"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "失敗"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "失敗 <0>· 7日</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "要更新"
 msgid "Needs update"
 msgstr "要更新"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "要対応"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "このホストではセットアップされていません"
 
 msgid "not sorted"
 msgstr "並べ替えなし"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "更新なし"
 
 msgid "Notes"
 msgstr "ノート"
@@ -11756,6 +11777,10 @@ msgstr "自分のランクを表示"
 
 msgid "Review"
 msgstr "レビュー"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "要確認"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "レビューとCIの待ち行列が、エージェントの生んだ余力を食い潰しています。"
@@ -15721,6 +15746,10 @@ msgstr "ワークフローのチュートリアル"
 
 msgid "Working"
 msgstr "作業中"
+
+msgctxt "agent status"
+msgid "Working"
+msgstr "実行中"
 
 msgid "Works when environments are clean. Environments are rarely clean."
 msgstr "環境がきれいなら動きます。環境がきれいなことは滅多にありません。"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -760,8 +760,8 @@ msgstr "{name}은(는) 기본 제공이라 교체할 수 없습니다"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name}이(가) 추가되지 않았습니다"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing}개 확인 필요 · 에이전트 {total}개"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, other {#개 확인 필요}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "클릭의 {nonBrandPct}"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, other {에이전트 PR # 건 머지}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName} 중단됨"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, other {에이전트 #개 작업 중}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, other {에이전트 #개}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#개 검사를 모두 통과했습니다} other {#개 검사를 모두 통과했습니다}}"
-
-msgid "{total} agents working"
-msgstr "에이전트 {total}개 작업 중"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub 이슈} other {GitHub 이슈}}"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -760,6 +760,9 @@ msgstr "{name}은(는) 기본 제공이라 교체할 수 없습니다"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name}이(가) 추가되지 않았습니다"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing}개 확인 필요 · 에이전트 {total}개"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "클릭의 {nonBrandPct}"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} 중단됨"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#개 검사를 모두 통과했습니다} other {#개 검사를 모두 통과했습니다}}"
 
+msgid "{total} agents working"
+msgstr "에이전트 {total}개 작업 중"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub 이슈} other {GitHub 이슈}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ 클릭"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {파일 #개} other {파일 #개}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden}개 더"
 
 msgid "+{hiddenCount} earlier"
 msgstr "이전 +{hiddenCount}개"
@@ -5653,6 +5662,10 @@ msgstr "실패"
 msgid "Failed"
 msgstr "실패"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "실패"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "실패 <0>· 7일</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "업데이트 필요"
 msgid "Needs update"
 msgstr "업데이트 필요"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "확인 필요"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "이 호스트에 설정되지 않음"
 
 msgid "not sorted"
 msgstr "정렬 안 됨"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "업데이트 없음"
 
 msgid "Notes"
 msgstr "노트"
@@ -11756,6 +11777,10 @@ msgstr "내 순위 공개"
 
 msgid "Review"
 msgstr "리뷰"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "검토"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "리뷰와 CI 대기열이 에이전트가 만든 이득을 깎아먹습니다."
@@ -15719,6 +15744,10 @@ msgstr "워크플로 실행 완료…"
 msgid "Workflow Tutorials"
 msgstr "워크플로 튜토리얼"
 
+msgid "Working"
+msgstr "작업 중"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "작업 중"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} is ingebouwd en kan niet worden vervangen"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} is niet toegevoegd"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} wacht op jou · {total} agents"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} van de klikken"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} onderbroken"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {De check is geslaagd} other {Alle # checks geslaagd}}"
 
+msgid "{total} agents working"
+msgstr "{total} agents bezig"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub-issue} other {GitHub-issues}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧-klik"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# bestand} other {# bestanden}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} meer"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} eerder"
@@ -5653,6 +5662,10 @@ msgstr "mislukt"
 msgid "Failed"
 msgstr "Mislukt"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Mislukt"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Mislukt <0>· 7d</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "update nodig"
 msgid "Needs update"
 msgstr "Update nodig"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Wacht op jou"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Niet ingesteld op deze host"
 
 msgid "not sorted"
 msgstr "niet gesorteerd"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Geen updates"
 
 msgid "Notes"
 msgstr "Notities"
@@ -11756,6 +11777,10 @@ msgstr "Mijn positie tonen"
 
 msgid "Review"
 msgstr "Review"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Beoordelen"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Review- en CI-wachtrijen eten de winst op die agents opleveren."
@@ -15719,6 +15744,10 @@ msgstr "Workflow-run afgerond…"
 msgid "Workflow Tutorials"
 msgstr "Workflow-tutorials"
 
+msgid "Working"
+msgstr "Bezig"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Bezig"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} is ingebouwd en kan niet worden vervangen"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} is niet toegevoegd"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} wacht op jou · {total} agents"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# wacht op jou} other {# wachten op jou}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} van de klikken"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# agent-PR gemerged} other {# agent-PR's gemerg
 msgid "{toolName} interrupted"
 msgstr "{toolName} onderbroken"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agent bezig} other {# agents bezig}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agent} other {# agents}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {De check is geslaagd} other {Alle # checks geslaagd}}"
-
-msgid "{total} agents working"
-msgstr "{total} agents bezig"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub-issue} other {GitHub-issues}}"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} jest wbudowany i nie można go zastąpić"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} nie został dodany"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} czeka na Ciebie · {total} agentów"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# czeka na Ciebie} few {# czekają na Ciebie} many {# czeka na Ciebie} other {# czeka na Ciebie}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} kliknięć"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {scalono # PR agenta} few {scalono # PR agenta} 
 msgid "{toolName} interrupted"
 msgstr "{toolName} przerwane"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agent pracuje} few {# agenci pracują} many {# agentów pracuje} other {# agentów pracuje}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agent} few {# agenci} many {# agentów} other {# agentów}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Kontrola przeszła} few {Wszystkie # kontrole przeszły} many {Wszystkie # kontroli przeszło} other {Wszystkie # kontroli przeszło}}"
-
-msgid "{total} agents working"
-msgstr "Pracuje {total} agentów"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {zgłoszenie GitHub} few {zgłoszenia GitHub} many {zgłoszeń GitHub} other {zgłoszenia GitHub}}"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} jest wbudowany i nie można go zastąpić"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} nie został dodany"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} czeka na Ciebie · {total} agentów"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} kliknięć"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} przerwane"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Kontrola przeszła} few {Wszystkie # kontrole przeszły} many {Wszystkie # kontroli przeszło} other {Wszystkie # kontroli przeszło}}"
 
+msgid "{total} agents working"
+msgstr "Pracuje {total} agentów"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {zgłoszenie GitHub} few {zgłoszenia GitHub} many {zgłoszeń GitHub} other {zgłoszenia GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ klik"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# plik} few {# pliki} many {# plików} other {# pliku}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} więcej"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} wcześniej"
@@ -5653,6 +5662,10 @@ msgstr "niepowodzenie"
 msgid "Failed"
 msgstr "Nieudane"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Niepowodzenie"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Nieudane <0>· 7 dni</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "wymaga aktualizacji"
 msgid "Needs update"
 msgstr "Wymaga aktualizacji"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Czeka na Ciebie"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Nieskonfigurowany na tym hoście"
 
 msgid "not sorted"
 msgstr "bez sortowania"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Brak aktualizacji"
 
 msgid "Notes"
 msgstr "Notatki"
@@ -11756,6 +11777,10 @@ msgstr "Pokaż moją pozycję"
 
 msgid "Review"
 msgstr "Przegląd"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Do przeglądu"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Kolejki przeglądów i CI zjadają zyski, które dają agenci."
@@ -15719,6 +15744,10 @@ msgstr "Przebieg workflow zakończony…"
 msgid "Workflow Tutorials"
 msgstr "Poradniki workflow"
 
+msgid "Working"
+msgstr "Pracuje"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Pracuje"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} é integrado e não pode ser substituído"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} não foi adicionado"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} precisa de você · {total} agentes"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# precisa de você} other {# precisam de você}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} dos cliques"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# PR de agente mesclado} other {# PRs de agente
 msgid "{toolName} interrupted"
 msgstr "{toolName} interrompida"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# agente trabalhando} other {# agentes trabalhando}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# agente} other {# agentes}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {A verificação passou} other {Todas as # verificações passaram}}"
-
-msgid "{total} agents working"
-msgstr "{total} agentes trabalhando"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue do GitHub} other {issues do GitHub}}"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} é integrado e não pode ser substituído"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} não foi adicionado"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} precisa de você · {total} agentes"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} dos cliques"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} interrompida"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {A verificação passou} other {Todas as # verificações passaram}}"
 
+msgid "{total} agents working"
+msgstr "{total} agentes trabalhando"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue do GitHub} other {issues do GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ clique"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# arquivo} other {# arquivos}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} mais"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} anteriores"
@@ -5653,6 +5662,10 @@ msgstr "falhou"
 msgid "Failed"
 msgstr "Falhou"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Falhou"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Falharam <0>· 7d</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "precisa atualizar"
 msgid "Needs update"
 msgstr "Precisa atualizar"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Precisa de você"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Não configurado neste host"
 
 msgid "not sorted"
 msgstr "sem ordenação"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Sem atualização"
 
 msgid "Notes"
 msgstr "Notas"
@@ -11756,6 +11777,10 @@ msgstr "Revelar minha posição"
 
 msgid "Review"
 msgstr "Revisão"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Revisar"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "As filas de revisão e de CI comem o ganho que os agentes criam."
@@ -15719,6 +15744,10 @@ msgstr "Execução de workflow concluída…"
 msgid "Workflow Tutorials"
 msgstr "Tutoriais de fluxo de trabalho"
 
+msgid "Working"
+msgstr "Trabalhando"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Trabalhando"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} встроен и не может быть заменён"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} не добавлен"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} ждёт вас · агентов: {total}"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} от кликов"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} прерван"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Проверка пройдена} few {Все # проверки пройдены} many {Все # проверок пройдены} other {Все # проверки пройдены}}"
 
+msgid "{total} agents working"
+msgstr "Работает агентов: {total}"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {задача GitHub} few {задачи GitHub} many {задач GitHub} other {задачи GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ клик"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# файл} few {# файла} many {# файлов} other {# файла}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} ещё"
 
 msgid "+{hiddenCount} earlier"
 msgstr "ещё +{hiddenCount} ранее"
@@ -5653,6 +5662,10 @@ msgstr "ошибка"
 msgid "Failed"
 msgstr "Ошибка"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Ошибка"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "С ошибкой <0>· 7 дн.</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "нужно обновить"
 msgid "Needs update"
 msgstr "Нужно обновить"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Ждёт вас"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Не настроен на этом хосте"
 
 msgid "not sorted"
 msgstr "без сортировки"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Нет обновлений"
 
 msgid "Notes"
 msgstr "Заметки"
@@ -11756,6 +11777,10 @@ msgstr "Показать моё место"
 
 msgid "Review"
 msgstr "Ревью"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "На проверку"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Очереди ревью и CI съедают выигрыш, который дают агенты."
@@ -15719,6 +15744,10 @@ msgstr "Запуск workflow завершён…"
 msgid "Workflow Tutorials"
 msgstr "Руководства по рабочим процессам"
 
+msgid "Working"
+msgstr "Работает"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Работает"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} встроен и не может быть заменён"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} не добавлен"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} ждёт вас · агентов: {total}"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# ждёт вас} few {# ждут вас} many {# ждут вас} other {# ждут вас}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} от кликов"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {влит # PR агента} few {влито # P
 msgid "{toolName} interrupted"
 msgstr "{toolName} прерван"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# агент работает} few {# агента работают} many {# агентов работают} other {# агентов работают}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# агент} few {# агента} many {# агентов} other {# агентов}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Проверка пройдена} few {Все # проверки пройдены} many {Все # проверок пройдены} other {Все # проверки пройдены}}"
-
-msgid "{total} agents working"
-msgstr "Работает агентов: {total}"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {задача GitHub} few {задачи GitHub} many {задач GitHub} other {задачи GitHub}}"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} yerleşiktir ve değiştirilemez"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} eklenmedi"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} seni bekliyor · {total} ajan"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, one {# seni bekliyor} other {# seni bekliyor}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "tıklamaların {nonBrandPct}"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, one {# ajan PR'ı birleştirildi} other {# ajan PR'�
 msgid "{toolName} interrupted"
 msgstr "{toolName} kesildi"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, one {# ajan çalışıyor} other {# ajan çalışıyor}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, one {# ajan} other {# ajan}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {# kontrolün tümü geçti} other {# kontrolün tümü geçti}}"
-
-msgid "{total} agents working"
-msgstr "{total} ajan çalışıyor"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} other {GitHub issue}}"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} yerleşiktir ve değiştirilemez"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} eklenmedi"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} seni bekliyor · {total} ajan"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "tıklamaların {nonBrandPct}"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} kesildi"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {# kontrolün tümü geçti} other {# kontrolün tümü geçti}}"
 
+msgid "{total} agents working"
+msgstr "{total} ajan çalışıyor"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub issue} other {GitHub issue}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ tık"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# dosya} other {# dosya}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} daha"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} daha önce"
@@ -5653,6 +5662,10 @@ msgstr "başarısız"
 msgid "Failed"
 msgstr "Başarısız"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Başarısız"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Başarısız <0>· 7g</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "güncelleme gerekli"
 msgid "Needs update"
 msgstr "Güncelleme gerekli"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Seni bekliyor"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Bu host'ta kurulu değil"
 
 msgid "not sorted"
 msgstr "sıralanmamış"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Güncellenmiyor"
 
 msgid "Notes"
 msgstr "Notlar"
@@ -11754,6 +11775,10 @@ msgstr "Kenar çubuğunda göster"
 msgid "Reveal my rank"
 msgstr "Sıralamamı göster"
 
+msgid "Review"
+msgstr "İnceleme"
+
+msgctxt "agent status"
 msgid "Review"
 msgstr "İnceleme"
 
@@ -15719,6 +15744,10 @@ msgstr "Workflow çalıştırması tamamlandı…"
 msgid "Workflow Tutorials"
 msgstr "İş akışı eğitimleri"
 
+msgid "Working"
+msgstr "Çalışıyor"
+
+msgctxt "agent status"
 msgid "Working"
 msgstr "Çalışıyor"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} là tích hợp sẵn nên không thể thay thế"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} chưa được thêm"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} cần bạn · {total} agent"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, other {# cần bạn}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} số lượt nhấp"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, other {đã hợp nhất # PR của tác nhân}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName} bị gián đoạn"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, other {# agent đang chạy}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, other {# agent}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Cả # check đều đạt} other {Cả # check đều đạt}}"
-
-msgid "{total} agents working"
-msgstr "{total} agent đang chạy"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issue GitHub}}"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} là tích hợp sẵn nên không thể thay thế"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} chưa được thêm"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} cần bạn · {total} agent"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "{nonBrandPct} số lượt nhấp"
 
@@ -877,6 +880,9 @@ msgstr "{toolName} bị gián đoạn"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {Cả # check đều đạt} other {Cả # check đều đạt}}"
 
+msgid "{total} agents working"
+msgstr "{total} agent đang chạy"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {issue GitHub} other {issue GitHub}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧ nhấp"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {# tệp} other {# tệp}}"
+
+msgid "+{hidden} more"
+msgstr "+{hidden} nữa"
 
 msgid "+{hiddenCount} earlier"
 msgstr "+{hiddenCount} trước đó"
@@ -5653,6 +5662,10 @@ msgstr "thất bại"
 msgid "Failed"
 msgstr "Thất bại"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "Thất bại"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "Thất bại <0>· 7 ngày</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "cần cập nhật"
 msgid "Needs update"
 msgstr "Cần cập nhật"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "Cần bạn"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "Chưa thiết lập trên host này"
 
 msgid "not sorted"
 msgstr "chưa sắp xếp"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "Không cập nhật"
 
 msgid "Notes"
 msgstr "Ghi chú"
@@ -11756,6 +11777,10 @@ msgstr "Hiện thứ hạng của tôi"
 
 msgid "Review"
 msgstr "Review"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "Xem lại"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "Hàng đợi review và CI ăn mất phần lợi mà agent tạo ra."
@@ -15721,6 +15746,10 @@ msgstr "Hướng dẫn quy trình"
 
 msgid "Working"
 msgstr "Đang làm"
+
+msgctxt "agent status"
+msgid "Working"
+msgstr "Đang chạy"
 
 msgid "Works when environments are clean. Environments are rarely clean."
 msgstr "Chạy được khi môi trường sạch. Môi trường hiếm khi sạch."

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} 是内置的，无法替换"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} 尚未添加"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} 个需要你 · 共 {total} 个智能体"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "占点击的 {nonBrandPct}"
 
@@ -877,6 +880,9 @@ msgstr "{toolName}已中断"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#项检查全部通过} other {#项检查全部通过}}"
 
+msgid "{total} agents working"
+msgstr "{total} 个智能体运行中"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub议题} other {GitHub议题}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧点击"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {#个文件} other {#个文件}}"
+
+msgid "+{hidden} more"
+msgstr "还有 {hidden} 个"
 
 msgid "+{hiddenCount} earlier"
 msgstr "更早的+{hiddenCount}条"
@@ -5653,6 +5662,10 @@ msgstr "失败"
 msgid "Failed"
 msgstr "失败"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "失败"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "失败 <0>· 7天</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "需要更新"
 msgid "Needs update"
 msgstr "需要更新"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "需要你"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "尚未在此主机上配置"
 
 msgid "not sorted"
 msgstr "未排序"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "未更新"
 
 msgid "Notes"
 msgstr "笔记"
@@ -11756,6 +11777,10 @@ msgstr "显示我的排名"
 
 msgid "Review"
 msgstr "审查"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "待查看"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "审查和CI排队把智能体带来的收益吃掉了。"
@@ -15721,6 +15746,10 @@ msgstr "工作流教程"
 
 msgid "Working"
 msgstr "工作中"
+
+msgctxt "agent status"
+msgid "Working"
+msgstr "运行中"
 
 msgid "Works when environments are clean. Environments are rarely clean."
 msgstr "环境干净时可行。而环境很少干净。"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} 是内置的，无法替换"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} 尚未添加"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} 个需要你 · 共 {total} 个智能体"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, other {# 个需要你}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "占点击的 {nonBrandPct}"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, other {已合并 # 个智能体 PR}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName}已中断"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, other {# 个智能体运行中}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, other {# 个智能体}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#项检查全部通过} other {#项检查全部通过}}"
-
-msgid "{total} agents working"
-msgstr "{total} 个智能体运行中"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub议题} other {GitHub议题}}"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -760,8 +760,8 @@ msgstr "{name} 是內建的，無法取代"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} 尚未新增"
 
-msgid "{needing} needs you · {total} agents"
-msgstr "{needing} 個需要你 · 共 {total} 個代理程式"
+msgid "{needing, plural, one {# needs you} other {# need you}}"
+msgstr "{needing, plural, other {# 個需要你}}"
 
 msgid "{nonBrandPct} of clicks"
 msgstr "佔點擊的 {nonBrandPct}"
@@ -877,11 +877,14 @@ msgstr "{threshold, plural, other {已合併 # 個智慧代理 PR}}"
 msgid "{toolName} interrupted"
 msgstr "{toolName}已中斷"
 
+msgid "{total, plural, one {# agent working} other {# agents working}}"
+msgstr "{total, plural, other {# 個代理程式執行中}}"
+
+msgid "{total, plural, one {# agent} other {# agents}}"
+msgstr "{total, plural, other {# 個代理程式}}"
+
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#項檢查全部通過} other {#項檢查全部通過}}"
-
-msgid "{total} agents working"
-msgstr "{total} 個代理程式執行中"
 
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub議題} other {GitHub議題}}"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -760,6 +760,9 @@ msgstr "{name} 是內建的，無法取代"
 msgid "serverError.plugins.marketplaceNotAdded"
 msgstr "{name} 尚未新增"
 
+msgid "{needing} needs you · {total} agents"
+msgstr "{needing} 個需要你 · 共 {total} 個代理程式"
+
 msgid "{nonBrandPct} of clicks"
 msgstr "佔點擊的 {nonBrandPct}"
 
@@ -877,6 +880,9 @@ msgstr "{toolName}已中斷"
 msgid "{total, plural, one {The check passed} other {All # checks passed}}"
 msgstr "{total, plural, one {#項檢查全部通過} other {#項檢查全部通過}}"
 
+msgid "{total} agents working"
+msgstr "{total} 個代理程式執行中"
+
 msgid "{totalCount, plural, one {GitHub issue} other {GitHub issues}}"
 msgstr "{totalCount, plural, one {GitHub議題} other {GitHub議題}}"
 
@@ -961,6 +967,9 @@ msgstr "⇧點選"
 #. placeholder {2}: changeset.files.length
 msgid "+{0} −{1} · {2, plural, one {# file} other {# files}}"
 msgstr "+{0} −{1} · {2, plural, one {#個檔案} other {#個檔案}}"
+
+msgid "+{hidden} more"
+msgstr "還有 {hidden} 個"
 
 msgid "+{hiddenCount} earlier"
 msgstr "更早的+{hiddenCount}條"
@@ -5653,6 +5662,10 @@ msgstr "失敗"
 msgid "Failed"
 msgstr "失敗"
 
+msgctxt "agent status"
+msgid "Failed"
+msgstr "失敗"
+
 msgid "Failed <0>· 7d</0>"
 msgstr "失敗 <0>· 7天</0>"
 
@@ -8586,6 +8599,10 @@ msgstr "需要更新"
 msgid "Needs update"
 msgstr "需要更新"
 
+msgctxt "agent status"
+msgid "Needs you"
+msgstr "需要你"
+
 msgid "Nerd Fonts"
 msgstr "Nerd Fonts"
 
@@ -9369,6 +9386,10 @@ msgstr "尚未在此主機上配置"
 
 msgid "not sorted"
 msgstr "未排序"
+
+msgctxt "agent status"
+msgid "Not updating"
+msgstr "未更新"
 
 msgid "Notes"
 msgstr "筆記"
@@ -11756,6 +11777,10 @@ msgstr "顯示我的排名"
 
 msgid "Review"
 msgstr "審查"
+
+msgctxt "agent status"
+msgid "Review"
+msgstr "待檢視"
 
 msgid "Review and CI queues eat the gains agents create."
 msgstr "審查和CI排隊把代理程式帶來的收益吃掉了。"
@@ -15721,6 +15746,10 @@ msgstr "工作流教程"
 
 msgid "Working"
 msgstr "工作中"
+
+msgctxt "agent status"
+msgid "Working"
+msgstr "執行中"
 
 msgid "Works when environments are clean. Environments are rarely clean."
 msgstr "環境乾淨時可行。而環境很少乾淨。"


### PR DESCRIPTION
Mirrors the home screen's agent rows onto the Lock Screen as a Live Activity, with the Dynamic Island carrying a count and elapsed time.

**One activity for the whole fleet, not one per agent.** With several of our own activities running, iOS shows exactly one in the Dynamic Island — highest relevance score, else first started — so eight agents would mean eight stacked Lock Screen cards and one arbitrary island entry. Apple's HIG recommends the aggregate directly: *"prefer a single Live Activity that uses a dynamic layout and rotates through events."*

### What it looks like

Design, iterations and on-device captures: https://app.superset.sh/page/live-activity-card-revised-tuyjia
Island design: https://app.superset.sh/page/dynamic-island-agent-status-uo64hm
Full spike writeup: https://app.superset.sh/page/agent-status-on-ios-rngur0

### Constraints this is shaped around

All measured on device rather than assumed — several were found only by photographing it:

- **Four rows is the ceiling.** A fifth pushes the card past the 160pt height at which the system truncates it. The rest collapse into `+N more`, and attention states are never the ones dropped.
- **Status is a word, never a bare colour.** `permission` (yellow-500) and `working` (amber-500) render as `srgba(234,179,8)` and `srgba(245,158,11)` — the app's palette, faithfully copied, and indistinguishable at 7pt on a translucent card. Naming the state is what makes it readable.
- **Icons travel as files, not payload.** The Live Activity sandbox *"can't access the network"*, and one 54pt PNG measures 35–76% of the entire 4KB ContentState budget. So the app downscales and caches icons into a shared App Group container and the extension reads them off disk. Apple anticipates this: on push-to-start the system *"grants it background runtime to allow you to download assets that the Live Activity needs."* A project without an icon draws its initial, matching `ProjectAvatar` — that's ~40% of projects.
- **Colours adapt.** The card inherits the Lock Screen's appearance; each status carries a darker light-mode partner.
- **Times are pre-formatted** (`12m`, `1h`). SwiftUI's free-ticking `Text(style:.timer)` can only render `mm:ss`, and units belong in the Lingui catalogs.

### One deliberate divergence

Row order is `permission > failed > review > working`, which is **not** desktop's `STATUS_PRIORITY` (that ranks `working` above `review`). On a glanceable card a finished session waiting to be read wants you more than a busy one that doesn't. It lives as `CARD_PRIORITY` next to the surface it serves rather than changing the shared constant. If the reasoning holds, desktop's ranking is arguably worth revisiting too.

### Scope

**Foreground-only.** Nothing server-side knows an agent needs attention yet, so the card carries a stale date and admits when it has stopped hearing anything rather than leaving "Working" on the Lock Screen indefinitely. ActivityKit push updates — which share an APNs layer with the push-notification spike — are the follow-up.

### Verified

- Built and captured on an iPhone 14 simulator across three rounds; icon cache, four-row layout, compact times and adaptive colours all confirmed on device.
- `lint`, `check:i18n` (8 new strings translated into all 16 locales), mobile tests (66 pass), i18n tests (119 pass).
- `typecheck` adds no errors in the changed files.

**Not verified:** dark appearance (adaptive values written, only light captured), and per-row `Link` routing — the widget declares one `Link` per row targeting `/workspace/<id>?tab=<terminalId>`, but the spike harness replaced the root layout so where a tap lands was never exercised.

https://claude.ai/code/session_01BQs5FoHQR3onyfU8va4WLc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Live Activity that mirrors the home screen's agent rows onto the Lock Screen and Dynamic Island while the app is open, so agent status is glanceable without unlocking.

**Key decisions**
- One aggregate activity for the whole fleet, not one per agent—iOS shows only one in the Dynamic Island, so per-agent activities would stack eight Lock Screen cards with an arbitrary island entry.
- Four rows is the measured ceiling before the system truncates the card; the rest collapse into "+N more", and the Dynamic Island reports the real agent total, not the number of rows that fit.
- Status is a word, never a bare colour: `permission` and `working` are indistinguishable at small sizes on the translucent card.
- Project icons are cached as files in a shared App Group container because the Live Activity sandbox has no network access and the payload budget is only 4KB.
- Times are pre-formatted (`12m`, `1h`) via Lingui catalogs, since SwiftUI's free-ticking timer can only render `mm:ss`.
- Row order is `permission > failed > review > working`, deliberately not desktop's `STATUS_PRIORITY`, because a finished session waiting to be read matters more than a busy one on a glanceable card.
- Card deliveries run serially with a newest-wins queue so two effect runs can't each start a card while awaiting the icon cache, and a payload is only marked delivered once the native call succeeds.

**Scope**
- Foreground-only: nothing server-side reports attention status yet, so the card marks itself stale via ActivityKit's `context.isStale` once the app closes. ActivityKit push updates are the follow-up.
- Start/update reconciles against ActivityKit's active activities, so app relaunches and user-dismissed cards can't cause silent no-ops or duplicate cards.

<sup>Written for commit e8fa19e09a7ae092526fe3a28fd9466e70c3d7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added iOS Live Activities showing agent terminal status on the Lock Screen and Dynamic Island.
  - Displays project icons, branches, statuses, elapsed time, attention indicators, stale-state messaging, and additional-agent counts.
  - Tapping an agent opens its workspace in the mobile app.
  - Live Activity data updates while the app is active and clears when no agents remain.

- **Localization**
  - Added translated agent-status labels and correctly pluralized activity summaries across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->