### PR TITLE
fix(terminal): treat a PTY resize as a sync boundary; withhold output from hidden clients

### DIFF
--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -991,6 +991,32 @@ test(
 				false,
 				"legacy clients must never receive seq-protocol messages",
 			);
+
+			// Output withheld from a hidden, resize-diverged client is not
+			// zero-socket output: it must not land in the FIFO and be replayed
+			// to the next legacy attach, whose screen it was not laid out for.
+			const phone = new SeqRenderer({ cols: 45, rows: 20 });
+			try {
+				await phone.connect(terminalId);
+				await phone.waitSynced();
+				await sleep(400);
+				phone.sendVisible(false);
+				await sleep(400);
+				await disconnectLegacy();
+				await sleep(300);
+				sendCommand(terminalId, "ticks 10");
+				await waitForTrackerText(terminalId, "INPUT 000020");
+				await connectLegacy();
+				await sleep(600);
+				await writeChain;
+				assert.ok(
+					!visibleText(term).includes("INPUT 000020"),
+					"bytes withheld from a hidden client must not be replayed as legacy FIFO",
+				);
+			} finally {
+				await phone.disconnect().catch(() => {});
+				phone.dispose();
+			}
 		} finally {
 			await disconnectLegacy().catch(() => {});
 			term.dispose();

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -436,6 +436,28 @@ function sendCommand(terminalId: string, command: string): void {
 	assert.ok(!("error" in result), JSON.stringify(result));
 }
 
+/**
+ * Waits for an attached client's stream position to hold still. A resize
+ * makes the TUI repaint under a trapped SIGWINCH, and bash drops a line it
+ * was mid-`read` on when the trap fires — so no command may be in flight
+ * until the repaint has landed.
+ */
+async function quiesce(renderer: SeqRenderer): Promise<void> {
+	let seen = -1;
+	await waitFor(
+		async () => {
+			const now = renderer.anchor?.seq ?? 0;
+			if (now === seen) return true;
+			seen = now;
+			await sleep(300);
+			return false;
+		},
+		15_000,
+		"renderer stream to quiesce",
+	);
+	await renderer.drain();
+}
+
 async function waitForTrackerText(
 	terminalId: string,
 	marker: string,
@@ -1217,6 +1239,225 @@ test(
 			phone.dispose();
 			await legacyPhone.disconnect().catch(() => {});
 			legacyPhone.dispose();
+			await desktop.disconnect().catch(() => {});
+			desktop.dispose();
+			await disposeSessionAndWait(terminalId, db).catch(() => {});
+		}
+	},
+);
+
+test(
+	"a reattach whose anchor predates a resize reanchors instead of catching up at the old width",
+	{ timeout: 120_000 },
+	async () => {
+		const terminalId = `seq-resize-${randomUUID().slice(0, 8)}`;
+		// Desktop-sized at ROWS tall so the tracker snapshot (last ROWS lines)
+		// covers the whole screen.
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			cols: 120,
+			rows: ROWS,
+			initialCommand: `exec bash '${path.join(TEST_HOME, "tui.sh")}'`,
+		});
+		if ("error" in session) assert.fail(session.error);
+
+		const desktop = new SeqRenderer({ cols: 120, rows: ROWS });
+		const phone = new SeqRenderer({ cols: 45, rows: 20 });
+		try {
+			await desktop.connect(terminalId);
+			await desktop.waitVisible("TUI READY");
+			await phone.connect(terminalId);
+			await phone.waitSynced();
+			// The phone's resize shrinks the PTY; the TUI repaints for it.
+			await waitForTrackerText(terminalId, "FULL-REDRAW");
+			await phone.waitVisible("FULL-REDRAW");
+			await quiesce(desktop);
+
+			// ── A: the phone goes to the background and comes back on the same socket.
+			// Off screen it leaves the size minimum, the PTY grows back to the
+			// desktop, and everything the program emits from here on is laid out
+			// for 120 columns. None of it may reach a 45-column buffer nobody is
+			// looking at.
+			const countedBeforeHide = phone.countedThisAttach;
+			phone.sendVisible(false);
+			await sleep(400);
+			await quiesce(desktop);
+			sendCommand(terminalId, "ticks 5");
+			await waitForTrackerText(terminalId, "INPUT 000005");
+			await desktop.waitVisible("INPUT 000005");
+			await phone.drain();
+			assert.equal(
+				phone.countedThisAttach,
+				countedBeforeHide,
+				"a hidden client must receive no output",
+			);
+			// Back on screen the PTY shrinks for it again and the program
+			// repaints at 45 columns: the phone is told its new position and
+			// converges by repaint, never by bytes laid out for another width.
+			phone.sendVisible(true);
+			await phone.waitVisible("INPUT 000005", 15_000);
+			await quiesce(phone);
+			assert.equal(
+				phone.lastSynced?.mode,
+				"reanchor",
+				"a client back on screen after a resize must be reanchored",
+			);
+			assert.equal(
+				visibleText(phone.term),
+				await trackerVisible(terminalId),
+				"a client back on screen after a resize must converge by repaint",
+			);
+
+			// ── B: the phone is dropped while hidden and redials with its anchor.
+			phone.sendVisible(false);
+			await sleep(400);
+			await quiesce(desktop);
+			sendCommand(terminalId, "ticks 5");
+			await waitForTrackerText(terminalId, "INPUT 000010");
+			await desktop.waitVisible("INPUT 000010");
+			// The liveness sweep would drop it here. Redialing restores its
+			// 45-column snapshot and asks to catch up from where it left off; the
+			// host must refuse the exact catch-up and let the program repaint.
+			await phone.disconnect();
+			await sleep(300);
+			await phone.connect(terminalId, { autoResize: false });
+			const synced = await phone.waitSynced();
+			assert.equal(
+				synced.mode,
+				"reanchor",
+				"an anchor from before the PTY resized must reanchor, not catch up bytes laid out for another width",
+			);
+			await sleep(400);
+			await phone.drain();
+			assert.equal(
+				phone.countedThisAttach,
+				0,
+				"a reanchor across a resize must deliver no content bytes",
+			);
+			phone.sendResize(45, 20);
+			await phone.waitVisible("INPUT 000010", 15_000);
+			await quiesce(phone);
+			assert.equal(
+				visibleText(phone.term),
+				await trackerVisible(terminalId),
+				"the repaint after the phone's resize must converge its grid",
+			);
+
+			// ── C: a client on screen when the PTY resized saw it in-band, so its
+			// anchor stays exact: a desktop that dragged a pane divider and later
+			// reconnects must keep receiving exactly the bytes it missed.
+			await phone.disconnect();
+			await sleep(400);
+			desktop.sendResize(100, ROWS);
+			await sleep(400);
+			await quiesce(desktop);
+			await desktop.disconnect();
+			await sleep(300);
+			sendCommand(terminalId, "ticks 5");
+			await waitForTrackerText(terminalId, "INPUT 000015");
+			await desktop.connect(terminalId);
+			assert.equal(
+				(await desktop.waitSynced()).mode,
+				"exact",
+				"a resize the client watched live is not a boundary for it",
+			);
+			await desktop.waitVisible("INPUT 000015");
+			desktop.assertNoReset("whole run");
+			phone.assertNoReset("whole run");
+		} finally {
+			await phone.disconnect().catch(() => {});
+			phone.dispose();
+			await desktop.disconnect().catch(() => {});
+			desktop.dispose();
+			await disposeSessionAndWait(terminalId, db).catch(() => {});
+		}
+	},
+);
+
+test(
+	"a client that said it is off screen is not dropped for silence",
+	{ timeout: 90_000 },
+	async () => {
+		const terminalId = `seq-hidden-${randomUUID().slice(0, 8)}`;
+		const session = await createTerminalSessionInternal({
+			terminalId,
+			workspaceId,
+			db,
+			listed: true,
+			cols: COLS,
+			rows: ROWS,
+			initialCommand: `exec bash '${path.join(TEST_HOME, "size.sh")}'`,
+		});
+		if ("error" in session) assert.fail(session.error);
+		__setClientPingIntervalForTesting(1_000);
+
+		const desktop = new SeqRenderer({ cols: 120, rows: 30 });
+		const phone = new SeqRenderer({ cols: 45, rows: 20 });
+		let probes = 0;
+		const probeSize = async (): Promise<string> => {
+			probes += 1;
+			const marker = `SIZE ${String(probes).padStart(3, "0")} `;
+			desktop.sendInput("size\n");
+			await desktop.waitVisible(marker);
+			await desktop.drain();
+			const line = visibleText(desktop.term)
+				.split("\n")
+				.find((text) => text.includes(marker));
+			assert.ok(line, `no size report for probe ${probes}`);
+			return line.slice(line.indexOf(marker) + marker.length).trim();
+		};
+		const wasDropped = () =>
+			Promise.race([
+				phone.droppedByHost.then(() => true),
+				sleep(0).then(() => false),
+			]);
+
+		try {
+			await desktop.connect(terminalId);
+			await desktop.waitVisible("READY-SIZE");
+			await phone.connect(terminalId);
+			await phone.waitSynced();
+			assert.equal(await probeSize(), "20x45");
+
+			// A backgrounded phone's page is suspended: it stops answering, and
+			// that silence is expected. It already sits outside the size
+			// minimum, so dropping it would only force a redial when it returns.
+			phone.sendVisible(false);
+			phone.answerPings = false;
+			await sleep(400);
+			assert.equal(await probeSize(), "30x120");
+			await sleep(3_500);
+			assert.equal(
+				await wasDropped(),
+				false,
+				"a hidden client that stops answering must keep its socket",
+			);
+
+			phone.answerPings = true;
+			phone.sendVisible(true);
+			await sleep(400);
+			assert.equal(
+				await probeSize(),
+				"20x45",
+				"coming back on screen re-imposes the constraint on the same socket",
+			);
+
+			// On screen and silent is the half-open case: still dropped.
+			phone.answerPings = false;
+			await Promise.race([
+				phone.droppedByHost,
+				sleep(15_000).then(() => {
+					throw new Error("host never dropped the silent visible client");
+				}),
+			]);
+			assert.equal(await probeSize(), "30x120");
+		} finally {
+			__setClientPingIntervalForTesting(15_000);
+			await phone.disconnect().catch(() => {});
+			phone.dispose();
 			await desktop.disconnect().catch(() => {});
 			desktop.dispose();
 			await disposeSessionAndWait(terminalId, db).catch(() => {});

--- a/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
+++ b/packages/host-service/src/terminal/terminal.seq-catchup.node-test.ts
@@ -458,6 +458,23 @@ async function quiesce(renderer: SeqRenderer): Promise<void> {
 	await renderer.drain();
 }
 
+/** Asks size.sh for the PTY's size as the kernel holds it, via `renderer`. */
+function makeSizeProbe(renderer: SeqRenderer): () => Promise<string> {
+	let probes = 0;
+	return async () => {
+		probes += 1;
+		const marker = `SIZE ${String(probes).padStart(3, "0")} `;
+		renderer.sendInput("size\n");
+		await renderer.waitVisible(marker);
+		await renderer.drain();
+		const line = visibleText(renderer.term)
+			.split("\n")
+			.find((text) => text.includes(marker));
+		assert.ok(line, `no size report for probe ${probes}`);
+		return line.slice(line.indexOf(marker) + marker.length).trim();
+	};
+}
+
 async function waitForTrackerText(
 	terminalId: string,
 	marker: string,
@@ -1075,19 +1092,7 @@ test(
 		// that never speaks the message has to keep constraining the size.
 		const desktop = new SeqRenderer({ cols: 120, rows: 30 });
 		const phone = new SeqRenderer({ cols: 45, rows: 20 });
-		let probes = 0;
-		const probeSize = async (): Promise<string> => {
-			probes += 1;
-			const marker = `SIZE ${String(probes).padStart(3, "0")} `;
-			desktop.sendInput("size\n");
-			await desktop.waitVisible(marker);
-			await desktop.drain();
-			const line = visibleText(desktop.term)
-				.split("\n")
-				.find((text) => text.includes(marker));
-			assert.ok(line, `no size report for probe ${probes}`);
-			return line.slice(line.indexOf(marker) + marker.length).trim();
-		};
+		const probeSize = makeSizeProbe(desktop);
 
 		try {
 			await desktop.connect(terminalId);
@@ -1180,19 +1185,7 @@ test(
 		// A current build that goes half-open mid-session: the socket stays up
 		// from the host's point of view, but nothing ever comes back on it.
 		const phone = new SeqRenderer({ cols: 45, rows: 20 });
-		let probes = 0;
-		const probeSize = async (): Promise<string> => {
-			probes += 1;
-			const marker = `SIZE ${String(probes).padStart(3, "0")} `;
-			desktop.sendInput("size\n");
-			await desktop.waitVisible(marker);
-			await desktop.drain();
-			const line = visibleText(desktop.term)
-				.split("\n")
-				.find((text) => text.includes(marker));
-			assert.ok(line, `no size report for probe ${probes}`);
-			return line.slice(line.indexOf(marker) + marker.length).trim();
-		};
+		const probeSize = makeSizeProbe(desktop);
 
 		try {
 			await desktop.connect(terminalId);
@@ -1365,6 +1358,33 @@ test(
 				"a resize the client watched live is not a boundary for it",
 			);
 			await desktop.waitVisible("INPUT 000015");
+
+			// ── D: hidden without a resize is not withheld. Parking the wide
+			// desktop while the phone still sets the size changes nothing about
+			// the PTY, so the desktop keeps streaming — its scrollback must be
+			// whole when it comes back, however long it was away.
+			await phone.connect(terminalId);
+			await phone.waitSynced();
+			await sleep(400);
+			await quiesce(desktop);
+			const countedBeforePark = desktop.countedThisAttach;
+			desktop.sendVisible(false);
+			await sleep(400);
+			sendCommand(terminalId, "ticks 5");
+			await waitForTrackerText(terminalId, "INPUT 000020");
+			await desktop.waitVisible("INPUT 000020");
+			assert.ok(
+				desktop.countedThisAttach > countedBeforePark,
+				"a hidden client keeps receiving output while the PTY size holds",
+			);
+			desktop.sendVisible(true);
+			await sleep(400);
+			await desktop.drain();
+			assert.equal(
+				desktop.lastSynced?.mode,
+				"exact",
+				"a hidden client that stayed in step needs no resync on return",
+			);
 			desktop.assertNoReset("whole run");
 			phone.assertNoReset("whole run");
 		} finally {
@@ -1396,19 +1416,7 @@ test(
 
 		const desktop = new SeqRenderer({ cols: 120, rows: 30 });
 		const phone = new SeqRenderer({ cols: 45, rows: 20 });
-		let probes = 0;
-		const probeSize = async (): Promise<string> => {
-			probes += 1;
-			const marker = `SIZE ${String(probes).padStart(3, "0")} `;
-			desktop.sendInput("size\n");
-			await desktop.waitVisible(marker);
-			await desktop.drain();
-			const line = visibleText(desktop.term)
-				.split("\n")
-				.find((text) => text.includes(marker));
-			assert.ok(line, `no size report for probe ${probes}`);
-			return line.slice(line.indexOf(marker) + marker.length).trim();
-		};
+		const probeSize = makeSizeProbe(desktop);
 		const wasDropped = () =>
 			Promise.race([
 				phone.droppedByHost.then(() => true),

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -199,11 +199,11 @@ type TerminalClientMessage =
 	// Whether this client is actually showing the terminal right now — its pane
 	// is on screen and its app is foregrounded. Distinct from keyboard focus: a
 	// visible unfocused pane still has to render at the right size. Only visible
-	// clients constrain the PTY size or receive output: a hidden client is
-	// suspended or not drawn, so its bytes wait in the ring and it is resynced
-	// when it comes back (exactly, or by repaint if the PTY resized meanwhile).
-	// A client that never sends this counts as visible, so builds predating
-	// the message keep their existing behaviour.
+	// clients constrain the PTY size. A hidden client keeps receiving output
+	// until the PTY changes size; from then on the bytes are laid out for a
+	// width it does not have, so they are withheld and it is repainted when it
+	// comes back. A client that never sends this counts as visible, so builds
+	// predating the message keep their existing behaviour.
 	| { type: "visible"; visible: boolean }
 	// Answer to the host's `ping`. A client that has answered once and then
 	// goes silent is dropped, which is the only way a half-open socket (a phone
@@ -668,14 +668,15 @@ interface TerminalSession {
 	 */
 	clientDims: Map<TerminalSocket, { cols: number; rows: number }>;
 	/**
-	 * Sockets whose client said it is off screen, keyed to the stream position
-	 * when it left. Absence means visible, so a client that never sends the
-	 * message keeps constraining the size and receiving output as it always
-	 * has. Hidden clients are excluded from the minimum — a backgrounded phone
-	 * must not hold the PTY narrow for whoever is actually looking — and get
-	 * no output until they return, when they are resynced from that position.
+	 * Sockets whose client said it is off screen. Absence means visible, so a
+	 * client that never sends the message keeps constraining the size as it
+	 * always has. Hidden clients are excluded from the minimum — a backgrounded
+	 * phone must not hold the PTY narrow for whoever is actually looking. They
+	 * keep receiving output (null) until the PTY changes size, which records
+	 * the stream position where their copy diverged; from there they are
+	 * withheld and get a reanchor on return.
 	 */
-	hiddenSockets: Map<TerminalSocket, number>;
+	hiddenSockets: Map<TerminalSocket, number | null>;
 
 	/**
 	 * Tail of the in-flight follow-up send (writeFramedInputToSession).
@@ -1635,7 +1636,16 @@ function applyEffectiveDims(
 	if (!next) return;
 	const changed = next.cols !== session.cols || next.rows !== session.rows;
 	if (!changed && !options.force) return;
-	if (changed) session.lastResizeSeq = session.outputSeq;
+	if (changed) {
+		session.lastResizeSeq = session.outputSeq;
+		// Whatever follows is laid out for the new size; hidden clients still
+		// in step stop being so here.
+		for (const [socket, divergedAt] of session.hiddenSockets) {
+			if (divergedAt === null) {
+				session.hiddenSockets.set(socket, session.outputSeq);
+			}
+		}
+	}
 	session.resizeGeneration += 1;
 	session.pty.resize(next.cols, next.rows);
 	session.modeTracker.resize(next.cols, next.rows);
@@ -1656,39 +1666,15 @@ function releaseSocketDims(session: TerminalSession, ws: TerminalSocket) {
 }
 
 /**
- * A client back on screen after its output was withheld. If the PTY kept its
- * size and the gap is still in the ring, it gets exactly the bytes it missed.
- * Otherwise those bytes were laid out for another width (or are gone): it is
- * told its new position and nothing else, and the program repaints — the
- * resize its return causes delivers the SIGWINCH, or a nudge does when the
- * size does not move. A legacy client cannot be told where it is; it gets
- * the bytes or the repaint, which is all it can use anyway.
+ * A client back on screen after its output was withheld: the PTY changed
+ * size while it was away, so what it missed was laid out for a width it does
+ * not have. It is told its new position and nothing else, and the program
+ * repaints — the resize its return causes delivers the SIGWINCH, or a nudge
+ * does when the size does not move. A legacy client cannot be told where it
+ * is; the repaint is all it can use anyway.
  */
-function resumeHiddenSocket(
-	session: TerminalSession,
-	ws: TerminalSocket,
-	hiddenSince: number,
-) {
-	const seqAware = seqSockets.has(ws);
-	const exact =
-		hiddenSince > session.lastResizeSeq &&
-		hiddenSince >= session.retainedStartSeq;
-	if (exact) {
-		if (seqAware) {
-			sendMessage(ws, {
-				type: "synced",
-				epoch: session.epoch,
-				seq: hiddenSince,
-				mode: "exact",
-			});
-		}
-		if (hiddenSince < session.outputSeq) {
-			sendBytes(ws, readRetainedFrom(session, hiddenSince));
-		}
-		applyEffectiveDims(session);
-		return;
-	}
-	if (seqAware) {
+function resumeHiddenSocket(session: TerminalSession, ws: TerminalSocket) {
+	if (seqSockets.has(ws)) {
 		sendMessage(ws, {
 			type: "synced",
 			epoch: session.epoch,
@@ -1840,11 +1826,9 @@ function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
 			}
 			continue;
 		}
-		// Off screen means suspended or not drawn: bytes sent now land in a
-		// buffer nobody is looking at, laid out for whatever width the PTY
-		// moved to once this client stopped constraining it. They wait in the
-		// ring; `visible` resyncs the client.
-		if (session.hiddenSockets.has(socket)) continue;
+		// A hidden client whose copy diverged at a resize: these bytes are laid
+		// out for a width it does not have. `visible` reanchors it.
+		if (typeof session.hiddenSockets.get(socket) === "number") continue;
 		// A renderer that can't keep up lets its send buffer grow without bound.
 		// Drop it past the cap rather than buffer forever; it reconnects and
 		// replays the tail. Returning this chunk as "not sent" routes it to the
@@ -3692,14 +3676,14 @@ export function registerWorkspaceTerminalRoute({
 
 					if (message.type === "visible") {
 						if (message.visible) {
-							const hiddenSince = session.hiddenSockets.get(ws);
+							const divergedAt = session.hiddenSockets.get(ws);
 							session.hiddenSockets.delete(ws);
-							if (hiddenSince !== undefined) {
-								resumeHiddenSocket(session, ws, hiddenSince);
+							if (typeof divergedAt === "number") {
+								resumeHiddenSocket(session, ws);
 								return;
 							}
 						} else if (!session.hiddenSockets.has(ws)) {
-							session.hiddenSockets.set(ws, session.outputSeq);
+							session.hiddenSockets.set(ws, null);
 						}
 						// Going hidden releases this client's size constraint;
 						// coming back re-imposes it.

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -1554,7 +1554,10 @@ function answerDsrCursorQueries(session: TerminalSession, count: number) {
 function deliverOutput(session: TerminalSession, bytes: Uint8Array) {
 	session.modeTracker.feed(bytes);
 	retainOutput(session, bytes);
-	if (broadcastBytes(session, bytes) === 0) {
+	// The legacy FIFO stands in for a client that has nobody attached, not
+	// for one withheld from hidden clients: the sweep may also have detached
+	// closed sockets, so check what remains rather than what was sent.
+	if (broadcastBytes(session, bytes) === 0 && session.sockets.size === 0) {
 		bufferOutput(session, bytes);
 	}
 }

--- a/packages/host-service/src/terminal/terminal.ts
+++ b/packages/host-service/src/terminal/terminal.ts
@@ -199,8 +199,11 @@ type TerminalClientMessage =
 	// Whether this client is actually showing the terminal right now — its pane
 	// is on screen and its app is foregrounded. Distinct from keyboard focus: a
 	// visible unfocused pane still has to render at the right size. Only visible
-	// clients constrain the PTY size. A client that never sends this counts as
-	// visible, so builds predating the message keep their existing sizing.
+	// clients constrain the PTY size or receive output: a hidden client is
+	// suspended or not drawn, so its bytes wait in the ring and it is resynced
+	// when it comes back (exactly, or by repaint if the PTY resized meanwhile).
+	// A client that never sends this counts as visible, so builds predating
+	// the message keep their existing behaviour.
 	| { type: "visible"; visible: boolean }
 	// Answer to the host's `ping`. A client that has answered once and then
 	// goes silent is dropped, which is the only way a half-open socket (a phone
@@ -326,7 +329,10 @@ const WS_SEND_BUFFER_CAP_BYTES = 8 * 1024 * 1024;
 // the size minimum, which pins every other client at phone width. TCP
 // keepalive would take hours. So the host pings each client at the
 // application level and drops one that answered before but has now missed
-// CLIENT_PONG_MISS_LIMIT pings in a row (30–45s of silence).
+// CLIENT_PONG_MISS_LIMIT pings in a row (30–45s of silence). A client that
+// said it is off screen is exempt: a backgrounded phone's page is suspended,
+// so its silence is expected, and it already sits outside the size minimum,
+// so dropping it would only force a redial when it comes back.
 const CLIENT_PING_INTERVAL_MS = 15_000;
 const CLIENT_PONG_MISS_LIMIT = 2;
 const SOCKET_OPEN = 1;
@@ -359,6 +365,8 @@ const socketLiveness = new WeakMap<
 	TerminalSocket,
 	{ answered: boolean; unansweredPings: number }
 >();
+/** Sockets that dialed with `?seq=`; only these can be told their position. */
+const seqSockets = new WeakSet<TerminalSocket>();
 let clientPingIntervalMs = CLIENT_PING_INTERVAL_MS;
 let clientLivenessSweep: ReturnType<typeof setInterval> | null = null;
 
@@ -636,6 +644,15 @@ interface TerminalSession {
 	/** Bumped on every client resize; guards the nudge's delayed restore. */
 	resizeGeneration: number;
 	/**
+	 * Stream position of the last PTY resize. A resize is a sync boundary:
+	 * bytes before and after it were laid out for different widths, so a
+	 * client anchored at or before it cannot be caught up exactly — it
+	 * reanchors and the program repaints. Clients attached and on screen at
+	 * the time saw the resize in-band and are unaffected. -1 until the first
+	 * resize.
+	 */
+	lastResizeSeq: number;
+	/**
 	 * Sockets whose client currently holds keyboard focus. The PTY receives
 	 * the AGGREGATE (any focused socket) — so an unfocused duplicate pane
 	 * attaching can't tell the program the focused pane lost focus (tmux's
@@ -651,12 +668,14 @@ interface TerminalSession {
 	 */
 	clientDims: Map<TerminalSocket, { cols: number; rows: number }>;
 	/**
-	 * Sockets whose client said it is off screen. Absence means visible, so a
-	 * client that never sends the message keeps constraining the size as it
-	 * always has. Hidden clients are excluded from the minimum: a backgrounded
-	 * phone must not hold the PTY narrow for whoever is actually looking.
+	 * Sockets whose client said it is off screen, keyed to the stream position
+	 * when it left. Absence means visible, so a client that never sends the
+	 * message keeps constraining the size and receiving output as it always
+	 * has. Hidden clients are excluded from the minimum — a backgrounded phone
+	 * must not hold the PTY narrow for whoever is actually looking — and get
+	 * no output until they return, when they are resynced from that position.
 	 */
-	hiddenSockets: Set<TerminalSocket>;
+	hiddenSockets: Map<TerminalSocket, number>;
 
 	/**
 	 * Tail of the in-flight follow-up send (writeFramedInputToSession).
@@ -1616,6 +1635,7 @@ function applyEffectiveDims(
 	if (!next) return;
 	const changed = next.cols !== session.cols || next.rows !== session.rows;
 	if (!changed && !options.force) return;
+	if (changed) session.lastResizeSeq = session.outputSeq;
 	session.resizeGeneration += 1;
 	session.pty.resize(next.cols, next.rows);
 	session.modeTracker.resize(next.cols, next.rows);
@@ -1633,6 +1653,54 @@ function releaseSocketDims(session: TerminalSession, ws: TerminalSocket) {
 	const wasHidden = session.hiddenSockets.delete(ws);
 	// A hidden client was already outside the minimum, so nothing moved.
 	if (hadDims && !wasHidden) applyEffectiveDims(session);
+}
+
+/**
+ * A client back on screen after its output was withheld. If the PTY kept its
+ * size and the gap is still in the ring, it gets exactly the bytes it missed.
+ * Otherwise those bytes were laid out for another width (or are gone): it is
+ * told its new position and nothing else, and the program repaints — the
+ * resize its return causes delivers the SIGWINCH, or a nudge does when the
+ * size does not move. A legacy client cannot be told where it is; it gets
+ * the bytes or the repaint, which is all it can use anyway.
+ */
+function resumeHiddenSocket(
+	session: TerminalSession,
+	ws: TerminalSocket,
+	hiddenSince: number,
+) {
+	const seqAware = seqSockets.has(ws);
+	const exact =
+		hiddenSince > session.lastResizeSeq &&
+		hiddenSince >= session.retainedStartSeq;
+	if (exact) {
+		if (seqAware) {
+			sendMessage(ws, {
+				type: "synced",
+				epoch: session.epoch,
+				seq: hiddenSince,
+				mode: "exact",
+			});
+		}
+		if (hiddenSince < session.outputSeq) {
+			sendBytes(ws, readRetainedFrom(session, hiddenSince));
+		}
+		applyEffectiveDims(session);
+		return;
+	}
+	if (seqAware) {
+		sendMessage(ws, {
+			type: "synced",
+			epoch: session.epoch,
+			seq: session.outputSeq,
+			mode: "reanchor",
+		});
+	}
+	const next = effectiveDims(session);
+	const dimsUnchanged =
+		next === null || (next.cols === session.cols && next.rows === session.rows);
+	applyEffectiveDims(session);
+	if (dimsUnchanged) nudgeRepaint(session);
 }
 
 /**
@@ -1658,10 +1726,10 @@ function pingSocket(ws: TerminalSocket) {
 }
 
 /**
- * Drop every attached client that answered a ping before and has now missed
- * CLIENT_PONG_MISS_LIMIT in a row, then ping the rest. Detaching first means
- * the PTY grows back immediately; the socket is destroyed rather than closed
- * because a half-open peer never completes the close handshake.
+ * Drop every attached on-screen client that answered a ping before and has
+ * now missed CLIENT_PONG_MISS_LIMIT in a row, then ping the rest. Detaching
+ * first means the PTY grows back immediately; the socket is destroyed rather
+ * than closed because a half-open peer never completes the close handshake.
  */
 function sweepClientLiveness() {
 	for (const session of sessions.values()) {
@@ -1669,6 +1737,11 @@ function sweepClientLiveness() {
 			if (ws.readyState !== SOCKET_OPEN) continue;
 			const liveness = socketLiveness.get(ws);
 			if (!liveness) continue;
+			if (session.hiddenSockets.has(ws)) {
+				// Expected silence; count from zero when it is back on screen.
+				liveness.unansweredPings = 0;
+				continue;
+			}
 			if (
 				liveness.answered &&
 				liveness.unansweredPings >= CLIENT_PONG_MISS_LIMIT
@@ -1767,6 +1840,11 @@ function broadcastBytes(session: TerminalSession, bytes: Uint8Array): number {
 			}
 			continue;
 		}
+		// Off screen means suspended or not drawn: bytes sent now land in a
+		// buffer nobody is looking at, laid out for whatever width the PTY
+		// moved to once this client stopped constraining it. They wait in the
+		// ring; `visible` resyncs the client.
+		if (session.hiddenSockets.has(socket)) continue;
 		// A renderer that can't keep up lets its send buffer grow without bound.
 		// Drop it past the cap rather than buffer forever; it reconnects and
 		// replays the tail. Returning this chunk as "not sent" routes it to the
@@ -1854,6 +1932,7 @@ function sendSeqAttach(
 		request.kind === "anchor" &&
 		request.epoch === session.epoch &&
 		request.seq >= session.retainedStartSeq &&
+		request.seq > session.lastResizeSeq &&
 		request.seq <= session.outputSeq;
 
 	if (exact) {
@@ -1884,9 +1963,10 @@ function sendSeqAttach(
 	}
 
 	// Unknown/unrecoverable position ("none", epoch mismatch, gap beyond the
-	// ring). The client's existing screen beats anything we could synthesize —
-	// never overwrite it (#6290). Re-anchor at the live head and ask the
-	// program to repaint itself.
+	// ring, or an anchor from before the PTY last resized — those bytes were
+	// laid out for another width). The client's existing screen beats
+	// anything we could synthesize — never overwrite it (#6290). Re-anchor at
+	// the live head and ask the program to repaint itself.
 	sendMessage(socket, {
 		type: "synced",
 		epoch: session.epoch,
@@ -3095,9 +3175,10 @@ export async function createTerminalSessionInternal({
 		retainedStartSeq: 0,
 		pendingRepaintNudge: null,
 		resizeGeneration: 0,
+		lastResizeSeq: -1,
 		focusedSockets: new Set(),
 		clientDims: new Map(),
-		hiddenSockets: new Set(),
+		hiddenSockets: new Map(),
 	};
 	reclaimSession = session;
 	sessions.set(terminalId, session);
@@ -3387,6 +3468,7 @@ export function registerWorkspaceTerminalRoute({
 					}
 					replayBuffer(session, ws);
 				} else {
+					seqSockets.add(ws);
 					sendSeqAttach(session, ws, seqRequest);
 				}
 				if (session.exited) {
@@ -3610,9 +3692,14 @@ export function registerWorkspaceTerminalRoute({
 
 					if (message.type === "visible") {
 						if (message.visible) {
+							const hiddenSince = session.hiddenSockets.get(ws);
 							session.hiddenSockets.delete(ws);
-						} else {
-							session.hiddenSockets.add(ws);
+							if (hiddenSince !== undefined) {
+								resumeHiddenSocket(session, ws, hiddenSince);
+								return;
+							}
+						} else if (!session.hiddenSockets.has(ws)) {
+							session.hiddenSockets.set(ws, session.outputSeq);
 						}
 						// Going hidden releases this client's size constraint;
 						// coming back re-imposes it.


### PR DESCRIPTION
## What broke

Two changes from the night of 09-08 interact:

- **#7358** terminates a client that stops answering pings (30–45s of silence).
- **#7346** has the phone restore a cached buffer on reopen and catch up with `?seq=`.

A backgrounded phone is suspended, so it stops answering. The host drops it, the PTY grows back to the desktop's width, and when the phone returns it restores a 45-column snapshot and is handed bytes the program laid out for 120 columns. Result: corrupted screen and the size flapping on every background/foreground — the terminal experience reported on this week's TestFlight build.

## The actual hole predates both PRs

Since #6872 (08-25) the PTY runs at the smallest *visible* client. Two things were missing that made every transition unsafe:

1. **A hidden client kept receiving output** at whatever width the PTY moved to once the client stopped constraining it. Its buffer was wrong before any reattach happened.
2. **A resize never invalidated a client's seq anchor.** `exact` catch-up checked only epoch and ring bounds, so a client could be caught up across a width change.

#7358 and #7346 didn't create the hole — they made it fire on every phone background and made the result worse.

## The invariant

tmux shares one PTY across differently-sized clients with the same smallest-client rule and has for fifteen years. What it has that we didn't: **a client never renders bytes produced at a size other than its own.** tmux gets it from a server-side screen model; this PR gets it from the sync layer we already have.

- **A resize is a sync boundary.** `lastResizeSeq` records where it happened. An anchor at or before it cannot be caught up exactly and takes the existing `reanchor` + repaint path. A client that was on screen at the time saw the resize in-band and keeps exact catch-up — a desktop that dragged a divider and later reconnects still gets exactly the bytes it missed.
- **A hidden client stays in step until the PTY changes size.** It keeps receiving output as today — a parked desktop pane comes back with its scrollback whole, however long it was away. The moment the PTY resizes, hidden clients' copies diverge: from there they are withheld, and on `visible:true` they are told their new position via `synced` and left to the program's repaint (the SIGWINCH their return causes, or a nudge when the size doesn't move). Parking the sole viewer of a session never resizes it, so that path is byte-for-byte unchanged. Both clients already accept `synced` mid-stream; legacy clients are never sent a seq message.
- **The liveness sweep exempts hidden clients.** A suspended page's silence is expected, and it already sits outside the size minimum, so dropping it only forced a redial. A *visible* client that goes silent — the half-open case #7358 targets — is still dropped.

## Verification

Two new e2e tests in `terminal.seq-catchup.node-test.ts`, run under the real host-service, pty-daemon, and `/bin/sh` TUI:

- *a reattach whose anchor predates a resize reanchors instead of catching up at the old width* — the phone hides (its departure resizes the PTY, so no more output reaches it), returns on the same socket (reanchored, converges by repaint), is dropped and redials (reanchored, zero content bytes, converges after its resize); a desktop that watched a resize live still gets `exact` on reconnect; and a desktop parked while the phone still sets the size keeps streaming and needs no resync.
- *a client that said it is off screen is not dropped for silence* — hidden + silent keeps its socket; back on screen re-imposes its size on the same socket; visible + silent is still dropped.

Both **fail on main** (`exact` granted across the resize; hidden client dropped) and pass here. Full `bun run test:e2e` (adoption + all seq/liveness tests) passes; host-service unit suite: 1715 pass; typecheck and biome clean.

Not verified on a physical phone; the e2e models the phone as a client that posts `visible:false` and stops answering pings, which is what the shipped WebView does when iOS suspends it.

https://claude.ai/code/session_018KWX1RQjKPDeQ6syS7AABi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal recovery when reconnecting after a window or device resize.
  - Hidden terminal views now resynchronize correctly when shown again.
  - Clients that remain off screen are no longer disconnected solely due to inactivity.
  - Prevented stale terminal positions from causing missed output or incorrect catch-up after resizing.
  - Improved synchronization for devices that disconnect and reconnect during terminal updates.
  - Prevented withheld output from being replayed incorrectly to a newly connected client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->