### PR TITLE
feat(mobile): give the plan alert a way to the web

### DIFF
--- a/apps/mobile/lib/web-links.ts
+++ b/apps/mobile/lib/web-links.ts
@@ -8,3 +8,11 @@ import { env } from "@/lib/env";
 export function workspaceShareUrl(workspaceId: string): string {
 	return `${env.EXPO_PUBLIC_WEB_URL.replace(/\/$/, "")}/workspaces/${workspaceId}`;
 }
+
+/**
+ * Where a plan is actually changed. The mobile app never sells a plan — the
+ * organization's owner does it on the web — so the settings row links here.
+ */
+export function billingSettingsUrl(): string {
+	return `${env.EXPO_PUBLIC_WEB_URL.replace(/\/$/, "")}/settings/billing`;
+}

--- a/apps/mobile/screens/(authenticated)/settings/SettingsScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/settings/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import { useSignOut } from "@/hooks/useSignOut";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "@/lib/auth/client";
 import { openUrl } from "@/lib/open-url";
+import { billingSettingsUrl } from "@/lib/web-links";
 import { ListRow } from "@/screens/(authenticated)/components/ListRow";
 import { ListRowValue } from "@/screens/(authenticated)/components/ListRowValue";
 import { OrganizationAvatar } from "@/screens/(authenticated)/components/OrganizationAvatar";
@@ -64,18 +65,24 @@ export function SettingsScreen() {
 		]);
 	};
 
-	// Informational only. Outside the US storefront, App Store guideline 3.1.1
-	// rejects in-app links to an external purchase page, so the plan row says
-	// where billing lives and stops there.
 	const handleManagePlan = () => {
 		Alert.alert(
 			t({
-				message: "Plan is managed on the web",
+				message: "Manage plan on the web",
 			}),
 			t({
-				message: `Your organization's plan is managed by its owner at ${COMPANY.DOMAIN}.`,
+				message: `You can't change this subscription in the app. Your organization's plan is managed by its owner at ${COMPANY.DOMAIN}.`,
 			}),
-			[{ text: t({ message: "OK" }) }],
+			[
+				{
+					style: "cancel",
+					text: t({ message: "Dismiss" }),
+				},
+				{
+					onPress: () => openUrl(billingSettingsUrl()),
+					text: t({ message: `Manage on ${COMPANY.DOMAIN}` }),
+				},
+			],
 		);
 	};
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Spravujte klíče pro přístup k MCP serveru a externí integrace, jako
 msgid "Manage members"
 msgstr "Spravovat členy"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Spravovat na {0}"
+
 msgid "Manage Plan"
 msgstr "Spravovat tarif"
+
+msgid "Manage plan on the web"
+msgstr "Správa tarifu na webu"
 
 msgid "Manage plugins"
 msgstr "Spravovat pluginy"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Offline / local-first režim"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Starší"
 
@@ -10512,9 +10516,6 @@ msgstr "Tarif"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Tarif"
-
-msgid "Plan is managed on the web"
-msgstr "Tarif se spravuje na webu"
 
 msgid "Plan restored"
 msgstr "Tarif obnoven"
@@ -16023,6 +16024,10 @@ msgstr "Jste jediný vlastník organizace, která má další členy. Nejprve p�
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Nemáš pořadí, dokud nebude dní s aktivitou: {0}. Bodování začne, až bude vidět celý obrázek."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Toto předplatné nelze změnit v aplikaci. Tarif vaší organizace spravuje její vlastník na {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Tuto akci nelze vrátit zpět. Panely terminálu zobrazí „Proces skončil“ a půjde je spustit znovu."
 
@@ -16105,10 +16110,6 @@ msgstr "Vaše jméno"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Vaše jméno <0>(pokud váš prompt použijeme, uvedeme vás v changelogu)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Tarif vaší organizace spravuje její vlastník na {0}."
 
 msgid "Your rank"
 msgstr "Vaše pozice"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Verwalte Schlüssel für den MCP-Server-Zugriff und externe Integratione
 msgid "Manage members"
 msgstr "Mitglieder verwalten"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Auf {0} verwalten"
+
 msgid "Manage Plan"
 msgstr "Tarif verwalten"
+
+msgid "Manage plan on the web"
+msgstr "Tarif im Web verwalten"
 
 msgid "Manage plugins"
 msgstr "Plugins verwalten"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Offline- / Local-First-Modus"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Älter"
 
