### PR TITLE
fix(review-host): keep the reviewer's session alive across restarts

### DIFF
--- a/apps/review-host/README.md
+++ b/apps/review-host/README.md
@@ -68,20 +68,30 @@ hostId would evict each other's relay tunnel in a loop.
 
 ## Staying current
 
-`SUPERSET_VERSION` in `setup.sh` is only the floor a fresh VM starts from. Two
-things keep the box current after that:
+`SUPERSET_VERSION` in `setup.sh` is only the floor a fresh VM starts from. One
+thing keeps the box current after that: **`self-update.sh`**, on a 30-minute
+systemd timer (`superset-review-update.timer`). It reads the latest `desktop-v*`
+release — the `cli-v*` tags are prereleases that `/releases/latest` never returns
+— and hands to `update.sh`.
 
-- **The release trigger** — an automation fires on `release.published` and
-  updates the box. This is the primary path.
-- **`self-update.sh`** — the backstop, on a 6h systemd timer
-  (`superset-review-update.timer`). It reads the latest `desktop-v*` release, the
-  `cli-v*` tags being prereleases that `/releases/latest` never returns, and hands
-  to `update.sh`.
-
-Both only ever move forward, `update.sh` rolls back unless the new build answers
-*and* the relay can see it, and `setup.sh` refuses to reinstall an older pin over
-a newer installed build. The reason for all of that is that this box went 21 days
+It only moves forward, `update.sh` rolls back unless the new build answers *and*
+the relay can see it, and `setup.sh` refuses to reinstall an older pin over a
+newer installed build. The reason for all of that is that this box went 21 days
 stale unnoticed, which is what the outside-in `check.sh` now also watches for.
+
+**An earlier version of this file said a `release.published` automation was the
+primary path and the timer only a backstop. No such automation exists, and one
+cannot be built the obvious way.** A GitHub App installation maps to exactly one
+organization (`apps/api/src/app/api/github/webhook/route.ts`), and
+`superset-sh/superset` is installed under Superset, so the release event only ever
+lands there — while an automation can only target a host registered in *its own*
+organization (`packages/trpc/src/router/automation/automation.ts`), and this box
+lives in App Review. So an automation in App Review can never fire, and one in
+Superset can never reach this box; it would have to run on someone's laptop and
+`gcloud ssh` in, which is the dependency that already failed on 2026-09-06 when
+that laptop's gcloud refresh token expired. Hence 30 minutes: at 6h the window
+where the box ran a release behind was wide enough to hit by accident, and did on
+2026-09-09.
 
 ## The GitHub token expires 2026-10-05
 
@@ -110,6 +120,31 @@ shell history locally and in `ps` output and the auth logs on the box.
 
 `check.sh` calls the API with it every run, so expiry surfaces as a FAIL rather
 than as a chip that quietly stops appearing.
+
+## The watchdog also owns the resident session
+
+Any restart takes the resident Claude session with it — an `update.sh` bump, the
+watchdog's own restart, a reboot — and until 2026-09-09 nothing put it back. That
+is worse than it sounds: the pull-request chip renders only while a terminal is
+open, so a box with no session shows the reviewer no pull request anywhere, and
+`check.sh` runs too rarely to catch the gap. `watchdog.sh` now asserts the session
+every pass and calls `agents.run` when it is genuinely absent; a probe that cannot
+answer does nothing, because reading it as "absent" would spawn the duplicate
+sessions `check.sh` fails on.
+
+It also pre-answers Claude Code's custom-API-key prompt. The key reaches the agent
+from `host_agent_configs.env_json`, and Claude Code asks once per key and
+remembers the answer as the key's last 20 characters in `customApiKeyResponses`
+in `/root/.claude.json` — so rotating the key left every new session parked on
+`Do you want to use this API key?` with `check.sh` green throughout, since it
+counts sessions rather than reading the screen. The watchdog seeds that approval
+from the key already in the host database, records only a hash of the suffix in
+`/opt/review-host/.approved-key`, and relaunches the session once per key so it
+is never left sitting on the prompt. Nothing about the key is written to this
+repo. Worth knowing: while a session sits on that prompt the agent's launch line
+is still on screen, and it carries the key in plain text — `envOverlayPrefix`
+prepends the agent's env to the command string, so the reviewer's first tap used
+to show it.
 
 ## Why there is no health check on the port
 

