### PR TITLE
chore(api): revert the region-move tracing sampler

### DIFF
--- a/apps/api/sentry.server.config.ts
+++ b/apps/api/sentry.server.config.ts
@@ -6,23 +6,17 @@ Sentry.init({
 	dsn: env.NEXT_PUBLIC_SENTRY_DSN_API,
 	environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 	enabled: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "production",
-	// Time-boxed: measuring what moving the database into the functions' region
-	// bought. Remove this sampler and go back to omitting both keys once the
-	// after-numbers are in — a flat rate here is what cost 115x the org quota
-	// in September, and every route not named below still returns 0.
+	// No tracesSampleRate or tracesSampler on purpose: the SDK treats a rate of
+	// 0 as "tracing on, sample nothing" and still records every span whose
+	// parent was sampled, and a sampler here was storing a flat 5% of ~20M
+	// requests a day (~19M spans, 115x the org quota). Omitting both disables
+	// spans outright.
 	//
-	// Three routes, chosen to answer one question each, at ~81k spans/day:
-	//   desktop/version  one query per request and nothing else, so its p50 is
-	//                    the round trip itself. 72ms before.
-	//   trpc GET         the volume case: 5.8 queries a request, 436ms before,
-	//                    of which ~389ms was wire.
-	//   gmail/push       the worst case at 11.2 queries a request, 3445ms.
-	tracesSampler: ({ name }) => {
-		if (name.includes("/api/desktop/version")) return 0.01;
-		if (name.includes("/api/integrations/google/gmail/push")) return 0.25;
-		if (name.includes("/api/trpc/")) return 0.00025;
-		return 0;
-	},
+	// #7388 put a narrow sampler back to measure the pdx1 move and got zero
+	// spans over 20 minutes of production traffic — errors flowing, quota
+	// clear, host-service tracing fine. So this app currently cannot be traced
+	// at all, cause unknown, and turning sampling back on is not enough on its
+	// own. The move was measured through Vercel Observability instead.
 	sendDefaultPii: true,
 	debug: false,
 });


### PR DESCRIPTION
## Why

The measurement #7388 existed to take is done. Vercel Observability, grouped by `function_region`:

| | p50 TTFB |
|---|---|
| `iad1` | 293.5ms |
| `pdx1` | 41.8ms |

**But the sampler was never what produced that.** It collected **zero spans** across twenty minutes of live production traffic — while errors flowed normally, `host-service` traced fine, quota sat clear, and the config was live and correct on `ba4bbec87`.

## Why revert instead of keeping a trickle

"Keep a small sample" isn't available. The sampler doesn't collect a small number of spans, it collects none — so leaving it in place gives config that *looks* like it samples and doesn't. The next person to read this file would believe it.

Reverting restores the honest state: tracing is off, and off is a thing you can reason about.

## What the note preserves

The comment now records that a narrow sampler was tried and produced nothing, so the next attempt starts from **"this app cannot currently be traced, cause unknown"** rather than from picking a sample rate. That's the actual finding, and it's worth chasing on its own merits — an untraceable API makes the next production mystery much harder than this one was.

Ruled out so far: quota, org-level span ingestion, DSN rate limits, a stale deploy, and `name` matching (Sentry's docs confirm `name` is unparametrized at sampling time, but all three route substrings match that form anyway). Suspect but unconfirmed: `@sentry/nextjs` 10.68 server instrumentation under Next.js 16.3 + Turbopack.

https://claude.ai/code/session_01Ho5jMfrUs1e65svM8M2Hc6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the region-move tracing sampler now that the measurement is done, restoring the previous state where tracing is off. The sampler collected zero spans across 20 minutes of production traffic, so leaving it would have implied sampling works when it doesn't. The comment now records the failed attempt and notes that the app currently cannot be traced for unknown reasons.

<sup>Written for commit f6ca02d0934a6fd5c725c816a5a313fbb22f7626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled span tracing for API routes, including desktop version checks, Gmail push notifications, and tRPC requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->