### PR TITLE
fix(email): name the desktop app in the download email, correct its platforms

### DIFF
--- a/packages/email/src/emails/marketing/DownloadLinkEmail/DownloadLinkEmail.tsx
+++ b/packages/email/src/emails/marketing/DownloadLinkEmail/DownloadLinkEmail.tsx
@@ -20,8 +20,8 @@ export function DownloadLinkEmail({
 				Get Superset on your Mac
 			</Heading>
 			<Text className="m-0 mb-6 text-[15px] leading-6 text-muted">
-				Open this email on your Mac, then use the button below to download
-				Superset. The right version will be selected automatically.
+				Open this email on your Mac, then use the button below to download the
+				Superset desktop app. The right version will be selected automatically.
 			</Text>
 
 			<Section className="mb-8">
@@ -29,8 +29,8 @@ export function DownloadLinkEmail({
 			</Section>
 
 			<Text className="m-0 text-[13px] leading-5 text-muted">
-				Superset is available for macOS today. Windows and Linux support is on
-				the way.
+				The desktop app runs on macOS and Linux today. Windows is not yet
+				available.
 			</Text>
 		</EmailLayout>
 	);


### PR DESCRIPTION
Follow-up to #7385 (already merged, so this is a separate PR rather than another commit on it).

Now that the iPhone app has shipped, "use the button below to download Superset" in the download-link email no longer says *which* app it means. This names it.

### Copy

| | Before | After |
|---|---|---|
| Body | "…download **Superset**. The right version will be selected automatically." | "…download **the Superset desktop app**. The right version will be selected automatically." |
| Footnote | "Superset is available for macOS today. **Windows and Linux support is on the way.**" | "**The desktop app runs on macOS and Linux today. Windows is not yet available.**" |

Two notes on the choices:

- **Lowercase "the Superset desktop app", not "Superset Desktop".** That is what marketing, docs and the FAQ already say in 7+ places; a capitalised product name would be a second way to name one thing.
- **The footnote was factually stale**, separately from naming. Linux ships today (an experimental AppImage per the FAQ) and Windows is the one that doesn't. The replacement matches `DownloadInterstitial`'s wording on `/download` verbatim.

The heading and button are untouched: `Get Superset on your Mac` is verbatim the `<h1>` on `/download` and worth keeping in sync, and the button sits under it, so it isn't ambiguous.

### Not in this PR

`/download`'s Mobile surface card still reads **"Coming soon"** with no App Store link (`SurfaceCards.tsx:99`). It is Lingui-wrapped, so fixing it re-keys the message and owes translations in every locale — worth its own change.

https://claude.ai/code/session_01NUDN3woJiZYR5SqCCCQt55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the download-link email by naming the Superset desktop app and updating the platform availability so it no longer misleads recipients.

- Replaces "download Superset" with "download the Superset desktop app" to match the naming already used across marketing, docs, and the FAQ.
- Updates the footnote to say the desktop app runs on macOS and Linux today, with Windows not yet available, matching the wording on `/download`.

<sup>Written for commit c144126904afc6bc3c7a9b2d1eb8a2767923fe0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Clarified download instructions to refer to the Superset desktop app.
  * Updated platform availability messaging to note current macOS and Linux support, with Windows not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->