--- a/apps/review-host/setup.sh
+++ b/apps/review-host/setup.sh
@@ -158,7 +158,7 @@ UNIT
 
 cat > /etc/systemd/system/superset-review-update.service <<UNIT
 [Unit]
-Description=Bring the review host up to the latest release (backstop; the release trigger is primary)
+Description=Bring the review host up to the latest release
 After=network-online.target
 Wants=network-online.target
 
@@ -169,14 +169,17 @@ UNIT
 
 cat > /etc/systemd/system/superset-review-update.timer <<UNIT
 [Unit]
-Description=Backstop check that the review host is on the current release
+Description=Keep the review host on the current release
 
 [Timer]
-# Every 6h. The primary path is the release trigger, which fires the moment a
-# release is published; this is what catches a missed or failed webhook, and a
-# box that came back from a reboot behind.
-OnCalendar=*-*-* 00/6:00:00
-RandomizedDelaySec=15m
+# Every 30m. This is the only thing that updates the box: a release-published
+# automation cannot reach it (see README, "Staying current"). At 6h the window
+# where the box ran a release behind was wide enough to hit by accident — it did
+# on 2026-09-09, when the timer ran 40 minutes before 1.28.0 was published.
+# update.sh only acts on a version change, so the extra runs cost one GitHub API
+# call each.
+OnCalendar=*:0/30
+RandomizedDelaySec=5m
 Persistent=true
 
 [Install]

--- a/apps/review-host/watchdog.sh
+++ b/apps/review-host/watchdog.sh
@@ -17,11 +17,20 @@ CONFIG=/root/.superset/config.json
 ORG="${REVIEW_ORG_ID:?}"
 RELAY_URL="${RELAY_URL:-https://relay.superset.sh}"
 HEALTH_SECRET="review-host-watchdog"
