### PR TITLE
chore(api): time-boxed tracing to measure the region move

### DIFF
--- a/apps/api/sentry.server.config.ts
+++ b/apps/api/sentry.server.config.ts
@@ -6,11 +6,23 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_API,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	// No tracesSampleRate or tracesSampler on purpose: the SDK treats a rate of
-	// 0 as "tracing on, sample nothing" and still records every span whose
-	// parent was sampled, and a sampler here was storing a flat 5% of ~20M
-	// requests a day (~19M spans, 115x the org quota). Omitting both disables
-	// spans outright.
+	// Time-boxed: measuring what moving the database into the functions' region
+	// bought. Remove this sampler and go back to omitting both keys once the
+	// after-numbers are in — a flat rate here is what cost 115x the org quota
+	// in September, and every route not named below still returns 0.
+	//
+	// Three routes, chosen to answer one question each, at ~81k spans/day:
+	//   desktop/version  one query per request and nothing else, so its p50 is
+	//                    the round trip itself. 72ms before.
+	//   trpc GET         the volume case: 5.8 queries a request, 436ms before,
+	//                    of which ~389ms was wire.
+	//   gmail/push       the worst case at 11.2 queries a request, 3445ms.
+	tracesSampler: ({ name }) => {
+		if (name.includes("/api/desktop/version")) return 0.01;
+		if (name.includes("/api/integrations/google/gmail/push")) return 0.25;
+		if (name.includes("/api/trpc/")) return 0.00025;
+		return 0;
+	},
 	sendDefaultPii: true,
 	debug: false,
 });


### PR DESCRIPTION
## Why

The five Vercel apps now run in `pdx1`, colocated with Neon in `us-west-2`. Nothing has measured what that bought — tracing went off in #7273, so the before-numbers have no after.

## The before

From the last 30d of spans, while everything still ran in `iad1`:

| route | requests | reads/req | p50 txn | p50 db call |
|---|---|---|---|---|
| `POST /api/integrations/google/gmail/push` | 210k | **11.17** | 3445ms | 71ms |
| `POST /api/integrations/linear/webhook` | 13.6M | 6.30 | 250ms | 71ms |
| `GET /api/trpc/[trpc]` | 183M | 5.84 | 436ms | 67ms |
| `POST /api/github/webhook` | 24.0M | 4.65 | 456ms | 71ms |
| `GET /api/auth/[...all]` | 75.7M | 1.01 | 75ms | 68ms |
| `GET /api/desktop/version` | 10.8M | 1.00 | 72ms | 66ms |

`iad1`→`us-west-2` is ~60–65ms of wire, so a 66–71ms p50 per call is essentially all network. On `trpc` GET that's ~389ms of a 436ms p50.

(`reads/req` is a mean against a median duration, so it's directional, not a literal share.)

## What this samples

Three routes, one question each:

- **`desktop/version`** — the control. One query, nothing else, so its p50 *is* the round trip. 72ms before; colocation should put it near 10ms.
- **`trpc` GET** — the volume case, 5.8 queries a request.
- **`gmail/push`** — the worst case, 11.2 queries a request.

~81k spans/day, **0.4%** of the ~19M/day that cost 115× quota in September. Every other route returns `0`.

## Why this is safer than what caused that incident

The September config defaulted to `0.05` across everything, including a 600M-request auth endpoint. This one defaults to `0`.

That `0` is also authoritative in a way the old comment correctly warned `tracesSampleRate: 0` is not: per Sentry's [sampling precedence](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/sampling/), a `tracesSampler` return value **overrides an inherited parent decision**, whereas `tracesSampleRate` loses to it. So an incoming sampled trace header can't reopen the firehose.

## Time-boxed

Revert once the after-numbers are in. The comment in the file says so.

https://claude.ai/code/session_01Ho5jMfrUs1e65svM8M2Hc6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds time-boxed Sentry tracing on three API routes to measure the latency impact of moving the Vercel apps into the same region as Neon.

- Samples `desktop/version`, `trpc` GET, and `gmail/push` at low rates (~81k spans/day total).
- Every other route returns `0`; the sampler's return value overrides inherited parent decisions, so incoming sampled traces can't reopen the firehose.
- This is temporary—revert once the after-numbers are captured.

<sup>Written for commit 3d52ca53cfcc2fd649c965e664fa3b70710c2cf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Added selective performance tracing for key API routes.
  * Other API routes remain excluded from performance trace sampling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->