### PR TITLE
feat(marketing): refresh careers page layout and company facts

### DIFF
--- a/apps/marketing/src/app/[lang]/join-us/page.tsx
+++ b/apps/marketing/src/app/[lang]/join-us/page.tsx
@@ -66,7 +66,9 @@ export default async function JoinUsPage() {
 	// Verified in PostHog on 2026-09-10: 54,570 identified desktop users,
 	// excluding test accounts. Cumulative adoption, rounded down.
 	const developerCount = formatNumber(50_000, {}, lang);
-	const applyLabel = i18n._(msg({ message: "Apply" }));
+	const applyLabel = i18n._(
+		msg({ message: "Apply", context: "job application" }),
+	);
 
 	return (
 		<main className="relative bg-background">
@@ -204,13 +206,14 @@ export default async function JoinUsPage() {
 							].join("");
 							const applyLabel = ${JSON.stringify(applyLabel)};
 							const cardCss = [
-								".job-card{position:relative;border:0 !important;padding:0 80px 24px 0 !important}",
+								".job-card{display:grid !important;grid-template-columns:minmax(0,1fr) auto;column-gap:24px;border:0 !important;padding:0 0 24px !important}",
 								".job-card:hover{background:rgba(255,255,255,0.04) !important}", // default rgba(0,0,0,.03) vanishes on dark bg
+								".job-title,.job-meta,.job-salary{grid-column:1}",
 								".job-title{font-size:17px !important;line-height:24px !important;font-weight:450 !important;letter-spacing:-0.015em !important;margin-bottom:8px !important}",
 								".job-meta,.job-salary{font-size:13px !important;line-height:20px !important}",
-								".superset-apply{position:absolute;right:0;top:0;" + mono + ";font-size:11px !important;line-height:24px !important}",
+								".superset-apply{grid-column:2;grid-row:1 / span 3;align-self:start;white-space:nowrap;" + mono + ";font-size:11px !important;line-height:24px !important}",
 								".job-card:hover .superset-apply{color:var(--brand)}",
-								"@container (max-width:400px){.job-card{padding-right:64px !important}}",
+								"@container (max-width:400px){.job-card{column-gap:16px}}",
 							].join("");
 							for (const board of document.querySelectorAll("waas-job-board")) {
 								board.showFilters = false;

--- a/apps/marketing/src/app/[lang]/join-us/page.tsx
+++ b/apps/marketing/src/app/[lang]/join-us/page.tsx
@@ -1,5 +1,6 @@
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
+import { formatNumber } from "@superset/i18n/format";
 import { getI18nInstance } from "@superset/i18n/server";
 import type { Metadata } from "next";
 import Script from "next/script";
@@ -59,61 +60,78 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function JoinUsPage() {
-	await initServerI18n();
+	const lang = await initServerI18n();
+	const i18n = getI18nInstance(lang);
+	const founderCount = formatNumber(4, {}, lang);
+	// Verified in PostHog on 2026-09-10: 54,570 identified desktop users,
+	// excluding test accounts. Cumulative adoption, rounded down.
+	const developerCount = formatNumber(50_000, {}, lang);
+	const applyLabel = i18n._(msg({ message: "Apply" }));
 
 	return (
-		<main className="relative min-h-screen bg-background">
-			<div className="max-w-[90rem] mx-auto px-6 pt-24 md:pt-32">
-				<section className="grid gap-10 md:grid-cols-[2fr_3fr] md:gap-24 lg:gap-32">
-					<h1 className="text-4xl md:text-6xl font-normal leading-tight tracking-[-0.02em] text-foreground m-0">
+		<main className="relative bg-background">
+			<div className="mx-auto max-w-[80rem] px-6 pt-12 pb-20 sm:px-8 sm:pt-24">
+				<section className="grid gap-8 lg:grid-cols-[2fr_3fr] lg:gap-24 xl:gap-32">
+					<h1 className="m-0 max-w-[41.25rem] text-balance text-[2.375rem] leading-[1.1] font-[450] tracking-[-0.035em] text-foreground sm:text-[3.5rem] sm:leading-[1.06]">
 						<Trans>Building the last piece of software</Trans>
 					</h1>
-
 					<div>
-						<p className="text-xl md:text-2xl text-foreground leading-snug m-0">
+						<p className="m-0 mb-5 max-w-[43.75rem] text-[19px] leading-normal tracking-[-0.015em] text-foreground/90 sm:text-xl">
 							<Trans>
 								Superset is building self-improving software. It starts with
 								giving engineers the best tools that adapt to their needs over
 								time.
 							</Trans>
 						</p>
-
-						<div
-							className="mt-8 space-y-5 text-base text-muted-foreground leading-relaxed"
-							style={{ fontFamily: "var(--font-inter), sans-serif" }}
-						>
+						<div className="max-w-[46.25rem] space-y-4 text-base leading-[1.65] tracking-[-0.01em] text-muted-foreground">
 							<p>
 								<Trans>
-									Today, tens of thousands of engineers run Superset as their
-									primary IDE, at companies like Wix, DoorDash, and Netflix.
-									Soon, teams will run 100s of agents in parallel - software
+									Soon, teams will run hundreds of agents in parallel—software
 									factories that autonomously manufacture and ship code. We're
 									making Superset the place where teams run and manage those
 									factories, starting with our own.
 								</Trans>
 							</p>
-
 							<p>
 								<Trans>
-									Superset is built in Superset, so we're our own #1 users - you
-									get paid to make your own life easier. We're building a flat
-									and talent-dense team, and we're looking for people who have
-									crazy ideas and are crazy enough to ship them. If you've ever
-									wanted to build a product you love to use, come build it with
-									us.
+									Superset is built in Superset, so we're our own #1 users—you
+									get paid to make your own life easier. If you've ever wanted
+									to build a product you love to use, come build it with us.
 								</Trans>
 							</p>
 						</div>
 					</div>
 				</section>
-			</div>
-
-			<div className="max-w-[90rem] mx-auto px-6 pb-24 md:pb-32">
-				<section id="open-roles" className="mt-24 md:mt-32 scroll-mt-24">
-					<h2 className="text-2xl md:text-3xl font-normal tracking-[-0.02em] text-foreground mb-6">
+				<dl className="my-8 grid grid-cols-1 gap-5 border-y border-border py-6 sm:mt-16 sm:mb-12 lg:mt-20 lg:mb-16 sm:grid-cols-3 sm:gap-x-8 sm:gap-y-2">
+					<div className="grid grid-cols-[5.5rem_minmax(0,1fr)] items-baseline gap-x-4 sm:row-span-2 sm:min-w-0 sm:grid-cols-1 sm:grid-rows-subgrid">
+						<dt className="font-mono text-[11px] leading-4 tracking-[0.07em] text-muted-foreground uppercase sm:order-2">
+							<Trans>Location</Trans>
+						</dt>
+						<dd className="m-0 text-xl leading-7 tracking-[-0.025em] sm:text-[26px] sm:leading-[34px]">
+							<Trans>San Francisco</Trans>
+						</dd>
+					</div>
+					<div className="grid grid-cols-[5.5rem_minmax(0,1fr)] items-baseline gap-x-4 sm:row-span-2 sm:min-w-0 sm:grid-cols-1 sm:grid-rows-subgrid">
+						<dt className="font-mono text-[11px] leading-4 tracking-[0.07em] text-muted-foreground uppercase sm:order-2">
+							<Trans>Team</Trans>
+						</dt>
+						<dd className="m-0 text-xl leading-7 tracking-[-0.025em] sm:text-[26px] sm:leading-[34px]">
+							<Trans>{founderCount} ex-YC founders</Trans>
+						</dd>
+					</div>
+					<div className="grid grid-cols-[5.5rem_minmax(0,1fr)] items-baseline gap-x-4 sm:row-span-2 sm:min-w-0 sm:grid-cols-1 sm:grid-rows-subgrid">
+						<dt className="font-mono text-[11px] leading-4 tracking-[0.07em] text-muted-foreground uppercase sm:order-2">
+							<Trans>Developers</Trans>
+						</dt>
+						<dd className="m-0 text-xl leading-7 tracking-[-0.025em] tabular-nums sm:text-[26px] sm:leading-[34px]">
+							<Trans>{developerCount}+</Trans>
+						</dd>
+					</div>
+				</dl>
+				<section id="open-roles" className="scroll-mt-24">
+					<h2 className="mb-6 text-[22px] leading-7 font-[450] tracking-[-0.025em] text-foreground sm:text-2xl sm:leading-8">
 						<Trans>Open roles</Trans>
 					</h2>
-
 					{/* Managed via YC Work at a Startup; layout/colors configured at bookface.ycombinator.com/workatastartup/job_board_settings */}
 					<style>{`
 						waas-job-board {
@@ -165,7 +183,7 @@ export default async function JoinUsPage() {
 							// site CTA recipe (see DownloadButton): mono uppercase, foreground/background flip, brand on hover
 							const mono = "font-family:var(--font-ibm-plex-mono),ui-monospace,monospace !important;text-transform:uppercase !important;letter-spacing:0.05em !important";
 							const detailCss = [
-								".two-col{gap:192px !important}",
+								".two-col{gap:40px !important}",
 								".tabs{margin-bottom:48px !important;gap:40px !important}",
 								".main-content{max-width:760px !important}",
 								".tab{" + mono + ";font-size:13px !important}",
@@ -184,10 +202,15 @@ export default async function JoinUsPage() {
 								".primary-button{" + mono + ";font-size:13px !important;font-weight:400 !important;background:var(--foreground) !important;color:var(--background) !important;transition:background-color .15s ease,color .15s ease !important}",
 								".primary-button:hover:not(:disabled){background:var(--brand) !important;color:#fff !important;filter:none !important}",
 							].join("");
+							const applyLabel = ${JSON.stringify(applyLabel)};
 							const cardCss = [
-								".job-card{border-bottom:none !important}",
+								".job-card{position:relative;border:0 !important;padding:0 80px 24px 0 !important}",
 								".job-card:hover{background:rgba(255,255,255,0.04) !important}", // default rgba(0,0,0,.03) vanishes on dark bg
-								".job-salary{font-family:var(--font-ibm-plex-mono),ui-monospace,monospace !important;letter-spacing:0.02em !important}",
+								".job-title{font-size:17px !important;line-height:24px !important;font-weight:450 !important;letter-spacing:-0.015em !important;margin-bottom:8px !important}",
+								".job-meta,.job-salary{font-size:13px !important;line-height:20px !important}",
+								".superset-apply{position:absolute;right:0;top:0;" + mono + ";font-size:11px !important;line-height:24px !important}",
+								".job-card:hover .superset-apply{color:var(--brand)}",
+								"@container (max-width:400px){.job-card{padding-right:64px !important}}",
 							].join("");
 							for (const board of document.querySelectorAll("waas-job-board")) {
 								board.showFilters = false;
@@ -198,6 +221,14 @@ export default async function JoinUsPage() {
 									const list = board.shadowRoot?.querySelector("waas-job-list");
 									for (const card of list?.shadowRoot?.querySelectorAll("waas-job-card") ?? []) {
 										inject(card.shadowRoot, cardCss);
+										const row = card.shadowRoot?.querySelector(".job-card");
+										if (row && !row.querySelector(".superset-apply")) {
+											const apply = document.createElement("span");
+											apply.className = "superset-apply";
+											apply.textContent = applyLabel + " ↗";
+											apply.setAttribute("aria-hidden", "true");
+											row.append(apply);
+										}
 									}
 								};
 								patch();

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -643,6 +643,9 @@ msgstr "před {days} d"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Váš účet je deaktivovaný a za # den bude trvale smazán. Obnovte ho a bude přesně takový, jaký jste ho opustili.} few {Váš účet je deaktivovaný a za # dny bude trvale smazán. Obnovte ho a bude přesně takový, jaký jste ho opustili.} many {Váš účet je deaktivovaný a za # dne bude trvale smazán. Obnovte ho a bude přesně takový, jaký jste ho opustili.} other {Váš účet je deaktivovaný a za # dní bude trvale smazán. Obnovte ho a bude přesně takový, jaký jste ho opustili.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "před {distance}"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} pro zaměření"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {vývojář} few {vývojáři} many {vývojáře} other {vývojářů}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} zakladatelé z YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Stejná verze jako tato aplikace."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO a provisioning přes SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Náhled sandboxu nemá URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Něco se pokazilo. Zkuste to znovu nebo napište na support@superset.sh.
 msgid "soon"
 msgstr "brzy"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Brzy budou týmy spouštět stovky agentů paralelně — softwarové továrny, které samostatně vytvářejí a dodávají kód. Ze Superset děláme místo, kde týmy tyto továrny provozují a spravují, počínaje tou naší."
+
 msgid "Sort"
 msgstr "Řazení"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset staví software, který se sám zlepšuje. Začíná to tím, �
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset staví tým se sídlem v San Franciscu v Kalifornii. S dotazy k produktu nebo účtu pište na <0>{supportEmail}</0> a ozveme se do jednoho pracovního dne. Partnerství, tisk, enterprise nebo cokoli pro zakladatelský tým směřujte na <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset se staví v Superset, takže jsme jeho uživatelé číslo jedna — dostáváte zaplaceno za to, že si usnadňujete život. Stavíme plochý tým s vysokou koncentrací talentu a hledáme lidi, kteří mají bláznivé nápady a jsou dost blázniví na to je dotáhnout. Pokud jste vždycky chtěli stavět produkt, který sami rádi používáte, pojďte ho stavět s námi."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset vyvíjíme v Superset, takže jsme sami jeho největšími uživateli — dostáváte zaplaceno za to, že si usnadňujete život. Pokud jste někdy chtěli vytvářet produkt, který rádi používáte, pojďte ho tvořit s námi."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset je navržený tak, aby fungoval s vaším stávajícím nástrojem. Nativně podporujeme hluboké odkazy do IDE, jako je Cursor, takže si pracovní prostory a soubory otevřete ve svém IDE."
@@ -14972,9 +14984,6 @@ msgstr "Dnes"
 
 msgid "TODAY"
 msgstr "DNES"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Dnes používají Superset jako hlavní IDE desítky tisíc inženýrů, ve firmách jako Wix, DoorDash nebo Netflix. Brzy budou týmy provozovat stovky agentů paralelně — softwarové továrny, které autonomně vyrábějí a dodávají kód. Ze Superset děláme místo, kde tyto továrny týmy provozují a spravují, počínaje tou naší."
 
 msgid "Todo"
 msgstr "K řešení"

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -668,7 +668,7 @@ msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {vývojář} few {vývojáři} many {vývojáře} other {vývojářů}}"
 
 msgid "{founderCount} ex-YC founders"
-msgstr "{founderCount} zakladatelé z YC"
+msgstr "{founderCount} zakladatelé, kteří prošli YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -2011,6 +2011,10 @@ msgstr "Platí pro URL v terminálech, zprávách chatu a prohlížečích úkol
 
 msgid "Apply"
 msgstr "Použít"
+
+msgctxt "job application"
+msgid "Apply"
+msgstr "Přihlásit se"
 
 msgid "Approve"
 msgstr "Schválit"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Gilt für URLs in Terminals, Chat-Nachrichten und Aufgaben-Browsern."
 msgid "Apply"
 msgstr "Anwenden"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Bewerben"
+
 msgid "Approve"
 msgstr "Genehmigen"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -643,6 +643,9 @@ msgstr "vor {days} T"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Dein Konto ist deaktiviert und wird in # Tag endgültig gelöscht. Reaktiviere es, um es genau so wiederherzustellen, wie du es verlassen hast.} other {Dein Konto ist deaktiviert und wird in # Tagen endgültig gelöscht. Reaktiviere es, um es genau so wiederherzustellen, wie du es verlassen hast.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "vor {distance}"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} zum Fokussieren"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {Entwickler} other {Entwickler}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} Gründer aus dem YC-Netzwerk"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Gleiche Version wie diese App."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML-SSO & SCIM-Provisionierung"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Die Sandbox-Vorschau hat keine URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Etwas ist schiefgelaufen. Versuche es erneut oder wende dich an support@
 msgid "soon"
 msgstr "bald"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Bald werden Teams Hunderte von Agenten parallel ausführen – Softwarefabriken, die eigenständig Code produzieren und ausliefern. Wir machen Superset zu dem Ort, an dem Teams diese Fabriken betreiben und verwalten, angefangen mit unserer eigenen."
+
 msgid "Sort"
 msgstr "Sortierung"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset baut sich selbst verbessernde Software. Es beginnt damit, Entwi
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset wird von einem Team in San Francisco, Kalifornien, entwickelt. Bei Produktsupport oder Kontofragen schreib an <0>{supportEmail}</0> — wir antworten innerhalb eines Werktags. Für Partnerschaften, Presse, Enterprise oder alles für das Gründungsteam schreib an <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset wird in Superset gebaut, wir sind also unsere eigenen Nutzer Nummer 1 - du wirst dafür bezahlt, dir selbst das Leben leichter zu machen. Wir bauen ein flaches, talentdichtes Team und suchen Leute mit verrückten Ideen, die verrückt genug sind, sie auch auszuliefern. Wenn du schon immer ein Produkt bauen wolltest, das du selbst gern nutzt, bau es mit uns."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset wird in Superset entwickelt. Wir sind also selbst unsere wichtigsten Nutzer – du wirst dafür bezahlt, dir das Leben leichter zu machen. Wenn du schon immer ein Produkt entwickeln wolltest, das du selbst gerne nutzt, dann bau es mit uns."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset ist darauf ausgelegt, mit deinem bestehenden Werkzeug zu arbeiten: Wir unterstützen Deep-Links in IDEs wie Cursor nativ, sodass du deine Arbeitsbereiche und Dateien direkt in deiner IDE öffnen kannst."
@@ -14972,9 +14984,6 @@ msgstr "Heute"
 
 msgid "TODAY"
 msgstr "HEUTE"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Heute nutzen Zehntausende Entwickler Superset als ihre primäre IDE, in Unternehmen wie Wix, DoorDash und Netflix. Bald werden Teams Hunderte Agenten parallel betreiben - Softwarefabriken, die autonom Code fertigen und ausliefern. Wir machen Superset zu dem Ort, an dem Teams diese Fabriken betreiben und steuern, angefangen bei unserer eigenen."
 
 msgid "Todo"
 msgstr "Zu erledigen"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}d ago"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} ago"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} to focus"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dev} other {devs}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} ex-YC founders"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Same version as this app."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO & SCIM provisioning"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Sandbox preview has no URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Something went wrong. Try again, or contact support@superset.sh."
 msgid "soon"
 msgstr "soon"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+
 msgid "Sort"
 msgstr "Sort"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset is building self-improving software. It starts with giving engi
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
@@ -14972,9 +14984,6 @@ msgstr "Today"
 
 msgid "TODAY"
 msgstr "TODAY"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
 
 msgid "Todo"
 msgstr "Todo"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Applies to URLs in terminals, chat messages, and task browsers."
 msgid "Apply"
 msgstr "Apply"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Apply"
+
 msgid "Approve"
 msgstr "Approve"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -668,7 +668,7 @@ msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {desarrollador} other {desarrolladores}}"
 
 msgid "{founderCount} ex-YC founders"
-msgstr "{founderCount} fundadores de la comunidad YC"
+msgstr "{founderCount} fundadores que pasaron por YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -2011,6 +2011,10 @@ msgstr "Se aplica a las URL en terminales, mensajes de chat y navegadores de tar
 
 msgid "Apply"
 msgstr "Aplicar"
+
+msgctxt "job application"
+msgid "Apply"
+msgstr "Postular"
 
 msgid "Approve"
 msgstr "Aprobar"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -643,6 +643,9 @@ msgstr "hace {days} d"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Tu cuenta está desactivada y se eliminará de forma permanente en # día. Reactivar la cuenta para restaurarla tal y como estaba.} other {Tu cuenta está desactivada y se eliminará de forma permanente en # días. Reactivar la cuenta para restaurarla tal y como estaba.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "hace {distance}"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} para enfocar"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {desarrollador} other {desarrolladores}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} fundadores de la comunidad YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Misma versión que esta app."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SSO por SAML y aprovisionamiento SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "La vista previa del sandbox no tiene URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Algo salió mal. Inténtalo de nuevo o escribe a support@superset.sh."
 msgid "soon"
 msgstr "pronto"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Pronto, los equipos ejecutarán cientos de agentes en paralelo: fábricas de software que producen y entregan código de forma autónoma. Estamos convirtiendo Superset en el lugar donde los equipos operan y gestionan esas fábricas, empezando por la nuestra."
+
 msgid "Sort"
 msgstr "Ordenar"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset construye software que se mejora a sí mismo. Empieza por dar a
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset lo desarrolla un equipo con sede en San Francisco, California. Para soporte del producto o dudas sobre tu cuenta, escribe a <0>{supportEmail}</0> y te responderemos en un día laborable. Para alianzas, prensa, enterprise o cualquier tema para el equipo fundador, escribe a <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset se construye dentro de Superset, así que somos nuestros propios usuarios número 1 - te pagan por hacerte la vida más fácil. Estamos formando un equipo plano y con mucho talento, y buscamos personas con ideas locas y lo bastante locas como para llevarlas a cabo. Si alguna vez quisiste construir un producto que te encante usar, ven a construirlo con nosotros."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset se desarrolla en Superset, así que somos nuestros propios usuarios principales: te pagan por hacerte la vida más fácil. Si alguna vez has querido crear un producto que te encante usar, ven a construirlo con nosotros."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset está pensado para funcionar con tu herramienta actual: admitimos de forma nativa los enlaces directos a IDE como Cursor, así que puedes abrir tus espacios de trabajo y archivos en tu IDE."
@@ -14972,9 +14984,6 @@ msgstr "Hoy"
 
 msgid "TODAY"
 msgstr "HOY"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Hoy, decenas de miles de ingenieros usan Superset como su IDE principal, en empresas como Wix, DoorDash y Netflix. Pronto, los equipos ejecutarán cientos de agentes en paralelo: fábricas de software que fabrican y publican código de forma autónoma. Estamos convirtiendo Superset en el lugar donde los equipos gestionan esas fábricas, empezando por la nuestra."
 
 msgid "Todo"
 msgstr "Por hacer"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -643,6 +643,9 @@ msgstr "il y a {days} j"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Votre compte est désactivé et sera définitivement supprimé dans # jour. Réactivez-le pour le retrouver exactement tel que vous l'avez laissé.} other {Votre compte est désactivé et sera définitivement supprimé dans # jours. Réactivez-le pour le retrouver exactement tel que vous l'avez laissé.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "il y a {distance}"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} pour activer"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dév.} other {dév.}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} fondateurs issus de YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Même version que cette application."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SSO SAML et provisionnement SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "L'aperçu du sandbox n'a pas d'URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Une erreur est survenue. Réessayez ou contactez support@superset.sh."
 msgid "soon"
 msgstr "bientôt"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Bientôt, les équipes feront tourner des centaines d’agents en parallèle : des usines logicielles qui produisent et livrent du code de façon autonome. Nous faisons de Superset l’endroit où les équipes exploitent et gèrent ces usines, à commencer par la nôtre."
+
 msgid "Sort"
 msgstr "Tri"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset construit du logiciel qui s'améliore tout seul. Cela commence 
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset est développé par une équipe basée à San Francisco, en Californie. Pour le support produit ou les questions de compte, écrivez à <0>{supportEmail}</0> et nous vous répondrons sous un jour ouvré. Pour les partenariats, la presse, l'enterprise ou tout ce qui s'adresse à l'équipe fondatrice, écrivez à <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset est construit dans Superset : nous sommes donc nos propres utilisateurs numéro un, et vous êtes payé pour vous simplifier la vie. Nous bâtissons une équipe plate et dense en talents, et nous cherchons des personnes qui ont des idées folles et sont assez folles pour les livrer. Si vous avez toujours voulu construire un produit que vous adorez utiliser, venez le construire avec nous."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset est développé dans Superset : nous sommes donc nos premiers utilisateurs. Vous êtes payé pour vous simplifier la vie. Si vous avez toujours voulu créer un produit que vous aimez utiliser, venez le construire avec nous."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset est conçu pour fonctionner avec votre outil actuel : nous prenons nativement en charge les liens profonds vers des IDE comme Cursor, pour que vous puissiez ouvrir vos espaces de travail et vos fichiers dans votre IDE."
@@ -14972,9 +14984,6 @@ msgstr "Aujourd'hui"
 
 msgid "TODAY"
 msgstr "AUJOURD'HUI"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Aujourd'hui, des dizaines de milliers d'ingénieurs utilisent Superset comme IDE principal, dans des entreprises comme Wix, DoorDash et Netflix. Bientôt, les équipes feront tourner des centaines d'agents en parallèle : des usines logicielles qui fabriquent et livrent du code de façon autonome. Nous faisons de Superset l'endroit où les équipes pilotent ces usines, en commençant par la nôtre."
 
 msgid "Todo"
 msgstr "À faire"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -2012,6 +2012,10 @@ msgstr "S'applique aux URL dans les terminaux, les messages du chat et les navig
 msgid "Apply"
 msgstr "Appliquer"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Postuler"
+
 msgid "Approve"
 msgstr "Approuver"
 
@@ -13898,7 +13902,7 @@ msgid "Superset is built by a team based in San Francisco, California. For produ
 msgstr "Superset est développé par une équipe basée à San Francisco, en Californie. Pour le support produit ou les questions de compte, écrivez à <0>{supportEmail}</0> et nous vous répondrons sous un jour ouvré. Pour les partenariats, la presse, l'enterprise ou tout ce qui s'adresse à l'équipe fondatrice, écrivez à <1>{foundersEmail}</1>."
 
 msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset est développé dans Superset : nous sommes donc nos premiers utilisateurs. Vous êtes payé pour vous simplifier la vie. Si vous avez toujours voulu créer un produit que vous aimez utiliser, venez le construire avec nous."
+msgstr "Superset est développé dans Superset : nous sommes donc nous-mêmes les utilisateurs n° 1 de Superset. Vous êtes payé pour vous simplifier la vie. Si vous avez toujours voulu créer un produit que vous aimez utiliser, venez le construire avec nous."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset est conçu pour fonctionner avec votre outil actuel : nous prenons nativement en charge les liens profonds vers des IDE comme Cursor, pour que vous puissiez ouvrir vos espaces de travail et vos fichiers dans votre IDE."

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}h lalu"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Akun Anda dinonaktifkan dan akan dihapus permanen dalam # hari. Aktifkan kembali untuk memulihkannya persis seperti yang Anda tinggalkan.} other {Akun Anda dinonaktifkan dan akan dihapus permanen dalam # hari. Aktifkan kembali untuk memulihkannya persis seperti yang Anda tinggalkan.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} lalu"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} untuk fokus"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dev} other {dev}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} pendiri alumni YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Versi yang sama dengan aplikasi ini."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO & provisioning SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Pratinjau sandbox tidak punya URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Terjadi kesalahan. Coba lagi, atau hubungi support@superset.sh."
 msgid "soon"
 msgstr "sebentar lagi"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Tak lama lagi, tim akan menjalankan ratusan agen secara paralel—pabrik perangkat lunak yang secara mandiri menghasilkan dan merilis kode. Kami menjadikan Superset tempat tim menjalankan dan mengelola pabrik tersebut, dimulai dari pabrik kami sendiri."
+
 msgid "Sort"
 msgstr "Urutkan"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset sedang membangun perangkat lunak yang memperbaiki dirinya sendi
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset dibangun oleh tim yang berbasis di San Francisco, California. Untuk dukungan produk atau pertanyaan akun, kirim email ke <0>{supportEmail}</0> dan kami akan membalas dalam satu hari kerja. Untuk kemitraan, media, enterprise, atau apa pun untuk tim pendiri, tulis ke <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset dibangun di dalam Superset, jadi kami pengguna nomor satu produk kami sendiri - Anda dibayar untuk membuat hidup Anda sendiri lebih mudah. Kami membangun tim yang datar dan padat talenta, dan kami mencari orang yang punya ide gila dan cukup gila untuk merilisnya. Kalau Anda pernah ingin membangun produk yang Anda sendiri senang memakainya, bangun bersama kami."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset dibangun di dalam Superset, jadi kami sendiri adalah pengguna utamanya—Anda dibayar untuk mempermudah pekerjaan Anda sendiri. Jika Anda ingin membangun produk yang senang Anda gunakan, mari bangun bersama kami."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset dirancang untuk bekerja dengan alat yang sudah Anda pakai; kami mendukung deep-link ke IDE seperti Cursor secara native sehingga Anda bisa membuka workspace dan file di IDE Anda."
@@ -14972,9 +14984,6 @@ msgstr "Hari ini"
 
 msgid "TODAY"
 msgstr "HARI INI"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Hari ini, puluhan ribu engineer memakai Superset sebagai IDE utama mereka, di perusahaan seperti Wix, DoorDash, dan Netflix. Tak lama lagi, tim akan menjalankan ratusan agen secara paralel - pabrik perangkat lunak yang secara otonom memproduksi dan merilis kode. Kami menjadikan Superset tempat tim menjalankan dan mengelola pabrik-pabrik itu, dimulai dari pabrik kami sendiri."
 
 msgid "Todo"
 msgstr "Todo"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Berlaku untuk URL di terminal, pesan chat, dan browser tugas."
 msgid "Apply"
 msgstr "Terapkan"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Lamar"
+
 msgid "Approve"
 msgstr "Setujui"
 
@@ -13898,7 +13902,7 @@ msgid "Superset is built by a team based in San Francisco, California. For produ
 msgstr "Superset dibangun oleh tim yang berbasis di San Francisco, California. Untuk dukungan produk atau pertanyaan akun, kirim email ke <0>{supportEmail}</0> dan kami akan membalas dalam satu hari kerja. Untuk kemitraan, media, enterprise, atau apa pun untuk tim pendiri, tulis ke <1>{foundersEmail}</1>."
 
 msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset dibangun di dalam Superset, jadi kami sendiri adalah pengguna utamanya—Anda dibayar untuk mempermudah pekerjaan Anda sendiri. Jika Anda ingin membangun produk yang senang Anda gunakan, mari bangun bersama kami."
+msgstr "Superset dibangun di dalam Superset, jadi kami sendiri adalah pengguna utamanya—Anda dibayar untuk mempermudah pekerjaan Anda sendiri. Jika Anda ingin membangun produk yang Anda sukai dan senang gunakan, mari bangun bersama kami."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset dirancang untuk bekerja dengan alat yang sudah Anda pakai; kami mendukung deep-link ke IDE seperti Cursor secara native sehingga Anda bisa membuka workspace dan file di IDE Anda."

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Si applica agli URL nei terminali, nei messaggi di chat e nei browser de
 msgid "Apply"
 msgstr "Applica"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Candidati"
+
 msgid "Approve"
 msgstr "Approva"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}g fa"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Il tuo account è disattivato e sarà eliminato definitivamente tra # giorno. Riattivalo per ripristinarlo esattamente come l'hai lasciato.} other {Il tuo account è disattivato e sarà eliminato definitivamente tra # giorni. Riattivalo per ripristinarlo esattamente come l'hai lasciato.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} fa"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} per attivare"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dev} other {dev}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} fondatori ex YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Stessa versione di questa app."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SSO SAML e provisioning SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "L'anteprima della sandbox non ha un URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Qualcosa è andato storto. Riprova o scrivi a support@superset.sh."
 msgid "soon"
 msgstr "a breve"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Presto i team eseguiranno centinaia di agenti in parallelo: fabbriche di software che producono e distribuiscono codice in autonomia. Stiamo facendo di Superset il luogo in cui i team gestiscono queste fabbriche, a partire dalla nostra."
+
 msgid "Sort"
 msgstr "Ordina"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset sta costruendo software che si migliora da solo. Si comincia da
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset è realizzato da un team con sede a San Francisco, California. Per il supporto sul prodotto o domande sull'account, scrivi a <0>{supportEmail}</0> e ti risponderemo entro un giorno lavorativo. Per partnership, stampa, enterprise o qualsiasi cosa per il team fondatore, scrivi a <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset è costruito dentro Superset, quindi siamo i nostri utenti numero uno: vieni pagato per rendere più facile la tua stessa vita. Stiamo costruendo un team piatto e denso di talento e cerchiamo persone con idee folli e abbastanza folli da realizzarle. Se hai sempre voluto costruire un prodotto che ami usare, vieni a costruirlo con noi."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset viene sviluppato in Superset, quindi siamo noi stessi i nostri primi utenti: vieni pagato per semplificarti la vita. Se hai sempre voluto creare un prodotto che ami usare, vieni a costruirlo con noi."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset è progettato per funzionare con lo strumento che già usi: supportiamo nativamente il deep-link verso IDE come Cursor, così puoi aprire i tuoi workspace e i tuoi file nel tuo IDE."
@@ -14972,9 +14984,6 @@ msgstr "Oggi"
 
 msgid "TODAY"
 msgstr "OGGI"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Oggi decine di migliaia di ingegneri usano Superset come IDE principale, in aziende come Wix, DoorDash e Netflix. Presto i team faranno girare centinaia di agenti in parallelo: fabbriche di software che producono e rilasciano codice in autonomia. Stiamo facendo di Superset il posto dove i team gestiscono quelle fabbriche, a partire dalla nostra."
 
 msgid "Todo"
 msgstr "Da fare"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -2012,6 +2012,10 @@ msgstr "ターミナル、チャットメッセージ、タスクのブラウザ
 msgid "Apply"
 msgstr "適用"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "応募"
+
 msgid "Approve"
 msgstr "承認"
 
@@ -13898,7 +13902,7 @@ msgid "Superset is built by a team based in San Francisco, California. For produ
 msgstr "Supersetは、米国カリフォルニア州サンフランシスコを拠点とするチームが開発しています。製品サポートやアカウントに関するご質問は<0>{supportEmail}</0>までメールをお送りください。1営業日以内に返信します。パートナーシップ、取材、エンタープライズ、創業チームへのご連絡は<1>{foundersEmail}</1>までお願いします。"
 
 msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "SupersetはSupersetで開発されています。私たち自身が一番のユーザーなので、自分の仕事を楽にすることが仕事になります。自分が使いたいと思えるプロダクトを作りたいなら、一緒に作りましょう。"
+msgstr "SupersetはSupersetで開発されています。私たち自身が一番のユーザーなので、自分の生活を楽にすることで報酬を得られます。自分が使いたいと思えるプロダクトを作りたいなら、一緒に作りましょう。"
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Supersetは既存のツールと併用できるように設計されています。CursorのようなIDEへのディープリンクをネイティブにサポートしているので、ワークスペースやファイルをそのままIDEで開けます。"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}日前"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {アカウントは無効化されており、#日後に完全に削除されます。再有効化すると元の状態に戻ります。} other {アカウントは無効化されており、#日後に完全に削除されます。再有効化すると元の状態に戻ります。}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance}前"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText}でフォーカス"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {人の開発者} other {人の開発者}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "YC出身の創業者{founderCount}人"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "このアプリと同じバージョンです。"
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSOとSCIMプロビジョニング"
 
+msgid "San Francisco"
+msgstr "サンフランシスコ"
+
 msgid "Sandbox preview has no URL"
 msgstr "サンドボックスのプレビューにURLがありません"
 
@@ -13415,6 +13424,9 @@ msgstr "問題が発生しました。もう一度お試しいただくか、sup
 msgid "soon"
 msgstr "まもなく"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "まもなく、チームは数百のエージェントを並列で動かすようになります。コードを自律的に生成して出荷するソフトウェア工場です。私たちは、自分たちの工場から始めて、チームがこうした工場を運営・管理する場所としてSupersetを作っています。"
+
 msgid "Sort"
 msgstr "並べ替え"
 
@@ -13885,8 +13897,8 @@ msgstr "Supersetは自己改善するソフトウェアを作っています。�
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Supersetは、米国カリフォルニア州サンフランシスコを拠点とするチームが開発しています。製品サポートやアカウントに関するご質問は<0>{supportEmail}</0>までメールをお送りください。1営業日以内に返信します。パートナーシップ、取材、エンタープライズ、創業チームへのご連絡は<1>{foundersEmail}</1>までお願いします。"
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "SupersetはSupersetの中で作られています。つまり私たち自身が一番のユーザーです。自分の仕事を楽にすることが、そのまま仕事になります。フラットで才能の密度が高いチームを目指しており、突拍子もないアイデアを持ち、それを本当に出荷してしまう人を探しています。自分が使って楽しいプロダクトを作りたいと思ったことがあるなら、一緒に作りましょう。"
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "SupersetはSupersetで開発されています。私たち自身が一番のユーザーなので、自分の仕事を楽にすることが仕事になります。自分が使いたいと思えるプロダクトを作りたいなら、一緒に作りましょう。"
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Supersetは既存のツールと併用できるように設計されています。CursorのようなIDEへのディープリンクをネイティブにサポートしているので、ワークスペースやファイルをそのままIDEで開けます。"
@@ -14972,9 +14984,6 @@ msgstr "今日"
 
 msgid "TODAY"
 msgstr "現在"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "現在、Wix、DoorDash、Netflixといった企業を含め、数万人のエンジニアがSupersetを主要なIDEとして使っています。まもなく、チームは数百体のエージェントを並列に動かすようになります。コードを自律的に製造し出荷する、ソフトウェア工場です。私たちはSupersetを、チームがそうした工場を動かし管理する場所にしようとしています。まずは自分たちの工場から。"
 
 msgid "Todo"
 msgstr "未着手"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}일 전"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {계정이 비활성화되었으며 #일 후에 영구적으로 삭제됩니다. 다시 활성화하면 이전 상태 그대로 복원됩니다.} other {계정이 비활성화되었으며 #일 후에 영구적으로 삭제됩니다. 다시 활성화하면 이전 상태 그대로 복원됩니다.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} 전"
 
@@ -663,6 +666,9 @@ msgstr "포커스하려면 {focusShortcutText}"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "개발자 {formatted}{count, plural, one {명} other {명}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "YC 출신 창업자 {founderCount}명"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "이 앱과 같은 버전입니다."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO 및 SCIM 프로비저닝"
 
+msgid "San Francisco"
+msgstr "샌프란시스코"
+
 msgid "Sandbox preview has no URL"
 msgstr "샌드박스 미리보기에 URL이 없습니다"
 
@@ -13415,6 +13424,9 @@ msgstr "문제가 발생했습니다. 다시 시도하거나 support@superset.sh
 msgid "soon"
 msgstr "곧"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "곧 팀들은 수백 개의 에이전트를 병렬로 실행하게 됩니다. 코드를 자율적으로 만들고 출시하는 소프트웨어 공장이 되는 것이죠. 우리는 Superset을 팀들이 이런 공장을 운영하고 관리하는 곳으로 만들고 있습니다. 우리 자신의 공장부터 시작합니다."
+
 msgid "Sort"
 msgstr "정렬"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset은 스스로 나아지는 소프트웨어를 만듭니다. 그 
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset은 캘리포니아 샌프란시스코에 있는 팀이 만듭니다. 제품 지원이나 계정 문의는 <0>{supportEmail}</0>으로 메일을 보내 주시면 영업일 기준 하루 안에 회신드립니다. 파트너십, 언론, 엔터프라이즈 문의나 창업팀에 전할 내용은 <1>{foundersEmail}</1>으로 보내 주세요."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset은 Superset 안에서 만들어집니다. 그래서 우리가 1호 사용자이고, 자기 일을 편하게 만드는 대가로 급여를 받습니다. 수평적이고 인재 밀도가 높은 팀을 만들고 있으며, 엉뚱한 아이디어를 내고 그것을 실제로 내보낼 만큼 대담한 사람을 찾습니다. 스스로 즐겨 쓰는 제품을 만들고 싶었다면, 함께 만들어요."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset은 Superset으로 개발됩니다. 우리가 가장 열심히 쓰는 사용자이므로, 자신의 일을 더 편하게 만드는 것이 곧 일이 됩니다. 직접 즐겨 쓰는 제품을 만들고 싶었다면 우리와 함께하세요."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset은 기존 도구와 함께 쓰도록 만들었습니다. Cursor 같은 IDE로의 딥링크를 기본 지원하므로 워크스페이스와 파일을 쓰던 IDE에서 열 수 있습니다."
@@ -14972,9 +14984,6 @@ msgstr "오늘"
 
 msgid "TODAY"
 msgstr "오늘"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "지금 수만 명의 엔지니어가 Wix, DoorDash, Netflix 같은 회사에서 Superset을 주력 IDE로 사용합니다. 머지않아 팀들은 수백 개의 에이전트를 병렬로 돌릴 것입니다. 코드를 자율적으로 만들어 내보내는 소프트웨어 공장이지요. 우리는 팀이 그런 공장을 운영하고 관리하는 곳으로 Superset을 만들고 있습니다. 우리 공장부터 시작해서요."
 
 msgid "Todo"
 msgstr "할 일"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -2012,6 +2012,10 @@ msgstr "터미널, 채팅 메시지, 작업 브라우저의 URL에 적용됩니�
 msgid "Apply"
 msgstr "적용"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "지원"
+
 msgid "Approve"
 msgstr "승인"
 
@@ -13898,7 +13902,7 @@ msgid "Superset is built by a team based in San Francisco, California. For produ
 msgstr "Superset은 캘리포니아 샌프란시스코에 있는 팀이 만듭니다. 제품 지원이나 계정 문의는 <0>{supportEmail}</0>으로 메일을 보내 주시면 영업일 기준 하루 안에 회신드립니다. 파트너십, 언론, 엔터프라이즈 문의나 창업팀에 전할 내용은 <1>{foundersEmail}</1>으로 보내 주세요."
 
 msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset은 Superset으로 개발됩니다. 우리가 가장 열심히 쓰는 사용자이므로, 자신의 일을 더 편하게 만드는 것이 곧 일이 됩니다. 직접 즐겨 쓰는 제품을 만들고 싶었다면 우리와 함께하세요."
+msgstr "Superset은 Superset으로 개발됩니다. 우리가 가장 열심히 쓰는 사용자이므로, 자신의 삶을 더 편하게 만드는 대가로 보수를 받게 됩니다. 직접 즐겨 쓰는 제품을 만들고 싶었다면 우리와 함께하세요."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset은 기존 도구와 함께 쓰도록 만들었습니다. Cursor 같은 IDE로의 딥링크를 기본 지원하므로 워크스페이스와 파일을 쓰던 IDE에서 열 수 있습니다."

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Geldt voor URL's in terminals, chatberichten en taakbrowsers."
 msgid "Apply"
 msgstr "Toepassen"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Solliciteer"
+
 msgid "Approve"
 msgstr "Goedkeuren"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}d geleden"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Je account is gedeactiveerd en wordt over # dag definitief verwijderd. Reactiveer het om alles terug te krijgen zoals je het achterliet.} other {Je account is gedeactiveerd en wordt over # dagen definitief verwijderd. Reactiveer het om alles terug te krijgen zoals je het achterliet.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} geleden"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} om te focussen"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dev} other {devs}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} oprichters uit het YC-netwerk"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Dezelfde versie als deze app."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO en SCIM-provisioning"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Sandboxpreview heeft geen URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Er is iets misgegaan. Probeer het opnieuw of neem contact op via support
 msgid "soon"
 msgstr "binnenkort"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Binnenkort laten teams honderden agents parallel draaien: softwarefabrieken die zelfstandig code produceren en opleveren. We maken van Superset de plek waar teams die fabrieken draaien en beheren, te beginnen met onze eigen fabriek."
+
 msgid "Sort"
 msgstr "Sorteren"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset bouwt zelfverbeterende software. Dat begint met engineers de be
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset wordt gebouwd door een team in San Francisco, Californië. Voor productsupport of vragen over je account mail je <0>{supportEmail}</0>; we reageren binnen één werkdag. Voor partnerships, pers, enterprise of iets voor het oprichtersteam schrijf je naar <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset wordt in Superset gebouwd, dus we zijn onze eigen gebruiker nummer één — je wordt betaald om je eigen leven makkelijker te maken. We bouwen een plat team vol talent en zoeken mensen met gekke ideeën die gek genoeg zijn om ze te bouwen. Als je ooit een product wilde bouwen dat je zelf graag gebruikt, kom het dan met ons bouwen."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset wordt gebouwd in Superset, dus we zijn zelf onze belangrijkste gebruikers: je krijgt betaald om je eigen leven makkelijker te maken. Als je altijd al een product wilde bouwen dat je graag gebruikt, kom het dan samen met ons bouwen."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset is gemaakt om samen te werken met je bestaande tool; we ondersteunen deeplinks naar IDE's zoals Cursor, zodat je je werkruimtes en bestanden in je IDE kunt openen."
@@ -14972,9 +14984,6 @@ msgstr "Vandaag"
 
 msgid "TODAY"
 msgstr "VANDAAG"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Vandaag draaien tienduizenden engineers Superset als hun belangrijkste IDE, bij bedrijven als Wix, DoorDash en Netflix. Binnenkort draaien teams honderden agents parallel — softwarefabrieken die autonoom code maken en uitleveren. Wij maken van Superset de plek waar teams die fabrieken draaien en beheren, te beginnen met de onze."
 
 msgid "Todo"
 msgstr "Te doen"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Dotyczy adresów URL w terminalach, wiadomościach czatu i przeglądarka
 msgid "Apply"
 msgstr "Zastosuj"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Aplikuj"
+
 msgid "Approve"
 msgstr "Zatwierdź"
 
@@ -13898,7 +13902,7 @@ msgid "Superset is built by a team based in San Francisco, California. For produ
 msgstr "Superset tworzy zespół z San Francisco w Kalifornii. W sprawach wsparcia produktu lub konta napisz na <0>{supportEmail}</0> — odpowiemy w ciągu jednego dnia roboczego. W sprawach partnerstw, prasy, enterprise lub do zespołu założycielskiego pisz na <1>{foundersEmail}</1>."
 
 msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset powstaje w Superset, więc sami jesteśmy jego najważniejszymi użytkownikami — dostajesz wynagrodzenie za ułatwianie sobie życia. Jeśli chcesz tworzyć produkt, z którego samodzielnie korzystasz z przyjemnością, dołącz do nas."
+msgstr "Superset powstaje w Superset, więc sami jesteśmy jego głównymi użytkownikami — dostajesz wynagrodzenie za ułatwianie sobie życia. Jeśli chcesz tworzyć produkt, z którego korzystasz z przyjemnością, dołącz do nas."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset jest zaprojektowany tak, aby działać z narzędziem, którego już używasz — natywnie obsługujemy głębokie linki do IDE takich jak Cursor, więc otworzysz swoje obszary robocze i pliki we własnym IDE."

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -643,6 +643,9 @@ msgstr "{days} dni temu"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Konto jest dezaktywowane i zostanie trwale usunięte za # dzień. Reaktywuj je, aby przywrócić dokładnie taki stan jak przedtem.} few {Konto jest dezaktywowane i zostanie trwale usunięte za # dni. Reaktywuj je, aby przywrócić dokładnie taki stan jak przedtem.} many {Konto jest dezaktywowane i zostanie trwale usunięte za # dni. Reaktywuj je, aby przywrócić dokładnie taki stan jak przedtem.} other {Konto jest dezaktywowane i zostanie trwale usunięte za # dnia. Reaktywuj je, aby przywrócić dokładnie taki stan jak przedtem.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} temu"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} aby aktywować"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {programista} few {programiści} many {programistów} other {programisty}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} założycieli z doświadczeniem w YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Ta sama wersja co ta aplikacja."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO i provisioning SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Podgląd piaskownicy nie ma adresu URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Coś poszło nie tak. Spróbuj ponownie lub napisz na support@superset.s
 msgid "soon"
 msgstr "wkrótce"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Wkrótce zespoły będą uruchamiać setki agentów równolegle — fabryki oprogramowania, które samodzielnie tworzą i dostarczają kod. Budujemy Superset jako miejsce, w którym zespoły uruchamiają takie fabryki i nimi zarządzają, zaczynając od naszej własnej."
+
 msgid "Sort"
 msgstr "Sortowanie"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset buduje samodoskonalące się oprogramowanie. Zaczyna się od da
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset tworzy zespół z San Francisco w Kalifornii. W sprawach wsparcia produktu lub konta napisz na <0>{supportEmail}</0> — odpowiemy w ciągu jednego dnia roboczego. W sprawach partnerstw, prasy, enterprise lub do zespołu założycielskiego pisz na <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset powstaje w Superset, więc jesteśmy własnym użytkownikiem numer 1 — dostajesz pieniądze za ułatwianie sobie życia. Budujemy płaski zespół o dużym zagęszczeniu talentu i szukamy ludzi, którzy mają szalone pomysły i są na tyle szaleni, żeby je wydać. Jeśli kiedykolwiek chciałeś zbudować produkt, którego sam uwielbiasz używać, zbuduj go z nami."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset powstaje w Superset, więc sami jesteśmy jego najważniejszymi użytkownikami — dostajesz wynagrodzenie za ułatwianie sobie życia. Jeśli chcesz tworzyć produkt, z którego samodzielnie korzystasz z przyjemnością, dołącz do nas."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset jest zaprojektowany tak, aby działać z narzędziem, którego już używasz — natywnie obsługujemy głębokie linki do IDE takich jak Cursor, więc otworzysz swoje obszary robocze i pliki we własnym IDE."
@@ -14972,9 +14984,6 @@ msgstr "Dziś"
 
 msgid "TODAY"
 msgstr "DZIŚ"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Dziś dziesiątki tysięcy inżynierów używa Superset jako swojego głównego IDE, w firmach takich jak Wix, DoorDash czy Netflix. Wkrótce zespoły będą uruchamiać setki agentów równolegle — fabryki oprogramowania, które autonomicznie wytwarzają i wydają kod. Robimy z Superset miejsce, w którym zespoły prowadzą i nadzorują te fabryki, zaczynając od naszej własnej."
 
 msgid "Todo"
 msgstr "Do zrobienia"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -643,6 +643,9 @@ msgstr "há {days}d"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Sua conta está desativada e será excluída permanentemente em # dia. Reative para restaurá-la exatamente como você deixou.} other {Sua conta está desativada e será excluída permanentemente em # dias. Reative para restaurá-la exatamente como você deixou.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "há {distance}"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} para focar"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dev} other {devs}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} fundadores ex-YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Mesma versão que este app."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SSO SAML e provisionamento SCIM"
 
+msgid "San Francisco"
+msgstr "São Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "A prévia do sandbox não tem URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Algo deu errado. Tente de novo ou escreva para support@superset.sh."
 msgid "soon"
 msgstr "em breve"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Em breve, as equipes executarão centenas de agentes em paralelo: fábricas de software que produzem e entregam código de forma autônoma. Estamos fazendo do Superset o lugar onde as equipes operam e gerenciam essas fábricas, começando pela nossa."
+
 msgid "Sort"
 msgstr "Ordenar"
 
@@ -13885,8 +13897,8 @@ msgstr "O Superset está construindo software que se aprimora sozinho. Isso come
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "O Superset é feito por um time em San Francisco, Califórnia. Para suporte do produto ou dúvidas sobre a conta, escreva para <0>{supportEmail}</0> e respondemos em até um dia útil. Para parcerias, imprensa, enterprise ou assuntos para o time fundador, escreva para <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "O Superset é construído dentro do Superset, então somos nossos próprios usuários número 1: você é pago para facilitar a sua própria vida. Estamos montando um time horizontal e denso em talento, e procuramos pessoas com ideias malucas e loucura suficiente para colocá-las de pé. Se você sempre quis construir um produto que ama usar, venha construir com a gente."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "O Superset é desenvolvido no Superset, então somos nossos próprios usuários número um: você recebe para facilitar a própria vida. Se você sempre quis criar um produto que adora usar, venha construí-lo com a gente."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "O Superset foi feito para funcionar com a ferramenta que você já usa. Temos suporte nativo a deep links para IDEs como o Cursor, então dá para abrir suas áreas de trabalho e arquivos direto na sua IDE."
@@ -14972,9 +14984,6 @@ msgstr "Hoje"
 
 msgid "TODAY"
 msgstr "HOJE"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Hoje, dezenas de milhares de pessoas de engenharia usam o Superset como IDE principal, em empresas como Wix, DoorDash e Netflix. Em breve, os times vão rodar centenas de agentes em paralelo: fábricas de software que produzem e entregam código de forma autônoma. Estamos fazendo do Superset o lugar onde os times rodam e gerenciam essas fábricas, começando pela nossa."
 
 msgid "Todo"
 msgstr "A fazer"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Vale para URLs em terminais, mensagens de chat e navegadores de tarefas.
 msgid "Apply"
 msgstr "Aplicar"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Candidatar-se"
+
 msgid "Approve"
 msgstr "Aprovar"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Применяется к URL в терминалах, сообщени�
 msgid "Apply"
 msgstr "Применить"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Откликнуться"
+
 msgid "Approve"
 msgstr "Одобрить"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -643,6 +643,9 @@ msgstr "{days} дн. назад"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Аккаунт деактивирован и будет безвозвратно удалён через # день. Активируйте его снова, чтобы восстановить всё в точности как было.} few {Аккаунт деактивирован и будет безвозвратно удалён через # дня. Активируйте его снова, чтобы восстановить всё в точности как было.} many {Аккаунт деактивирован и будет безвозвратно удалён через # дней. Активируйте его снова, чтобы восстановить всё в точности как было.} other {Аккаунт деактивирован и будет безвозвратно удалён через # дня. Активируйте его снова, чтобы восстановить всё в точности как было.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} назад"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} — фокус"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {разработчик} few {разработчика} many {разработчиков} other {разработчика}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} основателя — выпускника YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Та же версия, что и у этого приложения."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO и провижининг SCIM"
 
+msgid "San Francisco"
+msgstr "Сан-Франциско"
+
 msgid "Sandbox preview has no URL"
 msgstr "У предпросмотра песочницы нет URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Что-то пошло не так. Повторите или напиш
 msgid "soon"
 msgstr "скоро"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Скоро команды будут запускать сотни агентов параллельно — это будут программные фабрики, которые самостоятельно создают и выпускают код. Мы делаем Superset местом, где команды запускают такие фабрики и управляют ими, начиная с нашей собственной."
+
 msgid "Sort"
 msgstr "Сортировка"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset строит самоулучшающийся софт. Всё 
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset делает команда из Сан-Франциско, Калифорния. По вопросам продукта и аккаунта пишите на <0>{supportEmail}</0> — ответим в течение одного рабочего дня. По партнёрствам, прессе, enterprise или напрямую основателям — на <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset делается в Superset, так что мы — свои же пользователи №1: вам платят за то, чтобы вы облегчали себе жизнь. Мы строим плоскую команду с высокой концентрацией таланта и ищем людей с безумными идеями, достаточно безумных, чтобы их выпускать. Если вы всегда хотели делать продукт, которым сами любите пользоваться, приходите делать его с нами."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset разрабатывается в Superset, поэтому мы сами — его главные пользователи: вам платят за то, что вы упрощаете себе жизнь. Если вы когда-нибудь хотели создать продукт, которым сами любите пользоваться, приходите создавать его вместе с нами."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset рассчитан на работу с вашим текущим инструментом: мы нативно поддерживаем переход по ссылкам в IDE вроде Cursor, чтобы открывать рабочие области и файлы прямо там."
@@ -14972,9 +14984,6 @@ msgstr "Сегодня"
 
 msgid "TODAY"
 msgstr "СЕГОДНЯ"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Сегодня десятки тысяч инженеров используют Superset как основную IDE — в таких компаниях, как Wix, DoorDash и Netflix. Скоро команды будут запускать сотни агентов параллельно — софтверные фабрики, которые автономно производят и выпускают код. Мы делаем Superset местом, где команды запускают такие фабрики и управляют ими, начиная с нашей собственной."
 
 msgid "Todo"
 msgstr "К выполнению"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Terminallerdeki, sohbet mesajlarındaki ve görev tarayıcılarındaki U
 msgid "Apply"
 msgstr "Uygula"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Başvur"
+
 msgid "Approve"
 msgstr "Onayla"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}g önce"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Hesabınız devre dışı bırakıldı ve # gün içinde kalıcı olarak silinecek. Bıraktığınız gibi geri yüklemek için yeniden etkinleştirin.} other {Hesabınız devre dışı bırakıldı ve # gün içinde kalıcı olarak silinecek. Bıraktığınız gibi geri yüklemek için yeniden etkinleştirin.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} önce"
 
@@ -663,6 +666,9 @@ msgstr "Odaklanmak için {focusShortcutText}"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {geliştirici} other {geliştirici}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "YC mezunu {founderCount} kurucu"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Bu uygulamayla aynı sürüm."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO ve SCIM sağlama"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Sandbox önizlemesinin URL'si yok"
 
@@ -13415,6 +13424,9 @@ msgstr "Bir şeyler ters gitti. Yeniden deneyin veya support@superset.sh adresin
 msgid "soon"
 msgstr "yakında"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Yakında ekipler yüzlerce ajanı paralel çalıştıracak: otonom olarak kod üreten ve yayınlayan yazılım fabrikaları. Kendi fabrikamızdan başlayarak Superset'i ekiplerin bu fabrikaları çalıştırıp yönettiği yer hâline getiriyoruz."
+
 msgid "Sort"
 msgstr "Sırala"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset, kendini geliştiren yazılım üretiyor. Bu, mühendislere zam
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset, San Francisco, Kaliforniya merkezli bir ekip tarafından geliştirilir. Ürün desteği veya hesap soruları için <0>{supportEmail}</0> adresine e-posta gönderin; bir iş günü içinde size dönelim. İş birliği, basın, kurumsal veya kurucu ekibe iletilecek her konu için <1>{foundersEmail}</1> adresine yazın."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset, Superset içinde geliştiriliyor; yani bir numaralı kullanıcısı biziz - kendi hayatınızı kolaylaştırdığınız için para alıyorsunuz. Yatay ve yetenek yoğunluğu yüksek bir ekip kuruyoruz; çılgın fikirleri olan ve onları gönderecek kadar da çılgın insanlar arıyoruz. Kullanmayı seveceğiniz bir ürün geliştirmek istediyseniz, gelin birlikte geliştirelim."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset, Superset içinde geliştiriliyor; yani en büyük kullanıcımız biziz. Kendi hayatınızı kolaylaştırmak için para kazanıyorsunuz. Severek kullandığınız bir ürün geliştirmek istediyseniz, gelin birlikte geliştirelim."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset mevcut aracınızla çalışacak şekilde tasarlandı; Cursor gibi IDE'lere derin bağlantıyı yerel olarak destekliyoruz, böylece çalışma alanlarınızı ve dosyalarınızı IDE'nizde açabilirsiniz."
@@ -14972,9 +14984,6 @@ msgstr "Bugün"
 
 msgid "TODAY"
 msgstr "BUGÜN"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Bugün on binlerce mühendis Superset'i birincil IDE'si olarak kullanıyor; Wix, DoorDash ve Netflix gibi şirketlerde. Yakında takımlar yüzlerce ajanı paralel çalıştıracak - kodu otonom biçimde üreten ve gönderen yazılım fabrikaları. Superset'i, takımların bu fabrikaları çalıştırıp yönettiği yer hâline getiriyoruz; kendimizinkiyle başlayarak."
 
 msgid "Todo"
 msgstr "Yapılacak"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -643,6 +643,9 @@ msgstr "{days} ngày trước"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {Tài khoản của bạn đã bị vô hiệu hóa và sẽ bị xóa vĩnh viễn sau # ngày. Kích hoạt lại để khôi phục đúng như lúc bạn rời đi.} other {Tài khoản của bạn đã bị vô hiệu hóa và sẽ bị xóa vĩnh viễn sau # ngày. Kích hoạt lại để khôi phục đúng như lúc bạn rời đi.}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance} trước"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText} để focus"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted} {count, plural, one {dev} other {dev}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} nhà sáng lập từng tham gia YC"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "Cùng phiên bản với ứng dụng này."
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO & cấp phát SCIM"
 
+msgid "San Francisco"
+msgstr "San Francisco"
+
 msgid "Sandbox preview has no URL"
 msgstr "Bản xem trước sandbox không có URL"
 
@@ -13415,6 +13424,9 @@ msgstr "Đã xảy ra lỗi. Hãy thử lại hoặc liên hệ support@superset
 msgid "soon"
 msgstr "sắp tới"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "Sắp tới, các nhóm sẽ chạy hàng trăm tác tử song song—những nhà máy phần mềm tự động tạo và phát hành mã. Chúng tôi đang biến Superset thành nơi các nhóm vận hành và quản lý những nhà máy đó, bắt đầu từ chính nhà máy của mình."
+
 msgid "Sort"
 msgstr "Sắp xếp"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset đang xây dựng phần mềm tự cải thiện. Nó bắt đ
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset được xây dựng bởi một đội ngũ tại San Francisco, California. Với hỗ trợ sản phẩm hoặc câu hỏi về tài khoản, hãy gửi email tới <0>{supportEmail}</0> và chúng tôi sẽ phản hồi trong vòng một ngày làm việc. Với hợp tác, báo chí, doanh nghiệp hoặc bất cứ điều gì dành cho đội ngũ sáng lập, hãy viết tới <1>{foundersEmail}</1>."
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset được xây dựng trong Superset, nên chúng tôi là người dùng số 1 của chính mình - bạn được trả tiền để làm cuộc sống của chính bạn dễ hơn. Chúng tôi đang xây một đội phẳng và đậm đặc nhân tài, và tìm những người có ý tưởng điên rồ và đủ điên để ship chúng. Nếu bạn từng muốn xây một sản phẩm mà chính mình thích dùng, hãy đến xây cùng chúng tôi."
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset được xây dựng ngay trong Superset, nên chúng tôi chính là những người dùng hàng đầu—bạn được trả lương để giúp công việc của mình dễ dàng hơn. Nếu bạn từng muốn xây dựng một sản phẩm mà mình yêu thích sử dụng, hãy cùng chúng tôi tạo ra nó."
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset được thiết kế để làm việc cùng công cụ sẵn có của bạn, chúng tôi hỗ trợ sẵn deep-link tới các IDE như Cursor để bạn mở workspace và tệp ngay trong IDE của mình."
@@ -14972,9 +14984,6 @@ msgstr "Hôm nay"
 
 msgid "TODAY"
 msgstr "HÔM NAY"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "Hôm nay, hàng chục nghìn kỹ sư dùng Superset làm IDE chính, tại các công ty như Wix, DoorDash và Netflix. Sắp tới, các đội sẽ chạy hàng trăm agent song song - những nhà máy phần mềm tự động sản xuất và ship code. Chúng tôi đang biến Superset thành nơi các đội vận hành và quản lý những nhà máy đó, bắt đầu từ chính chúng tôi."
 
 msgid "Todo"
 msgstr "Cần làm"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -2012,6 +2012,10 @@ msgstr "Áp dụng cho URL trong terminal, tin nhắn chat và trình duyệt c�
 msgid "Apply"
 msgstr "Áp dụng"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "Ứng tuyển"
+
 msgid "Approve"
 msgstr "Duyệt"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -2012,6 +2012,10 @@ msgstr "适用于终端、聊天消息和任务浏览器中的URL。"
 msgid "Apply"
 msgstr "应用"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "申请"
+
 msgid "Approve"
 msgstr "批准"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}天前"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {你的账户已停用，将在#天后被永久删除。重新激活即可恢复到你离开时的状态。} other {你的账户已停用，将在#天后被永久删除。重新激活即可恢复到你离开时的状态。}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance}前"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText}聚焦"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted}{count, plural, one {位开发者} other {位开发者}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} 位 YC 校友创始人"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "与此应用版本相同。"
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO与SCIM账号开通"
 
+msgid "San Francisco"
+msgstr "旧金山"
+
 msgid "Sandbox preview has no URL"
 msgstr "沙箱预览没有URL"
 
@@ -13415,6 +13424,9 @@ msgstr "出了点问题。请重试，或联系support@superset.sh。"
 msgid "soon"
 msgstr "即将"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "很快，团队就会并行运行数百个智能体，组成自主生产并交付代码的软件工厂。我们正在将 Superset 打造成团队运行和管理这些工厂的平台，先从我们自己的工厂开始。"
+
 msgid "Sort"
 msgstr "排序"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset正在构建能自我改进的软件。第一步，是给工程�
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset由一支位于加州旧金山的团队打造。产品支持或账户问题，请发邮件至<0>{supportEmail}</0>，我们会在一个工作日内回复。合作、媒体、企业版，或任何想直接找创始团队的事，请写信至<1>{foundersEmail}</1>。"
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset是用Superset自己造出来的，所以我们是自己的头号用户——你拿着工资让自己的日子更好过。我们在打造一支扁平、人才密度高的团队，想找那些有疯狂想法、也疯狂到真能把它做出来的人。如果你一直想做一个自己爱用的产品，来和我们一起做。"
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset 就是在 Superset 中构建的，因此我们自己就是它的头号用户——你可以通过让自己的工作更轻松来获得报酬。如果你一直想打造一款自己爱用的产品，就来和我们一起构建吧。"
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset的设计就是配合你现有的工具。我们原生支持深度链接到Cursor这类IDE，你可以直接在自己的IDE里打开工作区和文件。"
@@ -14972,9 +14984,6 @@ msgstr "今天"
 
 msgid "TODAY"
 msgstr "今天"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "如今，数万名工程师把Superset当作主力IDE，他们来自Wix、DoorDash、Netflix这样的公司。很快，团队会并行运行成百上千个智能体——自主制造并交付代码的软件工厂。我们要让Superset成为团队运行和管理这些工厂的地方，从我们自己开始。"
 
 msgid "Todo"
 msgstr "待办"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -643,6 +643,9 @@ msgstr "{days}天前"
 msgid "{daysRemaining, plural, one {Your account is deactivated and will be permanently deleted in # day. Reactivate to restore it exactly as you left it.} other {Your account is deactivated and will be permanently deleted in # days. Reactivate to restore it exactly as you left it.}}"
 msgstr "{daysRemaining, plural, one {你的帳戶已停用，將在#天後被永久刪除。重新啟用即可恢復到你離開時的狀態。} other {你的帳戶已停用，將在#天後被永久刪除。重新啟用即可恢復到你離開時的狀態。}}"
 
+msgid "{developerCount}+"
+msgstr "{developerCount}+"
+
 msgid "{distance} ago"
 msgstr "{distance}前"
 
@@ -663,6 +666,9 @@ msgstr "{focusShortcutText}聚焦"
 
 msgid "{formatted} {count, plural, one {dev} other {devs}}"
 msgstr "{formatted}{count, plural, one {位開發者} other {位開發者}}"
+
+msgid "{founderCount} ex-YC founders"
+msgstr "{founderCount} 位 YC 校友創辦人"
 
 msgid "{gate} · {statusLabel}"
 msgstr "{gate} · {statusLabel}"
@@ -12289,6 +12295,9 @@ msgstr "與此應用程式版本相同。"
 msgid "SAML SSO & SCIM provisioning"
 msgstr "SAML SSO與SCIM帳號開通"
 
+msgid "San Francisco"
+msgstr "舊金山"
+
 msgid "Sandbox preview has no URL"
 msgstr "沙箱預覽沒有URL"
 
@@ -13415,6 +13424,9 @@ msgstr "出了點問題。請重試，或聯絡support@superset.sh。"
 msgid "soon"
 msgstr "即將"
 
+msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
+msgstr "很快，團隊就會並行執行數百個代理，組成自主生產並交付程式碼的軟體工廠。我們正在將 Superset 打造成團隊執行和管理這些工廠的平台，先從我們自己的工廠開始。"
+
 msgid "Sort"
 msgstr "排序"
 
@@ -13885,8 +13897,8 @@ msgstr "Superset正在構建能自我改進的軟體。第一步，是給工程�
 msgid "Superset is built by a team based in San Francisco, California. For product support or account questions, email <0>{supportEmail}</0> and we'll get back to you within one business day. For partnerships, press, enterprise, or anything for the founding team, write to <1>{foundersEmail}</1>."
 msgstr "Superset由一支位於加州舊金山的團隊打造。產品支援或帳戶問題，請發郵件至<0>{supportEmail}</0>，我們會在一個工作日內回覆。合作、媒體、企業版，或任何想直接找創始團隊的事，請寫信至<1>{foundersEmail}</1>。"
 
-msgid "Superset is built in Superset, so we're our own #1 users - you get paid to make your own life easier. We're building a flat and talent-dense team, and we're looking for people who have crazy ideas and are crazy enough to ship them. If you've ever wanted to build a product you love to use, come build it with us."
-msgstr "Superset是用Superset自己造出來的，所以我們是自己的頭號使用者——你拿著工資讓自己的日子更好過。我們在打造一支扁平、人才密度高的團隊，想找那些有瘋狂想法、也瘋狂到真能把它做出來的人。如果你一直想做一個自己愛用的產品，來和我們一起做。"
+msgid "Superset is built in Superset, so we're our own #1 users—you get paid to make your own life easier. If you've ever wanted to build a product you love to use, come build it with us."
+msgstr "Superset 就是在 Superset 中建構的，因此我們自己就是它的頭號使用者——你可以透過讓自己的工作更輕鬆來獲得報酬。如果你一直想打造一款自己愛用的產品，就來和我們一起建構吧。"
 
 msgid "Superset is designed to work with your existing tool, we natively support deep-linking to IDEs like Cursor so you can open your workspaces and files in your IDE."
 msgstr "Superset的設計就是配合你現有的工具。我們原生支援深度連結到Cursor這類IDE，你可以直接在自己的IDE裡開啟工作區和檔案。"
@@ -14972,9 +14984,6 @@ msgstr "今天"
 
 msgid "TODAY"
 msgstr "今天"
-
-msgid "Today, tens of thousands of engineers run Superset as their primary IDE, at companies like Wix, DoorDash, and Netflix. Soon, teams will run 100s of agents in parallel - software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "如今，數萬名工程師把Superset當作主力IDE，他們來自Wix、DoorDash、Netflix這樣的公司。很快，團隊會並行執行成百上千個代理程式——自主製造並交付程式碼的軟體工廠。我們要讓Superset成為團隊執行和管理這些工廠的地方，從我們自己開始。"
 
 msgid "Todo"
 msgstr "待辦"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -2012,6 +2012,10 @@ msgstr "適用於終端、聊天訊息和任務瀏覽器中的URL。"
 msgid "Apply"
 msgstr "應用"
 
+msgctxt "job application"
+msgid "Apply"
+msgstr "應徵"
+
 msgid "Approve"
 msgstr "批准"
 
@@ -13425,7 +13429,7 @@ msgid "soon"
 msgstr "即將"
 
 msgid "Soon, teams will run hundreds of agents in parallel—software factories that autonomously manufacture and ship code. We're making Superset the place where teams run and manage those factories, starting with our own."
-msgstr "很快，團隊就會並行執行數百個代理，組成自主生產並交付程式碼的軟體工廠。我們正在將 Superset 打造成團隊執行和管理這些工廠的平台，先從我們自己的工廠開始。"
+msgstr "很快，團隊就會並行執行數百個代理程式，組成自主生產並交付程式碼的軟體工廠。我們正在將 Superset 打造成團隊執行和管理這些工廠的平台，先從我們自己的工廠開始。"
 
 msgid "Sort"
 msgstr "排序"


### PR DESCRIPTION
## What & why

Refresh `/join-us` with a spacious two-column introduction, consistent typography, and aligned company facts and open roles. Highlight San Francisco, 4 ex-YC founders, and 50,000+ developers; the adoption figure rounds down 54,570 identified desktop users verified in PostHog on September 10, excluding test accounts (cumulative, not monthly active).

Simplify the copy, translate it across all 17 locales, and add an Apply cue to the existing YC job row while removing its divider. Preserve the embedded job detail and application flow.

## How I tested it

- `bun run lint` — passed across the repository.
- Marketing `bun run typecheck` — passed.
- `bun run check:i18n` — extraction and strict compilation passed for all 17 locales.
- `bun test packages/i18n/test/catalog-integrity.test.ts` — 16 passed.
- Browser-checked the layout at desktop, tablet, and mobile widths, including French label alignment, and opened job details and the application form. Final Chrome checks confirmed the section spacing and job row at 1440, 390, and 320px in English, Japanese, Portuguese, and Russian. At 320px, the existing Russian global-footer privacy link extends 8px beyond the viewport; careers content remains aligned.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] Repository lint and affected marketing typecheck pass; full workspace checks run in CI.
- [x] Same-repository branch; fork permissions do not apply.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the `/join-us` careers page to match the approved design: a new two-column intro, a company facts strip, and shortened copy translated across all 17 locales.

The facts strip displays San Francisco, 4 ex-YC founders, and 50,000+ developers; the numbers and the YC job board's "Apply ↗" cue are now formatted and translated per locale. The developer count rounds down 54,570 identified desktop users verified in PostHog on September 10, excluding test accounts, and is cumulative (not monthly active). The job cards drop their divider, while job details and the application flow stay unchanged.

<sup>Written for commit 8b3d087d8bda9b56f35e8436d1e01f0b1521ff2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localized careers-page statistics for developers and founders, including the San Francisco location.
  - Added refreshed messaging about teams running software factories with parallel agents.
  - Added localized Apply actions to job listings.

- **Updates**
  - Refreshed the careers page layout, spacing, typography, and responsive behavior.
  - Updated careers messaging across supported languages for consistency.
  - Improved job-card presentation and application visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

