### PR TITLE
fix(desktop): preserve remembered workspace creation agent

### DIFF
--- a/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.test.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, afterEach, beforeEach, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+	getAgentEffortSupport,
+	getAgentModelSupport,
+} from "@superset/shared/agent-models";
+import { useAgentEffortPreference } from "../useAgentEffortPreference/useAgentEffortPreference";
+import { useAgentModelPreference } from "../useAgentModelPreference/useAgentModelPreference";
+import { useAgentLaunchPreferences } from "./useAgentLaunchPreferences";
+
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+const { act, cleanup, renderHook } = await import("@testing-library/react");
+const options = {
+	agentStorageKey: "test-agent",
+	defaultAgent: "claude",
+	fallbackAgent: "claude",
+	validAgents: ["none", "claude", "cursor"],
+	agentsReady: true,
+};
+beforeEach(() => window.localStorage.clear());
+afterEach(cleanup);
+afterAll(() => {
+	if (!alreadyRegistered) GlobalRegistrator.unregister();
+});
+
+test("remembers the explicitly selected agent across creations", () => {
+	const first = renderHook(() => useAgentLaunchPreferences(options));
+	act(() => first.result.current.setSelectedAgent("cursor"));
+	first.unmount();
+	const next = renderHook(() => useAgentLaunchPreferences(options));
+	expect(next.result.current.selectedAgent).toBe("cursor");
+});
+
+test("temporary unavailability does not erase the preference and it recovers", () => {
+	window.localStorage.setItem(options.agentStorageKey, "cursor");
+	const { result, rerender } = renderHook(useAgentLaunchPreferences, {
+		initialProps: options,
+	});
+	rerender({ ...options, validAgents: ["claude", "none"] });
+	expect(result.current.selectedAgent).toBe("claude");
+	expect(window.localStorage.getItem(options.agentStorageKey)).toBe("cursor");
+	rerender(options);
+	expect(result.current.selectedAgent).toBe("cursor");
+});
+
+test("asynchronous first-agent defaults are not saved as user choices", () => {
+	const { result, rerender } = renderHook(useAgentLaunchPreferences, {
+		initialProps: { ...options, defaultAgent: "none", agentsReady: false },
+	});
+	rerender(options);
+	expect(result.current.selectedAgent).toBe("claude");
+	expect(window.localStorage.getItem(options.agentStorageKey)).toBeNull();
+	act(() => result.current.setSelectedAgent("none"));
+	rerender({ ...options, defaultAgent: "cursor" });
+	expect(result.current.selectedAgent).toBe("none");
+});
+
+test("model and reasoning effort survive agent switches and remounts", () => {
+	const model = getAgentModelSupport("claude")?.models[0]?.id;
+	const effort = getAgentEffortSupport("claude")?.efforts[0]?.id;
+	expect(model).toBeDefined();
+	expect(effort).toBeDefined();
+	if (!model || !effort)
+		throw new Error("Expected Claude model and effort options");
+	const usePreferences = (presetId: string) => ({
+		...useAgentModelPreference("test-model", presetId),
+		...useAgentEffortPreference("test-effort", presetId),
+	});
+	const first = renderHook(usePreferences, { initialProps: "claude" });
+	act(() => {
+		first.result.current.setSelectedModel(model ?? null);
+		first.result.current.setSelectedEffort(effort ?? null);
+	});
+	first.rerender("cursor");
+	first.rerender("claude");
+	expect(first.result.current.selectedModel).toBe(model);
+	expect(first.result.current.selectedEffort).toBe(effort);
+	first.unmount();
+	const next = renderHook(usePreferences, { initialProps: "claude" });
+	expect(next.result.current.selectedModel).toBe(model);
+	expect(next.result.current.selectedEffort).toBe(effort);
+});

--- a/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.test.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.test.ts
@@ -81,3 +81,15 @@ test("model and reasoning effort survive agent switches and remounts", () => {
 	expect(next.result.current.selectedModel).toBe(model);
 	expect(next.result.current.selectedEffort).toBe(effort);
 });
+
+test("ignores empty native-select events during host option changes", () => {
+	window.localStorage.setItem(options.agentStorageKey, "cursor");
+	const { result, rerender } = renderHook(useAgentLaunchPreferences, {
+		initialProps: options,
+	});
+	rerender({ ...options, validAgents: ["claude", "none"] });
+	act(() => result.current.setSelectedAgent(""));
+	expect(window.localStorage.getItem(options.agentStorageKey)).toBe("cursor");
+	rerender(options);
+	expect(result.current.selectedAgent).toBe("cursor");
+});

--- a/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts
@@ -34,11 +34,13 @@ export function useAgentLaunchPreferences<TAgent extends string>({
 		if (typeof window === "undefined" || !projectStorageKey) return null;
 		return window.localStorage.getItem(projectStorageKey);
 	});
