### PR TITLE
fix(agent-setup): write all skill files to ~/.agents/skills

### DIFF
--- a/packages/agent-setup/src/managed-skills.test.ts
+++ b/packages/agent-setup/src/managed-skills.test.ts
@@ -4,6 +4,7 @@ import {
 	mkdirSync,
 	readFileSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -283,6 +284,57 @@ describe("createManagedSkills", () => {
 		expect(
 			existsSync(path.join(claudePlugin, "skills", "newskill", "SKILL.md")),
 		).toBe(true);
+	});
+
+	it("copies extras into ~/.agents/skills and reaps ones that left the source", async () => {
+		const auditSh = path.join(BUNDLED_PLUGIN, "skills", "10x", "scripts");
+		mkdirSync(auditSh, { recursive: true });
+		writeFileSync(path.join(auditSh, "audit.sh"), "#!/bin/bash\n", {
+			mode: 0o755,
+		});
+
+		await run();
+
+		const copied = path.join(
+			agentsSkills,
+			"superset-10x",
+			"scripts",
+			"audit.sh",
+		);
+		expect(existsSync(copied)).toBe(true);
+		expect(statSync(copied).mode & 0o111).not.toBe(0);
+
+		rmSync(
+			path.join(
+				BUNDLED_PLUGIN,
+				"skills",
+				"orchestrate",
+				"agents",
+				"openai.yaml",
+			),
+		);
+
+		await run();
+
+		expect(
+			existsSync(
+				path.join(
+					agentsSkills,
+					"superset-orchestrate",
+					"agents",
+					"openai.yaml",
+				),
+			),
+		).toBe(false);
+		expect(
+			existsSync(path.join(agentsSkills, "superset-orchestrate", "agents")),
+		).toBe(false);
+		const skillMd = readFileSync(
+			path.join(agentsSkills, "superset-orchestrate", "SKILL.md"),
+			"utf-8",
+		);
+		expect(skillMd).toContain(MANAGED_SKILL_MARKER);
+		expect(skillMd).toContain("name: superset-orchestrate");
 	});
 
 	it("removes files from the plugin dir that left the bundle", async () => {

--- a/packages/agent-setup/src/managed-skills.ts
+++ b/packages/agent-setup/src/managed-skills.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { cp, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { writeFileIfChanged } from "./agent-wrappers-common";
@@ -321,21 +321,6 @@ function listSourceSkills(sourceDir: string): string[] | null {
 	}
 }
 
-/** Copies a bundled skill's extra files (anything besides SKILL.md) verbatim. */
-async function copyBundledExtras(
-	sourceDir: string,
-	targetDir: string,
-): Promise<void> {
-	for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
-		if (entry.name === "SKILL.md") continue;
-		await cp(
-			path.join(sourceDir, entry.name),
-			path.join(targetDir, entry.name),
-			{ recursive: true },
-		);
-	}
-}
-
 function provisionedDirsFor(root: string, sourceName: string): string[] {
 	if (!fs.existsSync(root)) return [];
 	try {
@@ -477,9 +462,13 @@ export async function createManagedSkills(
 					withManagedMarker(setFrontmatterName(raw, dirName)),
 					0o644,
 				);
-				await copyBundledExtras(
+				const isSkillMd = (relativePath: string) => relativePath === "SKILL.md";
+				await syncDir(
 					path.join(source.dir, "skills", pluginSkill),
 					targetDir,
+					isSkillMd,
+					[],
+					isSkillMd,
 				);
 			} catch (error) {
 				desiredAgentsDirs.add(dirName);


### PR DESCRIPTION
## What & why

The desktop app reads the bundled plugin from `app.asar`.
`copyBundledExtras` used `fs.promises.cp` to copy the skill files.
The asar shim in Electron does not work with `cp`, so `cp` stopped with an error.
The code only wrote a warning to the log.
Because of this, each `~/.agents/skills/superset-*` directory contained only `SKILL.md`.
The `superset-10x` skill and the `superset-standup` skill could not start their scripts.

This change removes `copyBundledExtras`.
The `~/.agents/skills` directories now use `syncDir`.
The Claude plugin directory already uses `syncDir`.
`syncDir` reads each file with `readFileSync`, and the asar shim works with `readFileSync`.

This change has two more results:

- `syncDir` sets the executable bit from the mode of the source file.
- `syncDir` removes a file that is not in the source. This occurs only in managed directories.
  The Claude plugin directory has the same behavior.

Fixes #7396

## How I tested it

1. I added a unit test to `managed-skills.test.ts`. The test failed before the fix and passed after the fix.
2. I put the bundled plugin in an asar archive. Then I ran `createManagedSkills` with Electron as Node.
3. Before the fix, `superset-10x` contained only `SKILL.md`:

   ```
   /tmp/managed-skill-asar-61612/home-main/.agents/skills/superset-10x/SKILL.md
   ```

4. After the fix, `superset-10x` contained all the files:

   ```
   /tmp/managed-skill-asar-61612/home-fix/.agents/skills/superset-10x/agents/openai.yaml
   /tmp/managed-skill-asar-61612/home-fix/.agents/skills/superset-10x/scripts/audit.sh
   /tmp/managed-skill-asar-61612/home-fix/.agents/skills/superset-10x/SKILL.md
   ```

5. I ran `bun run lint` and `bun run typecheck` in `packages/agent-setup`. Both passed with no warnings.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes copying of skill supporting files from the bundled plugin so `superset-*` skills include their scripts and configs, not just `SKILL.md`.

- Replaces `copyBundledExtras` (which used `fs.promises.cp`) with `syncDir`, which works with Electron's asar shim.
- `syncDir` also sets executable permissions from source and removes files that are no longer in the source (only for managed directories).
- Adds a unit test covering copying and reaping.

Fixes #7396.

<sup>Written for commit 069d22e40d87250408d0a351b6e1b9ca95b42c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bundled skills now keep supporting files synchronized with the latest version.
  - Executable permissions on bundled skill files are preserved.
  - Files removed from a bundled skill are also removed from the installed copy.
  - The main skill instructions remain intact while additional files are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->