### PR TITLE
fix(desktop): focus workspace deletion dialogs for native keyboard confirmation

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.test.tsx
@@ -84,14 +84,87 @@ describe("DestroyConfirmPane Enter-to-confirm", () => {
 		expect(page().getByRole("alertdialog")).toBeTruthy();
 		expect(onConfirm).not.toHaveBeenCalled();
 
-		// Once the opening keystroke has finished dispatching, Enter confirms
-		// from anywhere: the closing menu hands focus back outside the dialog.
+		// Focus stays in the dialog after the context menu closes.
 		await act(async () => {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		});
 		await act(async () => {
-			fireEvent.keyDown(document.body, { key: "Enter", code: "Enter" });
+			expect(document.activeElement).toBe(
+				within(page().getByRole("alertdialog")).getByRole("button", {
+					name: "Delete",
+				}),
+			);
+			const action = document.activeElement ?? document.body;
+			expect(fireEvent.keyDown(action, { key: "Enter", code: "Enter" })).toBe(
+				true,
+			);
+			// happy-dom does not synthesize native button activation from keys.
+			// CDP coverage exercises the browser's real Enter-to-click behavior.
+			fireEvent.click(action);
 		});
 		expect(onConfirm).toHaveBeenCalledTimes(1);
 	});
+});
+
+test("opening from an agent input focuses the native action without intercepting typing", async () => {
+	const onConfirm = mock(() => {});
+	const onOpenChange = mock(() => {});
+	const agentKeyDown = mock(() => {});
+	const input = document.createElement("textarea");
+	document.body.append(input);
+	input.focus();
+	window.addEventListener("keydown", agentKeyDown);
+	const props = {
+		open: false,
+		onOpenChange,
+		workspaceName: "ws",
+		deleteBranch: false,
+		onDeleteBranchChange: () => {},
+		hasChanges: false,
+		hasUnpushedCommits: false,
+		canConfirm: true,
+		blockingReason: null,
+		onConfirm,
+		confirmLabel: "Delete",
+	};
+	try {
+		const view = render(<DestroyConfirmPane {...props} />);
+		view.rerender(<DestroyConfirmPane {...props} open />);
+		const dialog = within(document.body).getByRole("alertdialog");
+		const confirm = within(dialog).getByRole("button", { name: "Delete" });
+		expect(document.activeElement).toBe(confirm);
+		fireEvent.keyDown(document.activeElement ?? document.body, { key: "a" });
+		expect(agentKeyDown).toHaveBeenCalledTimes(1);
+		input.focus();
+		expect(document.activeElement).toBe(confirm);
+		expect(fireEvent.keyDown(confirm, { key: "Enter", repeat: true })).toBe(
+			false,
+		);
+		expect(
+			fireEvent.keyDown(confirm, { key: "Enter", isComposing: true }),
+		).toBe(false);
+		expect(onConfirm).not.toHaveBeenCalled();
+		expect(fireEvent.keyDown(confirm, { key: "Enter" })).toBe(true);
+		fireEvent.click(confirm);
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		fireEvent.keyDown(within(dialog).getByRole("button", { name: "Cancel" }), {
+			key: "Enter",
+		});
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		view.rerender(<DestroyConfirmPane {...props} open canConfirm={false} />);
+		fireEvent.keyDown(dialog, { key: "Enter" });
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		view.rerender(<DestroyConfirmPane {...props} />);
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+		input.focus();
+		view.rerender(<DestroyConfirmPane {...props} open canConfirm={false} />);
+		expect(document.activeElement).toBe(
+			within(document.body).getByRole("button", { name: "Cancel" }),
+		);
+	} finally {
+		window.removeEventListener("keydown", agentKeyDown);
+		input.remove();
+	}
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/DestroyConfirmPane/DestroyConfirmPane.tsx
@@ -1,16 +1,17 @@
 import { Trans } from "@lingui/react/macro";
 import {
 	AlertDialog,
-	AlertDialogContent,
+	AlertDialogAction,
+	AlertDialogCancel,
 	AlertDialogDescription,
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
+	EnterEnabledAlertDialogContent,
 } from "@superset/ui/alert-dialog";
-import { Button } from "@superset/ui/button";
 import { Checkbox } from "@superset/ui/checkbox";
 import { Label } from "@superset/ui/label";
-import { useEffect, useId, useRef } from "react";
+import { useId } from "react";
 import { shouldConfirmDeleteDialogKey } from "../../utils/shouldConfirmDeleteDialogKey";
 
 interface DestroyConfirmPaneProps {
@@ -46,38 +47,9 @@ export function DestroyConfirmPane({
 	const checkboxId = useId();
 	const hasWarnings = hasChanges || hasUnpushedCommits;
 
-	// Read through a ref so a re-render while the dialog is open (checkbox
-	// toggle, warning banner) doesn't tear down and re-arm the listener.
-	const onConfirmRef = useRef(onConfirm);
-	useEffect(() => {
-		onConfirmRef.current = onConfirm;
-	}, [onConfirm]);
-
-	useEffect(() => {
-		if (!open || !canConfirm) return;
-
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (!shouldConfirmDeleteDialogKey(event)) return;
-			event.preventDefault();
-			onConfirmRef.current();
-		};
-
-		// Arm after the current task: the Enter that selected "Delete" in a
-		// context menu is still bubbling when this pane mounts, and a listener
-		// added now would confirm the delete on that same keystroke.
-		const timer = setTimeout(
-			() => window.addEventListener("keydown", handleKeyDown),
-			0,
-		);
-		return () => {
-			clearTimeout(timer);
-			window.removeEventListener("keydown", handleKeyDown);
-		};
-	}, [canConfirm, open]);
-
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent className="max-w-[340px] gap-0 p-0">
+			<EnterEnabledAlertDialogContent className="max-w-[340px] gap-0 p-0">
 				<AlertDialogHeader className="px-4 pt-4 pb-2">
 					<AlertDialogTitle className="font-medium">
 						{isSession ? (
@@ -149,15 +121,19 @@ export function DestroyConfirmPane({
 					</div>
 				)}
 				<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-7 px-3 text-xs"
-						onClick={() => onOpenChange(false)}
-					>
+					<AlertDialogCancel className="h-7 border-0 bg-transparent px-3 text-xs shadow-none">
 						<Trans>Cancel</Trans>
-					</Button>
-					<Button
+					</AlertDialogCancel>
+					<AlertDialogAction
+						onKeyDown={(event) => {
+							// Let the button handle Enter natively, except held keys and IME.
+							if (
+								event.key === "Enter" &&
+								!shouldConfirmDeleteDialogKey(event.nativeEvent)
+							) {
+								event.preventDefault();
+							}
+						}}
 						variant="destructive"
 						size="sm"
 						className="h-7 px-3 text-xs"
@@ -165,9 +141,9 @@ export function DestroyConfirmPane({
 						disabled={!canConfirm}
 					>
 						{confirmLabel}
-					</Button>
+					</AlertDialogAction>
 				</AlertDialogFooter>
-			</AlertDialogContent>
+			</EnterEnabledAlertDialogContent>
 		</AlertDialog>
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarDeleteDialog/components/TeardownFailedPane/TeardownFailedPane.tsx
@@ -2,14 +2,14 @@ import { Trans } from "@lingui/react/macro";
 import type { TeardownFailureCause } from "@superset/host-service";
 import {
 	AlertDialog,
-	AlertDialogContent,
+	AlertDialogAction,
+	AlertDialogCancel,
 	AlertDialogDescription,
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
+	EnterEnabledAlertDialogContent,
 } from "@superset/ui/alert-dialog";
-import { Button } from "@superset/ui/button";
-import { useEffect } from "react";
 import stripAnsi from "strip-ansi";
 import { shouldConfirmDeleteDialogKey } from "../../utils/shouldConfirmDeleteDialogKey";
 import { formatTeardownReason } from "./formatTeardownReason";
@@ -33,22 +33,9 @@ export function TeardownFailedPane({
 	// Strip ANSI so raw PTY bytes render readably in the <pre>.
 	const cleanTail = stripAnsi(cause.outputTail ?? "");
 
-	useEffect(() => {
-		if (!open) return;
-
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (!shouldConfirmDeleteDialogKey(event)) return;
-			event.preventDefault();
-			onForceDelete();
-		};
-
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [onForceDelete, open]);
-
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent className="max-w-[500px] gap-0 p-0">
+			<EnterEnabledAlertDialogContent className="max-w-[500px] gap-0 p-0">
 				<AlertDialogHeader className="px-4 pt-4 pb-2">
 					<AlertDialogTitle className="font-medium">{reason}</AlertDialogTitle>
 					<AlertDialogDescription>
@@ -61,24 +48,28 @@ export function TeardownFailedPane({
 					</pre>
 				)}
 				<AlertDialogFooter className="px-4 pb-4 pt-2 flex-row justify-end gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						className="h-7 px-3 text-xs"
-						onClick={() => onOpenChange(false)}
-					>
+					<AlertDialogCancel className="h-7 border-0 bg-transparent px-3 text-xs shadow-none">
 						<Trans>Cancel</Trans>
-					</Button>
-					<Button
+					</AlertDialogCancel>
+					<AlertDialogAction
+						onKeyDown={(event) => {
+							// Let the button handle Enter natively, except held keys and IME.
+							if (
+								event.key === "Enter" &&
+								!shouldConfirmDeleteDialogKey(event.nativeEvent)
+							) {
+								event.preventDefault();
+							}
+						}}
 						variant="destructive"
 						size="sm"
 						className="h-7 px-3 text-xs"
 						onClick={onForceDelete}
 					>
 						<Trans>Delete anyway</Trans>
-					</Button>
+					</AlertDialogAction>
 				</AlertDialogFooter>
-			</AlertDialogContent>
+			</EnterEnabledAlertDialogContent>
 		</AlertDialog>
 	);
 }


### PR DESCRIPTION
## What & why

Opening the workspace delete dialog with Cmd+Shift+Backspace could leave focus in the agent input, so typing went behind the modal and Enter was handled by the underlying input.

Use the existing Enter-enabled alert dialog and its native action/cancel buttons in both the confirmation and teardown-failure panes. Delete receives focus when available, Cancel receives focus when deletion is disabled, and native button activation handles Enter. Remove the global Enter listeners; retain only the action-button guard against held, modified, or composing Enter events.

## How I tested it

- Reproduced the original focus leak in this worktree's authenticated Electron renderer over CDP, then verified the fix using real keyboard and mouse input.
- 51 keyboard assertions: typing isolation, Tab/Shift-Tab wrapping, Space on the branch checkbox, Enter on Cancel, Escape, held/modified Enter, repeated delete hotkeys, and eight open/close cycles.
- Exercised chat, rich agent input, and raw terminal input. Tested context-menu Enter without accidental confirmation.
- Deleted disposable worktrees with Enter. Forced a teardown script failure, confirmed the retry dialog receives focus, and verified a fresh Enter deletes without rerunning teardown. Cleaned up test worktrees and branches. No console errors in the final runs.
- All 3,721 desktop tests pass, including the six dialog/helper tests for disabled-action fallback and IME guards.
- `bun run lint`, `bun run typecheck`, and `bun run check:plugins` pass.
- The default monorepo `bun run test` stops at tRPC environment validation. With `SKIP_ENV_VALIDATION=1 bun run test --env-mode=loose`, 22/23 tasks pass; two unrelated host-agent assertions pick up this machine’s saved Claude profile. Rerunning their test file with an isolated `SUPERSET_HOME_DIR` passes all 51 tests. No source changes were needed for those environment issues.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (same-repository branch)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace deletion dialogs so opening them no longer leaves keyboard focus in the underlying agent input, where typing went behind the modal and Enter was handled by the wrong field.

The Delete button now receives focus when enabled, Cancel receives focus when deletion is disabled, and Enter activates the focused button natively. Global Enter key listeners are removed in favor of the dialog's native buttons; the teardown-failure retry pane gets the same treatment.

<sup>Written for commit c15ed6212e41a2885963b365b750d3bf5d441101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard behavior in deletion confirmation dialogs.
  - The Delete action receives focus when the dialog opens from a context menu.
  - Prevented the key used to open the dialog from immediately confirming deletion.
  - Preserved normal typing and ignored repeated or composing Enter events.
  - Cancel, disabled actions, and native action activation now behave correctly.
  - Updated failed-teardown dialogs to use consistent keyboard handling and prevent unintended force deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

![Before: typing leaks into the agent textarea behind the delete dialog](https://github.com/user-attachments/assets/3ebbeb2b-34ca-4bfd-a35f-a884b49f4043)

![After: Delete has keyboard focus and typing leaves the agent input unchanged](https://github.com/user-attachments/assets/339da3ac-5e64-4fd6-881d-b8e1c83a3f23)