@@ -10512,9 +10516,6 @@ msgstr "Plan"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Tarif"
-
-msgid "Plan is managed on the web"
-msgstr "Tarif wird im Web verwaltet"
 
 msgid "Plan restored"
 msgstr "Tarif wiederhergestellt"
@@ -16023,6 +16024,10 @@ msgstr "Du bist die einzige Inhaberin einer Organisation, die weitere Mitglieder
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Du bist ohne Rang, bis {0} Tage Nutzung aufweisen. Die Bewertung beginnt, sobald das Gesamtbild sichtbar ist."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Dieses Abo lässt sich nicht in der App ändern. Der Tarif deiner Organisation wird von der Inhaberin oder dem Inhaber unter {0} verwaltet."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Das lässt sich nicht rückgängig machen. Terminal-Bereiche zeigen dann \"Process exited\" und können neu gestartet werden."
 
@@ -16105,10 +16110,6 @@ msgstr "Dein Name"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Dein Name <0>(wenn wir deinen Prompt verwenden, nennen wir dich im Changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Der Tarif deiner Organisation wird von der Inhaberin oder dem Inhaber unter {0} verwaltet."
 
 msgid "Your rank"
 msgstr "Dein Rang"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Manage keys for MCP server access and external integrations like Claude 
 msgid "Manage members"
 msgstr "Manage members"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Manage on {0}"
+
 msgid "Manage Plan"
 msgstr "Manage Plan"
+
+msgid "Manage plan on the web"
+msgstr "Manage plan on the web"
 
 msgid "Manage plugins"
 msgstr "Manage plugins"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Offline / local-first mode"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Older"
 
@@ -10512,9 +10516,6 @@ msgstr "Plan"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Plan"
-
-msgid "Plan is managed on the web"
-msgstr "Plan is managed on the web"
 
 msgid "Plan restored"
 msgstr "Plan restored"
@@ -16023,6 +16024,10 @@ msgstr "You are the only owner of an organization that has other members. Transf
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 
@@ -16105,10 +16110,6 @@ msgstr "Your name"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Your organization's plan is managed by its owner at {0}."
 
 msgid "Your rank"
 msgstr "Your rank"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Gestiona las claves de acceso a servidores MCP y a integraciones externa
 msgid "Manage members"
 msgstr "Gestionar miembros"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Gestionar en {0}"
+
 msgid "Manage Plan"
 msgstr "Gestionar el plan"
+
+msgid "Manage plan on the web"
+msgstr "Gestionar el plan en la web"
 
 msgid "Manage plugins"
 msgstr "Gestionar plugins"
@@ -9525,9 +9532,6 @@ msgstr "Sin conexión"
 msgid "Offline / local-first mode"
 msgstr "Modo sin conexión / local primero"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Más antiguo"
 
@@ -10512,9 +10516,6 @@ msgstr "Plan"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Plan"
-
-msgid "Plan is managed on the web"
-msgstr "El plan se gestiona en la web"
 
 msgid "Plan restored"
 msgstr "Plan restaurado"
@@ -16023,6 +16024,10 @@ msgstr "Eres el único propietario de una organización que tiene otros miembros
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "No estás clasificado hasta que haya {0} días con actividad. La puntuación empieza cuando se ve el panorama completo."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "No puedes cambiar esta suscripción en la app. El plan de tu organización lo gestiona su propietario en {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Esta acción no se puede deshacer. Los paneles de terminal mostrarán \"Process exited\" y se pueden reiniciar."
 
@@ -16105,10 +16110,6 @@ msgstr "Tu nombre"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Tu nombre <0>(si usamos tu prompt, te acreditaremos en el registro de cambios)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "El plan de tu organización lo gestiona su propietario en {0}."
 
 msgid "Your rank"
 msgstr "Tu puesto"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Gérez les clés d'accès aux serveurs MCP et aux intégrations externes
 msgid "Manage members"
 msgstr "Gérer les membres"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Gérer sur {0}"
+
 msgid "Manage Plan"
 msgstr "Gérer le forfait"
+
+msgid "Manage plan on the web"
+msgstr "Gérer le forfait sur le web"
 
 msgid "Manage plugins"
 msgstr "Gérer les plugins"
@@ -9525,9 +9532,6 @@ msgstr "Hors ligne"
 msgid "Offline / local-first mode"
 msgstr "Mode hors ligne / local d'abord"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Plus ancien"
 
@@ -10512,9 +10516,6 @@ msgstr "Forfait"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Forfait"
-
-msgid "Plan is managed on the web"
-msgstr "Le forfait est géré sur le web"
 
 msgid "Plan restored"
 msgstr "Forfait rétabli"
@@ -16023,6 +16024,10 @@ msgstr "Vous êtes le seul propriétaire d'une organisation qui compte d'autres 
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Vous n'êtes pas classé tant que {0} jours n'ont pas d'activité. Le score démarre une fois la vue d'ensemble disponible."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Vous ne pouvez pas modifier cet abonnement dans l'application. Le forfait de votre organisation est géré par son propriétaire sur {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Cette action est irréversible. Les volets de terminal afficheront « Processus terminé » et pourront être relancés."
 
@@ -16105,10 +16110,6 @@ msgstr "Votre nom"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Votre nom <0>(si nous utilisons votre prompt, nous vous créditerons dans le changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Le forfait de votre organisation est géré par son propriétaire sur {0}."
 
 msgid "Your rank"
 msgstr "Votre rang"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Kelola kunci untuk akses server MCP dan integrasi eksternal seperti Clau
 msgid "Manage members"
 msgstr "Kelola anggota"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Kelola di {0}"
+
 msgid "Manage Plan"
 msgstr "Kelola Paket"
+
+msgid "Manage plan on the web"
+msgstr "Kelola paket lewat web"
 
 msgid "Manage plugins"
 msgstr "Kelola plugin"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Mode offline / local-first"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Lebih lama"
 
@@ -10512,9 +10516,6 @@ msgstr "Paket"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Paket"
-
-msgid "Plan is managed on the web"
-msgstr "Paket dikelola lewat web"
 
 msgid "Plan restored"
 msgstr "Paket dipulihkan"
@@ -16023,6 +16024,10 @@ msgstr "Anda satu-satunya pemilik organisasi yang punya anggota lain. Alihkan ke
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Anda tanpa peringkat sampai ada {0} hari dengan penggunaan. Penilaian dimulai setelah gambaran utuh terlihat."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Anda tidak bisa mengubah langganan ini di aplikasi. Paket organisasi Anda dikelola oleh pemiliknya di {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Tindakan ini tidak bisa dibatalkan. Panel terminal akan menampilkan \"Process exited\" dan bisa dijalankan ulang."
 
@@ -16105,10 +16110,6 @@ msgstr "Nama Anda"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Nama Anda <0>(kalau prompt Anda kami pakai, kami akan mencantumkan Anda di changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Paket organisasi Anda dikelola oleh pemiliknya di {0}."
 
 msgid "Your rank"
 msgstr "Peringkat Anda"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Gestisci le chiavi per l'accesso ai server MCP e per le integrazioni est
 msgid "Manage members"
 msgstr "Gestisci i membri"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Gestisci su {0}"
+
 msgid "Manage Plan"
 msgstr "Gestisci il piano"
+
+msgid "Manage plan on the web"
+msgstr "Gestisci il piano sul web"
 
 msgid "Manage plugins"
 msgstr "Gestisci i plugin"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Modalità offline / local-first"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Più vecchi"
 
@@ -10512,9 +10516,6 @@ msgstr "Piano"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Piano"
-
-msgid "Plan is managed on the web"
-msgstr "Il piano si gestisce sul web"
 
 msgid "Plan restored"
 msgstr "Piano ripristinato"
@@ -16023,6 +16024,10 @@ msgstr "Sei l'unico proprietario di un'organizzazione che ha altri membri. Trasf
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Non sei classificato finché {0} giorni non registrano attività. Il punteggio parte quando il quadro è completo."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Non puoi modificare questo abbonamento nell'app. Il piano della tua organizzazione è gestito dal proprietario su {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Non puoi annullare questa azione. I pannelli del terminale mostreranno \"Processo terminato\" e potranno essere riavviati."
 
@@ -16105,10 +16110,6 @@ msgstr "Il tuo nome"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Il tuo nome <0>(se usiamo il tuo prompt, ti citeremo nel changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Il piano della tua organizzazione è gestito dal proprietario su {0}."
 
 msgid "Your rank"
 msgstr "La tua posizione"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -8139,8 +8139,15 @@ msgstr "MCPサーバーアクセスやClaude Desktop・Claude Codeなどの外�
 msgid "Manage members"
 msgstr "メンバーを管理"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "{0}で管理"
+
 msgid "Manage Plan"
 msgstr "プランを管理"
+
+msgid "Manage plan on the web"
+msgstr "プランはWebで管理"
 
 msgid "Manage plugins"
 msgstr "プラグインを管理"
@@ -9525,9 +9532,6 @@ msgstr "オフライン"
 msgid "Offline / local-first mode"
 msgstr "オフライン/ローカルファーストモード"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "それ以前"
 
@@ -10512,9 +10516,6 @@ msgstr "計画"
 msgctxt "billing"
 msgid "Plan"
 msgstr "プラン"
-
-msgid "Plan is managed on the web"
-msgstr "プランはWebで管理されています"
 
 msgid "Plan restored"
 msgstr "プランを復元しました"
@@ -16023,6 +16024,10 @@ msgstr "他にメンバーがいる組織の唯一のオーナーです。先に
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "{0}日分の使用実績がそろうまではランク外です。全体像が見えるようになってからスコアリングが始まります。"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "このサブスクリプションはアプリでは変更できません。組織のプランは{0}でオーナーが管理しています。"
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "この操作は元に戻せません。ターミナルペインに「Process exited」と表示され、再起動できます。"
 
@@ -16105,10 +16110,6 @@ msgstr "あなたの名前"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "お名前 <0>(プロンプトを採用した場合、changelogでクレジットします)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "組織のプランは{0}でオーナーが管理しています。"
 
 msgid "Your rank"
 msgstr "あなたのランク"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -8139,8 +8139,15 @@ msgstr "MCP 서버 접근과 Claude Desktop, Claude Code 같은 외부 연동에
 msgid "Manage members"
 msgstr "멤버 관리"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "{0}에서 관리"
+
 msgid "Manage Plan"
 msgstr "플랜 관리"
+
+msgid "Manage plan on the web"
+msgstr "웹에서 플랜 관리"
 
 msgid "Manage plugins"
 msgstr "플러그인 관리"
@@ -9525,9 +9532,6 @@ msgstr "오프라인"
 msgid "Offline / local-first mode"
 msgstr "오프라인 / 로컬 우선 모드"
 
-msgid "OK"
-msgstr "확인"
-
 msgid "Older"
 msgstr "이전"
 
@@ -10512,9 +10516,6 @@ msgstr "계획"
 msgctxt "billing"
 msgid "Plan"
 msgstr "플랜"
-
-msgid "Plan is managed on the web"
-msgstr "플랜은 웹에서 관리합니다"
 
 msgid "Plan restored"
 msgstr "플랜이 복원되었습니다"
@@ -16023,6 +16024,10 @@ msgstr "다른 멤버가 있는 조직의 유일한 소유자입니다. 먼저 �
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "{0}일치 사용 기록이 쌓이기 전까지는 순위가 없습니다. 전체 그림이 보이면 점수 산정이 시작됩니다."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "이 구독은 앱에서 변경할 수 없습니다. 조직의 플랜은 소유자가 {0}에서 관리합니다."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "이 작업은 되돌릴 수 없습니다. 터미널 패널에 \"Process exited\"가 표시되며 다시 시작할 수 있습니다."
 
@@ -16105,10 +16110,6 @@ msgstr "이름"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "이름 <0>(프롬프트를 채택하면 변경 로그에 이름을 남겨 드립니다)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "조직의 플랜은 소유자가 {0}에서 관리합니다."
 
 msgid "Your rank"
 msgstr "내 순위"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Beheer sleutels voor toegang tot MCP-servers en externe integraties zoal
 msgid "Manage members"
 msgstr "Leden beheren"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Beheren op {0}"
+
 msgid "Manage Plan"
 msgstr "Plan beheren"
+
+msgid "Manage plan on the web"
+msgstr "Plan beheren op het web"
 
 msgid "Manage plugins"
 msgstr "Plugins beheren"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Offline / local-first modus"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Ouder"
 
@@ -10512,9 +10516,6 @@ msgstr "Plan"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Plan"
-
-msgid "Plan is managed on the web"
-msgstr "Plan wordt op het web beheerd"
 
 msgid "Plan restored"
 msgstr "Plan hersteld"
@@ -16023,6 +16024,10 @@ msgstr "Je bent de enige eigenaar van een organisatie met andere leden. Draag he
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Je hebt geen positie tot {0} dagen gebruik tonen. De score start zodra het volledige beeld zichtbaar is."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Je kunt dit abonnement niet in de app wijzigen. Het plan van je organisatie wordt beheerd door de eigenaar op {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Dit kun je niet ongedaan maken. Terminalpanelen tonen \"Process exited\" en zijn opnieuw te starten."
 
@@ -16105,10 +16110,6 @@ msgstr "Je naam"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Je naam <0>(als we je prompt gebruiken, vermelden we je in de changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Het plan van je organisatie wordt beheerd door de eigenaar op {0}."
 
 msgid "Your rank"
 msgstr "Je positie"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Zarządzaj kluczami dostępu do serwerów MCP i zewnętrznych integracji
 msgid "Manage members"
 msgstr "Zarządzaj członkami"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Zarządzaj na {0}"
+
 msgid "Manage Plan"
 msgstr "Zarządzaj planem"
+
+msgid "Manage plan on the web"
+msgstr "Zarządzanie planem w przeglądarce"
 
 msgid "Manage plugins"
 msgstr "Zarządzaj wtyczkami"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Tryb offline / local-first"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Starsze"
 
@@ -10512,9 +10516,6 @@ msgstr "Plan"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Plan"
-
-msgid "Plan is managed on the web"
-msgstr "Planem zarządza się w przeglądarce"
 
 msgid "Plan restored"
 msgstr "Plan przywrócony"
@@ -16023,6 +16024,10 @@ msgstr "Jesteś jedynym właścicielem organizacji, która ma innych członków.
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Nie masz rangi, dopóki nie uzbiera się dni z aktywnością: {0}. Punktacja rusza, gdy widać pełny obraz."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Tej subskrypcji nie zmienisz w aplikacji. Planem Twojej organizacji zarządza jej właściciel na {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Tej operacji nie można cofnąć. Panele terminala pokażą „Proces zakończony” i będzie można je uruchomić ponownie."
 
@@ -16105,10 +16110,6 @@ msgstr "Twoje imię"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Twoje imię <0>(jeśli użyjemy Twojego promptu, wymienimy Cię w changelogu)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Planem Twojej organizacji zarządza jej właściciel na {0}."
 
 msgid "Your rank"
 msgstr "Twoja pozycja"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Gerencie as chaves de acesso ao servidor MCP e a integrações externas 
 msgid "Manage members"
 msgstr "Gerenciar membros"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Gerenciar em {0}"
+
 msgid "Manage Plan"
 msgstr "Gerenciar plano"
+
+msgid "Manage plan on the web"
+msgstr "Gerenciar o plano na web"
 
 msgid "Manage plugins"
 msgstr "Gerenciar plugins"
@@ -9525,9 +9532,6 @@ msgstr "Offline"
 msgid "Offline / local-first mode"
 msgstr "Modo offline / local-first"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Mais antigo"
 
@@ -10512,9 +10516,6 @@ msgstr "Plano"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Plano"
-
-msgid "Plan is managed on the web"
-msgstr "O plano é gerenciado na web"
 
 msgid "Plan restored"
 msgstr "Plano restaurado"
@@ -16023,6 +16024,10 @@ msgstr "Você é o único proprietário de uma organização que tem outros memb
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Você fica sem classificação até que {0} dias tenham atividade. A pontuação começa quando o quadro enxerga o quadro completo."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Você não pode alterar esta assinatura no app. O plano da sua organização é gerenciado pelo proprietário em {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Não dá para desfazer. Os painéis de terminal vão mostrar \"Processo encerrado\" e podem ser reiniciados."
 
@@ -16105,10 +16110,6 @@ msgstr "Seu nome"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Seu nome <0>(se usarmos seu prompt, damos os créditos no changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "O plano da sua organização é gerenciado pelo proprietário em {0}."
 
 msgid "Your rank"
 msgstr "Sua posição"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Управляйте ключами для доступа к серве�
 msgid "Manage members"
 msgstr "Управление участниками"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Управлять на {0}"
+
 msgid "Manage Plan"
 msgstr "Управление тарифом"
+
+msgid "Manage plan on the web"
+msgstr "Управление тарифом в веб-версии"
 
 msgid "Manage plugins"
 msgstr "Управление плагинами"
@@ -9525,9 +9532,6 @@ msgstr "Офлайн"
 msgid "Offline / local-first mode"
 msgstr "Офлайн / local-first режим"
 
-msgid "OK"
-msgstr "ОК"
-
 msgid "Older"
 msgstr "Ранее"
 
@@ -10512,9 +10516,6 @@ msgstr "План"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Тариф"
-
-msgid "Plan is managed on the web"
-msgstr "Тарифом управляют в веб-версии"
 
 msgid "Plan restored"
 msgstr "Тариф восстановлен"
@@ -16023,6 +16024,10 @@ msgstr "Вы единственный владелец организации, �
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Вы вне рейтинга, пока не наберётся дней с активностью: {0}. Подсчёт очков начнётся, когда картина станет полной."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Изменить эту подписку в приложении нельзя. Тарифом вашей организации управляет её владелец на {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Это действие нельзя отменить. В панелях терминала появится «Process exited», их можно перезапустить."
 
@@ -16105,10 +16110,6 @@ msgstr "Ваше имя"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Ваше имя <0>(если возьмём ваш промпт, укажем вас в changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Тарифом вашей организации управляет её владелец на {0}."
 
 msgid "Your rank"
 msgstr "Ваше место"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -8139,8 +8139,15 @@ msgstr "MCP sunucusu erişimi ve Claude Desktop veya Claude Code gibi harici ent
 msgid "Manage members"
 msgstr "Üyeleri yönet"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "{0} adresinde yönet"
+
 msgid "Manage Plan"
 msgstr "Planı yönet"
+
+msgid "Manage plan on the web"
+msgstr "Planı web'den yönet"
 
 msgid "Manage plugins"
 msgstr "Eklentileri yönet"
@@ -9525,9 +9532,6 @@ msgstr "Çevrimdışı"
 msgid "Offline / local-first mode"
 msgstr "Çevrimdışı / yerel öncelikli mod"
 
-msgid "OK"
-msgstr "Tamam"
-
 msgid "Older"
 msgstr "Daha eski"
 
@@ -10512,9 +10516,6 @@ msgstr "Plan"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Plan"
-
-msgid "Plan is managed on the web"
-msgstr "Plan web'den yönetiliyor"
 
 msgid "Plan restored"
 msgstr "Plan geri yüklendi"
@@ -16023,6 +16024,10 @@ msgstr "Başka üyeleri olan bir kuruluşun tek sahibisiniz. Önce sahipliği de
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "{0} gün kullanım birikene kadar sıralama dışısın. Tablo bütün resmi gördüğünde puanlama başlar."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Bu aboneliği uygulamada değiştiremezsiniz. Kuruluşunuzun planı, {0} adresinde sahibi tarafından yönetiliyor."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Bu işlemi geri alamazsınız. Terminal bölmelerinde \"Process exited\" görünür ve yeniden başlatılabilirler."
 
@@ -16105,10 +16110,6 @@ msgstr "Adınız"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Adınız <0>(isteminizi kullanırsak değişiklik günlüğünde size teşekkür ederiz)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Kuruluşunuzun planı, {0} adresinde sahibi tarafından yönetiliyor."
 
 msgid "Your rank"
 msgstr "Sıralamanız"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -8139,8 +8139,15 @@ msgstr "Quản lý khóa để truy cập server MCP và các tích hợp bên n
 msgid "Manage members"
 msgstr "Quản lý thành viên"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "Quản lý tại {0}"
+
 msgid "Manage Plan"
 msgstr "Quản lý gói"
+
+msgid "Manage plan on the web"
+msgstr "Quản lý gói trên web"
 
 msgid "Manage plugins"
 msgstr "Quản lý plugin"
@@ -9525,9 +9532,6 @@ msgstr "Ngoại tuyến"
 msgid "Offline / local-first mode"
 msgstr "Chế độ ngoại tuyến / ưu tiên cục bộ"
 
-msgid "OK"
-msgstr "OK"
-
 msgid "Older"
 msgstr "Cũ hơn"
 
@@ -10512,9 +10516,6 @@ msgstr "Kế hoạch"
 msgctxt "billing"
 msgid "Plan"
 msgstr "Gói"
-
-msgid "Plan is managed on the web"
-msgstr "Gói được quản lý trên web"
 
 msgid "Plan restored"
 msgstr "Đã khôi phục gói"
@@ -16023,6 +16024,10 @@ msgstr "Bạn là chủ sở hữu duy nhất của một tổ chức còn thàn
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "Bạn chưa được xếp hạng cho đến khi có {0} ngày hoạt động. Việc tính điểm bắt đầu khi thấy được bức tranh đầy đủ."
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "Bạn không thể thay đổi gói đăng ký này trong ứng dụng. Gói của tổ chức bạn do chủ sở hữu quản lý tại {0}."
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "Không thể hoàn tác thao tác này. Các khung terminal sẽ hiện \"Process exited\" và có thể khởi động lại."
 
@@ -16105,10 +16110,6 @@ msgstr "Tên của bạn"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "Tên của bạn <0>(nếu dùng prompt của bạn, chúng tôi sẽ ghi công trong changelog)</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "Gói của tổ chức bạn do chủ sở hữu quản lý tại {0}."
 
 msgid "Your rank"
 msgstr "Thứ hạng của bạn"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -8139,8 +8139,15 @@ msgstr "管理用于MCP服务器访问以及Claude Desktop、Claude Code等外�
 msgid "Manage members"
 msgstr "管理成员"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "在{0}管理"
+
 msgid "Manage Plan"
 msgstr "管理方案"
+
+msgid "Manage plan on the web"
+msgstr "在网页端管理方案"
 
 msgid "Manage plugins"
 msgstr "管理插件"
@@ -9525,9 +9532,6 @@ msgstr "离线"
 msgid "Offline / local-first mode"
 msgstr "离线/本地优先模式"
 
-msgid "OK"
-msgstr "确定"
-
 msgid "Older"
 msgstr "更早"
 
@@ -10512,9 +10516,6 @@ msgstr "计划"
 msgctxt "billing"
 msgid "Plan"
 msgstr "方案"
-
-msgid "Plan is managed on the web"
-msgstr "方案在网页端管理"
 
 msgid "Plan restored"
 msgstr "方案已恢复"
@@ -16023,6 +16024,10 @@ msgstr "你是某个仍有其他成员的组织的唯一所有者。请先转移
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "在累计 {0} 天使用记录之前你不参与排名。等看板掌握完整情况后才会开始计分。"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "无法在应用内更改此订阅。你所在组织的方案由所有者在{0}管理。"
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "此操作无法撤销。终端窗格会显示“进程已退出”，之后可以重新启动。"
 
@@ -16105,10 +16110,6 @@ msgstr "你的姓名"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "你的名字 <0>（若我们采用你的提示词，会在更新日志中署名致谢）</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "你所在组织的方案由所有者在{0}管理。"
 
 msgid "Your rank"
 msgstr "你的排名"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -8139,8 +8139,15 @@ msgstr "管理用於MCP伺服器存取以及Claude Desktop、Claude Code等外�
 msgid "Manage members"
 msgstr "管理成員"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "Manage on {0}"
+msgstr "在{0}管理"
+
 msgid "Manage Plan"
 msgstr "管理方案"
+
+msgid "Manage plan on the web"
+msgstr "在網頁端管理方案"
 
 msgid "Manage plugins"
 msgstr "管理外掛"
@@ -9525,9 +9532,6 @@ msgstr "離線"
 msgid "Offline / local-first mode"
 msgstr "離線/本地優先模式"
 
-msgid "OK"
-msgstr "確定"
-
 msgid "Older"
 msgstr "更早"
 
@@ -10512,9 +10516,6 @@ msgstr "計劃"
 msgctxt "billing"
 msgid "Plan"
 msgstr "方案"
-
-msgid "Plan is managed on the web"
-msgstr "方案在網頁端管理"
 
 msgid "Plan restored"
 msgstr "方案已恢復"
@@ -16023,6 +16024,10 @@ msgstr "你是某個仍有其他成員的組織的唯一擁有者。請先轉移
 msgid "You are unranked until {0} days carry usage. Scoring starts once the board can see a full picture."
 msgstr "在累計 {0} 天使用紀錄之前你不參與排名。等看板掌握完整情況後才會開始計分。"
 
+#. placeholder {0}: COMPANY.DOMAIN
+msgid "You can't change this subscription in the app. Your organization's plan is managed by its owner at {0}."
+msgstr "無法在應用程式內變更此訂閱。你所在組織的方案由擁有者在{0}管理。"
+
 msgid "You can't undo this action. Terminal panes will show \"Process exited\" and can be restarted."
 msgstr "此操作無法復原。終端窗格會顯示「處理程序已退出」，之後可以重新啟動。"
 
@@ -16105,10 +16110,6 @@ msgstr "你的姓名"
 
 msgid "Your name <0>(if we use your prompt, we'll credit you in the changelog)</0>"
 msgstr "你的名字 <0>（若我們採用你的提示詞，會在更新日誌中署名致謝）</0>"
-
-#. placeholder {0}: COMPANY.DOMAIN
-msgid "Your organization's plan is managed by its owner at {0}."
-msgstr "你所在組織的方案由擁有者在{0}管理。"
 
 msgid "Your rank"
 msgstr "你的排名"


### PR DESCRIPTION
Tapping **Manage Plan** in mobile settings explained that billing lives on the web and then stopped at an `OK` button. It now offers a way to act.

| | before | after |
|---|---|---|
| Title | Plan is managed on the web | Manage plan on the web |
| Body | Your organization's plan is managed by its owner at superset.sh. | You can't change this subscription in the app. Your organization's plan is managed by its owner at superset.sh. |
| Buttons | OK | **Manage on superset.sh** · Dismiss |

`billingSettingsUrl()` joins `workspaceShareUrl()` in `apps/mobile/lib/web-links.ts` and points at `${EXPO_PUBLIC_WEB_URL}/settings/billing`. Title stays sentence case to match the file's other alerts ("Log out?", "Delete account?"), and the body keeps "by its owner" because only the organization owner can actually change the plan. All 16 non-English catalogs are translated; `check:i18n` reports 0 missing.

### Two things worth a second opinion

**This reverses an earlier call on App Store guideline 3.1.1.** The comment this PR deletes read: *"Outside the US storefront, App Store guideline 3.1.1 rejects in-app links to an external purchase page, so the plan row says where billing lives and stops there."* A "Manage on superset.sh" button is that link. The case for shipping it: we never sell a plan through in-app purchase, so this is account management for a multiplatform service. The risk is a review rejection, not a takedown. The alternative is gating the button to the US storefront.

**The destination is thin on a phone.** `app.superset.sh/settings/billing` currently renders "Manage your subscription and billing in the desktop app" with an *Open in Desktop App* deep link and a *Download for Mac* button (`apps/web/src/app/(app)/(page)/settings/billing/page.tsx:42`). Someone tapping through from an iPhone is told to go find a Mac. The real flow is the Stripe portal behind `billing.portal`, but that is owner-only and needs an existing Stripe customer, so wiring mobile to it is a larger change than this one.

### Testing

- `bun run check:i18n` — 0 missing across all 17 locales, `compile --strict` clean
- `bun run --cwd apps/mobile test` — 66 pass
- `bunx biome check` on both changed files — clean
- Typecheck shows no errors in the changed files (the app has pre-existing unrelated errors from unbuilt workspace deps)
- Not yet exercised in a simulator; the alert is a native `Alert.alert`, so iOS decides whether the two buttons sit side by side or stack.

https://claude.ai/code/session_01LyuQjQGF9Cw6sR5cT77PMV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tapping Manage Plan in mobile settings now opens the web app's billing settings instead of stopping at an informational OK dialog. The alert now offers a Manage on superset.sh button and a Dismiss button, with a new title and body translated across all 16 non-English locales.

**Considerations**
- The link out reverses the earlier decision to avoid external billing links due to App Store guideline 3.1.1; the app never sells plans via in-app purchase, so this is account management, but a review rejection remains possible outside the US storefront.
- The destination page renders a desktop-only flow with an Open in Desktop App deep link, so iPhone users may still be steered toward a Mac to actually change billing.

<sup>Written for commit b810796a9cda66af3f800fb8d99a499fb681a3ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a billing settings link from the mobile app to manage plans on the web.
  - Added clearer guidance when subscriptions must be managed online, including organization-owned plans.
  - Billing management messaging is now available in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->