### PR TITLE
fix(admin): size dashboard tiles by width ratio, and line up funnel bars

### DIFF
--- a/apps/admin/src/app/(dashboard)/components/FunnelChart/FunnelChart.tsx
+++ b/apps/admin/src/app/(dashboard)/components/FunnelChart/FunnelChart.tsx
@@ -118,9 +118,13 @@ export function FunnelChart({
 			</p>
 		</div>
 	) : (
-		<div className="h-full overflow-x-auto">
+		<div className="h-full overflow-auto">
+			{/* Bars and footers sit in two shared rows, so every bar ends on the
+			    same baseline however many lines its step's label and stats take.
+			    The bar row carries the minimum, not the bars: an item taller than
+			    its row would paint over the labels below it. */}
 			<div
-				className="grid h-full min-w-[720px] gap-0"
+				className="grid h-full min-w-[720px] grid-rows-[minmax(120px,1fr)_auto] gap-x-0 gap-y-2"
 				style={{
 					gridTemplateColumns: `repeat(${steps.length}, minmax(0, 1fr))`,
 				}}
@@ -153,9 +157,9 @@ export function FunnelChart({
 					return (
 						<div
 							key={step.name + String(index)}
-							className="border-border/60 flex h-full flex-col gap-2 border-l px-2 first:border-l-0"
+							className="border-border/60 grid row-span-2 grid-rows-subgrid border-l px-2 first:border-l-0"
 						>
-							<div className="relative min-h-[160px] flex-1 overflow-hidden rounded-sm">
+							<div className="relative overflow-hidden rounded-sm">
 								{pctOfFirst < 100 ? (
 									<Tooltip>
 										<TooltipTrigger asChild>

--- a/apps/admin/src/app/(dashboard)/components/TileGrid/TileGrid.tsx
+++ b/apps/admin/src/app/(dashboard)/components/TileGrid/TileGrid.tsx
@@ -18,7 +18,8 @@ import { useTileLayout } from "../../providers/TileLayoutProvider";
 export interface GridTile {
 	key: string;
 	node: ReactNode;
-	// Width in twelfths of the row; height in grid rows (ROW_HEIGHT px each).
+	// Both in twelfths of the row width: a row unit is as tall as a column is
+	// wide, so w === h is a square and a tile keeps its shape at any width.
 	w?: number;
 	h?: number;
 }
@@ -29,14 +30,20 @@ interface TileGridProps {
 }
 
 const COLS = 12;
-const ROW_HEIGHT = 20;
 const MARGIN: [number, number] = [24, 24];
 const DEFAULT_W = 6;
-const DEFAULT_H = 13;
+const DEFAULT_H = 4;
 const MIN_W = 3;
-const MIN_H = 8;
+const MIN_H = 2;
 // Below this width the grid is one column and tiles stack in order.
 const STACK_BELOW_PX = 900;
+
+// The library's column width for a grid of `cols` across `width`, which is
+// also the row height. Stacked tiles take the shape a half-width tile has on
+// the wide grid rather than a twelfth of a narrow one.
+function unitPx(width: number, cols: number): number {
+	return (width - MARGIN[0] * (cols - 1)) / cols;
+}
 
 function defaultLayout(tiles: GridTile[], cols: number): Layout {
 	let x = 0;
@@ -98,6 +105,7 @@ export function TileGrid({ section, tiles }: TileGridProps) {
 	const { version, readLayout, writeLayout } = useTileLayout();
 	const stacked = width < STACK_BELOW_PX;
 	const cols = stacked ? 1 : COLS;
+	const rowHeight = unitPx(width, stacked ? COLS / 2 : COLS);
 
 	const [layout, setLayout] = useState<Layout>(() =>
 		defaultLayout(tiles, COLS),
@@ -135,7 +143,7 @@ export function TileGrid({ section, tiles }: TileGridProps) {
 					width={width}
 					gridConfig={{
 						cols,
-						rowHeight: ROW_HEIGHT,
+						rowHeight,
 						margin: MARGIN,
 						containerPadding: [0, 0],
 					}}

--- a/apps/admin/src/app/(dashboard)/growth/page.tsx
+++ b/apps/admin/src/app/(dashboard)/growth/page.tsx
@@ -34,9 +34,12 @@ import { GrowthRangeProvider } from "./providers/GrowthRangeProvider";
 // Discord, Google) that feed the top of that path. Tiles can be dragged and
 // resized within their section; the arrangement is remembered per browser.
 
-const CHART_H = 13;
-const TABLE_H = 18;
-const FUNNEL_H = 16;
+// Sizes are in twelfths of the row width, height included; see the
+// dashboard page for how the heights were chosen.
+const CHART_H = 4;
+const TALL_CHART_H = 5;
+const TABLE_H = 6;
+const FUNNEL_H = 4;
 const FULL_W = 12;
 
 function GrowthPageContent() {
@@ -145,7 +148,7 @@ function GrowthPageContent() {
 						key: "content-inventory",
 						node: <ContentInventoryTile />,
 						w: FULL_W,
-						h: CHART_H + 3,
+						h: TALL_CHART_H,
 					},
 				]}
 			/>
@@ -163,7 +166,7 @@ function GrowthPageContent() {
 						key: "conversions",
 						node: <ConversionsTile />,
 						w: FULL_W,
-						h: CHART_H + 3,
+						h: TALL_CHART_H,
 					},
 					{
 						key: "activation-funnel",
@@ -204,11 +207,11 @@ function GrowthPageContent() {
 					<Trans>Whether the people acquired stay and what they pay.</Trans>
 				}
 				tiles={[
-					{ key: "mrr", node: <MrrTile />, h: CHART_H + 2 },
+					{ key: "mrr", node: <MrrTile />, h: TALL_CHART_H },
 					{
 						key: "logo-retention",
 						node: <LogoRetentionTile />,
-						h: CHART_H + 2,
+						h: TALL_CHART_H,
 					},
 					{
 						key: "churn-heatmap",
@@ -229,8 +232,8 @@ function GrowthPageContent() {
 					</Trans>
 				}
 				tiles={[
-					{ key: "github", node: <GithubTile />, w: 8, h: TABLE_H + 2 },
-					{ key: "discord", node: <DiscordTile />, w: 4, h: 8 },
+					{ key: "github", node: <GithubTile />, w: 8, h: TABLE_H },
+					{ key: "discord", node: <DiscordTile />, w: 4, h: 3 },
 				]}
 			/>
 
@@ -247,7 +250,7 @@ function GrowthPageContent() {
 						key: "search-console",
 						node: <SearchConsoleTile />,
 						w: FULL_W,
-						h: TABLE_H + 8,
+						h: TABLE_H + 2,
 					},
 				]}
 			/>

--- a/apps/admin/src/app/(dashboard)/page.tsx
+++ b/apps/admin/src/app/(dashboard)/page.tsx
@@ -28,16 +28,17 @@ import { TileLayoutProvider } from "./providers/TileLayoutProvider";
 // sizes below are the defaults, not a fixed arrangement — money first, then
 // usage, then the slower-moving vanity and vendor tiles.
 
-// Grid heights, in 20px rows, measured against what each tile actually draws:
-// a chart stretches to its cell, so it gets a height that reads well, while a
-// list or a table gets the height of its rows so the tile isn't half empty.
-// Tiles that share a row want the same height — a row is as tall as its
-// tallest tile, so a short tile beside a tall one leaves a hole under it.
-const CHART_H = 13;
-const LIST_H = 8;
-const TABLE_H = 18;
-const FUNNEL_H = 16;
-const STAR_H = 19;
+// Sizes are in twelfths of the row width, height included, so a half-width
+// chart at 6 × 4 is 3:2 on any screen. A chart stretches to its cell, so it
+// gets a height that reads well; a list or a table gets the height of its
+// rows so the tile isn't half empty. Tiles that share a row want the same
+// height — a row is as tall as its tallest tile, so a short tile beside a
+// tall one leaves a hole under it.
+const CHART_H = 4;
+const LIST_H = 3;
+const TABLE_H = 6;
+const FUNNEL_H = 4;
+const STAR_H = 6;
 const FULL_W = 12;
 const HALF_W = 6;
 

--- a/apps/admin/src/app/(dashboard)/providers/TileLayoutProvider/TileLayoutProvider.tsx
+++ b/apps/admin/src/app/(dashboard)/providers/TileLayoutProvider/TileLayoutProvider.tsx
@@ -10,10 +10,10 @@ import {
 } from "react";
 import type { Layout } from "react-grid-layout";
 
-// The key still says "growth" because that is where these layouts started;
-// renaming it would silently reset every arrangement already saved in someone's
-// browser. Sections are namespaced within it.
-const STORAGE_PREFIX = "admin.growth.layout.";
+// Bump the version when the grid's units change: heights saved in the old
+// unit would draw at the wrong size, so a reset is the right outcome then.
+// Sections are namespaced within it.
+const STORAGE_PREFIX = "admin.tile-layout.v2.";
 
 interface TileLayout {
 	// Bumped on reset so every grid re-reads its default layout.


### PR DESCRIPTION
## Why

After #7393 put the dashboard on the tile grid, tiles came out squarish and the activation funnel far taller than it needed to be, with its step footers at different heights.

The grid row was a fixed 20px plus a 24px gutter, so heights were absolute pixels while widths scaled with the window. A 13-row chart was 548px on every screen: 700×548 on a 16" MacBook, portrait on smaller laptops. Each funnel column laid out its own footer, so a two-line label with a drop-off row pushed that bar up while step one kept a taller bar.

## What

- **Row unit = column width.** `TileGrid` derives `rowHeight` from the measured width, so `h` is in the same twelfths as `w` and `w === h` is a square. Stacked mode uses a half-grid unit so single-column tiles keep the half-tile shape.
- **New defaults.** Half-width charts 6×4 (3:2), full-width charts and both funnels 12×4, lists 3, tables and the star chart 6, taller Growth charts 5. The funnel goes from 680px to 464px at a 16" window.
- **Funnel baseline.** Bars and footers sit in two shared grid rows via `grid-rows-subgrid`; the 120px minimum lives on the row, not the bar, because an over-tall bar painted over the labels at laptop width.
- **Saved layouts reset once.** The localStorage key is versioned since stored heights are in the old unit.

## Verified

Rendered the Company and Product tabs and the Growth page in the running admin app against live PostHog/Stripe/Neon data at 1440, 1728 and 1920px windows and a stacked 1000px window, measuring every tile over CDP:

- half tiles are 1.53:1 at every width; full-width charts 3.1:1
- all six funnel bars end on the same pixel; every step label fully visible
- nothing overflows at 1728 or wider; at 1440 the burn-by-vendor list scrolls ~60px and the two ten-row Growth tables ~110px, which a ratio grid cannot avoid for content-height tiles

Typecheck and biome pass. No strings changed.

https://claude.ai/code/session_01XQWxiUQYj5vjTszp35F1xS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes dashboard tiles scale with the window by deriving the grid row height from column width instead of a fixed pixel count, and lines up all funnel bars on one baseline.

Previously every row was a fixed 20px, so tile heights were absolute while widths scaled — a 13-row chart was 548px tall on every screen. Now a row unit is as tall as a column is wide, so a 6×4 tile keeps a 3:2 shape at any window width. Funnel step bars and footers now share two grid rows via `grid-rows-subgrid` instead of each column laying out its own footer, so every bar ends on the same pixel.

Saved tile arrangements reset once: the localStorage key is versioned because heights stored in the old unit would draw at the wrong size.

<sup>Written for commit 2f047ff48f16fcf1e3486d1154bec01b44628a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dashboard tiles now maintain more consistent proportions across screen sizes.
  * Funnel chart bars align evenly, regardless of label or statistics length.
  * Funnel charts now scroll vertically when additional content requires it.
  * Dashboard chart, list, table, funnel, and star tiles have updated sizing for a more balanced layout.
  * Updated tile layouts may require users to arrange dashboard tiles again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->