### PR TITLE
fix(desktop): truncate terminal titles in narrow panes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -362,7 +362,7 @@ export function TerminalSessionDropdown({
 							message: "Terminal sessions",
 						})}
 						title={triggerTitle}
-						className="flex min-w-32 max-w-96 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+						className="flex min-w-0 max-w-96 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 						onMouseDown={(event) => event.stopPropagation()}
 						onClick={(event) => event.stopPropagation()}
 					>


### PR DESCRIPTION
## What & why

When a terminal pane is narrow, the session title's 128px minimum width lets it overlap the header action buttons. Replace `min-w-32` with `min-w-0` so the title can shrink and its existing ellipsis styling can take effect.

[Evidence page](https://app.superset.sh/page/narrow-terminal-pane-fix-evidence-he8c55) includes the original screenshot and an interactive synthetic CSS before/after comparison (org access required).

## How I tested it

- Targeted Biome check passed for the changed file.
- `git diff --check` passed.
- Live desktop verification and full lint/typecheck were not run: this worktree has no installed dependencies, `.env`, or running dev app. The evidence page is a synthetic demonstration, not an end-to-end verification.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not applicable; same-repo PR)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal session titles overlapping the header action buttons in narrow panes. Replaces the 128px minimum width with `min-w-0` so the title can shrink and its existing ellipsis truncation takes effect.

<sup>Written for commit adc958dc766ad7edb4f5c340cf33b02e321c7951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the terminal session dropdown layout so its trigger button can shrink to fit its content, reducing unnecessary reserved space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->