### PR TITLE
fix(shared): handle ST terminator in shell-ready scanner

### DIFF
--- a/packages/shared/src/shell-ready-scanner.test.ts
+++ b/packages/shared/src/shell-ready-scanner.test.ts
@@ -42,4 +42,35 @@ describe("shell-ready scanner (bytes)", () => {
 		combined.set(b.output, a.output.length);
 		expect(dec.decode(combined)).toBe("🙂");
 	});
+
+	it("strips the marker terminated by ST (ESC \\) in a single chunk", () => {
+		const state = createScanState();
+		const r = scanForShellReady(
+			state,
+			enc.encode("hello\x1b]133;A\x1b\\$ "),
+		);
+		expect(r.matched).toBe(true);
+		expect(dec.decode(r.output)).toBe("hello$ ");
+	});
+
+	it("matches ST spanning two chunks (ESC in first, \\ in second)", () => {
+		const state = createScanState();
+		const a = scanForShellReady(state, enc.encode("\x1b]133;A\x1b"));
+		expect(a.matched).toBe(false);
+		expect(a.output.length).toBe(0);
+		const b = scanForShellReady(state, enc.encode("\\trailing"));
+		expect(b.matched).toBe(true);
+		expect(dec.decode(b.output)).toBe("trailing");
+	});
+
+	it("does not false-match ESC followed by a non-backslash byte as ST", () => {
+		const state = createScanState();
+		// ESC [ after the prefix is not ST — bytes stay held, no match yet.
+		const a = scanForShellReady(state, enc.encode("\x1b]133;A\x1b["));
+		expect(a.matched).toBe(false);
+		// The actual terminator arrives later.
+		const b = scanForShellReady(state, enc.encode("\x07done"));
+		expect(b.matched).toBe(true);
+		expect(dec.decode(b.output)).toBe("done");
+	});
 });

--- a/packages/shared/src/shell-ready-scanner.test.ts
+++ b/packages/shared/src/shell-ready-scanner.test.ts
@@ -45,10 +45,7 @@ describe("shell-ready scanner (bytes)", () => {
 
 	it("strips the marker terminated by ST (ESC \\) in a single chunk", () => {
 		const state = createScanState();
-		const r = scanForShellReady(
-			state,
-			enc.encode("hello\x1b]133;A\x1b\\$ "),
-		);
+		const r = scanForShellReady(state, enc.encode("hello\x1b]133;A\x1b\\$ "));
 		expect(r.matched).toBe(true);
 		expect(dec.decode(r.output)).toBe("hello$ ");
 	});

--- a/packages/shared/src/shell-ready-scanner.ts
+++ b/packages/shared/src/shell-ready-scanner.ts
@@ -6,6 +6,9 @@
  * is identical to char-level matching while letting callers keep PTY
  * output as opaque bytes from the daemon all the way to xterm.js.
  *
+ * The OSC string terminator is either BEL (0x07) or ST (ESC \, 0x1b 0x5c);
+ * both are recognized.
+ *
  * Protocol ref: https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md
  * Vendored from WezTerm (MIT, Copyright 2018-Present Wez Furlong).
  */
@@ -14,6 +17,8 @@ const OSC_133_A_BYTES = Uint8Array.from(
 	[..."\x1b]133;A"].map((c) => c.charCodeAt(0)),
 );
 const BEL_BYTE = 0x07;
+const ESC_BYTE = 0x1b;
+const BACKSLASH_BYTE = 0x5c;
 
 /** Shells whose wrapper files inject OSC 133 markers. */
 export const SHELLS_WITH_READY_MARKER = new Set(["zsh", "bash", "fish"]);
@@ -26,6 +31,8 @@ export interface ShellReadyScanState {
 	matchPos: number;
 	/** Bytes withheld from output while a match is in progress. */
 	heldBytes: number[];
+	/** True when the last held byte was ESC, potentially starting ST (ESC \). */
+	awaitingST: boolean;
 }
 
 export interface ShellReadyScanResult {
@@ -36,16 +43,17 @@ export interface ShellReadyScanResult {
 }
 
 export function createScanState(): ShellReadyScanState {
-	return { matchPos: 0, heldBytes: [] };
+	return { matchPos: 0, heldBytes: [], awaitingST: false };
 }
 
 /**
  * Scan a chunk of PTY output for the OSC 133;A (prompt start) marker.
  *
  * Matching bytes are held back from output. On full match (prefix + optional
- * params + string terminator `\a`), they're discarded and `matched` is true.
+ * params + string terminator), they're discarded and `matched` is true.
  * On mismatch, held bytes are flushed as regular terminal output.
  *
+ * Both OSC string terminators are recognized: BEL (0x07) and ST (ESC \).
  * The scanner handles the marker spanning multiple data chunks.
  */
 export function scanForShellReady(
@@ -72,22 +80,36 @@ export function scanForShellReady(
 				}
 			}
 		} else {
+			if (state.awaitingST && b === BACKSLASH_BYTE) {
+				return completeMatch(state, data, i, out);
+			}
+			state.awaitingST = b === ESC_BYTE;
 			if (b === BEL_BYTE) {
-				state.heldBytes.length = 0;
-				state.matchPos = 0;
-				const remaining = data.subarray(i + 1);
-				const head = Uint8Array.from(out);
-				if (remaining.length === 0) {
-					return { output: head, matched: true };
-				}
-				const merged = new Uint8Array(head.length + remaining.length);
-				merged.set(head, 0);
-				merged.set(remaining, head.length);
-				return { output: merged, matched: true };
+				return completeMatch(state, data, i, out);
 			}
 			state.heldBytes.push(b);
 		}
 	}
 
 	return { output: Uint8Array.from(out), matched: false };
+}
+
+function completeMatch(
+	state: ShellReadyScanState,
+	data: Uint8Array,
+	i: number,
+	out: number[],
+): ShellReadyScanResult {
+	state.heldBytes.length = 0;
+	state.matchPos = 0;
+	state.awaitingST = false;
+	const remaining = data.subarray(i + 1);
+	const head = Uint8Array.from(out);
+	if (remaining.length === 0) {
+		return { output: head, matched: true };
+	}
+	const merged = new Uint8Array(head.length + remaining.length);
+	merged.set(head, 0);
+	merged.set(remaining, head.length);
+	return { output: merged, matched: true };
 }