-	const [selectedAgent, setSelectedAgentState] = useState<TAgent>(() => {
-		if (typeof window === "undefined") return defaultAgent;
-		const stored = window.localStorage.getItem(agentStorageKey);
-		return stored ? (stored as TAgent) : defaultAgent;
-	});
+	const [preferredAgent, setSelectedAgentState] = useState<TAgent | null>(
+		() => {
+			if (typeof window === "undefined") return null;
+			const stored = window.localStorage.getItem(agentStorageKey);
+			return stored ? (stored as TAgent) : null;
+		},
+	);
 	const [autoRun, setAutoRunState] = useState(() => {
 		if (typeof window === "undefined" || !autoRunStorageKey) {
 			return initialAutoRun;
@@ -60,33 +62,13 @@ export function useAgentLaunchPreferences<TAgent extends string>({
 		window.localStorage.setItem(projectStorageKey, initialProjectId);
 	}, [projectStorageKey, recentProjects, selectedProjectId]);
 
-	// Never persist the fallback to localStorage — a transient unavailability
-	// should not permanently overwrite the user's explicit choice.
-	useEffect(() => {
-		if (!agentsReady) {
-			return;
-		}
-		if (validAgentSet.has(selectedAgent)) {
-			return;
-		}
-
-		const stored =
-			typeof window === "undefined"
-				? null
-				: window.localStorage.getItem(agentStorageKey);
-		if (stored && validAgentSet.has(stored as TAgent)) {
-			setSelectedAgentState(stored as TAgent);
-			return;
-		}
-
-		setSelectedAgentState(fallbackAgent);
-	}, [
-		agentStorageKey,
-		agentsReady,
-		fallbackAgent,
-		selectedAgent,
-		validAgentSet,
-	]);
+	// Availability is display state, not a new preference. Keeping the explicit
+	// choice lets it recover after host switches or asynchronous agent loading.
+	const requestedAgent = preferredAgent ?? defaultAgent;
+	const selectedAgent =
+		!agentsReady || validAgentSet.has(requestedAgent)
+			? requestedAgent
+			: fallbackAgent;
 
 	const setSelectedProjectId = (projectId: string | null) => {
 		setSelectedProjectIdState(projectId);

--- a/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentLaunchPreferences/useAgentLaunchPreferences.ts
@@ -81,6 +81,9 @@ export function useAgentLaunchPreferences<TAgent extends string>({
 	};
 
 	const setSelectedAgent = (agent: TAgent) => {
+		// Radix's native select can emit an empty value as host options change.
+		// It is not a user choice (the explicit opt-out is "none").
+		if (!agent) return;
 		setSelectedAgentState(agent);
 		if (typeof window !== "undefined") {
 			window.localStorage.setItem(agentStorageKey, agent);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/NewWorkspaceScreen/NewWorkspaceScreen.tsx
@@ -481,25 +481,11 @@ export function NewWorkspaceScreen({
 	const { selectedAgent, setSelectedAgent } =
 		useAgentLaunchPreferences<WorkspaceCreateAgent>({
 			agentStorageKey: AGENT_STORAGE_KEY,
-			defaultAgent: "none",
-			fallbackAgent: "none",
+			defaultAgent: selectableAgentIds[0] ?? "none",
+			fallbackAgent: selectableAgentIds[0] ?? "none",
 			validAgents: ["none", ...selectableAgentIds],
 			agentsReady: v2AgentsFetched,
 		});
-
-	// Same "none" → first-agent promotion as the control modal: new users land
-	// here with no stored preference, and the screen must not default to no agent.
-	useEffect(() => {
-		if (!v2AgentsFetched) return;
-		if (selectedAgent !== "none") return;
-		const stored =
-			typeof window !== "undefined"
-				? window.localStorage.getItem(AGENT_STORAGE_KEY)
-				: null;
-		if (stored === "none") return;
-		const first = selectableAgentIds[0];
-		if (first) setSelectedAgent(first);
-	}, [v2AgentsFetched, selectableAgentIds, selectedAgent, setSelectedAgent]);
 
 	const selectedPresetId = useMemo(() => {
 		const agent = v2Agents.find((candidate) => candidate.id === selectedAgent);


### PR DESCRIPTION
## What & why

Switching from Local Device to Cloud and back could replace a remembered Cursor Agent choice with Claude. Keep the explicit global preference separate from the displayed fallback and ignore the empty value emitted by the native select when its host-specific options change. Only user selections persist, including an explicit “no agent” choice.

Existing global host memory and per-agent model, reasoning effort, and mode preferences continue to apply.

## How I tested it

Real Electron UI tested over CDP in this branch's worktree: renderer `localhost:4725`, API `localhost:4721`, CDP `9475`. Confirmed the Electron process belongs to the worktree and verified the signed-in session through the app auth client.

- **Before:** ran the pre-fix source, selected Cursor Agent, switched Local Device → Cloud → Local Device. The saved agent changed to Claude and the UI showed Claude.
- **After:** repeated the same mouse-input sequence. Cloud displays its fallback without overwriting the saved Cursor ID; returning locally restores Cursor Agent and Composer 2.5.
- Navigated Workspaces → New Workspace: Cursor and its model persisted.
- Reloaded the renderer: Cursor, Composer 2.5, and the local host persisted.
- Selected Codex / GPT-5.6 Sol / High reasoning effort, navigated away and reopened: all three persisted. No console/window errors captured during this monitored sequence.
- Before/after screenshots were captured and visually inspected alongside persisted-state JSON; assertions on the recorded state passed. Local evidence is at `/tmp/creation-cdp-evidence/README.md` in the development workspace; screenshots are not public attachments.

CDP testing found the empty select-event issue that the initial hook tests missed; the final fix includes a regression test for it. No workspace submission, agent execution, or remote-host execution was tested.

Additional checks: five regression tests passed, desktop typecheck passed, changed-file Biome checks passed, `git diff --check` passed, and `bun run check:plugins` passed.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (targeted checks above passed; full monorepo checks left to CI)
- [ ] "Allow edits from maintainers" is checked on fork PRs (not a fork PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Agent selections are remembered across workspace screen reloads and remounts.
  - Previously selected agents are restored when they become available again.
  - The first selectable agent is chosen by default when no preference exists.
  - Model and reasoning-effort preferences persist when switching agents.
  - Temporary fallback agents no longer replace saved preferences.

- **Bug Fixes**
  - Empty agent-selection events no longer overwrite the saved agent preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->