### PR TITLE
fix(host-service): persist PR links before fetching review details

### DIFF
--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -2582,3 +2582,72 @@ describe("PR identity is published before enrichment", () => {
 		});
 	}
 });
+
+for (const nextBranch of ["new-branch", "feature"]) {
+	test(`a queued ref sync revalidates discovery before database refs catch up: ${nextBranch}`, async () => {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "feature",
+			headSha: "abc123",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "feature",
+		});
+		let branch = "feature";
+		let release!: () => void;
+		let entered!: () => void;
+		const pending = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const started = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		const answer = ghAnsweringPr(
+			makePrNode({ number: 7, headRef: "feature", headSha: "abc123" }),
+			{},
+		);
+		const manager = createManager(db, {
+			readWorkspaceRefs: async () => ({
+				branch,
+				headSha: "abc123",
+				upstream:
+					branch === "feature"
+						? { owner: REPO.owner, name: REPO.name, branch }
+						: null,
+			}),
+			execGh: async (args) => {
+				entered();
+				await pending;
+				return answer(args);
+			},
+		});
+		const refresh = manager.refreshPullRequestsByWorkspaces(["ws"]);
+		try {
+			await started;
+			branch = nextBranch;
+			const queued = (
+				manager as unknown as {
+					enqueueWorkspaceSync(id: string): Promise<void>;
+				}
+			).enqueueWorkspaceSync("ws");
+			expect(getWorkspace(db, "ws")?.branch).toBe("feature");
+			release();
+			await Promise.all([refresh, queued]);
+			expect(getWorkspace(db, "ws")?.branch).toBe(nextBranch);
+			if (nextBranch === "new-branch") {
+				expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
+				expect(
+					db.select().from(schema.workspacePullRequests).all(),
+				).toHaveLength(0);
+			} else {
+				expect(getWorkspace(db, "ws")?.pullRequestId).toBeTruthy();
+			}
+		} finally {
+			release();
+			await refresh;
+			manager.stop();
+		}
+	});
+}

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.test.ts
@@ -2426,3 +2426,159 @@ describe("PullRequestRuntimeManager GitHub traffic", () => {
 		expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
 	});
 });
