### PR TITLE
fix(panes): make the pane close X reliably clickable

### DIFF
--- a/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneToolbarActions/PaneToolbarActions.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/WorkspaceView/ContentView/TabsContent/TabView/components/PaneToolbarActions/PaneToolbarActions.tsx
@@ -25,13 +25,26 @@ export function PaneToolbarActions({
 		);
 
 	return (
-		<div className="flex items-center gap-0.5">
+		// The mosaic toolbar is a native drag source, so a press that moves a few
+		// pixels starts a pane drag and the click never fires: making this
+		// wrapper the nearest draggable and canceling its dragstart keeps such a
+		// press a click.
+		// biome-ignore lint/a11y/noStaticElementInteractions: propagation shield around the action buttons, not an interactive control
+		<div
+			className="flex items-center gap-0.5"
+			draggable
+			onDragStart={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+			}}
+		>
 			{leadingActions}
 			<Tooltip delayDuration={1000}>
 				<TooltipTrigger asChild>
 					<button
 						type="button"
 						onClick={onSplitPane}
+						onMouseDown={(e) => e.preventDefault()}
 						className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
 					>
 						{splitIcon}
@@ -44,6 +57,7 @@ export function PaneToolbarActions({
 			<button
 				type="button"
 				onClick={onClosePane}
+				onMouseDown={(e) => e.preventDefault()}
 				className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
 			>
 				<HiMiniXMark className="size-3.5" />

--- a/packages/panes/src/core/store/store.test.ts
+++ b/packages/panes/src/core/store/store.test.ts
@@ -110,6 +110,33 @@ describe("pane operations", () => {
 		expect(store.getState().tabs[0]?.activePaneId).toBe("p2");
 	});
 
+	it("bails out of setActivePane when the pane is already active", () => {
+		const store = makeStore();
+		store.getState().addTab({
+			id: "t1",
+			panes: [tp("p1"), tp("p2")],
+			activePaneId: "p1",
+		});
+
+		const before = store.getState().tabs;
+		store.getState().setActivePane({ tabId: "t1", paneId: "p1" });
+		expect(store.getState().tabs).toBe(before);
+	});
+
+	it("still activates the tab when its already-active pane is focused from another tab", () => {
+		const store = makeStore();
+		store.getState().addTab({
+			id: "t1",
+			panes: [tp("p1")],
+			activePaneId: "p1",
+		});
+		store.getState().addTab({ id: "t2", panes: [tp("p2")] });
+		expect(store.getState().activeTabId).toBe("t2");
+
+		store.getState().setActivePane({ tabId: "t1", paneId: "p1" });
+		expect(store.getState().activeTabId).toBe("t1");
+	});
+
 	it("gets pane by ID across tabs", () => {
 		const store = makeStore();
 		store.getState().addTab({ id: "t1", panes: [tp("p1")] });

--- a/packages/panes/src/core/store/store.ts
+++ b/packages/panes/src/core/store/store.ts
@@ -250,6 +250,11 @@ export function createWorkspaceStore<TData>(
 				const tab = s.tabs.find((t) => t.id === args.tabId);
 				if (!tab || !tab.panes[args.paneId]) return s;
 
+				// Bail out when nothing changes — this fires on every mousedown in a
+				// pane, and new tab objects re-render every pane in the tab.
+				if (s.activeTabId === args.tabId && tab.activePaneId === args.paneId)
+					return s;
+
 				return {
 					activeTabId: args.tabId,
 					tabs: s.tabs.map((t) =>

--- a/packages/panes/src/react/components/PaneHeaderActions/PaneHeaderActions.tsx
+++ b/packages/panes/src/react/components/PaneHeaderActions/PaneHeaderActions.tsx
@@ -10,10 +10,26 @@ export function PaneHeaderActions<TData>({
 	context: RendererContext<TData>;
 }) {
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: stop mousedown from triggering pane focus re-render before click fires
+		// The pane header is a native drag source, so a press that moves a few
+		// pixels starts a pane drag and the click never fires: making this
+		// wrapper the nearest draggable and canceling its dragstart keeps such a
+		// press a click. Preventing mousedown keeps the press from stealing
+		// focus (blurring the terminal) and from triggering the pane-focus
+		// re-render before the click lands; stopping click keeps actions from
+		// also firing the header's click-to-pin.
+		// biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: propagation shield around the action buttons, not an interactive control
 		<div
 			className="flex shrink-0 items-center gap-0.5"
-			onMouseDown={(e) => e.stopPropagation()}
+			draggable
+			onDragStart={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+			}}
+			onMouseDown={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+			}}
+			onClick={(e) => e.stopPropagation()}
 		>
 			{actions.map((action, _index) => {
 				const icon =

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -82,6 +82,29 @@ export function Pane<TData>({
 	const tabs = store.getState().tabs;
 	const tabPosition = tabs.findIndex((t) => t.id === tab.id);
 
+	// Stable component identity for ctx.components.PaneHeaderActions: a fresh
+	// closure per context recompute changes the element type, and React then
+	// remounts the header buttons — a remount between mousedown and mouseup
+	// swallows the click (the close X misfiring). The slot reads the latest
+	// values from a ref instead.
+	const latestHeaderActions = useRef<{
+		actions: PaneActionConfig<TData>[];
+		context: RendererContext<TData>;
+	} | null>(null);
+	const [HeaderActionsSlot] = useState(
+		() =>
+			function HeaderActionsSlot() {
+				const latest = latestHeaderActions.current;
+				if (!latest) return null;
+				return (
+					<PaneHeaderActions
+						actions={latest.actions}
+						context={latest.context}
+					/>
+				);
+			},
+	);
+
 	const context: RendererContext<TData> = useMemo(() => {
 		const ctx: RendererContext<TData> = {
 			pane: { ...pane, parentDirection },
@@ -135,9 +158,8 @@ export function Pane<TData>({
 			workspaceResolved,
 		);
 
-		ctx.components.PaneHeaderActions = () => (
-			<PaneHeaderActions actions={finalActions} context={ctx} />
-		);
+		ctx.components.PaneHeaderActions = HeaderActionsSlot;
+		latestHeaderActions.current = { actions: finalActions, context: ctx };
 
 		return ctx;
 	}, [
@@ -149,6 +171,7 @@ export function Pane<TData>({
 		paneActions,
 		parentDirection,
 		tabPosition,
+		HeaderActionsSlot,
 	]);
 
 	const resolvedContextMenuActions = useMemo(() => {

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
@@ -43,10 +43,20 @@ export function DefaultHeaderContent({
 					</>
 				)}
 			</div>
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: stop drag from starting on action buttons */}
+			{/* The header is a native drag source: canceling dragstart here keeps a
+			    press that moves a few pixels on these controls a click instead of a
+			    pane drag, and stopped clicks keep them from also firing the
+			    header's click-to-pin. */}
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents lint/a11y/noStaticElementInteractions: propagation shield around header controls, not an interactive control */}
 			<div
 				className="flex shrink-0 items-center gap-0.5"
+				draggable
+				onDragStart={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+				}}
 				onMouseDown={(e) => e.stopPropagation()}
+				onClick={(e) => e.stopPropagation()}
 			>
 				{headerExtras}
 				{actionsContent}


### PR DESCRIPTION
## Summary
- The pane header's close X sometimes swallowed clicks and visually "unfocused" the pane, taking several attempts to close. Three stacked defects caused it; all are fixed, in both the v2 `@superset/panes` header and the v1 mosaic toolbar.

## Why / Context
Report from Avi: hovering/going to click the pane X sometimes unfocuses the pane or takes a few clicks to close. Root causes found:

1. **Native drag swallows the click.** The pane header is a react-dnd HTML5 drag source (`draggable=true` on the whole strip), and the X sits inside it. A press that drifts ~4px before release — normal for fast trackpad clicks — makes Chromium start a *pane drag* instead of a click: the click never fires and the header ghosts to `opacity-30` (the "unfocus" flash). The pre-existing `onMouseDown` `stopPropagation` can't prevent native drag initiation.
2. **The buttons remount under the cursor.** `Pane.tsx` created `ctx.components.PaneHeaderActions` as a fresh component *type* on every context recompute, so React unmounted/remounted the button DOM whenever tab state changed — and `setActivePane` wrote new tab objects even when the pane was already active (i.e. on every mousedown anywhere in a pane). A remount between mousedown and mouseup drops the click.
3. **X clicks bubbled into click-to-pin.** For panes with an async `onBeforeClose` (terminals), the bubbled header click pinned the pane before the close resolved — and left it silently pinned if the close confirm was cancelled.

## How It Works
- `PaneHeaderActions` / `DefaultHeaderContent`: the action clusters are now the nearest draggable and cancel their own `dragstart`, so a wiggly press stays a click while dragging by the title/header still works. Clicks no longer propagate to the header's click-to-pin. The X cluster also prevents mousedown default so pressing it can't steal focus from (blur) the terminal.
- `Pane.tsx`: one stable `HeaderActionsSlot` component per pane instance (reads current actions/context from a ref), so context recomputes re-render the buttons instead of remounting them. Public `ctx.components.PaneHeaderActions` API unchanged (BrowserPaneToolbar etc. keep working).
- `store.ts`: `setActivePane` bails out when that pane is already active in the active tab, instead of churning new tab objects on every mousedown.
- v1 `PaneToolbarActions`: same drag shield for the mosaic toolbar, plus mousedown-preventDefault on the split/close buttons.

## Manual QA (verified over CDP against the dev app, real input events, before/after on identical automation)
- [x] **Bug reproduced on HEAD**: 9px wiggle-press on the X → `dragstart` fired on the header, drag began (`Input.dragIntercepted`), pane did **not** close, header ghosted (screenshot captured)
- [x] **Fixed**: identical gesture → no drag initiates, pane closes
- [x] X button DOM node survives active-pane switches with the fix (it remounted on HEAD)
- [x] Clean single click closes (both before and after)
- [x] Pane drag from the title area still initiates and drops (`dragstart` on header + `dragIntercepted`)
- [x] No renderer console errors during any of the above
- [ ] Real-trackpad spot check on a packaged/dev build (CDP synthesizes input; worth one human wiggle-click)

## Testing
- `bun test` in `packages/panes` (112 pass; adds coverage for the `setActivePane` bail-out both ways: identity preserved when already active, tab still switches when focused from another tab)
- `tsc --noEmit` clean in `packages/panes` and `apps/desktop`
- `biome check` clean on all touched files

## Design Decisions
- **Cancelled `dragstart` on a draggable wrapper instead of a drag handle**: keeps the whole header draggable (existing UX) while carving the action buttons out of it; a dedicated drag handle would change interaction design.
- **Per-instance slot component + ref instead of a module-level component**: keeps the `ctx.components.PaneHeaderActions` zero-prop API intact for custom toolbars; precedent for a small in-file helper component is `RootDraggable` in `BasePaneWindow.tsx`.

## Known Limitations
- The browser pane's other toolbar controls (URL bar, nav buttons, overflow menu) still sit unshielded inside the draggable header — drag-to-select text in the URL bar can still start a pane drag. Only the X/actions clusters and default header controls are shielded here; happy to cover the browser toolbar in a follow-up.

https://claude.ai/code/session_014sRdfbRYwEY9qLydkwwdHW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pane close X so a click registers reliably in both `@superset/panes` v2 and the v1 mosaic toolbar. Three stacked defects previously made a slightly wiggly press start a pane drag, remount the button under the cursor, or silently pin the pane — now a single click closes the pane while title-area dragging still works.

**Bug Fixes**

- Action clusters cancel their own `dragstart`, stop click propagation, and prevent `mousedown` default, so fast presses stay clicks, actions no longer trigger the header's click-to-pin, and pressing a button doesn't blur the terminal.
- Header buttons no longer remount between `mousedown` and `mouseup`: each pane uses one stable slot component reading current values from a ref, and `setActivePane` skips redundant focus calls.
- The v1 mosaic toolbar's split/close buttons get the same shields.
- The browser toolbar's URL bar and nav buttons remain unshielded inside the draggable header; covering them would be a follow-up.

<sup>Written for commit c96b09413ebede366fe01a4a3edc4deea4cbedbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane header and toolbar controls so short pointer movements remain clicks instead of starting a drag.
  * Prevented control interactions from unintentionally changing focus, pinning panes, or triggering other header actions.
  * Improved pane selection behavior when the requested pane is already active, avoiding unnecessary state updates.
  * Stabilized pane header actions to prevent controls from unexpectedly resetting during workspace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->