+HOST_URL="http://127.0.0.1:48800"
+
+# The workspace carrying acme-demo#1, which check.sh asserts a Claude session on.
+RESIDENT_WORKSPACE_NAME="Fix input overflow handling"
+CLAUDE_CONFIG=/root/.claude.json
+HOST_DB="/root/.superset/host/$ORG/host.db"
+# sha256 of the key suffix a session was last relaunched for. A hash, so the
+# key itself is not written anywhere new.
+APPROVED_KEY_STATE=/opt/review-host/.approved-key
 
 relay_sees_us() {
   local host_id token
   host_id=$(curl -sf -m 5 -H "Authorization: Bearer $HEALTH_SECRET" \
-    "http://127.0.0.1:48800/trpc/host.info" 2>/dev/null \
+    "$HOST_URL/trpc/host.info" 2>/dev/null \
     | python3 -c 'import json,sys;print(json.load(sys.stdin)["result"]["data"]["json"]["hostId"])' 2>/dev/null)
   token=$(python3 -c "import json;print(json.load(open('$CONFIG'))['auth']['accessToken'])" 2>/dev/null)
   [ -n "$host_id" ] && [ -n "$token" ] || return 1
@@ -30,13 +39,215 @@ relay_sees_us() {
     | python3 -c 'import json,sys;h=json.load(sys.stdin)["hosts"];sys.exit(0 if any(v.get("online") for v in h.values()) else 1)' 2>/dev/null
 }
 
+# The pull-request chip renders only while a terminal is open
+# (`showComposer = activeTerminalId !== null`), so a box with no session shows a
+# reviewer no pull request anywhere — the diff the store listing sells is then
+# reachable only by guessing. Every restart takes the session with it: an
+# update.sh bump, the restart below, a reboot. Nothing put it back, so a release
+# landing at 3am left the box chipless until someone read a check.sh FAIL up to
+# six hours later. This is that restore, in the one place that already watches
+# steady state continuously.
+#
+# Prints the terminal id of the live Claude session on the resident workspace.
+# 0 = present (id on stdout), 1 = absent, 2 = could not tell. Only 1 acts: a
+# probe that did not answer must not be read as "no session" or this spawns
+# duplicates, which is its own check.sh failure.
+resident_terminal_id() {
+  local workspace_id="$1" sessions agents
+  sessions=$(curl -sf -m 10 -G -H "Authorization: Bearer $HEALTH_SECRET" \
+    --data-urlencode 'input={"json":{}}' "$HOST_URL/trpc/terminal.list" 2>/dev/null) || return 2
+  agents=$(curl -sf -m 10 -G -H "Authorization: Bearer $HEALTH_SECRET" \
+    --data-urlencode 'input={"json":{}}' "$HOST_URL/trpc/terminalAgents.list" 2>/dev/null) || return 2
+  printf '%s\n---\n%s\n---\n%s' "$sessions" "$agents" "$workspace_id" | python3 -c '
+import json, sys
+raw = sys.stdin.read().split("\n---\n")
+try:
+    live = [t for t in json.loads(raw[0])["result"]["data"]["json"]["sessions"] if not t.get("exited")]
+    agents = {a["terminalId"]: a.get("agentId") for a in json.loads(raw[1])["result"]["data"]["json"]}
+except Exception:
+    sys.exit(2)
+workspace_id = raw[2].strip()
+here = [t for t in live if t["workspaceId"] == workspace_id and agents.get(t["terminalId"]) == "claude"]
+if not here:
+    sys.exit(1)
+print(here[0]["terminalId"])
+' 2>/dev/null
+}
+
+resident_workspace_id() {
+  curl -sf -m 10 -H "Authorization: Bearer $HEALTH_SECRET" \
+    "$HOST_URL/trpc/workspace.list" 2>/dev/null \
+    | python3 -c 'import json,sys
+d = json.load(sys.stdin)["result"]["data"]["json"]
+print(next((w["id"] for w in d if w.get("name") == sys.argv[1]), ""))' "$RESIDENT_WORKSPACE_NAME" 2>/dev/null
+}
+
+# Claude Code prompts once per custom key when ANTHROPIC_API_KEY is in the
+# environment ("Detected a custom API key in your environment ... Do you want to
+# use this API key?") and remembers the answer as the key's last 20 characters in
+# customApiKeyResponses. The reviewer's box gets its key from the host agent
+# config, so rotating that key leaves every new session sitting on that prompt
+# with the agent unusable — check.sh counts sessions, not what the PTY shows, so
+# it reports green throughout. This pre-seeds the same answer a human "Yes"
+# writes. The key is read from the host database that already holds it and never
+# written anywhere new; only a hash of its suffix is recorded.
+#
+# 10 = an approval was added and no session has been relaunched for this key yet,
+# 0 = nothing to do, 1 = could not tell.
+ensure_api_key_approved() {
+  python3 - "$HOST_DB" "$CLAUDE_CONFIG" "$APPROVED_KEY_STATE" <<'PY_APPROVE'
+import hashlib, json, os, sqlite3, sys, tempfile
+
+db_path, config_path, state_path = sys.argv[1:4]
+
+
+def read_key():
+    if not os.path.exists(db_path):
+        return None
+    try:
+        con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return None
+    try:
+        rows = con.execute("select env_json from host_agent_configs").fetchall()
+    except sqlite3.Error:
+        return None
+    finally:
+        con.close()
+    for (env_json,) in rows:
+        try:
+            env = json.loads(env_json) if env_json else {}
+        except ValueError:
+            continue
+        if env.get("ANTHROPIC_API_KEY"):
+            return env["ANTHROPIC_API_KEY"]
+    return None
+
+
+key = read_key()
+if not key:
+    # No custom key means no prompt to pre-answer.
+    sys.exit(1)
+suffix = key[-20:]
+digest = hashlib.sha256(suffix.encode()).hexdigest()
+
+try:
+    with open(config_path) as fh:
+        config = json.load(fh)
+except (OSError, ValueError):
+    sys.exit(1)
+
+responses = config.setdefault("customApiKeyResponses", {})
+approved = responses.setdefault("approved", [])
+rejected = responses.setdefault("rejected", [])
+changed = False
+if suffix in rejected:
+    rejected.remove(suffix)
+    changed = True
+if suffix not in approved:
+    approved.append(suffix)
+    changed = True
+
+if changed:
+    # Claude Code rewrites this file from its own in-memory copy, so write
+    # atomically and expect to have to redo it; the state file below is what
+    # keeps a rewrite from turning into a session-relaunch loop.
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(config_path) or ".")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(config, fh, indent=2)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, config_path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        sys.exit(1)
+
+previous = ""
+if os.path.exists(state_path):
+    try:
+        with open(state_path) as fh:
+            previous = fh.read().strip()
+    except OSError:
+        previous = ""
+if previous != digest:
+    try:
+        with open(state_path, "w") as fh:
+            fh.write(digest + "\n")
+    except OSError:
+        sys.exit(1)
+    sys.exit(10)
+sys.exit(0)
+PY_APPROVE
+}
+
+# agents.run, not terminal.createSession: the latter gives a shell with no
+# Claude avatar, which is not what the reviewer's first tap should land on.
+restore_resident_session() {
+  local workspace_id="$1"
+  curl -sf -m 60 -X POST -H "Authorization: Bearer $HEALTH_SECRET" \
+    -H "content-type: application/json" \
+    --data "{\"json\":{\"workspaceId\":\"$workspace_id\",\"agent\":\"claude\",\"prompt\":\"\"}}" \
+    "$HOST_URL/trpc/agents.run" >/dev/null 2>&1
+}
+
+kill_resident_session() {
+  local terminal_id="$1" workspace_id="$2"
+  curl -sf -m 30 -X POST -H "Authorization: Bearer $HEALTH_SECRET" \
+    -H "content-type: application/json" \
+    --data "{\"json\":{\"terminalId\":\"$terminal_id\",\"workspaceId\":\"$workspace_id\"}}" \
+    "$HOST_URL/trpc/terminal.killSession" >/dev/null 2>&1
+}
+
+assert_resident_session() {
+  local workspace_id terminal_id approval
+  workspace_id=$(resident_workspace_id)
+  if [ -z "$workspace_id" ]; then
+    echo "[review-host] cannot find the '$RESIDENT_WORKSPACE_NAME' workspace; resident session unverified"
+    return
+  fi
+
+  # Before the probe: a session started under an unapproved key is sitting on
+  # the approval prompt, so it has to be replaced rather than counted as healthy.
+  ensure_api_key_approved
+  approval=$?
+
+  terminal_id=$(resident_terminal_id "$workspace_id")
+  case "$?" in
+    2) echo "[review-host] could not read the session list; resident session unverified"; return ;;
+    0)
+      [ "$approval" = "10" ] || return
+      echo "[review-host] approved a new custom API key; relaunching the resident session so it is not left on the prompt"
+      kill_resident_session "$terminal_id" "$workspace_id"
+      ;;
+  esac
+
+  echo "[review-host] no Claude session on '$RESIDENT_WORKSPACE_NAME' — restoring it"
+  if restore_resident_session "$workspace_id"; then
+    echo "[review-host] resident session restored"
+  else
+    echo "[review-host] could not restore the resident session; the pull-request chip will not render"
+  fi
+}
+
 # Presence lags a cold boot by ~20s, so start late and require a sustained
 # failure before acting.
 sleep 120
 fails=0
