### PR TITLE
fix(agent-setup): notify when Codex waits for user input

### DIFF
--- a/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
+++ b/packages/agent-setup/src/agent-wrappers-claude-codex-opencode.ts
@@ -164,6 +164,10 @@ const CODEX_MANAGED_EVENTS: Record<string, { matcher?: string }> = {
 	SessionStart: {},
 	SessionEnd: {},
 	UserPromptSubmit: {},
+	// A planning question blocks on user input; resume working after its answer.
+	// Match only this tool so ordinary tool calls never signal a waiting state.
+	PreToolUse: { matcher: "^request_user_input$" },
+	PostToolUse: { matcher: "^request_user_input$" },
 	Stop: {},
 	Interrupt: {},
 	SubagentStart: {},

--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -1628,8 +1628,14 @@ describe("agent-wrappers codex hooks.json", () => {
 			).toBe(true);
 		}
 
-		expect(parsed.hooks.PreToolUse).toBeUndefined();
-		expect(parsed.hooks.PostToolUse).toBeUndefined();
+		for (const eventName of ["PreToolUse", "PostToolUse"]) {
+			expect(parsed.hooks[eventName]).toEqual([
+				{
+					matcher: "^request_user_input$",
+					hooks: [{ type: "command", command: expectedCommand }],
+				},
+			]);
+		}
 	});
 
 	it("preserves user hooks when merging", () => {
@@ -1691,7 +1697,7 @@ describe("agent-wrappers codex hooks.json", () => {
 
 		const parsed = JSON.parse(content);
 
-		// Preserves user hooks (including PreToolUse/PostToolUse which we don't manage)
+		// Preserves user hooks, including tool hooks alongside our scoped entries.
 		expect(
 			parsed.hooks.Stop.some((def: { hooks: Array<{ command: string }> }) =>
 				def.hooks.some(
@@ -1748,25 +1754,13 @@ describe("agent-wrappers codex hooks.json", () => {
 			).toBe(true);
 		}
 
-		// Does NOT inject managed hooks for PreToolUse/PostToolUse
-		expect(
-			parsed.hooks.PreToolUse.some(
-				(def: { hooks: Array<{ command: string }> }) =>
-					def.hooks.some(
-						(hook: { command: string }) =>
-							hook.command === expectedManagedCommand,
-					),
-			),
-		).toBe(false);
-		expect(
-			parsed.hooks.PostToolUse.some(
-				(def: { hooks: Array<{ command: string }> }) =>
-					def.hooks.some(
-						(hook: { command: string }) =>
-							hook.command === expectedManagedCommand,
-					),
-			),
-		).toBe(false);
+		for (const eventName of ["PreToolUse", "PostToolUse"]) {
+			expect(parsed.hooks[eventName]).toHaveLength(2);
+			expect(parsed.hooks[eventName]).toContainEqual({
+				matcher: "^request_user_input$",
+				hooks: [{ type: "command", command: expectedManagedCommand }],
+			});
+		}
 	});
 
 	it("replaces stale Codex hook commands from old superset paths", () => {


### PR DESCRIPTION
## What & why

Codex Plan Mode can block on `request_user_input` while Superset continues showing the working spinner and never plays the background attention sound. Register `PreToolUse` and `PostToolUse` with the exact regex `^request_user_input$`, using the existing event mappings to enter `PermissionRequest` before the question and return to `Start` after its answer. Ordinary tool calls do not match, and existing user hooks are preserved.

Fixes #7362. Implements the scoped hook approach proposed by @haydenfd.

## How I tested it

- Real macOS Electron dev app over CDP, matched to this worktree (`localhost:4845`, CDP `9245`), with Codex CLI 0.153.4.
- Before: a real Plan Mode Light/Dark question remained on the working spinner; with the pane hidden, zero ringtone playback calls despite unmuted volume 100. Background completion did play audio.
- After: repeated the same question in a fresh Codex session. The working spinner stopped, the existing yellow waiting indicator appeared, and background ringtone playback occurred. After submitting the answer, 100ms DOM samples recorded waiting → working → idle.
- Before/after screenshots captured and inspected locally; native OS notification presentation was not verified.
- `bun test packages/agent-setup`: 323 passed.
- Event mapping and terminal status tests: 16 passed.
- `bun run lint:fix`, `bun run lint`, `bun run typecheck` (38 packages), `bun run check:plugins`: passed.
- `bun run test`: blocked by missing required environment variables in `@superset/trpc` (including `OPENAI_API_KEY` and Google OAuth settings).

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — same-repository branch


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7362. Codex Plan Mode can block on `request_user_input` while Superset keeps showing the working spinner and never plays the attention sound. The agent setup now registers scoped `PreToolUse` and `PostToolUse` hooks matching `^request_user_input$`, so the waiting state appears before the question and working resumes after the answer. Ordinary tool calls don't match the regex, and existing user hooks are preserved.

<sup>Written for commit 969bd2c0a87e64d8a6b9434b9c9bd1e5e94d79cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex-managed hooks now recognize user-input planning requests and signal when the agent is waiting for or resuming from user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->