### PR TITLE
feat(desktop): support multiple PR author filters

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/PullRequestsView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/PullRequestsView.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDebouncedSearchNavigation } from "renderer/routes/_authenticated/_dashboard/hooks/useDebouncedSearchNavigation";
 import { useProjectQueryTargets } from "renderer/routes/_authenticated/_dashboard/hooks/useProjectQueryTargets";
-import { normalizeAuthorFilter } from "renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter";
+import { normalizeAuthorFilters } from "renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter";
 import {
 	normalizePullRequestReviewFilter,
 	type PullRequestReviewFilter,
@@ -57,7 +57,7 @@ export function PullRequestsView({
 	const authorFilter =
 		initialAuthor === undefined
 			? storedAuthorFilter
-			: normalizeAuthorFilter(initialAuthor);
+			: normalizeAuthorFilters(initialAuthor);
 	const reviewFilter =
 		initialReview === undefined
 			? storedReviewFilter

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsTopBar/components/AuthorFilter/AuthorFilter.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsTopBar/components/AuthorFilter/AuthorFilter.test.tsx
@@ -1,0 +1,91 @@
+import { afterAll, afterEach, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const { act, cleanup, fireEvent, render, within } = await import(
+	"@testing-library/react"
+);
+const { QueryClient, QueryClientProvider } = await import(
+	"@tanstack/react-query"
+);
+const { useState } = await import("react");
+const { AuthorFilter } = await import("./AuthorFilter");
+
+afterEach(cleanup);
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+function FilterHarness() {
+	const [value, setValue] = useState<string | null>(null);
+	return <AuthorFilter value={value} onChange={setValue} projectTargets={[]} />;
+}
+
+test("selects multiple custom authors, retains them on reopen, and toggles or clears them", async () => {
+	const client = new QueryClient();
+	render(
+		<QueryClientProvider client={client}>
+			<FilterHarness />
+		</QueryClientProvider>,
+	);
+	const page = within(document.body);
+	await act(async () => {
+		fireEvent.click(page.getByRole("button", { name: "Author: All authors" }));
+	});
+	for (const login of ["alice", "bob"]) {
+		await act(async () => {
+			fireEvent.change(page.getByRole("combobox"), {
+				target: { value: login },
+			});
+		});
+		await act(async () => {
+			fireEvent.click(
+				page.getByRole("option", { name: `Filter by @${login}` }),
+			);
+		});
+		expect(page.getByRole("dialog")).toBeTruthy();
+		expect(
+			page.getByRole("option", { name: login }).getAttribute("aria-checked"),
+		).toBe("true");
+	}
+	expect(
+		page.getByRole("button", { name: "Author: @alice, @bob" }),
+	).toBeTruthy();
+	await act(async () => {
+		fireEvent.keyDown(page.getByRole("combobox"), {
+			key: "Escape",
+			code: "Escape",
+		});
+	});
+	expect(page.queryByRole("dialog")).toBeNull();
+	await act(async () => {
+		fireEvent.click(page.getByRole("button", { name: "Author: @alice, @bob" }));
+	});
+	expect(
+		page.getByRole("option", { name: "alice" }).getAttribute("aria-checked"),
+	).toBe("true");
+	expect(
+		page.getByRole("option", { name: "bob" }).getAttribute("aria-checked"),
+	).toBe("true");
+	await act(async () => {
+		fireEvent.click(page.getByRole("option", { name: "alice" }));
+	});
+	expect(page.getByRole("button", { name: "Author: @bob" })).toBeTruthy();
+	await act(async () => {
+		fireEvent.click(page.getByRole("option", { name: "All authors" }));
+	});
+	expect(
+		page.getByRole("button", { name: "Author: All authors" }),
+	).toBeTruthy();
+	expect(
+		page
+			.getByRole("option", { name: "All authors" })
+			.getAttribute("aria-checked"),
+	).toBe("true");
+	client.clear();
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsTopBar/components/AuthorFilter/AuthorFilter.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/components/PullRequestsView/components/PullRequestsTopBar/components/AuthorFilter/AuthorFilter.tsx
@@ -15,7 +15,10 @@ import { useMemo, useState } from "react";
 import { HiCheck, HiChevronDown, HiOutlineUserCircle } from "react-icons/hi2";
 import { getHostServiceClientByUrl } from "renderer/lib/host-service-client";
 import type { ProjectQueryTarget } from "renderer/routes/_authenticated/_dashboard/hooks/useProjectQueryTargets";
-import { normalizeAuthorFilter } from "renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter";
+import {
+	normalizeAuthorFilter,
+	normalizeAuthorFilters,
+} from "renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter";
 
 interface AuthorFilterProps {
 	value: string | null;
@@ -34,8 +37,13 @@ export function AuthorFilter({
 	const { t } = useLingui();
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
+	const selectedAuthors = useMemo(() => value?.split(",") ?? [], [value]);
+	const isSelected = (login: string) =>
+		selectedAuthors.some(
+			(author) => author.toLowerCase() === login.toLowerCase(),
+		);
 	const label = value
-		? `@${value}`
+		? selectedAuthors.map((author) => `@${author}`).join(", ")
 		: t({
 				message: "All authors",
 			});
@@ -68,10 +76,20 @@ export function AuthorFilter({
 
 	const filtered = useMemo(() => {
 		const q = search.trim().replace(/^@/, "").toLowerCase();
-		const list = contributors ?? [];
+		const list = [...(contributors ?? [])];
+		for (const login of selectedAuthors) {
+			if (
+				!list.some(
+					(contributor) =>
+						contributor.login.toLowerCase() === login.toLowerCase(),
+				)
+			) {
+				list.push({ login });
+			}
+		}
 		if (!q) return list;
 		return list.filter((c) => c.login.toLowerCase().includes(q));
-	}, [contributors, search]);
+	}, [contributors, search, selectedAuthors]);
 
 	const normalizedSearch = normalizeAuthorFilter(search)?.toLowerCase() ?? null;
 	const showCustomOption =
@@ -84,8 +102,16 @@ export function AuthorFilter({
 	};
 
 	const handleSelect = (login: string | null) => {
-		onChange(login);
-		setOpen(false);
+		const next =
+			login === null
+				? []
+				: isSelected(login)
+					? selectedAuthors.filter(
+							(author) => author.toLowerCase() !== login.toLowerCase(),
+						)
+					: [...selectedAuthors, login];
+		onChange(normalizeAuthorFilters(next.join(",")));
+		setSearch("");
 	};
 
 	return (
@@ -129,7 +155,10 @@ export function AuthorFilter({
 						{(!search || filtered.length > 0 || showCustomOption) && (
 							<CommandGroup>
 								{!search && (
-									<CommandItem onSelect={() => handleSelect(null)}>
+									<CommandItem
+										aria-checked={!value}
+										onSelect={() => handleSelect(null)}
+									>
 										<HiOutlineUserCircle className="size-4 shrink-0" />
 										<span className="text-sm">
 											<Trans>All authors</Trans>
@@ -142,6 +171,12 @@ export function AuthorFilter({
 								{filtered.map((contributor) => (
 									<CommandItem
 										key={contributor.login}
+										aria-label={contributor.login}
+										aria-checked={isSelected(contributor.login)}
+										disabled={
+											!isSelected(contributor.login) &&
+											selectedAuthors.length >= 20
+										}
 										onSelect={() => handleSelect(contributor.login)}
 									>
 										<Avatar className="size-4 shrink-0 rounded-sm">
@@ -156,13 +191,16 @@ export function AuthorFilter({
 										<span className="truncate text-sm">
 											{contributor.login}
 										</span>
-										{value === contributor.login && (
+										{isSelected(contributor.login) && (
 											<HiCheck className="ml-auto size-3.5 shrink-0" />
 										)}
 									</CommandItem>
 								))}
 								{showCustomOption && normalizedSearch && (
-									<CommandItem onSelect={() => handleSelect(normalizedSearch)}>
+									<CommandItem
+										disabled={selectedAuthors.length >= 20}
+										onSelect={() => handleSelect(normalizedSearch)}
+									>
 										<HiOutlineUserCircle className="size-4 shrink-0" />
 										<span className="text-sm">
 											<Trans>Filter by @{normalizedSearch}</Trans>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/stores/pullRequestsFilterStore/pullRequestsFilterStore.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/stores/pullRequestsFilterStore/pullRequestsFilterStore.test.ts
@@ -43,7 +43,7 @@ describe("pullRequestsSearchFromFilters", () => {
 			pullRequestsSearchFromFilters({
 				search: "remote host",
 				projectFilters: ["project-1", "project-2"],
-				authorFilter: "octocat",
+				authorFilter: "octocat,teammate",
 				reviewFilter: "changes-requested",
 				includeClosed: true,
 				mergedOnly: false,
@@ -51,7 +51,7 @@ describe("pullRequestsSearchFromFilters", () => {
 		).toEqual({
 			search: "remote host",
 			projects: "project-1,project-2",
-			author: "octocat",
+			author: "octocat,teammate",
 			review: "changes-requested",
 			state: "all",
 		});
@@ -110,4 +110,15 @@ describe("migratePullRequestsFilterState", () => {
 			mergedOnly: false,
 		});
 	});
+});
+
+test("restores saved multiple authors", () => {
+	expect(
+		migratePullRequestsFilterState({ authorFilter: "alice, @bob, ALICE" })
+			.authorFilter,
+	).toBe("alice,bob");
+	usePullRequestsFilterStore.getState().setAuthorFilter("alice, @bob, ALICE");
+	expect(usePullRequestsFilterStore.getState().authorFilter).toBe("alice,bob");
+	usePullRequestsFilterStore.getState().setAuthorFilter(null);
+	expect(usePullRequestsFilterStore.getState().authorFilter).toBeNull();
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/stores/pullRequestsFilterStore/pullRequestsFilterStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/stores/pullRequestsFilterStore/pullRequestsFilterStore.ts
@@ -3,7 +3,7 @@ import {
 	normalizeProjectFilters,
 	serializeProjectFilters,
 } from "renderer/routes/_authenticated/_dashboard/components/ProjectFilter/project-filter-utils";
-import { normalizeAuthorFilter } from "renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter";
+import { normalizeAuthorFilters } from "renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter";
 import {
 	normalizePullRequestReviewFilter,
 	type PullRequestReviewFilter,
@@ -50,7 +50,7 @@ export function migratePullRequestsFilterState(
 		projectFilters: normalizeProjectFilters(
 			state.projectFilters ?? (legacyProject ? [legacyProject] : []),
 		),
-		authorFilter: normalizeAuthorFilter(state.authorFilter),
+		authorFilter: normalizeAuthorFilters(state.authorFilter),
 		reviewFilter: normalizePullRequestReviewFilter(state.reviewFilter),
 		includeClosed: state.includeClosed === true,
 		mergedOnly: state.mergedOnly === true,
@@ -77,7 +77,7 @@ export const usePullRequestsFilterStore = create<PullRequestsFilterState>()(
 						: { projectFilters: next };
 				}),
 			setAuthorFilter: (authorFilter) =>
-				set({ authorFilter: normalizeAuthorFilter(authorFilter) }),
+				set({ authorFilter: normalizeAuthorFilters(authorFilter) }),
 			setReviewFilter: (reviewFilter) =>
 				set({
 					reviewFilter: normalizePullRequestReviewFilter(reviewFilter),

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter/index.ts
@@ -1,1 +1,4 @@
-export { normalizeAuthorFilter } from "./normalizeAuthorFilter";
+export {
+	normalizeAuthorFilter,
+	normalizeAuthorFilters,
+} from "./normalizeAuthorFilter";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter/normalizeAuthorFilter.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter/normalizeAuthorFilter.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeAuthorFilter } from "./normalizeAuthorFilter";
+import {
+	normalizeAuthorFilter,
+	normalizeAuthorFilters,
+} from "./normalizeAuthorFilter";
 
 describe("normalizeAuthorFilter", () => {
 	test("normalizes GitHub usernames and bot logins", () => {
@@ -12,5 +15,33 @@ describe("normalizeAuthorFilter", () => {
 		expect(normalizeAuthorFilter("octo--cat")).toBeNull();
 		expect(normalizeAuthorFilter("octocat author:someone-else")).toBeNull();
 		expect(normalizeAuthorFilter(42)).toBeNull();
+	});
+});
+
+describe("normalizeAuthorFilters", () => {
+	test("preserves legacy single-author links and normalizes multiple authors", () => {
+		expect(normalizeAuthorFilters(" @octocat ")).toBe("octocat");
+		expect(
+			normalizeAuthorFilters(" @octocat, teammate, OCTOCAT, dependabot[bot] "),
+		).toBe("octocat,teammate,dependabot[bot]");
+	});
+	test("rejects malformed lists and injected search qualifiers", () => {
+		for (const value of [
+			null,
+			42,
+			"",
+			"alice,",
+			"alice,bob author:carol",
+			"alice,octo--cat",
+		]) {
+			expect(normalizeAuthorFilters(value)).toBeNull();
+		}
+	});
+	test("bounds persisted selections", () => {
+		expect(
+			normalizeAuthorFilters(
+				Array.from({ length: 30 }, (_, i) => `user${i}`).join(","),
+			)?.split(","),
+		).toHaveLength(20);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter/normalizeAuthorFilter.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pull-requests/utils/normalizeAuthorFilter/normalizeAuthorFilter.ts
@@ -6,3 +6,18 @@ export function normalizeAuthorFilter(value: unknown): string | null {
 	const login = value.trim().replace(/^@/, "");
 	return GITHUB_AUTHOR_PATTERN.test(login) ? login : null;
 }
+
+/** Comma-separated logins keep saved filters and existing author URLs compatible.
+ * Bound this singleton preference to 20 authors; GitHub logins are length-limited.
+ */
+export function normalizeAuthorFilters(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const authors = new Map<string, string>();
+	for (const entry of value.split(",")) {
+		const login = normalizeAuthorFilter(entry);
+		if (!login) return null;
+		const key = login.toLowerCase();
+		if (!authors.has(key)) authors.set(key, login);
+	}
+	return [...authors.values()].slice(0, 20).join(",") || null;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/v2-project/$projectId/components/V2ProjectSettings/V2ProjectSettings.test.tsx
@@ -46,8 +46,14 @@ const hostProject = {
 
 // External data/host dependencies — stubbed so the component renders in a
 // plain SSR pass without providers.
+// Bun module mocks persist across test files. Only replace this settings
+// query so unrelated components still receive their real query results.
+const { useQuery: realUseQuery } = await import("@tanstack/react-query");
 mock.module("@tanstack/react-query", () => ({
-	useQuery: () => ({ data: hostProject, refetch: () => {} }),
+	useQuery: (...args: Parameters<typeof realUseQuery>) =>
+		args[0].queryKey[0] === "host-project" && args[0].queryKey[1] === "get"
+			? { data: hostProject, refetch: () => {} }
+			: realUseQuery(...args),
 }));
 mock.module("@tanstack/react-router", () => ({
 	useNavigate: () => () => {},

--- a/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
+++ b/packages/host-service/src/trpc/router/workspace-creation/procedures/search-pull-requests.ts
@@ -130,7 +130,11 @@ const VIEWER_RELATIONSHIP_QUALIFIERS: Record<ViewerRelationship, string> = {
 
 const searchPullRequestsInputSchema = githubSearchInputSchema
 	.extend({
-		author: githubAuthorSchema.optional(),
+		author: z
+			.string()
+			.transform((value) => value.split(","))
+			.pipe(z.array(githubAuthorSchema).min(1).max(20))
+			.optional(),
 		review: pullRequestReviewFilterSchema.optional(),
 		// mergedOnly always wins over includeClosed — see the qualifiers
 		// construction below — so only pass this when includeClosed is true
@@ -163,10 +167,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function matchesAuthor(
 	authorLogin: string | null,
-	authorFilter: string | undefined,
+	authorFilter: string[] | undefined,
 ): boolean {
 	return (
-		!authorFilter || authorLogin?.toLowerCase() === authorFilter.toLowerCase()
+		!authorFilter ||
+		authorFilter.some(
+			(author) => authorLogin?.toLowerCase() === author.toLowerCase(),
+		)
 	);
 }
 
@@ -380,7 +387,7 @@ async function ghDirectLookupRow(
 	execGh: ExecGh,
 	target: ProjectRepo,
 	prNumber: number,
-	author: string | undefined,
+	author: string[] | undefined,
 	reviewFilter: PullRequestReviewFilter | undefined,
 	mergedOnly: boolean | undefined,
 	viewerRelationship: ViewerRelationship | undefined,
@@ -538,7 +545,7 @@ async function octokitDirectLookupRow(
 	octokit: Octokit,
 	target: ProjectRepo,
 	prNumber: number,
-	author: string | undefined,
+	author: string[] | undefined,
 	reviewFilter: PullRequestReviewFilter | undefined,
 	mergedOnly: boolean | undefined,
 	viewerRelationship: ViewerRelationship | undefined,
@@ -1021,7 +1028,7 @@ export const searchPullRequests = protectedProcedure
 
 		const effectiveQuery = [
 			normalizedTargets[0]?.normalized.query ?? "",
-			input.author ? `author:${input.author}` : "",
+			input.author?.map((author) => `author:${author}`).join(" ") ?? "",
 			input.review ? REVIEW_QUERY_BY_FILTER[input.review] : "",
 			input.viewerRelationship
 				? VIEWER_RELATIONSHIP_QUALIFIERS[input.viewerRelationship]

--- a/packages/host-service/test/integration/workspace-creation-github.integration.test.ts
+++ b/packages/host-service/test/integration/workspace-creation-github.integration.test.ts
@@ -274,6 +274,19 @@ describe("workspaceCreation github procedures with mocked Octokit", () => {
 		});
 	});
 
+	test("searchPullRequests direct lookup matches any selected author", async () => {
+		const result = await host.trpc.workspaceCreation.searchPullRequests.query({
+			projectId,
+			query: "#33",
+			author: "alice, @BOB",
+		});
+		expect(result.pullRequests).toHaveLength(1);
+		const excluded = await host.trpc.workspaceCreation.searchPullRequests.query(
+			{ projectId, query: "#33", author: "alice,carol" },
+		);
+		expect(excluded.pullRequests).toEqual([]);
+	});
+
 	test("searchPullRequests filters a direct lookup by author", async () => {
 		const result = await host.trpc.workspaceCreation.searchPullRequests.query({
 			projectId,
@@ -289,7 +302,7 @@ describe("workspaceCreation github procedures with mocked Octokit", () => {
 		await expect(
 			host.trpc.workspaceCreation.searchPullRequests.query({
 				projectId,
-				author: "octo--cat",
+				author: "alice,octo--cat",
 			}),
 		).rejects.toThrow("Author must be a valid GitHub username");
 		expect(calls).toHaveLength(0);
@@ -407,14 +420,14 @@ describe("workspaceCreation github procedures with mocked Octokit", () => {
 		const result = await host.trpc.workspaceCreation.searchPullRequests.query({
 			projectId,
 			query: "find me",
-			author: "carol",
+			author: "carol,bob",
 			review: "approved",
 		});
 		// Our fake search returns one issue (no `pull_request`), so no PRs.
 		expect(result.pullRequests).toEqual([]);
 		expect(calls[0].method).toBe("search.issuesAndPullRequests");
 		const searchArgs = calls[0].args as { q: string };
-		expect(searchArgs.q).toContain("author:carol");
+		expect(searchArgs.q).toContain("author:carol author:bob");
 		expect(searchArgs.q).toContain("review:approved");
 	});
 });
@@ -774,6 +787,19 @@ describe("gh CLI is first-class when execGh succeeds", () => {
 		expect(ghCalls[0].cwd).toBe(realpathSync(repoDir));
 	});
 
+	test("searchPullRequests direct lookup matches any selected author", async () => {
+		const result = await host.trpc.workspaceCreation.searchPullRequests.query({
+			projectId,
+			query: "#33",
+			author: "alice, @BOB",
+		});
+		expect(result.pullRequests).toHaveLength(1);
+		const excluded = await host.trpc.workspaceCreation.searchPullRequests.query(
+			{ projectId, query: "#33", author: "alice,carol" },
+		);
+		expect(excluded.pullRequests).toEqual([]);
+	});
+
 	test("searchPullRequests filters a gh direct lookup by author", async () => {
 		const result = await host.trpc.workspaceCreation.searchPullRequests.query({
 			projectId,
@@ -841,7 +867,7 @@ describe("gh CLI is first-class when execGh succeeds", () => {
 		const result = await host.trpc.workspaceCreation.searchPullRequests.query({
 			projectId,
 			query: "find me",
-			author: "carol",
+			author: "carol,bob",
 			review: "team-review-requested",
 		});
 		expect(result.pullRequests).toHaveLength(1);
@@ -858,7 +884,7 @@ describe("gh CLI is first-class when execGh succeeds", () => {
 		expect(qArg).toContain("is:pr");
 		expect(qArg).toContain("is:open");
 		expect(qArg).toContain("find me");
-		expect(qArg).toContain("author:carol");
+		expect(qArg).toContain("author:carol author:bob");
 		expect(qArg).toContain("review-requested:@me");
 		expect(qArg).not.toContain("team-review-requested:@me");
 		expect(ghCalls[1].args.slice(0, 2)).toEqual(["api", "graphql"]);


### PR DESCRIPTION
## What & why

The PR author filter previously allowed one author or everyone, making it difficult to follow a small team's PRs. Authors can now be toggled individually while the picker stays open, with “All authors” clearing the selection. Selected usernames remain available even when absent from the repository's contributor list.

The shared PR list/detail view saves multiple authors and carries them through navigation. GitHub searches and direct PR lookups match any selected author, while retaining repository, state, and review filters. Existing single-author links and preferences remain compatible. The separate New Workspace PR picker is unchanged.

## How I tested it

- Real Electron CDP test in this worktree: captured the original single-author replacement behavior, then selected two authors with the updated picker (30 combined PRs), navigated to Tasks and back, removed one author (29 PRs), and cleared the filter. No console errors during the updated-picker flow.
- [Before/after screenshots and captured CDP state](https://app.superset.sh/page/multi-author-pr-filtering-evidence-60udq7) (Superset organization access required). Evidence assets are kept outside the code diff.
- 57 targeted tests passed: author-picker interaction (1), filter normalization/persistence (12), and GitHub procedure integration tests covering gh and Octokit (44).
- Repo-wide `bun run lint` and `bun run typecheck` passed, as did `bun run check:i18n` and `bun run check:plugins`.
- The full desktop suite now passes: 3,734 tests, zero failures. CI initially exposed a global React Query mock in the project-settings test; that mock is now scoped to its own query so it cannot corrupt the author-picker test. Desktop typecheck also passed after this correction.
- Full `bun run test` stopped on `Invalid environment variables` in `packages/trpc/src/env.ts`; it did not complete.

The CDP walkthrough covered one repository's open PRs. Other state/review combinations and the open-detail flow share the implementation but were not separately exercised in the live app.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — not applicable; same-repository branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull request author filtering now supports selecting multiple authors, with selections displayed together and retained when reopening the filter.
  - Search results can match pull requests from any selected author.
  - Supports up to 20 authors while preserving valid custom selections.

- **Bug Fixes**
  - Author filters are now normalized consistently, removing duplicates and rejecting invalid entries.
  - Resetting the filter correctly returns to “All authors.”

- **Tests**
  - Added coverage for multi-author selection, persistence, validation, and search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->