### PR DESCRIPTION
## Summary

- The shell-ready scanner (`packages/shared/src/shell-ready-scanner.ts`) only recognized BEL (0x07) as the OSC string terminator. The [FinalTerm semantic prompt spec](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md) allows both BEL and ST (ESC \, 0x1b 0x5c).
- If an ST-terminated `OSC 133;A` marker ever reached the scanner — from a third-party shell integration, a terminal multiplexer, or a future wrapper change — the scanner would enter its post-prefix state and hold all subsequent PTY output indefinitely, effectively freezing the terminal with no visible error.
- Add ST recognition alongside BEL, handling the two-byte sequence across chunk boundaries via a one-bit `awaitingST` flag. Extract the match-completion path into a shared `completeMatch` helper to avoid duplicating the BEL logic.

## What changed

**`shell-ready-scanner.ts`**
- New constants `ESC_BYTE` and `BACKSLASH_BYTE` for the ST byte pair.
- `ShellReadyScanState` gains an `awaitingST: boolean` field (initialized `false`).
- In state 2 (prefix matched, awaiting terminator): when ESC is seen, `awaitingST` is set; if the next byte is `\`, the match completes identically to BEL. Non-`\` bytes clear the flag and continue holding.
- `completeMatch()` extracted from the inline BEL path — no behavioral change for BEL-terminated markers.

**`shell-ready-scanner.test.ts`** — three new cases:
1. ST-terminated marker stripped from a single chunk
2. ST spanning two chunks (ESC in first, `\` in second)
3. ESC followed by a non-`\` byte is not false-matched as ST

## Test plan

- [x] All 7 tests pass (`bun test packages/shared/src/shell-ready-scanner.test.ts`) — 4 existing + 3 new
- [x] Existing BEL tests unchanged and still green (refactored to use shared helper, same behavior)
- [x] New ST tests prove the fix: single-chunk, cross-chunk, and negative case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shell-ready scanner to recognize the ST terminator (ESC `\`) for OSC 133;A markers. Previously only BEL (`0x07`) was recognized, so an ST-terminated marker would hold all subsequent PTY output indefinitely, freezing the terminal. Both terminators are now handled, including when ST spans chunk boundaries.

- Adds a one-bit `awaitingST` flag in the scan state to track ST across chunks.
- Extracts the match-completion path into a shared helper; BEL behavior is unchanged.
- Adds tests for ST in one chunk, ST spanning two chunks, and a negative case where ESC isn't followed by a backslash.

<sup>Written for commit 931fa21875a681583cbd2594c08eab6e76d2474f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Shell readiness detection now recognizes OSC 133;A markers terminated by either BEL or ST (`ESC \`).
  - Correctly handles terminators received in separate data chunks.
  - Prevents premature matches when an `ESC` byte is not followed by a backslash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->