### PR TITLE
fix(desktop): keep new sidebar groups at their source position

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkActions/DashboardSidebarBulkActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarBulkActions/DashboardSidebarBulkActions.tsx
@@ -144,11 +144,6 @@ export function DashboardSidebarBulkActions({
 							</TooltipContent>
 						</Tooltip>
 						<DropdownMenuContent align="end" side="bottom" className="w-48">
-							<DropdownMenuItem onSelect={createGroupFromSelection}>
-								<LuFolderPlus className="size-4" />
-								<Trans>New group</Trans>
-							</DropdownMenuItem>
-							{sectionMenuState === "populated" && <DropdownMenuSeparator />}
 							{sections?.map((section) => (
 								<DropdownMenuItem
 									key={section.id}
@@ -174,6 +169,11 @@ export function DashboardSidebarBulkActions({
 									)}
 								</DropdownMenuItem>
 							)}
+							<DropdownMenuSeparator />
+							<DropdownMenuItem onSelect={createGroupFromSelection}>
+								<LuFolderPlus className="size-4" />
+								<Trans>Create new group</Trans>
+							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceBulkContextMenu/DashboardSidebarWorkspaceBulkContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceBulkContextMenu/DashboardSidebarWorkspaceBulkContextMenu.tsx
@@ -63,11 +63,6 @@ export function DashboardSidebarWorkspaceBulkContextMenu({
 						<Trans>Move {count} to Group</Trans>
 					</ContextMenuSubTrigger>
 					<ContextMenuSubContent>
-						<ContextMenuItem onSelect={createGroupFromSelection}>
-							<LuFolderPlus className="size-4 mr-2" />
-							<Trans>New group</Trans>
-						</ContextMenuItem>
-						{sectionMenuState === "populated" && <ContextMenuSeparator />}
 						{sections?.map((section) => (
 							<ContextMenuItem
 								key={section.id}
@@ -91,6 +86,11 @@ export function DashboardSidebarWorkspaceBulkContextMenu({
 								)}
 							</ContextMenuItem>
 						)}
+						<ContextMenuSeparator />
+						<ContextMenuItem onSelect={createGroupFromSelection}>
+							<LuFolderPlus className="size-4 mr-2" />
+							<Trans>Create new group</Trans>
+						</ContextMenuItem>
 					</ContextMenuSubContent>
 				</ContextMenuSub>
 				{groupedWorkspaceIds.length > 0 && (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/components/DashboardSidebarWorkspaceContextMenu/DashboardSidebarWorkspaceContextMenu.tsx
@@ -133,7 +133,6 @@ export function DashboardSidebarWorkspaceContextMenu({
 						</>
 					)}
 				</ContextMenuItem>
-				<ContextMenuSeparator />
 				{onRename && (
 					<ContextMenuItem onSelect={onRename}>
 						<LuPencil className="size-4 mr-2" />
@@ -208,31 +207,33 @@ export function DashboardSidebarWorkspaceContextMenu({
 							<LuFolderPlus className="size-4 mr-2" />
 							<Trans>New group from workspace</Trans>
 						</ContextMenuItem>
-						{(sections.length > 0 || isInSection) && <ContextMenuSeparator />}
-						{sections.length > 0 && (
-							<ContextMenuSub>
-								<ContextMenuSubTrigger>
-									<LuArrowRightLeft className="size-4 mr-2" />
-									<Trans>Move to group</Trans>
-								</ContextMenuSubTrigger>
-								<ContextMenuSubContent>
-									{sections.map((section) => (
-										<ContextMenuItem
-											key={section.id}
-											onSelect={() => onMoveToSection(section.id)}
-										>
-											{section.color && (
-												<span
-													className="size-2 shrink-0 rounded-full mr-2"
-													style={{ backgroundColor: section.color }}
-												/>
-											)}
-											{section.name}
-										</ContextMenuItem>
-									))}
-								</ContextMenuSubContent>
-							</ContextMenuSub>
-						)}
+						<ContextMenuSub>
+							<ContextMenuSubTrigger>
+								<LuArrowRightLeft className="size-4 mr-2" />
+								<Trans>Move to group</Trans>
+							</ContextMenuSubTrigger>
+							<ContextMenuSubContent>
+								{sections.map((section) => (
+									<ContextMenuItem
+										key={section.id}
+										onSelect={() => onMoveToSection(section.id)}
+									>
+										{section.color && (
+											<span
+												className="size-2 shrink-0 rounded-full mr-2"
+												style={{ backgroundColor: section.color }}
+											/>
+										)}
+										{section.name}
+									</ContextMenuItem>
+								))}
+								{sections.length > 0 && <ContextMenuSeparator />}
+								<ContextMenuItem onSelect={onCreateSection}>
+									<LuFolderPlus className="size-4 mr-2" />
+									<Trans>Create new group</Trans>
+								</ContextMenuItem>
+							</ContextMenuSubContent>
+						</ContextMenuSub>
 						{isInSection && (
 							<ContextMenuItem onSelect={() => onMoveToSection(null)}>
 								<LuArrowUp className="size-4 mr-2" />

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarWorkspaceItem/hooks/useDashboardSidebarWorkspaceItemActions/useDashboardSidebarWorkspaceItemActions.ts
@@ -1,9 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
 import { errorMessage } from "@superset/i18n/errors";
-import {
-	normalizeWorkspaceTags,
-	SESSIONS_TAG_SCOPE,
-} from "@superset/shared/workspace-tags";
+import { normalizeWorkspaceTags } from "@superset/shared/workspace-tags";
 import { toast } from "@superset/ui/sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
@@ -24,11 +21,7 @@ import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/u
 import { useOptimisticActions } from "renderer/routes/_authenticated/hooks/useOptimisticActions";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLocalHostService } from "renderer/routes/_authenticated/providers/LocalHostServiceProvider";
-import {
-	applyFolderTagChange,
-	buildSidebarFolderKey,
-	mintFolderTag,
-} from "renderer/routes/_authenticated/utils/workspaceTagFolders";
+import { applyFolderTagChange } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import { useDeleteWorkspaceIntent } from "renderer/stores/delete-workspace-intent";
 import { useRemoveFromSidebarIntent } from "renderer/stores/remove-workspace-from-sidebar-intent";
 import { useV2NotificationStore } from "renderer/stores/v2-notifications";
@@ -169,16 +162,8 @@ export function useDashboardSidebarWorkspaceItemActions({
 	};
 
 	const handleCreateSection = () => {
-		if (projectId === null) {
-			if (!isSessionWorkspace) return;
-			const tag = mintFolderTag("New group", sessionGroupTags);
-			void workspaceActions.updateWorkspace(workspaceId, {
-				tags: applyFolderTagChange(currentWorkspaceTags, sessionGroupTags, tag),
-			});
-			requestSectionRename(buildSidebarFolderKey(SESSIONS_TAG_SCOPE, tag));
-			return;
-		}
-		const sectionId = createSection(projectId);
+		if (projectId === null && !isSessionWorkspace) return;
+		const sectionId = createSection(projectId, { workspaceIds: [workspaceId] });
 		moveWorkspaceToSection(workspaceId, projectId, sectionId);
 		requestSectionRename(sectionId);
 	};

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useBulkWorkspaceMoveActions/useBulkWorkspaceMoveActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/hooks/useBulkWorkspaceMoveActions/useBulkWorkspaceMoveActions.ts
@@ -1,15 +1,8 @@
-import {
-	normalizeWorkspaceTags,
-	SESSIONS_TAG_SCOPE,
-} from "@superset/shared/workspace-tags";
+import { normalizeWorkspaceTags } from "@superset/shared/workspace-tags";
 import { useDashboardSidebarState } from "renderer/routes/_authenticated/hooks/useDashboardSidebarState";
 import { useOptimisticActions } from "renderer/routes/_authenticated/hooks/useOptimisticActions";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
-import {
-	applyFolderTagChange,
-	buildSidebarFolderKey,
-	mintFolderTag,
-} from "renderer/routes/_authenticated/utils/workspaceTagFolders";
+import { applyFolderTagChange } from "renderer/routes/_authenticated/utils/workspaceTagFolders";
 import { useDashboardSidebarSectionRename } from "../../components/DashboardSidebarSectionRenameContext";
 import { useDashboardSidebarSelection } from "../../providers/DashboardSidebarSelectionProvider";
 import type { DashboardSidebarWorkspace } from "../../types";
@@ -90,15 +83,8 @@ export function useBulkWorkspaceMoveActions({
 	};
 
 	const createGroupFromSelection = () => {
-		if (projectId === null) {
-			const tag = mintFolderTag("New group", sessionTags);
-			for (const workspaceId of selectedIds)
-				updateSessionWorkspaceGroup(workspaceId, tag);
-			clearSelection();
-			requestSectionRename(buildSidebarFolderKey(SESSIONS_TAG_SCOPE, tag));
-			return;
-		}
-		const sectionId = createSection(projectId);
+		if (selectedIds.length === 0) return;
+		const sectionId = createSection(projectId, { workspaceIds: selectedIds });
 		for (const workspaceId of selectedIds) {
 			moveWorkspaceToSection(workspaceId, projectId, sectionId);
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/useDashboardSidebarState.ts
@@ -47,6 +47,8 @@ import {
 	tombstoneSidebarWorkspaceRecord,
 } from "./sidebarMutations";
 
+import { getNewGroupTabOrder } from "./utils/getNewGroupTabOrder";
+
 type ProjectTopLevelItem = {
 	type: "workspace" | "section";
 	id: string;
@@ -575,40 +577,67 @@ export function useDashboardSidebarState() {
 	);
 
 	const createSection = useCallback(
-		(projectId: string, options: { name?: string } = {}) => {
-			const { name = "New group" } = options;
-			ensureSidebarProjectRecord(collections, projectId);
-
-			// A folder IS a tag: mint one from the name (collisions get -2)
-			// and key the presentation row by it.
-			const tag = mintFolderTag(
-				name,
-				getProjectFolderIndex(
-					collections,
-					hostWorkspaces,
-					tagFolderContext,
-					projectId,
-				).keys(),
+		(
+			projectId: string | null,
+			options: { name?: string; workspaceIds?: readonly string[] } = {},
+		) => {
+			const { name = "New group", workspaceIds = [] } = options;
+			if (projectId !== null)
+				ensureSidebarProjectRecord(collections, projectId);
+			const scope = tagFolderScope(projectId);
+			const folderIndex = getProjectFolderIndex(
+				collections,
+				hostWorkspaces,
+				tagFolderContext,
+				projectId,
 			);
-			const sectionId = buildSidebarFolderKey(projectId, tag);
+			const tag = mintFolderTag(name, folderIndex.keys());
+			const sectionId = buildSidebarFolderKey(scope, tag);
 			if (collections.v2SidebarSections.get(sectionId)) return sectionId;
 			const randomColor =
 				PROJECT_CUSTOM_COLORS[
 					Math.floor(Math.random() * PROJECT_CUSTOM_COLORS.length)
 				].value;
 
-			const tabOrder = getNextTabOrder(
-				getProjectTopLevelItems(
+			const topLevelItems = getProjectTopLevelItems(
+				collections,
+				hostWorkspaces,
+				tagFolderContext,
+				projectId,
+			);
+			const folders = [...folderIndex.values()];
+			const sources = workspaceIds.flatMap((workspaceId) => {
+				const workspace = collections.v2WorkspaceLocalState.get(workspaceId);
+				if (!workspace || workspace.sidebarState.projectId !== projectId)
+					return [];
+				const sourceSectionId = getEffectiveSectionId(
 					collections,
 					hostWorkspaces,
 					tagFolderContext,
-					projectId,
-				),
+					workspace,
+				);
+				if (sourceSectionId === null) {
+					return [
+						{ tabOrder: workspace.sidebarState.tabOrder, isGrouped: false },
+					];
+				}
+				const folder =
+					folders.find((item) => item.sectionId === sourceSectionId) ??
+					collections.v2SidebarSections.get(sourceSectionId);
+				return folder ? [{ tabOrder: folder.tabOrder, isGrouped: true }] : [];
+			});
+			const tabOrder = getNewGroupTabOrder(
+				sources,
+				[
+					...topLevelItems.map((item) => item.tabOrder),
+					...folders.map((item) => item.tabOrder),
+				],
+				getNextTabOrder(topLevelItems),
 			);
 
 			collections.v2SidebarSections.insert({
 				sectionId,
-				projectId,
+				projectId: scope,
 				name,
 				createdAt: new Date(),
 				tabOrder,
@@ -617,7 +646,7 @@ export function useDashboardSidebarState() {
 				tag,
 			});
 			// Seed presentation beside the host-owned membership tags.
-			writeTagSetting(projectId, tag, {
+			writeTagSetting(scope, tag, {
 				displayName: name,
 				color: randomColor,
 			});

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/utils/getNewGroupTabOrder/getNewGroupTabOrder.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/utils/getNewGroupTabOrder/getNewGroupTabOrder.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { getNewGroupTabOrder } from "./getNewGroupTabOrder";
+
+describe("getNewGroupTabOrder", () => {
+	test("replaces the source workspace slot without moving later siblings", () => {
+		expect(
+			getNewGroupTabOrder([{ tabOrder: 2, isGrouped: false }], [1, 2, 3, 8], 9),
+		).toBe(2);
+	});
+	test("uses the first visual position regardless of selection order", () => {
+		expect(
+			getNewGroupTabOrder(
+				[
+					{ tabOrder: 8, isGrouped: false },
+					{ tabOrder: 2, isGrouped: false },
+				],
+				[1, 2, 3, 8],
+				9,
+			),
+		).toBe(2);
+	});
+	test("places a former group member between that group and its next sibling", () => {
+		expect(
+			getNewGroupTabOrder(
+				[{ tabOrder: 2, isGrouped: true }],
+				[1, 2, 2.5, 8],
+				9,
+			),
+		).toBe(2.25);
+	});
+	test("places a member of the last group immediately after it", () => {
+		expect(
+			getNewGroupTabOrder([{ tabOrder: 8, isGrouped: true }], [1, 2, 8], 9),
+		).toBe(9);
+	});
+	test("keeps standalone group creation at the supplied default", () => {
+		expect(getNewGroupTabOrder([], [1, 2, 8], 9)).toBe(9);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/utils/getNewGroupTabOrder/getNewGroupTabOrder.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/utils/getNewGroupTabOrder/getNewGroupTabOrder.ts
@@ -1,0 +1,25 @@
+interface GroupSourcePosition {
+	tabOrder: number;
+	isGrouped: boolean;
+}
+
+/** Replace an ungrouped row's slot, or insert just after its existing group. */
+export function getNewGroupTabOrder(
+	sources: GroupSourcePosition[],
+	topLevelOrders: number[],
+	fallback: number,
+): number {
+	const first = sources.reduce<GroupSourcePosition | undefined>(
+		(earliest, source) =>
+			!earliest || source.tabOrder < earliest.tabOrder ? source : earliest,
+		undefined,
+	);
+	if (!first) return fallback;
+	if (!first.isGrouped) return first.tabOrder;
+	const next = Math.min(
+		...topLevelOrders.filter((order) => order > first.tabOrder),
+	);
+	return Number.isFinite(next)
+		? first.tabOrder + (next - first.tabOrder) / 2
+		: first.tabOrder + 1;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/utils/getNewGroupTabOrder/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useDashboardSidebarState/utils/getNewGroupTabOrder/index.ts
@@ -1,0 +1,1 @@
+export { getNewGroupTabOrder } from "./getNewGroupTabOrder";

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Vytvořit merge commit"
 msgid "Create Merge Commit"
 msgstr "Vytvořit merge commit"
 
+msgid "Create new group"
+msgstr "Vytvořit novou skupinu"
+
 msgid "Create new project"
 msgstr "Vytvořit nový projekt"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Merge-Commit erstellen"
 msgid "Create Merge Commit"
 msgstr "Merge-Commit erstellen"
 
+msgid "Create new group"
+msgstr "Neue Gruppe erstellen"
+
 msgid "Create new project"
 msgstr "Neues Projekt erstellen"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Create merge commit"
 msgid "Create Merge Commit"
 msgstr "Create Merge Commit"
 
+msgid "Create new group"
+msgstr "Create new group"
+
 msgid "Create new project"
 msgstr "Create new project"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Crear un commit de fusión"
 msgid "Create Merge Commit"
 msgstr "Crear commit de fusión"
 
+msgid "Create new group"
+msgstr "Crear nuevo grupo"
+
 msgid "Create new project"
 msgstr "Crear un proyecto nuevo"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Créer un commit de fusion"
 msgid "Create Merge Commit"
 msgstr "Créer un commit de fusion"
 
+msgid "Create new group"
+msgstr "Créer un nouveau groupe"
+
 msgid "Create new project"
 msgstr "Créer un projet"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Buat merge commit"
 msgid "Create Merge Commit"
 msgstr "Buat Merge Commit"
 
+msgid "Create new group"
+msgstr "Buat grup baru"
+
 msgid "Create new project"
 msgstr "Buat proyek baru"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Crea un commit di merge"
 msgid "Create Merge Commit"
 msgstr "Crea un commit di merge"
 
+msgid "Create new group"
+msgstr "Crea nuovo gruppo"
+
 msgid "Create new project"
 msgstr "Crea un nuovo progetto"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -4296,6 +4296,9 @@ msgstr "マージコミットを作成"
 msgid "Create Merge Commit"
 msgstr "マージコミットを作成"
 
+msgid "Create new group"
+msgstr "新しいグループを作成"
+
 msgid "Create new project"
 msgstr "新規プロジェクトを作成"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -4296,6 +4296,9 @@ msgstr "머지 커밋 만들기"
 msgid "Create Merge Commit"
 msgstr "머지 커밋 만들기"
 
+msgid "Create new group"
+msgstr "새 그룹 만들기"
+
 msgid "Create new project"
 msgstr "새 프로젝트 만들기"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Merge-commit maken"
 msgid "Create Merge Commit"
 msgstr "Merge-commit maken"
 
+msgid "Create new group"
+msgstr "Nieuwe groep maken"
+
 msgid "Create new project"
 msgstr "Nieuw project maken"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Utwórz commit scalający"
 msgid "Create Merge Commit"
 msgstr "Utwórz commit scalający"
 
+msgid "Create new group"
+msgstr "Utwórz nową grupę"
+
 msgid "Create new project"
 msgstr "Utwórz nowy projekt"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Criar commit de merge"
 msgid "Create Merge Commit"
 msgstr "Criar commit de merge"
 
+msgid "Create new group"
+msgstr "Criar novo grupo"
+
 msgid "Create new project"
 msgstr "Criar novo projeto"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Создать коммит слияния"
 msgid "Create Merge Commit"
 msgstr "Создать коммит слияния"
 
+msgid "Create new group"
+msgstr "Создать новую группу"
+
 msgid "Create new project"
 msgstr "Создать проект"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Birleştirme commit'i oluştur"
 msgid "Create Merge Commit"
 msgstr "Birleştirme commit'i oluştur"
 
+msgid "Create new group"
+msgstr "Yeni grup oluştur"
+
 msgid "Create new project"
 msgstr "Yeni proje oluştur"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -4296,6 +4296,9 @@ msgstr "Tạo merge commit"
 msgid "Create Merge Commit"
 msgstr "Tạo merge commit"
 
+msgid "Create new group"
+msgstr "Tạo nhóm mới"
+
 msgid "Create new project"
 msgstr "Tạo dự án mới"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -4296,6 +4296,9 @@ msgstr "创建合并提交"
 msgid "Create Merge Commit"
 msgstr "创建合并提交"
 
+msgid "Create new group"
+msgstr "创建新分组"
+
 msgid "Create new project"
 msgstr "新建项目"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -4296,6 +4296,9 @@ msgstr "建立合併提交"
 msgid "Create Merge Commit"
 msgstr "建立合併提交"
 
+msgid "Create new group"
+msgstr "建立新群組"
+
 msgid "Create new project"
 msgstr "新建專案"
 


### PR DESCRIPTION
## What & why

Creating a sidebar group from a workspace now places the group at the source workspace's position instead of appending it. Bulk creation uses the earliest selected position; an already-grouped workspace creates a sibling group directly after its current group. Project workspaces and sessions share this behavior.

Add **Create new group** at the bottom of the single-workspace and bulk move menus, including when no groups exist. Keep group actions together and put Pin alongside Rename. Translate the new label in every shipping locale.

![Updated workspace context menu](https://raw.githubusercontent.com/superset-sh/superset/pr-evidence/sidebar-groups-31192ab5/menu.png)

## How I tested it

- CDP against this worktree's signed-in Electron renderer (`localhost:4245`, CDP `9248`), using real menu clicks and before/after screenshots.
- Reproduced the position jump before the fix. Afterward, a project workspace at y=780 creates its group header at y=780 without scrolling; a session at y=420 likewise creates its group at y=420.
- Verified single-workspace submenu and bulk menu creation, focused/selected rename input, saving a name, and navigation. The originally reported missing rename focus did not reproduce; rename focus logic is unchanged.
- Five ordering tests pass, covering source position, bulk selection order, existing groups, and standalone creation.
- `bun run lint`, `bun run typecheck`, `bun run check:i18n`, and `bun run check:plugins` pass.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not a fork)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creating a sidebar group from a workspace now places the group at the source workspace's position instead of appending it at the end.

**Behavior changes**
- Bulk creation uses the earliest selected workspace's position; a workspace already in a group creates a sibling group directly after it.
- Added "Create new group" to the single-workspace and bulk move menus, including when no groups exist, and moved Pin next to Rename.
- Translated the new menu label in all shipping locales.

<sup>Written for commit 31192ab5b998765a6f26c7cba6e6ac644320c0c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Create new group** option at the bottom of move-to-group menus.
  - Group creation is now available even when no groups currently exist.
  - Creating a group from selected workspaces preserves intuitive sidebar ordering.
  - Workspace and bulk actions now use the same group-creation flow.

- **Localization**
  - Added translations for the new action across supported languages.

- **Tests**
  - Added coverage for group placement and ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->