### PR TITLE
fix(desktop): recover missing hosts when toggling remote access

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -737,16 +737,15 @@ export const createSettingsRouter = () => {
 					})
 					.run();
 
-				// Restart active host-service children so they pick up the new
-				// RELAY_URL from buildEnv(). No-op if the user isn't signed in.
+				// Restart host services, including missing authenticated orgs, so
+				// they pick up the new RELAY_URL. No-op when not signed in.
 				const { token } = await loadToken();
 				if (!token) {
 					return { restartedOrgCount: 0 };
 				}
 
 				const coordinator = getHostServiceCoordinator();
-				const restartedOrgCount = coordinator.getActiveOrganizationIds().length;
-				await coordinator.restartAll({
+				const restartedOrgCount = await coordinator.restartAll({
 					authToken: token,
 					cloudApiUrl: env.NEXT_PUBLIC_API_URL,
 				});

--- a/apps/desktop/src/main/lib/host-service-coordinator.test.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.test.ts
@@ -425,6 +425,72 @@ describe("HostServiceCoordinator.reconcile", () => {
 		expect(killedPids).toContainEqual({ pid: 4001, signal: "SIGTERM" });
 	});
 
+	test("restartAll retries and counts authenticated orgs after startup failure", async () => {
+		coordinator.start = mock(async () => {
+			throw new Error("start failed");
+		});
+		await coordinator.reconcile(["org-1", "org-2"], spawnConfig);
+		expect(coordinator.getActiveOrganizationIds()).toEqual([]);
+
+		const restartMock = mock(async () => ({
+			port: 60_000,
+			secret: "secret",
+			machineId: "host-1",
+		}));
+		coordinator.restart = restartMock;
+
+		expect(await coordinator.restartAll(spawnConfig)).toBe(2);
+		expect(restartMock).toHaveBeenCalledWith("org-1", spawnConfig);
+		expect(restartMock).toHaveBeenCalledWith("org-2", spawnConfig);
+
+		await coordinator.reconcile([], spawnConfig);
+		restartMock.mockClear();
+		expect(await coordinator.restartAll(spawnConfig)).toBe(0);
+		expect(restartMock).not.toHaveBeenCalled();
+	});
+
+	test("restartAll restarts an active authenticated org only once", async () => {
+		const connection = { port: 60_000, secret: "secret", machineId: "host-1" };
+		coordinator.start = mock(async () => connection);
+		await coordinator.reconcile(["org-1"], spawnConfig);
+		internals.instances.set("org-1", {
+			...connection,
+			pid: 1001,
+			status: "running",
+			owned: true,
+		});
+		const restartMock = mock(async () => connection);
+		coordinator.restart = restartMock;
+
+		expect(await coordinator.restartAll(spawnConfig)).toBe(1);
+		expect(restartMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("restartAll waits for every org before reporting a startup failure", async () => {
+		const connection = { port: 60_000, secret: "secret", machineId: "host-1" };
+		coordinator.start = mock(async () => connection);
+		await coordinator.reconcile(["org-1", "org-2"], spawnConfig);
+		let releaseStart!: () => void;
+		const pending = new Promise<void>((resolve) => {
+			releaseStart = resolve;
+		});
+		const failure = new Error("Host service process exited during startup");
+		coordinator.restart = mock(async (organizationId: string) => {
+			if (organizationId === "org-1") throw failure;
+			await pending;
+			return connection;
+		});
+		let settled = false;
+		const result = coordinator.restartAll(spawnConfig).catch((error) => {
+			settled = true;
+			return error;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(settled).toBe(false);
+		releaseStart();
+		expect(await result).toBe(failure);
+	});
+
 	test("cancels startup recovery when membership is removed", async () => {
 		coordinator.start = mock(async () => {
 			throw new Error("start failed");

--- a/apps/desktop/src/main/lib/host-service-coordinator.ts
+++ b/apps/desktop/src/main/lib/host-service-coordinator.ts
@@ -574,12 +574,23 @@ export class HostServiceCoordinator extends EventEmitter {
 			.map(([id]) => id);
 	}
 
-	async restartAll(config: SpawnConfig): Promise<void> {
-		await Promise.all(
-			this.getActiveOrganizationIds().map((orgId) =>
-				this.restart(orgId, config),
-			),
+	async restartAll(config: SpawnConfig): Promise<number> {
+		// Failed starts and crashed children may have no active instance. Keep
+		// them in a manual retry using the authenticated membership set, never
+		// host directories left on disk by a previous session.
+		const organizationIds = new Set([
+			...this.desiredOrganizationIds,
+			...this.getActiveOrganizationIds(),
+		]);
+		const results = await Promise.allSettled(
+			[...organizationIds].map((orgId) => this.restart(orgId, config)),
 		);
+		// Don't release the settings mutation while another org is still
+		// restarting: a second toggle could otherwise race that pending start.
+		for (const result of results) {
+			if (result.status === "rejected") throw result.reason;
+		}
+		return organizationIds.size;
 	}
 
 	/**


### PR DESCRIPTION
## What & why

When an authenticated organization's host service is missing after a failed start or crash, toggling Remote Access can show “Setting saved” without starting it. Restart all authenticated desired organizations as well as active services, deduplicating the set, and return the actual target count for the success toast.

Wait for every restart to settle before reporting a failure, so the settings mutation does not release the toggle while another organization's restart is still pending.

Keep Remote Access device-wide: each organization has its own process, and turning remote access off must apply to all of them. This does not introduce per-organization settings or change the existing save-before-restart behavior.

## How I tested it

- `bun test src/main/lib/host-service-coordinator.test.ts` from `apps/desktop`: 61 pass, including regressions for missing-service recovery, deduplication, removed membership, and waiting for pending restarts after a failure.
- `bun run lint`: pass.
- `bun run typecheck`: all 38 tasks pass.
- `bun run check:plugins`: pass.
- `bun run test`: blocked in `@superset/trpc` by missing required environment variables, including `GH_WEBHOOK_SECRET`, provider API keys, and OAuth credentials.
- Real Electron UI via CDP, matched to this worktree at `http://localhost:4845/#/settings/security`, with the authenticated session verified. On the original and fixed builds, disabled Remote Access, deliberately stopped the three services while preserving the authenticated desired set, then clicked the toggle, typed the confirmation, and clicked Enable and restart.

| Observation | Before | After |
| --- | --- | --- |
| Toast | Setting saved | Restarted 3 host services |
| Running services | 0 of 3 | 3 of 3 |
| Local health checks | No active services | HTTP 200 for all three |

Repeated the fixed flow successfully, navigated away and back, and confirmed the toggle remained enabled with no recorded renderer errors. The missing-service setup was deliberately injected; this does not establish the customer's original startup failure or verify relay access from another computer. Temporary diagnostic instrumentation was removed.

Screenshots are stored on a separate verification branch so they do not add binaries to this PR's diff.

| Before | After |
| --- | --- |
| ![Before: Setting saved without recovering services](https://raw.githubusercontent.com/superset-sh/superset/51bcd49595e83dbaa81d415981b258fc018b6cb0/before.png) | ![After: Restarted 3 host services](https://raw.githubusercontent.com/superset-sh/superset/51bcd49595e83dbaa81d415981b258fc018b6cb0/after.png) |

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — not applicable, same-repository branch


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Remote Access toggling so missing host services are recovered after a failed start or crash instead of showing “Setting saved” without starting them. The toggle now restarts all authenticated orgs plus active services, deduplicates overlapping entries, and reports the actual restart count in the success toast.

- Restart failures are only reported after every org’s restart settles, so the settings mutation doesn't release the toggle while another org is still starting.
- Remote Access remains device-wide: each org has its own process, and turning it off applies to all of them. No per-org settings or save-before-restart behavior changes.

<sup>Written for commit f5d78cfa2e39a29f109a2b07817b3e4ccba97891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host service restarts when enabling relay access, including services that previously failed to start or unexpectedly stopped.
  * Ensured all applicable host services are given a restart attempt before an error is reported.
  * Corrected restart counts so status information reflects the services that were actually restarted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->