+# A restore that is still starting must not be spawned twice, so back off a few
+# passes after each attempt rather than re-probing 30s later.
+session_cooldown=0
 while true; do
   if relay_sees_us; then
     fails=0
+    if [ "$session_cooldown" -gt 0 ]; then
+      session_cooldown=$((session_cooldown - 1))
+    else
+      assert_resident_session
+      session_cooldown=4
+    fi
   else
     fails=$((fails + 1))
     echo "[review-host] relay does not see this host ($fails/10)"


### PR DESCRIPTION
## What was wrong

`update.sh` restarts host-service and never restored the resident Claude session. Every unattended bump left the box with **zero sessions** — and the pull-request chip renders only while a terminal is open, so a reviewer would have opened the app and found no pull request anywhere, which is the feature the store listing sells. Tonight's 00:00 UTC timer would have taken 1.28.0 and done exactly that.

Separately, every relaunched session was parked on Claude Code's `Detected a custom API key in your environment … Yes / No (recommended)` prompt. `check.sh` was green through both, because it counts sessions rather than reading the screen.

## What changed

- **`watchdog.sh` asserts the resident session every pass.** The session dies from three causes (an update, the watchdog's own restart, a reboot) and the watchdog is the one component already polling steady state every 30s, so the restore lives there rather than in three restart paths. A probe that cannot answer does nothing — reading it as "absent" would spawn the duplicate sessions `check.sh` fails on.
- **It pre-answers the custom-API-key prompt.** Claude Code asks once per key and remembers the answer as the key's last 20 characters in `customApiKeyResponses`. The approval is seeded from the key already in `host_agent_configs.env_json` on the box; only a **hash** of the suffix is stored, in `/opt/review-host/.approved-key`, so a rotation triggers exactly one session relaunch and a Claude-Code rewrite of the config can never become a relaunch loop. **Nothing about the key enters this repo.**
- **Update timer 6h → 30m.** At 6h the window where the box ran a release behind was wide enough to hit by accident, and did on 2026-09-09 — the timer ran 40 minutes before 1.28.0 was published.
- **README and unit descriptions stop claiming a `release.published` automation is the primary path.** None exists, and one cannot be built the obvious way: a GitHub App installation maps to exactly one organization, so the release event only lands in Superset, while an automation can only target a host registered in its own organization and this box lives in App Review.

## Verification

Run against the live box, not just read:

- Killed the resident session → restored in <10s, `no Claude session on 'Fix input overflow handling' — restoring it` / `resident session restored`.
- The stuck API-key prompt: approved, killed, relaunched in one pass; the new session came up clean (Opus 5, accept-edits on) with **no prompt on screen**.
- Silent for 15+ minutes afterwards on the "session present, nothing to do" path, and the approval survived — Claude Code did not clobber it.
- `check.sh` green on all 12 assertions, box on 1.28.0.

## Follow-up, deliberately not in this PR

`envOverlayPrefix` (`packages/shared/src/agent-prompt-launch.ts:51-56`) prepends the agent's env to the command string handed to `terminal.launchSession` as `initialCommand`, which has no `env` field — so a secret in an agent env config is echoed into the PTY, kept in scrollback, and visible in `ps`. That is what made the key readable on the reviewer's first tap while a session sat on the approval prompt. It affects any Superset user with a secret in an agent env config, and the fix changes the visible command line, so it is not going in right before a review cycle.

https://claude.ai/code/session_01RnArMVQQem3ozc4jXy9AKt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the review host's resident Claude session alive across restarts and pre-answers the custom API key prompt, so the pull-request chip never disappears and sessions don't sit stuck on a prompt.

**Resident session restore**
- `watchdog.sh` asserts the session every pass and restores it via `agents.run` when genuinely absent; an unanswered probe is treated as unknown, not absent, to avoid duplicate sessions.
- The API key approval is seeded from the key already in the host database; only a hash of its suffix is stored on the box, and a rotation triggers exactly one relaunch.
- The `envOverlayPrefix` issue that exposes the key in the launch line is known and deliberately deferred.

**Update timer and docs**
- The timer drops from 6h to 30m; at 6h the box ran a release behind for 40 minutes on 2026-09-09.
- README and unit descriptions no longer claim a `release.published` automation is the primary path — none exists, and one can't be built the obvious way since a GitHub App installation maps to a single organization.

<sup>Written for commit 2ec9d021e610dbe259fe3e33d1a509f5887a80e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

