### PR TITLE
chore(cursor): set up Cloud Agent dev environment

### DIFF
--- a/.cursor/docker-up.sh
+++ b/.cursor/docker-up.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Bring up a nested Docker daemon for the local dev DB stack.
+#
+# Cloud Agent VMs have no init system, so dockerd must be started by hand, and
+# the nested-container sandbox needs two tweaks the docker-compose stack in
+# ../docker-compose.yml relies on. Idempotent: safe to run on every boot.
+set -uo pipefail
+
+# 1) Daemon: start only if it isn't already serving.
+if ! docker info >/dev/null 2>&1; then
+  sudo mkdir -p /etc/docker
+  # The VM root is an overlay/tmpfs, so the default overlay2 storage driver is
+  # unavailable; fuse-overlayfs is the driver that works in the sandbox.
+  if [ ! -f /etc/docker/daemon.json ]; then
+    echo '{"storage-driver":"fuse-overlayfs"}' | sudo tee /etc/docker/daemon.json >/dev/null
+  fi
+  sudo sh -c 'nohup dockerd >/var/log/dockerd.log 2>&1 &'
+  for _ in $(seq 1 30); do
+    docker info >/dev/null 2>&1 && break
+    sleep 1
+  done
+fi
+
+# 2) Let this (non-root) user reach the daemon without sudo.
+sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
+
+# 3) Nested-Docker networking: same-subnet container<->container traffic on the
+# compose bridge is dropped when bridged frames traverse iptables (the sandbox's
+# nft/legacy split has no ACCEPT rule for it), which makes neon-proxy->postgres
+# and srh->redis time out. Turning bridge-nf off lets intra-bridge L2 traffic
+# flow. This is kernel runtime state, so it is reapplied on every boot.
+sudo modprobe br_netfilter 2>/dev/null || true
+sudo sysctl -w net.bridge.bridge-nf-call-iptables=0 >/dev/null 2>&1 || true
+sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=0 >/dev/null 2>&1 || true
+
+if ! docker info >/dev/null 2>&1; then
+  echo "docker daemon failed to start (see /var/log/dockerd.log)" >&2
+  exit 1
+fi
+echo "docker daemon ready"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Cloud Agent install: refresh dependencies and prepare the local dev stack.
+#
+# With environment builds this runs once to create the baseline snapshot; the
+# node_modules, generated .env, pulled Docker images, and the migrated+seeded
+# Postgres volume it produces are all baked into that snapshot. Per-boot
+# bring-up lives in start.sh. Idempotent: safe to re-run.
+set -euo pipefail
+export PATH="$HOME/.bun/bin:$PATH"
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+
+# The dev DB stack (Postgres + neon-http proxy + Redis + SRH shim) runs in
+# Docker; bring the nested daemon up so the setup below can create it and run
+# migrate/seed against it.
+./.cursor/docker-up.sh
+
+# Regenerate .env from scratch so repeated installs never append duplicate
+# workspace-override blocks (setup.local.sh appends on every run).
+rm -f .env
+
+# Reuse the repository's maintained local-dev setup end to end: bun install,
+# per-workspace .env, the Docker DB stack, database migrations, and the seeded
+# dev account (admin@local.test / supersetdev). No external credentials needed.
+./.superset/setup.local.sh

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Cloud Agent start: per-boot bring-up of the local dev DB stack.
+#
+# A fresh pod boots from the snapshot with node_modules, .env, Docker images and
+# the Postgres volume already on disk, but nothing running. This starts the
+# nested Docker daemon, brings the DB stack back up against its persistent
+# volume, waits for it to actually serve queries, and applies any migrations
+# that landed since the snapshot. Idempotent; returns once the stack is ready.
+set -uo pipefail
+export PATH="$HOME/.bun/bin:$PATH"
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+
+# Nested Docker daemon + networking (see docker-up.sh).
+./.cursor/docker-up.sh || exit 1
+
+# .env holds the per-workspace ports + DB URLs written by install. If a pod ever
+# boots without it (e.g. install never ran), fall back to the full local setup.
+if [ ! -f .env ]; then
+  echo "start: .env missing, running full setup.local.sh"
+  exec ./.superset/setup.local.sh
+fi
+
+set -a
+# shellcheck source=/dev/null
+. ./.env
+set +a
+
+# Match the docker-compose project name setup.local.sh uses (sanitized name).
+name="${SUPERSET_WORKSPACE_NAME:-$(basename "$PWD")}"
+PROJECT="superset-$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g; s/--*/-/g; s/^-//; s/-$//' | cut -c1-48)"
+
+echo "🗄️  Bringing up DB stack ($PROJECT)..."
+docker compose -p "$PROJECT" -f docker-compose.yml up -d || exit 1
+
+# Postgres health.
+cid="$(docker compose -p "$PROJECT" -f docker-compose.yml ps -q postgres 2>/dev/null)"
+for _ in $(seq 1 30); do
+  [ "$(docker inspect --format '{{.State.Health.Status}}' "$cid" 2>/dev/null)" = "healthy" ] && break
+  sleep 2
+done
+
+# neon-http proxy: the app's actual DB path. Probe a real query.
+proxy_ready=0
+for _ in $(seq 1 30); do
+  if curl -s --max-time 3 -X POST "http://localhost:${LOCAL_NEON_PROXY_PORT}/sql" \
+      -H "Neon-Connection-String: ${DATABASE_URL}" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"select 1","params":[]}' 2>/dev/null | grep -q '"command"'; then
+    proxy_ready=1; break
+  fi
+  sleep 1
+done
+[ "$proxy_ready" = 1 ] || { echo "neon-proxy not ready on :${LOCAL_NEON_PROXY_PORT}" >&2; exit 1; }
+
+# SRH (Redis HTTP shim) used by the relay.
+srh_ready=0
+for _ in $(seq 1 30); do
+  if curl -s --max-time 3 -X POST "http://localhost:${LOCAL_SRH_PORT}/" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer local_dev_token" \
+      -d '["PING"]' 2>/dev/null | grep -q 'PONG'; then
+    srh_ready=1; break
+  fi
+  sleep 1
+done
+[ "$srh_ready" = 1 ] || { echo "serverless-redis-http not ready on :${LOCAL_SRH_PORT}" >&2; exit 1; }
+
+# Apply any migrations that landed since the snapshot (idempotent), and ensure
+# the dev account exists (idempotent) so "Sign in as dev" always works.
+echo "📜 Applying migrations + ensuring dev account..."
+bun run db:migrate || exit 1
+NODE_ENV=development bun run db:seed-dev || true
+
+echo "✅ Dev DB stack ready ($PROJECT)"

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@blaxel/core": "0.3.19",
         "@types/bun": "1.3.14",
         "@types/semver": "7.7.1",