+
+describe("PR identity is published before enrichment", () => {
+	function fixture(execGh?: (args: string[]) => Promise<unknown>) {
+		const db = createRealDb();
+		seedProject(db);
+		seedWorkspace(db, {
+			id: "ws",
+			branch: "feature",
+			headSha: "abc123",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "feature",
+		});
+		return { db, manager: createManager(db, { execGh }) };
+	}
+
+	test("publishes a link while reviews are pending and does not restore it after unlink", async () => {
+		let release!: () => void;
+		let entered!: () => void;
+		const pending = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const started = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		const answer = ghAnsweringPr(
+			makePrNode({ number: 7, headRef: "feature", headSha: "abc123" }),
+			{},
+		);
+		const { db, manager } = fixture(async (args) => {
+			if (args.some((arg) => arg.endsWith("/reviews"))) {
+				entered();
+				await pending;
+			}
+			return answer(args);
+		});
+		const refresh = projectRefresher(manager)(PROJECT_ID);
+		try {
+			await started;
+			expect(getWorkspace(db, "ws")?.pullRequestId).toBeTruthy();
+			await manager.unlinkWorkspacePullRequest("ws");
+			release();
+			await refresh;
+			expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
+		} finally {
+			release();
+			await refresh;
+			manager.stop();
+		}
+	});
+
+	test("publishes a discovered link before another branch lookup finishes", async () => {
+		let release!: () => void;
+		const pending = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const answer = ghAnsweringPr(
+			makePrNode({ number: 7, headRef: "feature", headSha: "abc123" }),
+			{},
+		);
+		const { db, manager } = fixture(async (args) => {
+			if (args.some((arg) => arg.includes(":slow"))) await pending;
+			return answer(args);
+		});
+		seedWorkspace(db, {
+			id: "slow",
+			branch: "slow",
+			upstreamOwner: REPO.owner,
+			upstreamRepo: REPO.name,
+			upstreamBranch: "slow",
+		});
+		const refresh = projectRefresher(manager)(PROJECT_ID);
+		try {
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(getWorkspace(db, "ws")?.pullRequestId).toBeTruthy();
+		} finally {
+			release();
+			await refresh;
+			manager.stop();
+		}
+	});
+
+	test("does not link an old branch when its lookup completes after a branch change", async () => {
+		let release!: () => void;
+		let entered!: () => void;
+		const pending = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const started = new Promise<void>((resolve) => {
+			entered = resolve;
+		});
+		const answer = ghAnsweringPr(
+			makePrNode({ number: 7, headRef: "feature", headSha: "abc123" }),
+			{},
+		);
+		const { db, manager } = fixture(async (args) => {
+			entered();
+			await pending;
+			return answer(args);
+		});
+		const refresh = projectRefresher(manager)(PROJECT_ID);
+		try {
+			await started;
+			db.update(workspaces)
+				.set({ branch: "other", upstreamBranch: "other" })
+				.where(eq(workspaces.id, "ws"))
+				.run();
+			release();
+			await refresh;
+			expect(getWorkspace(db, "ws")?.pullRequestId).toBeNull();
+		} finally {
+			release();
+			await refresh;
+			manager.stop();
+		}
+	});
+
+	for (const moved of [false, true]) {
+		test(`created PR persists without GitHub requests or ref changes (workspace moved: ${moved})`, async () => {
+			const { db, manager } = fixture();
+			const expectedWorkspace = getWorkspace(db, "ws");
+			if (!expectedWorkspace) throw new Error("Missing fixture workspace");
+			if (moved)
+				db.update(workspaces)
+					.set({ headSha: "new-head" })
+					.where(eq(workspaces.id, "ws"))
+					.run();
+			const before = getWorkspace(db, "ws");
+			if (!before) throw new Error("Missing fixture workspace");
+			try {
+				const id = await manager.linkWorkspaceToCreatedPullRequest({
+					workspaceId: "ws",
+					projectId: PROJECT_ID,
+					expectedWorkspace,
+					pullRequest: {
+						number: 7,
+						url: "https://github.com/base-owner/base-repo/pull/7",
+						title: "Known PR",
+						state: "open",
+						headRefName: "feature",
+						headRefOid: "remote-head",
+						isCrossRepository: false,
+					},
+				});
+				expect(id === null).toBe(moved);
+				expect(getPrByNumber(db, 7)?.title).toBe("Known PR");
+				expect(getWorkspace(db, "ws")).toEqual({
+					...before,
+					pullRequestId: id,
+				});
+			} finally {
+				manager.stop();
+			}
+		});
+	}
+});

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -942,6 +942,15 @@ export class PullRequestRuntimeManager {
 	private workspaceStillMatches(
 		expected: typeof workspaces.$inferSelect,
 	): boolean {
+		// A Git event can queue behind the refresh currently awaiting GitHub.
+		// Its database refs are still old, so equality alone cannot authorize
+		// this result. Let the queued sync re-read refs and retry discovery even
+		// when the event turns out not to have changed the branch.
+		const sync = this.workspaceSyncState.get(expected.id);
+		if (sync?.rerunPending) {
+			sync.bypassCache = true;
+			return false;
+		}
 		const current = this.db
 			.select()
 			.from(workspaces)

--- a/packages/host-service/src/runtime/pull-requests/pull-requests.ts
+++ b/packages/host-service/src/runtime/pull-requests/pull-requests.ts
@@ -566,6 +566,33 @@ export class PullRequestRuntimeManager {
 		projectId: string;
 		pullRequest: CheckoutPullRequestMetadata;
 	}): Promise<string | null> {
+		return this.linkWorkspaceToKnownPullRequest({
+			workspaceId,
+			projectId,
+			pullRequest,
+		});
+	}
+
+	async linkWorkspaceToCreatedPullRequest(input: {
+		workspaceId: string;
+		projectId: string;
+		pullRequest: CheckoutPullRequestMetadata;
+		expectedWorkspace: typeof workspaces.$inferSelect;
+	}): Promise<string | null> {
+		return this.linkWorkspaceToKnownPullRequest(input);
+	}
+
+	private async linkWorkspaceToKnownPullRequest({
+		workspaceId,
+		projectId,
+		pullRequest,
+		expectedWorkspace,
+	}: {
+		workspaceId: string;
+		projectId: string;
+		pullRequest: CheckoutPullRequestMetadata;
+		expectedWorkspace?: typeof workspaces.$inferSelect;
+	}): Promise<string | null> {
 		const repo = await this.getProjectRepository(projectId);
 		if (!repo) {
 			console.warn(
@@ -599,17 +626,22 @@ export class PullRequestRuntimeManager {
 			now,
 		});
 
+		if (expectedWorkspace && !this.workspaceStillMatches(expectedWorkspace))
+			return null;
 		const upstream = deriveCheckoutPullRequestUpstream(repo, pullRequest);
 		this.db
 			.update(workspaces)
 			.set({
 				pullRequestId: rowId,
-				// An explicit checkout link overrides an earlier "Remove PR Link".
 				suppressedPullRequestId: null,
-				headSha: pullRequest.headRefOid,
-				upstreamOwner: upstream?.owner ?? null,
-				upstreamRepo: upstream?.name ?? null,
-				upstreamBranch: upstream?.branch ?? null,
+				...(expectedWorkspace
+					? {}
+					: {
+							headSha: pullRequest.headRefOid,
+							upstreamOwner: upstream?.owner ?? null,
+							upstreamRepo: upstream?.name ?? null,
+							upstreamBranch: upstream?.branch ?? null,
+						}),
 			})
 			.where(eq(workspaces.id, workspaceId))
 			.run();
@@ -907,6 +939,28 @@ export class PullRequestRuntimeManager {
 		await refreshPromise;
 	}
 
+	private workspaceStillMatches(
+		expected: typeof workspaces.$inferSelect,
+	): boolean {
+		const current = this.db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.id, expected.id))
+			.get();
+		return (
+			!!current &&
+			current.archivedAt == null &&
+			current.projectId === expected.projectId &&
+			current.pullRequestId === expected.pullRequestId &&
+			current.branch === expected.branch &&
+			current.headSha === expected.headSha &&
+			current.upstreamOwner === expected.upstreamOwner &&
+			current.upstreamRepo === expected.upstreamRepo &&
+			current.upstreamBranch === expected.upstreamBranch &&
+			current.suppressedPullRequestId === expected.suppressedPullRequestId
+		);
+	}
+
 	private async performProjectRefresh(
 		projectId: string,
 		options: ProjectRefreshOptions = {},
@@ -930,12 +984,16 @@ export class PullRequestRuntimeManager {
 		if (projectWorkspaces.length === 0) return;
 
 		const wantedRefs = new Map<string, GitHubPullRequestHeadRef>();
+		const workspacesByKey = new Map<string, typeof projectWorkspaces>();
 		for (const workspace of projectWorkspaces) {
 			const upstreamOwner = workspace.upstreamOwner;
 			const upstreamRepo = workspace.upstreamRepo;
 			const upstreamBranch = workspace.upstreamBranch ?? workspace.branch;
 			const key = this.effectiveUpstreamKey(workspace, repo);
 			if (key && upstreamOwner && upstreamRepo) {
+				const interested = workspacesByKey.get(key) ?? [];
+				interested.push(workspace);
+				workspacesByKey.set(key, interested);
 				wantedRefs.set(key, {
 					owner: upstreamOwner,
 					repo: upstreamRepo,
@@ -945,9 +1003,31 @@ export class PullRequestRuntimeManager {
 		}
 
 		const { failedKeys, matched: keyToPullRequest } =
-			await this.fetchRepoPullRequests(projectId, repo, wantedRefs, options);
+			await this.fetchRepoPullRequests(
+				projectId,
+				repo,
+				wantedRefs,
+				options,
+				(key, id) => {
+					for (const workspace of workspacesByKey.get(key) ?? []) {
+						if (
+							workspace.suppressedPullRequestId === id ||
+							!this.workspaceStillMatches(workspace)
+						)
+							continue;
+						this.db
+							.update(workspaces)
+							.set({ pullRequestId: id })
+							.where(eq(workspaces.id, workspace.id))
+							.run();
+						this.recordWorkspacePullRequestLink(workspace.id, id, Date.now());
+						workspace.pullRequestId = id;
+					}
+				},
+			);
 
 		for (const workspace of projectWorkspaces) {
+			if (!this.workspaceStillMatches(workspace)) continue;
 			const key = this.effectiveUpstreamKey(workspace, repo);
 			if (!key) {
 				// PR checkouts recovered from GitHub's archived refs intentionally
@@ -1513,6 +1593,7 @@ export class PullRequestRuntimeManager {
 		repo: NormalizedRepoIdentity,
 		wantedRefs: Map<string, GitHubPullRequestHeadRef>,
 		options: { bypassCache?: boolean } = {},
+		onDiscovered?: (key: string, id: string) => void,
 	): Promise<{
 		matched: Map<string, { id: string }>;
 		failedKeys: Set<string>;
@@ -1520,6 +1601,47 @@ export class PullRequestRuntimeManager {
 		const matched = new Map<string, { id: string }>();
 		const failedKeys = new Set<string>();
 		if (wantedRefs.size === 0) return { matched, failedKeys };
+
+		const persist = (
+			key: string,
+			node: GitHubPullRequestNode,
+			details?: PullRequestDetails,
+		) => {
+			const now = Date.now();
+			const existing = this.findPullRequestRow(repo, node.number);
+			// Identity can be saved before details; keep their last-known state.
+			const checks = details
+				? parseCheckContexts(details.checks)
+				: parseChecksJson(existing?.checksJson ?? null);
+			const reviewDecision = details
+				? mapReviewDecision(details.reviewDecision)
+				: coerceReviewDecision(existing?.reviewDecision ?? null);
+			const isInMergeQueue =
+				details?.isInMergeQueue ??
+				coercePullRequestState(existing?.state ?? null) === "queued";
+			const rowId = this.upsertPullRequestRow({
+				existing,
+				projectId,
+				prNumber: node.number,
+				repo,
+				url: node.url,
+				title: node.title,
+				state: mapPullRequestState(node.state, node.isDraft, isInMergeQueue),
+				isDraft: node.isDraft,
+				headBranch: node.headRefName,
+				headSha: node.headRefOid,
+				mergedAt: node.mergedAt,
+				reviewDecision,
+				checksStatus: computeChecksStatus(checks),
+				checksJson: JSON.stringify(checks),
+				lastFetchedAt: now,
+				error: null,
+				now,
+			});
+
+			matched.set(key, { id: rowId });
+			if (!details) onDiscovered?.(key, rowId);
+		};
 
 		const latestByKey = new Map<string, GitHubPullRequestNode>();
 		await Promise.all(
@@ -1537,7 +1659,10 @@ export class PullRequestRuntimeManager {
 						node.headRepository?.name ?? null,
 						node.headRefName,
 					);
-					if (nodeKey === key) latestByKey.set(key, node);
+					if (nodeKey === key) {
+						latestByKey.set(key, node);
+						persist(key, node);
+					}
 				} catch (error) {
 					failedKeys.add(key);
 					console.warn(
@@ -1581,7 +1706,10 @@ export class PullRequestRuntimeManager {
 				}
 				for (const key of unmatchedKeys) {
 					const node = openByLowerKey.get(key.toLowerCase());
-					if (node) latestByKey.set(key, node);
+					if (node) {
+						latestByKey.set(key, node);
+						persist(key, node);
+					}
 				}
 			} catch (error) {
 				// Treat the whole sweep as failed lookups so existing links are
@@ -1594,16 +1722,20 @@ export class PullRequestRuntimeManager {
 			}
 		}
 
-		const now = Date.now();
-
-		const detailsByNumber = new Map<number, PullRequestDetails>();
 		await Promise.all(
-			Array.from(latestByKey.values()).map(async (node) => {
+			Array.from(latestByKey.entries()).map(async ([key, node]) => {
 				try {
-					detailsByNumber.set(
-						node.number,
-						await this.getCachedPullRequestDetails(repo, node, options),
+					const details = await this.getCachedPullRequestDetails(
+						repo,
+						node,
+						options,
 					);
+					// A newer discovery may have advanced this PR while details were in flight.
+					if (
+						this.findPullRequestRow(repo, node.number)?.headSha ===
+						node.headRefOid
+					)
+						persist(key, node, details);
 				} catch (error) {
 					console.warn(
 						"[host-service:pull-request-runtime] Failed to fetch PR review/check state",
@@ -1618,42 +1750,6 @@ export class PullRequestRuntimeManager {
 				}
 			}),
 		);
-
-		for (const [key, node] of latestByKey) {
-			const existing = this.findPullRequestRow(repo, node.number);
-			// A failed fetch keeps the last-known state rather than blanking it.
-			const details = detailsByNumber.get(node.number);
-			const checks = details
-				? parseCheckContexts(details.checks)
-				: parseChecksJson(existing?.checksJson ?? null);
-			const reviewDecision = details
-				? mapReviewDecision(details.reviewDecision)
-				: coerceReviewDecision(existing?.reviewDecision ?? null);
-			const isInMergeQueue =
-				details?.isInMergeQueue ??
-				coercePullRequestState(existing?.state ?? null) === "queued";
-			const rowId = this.upsertPullRequestRow({
-				existing,
-				projectId,
-				prNumber: node.number,
-				repo,
-				url: node.url,
-				title: node.title,
-				state: mapPullRequestState(node.state, node.isDraft, isInMergeQueue),
-				isDraft: node.isDraft,
-				headBranch: node.headRefName,
-				headSha: node.headRefOid,
-				mergedAt: node.mergedAt,
-				reviewDecision,
-				checksStatus: computeChecksStatus(checks),
-				checksJson: JSON.stringify(checks),
-				lastFetchedAt: now,
-				error: null,
-				now,
-			});
-
-			matched.set(key, { id: rowId });
-		}
 
 		return { matched, failedKeys };
 	}

--- a/packages/host-service/src/trpc/router/pull-requests/procedures/create-for-workspace.ts
+++ b/packages/host-service/src/trpc/router/pull-requests/procedures/create-for-workspace.ts
@@ -1,3 +1,4 @@
+import type { Octokit } from "@octokit/rest";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
@@ -21,8 +22,8 @@ const createInputSchema = z.object({
  * Creates a GitHub PR from the workspace's current branch. The base is the
  * branch's configured `branch.<name>.base` (what the Changes panel's base
  * selector writes) falling back to the repo default branch. After creation
- * the workspace's PR link is refreshed immediately so the UI doesn't wait
- * out the next background sync tick.
+ * persist the returned PR directly; discovery and review/check requests must
+ * not delay the workspace link.
  */
 export const createForWorkspace = protectedProcedure
 	.input(createInputSchema)
@@ -70,7 +71,7 @@ export const createForWorkspace = protectedProcedure
 
 		const repo = await resolveGithubRepo(ctx, workspace.projectId);
 		const octokit = await ctx.github();
-		let created: { number: number; html_url: string };
+		let created: Awaited<ReturnType<Octokit["pulls"]["create"]>>["data"];
 		try {
 			const { data } = await octokit.pulls.create({
 				owner: repo.owner,
@@ -88,16 +89,36 @@ export const createForWorkspace = protectedProcedure
 				"GitHub refused to create the pull request.",
 			);
 		}
-		// The PR exists at this point — a refresh hiccup (rate limit, transient
-		// network) must not surface as a create failure; the background sync
-		// links it within its next pass anyway.
+		// The PR exists at this point. A local persistence failure must not
+		// report creation as failed and encourage a duplicate remote mutation.
+		// Background discovery can retry the association.
 		try {
-			await ctx.runtime.pullRequests.refreshPullRequestsByWorkspaces([
-				input.workspaceId,
-			]);
+			await ctx.runtime.pullRequests.linkWorkspaceToCreatedPullRequest({
+				workspaceId: input.workspaceId,
+				projectId: workspace.projectId,
+				expectedWorkspace: workspace,
+				pullRequest: {
+					number: created.number,
+					url: created.html_url,
+					title: created.title,
+					state: created.merged_at
+						? "merged"
+						: created.state === "closed"
+							? "closed"
+							: "open",
+					isDraft: created.draft,
+					mergedAt: created.merged_at,
+					headRefName: created.head.ref,
+					headRefOid: created.head.sha,
+					headRepositoryOwner: created.head.repo?.owner.login,
+					headRepositoryName: created.head.repo?.name,
+					isCrossRepository:
+						created.head.repo?.full_name !== created.base.repo.full_name,
+				},
+			});
 		} catch (error) {
 			console.warn(
-				"[pull-requests:create-for-workspace] created PR but failed to refresh workspace link",
+				"[pull-requests:create-for-workspace] created PR but failed to save workspace link",
 				{ workspaceId: input.workspaceId, prNumber: created.number, error },
 			);
 		}


### PR DESCRIPTION
## What & why

PR discovery previously waited for every review/check request in a project before saving workspace links. A slow request could leave an already-discovered PR invisible. Save each discovered link immediately, then persist detail results as they complete. PR creation now saves GitHub's successful response directly instead of running discovery again.

Recheck workspace refs, archive status and link/suppression state before applying delayed results. The create path preserves the local HEAD/upstream; checkout linking retains its existing behavior. Seven regressions cover pending reviews, an unrelated slow lookup, branch changes, and direct creation linking with and without a concurrent workspace change, plus changed/unchanged refs queued during discovery.

This is the small first fix from the PR-discovery investigation. CLI commands, shared quota scheduling, retry redesign and cloud synchronization remain follow-ups. It does not establish that James's host-specific issue is fully resolved.

## How I tested it

- 85 tests pass across runtime, GitHub query/availability and scaling integration suites (288 assertions), run from `packages/host-service` for its test setup.
- Host-service `bun run typecheck` passes.
- Repository-wide `bun run lint` passes.
- Repository-wide `bun run typecheck` passes after refreshing dependencies with the frozen lockfile.
- CDP on this worktree’s renderer :6545 / API :6541 / debugger :9245: reproduced the missing-link baseline, then verified links while reviews were held; context-menu unlink; 24 workspace switches; 20 review-tab switches; restart suppression; and the create form with discovery held. Provider responses were controlled; no remote test PR was created.
- A real terminal branch-switch test exposed a queued-ref race; the follow-up guard and two regressions fix it. Before/after screenshots and details: https://app.superset.sh/page/pr-discovery-make-the-link-immediate-w35nc9
- Removed all temporary instrumentation, restored the original branch and verified the live GitHub link/checks. No production release performed.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not a fork)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Pull requests created from a workspace are linked immediately.
  - Pull request identity is saved before reviews and checks are loaded.
  - Workspace links are protected from outdated branch or enrichment results.
  - Pull requests checked out or discovered during project refreshes are associated more reliably.
  - Workspace synchronization revalidates branch changes, removing outdated links without creating unnecessary history entries.
  - If immediate linking is unavailable, background discovery can retry without interrupting pull request creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->