### PR TITLE
feat(terminal): name a terminal session, on the desktop and the phone

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -14,7 +14,7 @@ import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { eq } from "@tanstack/db";
 import { useLiveQuery } from "@tanstack/react-db";
-import { Check, LoaderCircle, Plus, Trash2 } from "lucide-react";
+import { Check, LoaderCircle, Pencil, Plus, Trash2 } from "lucide-react";
 import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 import { useRenderStressInstrumentation } from "renderer/lib/performance/stress-instrumentation";
 import { markTerminalForBackground } from "renderer/lib/terminal/terminal-background-intents";
@@ -27,6 +27,7 @@ import type {
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import { getRelativeTime } from "renderer/screens/main/components/WorkspacesListView/utils";
 import { TerminalPaneIcon } from "../TerminalPaneIcon";
+import { RenameSessionDialog } from "./components/RenameSessionDialog";
 import {
 	getTerminalDisplayTitle,
 	getTerminalSessionListRefetchInterval,
@@ -47,7 +48,14 @@ interface VisibleTerminalSession {
 	exitCode: number;
 	attached: boolean;
 	title: string | null;
+	customTitle: string | null;
 	pending?: boolean;
+}
+
+interface RenameTarget {
+	terminalId: string;
+	/** The session's name today, or "" when it has never been named. */
+	name: string;
 }
 
 interface TerminalPaneLocation {
@@ -103,6 +111,8 @@ export function TerminalSessionDropdown({
 	const terminalInstanceId = context.pane.id;
 	const utils = workspaceTrpc.useUtils();
 	const killTerminalSession = workspaceTrpc.terminal.killSession.useMutation();
+	const renameTerminalSession = workspaceTrpc.terminal.rename.useMutation();
+	const [renameTarget, setRenameTarget] = useState<RenameTarget | null>(null);
 	const sessionsInput = useMemo(() => ({ workspaceId }), [workspaceId]);
 	const sessionsQuery = workspaceTrpc.terminal.list.useQuery(sessionsInput, {
 		enabled: shouldQueryTerminalSessionList(isOpen),
@@ -150,6 +160,7 @@ export function TerminalSessionDropdown({
 				exitCode: 0,
 				attached: false,
 				title: null,
+				customTitle: null,
 				pending: true,
 			},
 			...ordered,
@@ -254,6 +265,55 @@ export function TerminalSessionDropdown({
 		});
 	};
 
+	const renameSession = async (target: RenameTarget, name: string) => {
+		await renameTerminalSession.mutateAsync({
+			terminalId: target.terminalId,
+			workspaceId,
+			title: name,
+		});
+		// A pane label from a preset or a launch would sit on top of the name
+		// the user just chose, so the name they chose retires it.
+		if (name.trim()) {
+			const state = context.store.getState();
+			const clearLabel = (location: { tabId: string; paneId: string }) =>
+				state.setPaneTitleOverride({ ...location, titleOverride: undefined });
+			for (const location of getTerminalPaneLocations(context).get(
+				target.terminalId,
+			) ?? []) {
+				clearLabel(location);
+			}
+			// getTerminalPaneLocations answers "where else is this terminal",
+			// so this pane — the usual one being renamed — is not in it.
+			if (target.terminalId === terminalId) {
+				clearLabel({ tabId: context.tab.id, paneId: context.pane.id });
+			}
+		}
+		await utils.terminal.list.invalidate({ workspaceId });
+	};
+
+	const handleRenameSession = (target: RenameTarget, name: string) => {
+		const trimmed = name.trim();
+		toast.promise(renameSession(target, name), {
+			loading: trimmed
+				? t({
+						message: `Renaming session to ${trimmed}...`,
+					})
+				: t({
+						message: "Clearing session name...",
+					}),
+			success: trimmed
+				? t({
+						message: `Session renamed to ${trimmed}`,
+					})
+				: t({
+						message: "Session name cleared",
+					}),
+			error: t({
+				message: "Failed to rename session",
+			}),
+		});
+	};
+
 	const handleNewTerminal = () => {
 		const state = context.store.getState();
 		const terminalPaneLocations = getTerminalPaneLocations(context);
@@ -285,150 +345,185 @@ export function TerminalSessionDropdown({
 	});
 
 	return (
-		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-			<DropdownMenuTrigger asChild>
-				<button
-					type="button"
-					aria-label={t({
-						message: "Terminal sessions",
-					})}
-					title={triggerTitle}
-					className="flex min-w-32 max-w-96 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-					onMouseDown={(event) => event.stopPropagation()}
-					onClick={(event) => event.stopPropagation()}
-				>
-					<TerminalPaneIcon workspaceId={workspaceId} terminalId={terminalId} />
-					{workspaceRunState && (
-						<span
-							className={
-								workspaceRunState === "running"
-									? "size-1.5 shrink-0 rounded-full bg-emerald-500"
-									: workspaceRunState === "stopped-by-user"
-										? "size-1.5 shrink-0 rounded-full bg-amber-500"
-										: "size-1.5 shrink-0 rounded-full bg-red-500"
-							}
-							title={t({
-								message: `Workspace run: ${workspaceRunState}`,
-							})}
-						/>
-					)}
-					<span className="min-w-0 flex-1 truncate text-left">
-						{triggerTitle}
-					</span>
-					{sessionsQuery.isFetching && isOpen && (
-						<LoaderCircle className="size-3 shrink-0 animate-spin" />
-					)}
-				</button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-96">
-				<DropdownMenuLabel className="flex items-center gap-2 text-xs">
-					<span className="min-w-0 flex-1 truncate">
-						<Trans>Terminal Sessions</Trans>
-					</span>
+		<>
+			{renameTarget && (
+				<RenameSessionDialog
+					key={renameTarget.terminalId}
+					name={renameTarget.name}
+					onClose={() => setRenameTarget(null)}
+					onSubmit={(name) => handleRenameSession(renameTarget, name)}
+				/>
+			)}
+			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+				<DropdownMenuTrigger asChild>
 					<button
 						type="button"
 						aria-label={t({
-							message: "New terminal",
+							message: "Terminal sessions",
 						})}
-						title={t({
-							message: "New terminal",
-						})}
-						className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-						onClick={(event) => {
-							event.preventDefault();
-							event.stopPropagation();
-							handleNewTerminal();
-						}}
+						title={triggerTitle}
+						className="flex min-w-32 max-w-96 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+						onMouseDown={(event) => event.stopPropagation()}
+						onClick={(event) => event.stopPropagation()}
 					>
-						<Plus className="size-3.5" />
+						<TerminalPaneIcon
+							workspaceId={workspaceId}
+							terminalId={terminalId}
+						/>
+						{workspaceRunState && (
+							<span
+								className={
+									workspaceRunState === "running"
+										? "size-1.5 shrink-0 rounded-full bg-emerald-500"
+										: workspaceRunState === "stopped-by-user"
+											? "size-1.5 shrink-0 rounded-full bg-amber-500"
+											: "size-1.5 shrink-0 rounded-full bg-red-500"
+								}
+								title={t({
+									message: `Workspace run: ${workspaceRunState}`,
+								})}
+							/>
+						)}
+						<span className="min-w-0 flex-1 truncate text-left">
+							{triggerTitle}
+						</span>
+						{sessionsQuery.isFetching && isOpen && (
+							<LoaderCircle className="size-3 shrink-0 animate-spin" />
+						)}
 					</button>
-				</DropdownMenuLabel>
-				<DropdownMenuSeparator />
-				<div className="max-h-80 overflow-y-auto">
-					{sessions.length > 0 ? (
-						sessions.map((session) => {
-							const isCurrent = session.terminalId === terminalId;
-							const location = renderTerminalPaneLocations.get(
-								session.terminalId,
-							)?.[0];
-							const createdAtLabel = formatCreatedAt(session.createdAt);
-							const status = isCurrent
-								? t({
-										message: "Current",
-									})
-								: workspaceRunTerminals[session.terminalId]
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="start" className="w-96">
+					<DropdownMenuLabel className="flex items-center gap-2 text-xs">
+						<span className="min-w-0 flex-1 truncate">
+							<Trans>Terminal Sessions</Trans>
+						</span>
+						<button
+							type="button"
+							aria-label={t({
+								message: "New terminal",
+							})}
+							title={t({
+								message: "New terminal",
+							})}
+							className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+							onClick={(event) => {
+								event.preventDefault();
+								event.stopPropagation();
+								handleNewTerminal();
+							}}
+						>
+							<Plus className="size-3.5" />
+						</button>
+					</DropdownMenuLabel>
+					<DropdownMenuSeparator />
+					<div className="max-h-80 overflow-y-auto">
+						{sessions.length > 0 ? (
+							sessions.map((session) => {
+								const isCurrent = session.terminalId === terminalId;
+								const location = renderTerminalPaneLocations.get(
+									session.terminalId,
+								)?.[0];
+								const createdAtLabel = formatCreatedAt(session.createdAt);
+								const status = isCurrent
 									? t({
-											message: "Run",
+											message: "Current",
 										})
-									: session.pending
+									: workspaceRunTerminals[session.terminalId]
 										? t({
-												message: "Starting",
+												message: "Run",
 											})
-										: session.attached
+										: session.pending
 											? t({
-													message: "Attached",
+													message: "Starting",
 												})
-											: t({
-													message: "Detached",
-												});
-							const title = isCurrent
-								? triggerTitle
-								: getTerminalDisplayTitle({
-										titleOverride: location?.titleOverride,
-										sessionTitle: session.title,
-									});
-
-							return (
-								<DropdownMenuItem
-									key={session.terminalId}
-									className="group flex items-center gap-2"
-									onSelect={(_event) => {
-										handleSelectSession(session);
-									}}
-								>
-									<span className="w-4 shrink-0">
-										{isCurrent && <Check className="size-3.5" />}
-									</span>
-									<span className="min-w-0 flex-1 truncate text-xs">
-										{title}
-									</span>
-									<span className="shrink-0 text-xs text-muted-foreground/70">
-										{createdAtLabel}
-									</span>
-									<span className="shrink-0 text-xs text-muted-foreground">
-										{status}
-									</span>
-									<button
-										type="button"
-										aria-label={
-											session.createdAt
+											: session.attached
 												? t({
-														message: `Remove terminal ${createdAtLabel}`,
+														message: "Attached",
 													})
 												: t({
-														message: "Remove terminal session",
-													})
-										}
-										disabled={killTerminalSession.isPending}
-										className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
-										onClick={(event) => {
-											event.preventDefault();
-											event.stopPropagation();
-											handleRemoveTerminal(session);
+														message: "Detached",
+													});
+								const title = isCurrent
+									? triggerTitle
+									: getTerminalDisplayTitle({
+											titleOverride: location?.titleOverride,
+											sessionTitle: session.title,
+										});
+
+								return (
+									<DropdownMenuItem
+										key={session.terminalId}
+										className="group flex items-center gap-2"
+										onSelect={(_event) => {
+											handleSelectSession(session);
 										}}
 									>
-										<Trash2 className="size-3" />
-									</button>
-								</DropdownMenuItem>
-							);
-						})
-					) : (
-						<div className="px-2 py-1.5 text-xs text-muted-foreground">
-							<Trans>No live sessions</Trans>
-						</div>
-					)}
-				</div>
-			</DropdownMenuContent>
-		</DropdownMenu>
+										<span className="w-4 shrink-0">
+											{isCurrent && <Check className="size-3.5" />}
+										</span>
+										<span className="min-w-0 flex-1 truncate text-xs">
+											{title}
+										</span>
+										<span className="shrink-0 text-xs text-muted-foreground/70">
+											{createdAtLabel}
+										</span>
+										<span className="shrink-0 text-xs text-muted-foreground">
+											{status}
+										</span>
+										{/* Nothing to rename until the session exists on the
+										    host: a pending row is a terminal id this pane has
+										    minted and not yet attached. */}
+										<button
+											type="button"
+											hidden={session.pending}
+											aria-label={t({
+												message: `Rename ${title}`,
+											})}
+											className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+											onClick={(event) => {
+												event.preventDefault();
+												event.stopPropagation();
+												setIsOpen(false);
+												setRenameTarget({
+													terminalId: session.terminalId,
+													name: session.customTitle ?? "",
+												});
+											}}
+										>
+											<Pencil className="size-3" />
+										</button>
+										<button
+											type="button"
+											aria-label={
+												session.createdAt
+													? t({
+															message: `Remove terminal ${createdAtLabel}`,
+														})
+													: t({
+															message: "Remove terminal session",
+														})
+											}
+											disabled={killTerminalSession.isPending}
+											className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-30 group-hover:opacity-100"
+											onClick={(event) => {
+												event.preventDefault();
+												event.stopPropagation();
+												handleRemoveTerminal(session);
+											}}
+										>
+											<Trash2 className="size-3" />
+										</button>
+									</DropdownMenuItem>
+								);
+							})
+						) : (
+							<div className="px-2 py-1.5 text-xs text-muted-foreground">
+								<Trans>No live sessions</Trans>
+							</div>
+						)}
+					</div>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/components/RenameSessionDialog/RenameSessionDialog.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/components/RenameSessionDialog/RenameSessionDialog.tsx
@@ -1,0 +1,92 @@
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button } from "@superset/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@superset/ui/dialog";
+import { Input } from "@superset/ui/input";
+import { useState } from "react";
+
+interface RenameSessionDialogProps {
+	/** The session's current name, or "" when it has never been named. */
+	name: string;
+	onClose: () => void;
+	onSubmit: (name: string) => void;
+}
+
+/**
+ * Names a terminal session, or clears the name by submitting nothing.
+ *
+ * Mounted only while it is open, so each session it opens on starts from that
+ * session's name with no copying back and forth.
+ */
+export function RenameSessionDialog({
+	name,
+	onClose,
+	onSubmit,
+}: RenameSessionDialogProps) {
+	const { t } = useLingui();
+	const [value, setValue] = useState(name);
+
+	const handleSubmit = () => {
+		onClose();
+		if (value.trim() === name.trim()) return;
+		onSubmit(value);
+	};
+
+	return (
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open) onClose();
+			}}
+		>
+			<DialogContent className="max-w-[360px]">
+				<DialogHeader>
+					<DialogTitle className="font-medium">
+						<Trans>Rename session</Trans>
+					</DialogTitle>
+					<DialogDescription>
+						<Trans>
+							Leave it empty to go back to the name the terminal reports.
+						</Trans>
+					</DialogDescription>
+				</DialogHeader>
+				<form
+					className="flex flex-col gap-4"
+					onSubmit={(event) => {
+						event.preventDefault();
+						handleSubmit();
+					}}
+				>
+					<Input
+						autoFocus
+						value={value}
+						onChange={(event) => setValue(event.target.value)}
+						onFocus={(event) => event.target.select()}
+						aria-label={t({ message: "Session name" })}
+						className="h-8 text-sm"
+					/>
+					<DialogFooter className="flex-row justify-end gap-2">
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-7 px-3 text-xs"
+							onClick={onClose}
+						>
+							<Trans>Cancel</Trans>
+						</Button>
+						<Button type="submit" size="sm" className="h-7 px-3 text-xs">
+							<Trans>Save</Trans>
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/components/RenameSessionDialog/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/components/RenameSessionDialog/index.ts
@@ -1,0 +1,1 @@
+export { RenameSessionDialog } from "./RenameSessionDialog";

--- a/apps/mobile/modules/composer/ios/ComposerModel.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModel.swift
@@ -125,6 +125,7 @@ final class ComposerModel {
   /// there — where the "Copied" notice already lives.
   @ObservationIgnored var onSessionTabPress: ((String) -> Void)?
   @ObservationIgnored var onSessionTabClose: ((String) -> Void)?
+  @ObservationIgnored var onSessionTabRename: ((String) -> Void)?
   @ObservationIgnored var onSessionTabCopyId: ((String) -> Void)?
   @ObservationIgnored var onNewSessionPress: (() -> Void)?
   @ObservationIgnored var onAllSessionsPress: (() -> Void)?

--- a/apps/mobile/modules/composer/ios/ComposerModule.swift
+++ b/apps/mobile/modules/composer/ios/ComposerModule.swift
@@ -17,6 +17,7 @@ public final class ComposerModule: Module {
         "onQuickKeyPress",
         "onSessionTabPress",
         "onSessionTabClose",
+        "onSessionTabRename",
         "onSessionTabCopyId",
         "onQuickKeysActionPress",
         "onNewSessionPress",
@@ -189,6 +190,7 @@ final class ComposerAnchorView: ExpoView {
   private let onQuickKeyPress = EventDispatcher()
   private let onSessionTabPress = EventDispatcher()
   private let onSessionTabClose = EventDispatcher()
+  private let onSessionTabRename = EventDispatcher()
   private let onSessionTabCopyId = EventDispatcher()
   private let onQuickKeysActionPress = EventDispatcher()
   private let onNewSessionPress = EventDispatcher()
@@ -220,6 +222,9 @@ final class ComposerAnchorView: ExpoView {
     }
     overlay.model.onSessionTabClose = { [weak self] id in
       self?.onSessionTabClose(["id": id])
+    }
+    overlay.model.onSessionTabRename = { [weak self] id in
+      self?.onSessionTabRename(["id": id])
     }
     overlay.model.onSessionTabCopyId = { [weak self] id in
       self?.onSessionTabCopyId(["id": id])

--- a/apps/mobile/modules/composer/ios/ComposerRootView.swift
+++ b/apps/mobile/modules/composer/ios/ComposerRootView.swift
@@ -302,6 +302,7 @@ struct ComposerRootView: View {
                 labels: model.sessionTabLabels,
                 onSelect: { model.onSessionTabPress?($0) },
                 onClose: { model.onSessionTabClose?($0) },
+                onRename: { model.onSessionTabRename?($0) },
                 onCopyId: { model.onSessionTabCopyId?($0) },
                 onNewSession: { model.onNewSessionPress?() },
                 onAllSessions: { model.onAllSessionsPress?() }

--- a/apps/mobile/modules/composer/ios/ComposerSessionTab.swift
+++ b/apps/mobile/modules/composer/ios/ComposerSessionTab.swift
@@ -43,6 +43,8 @@ struct ComposerSessionTab: Record, Identifiable, Equatable {
 /// Same reasoning as `ComposerQuickKey.label`, which is also handed over rather
 /// than derived.
 struct ComposerSessionTabLabels: Record, Equatable {
+  /// Menu item: opens React Native's prompt for the session's name.
+  @Field var rename: String = ""
   /// Menu item: puts the session's terminal id on the pasteboard.
   @Field var copyId: String = ""
   /// Menu item, destructive. React Native still confirms before killing.
@@ -56,7 +58,7 @@ struct ComposerSessionTabLabels: Record, Equatable {
   @Field var scrollToStart: String = ""
 
   static func == (lhs: ComposerSessionTabLabels, rhs: ComposerSessionTabLabels) -> Bool {
-    lhs.copyId == rhs.copyId && lhs.close == rhs.close
+    lhs.rename == rhs.rename && lhs.copyId == rhs.copyId && lhs.close == rhs.close
       && lhs.newSession == rhs.newSession && lhs.allSessions == rhs.allSessions
       && lhs.scrollToStart == rhs.scrollToStart
   }

--- a/apps/mobile/modules/composer/ios/ComposerSessionTabs.swift
+++ b/apps/mobile/modules/composer/ios/ComposerSessionTabs.swift
@@ -17,6 +17,7 @@ struct ComposerSessionTabs: View {
   let labels: ComposerSessionTabLabels
   let onSelect: (String) -> Void
   let onClose: (String) -> Void
+  let onRename: (String) -> Void
   let onCopyId: (String) -> Void
   let onNewSession: () -> Void
   let onAllSessions: () -> Void
@@ -42,6 +43,7 @@ struct ComposerSessionTabs: View {
                 labels: labels,
                 onSelect: { onSelect(tab.id) },
                 onClose: { onClose(tab.id) },
+                onRename: { onRename(tab.id) },
                 onCopyId: { onCopyId(tab.id) }
               )
               .id(tab.id)
@@ -133,6 +135,7 @@ private struct ComposerSessionTabPill: View {
   let labels: ComposerSessionTabLabels
   let onSelect: () -> Void
   let onClose: () -> Void
+  let onRename: () -> Void
   let onCopyId: () -> Void
 
   private var shape: RoundedRectangle {
@@ -209,6 +212,9 @@ private struct ComposerSessionTabPill: View {
     // selected tab, and closing one you are not looking at is the more common
     // want.
     .contextMenu {
+      Button(action: onRename) {
+        Label(labels.rename, systemImage: "pencil")
+      }
       Button(action: onCopyId) {
         Label(labels.copyId, systemImage: "doc.on.doc")
       }

--- a/apps/mobile/modules/composer/src/index.tsx
+++ b/apps/mobile/modules/composer/src/index.tsx
@@ -36,6 +36,7 @@ interface NativeComposerViewProps {
 	onQuickKeyPress?: (event: { nativeEvent: { id: string } }) => void;
 	onSessionTabPress?: (event: { nativeEvent: { id: string } }) => void;
 	onSessionTabClose?: (event: { nativeEvent: { id: string } }) => void;
+	onSessionTabRename?: (event: { nativeEvent: { id: string } }) => void;
 	onSessionTabCopyId?: (event: { nativeEvent: { id: string } }) => void;
 	onNewSessionPress?: () => void;
 	onAllSessionsPress?: () => void;
@@ -181,6 +182,8 @@ export interface ComposerQuickKeysAction {
  * untranslated string on a translated screen.
  */
 export interface ComposerSessionTabLabels {
+	/** Context menu: opens the prompt for the session's name. */
+	rename: string;
 	/** Context menu: copies the session's id to the pasteboard. */
 	copyId: string;
 	/** Context menu, destructive, and the close disc's accessibility label. */
@@ -337,6 +340,12 @@ interface ComposerBaseProps {
 	 */
 	onSessionTabClose?: (id: string) => void;
 	/**
+	 * Rename was chosen from the press-and-hold menu. The composer neither
+	 * asks for the new name nor knows what a session's name is — a menu cannot
+	 * take text, and the name is the host's — so the caller prompts and saves.
+	 */
+	onSessionTabRename?: (id: string) => void;
+	/**
 	 * Copy id was chosen from the press-and-hold menu. The caller owns the
 	 * pasteboard write and whatever it shows afterwards, so the confirmation
 	 * matches every other copy on the screen.
@@ -426,6 +435,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 			onQuickKeyPress,
 			onSessionTabPress,
 			onSessionTabClose,
+			onSessionTabRename,
 			onSessionTabCopyId,
 			onNewSessionPress,
 			onAllSessionsPress,
@@ -482,6 +492,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
 				onQuickKeyPress={(event) => onQuickKeyPress?.(event.nativeEvent.id)}
 				onSessionTabPress={(event) => onSessionTabPress?.(event.nativeEvent.id)}
 				onSessionTabClose={(event) => onSessionTabClose?.(event.nativeEvent.id)}
+				onSessionTabRename={(event) =>
+					onSessionTabRename?.(event.nativeEvent.id)
+				}
 				onSessionTabCopyId={(event) =>
 					onSessionTabCopyId?.(event.nativeEvent.id)
 				}

--- a/apps/mobile/screens/(authenticated)/(home)/home/hooks/useHostTerminals/useHostTerminals.ts
+++ b/apps/mobile/screens/(authenticated)/(home)/home/hooks/useHostTerminals/useHostTerminals.ts
@@ -33,7 +33,10 @@ const ATTENTION_PRIORITY: Record<TerminalAttention, number> = {
 export interface TerminalRowData {
 	terminalId: string;
 	workspaceId: string;
+	/** What to show: the name the user gave the session, else the shell's. */
 	title: string;
+	/** The user's name on its own, for prefilling a rename. */
+	customTitle: string | null;
 	ts: number;
 	/** Session creation time — the stable ordering key for tab strips. */
 	createdAt: number;
@@ -157,6 +160,7 @@ export function useHostsTerminals(
 					terminalId: session.terminalId,
 					workspaceId: session.workspaceId,
 					title: session.title ?? (binding ? binding.agentId : "Terminal"),
+					customTitle: session.customTitle,
 					ts: binding?.lastEventAt ?? session.createdAt,
 					createdAt: session.createdAt,
 					lastEventAt: binding?.lastEventAt ?? null,

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/WorkspaceScreen/WorkspaceScreen.tsx
@@ -551,6 +551,60 @@ export function WorkspaceScreen() {
 		[t],
 	);
 
+	// Press and hold a tab → Rename. The prompt lives here rather than in the
+	// composer for the same reason the close confirm does: a context menu
+	// cannot take text, and the name belongs to the host, not to the strip.
+	const renameTerminal = useCallback(
+		(terminalId: string, title: string) => {
+			if (!workspace || !hostUrl) return;
+			void getHostServiceClientByUrl(hostUrl)
+				.terminal.rename.mutate({
+					terminalId,
+					workspaceId: workspace.id,
+					title,
+				})
+				.catch((cause: unknown) =>
+					Alert.alert(
+						t({
+							message: "Could not rename the session",
+						}),
+						errorCopy(cause),
+					),
+				)
+				.finally(invalidateTerminals);
+		},
+		[workspace, hostUrl, invalidateTerminals, t],
+	);
+
+	const promptRenameTerminal = useCallback(
+		(terminalId: string) => {
+			const row = rows.find((candidate) => candidate.terminalId === terminalId);
+			Alert.prompt(
+				t({
+					message: "Rename session",
+				}),
+				t({
+					message:
+						"Leave it empty to go back to the name the terminal reports.",
+				}),
+				[
+					{
+						text: t({ message: "Cancel" }),
+						style: "cancel",
+					},
+					{
+						text: t({ message: "Save" }),
+						onPress: (value?: string) =>
+							renameTerminal(terminalId, value ?? ""),
+					},
+				],
+				"plain-text",
+				row?.customTitle ?? "",
+			);
+		},
+		[rows, renameTerminal, t],
+	);
+
 	// Press and hold a tab → Copy session ID. The pasteboard write lands here
 	// rather than natively so it shares the header notice every other copy on
 	// this screen already uses.
@@ -928,6 +982,7 @@ export function WorkspaceScreen() {
 					sessionTabs={cloud && !workspace ? [] : sessionTabs}
 					onSessionTabPress={pickTerminal}
 					onSessionTabClose={confirmCloseTerminal}
+					onSessionTabRename={promptRenameTerminal}
 					onSessionTabCopyId={copyTerminalId}
 					onNewSessionPress={openAddMenu}
 					onAllSessionsPress={openSessions}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalComposer/TerminalComposer.tsx
@@ -61,6 +61,8 @@ interface TerminalComposerProps {
 	onSessionTabPress: (terminalId: string) => void;
 	/** Close was chosen. Nothing is dead yet — this is where the confirm goes. */
 	onSessionTabClose: (terminalId: string) => void;
+	/** Rename was chosen from the press-and-hold menu. */
+	onSessionTabRename: (terminalId: string) => void;
 	/** Copy id was chosen from the press-and-hold menu. */
 	onSessionTabCopyId: (terminalId: string) => void;
 	onNewSessionPress: () => void;
@@ -108,6 +110,7 @@ export const TerminalComposer = forwardRef<
 		sessionTabs,
 		onSessionTabPress,
 		onSessionTabClose,
+		onSessionTabRename,
 		onSessionTabCopyId,
 		onNewSessionPress,
 		onAllSessionsPress,
@@ -232,6 +235,9 @@ export const TerminalComposer = forwardRef<
 				sessionTabs={sessionTabs}
 				// Translated here because the composer has no catalog of its own.
 				sessionTabLabels={{
+					rename: t({
+						message: "Rename session",
+					}),
 					copyId: t({
 						message: "Copy session ID",
 					}),
@@ -250,6 +256,7 @@ export const TerminalComposer = forwardRef<
 				}}
 				onSessionTabPress={onSessionTabPress}
 				onSessionTabClose={onSessionTabClose}
+				onSessionTabRename={onSessionTabRename}
 				onSessionTabCopyId={onSessionTabCopyId}
 				onNewSessionPress={onNewSessionPress}
 				onAllSessionsPress={onAllSessionsPress}

--- a/packages/host-service/drizzle/0034_terminal_session_custom_title.sql
+++ b/packages/host-service/drizzle/0034_terminal_session_custom_title.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `terminal_sessions` ADD `custom_title` text;

--- a/packages/host-service/drizzle/meta/0034_snapshot.json
+++ b/packages/host-service/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1169 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0e715723-7da8-490d-b410-e79c1f887fb7",
+  "prevId": "f77cc140-c83b-40db-af5f-7d3764484049",
+  "tables": {
+    "host_agent_configs": {
+      "name": "host_agent_configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_id": {
+          "name": "preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prompt_transport": {
+          "name": "prompt_transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_args_json": {
+          "name": "prompt_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "resume_args_json": {
+          "name": "resume_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "fork_args_json": {
+          "name": "fork_args_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "env_json": {
+          "name": "env_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_agent_configs_display_order_idx": {
+          "name": "host_agent_configs_display_order_idx",
+          "columns": [
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "host_settings": {
+      "name": "host_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_claude_config_dir": {
+          "name": "default_claude_config_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_codex_home": {
+          "name": "default_codex_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_base_dir": {
+          "name": "worktree_base_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_mode": {
+          "name": "branch_prefix_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch_prefix_custom": {
+          "name": "branch_prefix_custom",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sparse_checkout_paths": {
+          "name": "sparse_checkout_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "naming_instructions": {
+          "name": "naming_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_repo_path_idx": {
+          "name": "projects_repo_path_idx",
+          "columns": [
+            "repo_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_provider": {
+          "name": "repo_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_owner": {
+          "name": "repo_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checks_status": {
+          "name": "checks_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "checks_json": {
+          "name": "checks_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pull_requests_project_id_idx": {
+          "name": "pull_requests_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_branch_idx": {
+          "name": "pull_requests_repo_branch_idx",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "head_branch"
+          ],
+          "isUnique": false
+        },
+        "pull_requests_repo_pr_unique": {
+          "name": "pull_requests_repo_pr_unique",
+          "columns": [
+            "repo_provider",
+            "repo_owner",
+            "repo_name",
+            "pr_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_project_id_projects_id_fk": {
+          "name": "pull_requests_project_id_projects_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag_folder_settings": {
+      "name": "tag_folder_settings",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tab_order": {
+          "name": "tab_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tag_folder_settings_scope_tag_created_by_user_id_pk": {
+          "columns": [
+            "scope",
+            "tag",
+            "created_by_user_id"
+          ],
+          "name": "tag_folder_settings_scope_tag_created_by_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_agent_bindings": {
+      "name": "terminal_agent_bindings",
+      "columns": {
+        "terminal_id": {
+          "name": "terminal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_event_type": {
+          "name": "last_event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_reason": {
+          "name": "end_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resumed_into_terminal_id": {
+          "name": "resumed_into_terminal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_agent_bindings_workspace_id_idx": {
+          "name": "terminal_agent_bindings_workspace_id_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk": {
+          "name": "terminal_agent_bindings_terminal_id_terminal_sessions_id_fk",
+          "tableFrom": "terminal_agent_bindings",
+          "tableTo": "terminal_sessions",
+          "columnsFrom": [
+            "terminal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_workspace_id": {
+          "name": "origin_workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "custom_title": {
+          "name": "custom_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_attached_at": {
+          "name": "last_attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dispose_requested_at": {
+          "name": "dispose_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_origin_workspace_id_idx": {
+          "name": "terminal_sessions_origin_workspace_id_idx",
+          "columns": [
+            "origin_workspace_id"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_status_idx": {
+          "name": "terminal_sessions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_origin_workspace_id_workspaces_id_fk": {
+          "name": "terminal_sessions_origin_workspace_id_workspaces_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "origin_workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_pull_requests": {
+      "name": "workspace_pull_requests",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_pull_requests_workspace_idx": {
+          "name": "workspace_pull_requests_workspace_idx",
+          "columns": [
+            "workspace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_pull_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspace_pull_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_pull_requests_pull_request_id_pull_requests_id_fk": {
+          "name": "workspace_pull_requests_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspace_pull_requests",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_pull_requests_workspace_id_pull_request_id_pk": {
+          "columns": [
+            "workspace_id",
+            "pull_request_id"
+          ],
+          "name": "workspace_pull_requests_workspace_id_pull_request_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_tags": {
+      "name": "workspace_tags",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_tags_tag_idx": {
+          "name": "workspace_tags_tag_idx",
+          "columns": [
+            "tag"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_tags_workspace_id_workspaces_id_fk": {
+          "name": "workspace_tags_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_tags",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_tags_workspace_id_tag_created_by_user_id_pk": {
+          "columns": [
+            "workspace_id",
+            "tag",
+            "created_by_user_id"
+          ],
+          "name": "workspace_tags_workspace_id_tag_created_by_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_owner": {
+          "name": "upstream_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_repo": {
+          "name": "upstream_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_branch": {
+          "name": "upstream_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suppressed_pull_request_id": {
+          "name": "suppressed_pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'worktree'"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_project_id_idx": {
+          "name": "workspaces_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_archived_at_idx": {
+          "name": "workspaces_archived_at_idx",
+          "columns": [
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "workspaces_upstream_ref_idx": {
+          "name": "workspaces_upstream_ref_idx",
+          "columns": [
+            "upstream_owner",
+            "upstream_repo",
+            "upstream_branch"
+          ],
+          "isUnique": false
+        },
+        "workspaces_pull_request_id_idx": {
+          "name": "workspaces_pull_request_id_idx",
+          "columns": [
+            "pull_request_id"
+          ],
+          "isUnique": false
+        },
+        "workspaces_one_main_per_project": {
+          "name": "workspaces_one_main_per_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true,
+          "where": "type = 'main'"
+        }
+      },
+      "foreignKeys": {
+        "workspaces_project_id_projects_id_fk": {
+          "name": "workspaces_project_id_projects_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspaces_suppressed_pull_request_id_pull_requests_id_fk": {
+          "name": "workspaces_suppressed_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "suppressed_pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/host-service/drizzle/meta/_journal.json
+++ b/packages/host-service/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1788765042633,
       "tag": "0033_binding_resumed_into",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1788979878905,
+      "tag": "0034_terminal_session_custom_title",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/host-service/src/db/schema.ts
+++ b/packages/host-service/src/db/schema.ts
@@ -22,6 +22,14 @@ export const terminalSessions = sqliteTable(
 			{ onDelete: "set null" },
 		),
 		status: text().notNull().default("active"),
+		/**
+		 * The name the user gave this session, or null for "no name" — which
+		 * is also what an empty or whitespace-only rename stores. Titles the
+		 * shell reports over OSC are not persisted at all; this column is the
+		 * only durable name a session has, and it outranks the OSC one
+		 * wherever a session is displayed.
+		 */
+		customTitle: text("custom_title"),
 		createdAt: integer("created_at")
 			.notNull()
 			.$defaultFn(() => Date.now()),

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -532,7 +532,14 @@ interface TerminalSession {
 	exitCode: number;
 	exitSignal: number;
 	listed: boolean;
+	/** Last title the shell reported over OSC. Lives and dies with the process. */
 	title: string | null;
+	/**
+	 * The name the user gave this session, mirrored from `custom_title`. It
+	 * outranks `title` everywhere a session is named, so a session keeps its
+	 * name while the shell retitles itself underneath.
+	 */
+	customTitle: string | null;
 	titleScanState: TerminalTitleScanState;
 	/**
 	 * Bus for lifecycle broadcasts. Kept on the session so dispose (which
@@ -805,7 +812,10 @@ export interface TerminalSessionSummary {
 	exited: boolean;
 	exitCode: number;
 	attached: boolean;
+	/** What to show: the user's name if set, else the shell's OSC title. */
 	title: string | null;
+	/** The user's name on its own — null when the session has never been named. */
+	customTitle: string | null;
 }
 
 /**
@@ -871,7 +881,8 @@ export function listTerminalSessions(
 			exited: session.exited,
 			exitCode: session.exitCode,
 			attached: pruneAndCountOpenSockets(session) > 0,
-			title: session.title,
+			title: sessionDisplayTitle(session),
+			customTitle: session.customTitle,
 		}));
 }
 
@@ -890,7 +901,7 @@ export function listTerminalSessions(
  * daemon session joined to an active workspace-owned row. Dispose-stamped
  * rows are scheduled kills awaiting the reaper — never resurfaced. A session
  * only the daemon knows has never been attached in this process's lifetime,
- * hence `attached: false, title: null`.
+ * hence `attached: false` and no OSC title — only the name it was given.
  */
 export async function listLiveTerminalSessions(
 	db: HostDb,
@@ -931,6 +942,7 @@ export async function listLiveTerminalSessions(
 			originWorkspaceId: terminalSessions.originWorkspaceId,
 			status: terminalSessions.status,
 			createdAt: terminalSessions.createdAt,
+			customTitle: terminalSessions.customTitle,
 			disposeRequestedAt: terminalSessions.disposeRequestedAt,
 		})
 		.from(terminalSessions)
@@ -954,7 +966,10 @@ export async function listLiveTerminalSessions(
 			exited: false,
 			exitCode: 0,
 			attached: false,
-			title: null,
+			// No OSC title to fall back on — this process has never watched
+			// this session's output — but the name it was given is durable.
+			title: row.customTitle,
+			customTitle: row.customTitle,
 		});
 	}
 	return merged;
@@ -1345,10 +1360,61 @@ function broadcastMessage(
 	return sent;
 }
 
+/**
+ * What this session is called: the user's name if it has one, else whatever
+ * the shell last reported. The single place that precedence is decided —
+ * clients are handed the answer, never the two inputs.
+ */
+function sessionDisplayTitle(session: TerminalSession): string | null {
+	return session.customTitle ?? session.title;
+}
+
+/**
+ * Announce the display title if what just changed actually changed it. A
+ * named session swallows the shell's retitles this way: it still tracks them
+ * (clearing the name falls back to the latest one) but nothing is announced.
+ */
+function broadcastDisplayTitle(
+	session: TerminalSession,
+	before: string | null,
+) {
+	const after = sessionDisplayTitle(session);
+	if (before === after) return;
+	broadcastMessage(session, { type: "title", title: after });
+}
+
 function setSessionTitle(session: TerminalSession, title: string | null) {
 	if (session.title === title) return;
+	const before = sessionDisplayTitle(session);
 	session.title = title;
-	broadcastMessage(session, { type: "title", title });
+	broadcastDisplayTitle(session, before);
+}
+
+/**
+ * Give a session a name, or clear it with null. The db row is the truth —
+ * a session with no pane, or none in this process's memory at all, is named
+ * just the same — and any live session is caught up so attached clients
+ * (this desktop, a phone) see it without waiting for their next poll.
+ */
+export function renameTerminalSession({
+	terminalId,
+	customTitle,
+	db,
+}: {
+	terminalId: string;
+	customTitle: string | null;
+	db: HostDb;
+}): void {
+	db.update(terminalSessions)
+		.set({ customTitle })
+		.where(eq(terminalSessions.id, terminalId))
+		.run();
+
+	const session = sessions.get(terminalId);
+	if (!session || session.customTitle === customTitle) return;
+	const before = sessionDisplayTitle(session);
+	session.customTitle = customTitle;
+	broadcastDisplayTitle(session, before);
 }
 
 function bufferOutput(session: TerminalSession, data: Uint8Array) {
@@ -2943,6 +3009,16 @@ export async function createTerminalSessionInternal({
 		})
 		.run();
 
+	// Read back rather than default to null: relaunching into the same
+	// terminal id (adoption, an agent resume) must keep the name it was given,
+	// and the conflict update above deliberately leaves the column alone.
+	const customTitle =
+		db
+			.select({ customTitle: terminalSessions.customTitle })
+			.from(terminalSessions)
+			.where(eq(terminalSessions.id, terminalId))
+			.get()?.customTitle ?? null;
+
 	// Determine shell readiness support. Adopted sessions are already past
 	// shell startup, so treat them as immediately ready — the OSC 133;A
 	// marker has already flown by and we don't want to gate writes on it.
@@ -2989,6 +3065,7 @@ export async function createTerminalSessionInternal({
 		exitSignal: 0,
 		listed,
 		title: null,
+		customTitle,
 		titleScanState: createTerminalTitleScanState(),
 		eventBus,
 		shellReadyState: shellSupportsReady
@@ -3298,7 +3375,7 @@ export function registerWorkspaceTerminalRoute({
 					.where(eq(terminalSessions.id, terminalId))
 					.run();
 
-				sendMessage(ws, { type: "title", title: session.title });
+				sendMessage(ws, { type: "title", title: sessionDisplayTitle(session) });
 				if (seqRequest.kind === "legacy") {
 					// Pre-seq contract: `?replay=0` means "my xterm already has
 					// the scrollback". Adoption now always pulls the daemon ring

--- a/packages/host-service/src/trpc/router/terminal/terminal.ts
+++ b/packages/host-service/src/trpc/router/terminal/terminal.ts
@@ -1,4 +1,5 @@
 import { TERMINAL_HANDOFF_MAX_CHARS } from "@superset/shared/terminal-session-handoff";
+import { normalizeTerminalTitle } from "@superset/shared/terminal-title-scanner";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -11,6 +12,7 @@ import {
 	disposeSessionsByWorktreePath,
 	listLiveTerminalSessions,
 	parseThemeType,
+	renameTerminalSession,
 	sessionHasRunningProcess,
 	snapshotSession,
 	transcriptSession,
@@ -248,6 +250,47 @@ export const terminalRouter = router({
 			}
 			const { success: _success, ...transcript } = result;
 			return { terminalId: input.terminalId, ...transcript };
+		}),
+
+	// Name a session, or clear the name with an empty string. The name is the
+	// session's, not the pane's or the tab's: it is stored on the host and
+	// every client that lists the session — this desktop, another one, a
+	// phone — sees it.
+	rename: protectedProcedure
+		.input(
+			z.object({
+				terminalId: z.string(),
+				workspaceId: z.string(),
+				// Same normalization the shell's own titles get: controls
+				// stripped, trimmed, capped — and nothing left means no name.
+				title: z.string().max(1_000).transform(normalizeTerminalTitle),
+			}),
+		)
+		.mutation(({ ctx, input }) => {
+			const session = ctx.db.query.terminalSessions
+				.findFirst({ where: eq(terminalSessions.id, input.terminalId) })
+				.sync();
+
+			if (!session) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Terminal session not found",
+				});
+			}
+
+			if (session.originWorkspaceId !== input.workspaceId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Terminal session does not belong to this workspace",
+				});
+			}
+
+			renameTerminalSession({
+				terminalId: input.terminalId,
+				customTitle: input.title,
+				db: ctx.db,
+			});
+			return { terminalId: input.terminalId, title: input.title };
 		}),
 
 	killSession: protectedProcedure

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator dosažen v okně Run 01"
 msgid "Cleared terminal history"
 msgstr "Historie terminálu vymazána"
 
+msgid "Clearing session name..."
+msgstr "Maži název relace..."
+
 msgid "Clearing…"
 msgstr "Mažu…"
 
@@ -4047,6 +4050,9 @@ msgstr "Nepodařilo se přečíst účet Google. Zkuste to prosím znovu."
 
 msgid "Could not record cloud workspace"
 msgstr "Nepodařilo se zaznamenat cloudový pracovní prostor"
+
+msgid "Could not rename the session"
+msgstr "Relaci se nepodařilo přejmenovat"
 
 msgid "Could not reopen"
 msgstr "Nepodařilo se znovu otevřít"
@@ -5963,6 +5969,9 @@ msgstr "Nepodařilo se přejmenovat"
 msgid "Failed to rename branch"
 msgstr "Nepodařilo se přejmenovat větev"
 
+msgid "Failed to rename session"
+msgstr "Přejmenování relace se nezdařilo"
+
 msgid "Failed to reorder"
 msgstr "Nepodařilo se změnit pořadí"
 
@@ -7718,6 +7727,9 @@ msgstr "Odejít a smazat"
 
 msgid "Leave comment mode"
 msgstr "Opustit režim komentářů"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Nechte prázdné pro návrat k názvu, který hlásí terminál."
 
 msgid "Leave Organization"
 msgstr "Opustit organizaci"
@@ -11414,6 +11426,9 @@ msgstr "Odebírám…"
 msgid "Rename"
 msgstr "Přejmenovat"
 
+msgid "Rename {title}"
+msgstr "Přejmenovat {title}"
+
 msgid "Rename branch"
 msgstr "Přejmenovat větev"
 
@@ -11430,6 +11445,9 @@ msgstr "Přejmenovat skupinu"
 msgid "Rename host"
 msgstr "Přejmenovat hosta"
 
+msgid "Rename session"
+msgstr "Přejmenovat relaci"
+
 msgid "rename the branch"
 msgstr "přejmenovat větev"
 
@@ -11441,6 +11459,9 @@ msgstr "Přejmenovat..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Přejmenovávám větev na {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Přejmenovávám relaci na {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Vykreslený výstup: kód, zdroje, citace, kontext"
@@ -12598,8 +12619,17 @@ msgstr "Vytváření relací na webu bude brzy k dispozici"
 msgid "Session details"
 msgstr "Podrobnosti relace"
 
+msgid "Session name"
+msgstr "Název relace"
+
+msgid "Session name cleared"
+msgstr "Název relace byl smazán"
+
 msgid "Session notes and context."
 msgstr "Poznámky k relaci a kontext."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Relace přejmenována na {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Snímky relace a návrat zpět"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator im Run-01-Zeitraum erreicht"
 msgid "Cleared terminal history"
 msgstr "Terminal-Verlauf gelöscht"
 
+msgid "Clearing session name..."
+msgstr "Sitzungsname wird gelöscht..."
+
 msgid "Clearing…"
 msgstr "Wird gelöscht…"
 
@@ -4047,6 +4050,9 @@ msgstr "Das Google-Konto konnte nicht gelesen werden. Bitte versuche es erneut."
 
 msgid "Could not record cloud workspace"
 msgstr "Cloud-Arbeitsbereich konnte nicht erfasst werden"
+
+msgid "Could not rename the session"
+msgstr "Sitzung konnte nicht umbenannt werden"
 
 msgid "Could not reopen"
 msgstr "Konnte nicht wieder geöffnet werden"
@@ -5963,6 +5969,9 @@ msgstr "Umbenennen fehlgeschlagen"
 msgid "Failed to rename branch"
 msgstr "Branch konnte nicht umbenannt werden"
 
+msgid "Failed to rename session"
+msgstr "Umbenennen der Sitzung fehlgeschlagen"
+
 msgid "Failed to reorder"
 msgstr "Umsortieren fehlgeschlagen"
 
@@ -7718,6 +7727,9 @@ msgstr "Austreten und löschen"
 
 msgid "Leave comment mode"
 msgstr "Kommentarmodus verlassen"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Leer lassen, um zum Namen zurückzukehren, den das Terminal meldet."
 
 msgid "Leave Organization"
 msgstr "Organisation verlassen"
@@ -11414,6 +11426,9 @@ msgstr "Wird entfernt…"
 msgid "Rename"
 msgstr "Umbenennen"
 
+msgid "Rename {title}"
+msgstr "{title} umbenennen"
+
 msgid "Rename branch"
 msgstr "Branch umbenennen"
 
@@ -11430,6 +11445,9 @@ msgstr "Gruppe umbenennen"
 msgid "Rename host"
 msgstr "Host umbenennen"
 
+msgid "Rename session"
+msgstr "Sitzung umbenennen"
+
 msgid "rename the branch"
 msgstr "den Branch umbenennen"
 
@@ -11441,6 +11459,9 @@ msgstr "Umbenennen..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Branch wird in {newName} umbenannt..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Sitzung wird in {trimmed} umbenannt..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Gerenderte Ausgabe: Code, Quellen, Zitate, Kontext"
@@ -12598,8 +12619,17 @@ msgstr "Das Erstellen von Sitzungen im Web kommt bald"
 msgid "Session details"
 msgstr "Sitzungsdetails"
 
+msgid "Session name"
+msgstr "Sitzungsname"
+
+msgid "Session name cleared"
+msgstr "Sitzungsname gelöscht"
+
 msgid "Session notes and context."
 msgstr "Sitzungsnotizen und Kontext."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Sitzung in {trimmed} umbenannt"
 
 msgid "Session snapshots & revert"
 msgstr "Sitzungs-Snapshots & Zurücksetzen"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Cleared Operator inside the Run 01 window"
 msgid "Cleared terminal history"
 msgstr "Cleared terminal history"
 
+msgid "Clearing session name..."
+msgstr "Clearing session name..."
+
 msgid "Clearing…"
 msgstr "Clearing…"
 
@@ -4047,6 +4050,9 @@ msgstr "Could not read the Google account. Please try again."
 
 msgid "Could not record cloud workspace"
 msgstr "Could not record cloud workspace"
+
+msgid "Could not rename the session"
+msgstr "Could not rename the session"
 
 msgid "Could not reopen"
 msgstr "Could not reopen"
@@ -5963,6 +5969,9 @@ msgstr "Failed to rename"
 msgid "Failed to rename branch"
 msgstr "Failed to rename branch"
 
+msgid "Failed to rename session"
+msgstr "Failed to rename session"
+
 msgid "Failed to reorder"
 msgstr "Failed to reorder"
 
@@ -7718,6 +7727,9 @@ msgstr "Leave and delete"
 
 msgid "Leave comment mode"
 msgstr "Leave comment mode"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Leave it empty to go back to the name the terminal reports."
 
 msgid "Leave Organization"
 msgstr "Leave Organization"
@@ -11414,6 +11426,9 @@ msgstr "Removing…"
 msgid "Rename"
 msgstr "Rename"
 
+msgid "Rename {title}"
+msgstr "Rename {title}"
+
 msgid "Rename branch"
 msgstr "Rename branch"
 
@@ -11430,6 +11445,9 @@ msgstr "Rename group"
 msgid "Rename host"
 msgstr "Rename host"
 
+msgid "Rename session"
+msgstr "Rename session"
+
 msgid "rename the branch"
 msgstr "rename the branch"
 
@@ -11441,6 +11459,9 @@ msgstr "Rename..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Renaming branch to {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Renaming session to {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Rendered output: code, sources, citations, context"
@@ -12598,8 +12619,17 @@ msgstr "Session creation on web is coming soon"
 msgid "Session details"
 msgstr "Session details"
 
+msgid "Session name"
+msgstr "Session name"
+
+msgid "Session name cleared"
+msgstr "Session name cleared"
+
 msgid "Session notes and context."
 msgstr "Session notes and context."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Session renamed to {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Session snapshots & revert"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator alcanzado dentro de la ventana Run 01"
 msgid "Cleared terminal history"
 msgstr "Historial de la terminal borrado"
 
+msgid "Clearing session name..."
+msgstr "Borrando el nombre de la sesión..."
+
 msgid "Clearing…"
 msgstr "Borrando…"
 
@@ -4047,6 +4050,9 @@ msgstr "No se pudo leer la cuenta de Google. Inténtalo de nuevo."
 
 msgid "Could not record cloud workspace"
 msgstr "No se pudo registrar el espacio de trabajo en la nube"
+
+msgid "Could not rename the session"
+msgstr "No se pudo cambiar el nombre de la sesión"
 
 msgid "Could not reopen"
 msgstr "No se pudo reabrir"
@@ -5963,6 +5969,9 @@ msgstr "No se pudo cambiar el nombre"
 msgid "Failed to rename branch"
 msgstr "No se pudo cambiar el nombre de la rama"
 
+msgid "Failed to rename session"
+msgstr "Error al cambiar el nombre de la sesión"
+
 msgid "Failed to reorder"
 msgstr "No se pudo reordenar"
 
@@ -7718,6 +7727,9 @@ msgstr "Salir y eliminar"
 
 msgid "Leave comment mode"
 msgstr "Salir del modo comentario"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Déjalo vacío para volver al nombre que indica la terminal."
 
 msgid "Leave Organization"
 msgstr "Salir de la organización"
@@ -11414,6 +11426,9 @@ msgstr "Quitando…"
 msgid "Rename"
 msgstr "Cambiar nombre"
 
+msgid "Rename {title}"
+msgstr "Cambiar el nombre de {title}"
+
 msgid "Rename branch"
 msgstr "Cambiar nombre de la rama"
 
@@ -11430,6 +11445,9 @@ msgstr "Cambiar nombre del grupo"
 msgid "Rename host"
 msgstr "Cambiar el nombre del host"
 
+msgid "Rename session"
+msgstr "Cambiar el nombre de la sesión"
+
 msgid "rename the branch"
 msgstr "cambiar el nombre de la rama"
 
@@ -11441,6 +11459,9 @@ msgstr "Cambiar el nombre..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Cambiando el nombre de la rama a {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Cambiando el nombre de la sesión a {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Salida renderizada: código, fuentes, citas, contexto"
@@ -12598,8 +12619,17 @@ msgstr "La creación de sesiones en la web llegará pronto"
 msgid "Session details"
 msgstr "Detalles de la sesión"
 
+msgid "Session name"
+msgstr "Nombre de la sesión"
+
+msgid "Session name cleared"
+msgstr "Nombre de la sesión borrado"
+
 msgid "Session notes and context."
 msgstr "Notas y contexto de la sesión."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Nombre de la sesión cambiado a {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Instantáneas de sesión y reversión"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Palier Operator atteint pendant la fenêtre Run 01"
 msgid "Cleared terminal history"
 msgstr "Historique du terminal effacé"
 
+msgid "Clearing session name..."
+msgstr "Effacement du nom de la session..."
+
 msgid "Clearing…"
 msgstr "Effacement…"
 
@@ -4047,6 +4050,9 @@ msgstr "Impossible de lire le compte Google. Veuillez réessayer."
 
 msgid "Could not record cloud workspace"
 msgstr "Impossible d'enregistrer l'espace de travail cloud"
+
+msgid "Could not rename the session"
+msgstr "Impossible de renommer la session"
 
 msgid "Could not reopen"
 msgstr "Impossible de rouvrir"
@@ -5963,6 +5969,9 @@ msgstr "Échec du renommage"
 msgid "Failed to rename branch"
 msgstr "Échec du renommage de la branche"
 
+msgid "Failed to rename session"
+msgstr "Échec du renommage de la session"
+
 msgid "Failed to reorder"
 msgstr "Échec de la réorganisation"
 
@@ -7718,6 +7727,9 @@ msgstr "Quitter et supprimer"
 
 msgid "Leave comment mode"
 msgstr "Quitter le mode commentaire"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Laissez vide pour revenir au nom indiqué par le terminal."
 
 msgid "Leave Organization"
 msgstr "Quitter l'organisation"
@@ -11414,6 +11426,9 @@ msgstr "Suppression…"
 msgid "Rename"
 msgstr "Renommer"
 
+msgid "Rename {title}"
+msgstr "Renommer {title}"
+
 msgid "Rename branch"
 msgstr "Renommer la branche"
 
@@ -11430,6 +11445,9 @@ msgstr "Renommer le groupe"
 msgid "Rename host"
 msgstr "Renommer l'hôte"
 
+msgid "Rename session"
+msgstr "Renommer la session"
+
 msgid "rename the branch"
 msgstr "renommer la branche"
 
@@ -11441,6 +11459,9 @@ msgstr "Renommer..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Renommage de la branche en {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Renommage de la session en {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Sortie rendue : code, sources, citations, contexte"
@@ -12598,8 +12619,17 @@ msgstr "La création de sessions sur le web arrive bientôt"
 msgid "Session details"
 msgstr "Détails de la session"
 
+msgid "Session name"
+msgstr "Nom de la session"
+
+msgid "Session name cleared"
+msgstr "Nom de la session effacé"
+
 msgid "Session notes and context."
 msgstr "Notes et contexte de session."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Session renommée en {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Instantanés de session et retour arrière"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Mencapai Operator dalam periode Run 01"
 msgid "Cleared terminal history"
 msgstr "Riwayat terminal dibersihkan"
 
+msgid "Clearing session name..."
+msgstr "Menghapus nama sesi..."
+
 msgid "Clearing…"
 msgstr "Membersihkan…"
 
@@ -4047,6 +4050,9 @@ msgstr "Tidak bisa membaca akun Google. Silakan coba lagi."
 
 msgid "Could not record cloud workspace"
 msgstr "Tidak bisa mencatat workspace cloud"
+
+msgid "Could not rename the session"
+msgstr "Tidak dapat mengganti nama sesi"
 
 msgid "Could not reopen"
 msgstr "Tidak bisa membuka lagi"
@@ -5963,6 +5969,9 @@ msgstr "Gagal mengganti nama"
 msgid "Failed to rename branch"
 msgstr "Gagal mengganti nama branch"
 
+msgid "Failed to rename session"
+msgstr "Gagal mengganti nama sesi"
+
 msgid "Failed to reorder"
 msgstr "Gagal mengurutkan ulang"
 
@@ -7718,6 +7727,9 @@ msgstr "Keluar dan hapus"
 
 msgid "Leave comment mode"
 msgstr "Keluar dari mode komentar"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Kosongkan untuk kembali ke nama yang dilaporkan terminal."
 
 msgid "Leave Organization"
 msgstr "Keluar dari Organisasi"
@@ -11414,6 +11426,9 @@ msgstr "Menghapus…"
 msgid "Rename"
 msgstr "Ganti nama"
 
+msgid "Rename {title}"
+msgstr "Ganti nama {title}"
+
 msgid "Rename branch"
 msgstr "Ganti nama branch"
 
@@ -11430,6 +11445,9 @@ msgstr "Ganti nama grup"
 msgid "Rename host"
 msgstr "Ganti nama host"
 
+msgid "Rename session"
+msgstr "Ganti nama sesi"
+
 msgid "rename the branch"
 msgstr "mengganti nama branch"
 
@@ -11441,6 +11459,9 @@ msgstr "Ganti nama..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Mengganti nama branch menjadi {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Mengganti nama sesi menjadi {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Output yang dirender: kode, sumber, kutipan, konteks"
@@ -12598,8 +12619,17 @@ msgstr "Pembuatan sesi di web segera hadir"
 msgid "Session details"
 msgstr "Detail sesi"
 
+msgid "Session name"
+msgstr "Nama sesi"
+
+msgid "Session name cleared"
+msgstr "Nama sesi dihapus"
+
 msgid "Session notes and context."
 msgstr "Catatan dan konteks sesi."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Nama sesi diganti menjadi {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Snapshot sesi & pengembalian"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator raggiunto nella finestra Run 01"
 msgid "Cleared terminal history"
 msgstr "Cronologia del terminale cancellata"
 
+msgid "Clearing session name..."
+msgstr "Cancellazione del nome della sessione..."
+
 msgid "Clearing…"
 msgstr "Cancellazione…"
 
@@ -4047,6 +4050,9 @@ msgstr "Impossibile leggere l'account Google. Riprova."
 
 msgid "Could not record cloud workspace"
 msgstr "Impossibile registrare il workspace cloud"
+
+msgid "Could not rename the session"
+msgstr "Impossibile rinominare la sessione"
 
 msgid "Could not reopen"
 msgstr "Impossibile riaprire"
@@ -5963,6 +5969,9 @@ msgstr "Rinomina non riuscita"
 msgid "Failed to rename branch"
 msgstr "Rinomina del branch non riuscita"
 
+msgid "Failed to rename session"
+msgstr "Rinomina della sessione non riuscita"
+
 msgid "Failed to reorder"
 msgstr "Riordino non riuscito"
 
@@ -7718,6 +7727,9 @@ msgstr "Esci ed elimina"
 
 msgid "Leave comment mode"
 msgstr "Esci dalla modalità commento"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Lascialo vuoto per tornare al nome indicato dal terminale."
 
 msgid "Leave Organization"
 msgstr "Esci dall'organizzazione"
@@ -11414,6 +11426,9 @@ msgstr "Rimozione…"
 msgid "Rename"
 msgstr "Rinomina"
 
+msgid "Rename {title}"
+msgstr "Rinomina {title}"
+
 msgid "Rename branch"
 msgstr "Rinomina il branch"
 
@@ -11430,6 +11445,9 @@ msgstr "Rinomina il gruppo"
 msgid "Rename host"
 msgstr "Rinomina l'host"
 
+msgid "Rename session"
+msgstr "Rinomina la sessione"
+
 msgid "rename the branch"
 msgstr "rinominare il branch"
 
@@ -11441,6 +11459,9 @@ msgstr "Rinomina..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Rinomina del branch in {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Rinomina della sessione in {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Output renderizzato: codice, fonti, citazioni, contesto"
@@ -12598,8 +12619,17 @@ msgstr "La creazione di sessioni sul web arriverà presto"
 msgid "Session details"
 msgstr "Dettagli della sessione"
 
+msgid "Session name"
+msgstr "Nome della sessione"
+
+msgid "Session name cleared"
+msgstr "Nome della sessione cancellato"
+
 msgid "Session notes and context."
 msgstr "Note e contesto della sessione."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Sessione rinominata in {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Snapshot e ripristino delle sessioni"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Run 01 期間中に Operator を達成"
 msgid "Cleared terminal history"
 msgstr "ターミナル履歴をクリアしました"
 
+msgid "Clearing session name..."
+msgstr "セッション名をクリア中..."
+
 msgid "Clearing…"
 msgstr "消去中…"
 
@@ -4047,6 +4050,9 @@ msgstr "Googleアカウントを読み取れませんでした。もう一度お
 
 msgid "Could not record cloud workspace"
 msgstr "クラウドワークスペースを記録できませんでした"
+
+msgid "Could not rename the session"
+msgstr "セッションの名前を変更できませんでした"
 
 msgid "Could not reopen"
 msgstr "再オープンできませんでした"
@@ -5963,6 +5969,9 @@ msgstr "名前の変更に失敗しました"
 msgid "Failed to rename branch"
 msgstr "ブランチ名の変更に失敗しました"
 
+msgid "Failed to rename session"
+msgstr "セッションの名前の変更に失敗しました"
+
 msgid "Failed to reorder"
 msgstr "並べ替えに失敗しました"
 
@@ -7718,6 +7727,9 @@ msgstr "退出して削除"
 
 msgid "Leave comment mode"
 msgstr "コメントモードを終了"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "空欄にすると、ターミナルが報告する名前に戻ります。"
 
 msgid "Leave Organization"
 msgstr "組織から退出"
@@ -11414,6 +11426,9 @@ msgstr "削除中…"
 msgid "Rename"
 msgstr "名前を変更"
 
+msgid "Rename {title}"
+msgstr "{title} の名前を変更"
+
 msgid "Rename branch"
 msgstr "ブランチ名を変更"
 
@@ -11430,6 +11445,9 @@ msgstr "グループ名を変更"
 msgid "Rename host"
 msgstr "ホストの名前を変更"
 
+msgid "Rename session"
+msgstr "セッションの名前を変更"
+
 msgid "rename the branch"
 msgstr "ブランチ名を変更する"
 
@@ -11441,6 +11459,9 @@ msgstr "名前を変更..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "ブランチ名を{newName}に変更中..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "セッション名を {trimmed} に変更中..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "描画される出力: コード、ソース、引用、コンテキスト"
@@ -12598,8 +12619,17 @@ msgstr "Web版でのセッション作成は近日公開"
 msgid "Session details"
 msgstr "セッションの詳細"
 
+msgid "Session name"
+msgstr "セッション名"
+
+msgid "Session name cleared"
+msgstr "セッション名をクリアしました"
+
 msgid "Session notes and context."
 msgstr "セッションのノートとコンテキスト。"
+
+msgid "Session renamed to {trimmed}"
+msgstr "セッション名を {trimmed} に変更しました"
 
 msgid "Session snapshots & revert"
 msgstr "セッションのスナップショットと巻き戻し"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Run 01 기간에 Operator 달성"
 msgid "Cleared terminal history"
 msgstr "터미널 기록을 지웠습니다"
 
+msgid "Clearing session name..."
+msgstr "세션 이름을 지우는 중..."
+
 msgid "Clearing…"
 msgstr "삭제하는 중…"
 
@@ -4047,6 +4050,9 @@ msgstr "Google 계정을 읽을 수 없습니다. 다시 시도해 주세요."
 
 msgid "Could not record cloud workspace"
 msgstr "클라우드 워크스페이스를 기록할 수 없습니다"
+
+msgid "Could not rename the session"
+msgstr "세션 이름을 변경할 수 없습니다"
 
 msgid "Could not reopen"
 msgstr "다시 열 수 없습니다"
@@ -5963,6 +5969,9 @@ msgstr "이름을 변경하지 못했습니다"
 msgid "Failed to rename branch"
 msgstr "브랜치 이름을 변경하지 못했습니다"
 
+msgid "Failed to rename session"
+msgstr "세션 이름 변경 실패"
+
 msgid "Failed to reorder"
 msgstr "순서를 변경하지 못했습니다"
 
@@ -7718,6 +7727,9 @@ msgstr "나가고 삭제"
 
 msgid "Leave comment mode"
 msgstr "댓글 모드 나가기"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "비워 두면 터미널이 보고하는 이름으로 돌아갑니다."
 
 msgid "Leave Organization"
 msgstr "조직 나가기"
@@ -11414,6 +11426,9 @@ msgstr "제거하는 중…"
 msgid "Rename"
 msgstr "이름 변경"
 
+msgid "Rename {title}"
+msgstr "{title} 이름 변경"
+
 msgid "Rename branch"
 msgstr "브랜치 이름 변경"
 
@@ -11430,6 +11445,9 @@ msgstr "그룹 이름 변경"
 msgid "Rename host"
 msgstr "호스트 이름 변경"
 
+msgid "Rename session"
+msgstr "세션 이름 변경"
+
 msgid "rename the branch"
 msgstr "브랜치 이름을 변경할"
 
@@ -11441,6 +11459,9 @@ msgstr "이름 변경..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "브랜치 이름을 {newName}(으)로 변경하는 중..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "세션 이름을 {trimmed}(으)로 변경하는 중..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "렌더링된 출력: 코드, 출처, 인용, 컨텍스트"
@@ -12598,8 +12619,17 @@ msgstr "웹에서 세션 만들기는 곧 지원됩니다"
 msgid "Session details"
 msgstr "세션 상세"
 
+msgid "Session name"
+msgstr "세션 이름"
+
+msgid "Session name cleared"
+msgstr "세션 이름을 지웠습니다"
+
 msgid "Session notes and context."
 msgstr "세션 노트와 컨텍스트입니다."
+
+msgid "Session renamed to {trimmed}"
+msgstr "세션 이름을 {trimmed}(으)로 변경했습니다"
 
 msgid "Session snapshots & revert"
 msgstr "세션 스냅샷 및 되돌리기"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator gehaald binnen het Run 01-venster"
 msgid "Cleared terminal history"
 msgstr "Terminalgeschiedenis gewist"
 
+msgid "Clearing session name..."
+msgstr "Sessienaam wissen..."
+
 msgid "Clearing…"
 msgstr "Wissen…"
 
@@ -4047,6 +4050,9 @@ msgstr "Kan het Google-account niet uitlezen. Probeer het opnieuw."
 
 msgid "Could not record cloud workspace"
 msgstr "Kan cloudwerkruimte niet vastleggen"
+
+msgid "Could not rename the session"
+msgstr "Kan de naam van de sessie niet wijzigen"
 
 msgid "Could not reopen"
 msgstr "Kan niet heropenen"
@@ -5963,6 +5969,9 @@ msgstr "Naam wijzigen mislukt"
 msgid "Failed to rename branch"
 msgstr "Naam van branch wijzigen mislukt"
 
+msgid "Failed to rename session"
+msgstr "Naam van de sessie wijzigen mislukt"
+
 msgid "Failed to reorder"
 msgstr "Herordenen mislukt"
 
@@ -7718,6 +7727,9 @@ msgstr "Verlaten en verwijderen"
 
 msgid "Leave comment mode"
 msgstr "Opmerkingsmodus verlaten"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Laat leeg om terug te gaan naar de naam die de terminal doorgeeft."
 
 msgid "Leave Organization"
 msgstr "Organisatie verlaten"
@@ -11414,6 +11426,9 @@ msgstr "Verwijderen…"
 msgid "Rename"
 msgstr "Naam wijzigen"
 
+msgid "Rename {title}"
+msgstr "Naam van {title} wijzigen"
+
 msgid "Rename branch"
 msgstr "Branchnaam wijzigen"
 
@@ -11430,6 +11445,9 @@ msgstr "Groepsnaam wijzigen"
 msgid "Rename host"
 msgstr "Host hernoemen"
 
+msgid "Rename session"
+msgstr "Sessienaam wijzigen"
+
 msgid "rename the branch"
 msgstr "de branch hernoemen"
 
@@ -11441,6 +11459,9 @@ msgstr "Naam wijzigen..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Branch hernoemen naar {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Sessienaam wijzigen in {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Weergegeven output: code, bronnen, citaten, context"
@@ -12598,8 +12619,17 @@ msgstr "Sessies aanmaken op het web komt binnenkort"
 msgid "Session details"
 msgstr "Sessiedetails"
 
+msgid "Session name"
+msgstr "Sessienaam"
+
+msgid "Session name cleared"
+msgstr "Sessienaam gewist"
+
 msgid "Session notes and context."
 msgstr "Sessienotities en context."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Sessienaam gewijzigd in {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Sessiesnapshots en terugdraaien"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator osiągnięty w oknie Run 01"
 msgid "Cleared terminal history"
 msgstr "Wyczyszczono historię terminala"
 
+msgid "Clearing session name..."
+msgstr "Czyszczenie nazwy sesji..."
+
 msgid "Clearing…"
 msgstr "Czyszczenie…"
 
@@ -4047,6 +4050,9 @@ msgstr "Nie udało się odczytać konta Google. Spróbuj ponownie."
 
 msgid "Could not record cloud workspace"
 msgstr "Nie udało się zapisać obszaru roboczego w chmurze"
+
+msgid "Could not rename the session"
+msgstr "Nie można zmienić nazwy sesji"
 
 msgid "Could not reopen"
 msgstr "Nie udało się otworzyć ponownie"
@@ -5963,6 +5969,9 @@ msgstr "Nie udało się zmienić nazwy"
 msgid "Failed to rename branch"
 msgstr "Nie udało się zmienić nazwy gałęzi"
 
+msgid "Failed to rename session"
+msgstr "Nie udało się zmienić nazwy sesji"
+
 msgid "Failed to reorder"
 msgstr "Nie udało się zmienić kolejności"
 
@@ -7718,6 +7727,9 @@ msgstr "Opuść i usuń"
 
 msgid "Leave comment mode"
 msgstr "Wyjdź z trybu komentarzy"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Zostaw puste, aby wrócić do nazwy zgłaszanej przez terminal."
 
 msgid "Leave Organization"
 msgstr "Opuść organizację"
@@ -11414,6 +11426,9 @@ msgstr "Usuwanie…"
 msgid "Rename"
 msgstr "Zmień nazwę"
 
+msgid "Rename {title}"
+msgstr "Zmień nazwę {title}"
+
 msgid "Rename branch"
 msgstr "Zmień nazwę gałęzi"
 
@@ -11430,6 +11445,9 @@ msgstr "Zmień nazwę grupy"
 msgid "Rename host"
 msgstr "Zmień nazwę hosta"
 
+msgid "Rename session"
+msgstr "Zmień nazwę sesji"
+
 msgid "rename the branch"
 msgstr "zmienić nazwy gałęzi"
 
@@ -11441,6 +11459,9 @@ msgstr "Zmień nazwę..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Zmiana nazwy gałęzi na {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Zmiana nazwy sesji na {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Wyrenderowane wyjście: kod, źródła, cytaty, kontekst"
@@ -12598,8 +12619,17 @@ msgstr "Tworzenie sesji w przeglądarce już wkrótce"
 msgid "Session details"
 msgstr "Szczegóły sesji"
 
+msgid "Session name"
+msgstr "Nazwa sesji"
+
+msgid "Session name cleared"
+msgstr "Nazwa sesji wyczyszczona"
+
 msgid "Session notes and context."
 msgstr "Notatki sesji i kontekst."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Zmieniono nazwę sesji na {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Migawki sesji i cofanie"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator alcançado dentro da janela do Run 01"
 msgid "Cleared terminal history"
 msgstr "Histórico do terminal limpo"
 
+msgid "Clearing session name..."
+msgstr "Limpando o nome da sessão..."
+
 msgid "Clearing…"
 msgstr "Limpando…"
 
@@ -4047,6 +4050,9 @@ msgstr "Não foi possível ler a conta Google. Tente novamente."
 
 msgid "Could not record cloud workspace"
 msgstr "Não foi possível registrar a área de trabalho na nuvem"
+
+msgid "Could not rename the session"
+msgstr "Não foi possível renomear a sessão"
 
 msgid "Could not reopen"
 msgstr "Não foi possível reabrir"
@@ -5963,6 +5969,9 @@ msgstr "Falha ao renomear"
 msgid "Failed to rename branch"
 msgstr "Falha ao renomear a branch"
 
+msgid "Failed to rename session"
+msgstr "Falha ao renomear a sessão"
+
 msgid "Failed to reorder"
 msgstr "Falha ao reordenar"
 
@@ -7718,6 +7727,9 @@ msgstr "Sair e apagar"
 
 msgid "Leave comment mode"
 msgstr "Sair do modo de comentários"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Deixe em branco para voltar ao nome informado pelo terminal."
 
 msgid "Leave Organization"
 msgstr "Sair da organização"
@@ -11414,6 +11426,9 @@ msgstr "Removendo…"
 msgid "Rename"
 msgstr "Renomear"
 
+msgid "Rename {title}"
+msgstr "Renomear {title}"
+
 msgid "Rename branch"
 msgstr "Renomear branch"
 
@@ -11430,6 +11445,9 @@ msgstr "Renomear grupo"
 msgid "Rename host"
 msgstr "Renomear host"
 
+msgid "Rename session"
+msgstr "Renomear sessão"
+
 msgid "rename the branch"
 msgstr "renomear a branch"
 
@@ -11441,6 +11459,9 @@ msgstr "Renomear..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Renomeando a branch para {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Renomeando a sessão para {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Saída renderizada: código, fontes, citações, contexto"
@@ -12598,8 +12619,17 @@ msgstr "Criar sessões pela web chega em breve"
 msgid "Session details"
 msgstr "Detalhes da sessão"
 
+msgid "Session name"
+msgstr "Nome da sessão"
+
+msgid "Session name cleared"
+msgstr "Nome da sessão limpo"
+
 msgid "Session notes and context."
 msgstr "Notas e contexto da sessão."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Sessão renomeada para {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Snapshots de sessão e reversão"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Operator достигнут в окне Run 01"
 msgid "Cleared terminal history"
 msgstr "История терминала очищена"
 
+msgid "Clearing session name..."
+msgstr "Очистка имени сессии..."
+
 msgid "Clearing…"
 msgstr "Очистка…"
 
@@ -4047,6 +4050,9 @@ msgstr "Не удалось прочитать аккаунт Google. Попро
 
 msgid "Could not record cloud workspace"
 msgstr "Не удалось записать облачную рабочую область"
+
+msgid "Could not rename the session"
+msgstr "Не удалось переименовать сессию"
 
 msgid "Could not reopen"
 msgstr "Не удалось открыть заново"
@@ -5963,6 +5969,9 @@ msgstr "Не удалось переименовать"
 msgid "Failed to rename branch"
 msgstr "Не удалось переименовать ветку"
 
+msgid "Failed to rename session"
+msgstr "Ошибка переименования сессии"
+
 msgid "Failed to reorder"
 msgstr "Не удалось изменить порядок"
 
@@ -7718,6 +7727,9 @@ msgstr "Выйти и удалить"
 
 msgid "Leave comment mode"
 msgstr "Выйти из режима комментариев"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Оставьте поле пустым, чтобы вернуть имя, которое сообщает терминал."
 
 msgid "Leave Organization"
 msgstr "Покинуть организацию"
@@ -11414,6 +11426,9 @@ msgstr "Удаление…"
 msgid "Rename"
 msgstr "Переименовать"
 
+msgid "Rename {title}"
+msgstr "Переименовать {title}"
+
 msgid "Rename branch"
 msgstr "Переименовать ветку"
 
@@ -11430,6 +11445,9 @@ msgstr "Переименовать группу"
 msgid "Rename host"
 msgstr "Переименовать хост"
 
+msgid "Rename session"
+msgstr "Переименовать сессию"
+
 msgid "rename the branch"
 msgstr "переименовать ветку"
 
@@ -11441,6 +11459,9 @@ msgstr "Переименовать..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Переименование ветки в {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Переименование сессии в {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Отрендеренный вывод: код, источники, цитаты, контекст"
@@ -12598,8 +12619,17 @@ msgstr "Создание сессий в вебе скоро появится"
 msgid "Session details"
 msgstr "Детали сессии"
 
+msgid "Session name"
+msgstr "Имя сессии"
+
+msgid "Session name cleared"
+msgstr "Имя сессии очищено"
+
 msgid "Session notes and context."
 msgstr "Заметки и контекст сессии."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Сессия переименована в {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Снимки сессий и откат"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Run 01 penceresinde Operator tamamlandı"
 msgid "Cleared terminal history"
 msgstr "Terminal geçmişi temizlendi"
 
+msgid "Clearing session name..."
+msgstr "Oturum adı temizleniyor..."
+
 msgid "Clearing…"
 msgstr "Temizleniyor…"
 
@@ -4047,6 +4050,9 @@ msgstr "Google hesabı okunamadı. Lütfen yeniden deneyin."
 
 msgid "Could not record cloud workspace"
 msgstr "Bulut çalışma alanı kaydedilemedi"
+
+msgid "Could not rename the session"
+msgstr "Oturum yeniden adlandırılamadı"
 
 msgid "Could not reopen"
 msgstr "Yeniden açılamadı"
@@ -5963,6 +5969,9 @@ msgstr "Yeniden adlandırılamadı"
 msgid "Failed to rename branch"
 msgstr "Dal yeniden adlandırılamadı"
 
+msgid "Failed to rename session"
+msgstr "Oturumu yeniden adlandırma başarısız oldu"
+
 msgid "Failed to reorder"
 msgstr "Yeniden sıralanamadı"
 
@@ -7718,6 +7727,9 @@ msgstr "Ayrıl ve sil"
 
 msgid "Leave comment mode"
 msgstr "Yorum modundan çık"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Terminalin bildirdiği ada dönmek için boş bırakın."
 
 msgid "Leave Organization"
 msgstr "Kuruluştan ayrıl"
@@ -11414,6 +11426,9 @@ msgstr "Kaldırılıyor…"
 msgid "Rename"
 msgstr "Yeniden adlandır"
 
+msgid "Rename {title}"
+msgstr "{title} adını değiştir"
+
 msgid "Rename branch"
 msgstr "Dalı yeniden adlandır"
 
@@ -11430,6 +11445,9 @@ msgstr "Grubu yeniden adlandır"
 msgid "Rename host"
 msgstr "Host'u yeniden adlandır"
 
+msgid "Rename session"
+msgstr "Oturumu yeniden adlandır"
+
 msgid "rename the branch"
 msgstr "dalı yeniden adlandırma"
 
@@ -11441,6 +11459,9 @@ msgstr "Yeniden adlandır..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Dal {newName} olarak yeniden adlandırılıyor..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Oturum {trimmed} olarak yeniden adlandırılıyor..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "İşlenmiş çıktı: kod, kaynaklar, alıntılar, bağlam"
@@ -12598,8 +12619,17 @@ msgstr "Web'de oturum oluşturma yakında geliyor"
 msgid "Session details"
 msgstr "Oturum ayrıntıları"
 
+msgid "Session name"
+msgstr "Oturum adı"
+
+msgid "Session name cleared"
+msgstr "Oturum adı temizlendi"
+
 msgid "Session notes and context."
 msgstr "Oturum notları ve bağlam."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Oturum {trimmed} olarak yeniden adlandırıldı"
 
 msgid "Session snapshots & revert"
 msgstr "Oturum anlık görüntüleri ve geri alma"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -3069,6 +3069,9 @@ msgstr "Đạt Operator trong khoảng thời gian Run 01"
 msgid "Cleared terminal history"
 msgstr "Đã xóa lịch sử terminal"
 
+msgid "Clearing session name..."
+msgstr "Đang xóa tên phiên..."
+
 msgid "Clearing…"
 msgstr "Đang xóa…"
 
@@ -4047,6 +4050,9 @@ msgstr "Không đọc được tài khoản Google. Vui lòng thử lại."
 
 msgid "Could not record cloud workspace"
 msgstr "Không thể ghi nhận workspace trên cloud"
+
+msgid "Could not rename the session"
+msgstr "Không thể đổi tên phiên"
 
 msgid "Could not reopen"
 msgstr "Không thể mở lại"
@@ -5963,6 +5969,9 @@ msgstr "Không thể đổi tên"
 msgid "Failed to rename branch"
 msgstr "Không thể đổi tên nhánh"
 
+msgid "Failed to rename session"
+msgstr "Đổi tên phiên thất bại"
+
 msgid "Failed to reorder"
 msgstr "Không thể sắp xếp lại"
 
@@ -7718,6 +7727,9 @@ msgstr "Rời và xóa"
 
 msgid "Leave comment mode"
 msgstr "Thoát chế độ bình luận"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "Để trống để quay lại tên do terminal báo cáo."
 
 msgid "Leave Organization"
 msgstr "Rời tổ chức"
@@ -11414,6 +11426,9 @@ msgstr "Đang gỡ…"
 msgid "Rename"
 msgstr "Đổi tên"
 
+msgid "Rename {title}"
+msgstr "Đổi tên {title}"
+
 msgid "Rename branch"
 msgstr "Đổi tên nhánh"
 
@@ -11430,6 +11445,9 @@ msgstr "Đổi tên nhóm"
 msgid "Rename host"
 msgstr "Đổi tên host"
 
+msgid "Rename session"
+msgstr "Đổi tên phiên"
+
 msgid "rename the branch"
 msgstr "đổi tên nhánh"
 
@@ -11441,6 +11459,9 @@ msgstr "Đổi tên..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "Đang đổi tên nhánh thành {newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "Đang đổi tên phiên thành {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "Kết quả hiển thị: code, nguồn, trích dẫn, ngữ cảnh"
@@ -12598,8 +12619,17 @@ msgstr "Tạo phiên trên web sẽ sớm có"
 msgid "Session details"
 msgstr "Chi tiết phiên"
 
+msgid "Session name"
+msgstr "Tên phiên"
+
+msgid "Session name cleared"
+msgstr "Đã xóa tên phiên"
+
 msgid "Session notes and context."
 msgstr "Ghi chú và ngữ cảnh của phiên."
+
+msgid "Session renamed to {trimmed}"
+msgstr "Đã đổi tên phiên thành {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "Ảnh chụp phiên & hoàn tác"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -3069,6 +3069,9 @@ msgstr "在 Run 01 期间达到 Operator"
 msgid "Cleared terminal history"
 msgstr "已清除终端历史"
 
+msgid "Clearing session name..."
+msgstr "正在清除会话名称..."
+
 msgid "Clearing…"
 msgstr "正在清除…"
 
@@ -4047,6 +4050,9 @@ msgstr "无法读取该Google账户。请重试。"
 
 msgid "Could not record cloud workspace"
 msgstr "无法记录云端工作区"
+
+msgid "Could not rename the session"
+msgstr "无法重命名会话"
 
 msgid "Could not reopen"
 msgstr "无法重新打开"
@@ -5963,6 +5969,9 @@ msgstr "重命名失败"
 msgid "Failed to rename branch"
 msgstr "重命名分支失败"
 
+msgid "Failed to rename session"
+msgstr "重命名会话失败"
+
 msgid "Failed to reorder"
 msgstr "重新排序失败"
 
@@ -7718,6 +7727,9 @@ msgstr "退出并删除"
 
 msgid "Leave comment mode"
 msgstr "退出评论模式"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "留空即可恢复终端报告的名称。"
 
 msgid "Leave Organization"
 msgstr "退出组织"
@@ -11414,6 +11426,9 @@ msgstr "正在移除…"
 msgid "Rename"
 msgstr "重命名"
 
+msgid "Rename {title}"
+msgstr "重命名 {title}"
+
 msgid "Rename branch"
 msgstr "重命名分支"
 
@@ -11430,6 +11445,9 @@ msgstr "重命名分组"
 msgid "Rename host"
 msgstr "重命名主机"
 
+msgid "Rename session"
+msgstr "重命名会话"
+
 msgid "rename the branch"
 msgstr "重命名分支"
 
@@ -11441,6 +11459,9 @@ msgstr "重命名..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "正在将分支重命名为{newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "正在将会话重命名为 {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "渲染输出：代码、来源、引用、上下文"
@@ -12598,8 +12619,17 @@ msgstr "网页端创建会话即将推出"
 msgid "Session details"
 msgstr "会话详情"
 
+msgid "Session name"
+msgstr "会话名称"
+
+msgid "Session name cleared"
+msgstr "已清除会话名称"
+
 msgid "Session notes and context."
 msgstr "会话笔记与上下文。"
+
+msgid "Session renamed to {trimmed}"
+msgstr "会话已重命名为 {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "会话快照与回退"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -3069,6 +3069,9 @@ msgstr "在 Run 01 期間達到 Operator"
 msgid "Cleared terminal history"
 msgstr "已清除終端歷史"
 
+msgid "Clearing session name..."
+msgstr "正在清除會話名稱..."
+
 msgid "Clearing…"
 msgstr "正在清除…"
 
@@ -4047,6 +4050,9 @@ msgstr "無法讀取該Google帳戶。請重試。"
 
 msgid "Could not record cloud workspace"
 msgstr "無法記錄雲端工作區"
+
+msgid "Could not rename the session"
+msgstr "無法重新命名會話"
 
 msgid "Could not reopen"
 msgstr "無法重新開啟"
@@ -5963,6 +5969,9 @@ msgstr "重新命名失敗"
 msgid "Failed to rename branch"
 msgstr "重新命名分支失敗"
 
+msgid "Failed to rename session"
+msgstr "重新命名會話失敗"
+
 msgid "Failed to reorder"
 msgstr "重新排序失敗"
 
@@ -7718,6 +7727,9 @@ msgstr "退出並刪除"
 
 msgid "Leave comment mode"
 msgstr "退出評論模式"
+
+msgid "Leave it empty to go back to the name the terminal reports."
+msgstr "留空即可恢復終端回報的名稱。"
 
 msgid "Leave Organization"
 msgstr "退出組織"
@@ -11414,6 +11426,9 @@ msgstr "正在移除…"
 msgid "Rename"
 msgstr "重新命名"
 
+msgid "Rename {title}"
+msgstr "重新命名 {title}"
+
 msgid "Rename branch"
 msgstr "重新命名分支"
 
@@ -11430,6 +11445,9 @@ msgstr "重新命名群組"
 msgid "Rename host"
 msgstr "重新命名主機"
 
+msgid "Rename session"
+msgstr "重新命名會話"
+
 msgid "rename the branch"
 msgstr "重新命名分支"
 
@@ -11441,6 +11459,9 @@ msgstr "重新命名..."
 
 msgid "Renaming branch to {newName}..."
 msgstr "正在將分支重新命名為{newName}..."
+
+msgid "Renaming session to {trimmed}..."
+msgstr "正在將會話重新命名為 {trimmed}..."
 
 msgid "Rendered output: code, sources, citations, context"
 msgstr "渲染輸出：程式碼、來源、引用、上下文"
@@ -12598,8 +12619,17 @@ msgstr "網頁端建立會話即將推出"
 msgid "Session details"
 msgstr "會話詳情"
 
+msgid "Session name"
+msgstr "會話名稱"
+
+msgid "Session name cleared"
+msgstr "已清除會話名稱"
+
 msgid "Session notes and context."
 msgstr "會話筆記與上下文。"
+
+msgid "Session renamed to {trimmed}"
+msgstr "會話已重新命名為 {trimmed}"
 
 msgid "Session snapshots & revert"
 msgstr "會話快照與回退"


### PR DESCRIPTION
A session's name has until now been whatever the shell last reported over OSC: it lives in host-service memory, dies with the process, and changes under you every time an agent animates a spinner. There was no way to say what a session is *for*.

## The shape

- **`terminal_sessions.custom_title`** (migration `0034_terminal_session_custom_title`) plus a `terminal.rename` mutation. The name is a row on the host, not renderer state — so a session with no pane open anywhere can be renamed, the name survives a host-service restart, and a phone and a desktop looking at the same session read the same thing.
- **The host resolves `custom_title ?? oscTitle` in one place** (`sessionDisplayTitle`) and hands clients the answer: the websocket `title` message, the attach handshake, and `terminal.list` — which also returns `customTitle` on its own, so a rename prompt can prefill from it.
- **`normalizeTerminalTitle` does the normalizing**, the same function the shell's own titles go through: trimmed, control characters stripped, capped at 200 — and nothing left means no name, so clearing the field is how you undo a rename.

## Two entry points

| | |
|---|---|
| **Desktop (v2)** | A pencil beside the trash in the terminal session picker, opening a small dialog. Renaming also retires the pane's preset/launch label, which would otherwise sit on top of the name just chosen. v1 is untouched — it already renames a *tab*, renderer-local. |
| **Mobile** | Rename joins Copy session ID and Close in the tab strip's press-and-hold menu. The composer is native and a context menu cannot take text, so it reports the intent and React Native prompts — the same split the close confirm already uses. |

## Verification

Both surfaces were driven for real, not just unit-tested — [evidence page with the screenshots](https://claude.ai/code/artifact/42e94b5c-9cd1-4de0-9efd-7048d4a2e8ef).

- **Desktop**, over CDP against a dev stack: naming, clearing, trimming (`"  Nightly deploy  "` → `Nightly deploy` in the row), Enter and Save, the preset-labelled pane, and no console errors through any of it.
- **Mobile**, on a simulator build of this branch: the menu item, the prompt, the prefill on reopening, saving and clearing.
- **Across devices**: renamed on the phone, and the desktop attached to that same session showed the new name without being asked — pushed down the terminal's own websocket.

Suites green: host-service 1703, desktop 3720, mobile 66. `check:i18n` clean, with all 16 locales translated.

## Known gap

A phone talking to a host-service older than this change gets a procedure-not-found alert from `terminal.rename`. Mobile ships on its own App Store clock, so the two can be apart for a while.

https://claude.ai/code/session_013d4uKxLY3sC2t8xTovSEQ2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user-set name for terminal sessions, on the desktop session picker and the mobile tab strip. Sessions previously showed whatever the shell last reported over OSC — a name that died with the host process and changed whenever agents animated output.

- Names are stored on the host in `terminal_sessions.custom_title` (migration `0034`), so they survive host-service restarts and read the same on every device.
- The host resolves the custom name over the shell's OSC title in one place and sends it through the websocket title message, the attach handshake, and `terminal.list`, which also returns the raw name for prefilling a rename prompt.
- `terminal.rename` normalizes with the same rules as shell titles; submitting an empty name clears the custom name.
- Desktop v2 adds a pencil beside the trash in the session picker, and renaming also retires the pane's preset/launch label.
- Mobile adds Rename to the tab strip's press-and-hold menu; the native context menu can't take text, so React Native prompts like the close confirm already does.
- Known gap: a phone against a host-service older than this change gets a procedure-not-found alert from `terminal.rename`.

<sup>Written for commit a7bc29e9f62efc9a1ee5b762c9975c987111673d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to rename terminal sessions on desktop and mobile.
  - Session names persist across reconnects and appear throughout session lists and tabs.
  - Added options to clear custom names and restore terminal-reported names.
  - Added rename dialogs, context-menu actions, confirmation feedback, and error handling.
- **Localization**
  - Added translated session-renaming labels and messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->