### PR TITLE
fix(desktop): stop the terminal IME composition overlay clipping CJK

### DIFF
--- a/apps/desktop/src/renderer/globals.css
+++ b/apps/desktop/src/renderer/globals.css
@@ -209,6 +209,25 @@
 		font-family: var(--superset-terminal-font-family, ui-monospace, monospace);
 	}
 
+	/*
+	 * IME 조합 중인 글자("글" 등)는 WebGL 셀이 아니라 `.composition-view` DOM
+	 * 오버레이에 그려지고, 그 박스는 일반 DOM 텍스트 폭으로 재서 잘린다.
+	 * Nerd Font Mono 변형은 전각 CJK 글리프에도 반각 advance 를 주므로
+	 * (14px 기준 "글" 7px, 비-Mono 는 14px) 오버레이가 한 셀보다 좁아져 글자가
+	 * 잘린다. WebGL 셀 렌더러는 셀 단위로 그려서 영향이 없다.
+	 * xterm.js 가 이 오버레이의 font-family 를 인라인으로 써넣기 때문에
+	 * `!important` 가 필요하다. 업스트림 xterm.js PR#6162(open)이 반영되면
+	 * 이 재정의는 불필요해진다.
+	 * var() 폴백을 일부러 두지 않았다: 변수가 없으면 이 선언이
+	 * invalid-at-computed-value-time → `unset` 이 되어 위 `.xterm` 의
+	 * `--superset-terminal-font-family` 스택을 그대로 상속한다. 즉 사용자 폰트를
+	 * 잃지 않고 변경 이전 동작으로 degrade 된다.
+	 */
+	.superset-terminal-runtime .xterm .composition-view {
+		/* biome-ignore lint/complexity/noImportantStyles: xterm 이 이 오버레이의 font-family 를 인라인으로 써넣으므로 !important 없이는 덮어쓸 수 없다 */
+		font-family: var(--superset-terminal-ime-font-family) !important;
+	}
+
 	.xterm .xterm-rows a {
 		color: inherit;
 		cursor: pointer;

--- a/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/appearance.test.ts
@@ -1,10 +1,19 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import {
 	DEFAULT_TERMINAL_FONT_FAMILY,
 	NERD_FONT_FALLBACK_FAMILIES,
 	resolveTerminalAppearance,
 	sanitizeTerminalFontFamily,
 } from "./index";
+
+/**
+ * IME 오버레이 기본 스택 — 터미널 기본 스택에서 Nerd Font Mono 폴백만 뺀 값.
+ * Mono 변형은 DOM 텍스트에서 전각 CJK 에 반각 폭을 줘 조합 글자를 자른다.
+ */
+const DEFAULT_IME_FONT_FAMILY = DEFAULT_TERMINAL_FONT_FAMILY.replace(
+	'"Symbols Nerd Font Mono", ',
+	"",
+);
 
 /** Quoted nerd-font fallback tail, minus families already in the stack. */
 function nerdTail(...present: string[]): string {
@@ -215,6 +224,7 @@ describe("resolveTerminalAppearance", () => {
 			theme,
 			background: "#111111",
 			fontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
+			imeFontFamily: DEFAULT_IME_FONT_FAMILY,
 			fontSize: 14,
 			lineHeight: 1,
 			letterSpacing: 0,
@@ -251,5 +261,70 @@ describe("resolveTerminalAppearance", () => {
 			cursorStyle: "underline",
 			cursorBlink: false,
 		});
+	});
+
+	test("keeps Mono variants in the terminal stack but drops them from the IME stack", () => {
+		const appearance = resolveTerminalAppearance(
+			{ background: "#000000" },
+			{},
+			["D2CodingLigature Nerd Font Mono", "D2CodingLigature Nerd Font"],
+		);
+
+		// 본문(WebGL 셀 렌더러)은 아이콘이 한 셀에 맞도록 Mono 를 앞세운다 —
+		// 기존 동작 그대로여야 한다.
+		const monoAt = appearance.fontFamily.indexOf(
+			'"D2CodingLigature Nerd Font Mono"',
+		);
+		const nonMonoAt = appearance.fontFamily.indexOf(
+			'"D2CodingLigature Nerd Font"',
+		);
+		expect(monoAt).toBeGreaterThanOrEqual(0);
+		expect(monoAt).toBeLessThan(nonMonoAt);
+
+		// IME 오버레이는 DOM 폭으로 잘리므로 Mono 변형을 전부 뺀다.
+		expect(appearance.imeFontFamily).toContain('"D2CodingLigature Nerd Font"');
+		expect(appearance.imeFontFamily).not.toContain("Nerd Font Mono");
+		// 나머지 스택(주 폰트·기본 폴백·generic 꼬리)은 그대로 유지된다.
+		expect(appearance.imeFontFamily).toContain('"JetBrains Mono"');
+		expect(appearance.imeFontFamily).toContain('"Menlo"');
+		expect(appearance.imeFontFamily.endsWith(", monospace")).toBe(true);
+	});
+
+	test("validates once per resolve, so a poisoned setting warns exactly once", () => {
+		// 본문·IME 두 스택을 각각 검증하면 같은 경고가 두 번 찍힌다.
+		const restore = stubCanvas(() => proportionalWidths);
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const appearance = resolveTerminalAppearance(
+				{ background: "#000000" },
+				// 모듈 레벨 monospace 캐시에 걸리지 않도록 고유한 이름을 쓴다.
+				{ terminalFontFamily: "PoisonedProportional-XYZ" },
+			);
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(appearance.fontFamily).toBe(DEFAULT_TERMINAL_FONT_FAMILY);
+			expect(appearance.imeFontFamily).toBe(DEFAULT_IME_FONT_FAMILY);
+		} finally {
+			warn.mockRestore();
+			restore();
+		}
+	});
+
+	test("never drops a user-chosen Mono variant from the IME stack", () => {
+		const restore = stubCanvas(() => equalWidths);
+		try {
+			const appearance = resolveTerminalAppearance(
+				{ background: "#000000" },
+				{ terminalFontFamily: "Hack Nerd Font Mono" },
+			);
+			// 사용자가 고른 주 폰트는 Mono 변형이라도 유지한다(폴백만 걸러낸다).
+			expect(
+				appearance.imeFontFamily.startsWith('"Hack Nerd Font Mono", '),
+			).toBe(true);
+			expect(appearance.imeFontFamily).not.toContain(
+				'"Symbols Nerd Font Mono"',
+			);
+		} finally {
+			restore();
+		}
 	});
 });

