### PR TITLE
fix(ui): show toast close buttons on hover

### DIFF
--- a/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
+++ b/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
@@ -38,7 +38,7 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 	}
 
 	return (
-		<div className="w-[356px] rounded-lg border border-border bg-popover p-4 shadow-lg select-text">
+		<div className="group/star-toast w-[356px] rounded-lg border border-border bg-popover p-4 shadow-lg select-text">
 			<div className="flex items-start justify-between gap-2">
 				<p className="text-sm font-semibold text-popover-foreground">
 					<Trans>You're all set!</Trans>
@@ -49,7 +49,7 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 					aria-label={t({
 						message: "Dismiss",
 					})}
-					className="text-muted-foreground transition-colors hover:text-foreground"
+					className="text-muted-foreground transition-[color,opacity] hover:text-foreground [@media(hover:hover)]:opacity-0 group-hover/star-toast:opacity-100 group-focus-within/star-toast:opacity-100"
 				>
 					<X className="size-3.5" />
 				</button>

--- a/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
+++ b/apps/desktop/src/renderer/components/StarNagToast/StarNagToast.tsx
@@ -49,7 +49,7 @@ function StarNagToastContent({ toastId }: { toastId: string | number }) {
 					aria-label={t({
 						message: "Dismiss",
 					})}
-					className="text-muted-foreground transition-[color,opacity] hover:text-foreground [@media(hover:hover)]:opacity-0 group-hover/star-toast:opacity-100 group-focus-within/star-toast:opacity-100"
+					className="text-muted-foreground transition-[color,opacity] hover:text-foreground [@media(hover:hover)]:opacity-0 group-hover/star-toast:opacity-100 group-focus-within/star-toast:opacity-100 group-focus-within/toast:opacity-100"
 				>
 					<X className="size-3.5" />
 				</button>

--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -15,6 +15,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
 
 	return (
 		<Sonner
+			closeButton
 			theme={theme as ToasterProps["theme"]}
 			className="toaster group"
 			icons={{
@@ -32,6 +33,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
 					overflow: "hidden",
 				},
 				classNames: {
+					toast: "group/toast data-[styled=true]:pe-10!",
+					closeButton:
+						"start-auto! end-2! top-2! transform-none! [@media(hover:hover)]:opacity-0 group-hover/toast:opacity-100! group-focus-within/toast:opacity-100!",
 					description: "overflow-y-auto",
 				},
 			}}


### PR DESCRIPTION
## What & why

Enable close buttons on shared toasts, showing the X on hover or keyboard focus and keeping it visible on touch devices. Place the button inside the toast bounds and reserve space so it does not overlap content. Apply the same hover behavior to the custom onboarding toast.

## How I tested it

- Isolated browser test of the actual shared component: before/after screenshots, hover, keyboard focus, touch visibility, and click-to-dismiss passed.
- [Screenshots and measured evidence](https://app.superset.sh/page/toast-close-button-verification-evidence-6er5aa).
- `bun run lint`, `bun run typecheck` (38 packages), and `bun run check:plugins` passed.
- Local `bun run test` failed in tRPC environment validation because required integration environment variables were absent; the GitHub CI Test job passed.
- The initial CI desktop Build compiled successfully, then failed unpacking the downloaded Electron archive (`zip: not a valid zip file`). Retried the failed job.
- Desktop CDP passed in this worktree’s authenticated app (renderer localhost:4865, CDP 9485): Workspaces → right-click this workspace → Copy Branch Name → hover toast → click X. Baseline had no close button; updated toast had opacity 0 at rest / 1 on hover, then disappeared after click.
- Command palette → Preview: GitHub star nag toast also passed hover and dismissal; no console errors during the interaction. Alt+T then Tab focused the outer toast `<li>` and revealed its X (opacity 1).
- CodeRabbit found no critical issues. Its one minor finding—custom-toast container focus not revealing X—was fixed and verified through real CDP keyboard input. Full onboarding creation was not exercised.
- A Lingui provider error occurred during source-version hot reload; the final interactions passed after a clean reload.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (same-repository branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast dismiss buttons are now visible when the toast or its contents receive focus.
  * Toasts now include a close button that appears on hover or focus without overlapping the message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->