+        "babel-plugin-macros": "3.1.0",
         "dotenv-cli": "11.0.0",
         "semver": "7.7.4",
         "sherif": "1.11.0",
@@ -3529,6 +3530,8 @@
 
     "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
 
+    "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
+
     "@types/pg": ["@types/pg@8.21.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q=="],
 
     "@types/pidusage": ["@types/pidusage@2.0.5", "", {}, "sha512-MIiyZI4/MK9UGUXWt0jJcCZhVw7YdhBuTOuqP/BjuLDLZ2PmmViMIQgZiWxtaMicQfAz/kMrZ5T7PKxFSkTeUA=="],
@@ -3833,6 +3836,8 @@
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
+    "babel-plugin-macros": ["babel-plugin-macros@3.1.0", "", { "dependencies": { "@babel/runtime": "^7.12.5", "cosmiconfig": "^7.0.0", "resolve": "^1.19.0" } }, "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg=="],
+
     "babel-plugin-polyfill-corejs2": ["babel-plugin-polyfill-corejs2@0.4.17", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-define-polyfill-provider": "^0.6.8", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w=="],
 
     "babel-plugin-polyfill-corejs3": ["babel-plugin-polyfill-corejs3@0.13.0", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5", "core-js-compat": "^3.43.0" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A=="],
@@ -4109,7 +4114,7 @@
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
-    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
+    "cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "crc": ["crc@3.8.0", "", { "dependencies": { "buffer": "^5.1.0" } }, "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ=="],
 
@@ -4897,7 +4902,7 @@
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
-    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -7249,7 +7254,7 @@
 
     "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
-    "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+    "cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "crc/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -7286,8 +7291,6 @@
     "engine.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "error-ex/is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "esquery/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
@@ -7597,6 +7600,8 @@
 
     "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "shadcn/cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
+
     "shadcn/fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "shadcn/open": ["open@11.0.1", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.2.0", "wsl-utils": "^1.0.0" } }, "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw=="],
