### PR TITLE
chore(cloud): add Cloud Agent development environment setup

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Cloud Agent install phase: refresh workspace dependencies after checkout.
+#
+# Slow, stable system tooling (Bun, Docker, fuse-overlayfs) lives in the base
+# snapshot, not here. This script only reconciles source-derived state, so it
+# must stay idempotent and terminate — no daemons, servers, or migrations.
+set -euo pipefail
+
+export PATH="$HOME/.bun/bin:$PATH"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> bun install"
+# postinstall compiles the Lingui catalogs and rebuilds the desktop native deps.
+bun install
+
+echo "==> ensure babel-plugin-macros (optional @lingui/core peer)"
+# The apps strip `@lingui/*/macro` imports at build time via @lingui/swc-plugin,
+# but `.superset/setup.local.sh` runs `bun run db:seed-dev` unbundled, so the
+# macro shim tries to load babel-plugin-macros at runtime. It is an OPTIONAL
+# peer of @lingui/core, so bun never installs it automatically. --no-save keeps
+# it out of the committed package.json / bun.lock.
+if [ ! -d node_modules/babel-plugin-macros ]; then
+  bun add babel-plugin-macros@3 --no-save
+fi
+
+echo "==> install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Cloud Agent start phase: bring up per-boot runtime state.
+#
+# 1. Start the Docker daemon (the VM has no init system to do it for us) and
+#    adjust the nested-container network so intra-bridge traffic works.
+# 2. Run the repo's canonical local setup, which writes the workspace .env,
+#    brings up the Postgres + neon-proxy + Redis/SRH stack via docker compose,
+#    applies migrations, and seeds the dev account. It is idempotent, so it is
+#    safe to run on every boot.
+set -uo pipefail
+
+export PATH="$HOME/.bun/bin:$PATH"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+start_dockerd() {
+  if sudo docker info >/dev/null 2>&1; then
+    echo "==> dockerd already running"
+  else
+    echo "==> starting dockerd"
+    sudo rm -f /var/run/docker.pid
+    sudo nohup dockerd >/tmp/dockerd.log 2>&1 &
+    local i
+    for i in $(seq 1 60); do
+      if sudo docker info >/dev/null 2>&1; then
+        break
+      fi
+      sleep 1
+    done
+    if ! sudo docker info >/dev/null 2>&1; then
+      echo "ERROR: dockerd did not become ready within 60s" >&2
+      tail -n 40 /tmp/dockerd.log >&2 || true
+      return 1
+    fi
+  fi
+
+  # Let the ubuntu user reach the socket without sudo (setup.local.sh runs
+  # `docker compose` directly). The socket is recreated on every daemon start.
+  sudo chmod 666 /var/run/docker.sock
+
+  # In this nested VM, routing intra-bridge container traffic through iptables
+  # drops it (proxy -> postgres hangs in SYN_SENT). All DB-stack containers
+  # share one bridge subnet, so bypassing bridge netfilter lets frames bridge
+  # directly at L2. Must be set before `docker compose up` creates the network.
+  sudo sysctl -w net.bridge.bridge-nf-call-iptables=0 >/dev/null 2>&1 || true
+  sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=0 >/dev/null 2>&1 || true
+}
+
+start_dockerd || exit 1
+
+# A stable per-VM name keeps the docker compose project (and its data volume)
+# consistent across reboots.
+export SUPERSET_WORKSPACE_NAME="${SUPERSET_WORKSPACE_NAME:-cloud-agent}"
+
+echo "==> running .superset/setup.local.sh"
+bash ./.superset/setup.local.sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sets up a working Cursor Cloud Agent development environment for this monorepo. Cloud Agent VMs boot without Bun or Docker and can't run the desktop Electron app headless, so this establishes a base + lifecycle setup that brings the **web + API + local database stack** up end to end on a fresh VM.

The environment is delivered as a **proposed db-managed Cloud Agent config** (Bun 1.3.14 + Docker + fuse-overlayfs baked into the base snapshot; inline `install`/`start`). This PR adds the same logic as two committed, reviewable scripts so it is versioned and available if the team later prefers a repo-managed environment:

- `.cursor/install.sh` (install phase): `bun install` (postinstall compiles Lingui catalogs + rebuilds desktop native deps), plus a `--no-save` install of `babel-plugin-macros`. That package is an *optional* peer of `@lingui/core`; the apps strip `@lingui/*/macro` imports at build time via `@lingui/swc-plugin`, but `.superset/setup.local.sh` runs `bun run db:seed-dev` unbundled, so the macro shim needs it at runtime. `--no-save` keeps it out of `package.json`/`bun.lock`.
- `.cursor/start.sh` (start phase): starts `dockerd` (no init system on the VM), makes the socket usable by the `ubuntu` user, disables bridge netfilter (`net.bridge.bridge-nf-call-iptables=0`) so intra-bridge container traffic works in the nested VM, then runs the repo's canonical `.superset/setup.local.sh` (writes the workspace `.env`, brings up Postgres + neon-proxy + Redis/SRH via docker compose, applies migrations, seeds the dev account). All idempotent.

## How I tested it

On the Cloud Agent VM:
- `.cursor/install.sh` → `bun install` completes (5660 packages), native desktop deps rebuild.
- `.cursor/start.sh` → dockerd up, DB stack healthy (`pg`, neon-proxy, redis, SRH all ready on the first try), migrations applied, dev account seeded — "All steps completed successfully!" Re-running is idempotent.
- `bunx turbo run dev --filter=@superset/api --filter=@superset/web` → API ready on :3001, web on :3000.
- End-to-end sign-in with the seeded dev account against the DB-backed auth API returns `HTTP 200` with a session token and the `Local Admin` (`admin@local.test`) user.
- `bunx turbo run typecheck --filter=@superset/auth` passes.
- Browser walkthrough of the "Sign in as Local Admin (dev)" flow (screenshots/recording in the agent summary).

Validated in a prebuilt environment build + a fresh Cloud Agent booted from it: correct tool versions, `node_modules` + `babel-plugin-macros` present, DB stack up, `select 1` through the neon proxy, and end-to-end sign-in all pass.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run typecheck` passes (ran representative `@superset/auth` scope)
- [ ] "Allow edits from maintainers" is checked on fork PRs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1beeefdf-17d8-467c-8d93-4736831a8f41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1beeefdf-17d8-467c-8d93-4736831a8f41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.cursor/install.sh` and `.cursor/start.sh` so Cursor Cloud Agent VMs can run the web + API + local database stack end to end. The VMs boot without Bun or a running Docker daemon and can't run the desktop app headless, so these scripts handle dependency install and per-boot runtime setup; both are idempotent.

- `.cursor/install.sh` runs `bun install` and adds `babel-plugin-macros` with `--no-save`, since the unbundled `db:seed-dev` script needs the optional `@lingui/core` peer at runtime.
- `.cursor/start.sh` starts `dockerd`, disables bridge netfilter so nested container traffic works, then runs `.superset/setup.local.sh` to bring up Postgres, neon-proxy, Redis/SRH, apply migrations, and seed the dev account.

<sup>Written for commit 866a10f548e5646c5430fa1c98d75a4aec888ef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

