### PR TITLE
chore(desktop): bump version to 1.28.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.27.0",
+	"version": "1.28.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -841,7 +841,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/agent-setup": "workspace:*",
@@ -940,7 +940,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.27.0",
+	"version": "1.28.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.27.0",
+	"version": "1.28.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Bump desktop, host-service, and CLI from 1.27.0 to 1.28.0 and refresh the lockfile so main records the shared release version. The release is cut from main commit ca1d178f9d9db78cc4aa021e2041f8e1a232fb4e and tagged desktop-v1.28.0.

Validation: `bun run check:plugins` and `bun run check:versions` passed. The source commit passed CI and the desktop canary build. The daemon release guard found no pending daemon changes.

Desktop build and draft release: https://github.com/superset-sh/superset/actions/runs/34378206212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the desktop app, CLI, and host service to version 1.28.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->