--- a/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/index.ts
@@ -5,11 +5,14 @@ import {
 	DEFAULT_THEME_ID,
 	getTerminalColors,
 } from "shared/themes";
+import { isNerdFontMonoVariant } from "./installed-nerd-fonts";
 
 export interface TerminalAppearance {
 	theme: ITheme;
 	background: string;
 	fontFamily: string;
+	/** IME 조합 오버레이 전용 스택 — Nerd Font Mono 폴백을 뺀 `fontFamily`. */
+	imeFontFamily: string;
 	fontSize: number;
 	lineHeight: number;
 	letterSpacing: number;
@@ -40,6 +43,23 @@ export function applyTerminalFontFamilyCssVariable(
 	fontFamily: string,
 ): void {
 	element.style.setProperty(TERMINAL_FONT_FAMILY_CSS_VARIABLE, fontFamily);
+}
+
+export const TERMINAL_IME_FONT_FAMILY_CSS_VARIABLE =
+	"--superset-terminal-ime-font-family";
+
+/**
+ * IME 조합 오버레이(`.composition-view`)용 폰트 스택을 CSS 변수로 심는다.
+ *
+ * xterm.js 는 이 오버레이의 `font-family` 를 `terminal.options.fontFamily` 에서
+ * 매 갱신마다 인라인으로 써넣기 때문에, CSS 쪽에서 `!important` 로 덮어써야
+ * 별도 스택이 실제로 적용된다(globals.css 의 `.superset-terminal-runtime` 규칙).
+ */
+export function applyTerminalImeFontFamilyCssVariable(
+	element: HTMLElement,
+	fontFamily: string,
+): void {
+	element.style.setProperty(TERMINAL_IME_FONT_FAMILY_CSS_VARIABLE, fontFamily);
 }
 
 const GENERIC_FONT_FAMILIES = new Set([
@@ -185,15 +205,25 @@ export function sanitizeTerminalFontFamily(
 	cssValue: string | null | undefined,
 	installedIconFonts: readonly string[] = [],
 ): string {
-	const defaultStack = () =>
-		buildIconCapableStack(
-			[...DEFAULT_TERMINAL_FONT_FAMILIES],
-			installedIconFonts,
-		);
+	return buildIconCapableStack(
+		validatedFontFamilies(cssValue) ?? [...DEFAULT_TERMINAL_FONT_FAMILIES],
+		installedIconFonts,
+	);
+}
 
-	if (!cssValue || !cssValue.trim()) return defaultStack();
+/**
+ * 저장된 폰트 값을 검증해 사용할 family 목록을 돌려준다.
+ * 기본 스택으로 물러나야 하면 `null` 을 반환한다.
+ *
+ * `sanitizeTerminalFontFamily` 와 `buildTerminalFontStacks` 가 같은 판정을 쓰도록
+ * 검증부만 분리한 것으로, 판정 규칙 자체는 기존과 동일하다.
+ */
+function validatedFontFamilies(
+	cssValue: string | null | undefined,
+): string[] | null {
+	if (!cssValue || !cssValue.trim()) return null;
 	const families = parseFontFamilyList(cssValue);
-	if (families.length === 0) return defaultStack();
+	if (families.length === 0) return null;
 
 	// Validate the actual CSS primary (first entry), not the first non-generic.
 	// A value like `sans-serif, "JetBrains Mono"` resolves to sans-serif in the
@@ -207,15 +237,56 @@ export function sanitizeTerminalFontFamily(
 			console.warn(
 				`[terminal] Font stack "${cssValue}" has no monospace primary family; falling back to default terminal font.`,
 			);
-			return defaultStack();
+			return null;
 		}
 	} else if (!isFontFamilyMonospace(primary)) {
 		console.warn(
 			`[terminal] Font "${primary}" is not monospace; falling back to default terminal font.`,
 		);
-		return defaultStack();
+		return null;
 	}
-	return buildIconCapableStack(families, installedIconFonts);
+	return families;
+}
+
+/**
+ * 터미널 본문용 스택과 IME 조합 오버레이용 스택을 검증 한 번으로 함께 만든다.
+ *
+ * 검증(`validatedFontFamilies`)을 스택마다 부르면 오염된 설정에서 같은
+ * `console.warn` 이 두 번 찍히므로, resolve 당 한 번만 검증하고 그 결과를
+ * 두 스택이 나눠 쓴다.
+ *
+ * IME 스택을 따로 두는 이유: xterm.js 는 조합 중인 글자("글" 등)를 WebGL 셀이
+ * 아니라 `.composition-view` DOM 오버레이에 그리고, 그 박스를 일반 DOM 텍스트
+ * 폭으로 재서 `overflow: hidden` 으로 잘라낸다. Nerd Font Mono 변형은 전각 CJK
+ * 글리프에도 반각 advance 를 주므로(14px 기준 "글" 7px, 비-Mono 는 14px) Menlo
+ * 처럼 한글이 없는 주 폰트에서 한글이 Mono 폴백으로 떨어지면 오버레이 박스가
+ * 한 셀보다 좁아져 글자가 잘린다. 터미널 본문 스택은 아이콘이 한 셀에 맞아야
+ * 하므로 Mono 를 그대로 앞세우고, 이 DOM 오버레이 전용 스택에서만 제외한다.
+ *
+ * 사용자가 고른 family(주 폰트 등)는 Mono 변형이라도 절대 제거하지 않는다.
+ * 따라서 주 폰트로 Nerd Font Mono 변형을 직접 고르면 IME 오버레이는 여전히
+ * CJK 를 자른다 — 사용자의 선택을 덮어쓰지 않기 위해 감수하는 trade-off 다.
+ * 업스트림 xterm.js PR#6162 가 머지되면(현재 open) 이 우회는 불필요해진다.
+ */
+function buildTerminalFontStacks(
+	cssValue: string | null | undefined,
+	installedIconFonts: readonly string[],
+): { fontFamily: string; imeFontFamily: string } {
+	const families = validatedFontFamilies(cssValue);
+	return {
+		fontFamily: buildIconCapableStack(
+			families ?? [...DEFAULT_TERMINAL_FONT_FAMILIES],
+			installedIconFonts,
+		),
+		imeFontFamily: buildIconCapableStack(
+			// 기본 스택에는 사용자 선택이 없으므로 내장 Nerd Font 목록에서도 Mono
+			// 변형("Symbols Nerd Font Mono")을 걸러낸다.
+			families ??
+				DEFAULT_TERMINAL_FONT_FAMILIES.filter((f) => !isNerdFontMonoVariant(f)),
+			installedIconFonts,
+			{ excludeMonoVariantFallbacks: true },
+		),
+	};
 }
 
 /**
@@ -241,10 +312,15 @@ export function sanitizeTerminalFontFamily(
 function buildIconCapableStack(
 	families: string[],
 	installedIconFonts: readonly string[],
+	// IME 오버레이는 DOM 폭에 의존하므로 Mono 변형 폴백을 빼고 쌓는다.
+	options: { excludeMonoVariantFallbacks?: boolean } = {},
 ): string {
 	const seen = new Set(families.map((f) => f.toLowerCase()));
 	const fallbacks: string[] = [];
 	for (const f of [...NERD_FONT_FALLBACK_FAMILIES, ...installedIconFonts]) {
+		if (options.excludeMonoVariantFallbacks && isNerdFontMonoVariant(f)) {
+			continue;
+		}
 		const key = f.toLowerCase();
 		if (seen.has(key)) continue;
 		seen.add(key);
@@ -280,13 +356,16 @@ export function resolveTerminalAppearance(
 	fontSettings: TerminalFontSettings = {},
 	installedIconFonts: readonly string[] = [],
 ): TerminalAppearance {
+	// 본문/IME 스택을 한 번의 검증으로 함께 만든다(경고 중복 방지).
+	const { fontFamily, imeFontFamily } = buildTerminalFontStacks(
+		fontSettings.terminalFontFamily,
+		installedIconFonts,
+	);
 	return {
 		theme,
 		background: theme.background ?? "#151110",
-		fontFamily: sanitizeTerminalFontFamily(
-			fontSettings.terminalFontFamily,
-			installedIconFonts,
-		),
+		fontFamily,
+		imeFontFamily,
 		fontSize: fontSettings.terminalFontSize ?? DEFAULT_TERMINAL_FONT_SIZE,
 		lineHeight: fontSettings.terminalLineHeight ?? DEFAULT_TERMINAL_LINE_HEIGHT,
 		letterSpacing:

--- a/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	detectInstalledNerdFontFamilies,
 	isNerdFontFamily,
+	isNerdFontMonoVariant,
 } from "./installed-nerd-fonts";
 
 describe("isNerdFontFamily", () => {
@@ -19,6 +20,19 @@ describe("isNerdFontFamily", () => {
 		expect(isNerdFontFamily("JetBrains Mono")).toBe(false);
 		expect(isNerdFontFamily("Menlo")).toBe(false);
 		expect(isNerdFontFamily("Inter")).toBe(false);
+	});
+});
+
+describe("isNerdFontMonoVariant", () => {
+	test("matches Mono variants, long and abbreviated", () => {
+		expect(isNerdFontMonoVariant("D2CodingLigature Nerd Font Mono")).toBe(true);
+		expect(isNerdFontMonoVariant("Hack NFM")).toBe(true);
+		expect(isNerdFontMonoVariant("Symbols Nerd Font Mono")).toBe(true);
+	});
+
+	test("rejects non-Mono variants", () => {
+		expect(isNerdFontMonoVariant("D2CodingLigature Nerd Font")).toBe(false);
+		expect(isNerdFontMonoVariant("Hack NF")).toBe(false);
 	});
 });
 

--- a/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.ts
+++ b/apps/desktop/src/renderer/lib/terminal/appearance/installed-nerd-fonts.ts
@@ -11,6 +11,8 @@ const NERD_FONT_NAME_PATTERN = /nerd font/i;
 const NERD_FONT_ABBREV_PATTERN = / NFM?$/i;
 /** Proportional variants — their icons break monospace cell metrics. */
 const PROPORTIONAL_VARIANT_PATTERN = /(?: propo| NFP)$/i;
+/** Mono 변형 이름: "X Nerd Font Mono" 또는 축약형 "X NFM". */
+const MONO_VARIANT_PATTERN = /(?:nerd font mono| NFM)$/i;
 
 export function isNerdFontFamily(family: string): boolean {
 	if (PROPORTIONAL_VARIANT_PATTERN.test(family)) return false;
@@ -19,7 +21,27 @@ export function isNerdFontFamily(family: string): boolean {
 	);
 }
 
-/** Keep the CSS stack bounded when a user has many Nerd Fonts installed. */
+/**
+ * Nerd Font 의 Mono 변형인지 판정한다.
+ *
+ * Mono 변형은 모든 글리프에 단일 advance width 를 강제하므로, 아이콘이 셀
+ * 하나에 정확히 들어맞는다(WebGL 셀 렌더러에 유리 — 그래서 폰트 스택에서
+ * Mono 를 앞세운다). 반대로 DOM 텍스트 레이아웃에서는 전각 CJK 글리프까지
+ * 반각 폭으로 계산돼 버린다(14px 기준 "글" 실측: Mono 7px vs 비-Mono 14px).
+ * IME 조합 오버레이처럼 DOM 폭에 의존하는 곳에서는 이 변형을 걸러내야 한다.
+ */
+export function isNerdFontMonoVariant(family: string): boolean {
+	return MONO_VARIANT_PATTERN.test(family);
+}
+
+/**
+ * Keep the CSS stack bounded when a user has many Nerd Fonts installed.
+ *
+ * 주의: 이 상한은 Mono-first 정렬 **뒤에** 적용된다. Mono 변형이 8개 이상
+ * 깔린 머신에서는 비-Mono 형제가 전부 잘려 IME 오버레이 스택(Mono 제외)에
+ * 설치 폰트가 하나도 안 남는다. 이 머신은 대상 family 가 4개라 당장은
+ * 문제되지 않아 현 상태로 둔다.
+ */
 const MAX_DETECTED_FAMILIES = 8;
 
 let cached: Promise<string[]> | null = null;
@@ -49,7 +71,8 @@ export function detectInstalledNerdFontFamilies(): Promise<string[]> {
 			}
 			// Mono variants first — their icons are drawn to fit a single cell.
 			families.sort(
-				(a, b) => Number(/mono$/i.test(b)) - Number(/mono$/i.test(a)),
+				(a, b) =>
+					Number(isNerdFontMonoVariant(b)) - Number(isNerdFontMonoVariant(a)),
 			);
 			return families.slice(0, MAX_DETECTED_FAMILIES);
 		} catch {

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime-registry.test.ts
@@ -65,6 +65,7 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 			theme: {},
 			background: "#000",
 			fontFamily: "monospace",
+			imeFontFamily: "monospace",
 			fontSize: 14,
 			lineHeight: 1,
 			letterSpacing: 0,
@@ -109,6 +110,7 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 		).entries;
 		const addedKeys: string[] = [];
 		const setLigatures = mock(() => {});
+		const setProperty = mock((_name: string, _value: string) => {});
 
 		for (const [index, container] of [
 			[0, {} as HTMLDivElement],
@@ -123,7 +125,7 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 				runtime: {
 					container,
 					wrapper: {
-						style: { setProperty: mock(() => {}) },
+						style: { setProperty },
 					} as unknown as HTMLDivElement,
 					terminal: {
 						options: {
@@ -148,6 +150,7 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 				theme: { background: "#000" },
 				background: "#000",
 				fontFamily: "monospace",
+				imeFontFamily: 'monospace, "JetBrains Mono"',
 				fontSize: 15.5,
 				lineHeight: 1.2,
 				letterSpacing: 0.5,
@@ -177,6 +180,12 @@ describe("terminalRuntimeRegistry eviction cleanup", () => {
 				expect(entry.runtime.ligaturesEnabled).toBe(false);
 			}
 			expect(setLigatures).toHaveBeenCalledTimes(2);
+			// IME 오버레이 스택은 활성·주차 런타임 양쪽 wrapper 에 반영된다.
+			expect(
+				setProperty.mock.calls.filter(
+					([name]) => name === "--superset-terminal-ime-font-family",
+				),
+			).toHaveLength(2);
 		} finally {
 			for (const key of addedKeys) entries.delete(key);
 		}

--- a/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
+++ b/apps/desktop/src/renderer/lib/terminal/terminal-runtime.ts
@@ -8,6 +8,7 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { DEFAULT_TERMINAL_SCROLLBACK } from "shared/constants";
 import {
 	applyTerminalFontFamilyCssVariable,
+	applyTerminalImeFontFamilyCssVariable,
 	type TerminalAppearance,
 } from "./appearance";
 import { scheduleFontSettleRefit } from "./font-settle";
@@ -317,6 +318,10 @@ export function createRuntime(
 	wrapper.style.width = "100%";
 	wrapper.style.height = "100%";
 	applyTerminalFontFamilyCssVariable(wrapper, appearance.fontFamily);
+	// IME 조합 오버레이 폰트 재정의(globals.css)를 이 런타임에만 걸기 위한 표식.
+	// v1 터미널 경로(TabsContent/Terminal)는 이 클래스가 없어 영향받지 않는다.
+	wrapper.classList.add("superset-terminal-runtime");
+	applyTerminalImeFontFamilyCssVariable(wrapper, appearance.imeFontFamily);
 	terminal.open(wrapper);
 
 	installTerminalKeyEventHandler(terminal);
@@ -438,6 +443,14 @@ export function updateRuntimeAppearance(
 ) {
 	const { terminal } = runtime;
 	terminal.options.theme = appearance.theme;
+
+	// `terminalMeasurementsChanged` 는 `terminal.options` 만 비교하는데 거기에는
+	// IME 스택이 없다. 그 게이트 안에 넣으면 판정 근거가 없는 값이 되므로 밖에서
+	// 쓴다. CSS 변수 쓰기는 비용이 없고 멱등이라 매번 호출해도 무해하다.
+	applyTerminalImeFontFamilyCssVariable(
+		runtime.wrapper,
+		appearance.imeFontFamily,
+	);
 
 	const measurementsChanged = terminalMeasurementsChanged(runtime, appearance);
 	runtime._setLigaturesEnabled?.(appearance.ligatures);


### PR DESCRIPTION
## What & why

Composing CJK text (Korean / Japanese / Chinese) in the v2 terminal renders the **in-progress syllable clipped** — the Korean `글` shows only its left half while you are still composing it. It snaps back to normal once committed, so the *live* composition is the unreadable part.

This is not a rare edge case: it hits **every CJK IME user on macOS who has a Nerd Font "Mono" variant installed**, which is extremely common among terminal users (Starship/eza/LazyGit setups almost always install one). For those users the IME preedit is broken on every keystroke of every CJK word. That's why I think this is worth fixing rather than leaving for later.

## Root cause

xterm.js draws the in-progress composition in a DOM overlay (`.composition-view`) whose box is sized by normal **DOM text layout** and then clipped with `overflow: hidden`.

`installed-nerd-fonts.ts` auto-detects installed Nerd Fonts and appends them to the terminal font stack with the **Mono variants sorted first** (correct for the WebGL cell renderer — single-cell icons line up). But Nerd Font *Mono* variants force one advance width on **every** glyph, so a full-width CJK glyph gets a **half-width advance in DOM text**:

| font (14px) | advance of `글` |
|---|---|
| `D2CodingLigature Nerd Font Mono` | **7px** |
| `D2CodingLigature Nerd Font` (non-Mono) | 14px |
| Menlo cell width | 8px |

When the primary terminal font has no Hangul (e.g. Menlo), the glyph falls through to the Mono variant, the overlay box becomes **narrower than one cell**, and `overflow: hidden` clips it. The WebGL cell renderer is unaffected (it draws per cell), which is exactly why the committed line looks fine and only the overlay breaks.

## The fix

Give the composition overlay its **own font stack** (`imeFontFamily`): same validation as the terminal stack, but Nerd Font Mono variants are dropped from the icon fallbacks. A user-chosen primary is never dropped. It is delivered as a CSS variable on the terminal-runtime wrapper and applied to `.composition-view` with `!important`, because xterm writes that element's `font-family` **inline** on every update. The WebGL body stack keeps Mono-first, so icons still fit one cell.

- No behavior change for non-CJK input, or for users without a Nerd Font Mono in the stack.
- Scoped to the v2 terminal runtime via a wrapper class; the v1 path is untouched.

## Before / after

- **Before:** `.composition-view` box = 7px (< 1 cell) → `글` clipped to its left half.
- **After:** box = one full cell (14px) → `글` renders whole.

Reproduce in ~30s: set `terminalFontFamily` to a Nerd Font Mono (or just install one so it's auto-detected), keep a Latin primary like Menlo, switch to a Korean/Japanese IME, and compose in the terminal. Screenshots/crops from an Electron harness that drives the real xterm bundle via `Input.imeSetComposition` are available on request — happy to add them inline.

## Upstream relationship

The underlying cause is in xterm.js and is tracked by **xtermjs/xterm.js#6161** with fix PR **xtermjs/xterm.js#6162** ("Align the IME preedit to the renderer cell grid"). That is not released yet and this repo pins an xterm beta, so this small app-level fix restores CJK composition now; once #6162 ships and the pinned xterm is bumped, this override can be removed — the code comments say so.

## Testing

- `bun test` — terminal appearance/runtime suites, **44 pass / 0 fail** (5 new cases: the Mono-variant predicate, the IME stack dropping Mono while the body stack keeps it, a user-chosen Mono primary preserved, the runtime setting the CSS var on both runtimes, and a single-validation warn-once guard).
- `bun run typecheck` — clean.
- Biome — clean.

Allow edits from maintainers is enabled.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the terminal IME composition overlay clipping CJK characters while typing (e.g., Korean '글' shows only left half). The cause is Nerd Font Mono variants in the autodetected fallback stack forcing half-width advance for full-width glyphs in the DOM overlay. The overlay now gets its own font stack that drops Mono variants from auto-detected fallbacks, while the main terminal stack keeps them for icon alignment. No behavior change for non-CJK input or users without a Nerd Font Mono in the stack.

<sup>Written for commit eaa9e097bb14ca1ca105e26d5e5e6464e833f89e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input method editor (IME) text rendering for full-width CJK characters.
  * Fixed clipping and incorrect character widths when composing text with Nerd Font Mono terminal fonts.
  * Improved handling of abbreviated and full-name Nerd Font Mono variants.

* **Improvements**
  * Terminal appearance settings now apply consistently to active and inactive terminal sessions.
  * IME text uses a dedicated font configuration while preserving the selected terminal font.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->