### PR TITLE
feat(email): put the App Store badge back in the footer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -905,6 +905,7 @@
         "@react-email/components": "1.0.1",
         "@react-email/tailwind": "2.0.3",
         "@superset/db": "workspace:*",
+        "@superset/shared": "workspace:*",
         "@t3-oss/env-core": "0.13.11",
         "date-fns": "4.1.0",
         "drizzle-orm": "0.45.2",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -29,6 +29,7 @@
 		"@react-email/components": "1.0.1",
 		"@react-email/tailwind": "2.0.3",
 		"@superset/db": "workspace:*",
+		"@superset/shared": "workspace:*",
 		"@t3-oss/env-core": "0.13.11",
 		"date-fns": "4.1.0",
 		"drizzle-orm": "0.45.2",

--- a/packages/email/src/components/layout/EmailLayout/EmailLayout.tsx
+++ b/packages/email/src/components/layout/EmailLayout/EmailLayout.tsx
@@ -11,6 +11,7 @@ import {
 	Text,
 } from "@react-email/components";
 import { Tailwind } from "@react-email/tailwind";
+import { COMPANY } from "@superset/shared/constants";
 import type { ReactNode } from "react";
 import { env } from "../../../lib/env";
 
@@ -99,6 +100,17 @@ export function EmailLayout({
 								margin: "40px 0 20px",
 							}}
 						/>
+						<Section style={{ paddingBottom: "16px" }}>
+							<Link href={COMPANY.APP_STORE_URL}>
+								<Img
+									src={`${assets}/badge-appstore.png`}
+									alt="Download Superset on the App Store"
+									width="108"
+									height="32"
+									style={{ display: "inline-block" }}
+								/>
+							</Link>
+						</Section>
 						<Text style={footerText}>
 							<Link
 								href="https://superset.sh"


### PR DESCRIPTION
[#6671](https://github.com/superset-sh/superset/pull/6671) removed the App Store and Google Play badges from the email footer "for now", while the mobile app was still unreleased. It shipped — so the Apple badge comes back.

The footer was rebuilt by #6696 since then (the dark two-column layout that #6671 edited no longer exists), so this re-adds the badge to the current minimal footer rather than reverting that diff.

### Decisions

- **Apple only.** The Google Play badge stays out: mobile is iOS-only and there is no Play listing to link to. Easy to add later if that changes.
- **Link comes from `COMPANY.APP_STORE_URL`** (`packages/shared/src/constants.ts:42`) rather than a hardcoded ID, which is why `@superset/shared` joins `packages/email`'s dependencies. One-line lockfile change.
- **`PersonalLayout` untouched** — the founder note is deliberately plain-text, and a store badge would undercut that.

### Verification

- Rendered the welcome email and screenshotted it: the badge sits between the divider and the address line and reads correctly on the white footer.
- `https://superset.sh/assets/emails/badge-appstore.png` → `200`, 6502 b. The asset survived #6671 and is already live in production, so no marketing deploy is needed for images to resolve.
- `https://apps.apple.com/app/id6788926383` → 301 → *Superset: 100+ Coding Agents*, seller Superset Inc., bundle `sh.superset.mobile` — matches `apps/mobile/app.config.ts:40`.
- Typecheck, biome, and the `@superset/email` suite (3 pass) are green.

The badge now appears in every email built on `EmailLayout`: the activation sequence, all billing mail, team invitations, and the download-link email.

https://claude.ai/code/session_01NUDN3woJiZYR5SqCCCQt55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the App Store badge to the email footer, now that the iOS app is live. The badge was pulled before release and is now back, linked to the App Store URL from `COMPANY.APP_STORE_URL`.

- Google Play badge stays out (app is iOS-only).
- Adds `@superset/shared` as a dependency of `packages/email` to access the constant.
- Badge appears in all emails built on `EmailLayout` (activation, billing, invitations, download-link).

<sup>Written for commit 19ee07a5a9bac1785ceebc8233a94586f44f9f90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an App Store download badge to the footer of email layouts.
  - The badge links recipients directly to the app’s App Store listing, making it easier to download the mobile app from supported email communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->