@@ -7620,6 +7625,8 @@
     "shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
 
     "simple-plist/bplist-parser": ["bplist-parser@0.3.1", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA=="],
+
+    "simple-swizzle/is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
@@ -8700,6 +8707,8 @@
     "react-native/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
+
+    "shadcn/cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "shadcn/open/wsl-utils": ["wsl-utils@1.0.0", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"@blaxel/core": "0.3.19",
 		"@types/bun": "1.3.14",
 		"@types/semver": "7.7.1",
+		"babel-plugin-macros": "3.1.0",
 		"dotenv-cli": "11.0.0",
 		"semver": "7.7.4",
 		"sherif": "1.11.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sets up a working Cloud Agent development environment for the Superset monorepo and makes the documented from-scratch local setup succeed end to end.

Two changes:

1. **`fix(deps): add babel-plugin-macros`** — The Lingui macro entry `@lingui/core/macro` (pulled in transitively by the auth server via `packages/shared`) falls back to a runtime shim that `require`s `babel-plugin-macros` when it isn't transformed by the SWC/Babel plugin. Scripts run directly with bun — notably `bun run db:seed-dev`, invoked by `.superset/setup.local.sh` — have no such transform, so a from-scratch install fails with `Cannot find package 'babel-plugin-macros'`. It is only an *optional peer* of `@lingui/core`, so bun never installs it; this declares it explicitly. (With `linker = "isolated"` the `bun.lock` reshuffle of `cosmiconfig`/`is-arrayish` is bookkeeping only — each package still resolves its declared version.)

2. **`chore(cursor): add Cloud Agent dev environment scripts`** — `.cursor/{docker-up,install,start}.sh` run the existing `.superset/setup.local.sh` local stack (Postgres + neon-http proxy + Redis + SRH shim in Docker, migrations, and the seeded `admin@local.test` dev account) inside a Cloud Agent VM, which needs the nested Docker daemon started by hand plus a bridge-netfilter tweak so same-subnet container traffic on the compose bridge isn't dropped. No external credentials are required.

The environment base + `install`/`start` wiring are configured out-of-repo via the Cloud Agent environment panel (`install: ./.cursor/install.sh`, `start: ./.cursor/start.sh`); these committed scripts are what it invokes. The scripts must be on the default branch for a promotable default-branch build, which is why this PR carries them.

## How I tested it

**Local end-to-end (this VM):** installed Bun 1.3.14, Docker + fuse-overlayfs, caddy, jq; ran `.superset/setup.local.sh` to completion (bun install, DB stack up, 291 tables migrated, dev account seeded), then started web + API dev servers. Verified dev sign-in against the live stack (web → API → better-auth → neon-http proxy → Postgres):

- `POST /api/auth/sign-in/email` (dev creds) → `200` with a session token and the `Local Admin` user.
- `GET /api/auth/get-session` → `200` authenticated session (org, role `owner`, plan `pro`).
- Web sign-in page renders and "Sign in as Local Admin (dev)" completes into the authenticated app (recording below).

**Cloud Agent build + fresh-agent verification:** snapshotted the working VM, triggered a draft environment build (`install: ./.cursor/install.sh`, `start: ./.cursor/start.sh`) off this branch — **SUCCEEDED**. Build logs confirm the nested pieces work in a clean build pod: `docker daemon ready`, `bun install` incl. `babel-plugin-macros@3.1.0` (5668 packages), neon-proxy ready on first probe, migrations applied, dev account seeded, install exit 0. A fresh cloud agent booted from that build then passed every check: bun `1.3.14`, 4 DB containers up, `admin@local.test` present via the proxy, web+API dev servers ready, and sign-in `HTTP 200`.

Note: on the fresh-agent boot the platform did not auto-run `start` (no `/tmp/cursor/start-user/` output; Docker was down until `./.cursor/start.sh` was run manually). The script is idempotent and brought the full stack up cleanly; a normally-launched cloud agent using the saved environment runs `start` on boot.

[superset_web_dev_signin_demo.mp4](https://cursor.com/agents/bc-b0bed844-8f60-4509-94d2-2041ece33732/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuperset_web_dev_signin_demo.mp4)

[Sign-in page with dev button](https://cursor.com/agents/bc-b0bed844-8f60-4509-94d2-2041ece33732/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuperset_signin_page.webp)
[Authenticated app after dev sign-in](https://cursor.com/agents/bc-b0bed844-8f60-4509-94d2-2041ece33732/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuperset_authenticated_view.webp)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [ ] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [ ] "Allow edits from maintainers" is checked on fork PRs

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0bed844-8f60-4509-94d2-2041ece33732?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0bed844-8f60-4509-94d2-2041ece33732&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the from-scratch local dev setup failing with `Cannot find package 'babel-plugin-macros'` and adds Cloud Agent scripts that run the existing local stack end to end.

- Adds `babel-plugin-macros` to root dependencies; it's an optional peer of `@lingui/core` that's required when running scripts via bun without a Babel/SWC transform.
- Adds `.cursor/docker-up.sh`, `.cursor/install.sh`, and `.cursor/start.sh` to set up and manage the nested Docker daemon and the local DB stack (Postgres, neon-http proxy, Redis, SRH) inside a Cloud Agent VM.
- The scripts are idempotent and require no external credentials; the Cloud Agent environment panel invokes them for install and start.

<sup>Written for commit 54fcf606eb855b7cc4ddef0ec11409951c2a2da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

