### PR TITLE
fix(desktop): open agent browsers without switching workspaces

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -267,8 +267,8 @@ export const createBrowserRouter = () => {
 		}),
 
 		// External open requests (CLI/agents via the browser bridge). A global
-		// renderer hook consumes these and routes them through the same
-		// openUrl search-param flow the ports sidebar uses.
+		// renderer hook opens them in the background, navigating only when
+		// the caller explicitly requests that the browser be shown.
 		onOpenRequest: publicProcedure.subscription(() => {
 			return observable<BrowserOpenRequest>((emit) => {
 				const handler = (request: BrowserOpenRequest) => {

--- a/apps/desktop/src/main/lib/browser/browser-bridge.ts
+++ b/apps/desktop/src/main/lib/browser/browser-bridge.ts
@@ -109,7 +109,7 @@ export async function startBrowserBridge(): Promise<void> {
 	});
 
 	app.post("/open", (req, res) => {
-		const { workspaceId, url, target, show } = req.body ?? {};
+		const { workspaceId, projectId, url, target, show } = req.body ?? {};
 		if (typeof workspaceId !== "string" || typeof url !== "string") {
 			res.status(400).json({ error: "workspaceId and url are required" });
 			return;
@@ -188,6 +188,7 @@ export async function startBrowserBridge(): Promise<void> {
 
 				browserManager.requestOpen({
 					workspaceId,
+					projectId: typeof projectId === "string" ? projectId : null,
 					url: resolvedUrl,
 					target: resolvedTarget,
 					show: show === true,

--- a/apps/desktop/src/main/lib/browser/browser-bridge.ts
+++ b/apps/desktop/src/main/lib/browser/browser-bridge.ts
@@ -109,7 +109,7 @@ export async function startBrowserBridge(): Promise<void> {
 	});
 
 	app.post("/open", (req, res) => {
-		const { workspaceId, url, target } = req.body ?? {};
+		const { workspaceId, url, target, show } = req.body ?? {};
 		if (typeof workspaceId !== "string" || typeof url !== "string") {
 			res.status(400).json({ error: "workspaceId and url are required" });
 			return;
@@ -190,6 +190,7 @@ export async function startBrowserBridge(): Promise<void> {
 					workspaceId,
 					url: resolvedUrl,
 					target: resolvedTarget,
+					show: show === true,
 					requestId,
 				} satisfies BrowserOpenRequest);
 			});

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -44,6 +44,7 @@ export interface BrowserOpenRequest {
 	workspaceId: string;
 	url: string;
 	target: "current-tab" | "new-tab";
+	show: boolean;
 	requestId: string;
 }
 

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -42,6 +42,7 @@ export interface BrowserPaneInfo {
 
 export interface BrowserOpenRequest {
 	workspaceId: string;
+	projectId: string | null;
 	url: string;
 	target: "current-tab" | "new-tab";
 	show: boolean;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 
+const register = mock(async (_input: unknown) => ({ success: true }));
 const unregister = mock(async () => ({ success: true }));
 
 mock.module("renderer/lib/trpc-client", () => ({
 	electronTrpcClient: {
 		browser: {
-			register: { mutate: async () => ({ success: true }) },
+			register: { mutate: register },
 			unregister: { mutate: unregister },
 			onAgentActivePanes: { subscribe: () => ({ unsubscribe: () => {} }) },
 		},
@@ -345,6 +346,73 @@ describe("browserRuntimeRegistry guest lifecycle", () => {
 			browserRuntimeRegistry.reload(paneId);
 		} finally {
 			registryInternals.entries.delete(paneId);
+		}
+	});
+});
+
+describe("browserRuntimeRegistry background open", () => {
+	test("registers a hidden guest with a usable viewport and persists navigation without attaching", async () => {
+		const paneId = "background-open-pane";
+		const internals = browserRuntimeRegistry as unknown as {
+			ensureRootContainer: () => { appendChild: (element: unknown) => void };
+			entries: Map<
+				string,
+				{
+					webview: EventTarget & { style: Record<string, string> };
+					placeholder: unknown;
+					visible: boolean;
+				}
+			>;
+		};
+		const appended: unknown[] = [];
+		const rootSpy = spyOn(internals, "ensureRootContainer").mockReturnValue({
+			appendChild: (element) => {
+				appended.push(element);
+			},
+		});
+		const original = document.createElement;
+		document.createElement = (() =>
+			Object.assign(new EventTarget(), {
+				style: {},
+				setAttribute: () => {},
+				remove: () => {},
+				src: "",
+				getWebContentsId: () => 987,
+			})) as unknown as typeof original;
+		const persisted: string[] = [];
+		try {
+			browserRuntimeRegistry.openBackground(
+				paneId,
+				"https://example.com",
+				"agent-workspace",
+				(state) => persisted.push(state.url),
+			);
+			const entry = internals.entries.get(paneId);
+			if (!entry) throw new Error("Missing background runtime");
+			expect(appended).toHaveLength(2);
+			expect(entry.placeholder).toBeNull();
+			expect(entry.visible).toBe(false);
+			expect(entry.webview.style.visibility).toBe("hidden");
+			expect(entry.webview.style.width).toBe("1280px");
+			expect(entry.webview.style.height).toBe("720px");
+			entry.webview.dispatchEvent(new Event("dom-ready"));
+			expect(register).toHaveBeenCalledWith({
+				paneId,
+				webContentsId: 987,
+				workspaceId: "agent-workspace",
+			});
+			entry.webview.dispatchEvent(
+				Object.assign(new Event("did-navigate"), {
+					url: "https://example.com/next",
+				}),
+			);
+			entry.webview.dispatchEvent(new Event("did-stop-loading"));
+			expect(persisted).toEqual(["https://example.com/next"]);
+		} finally {
+			browserRuntimeRegistry.destroy(paneId);
+			document.createElement = original;
+			rootSpy.mockRestore();
+			await new Promise((resolve) => setTimeout(resolve, 0));
 		}
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -500,8 +500,9 @@ class BrowserRuntimeRegistryImpl {
 		url: string,
 		workspaceId: string,
 		onPersist: (state: PersistableBrowserState) => void,
-	): void {
-		if (this.entries.has(paneId)) return;
+	): RegistryEntry {
+		const existing = this.entries.get(paneId);
+		if (existing) return existing;
 		const root = this.ensureRootContainer();
 		const entry = this.createEntry(paneId, url, workspaceId);
 		entry.onPersist = onPersist;
@@ -514,6 +515,7 @@ class BrowserRuntimeRegistryImpl {
 		root.appendChild(entry.webview);
 		root.appendChild(entry.overlay);
 		this.scheduleHiddenEviction();
+		return entry;
 	}
 
 	attach(
@@ -524,36 +526,30 @@ class BrowserRuntimeRegistryImpl {
 		onPersist: (state: PersistableBrowserState) => void,
 		onClose: () => void,
 	): void {
-		const root = this.ensureRootContainer();
-		let entry = this.entries.get(paneId);
-		if (!entry) {
-			entry = this.createEntry(paneId, initialUrl, workspaceId);
-			this.entries.set(paneId, entry);
-			root.appendChild(entry.webview);
-			root.appendChild(entry.overlay);
-		} else {
-			// A reused pane can move between workspaces (the attach effect keys on
-			// workspaceId). Keep the registration's workspace current so main-side
-			// pane scoping addresses it under the new workspace, not the old one.
-			if (entry.workspaceId !== workspaceId) {
-				entry.workspaceId = workspaceId;
-				if (entry.webContentsId != null) {
-					electronTrpcClient.browser.register
-						.mutate({
-							paneId,
-							webContentsId: entry.webContentsId,
-							workspaceId,
-						})
-						.catch((err) => {
-							console.error(
-								"[browserRuntimeRegistry] re-register failed:",
-								err,
-							);
-						});
-				}
+		const entry = this.openBackground(
+			paneId,
+			initialUrl,
+			workspaceId,
+			onPersist,
+		);
+		// A reused pane can move between workspaces (the attach effect keys on
+		// workspaceId). Keep the registration's workspace current so main-side
+		// pane scoping addresses it under the new workspace, not the old one.
+		if (entry.workspaceId !== workspaceId) {
+			entry.workspaceId = workspaceId;
+			if (entry.webContentsId != null) {
+				electronTrpcClient.browser.register
+					.mutate({
+						paneId,
+						webContentsId: entry.webContentsId,
+						workspaceId,
+					})
+					.catch((err) => {
+						console.error("[browserRuntimeRegistry] re-register failed:", err);
+					});
 			}
-			this.refreshNavState(paneId);
 		}
+		this.refreshNavState(paneId);
 		entry.onPersist = onPersist;
 		entry.onClose = onClose;
 		entry.placeholder = placeholder;
@@ -562,7 +558,7 @@ class BrowserRuntimeRegistryImpl {
 
 		entry.resizeObserver?.disconnect();
 		const observer = new ResizeObserver(() => {
-			if (entry) this.updateLayout(entry);
+			this.updateLayout(entry);
 		});
 		observer.observe(placeholder);
 		entry.resizeObserver = observer;

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry.ts
@@ -494,6 +494,28 @@ class BrowserRuntimeRegistryImpl {
 		return entry;
 	}
 
+	/** Create an agent's guest without mounting or focusing its workspace route. */
+	openBackground(
+		paneId: string,
+		url: string,
+		workspaceId: string,
+		onPersist: (state: PersistableBrowserState) => void,
+	): void {
+		if (this.entries.has(paneId)) return;
+		const root = this.ensureRootContainer();
+		const entry = this.createEntry(paneId, url, workspaceId);
+		entry.onPersist = onPersist;
+		entry.lastUsedAt = ++this.useSeq;
+		// Give automation a usable viewport before this pane has ever been shown.
+		entry.webview.style.width = "1280px";
+		entry.webview.style.height = "720px";
+		this.entries.set(paneId, entry);
+		this.applyParkedStyle(paneId, entry);
+		root.appendChild(entry.webview);
+		root.appendChild(entry.overlay);
+		this.scheduleHiddenEviction();
+	}
+
 	attach(
 		paneId: string,
 		placeholder: HTMLElement,

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/useBrowserOpenRequests.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/useBrowserOpenRequests.ts
@@ -5,12 +5,12 @@ import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard
 import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
 import type { BrowserPaneData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { writeWorkspacePaneLayout } from "renderer/stores/workspace-creates/writeWorkspacePaneLayout";
 import { openBackgroundBrowser } from "./utils/openBackgroundBrowser";
 
 interface BrowserOpenRequest {
 	workspaceId: string;
+	projectId: string | null;
 	url: string;
 	target: "current-tab" | "new-tab";
 	requestId: string;
@@ -21,7 +21,6 @@ interface BrowserOpenRequest {
 export function useBrowserOpenRequests() {
 	const navigate = useNavigate();
 	const collections = useCollections();
-	const { workspaces } = useHostWorkspaces();
 
 	useEffect(() => {
 		const subscription = electronTrpcClient.browser.onOpenRequest.subscribe(
@@ -31,12 +30,15 @@ export function useBrowserOpenRequests() {
 					if (!request.show) {
 						try {
 							if (!collections.v2WorkspaceLocalState.get(request.workspaceId)) {
-								const workspace = workspaces.find(
-									(workspace) => workspace.id === request.workspaceId,
+								writeWorkspacePaneLayout(
+									collections,
+									{
+										id: request.workspaceId,
+										projectId: request.projectId,
+									},
+									[],
+									[],
 								);
-								if (!workspace)
-									throw new Error(`Unknown workspace ${request.workspaceId}`);
-								writeWorkspacePaneLayout(collections, workspace, [], []);
 							}
 							const paneId = openBackgroundBrowser({ collections, ...request });
 							browserRuntimeRegistry.openBackground(
@@ -86,5 +88,5 @@ export function useBrowserOpenRequests() {
 		return () => {
 			subscription.unsubscribe();
 		};
-	}, [navigate, collections, workspaces]);
+	}, [navigate, collections]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/useBrowserOpenRequests.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/useBrowserOpenRequests.ts
@@ -2,28 +2,75 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { electronTrpcClient } from "renderer/lib/trpc-client";
 import { navigateToV2Workspace } from "renderer/routes/_authenticated/_dashboard/utils/workspace-navigation";
+import { browserRuntimeRegistry } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/browserRuntimeRegistry";
+import type { BrowserPaneData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
+import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
+import { writeWorkspacePaneLayout } from "renderer/stores/workspace-creates/writeWorkspacePaneLayout";
+import { openBackgroundBrowser } from "./utils/openBackgroundBrowser";
 
 interface BrowserOpenRequest {
 	workspaceId: string;
 	url: string;
 	target: "current-tab" | "new-tab";
 	requestId: string;
+	show: boolean;
 }
 
-/**
- * Consumes external browser-open requests (CLI/agents via the browser
- * bridge). Navigating with the openUrl search params reuses the exact flow
- * the ports sidebar uses — the workspace route's useConsumeOpenUrlRequest
- * creates the pane, and its webview registration answers the bridge.
- */
+/** Opens agent browsers without navigation unless the caller explicitly asks to show them. */
 export function useBrowserOpenRequests() {
 	const navigate = useNavigate();
+	const collections = useCollections();
+	const { workspaces } = useHostWorkspaces();
 
 	useEffect(() => {
 		const subscription = electronTrpcClient.browser.onOpenRequest.subscribe(
 			undefined,
 			{
 				onData: (request: BrowserOpenRequest) => {
+					if (!request.show) {
+						try {
+							if (!collections.v2WorkspaceLocalState.get(request.workspaceId)) {
+								const workspace = workspaces.find(
+									(workspace) => workspace.id === request.workspaceId,
+								);
+								if (!workspace)
+									throw new Error(`Unknown workspace ${request.workspaceId}`);
+								writeWorkspacePaneLayout(collections, workspace, [], []);
+							}
+							const paneId = openBackgroundBrowser({ collections, ...request });
+							browserRuntimeRegistry.openBackground(
+								paneId,
+								request.url,
+								request.workspaceId,
+								(state) => {
+									if (
+										!collections.v2WorkspaceLocalState.get(request.workspaceId)
+									)
+										return;
+									collections.v2WorkspaceLocalState.update(
+										request.workspaceId,
+										(draft) => {
+											for (const tab of draft.paneLayout.tabs) {
+												const pane = tab.panes[paneId];
+												if (pane?.kind === "browser")
+													pane.data = {
+														...(pane.data as BrowserPaneData),
+														...state,
+													};
+											}
+										},
+									);
+								},
+							);
+						} catch (err) {
+							console.error(
+								"[useBrowserOpenRequests] background open failed:",
+								err,
+							);
+						}
+						return;
+					}
 					navigateToV2Workspace(request.workspaceId, navigate, {
 						search: {
 							openUrl: request.url,
@@ -39,5 +86,5 @@ export function useBrowserOpenRequests() {
 		return () => {
 			subscription.unsubscribe();
 		};
-	}, [navigate]);
+	}, [navigate, collections, workspaces]);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/utils/openBackgroundBrowser/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/utils/openBackgroundBrowser/index.ts
@@ -1,0 +1,1 @@
+export { openBackgroundBrowser } from "./openBackgroundBrowser";

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/utils/openBackgroundBrowser/openBackgroundBrowser.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/utils/openBackgroundBrowser/openBackgroundBrowser.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
+import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { openBackgroundBrowser } from "./openBackgroundBrowser";
+
+function fixture() {
+	const store = createWorkspaceStore<PaneViewerData>();
+	store.getState().addTab({
+		panes: [{ kind: "terminal", data: { terminalId: "working-terminal" } }],
+	});
+	const state = store.getState();
+	const initial: WorkspaceState<PaneViewerData> = {
+		version: 1,
+		tabs: state.tabs,
+		activeTabId: state.activeTabId,
+	};
+	const rows = new Map([
+		["agent", { paneLayout: structuredClone(initial) }],
+		["user", { paneLayout: structuredClone(initial) }],
+	]);
+	const collections = {
+		v2WorkspaceLocalState: {
+			get: (id: string) => rows.get(id),
+			update: (
+				id: string,
+				update: (row: { paneLayout: WorkspaceState<PaneViewerData> }) => void,
+			) => {
+				const row = rows.get(id);
+				if (row) update(row);
+			},
+		},
+	} as unknown as Pick<AppCollections, "v2WorkspaceLocalState">;
+	return { collections, rows, initial };
+}
+
+describe("openBackgroundBrowser", () => {
+	for (const target of ["current-tab", "new-tab"] as const) {
+		test(`${target} adds an addressable browser without changing existing selections or another workspace`, () => {
+			const { collections, rows, initial } = fixture();
+			const paneId = openBackgroundBrowser({
+				collections,
+				workspaceId: "agent",
+				url: "https://example.com",
+				target,
+			});
+			const layout = rows.get("agent")?.paneLayout;
+			expect(rows.get("user")?.paneLayout).toEqual(initial);
+			if (!layout) throw new Error("Missing layout");
+			expect(layout.activeTabId).toBe(initial.activeTabId);
+			expect(layout.tabs[0].activePaneId).toBe(initial.tabs[0].activePaneId);
+			const pane = layout.tabs
+				.flatMap((tab) => Object.values(tab.panes))
+				.find((pane) => pane.id === paneId);
+			expect(pane?.kind).toBe("browser");
+			expect(pane?.data).toEqual({ url: "https://example.com" });
+			expect(layout.tabs.length).toBe(target === "new-tab" ? 2 : 1);
+		});
+	}
+	test("successive opens return distinct panes and retain both new tabs", () => {
+		const { collections, rows } = fixture();
+		const request = {
+			collections,
+			workspaceId: "agent",
+			url: "https://example.com",
+			target: "new-tab" as const,
+		};
+		const first = openBackgroundBrowser(request);
+		const second = openBackgroundBrowser(request);
+		expect(first).not.toBe(second);
+		expect(rows.get("agent")?.paneLayout.tabs).toHaveLength(3);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/utils/openBackgroundBrowser/openBackgroundBrowser.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/GlobalBrowserLifecycle/hooks/useBrowserOpenRequests/utils/openBackgroundBrowser/openBackgroundBrowser.ts
@@ -1,0 +1,46 @@
+import { createWorkspaceStore, type WorkspaceState } from "@superset/panes";
+import { preserveLocalPaneSelection } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useV2WorkspacePaneLayout/utils/preserveLocalPaneSelection";
+import type { PaneViewerData } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/types";
+import {
+	openUrlInV2Workspace,
+	type V2WorkspaceUrlOpenTarget,
+} from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openUrlInV2Workspace";
+import type { AppCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider/collections";
+import { applyRememberedV2PaneSelection } from "renderer/stores/v2-pane-selection";
+
+export function openBackgroundBrowser({
+	collections,
+	workspaceId,
+	url,
+	target,
+}: {
+	collections: Pick<AppCollections, "v2WorkspaceLocalState">;
+	workspaceId: string;
+	url: string;
+	target: V2WorkspaceUrlOpenTarget;
+}): string {
+	const row = collections.v2WorkspaceLocalState.get(workspaceId);
+	if (!row)
+		throw new Error(`Workspace ${workspaceId} has no local pane layout`);
+	const previous = applyRememberedV2PaneSelection(
+		workspaceId,
+		row.paneLayout as WorkspaceState<PaneViewerData>,
+	);
+	const store = createWorkspaceStore<PaneViewerData>({
+		initialState: previous,
+	});
+	openUrlInV2Workspace({ store, url, target });
+	const next = store.getState();
+	const tab = next.tabs.find((tab) => tab.id === next.activeTabId);
+	const paneId = tab?.activePaneId;
+	if (!paneId) throw new Error("Browser open did not create a pane");
+	const paneLayout = preserveLocalPaneSelection(previous, {
+		version: next.version,
+		tabs: next.tabs,
+		activeTabId: next.activeTabId,
+	});
+	collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
+		draft.paneLayout = paneLayout;
+	});
+	return paneId;
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -301,12 +301,12 @@ function AuthenticatedLayout() {
 		<DndProvider manager={dragDropManager}>
 			<CollectionsProvider>
 				<WindowTitle />
+				<GlobalBrowserLifecycle />
 				<LocalHostServiceProvider>
 					{/* Above the workspace fan-out: it needs sandbox addresses to
 					    include them as hosts. */}
 					<SandboxAccessProvider>
 						<HostWorkspacesProvider>
-							<GlobalBrowserLifecycle />
 							<WorkerPoolContextProvider
 								poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}
 								highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}

--- a/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/layout.tsx
@@ -301,12 +301,12 @@ function AuthenticatedLayout() {
 		<DndProvider manager={dragDropManager}>
 			<CollectionsProvider>
 				<WindowTitle />
-				<GlobalBrowserLifecycle />
 				<LocalHostServiceProvider>
 					{/* Above the workspace fan-out: it needs sandbox addresses to
 					    include them as hosts. */}
 					<SandboxAccessProvider>
 						<HostWorkspacesProvider>
+							<GlobalBrowserLifecycle />
 							<WorkerPoolContextProvider
 								poolOptions={{ workerFactory: createPierreWorker, poolSize: 8 }}
 								highlighterOptions={{ preferredHighlighter: "shiki-wasm" }}

--- a/docs/agent-tooling.md
+++ b/docs/agent-tooling.md
@@ -83,6 +83,11 @@ bun scripts/dev-cli.ts browser list --workspace <id> --json
 bun run cli:dev -- browser open --workspace <id> --url http://localhost:3000
 ```
 
+`browser open` creates a live browser pane in the background and leaves the user
+in their current workspace. Pass `--show` only when you intend to bring the browser
+to the user’s attention by switching to its workspace. `--target new-tab` controls
+where the pane is created; it does not imply `--show`.
+
 To test in-development *skills* in Claude Code, run `bun run dev:skills`: it
 mirrors this worktree's `plugins/superset` into `~/.claude/skills/superset-dev`
 (a renamed copy so it doesn't collide with the installed prod `superset` plugin),

--- a/packages/cli/src/commands/browser/open/command.test.ts
+++ b/packages/cli/src/commands/browser/open/command.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const open = mock(async (input: { url: string }) => ({
+	paneId: "pane-1",
+	url: input.url,
+}));
+mock.module("../shared", () => ({
+	resolveBrowserTarget: async () => ({
+		client: { browser: { open: { mutate: open } } },
+	}),
+}));
+const { default: command } = await import("./command");
+
+function invoke(show?: boolean, target?: string) {
+	return command.run({
+		ctx: {} as never,
+		args: {} as never,
+		options: {
+			workspace: "agent-workspace",
+			url: "https://example.com",
+			show,
+			target,
+		} as never,
+		signal: new AbortController().signal,
+	});
+}
+
+describe("browser open", () => {
+	test("opens in the background by default, including new tabs", async () => {
+		for (const target of [undefined, "new-tab"]) {
+			await invoke(undefined, target);
+			expect(open).toHaveBeenLastCalledWith({
+				workspaceId: "agent-workspace",
+				url: "https://example.com",
+				target: target ?? "current-tab",
+				show: false,
+			});
+		}
+	});
+	test("forwards an explicit request to show the browser", async () => {
+		await invoke(true);
+		expect(open).toHaveBeenLastCalledWith({
+			workspaceId: "agent-workspace",
+			url: "https://example.com",
+			target: "current-tab",
+			show: true,
+		});
+	});
+});

--- a/packages/cli/src/commands/browser/open/command.ts
+++ b/packages/cli/src/commands/browser/open/command.ts
@@ -1,10 +1,13 @@
-import { CLIError, string } from "@superset/cli-framework";
+import { boolean, CLIError, string } from "@superset/cli-framework";
 import { command } from "../../../lib/command";
 import { resolveBrowserTarget } from "../shared";
 
 export default command({
 	description: "Open a URL in a workspace browser pane and return its pane id",
 	options: {
+		show: boolean().desc(
+			"Show the browser to the user by switching to its workspace",
+		),
 		workspace: string().required().desc("Workspace ID"),
 		host: string().desc("Host the workspace lives on (default: this machine)"),
 		url: string().required().desc("URL to open"),
@@ -27,6 +30,7 @@ export default command({
 			workspaceId: options.workspace,
 			url: options.url,
 			target,
+			show: options.show ?? false,
 		});
 		return {
 			data: result,

--- a/packages/host-service/src/runtime/browser-bridge/browser-bridge-client.ts
+++ b/packages/host-service/src/runtime/browser-bridge/browser-bridge-client.ts
@@ -61,6 +61,7 @@ export class BrowserBridgeClient {
 		workspaceId: string;
 		url: string;
 		target: "current-tab" | "new-tab";
+		show?: boolean;
 	}) {
 		return this.request<{ paneId: string; url: string; title: string }>(
 			"POST",

--- a/packages/host-service/src/runtime/browser-bridge/browser-bridge-client.ts
+++ b/packages/host-service/src/runtime/browser-bridge/browser-bridge-client.ts
@@ -59,6 +59,7 @@ export class BrowserBridgeClient {
 
 	open(input: {
 		workspaceId: string;
+		projectId: string | null;
 		url: string;
 		target: "current-tab" | "new-tab";
 		show?: boolean;

--- a/packages/host-service/src/trpc/router/browser/browser.ts
+++ b/packages/host-service/src/trpc/router/browser/browser.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { BrowserBridgeClient } from "../../../runtime/browser-bridge/browser-bridge-client";
 import type { HostServiceContext } from "../../../types";
+import { getLocalWorkspace } from "../../../workspaces/local-workspace-store";
 import { protectedProcedure, router } from "../../index";
 
 function requireBridge(ctx: HostServiceContext): BrowserBridgeClient {
@@ -29,14 +30,17 @@ export const browserRouter = router({
 				show: z.boolean().default(false),
 			}),
 		)
-		.mutation(({ ctx, input }) =>
-			requireBridge(ctx).open({
-				workspaceId: input.workspaceId,
-				url: input.url,
-				target: input.target,
-				show: input.show,
-			}),
-		),
+		.mutation(({ ctx, input }) => {
+			const bridge = requireBridge(ctx);
+			const workspace = getLocalWorkspace(ctx.db, input.workspaceId);
+			if (!workspace) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Workspace not found",
+				});
+			}
+			return bridge.open({ ...input, projectId: workspace.projectId });
+		}),
 
 	navigate: protectedProcedure
 		.input(

--- a/packages/host-service/src/trpc/router/browser/browser.ts
+++ b/packages/host-service/src/trpc/router/browser/browser.ts
@@ -26,6 +26,7 @@ export const browserRouter = router({
 				workspaceId: z.string(),
 				url: z.string(),
 				target: z.enum(["current-tab", "new-tab"]).default("current-tab"),
+				show: z.boolean().default(false),
 			}),
 		)
 		.mutation(({ ctx, input }) =>
@@ -33,6 +34,7 @@ export const browserRouter = router({
 				workspaceId: input.workspaceId,
 				url: input.url,
 				target: input.target,
+				show: input.show,
 			}),
 		),
 


### PR DESCRIPTION
## What & why

When an agent opened a browser in another workspace, the desktop navigated there immediately, interrupting the user's work. Browser opens now run in the background by default. Agents can explicitly pass `superset browser open --show` to bring the workspace into view.

Background opens persist the browser pane and create a hidden live webview with a usable viewport for automation, while preserving existing tab and pane selections. The `show` option is forwarded through the CLI, host service, and desktop bridge. Agent tooling documentation explains the new behavior. The host supplies workspace project metadata directly, so browser opens do not depend on the renderer workspace list being loaded. Visible and background browsers share webview creation.

## How I tested it

- 16 focused tests pass: CLI default/explicit `--show`, background pane creation and selection preservation, repeated opens, and browser runtime registration, persistence, and lifecycle.
- `bun run lint` passes.
- `bun run typecheck` passes across all 38 tasks.
- `bun run check:plugins` passes.
- `bun run test` stops on environment-variable validation in `@superset/trpc`; the full suite did not complete.
- CDP verification passed against this worktree’s signed-in Electron renderer (`localhost:4865`, CDP `9486`), including a rerun after cleanup. The baseline temporarily restored the original browser-open handler and reproduced the unwanted workspace switch. With the fix, new-tab and repeated current-tab opens preserved the user route and terminal focus; background evaluation and screenshots worked; only explicit `--show` switched workspaces. Both clean recordings had zero console errors.
- Captured a labeled before/after MP4 and timestamped route/focus measurements locally; video is not uploaded to GitHub.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs — not applicable; same-repository branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent browser opens no longer interrupt the user by switching workspaces. They now run in the background by default, and agents can pass `browser open --show` to bring the browser into view.

- Adds a `--show` flag that flows through the CLI, host service, and desktop bridge.
- Background opens create a hidden live webview with a usable viewport while preserving existing tab and pane selections.
- Visible and background opens now share webview creation, with the host supplying workspace project metadata directly rather than depending on the renderer workspace list.
- Updates agent tooling docs to explain the new default and the `--show` option.

<sup>Written for commit 2ab1e736fd13bf95c06b7453b188057bd46bda7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Browser links now open in the background by default, keeping the current workspace visible.
  - Added an option to show the browser workspace when opening a link.
  - Background opens support both the current tab and a new tab.
  - Browser opens now preserve the associated project context.

- **Documentation**
  - Added CLI guidance for background browser opens, the show option, and tab targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->