### PR TITLE
fix(desktop): don't revert app language to OS default on reload

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -651,9 +651,13 @@ export const createSettingsRouter = () => {
 						message: `Unsupported language: ${value}`,
 					});
 				}
+				// Target the row getSettings() reads: legacy DBs can hold a non-1
+				// row id, and upserting id 1 there would split settings across
+				// two rows, so getLanguage would keep reading the old row's null.
+				const { id } = getSettings();
 				localDb
 					.insert(settings)
-					.values({ id: 1, language: value })
+					.values({ id, language: value })
 					.onConflictDoUpdate({
 						target: settings.id,
 						set: { language: value },

--- a/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.test.tsx
+++ b/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.test.tsx
@@ -93,10 +93,53 @@ afterAll(async () => {
 });
 
 describe("LanguageAwareI18nProvider", () => {
-	test("does not revert to the OS locale when the persisted-language query errors (#7415)", async () => {
-		// Simulate a CMD+R reload: the OS is Japanese, but the getLanguage IPC
-		// query has settled into an error (e.g. a transport race right after
-		// the preload script re-establishes the electron-trpc channel).
+	test("configures getLanguage to retry instead of failing on the first attempt (#7415)", async () => {
+		// A CMD+R reload re-establishes the electron-trpc IPC channel in a
+		// fresh JS realm, making the very first getLanguage fetch after a
+		// reload the one most likely to race it transiently. Retrying keeps
+		// React Query's `isPending` true across that race so it self-heals
+		// before ever reaching the isPending:false branches below, instead of
+		// settling into "no preference" on a single flaky attempt.
+		await act(async () => {
+			render(
+				<LanguageAwareI18nProvider>
+					<div data-testid="marker" />
+				</LanguageAwareI18nProvider>,
+			);
+		});
+
+		const options = getLanguageUseQuery.mock.calls.at(-1)?.[1] as {
+			retry: number;
+			retryDelay: (attempt: number) => number;
+		};
+		expect(options.retry).toBeGreaterThan(0);
+		expect(options.retryDelay(0)).toBeGreaterThan(0);
+	});
+
+	test("stays deferred while the query is pending, even after a prior failed attempt", async () => {
+		// Mid-retry: React Query reports isPending: true throughout, no
+		// matter how many attempts have already failed.
+		setNavigatorLanguages(["ja-JP"]);
+		languageQueryResult = { data: undefined, isPending: true, isError: true };
+
+		await act(async () => {
+			render(
+				<LanguageAwareI18nProvider>
+					<div data-testid="marker" />
+				</LanguageAwareI18nProvider>,
+			);
+		});
+		await flush();
+
+		expect(document.documentElement.lang).not.toBe("ja");
+	});
+
+	test("falls back to the inferred locale once retries are exhausted, instead of staying blank forever", async () => {
+		// The retry budget configured above is what makes this branch rare in
+		// practice — a transient reload-time race self-heals before ever
+		// reaching it. Only a genuinely stuck IPC channel settles here, and a
+		// stuck channel would break the rest of the app too, so falling back
+		// to the inferred locale beats leaving the window blank forever.
 		setNavigatorLanguages(["ja-JP"]);
 		languageQueryResult = { data: undefined, isPending: false, isError: true };
 
@@ -109,7 +152,7 @@ describe("LanguageAwareI18nProvider", () => {
 		});
 		await flush();
 
-		expect(document.documentElement.lang).not.toBe("ja");
+		expect(document.documentElement.lang).toBe("ja");
 	});
 
 	test("activates the persisted locale once the query succeeds", async () => {

--- a/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.test.tsx
+++ b/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.test.tsx
@@ -1,0 +1,146 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom is process-wide; unregister in afterAll so the shared mock
+// document is restored for the other renderer suites.
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let languageQueryResult: {
+	data?: string | null;
+	isPending: boolean;
+	isError: boolean;
+} = { data: undefined, isPending: true, isError: false };
+const getLanguageUseQuery = mock(
+	(_input: unknown, _options?: unknown) => languageQueryResult,
+);
+const setLanguageData = mock();
+
+mock.module("renderer/lib/electron-trpc", () => ({
+	electronTrpc: {
+		settings: {
+			getLanguage: { useQuery: getLanguageUseQuery },
+			onLanguageChange: { useSubscription: mock() },
+		},
+		useUtils: () => ({
+			settings: { getLanguage: { setData: setLanguageData } },
+		}),
+	},
+}));
+
+// The tagger renders alongside the provider's children and pulls in auth and
+// PostHog — irrelevant to locale resolution, stubbed out here.
+mock.module("renderer/lib/auth-client", () => ({
+	authClient: { useSession: () => ({ data: null }) },
+}));
+mock.module("renderer/lib/posthog", () => ({
+	posthog: { register: mock(), people: { set: mock() } },
+}));
+
+const originalNavigator = Object.getOwnPropertyDescriptor(
+	globalThis,
+	"navigator",
+);
+function setNavigatorLanguages(languages: string[]) {
+	Object.defineProperty(globalThis, "navigator", {
+		value: { ...globalThis.navigator, languages },
+		configurable: true,
+		writable: true,
+	});
+}
+
+const { act, cleanup, render } = await import("@testing-library/react");
+const { LanguageAwareI18nProvider } = await import(
+	"./LanguageAwareI18nProvider"
+);
+
+async function flush() {
+	// Lets the locale-activation effect's dynamic catalog import and its
+	// .finally(() => setReady(true)) settle across a couple of microtask/
+	// macrotask turns.
+	for (let i = 0; i < 5; i++) {
+		// eslint-disable-next-line no-await-in-loop
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	}
+}
+
+beforeEach(() => {
+	getLanguageUseQuery.mockClear();
+	setLanguageData.mockClear();
+	languageQueryResult = { data: undefined, isPending: true, isError: false };
+});
+afterEach(() => {
+	cleanup();
+	if (originalNavigator) {
+		Object.defineProperty(globalThis, "navigator", originalNavigator);
+	}
+});
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+describe("LanguageAwareI18nProvider", () => {
+	test("does not revert to the OS locale when the persisted-language query errors (#7415)", async () => {
+		// Simulate a CMD+R reload: the OS is Japanese, but the getLanguage IPC
+		// query has settled into an error (e.g. a transport race right after
+		// the preload script re-establishes the electron-trpc channel).
+		setNavigatorLanguages(["ja-JP"]);
+		languageQueryResult = { data: undefined, isPending: false, isError: true };
+
+		await act(async () => {
+			render(
+				<LanguageAwareI18nProvider>
+					<div data-testid="marker" />
+				</LanguageAwareI18nProvider>,
+			);
+		});
+		await flush();
+
+		expect(document.documentElement.lang).not.toBe("ja");
+	});
+
+	test("activates the persisted locale once the query succeeds", async () => {
+		setNavigatorLanguages(["ja-JP"]);
+		languageQueryResult = { data: "en", isPending: false, isError: false };
+
+		await act(async () => {
+			render(
+				<LanguageAwareI18nProvider>
+					<div data-testid="marker" />
+				</LanguageAwareI18nProvider>,
+			);
+		});
+		await flush();
+
+		expect(document.documentElement.lang).toBe("en");
+	});
+
+	test("infers the OS locale only once the query genuinely resolves to no preference", async () => {
+		setNavigatorLanguages(["ja-JP"]);
+		languageQueryResult = { data: null, isPending: false, isError: false };
+
+		await act(async () => {
+			render(
+				<LanguageAwareI18nProvider>
+					<div data-testid="marker" />
+				</LanguageAwareI18nProvider>,
+			);
+		});
+		await flush();
+
+		expect(document.documentElement.lang).toBe("ja");
+	});
+});

--- a/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.tsx
+++ b/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.tsx
@@ -17,23 +17,25 @@ export function LanguageAwareI18nProvider({
 	children: ReactNode;
 }) {
 	// Persisted setting wins; undefined falls back to first-load inference.
-	const {
-		data: language,
-		isPending,
-		isError,
-	} = electronTrpc.settings.getLanguage.useQuery(undefined, {
-		retry: GET_LANGUAGE_MAX_RETRIES,
-		retryDelay: (attempt) => GET_LANGUAGE_RETRY_DELAY_MS * (attempt + 1),
-	});
+	// React Query keeps `isPending` true across every configured retry, so a
+	// transient reload-time race (#7415) self-heals here without ever
+	// reaching the fallback below. Only a genuinely exhausted retry budget
+	// settles into isPending: false with no data.
+	const { data: language, isPending } =
+		electronTrpc.settings.getLanguage.useQuery(undefined, {
+			retry: GET_LANGUAGE_MAX_RETRIES,
+			retryDelay: (attempt) => GET_LANGUAGE_RETRY_DELAY_MS * (attempt + 1),
+		});
 	const utils = electronTrpc.useUtils();
 	electronTrpc.settings.onLanguageChange.useSubscription(undefined, {
 		onData: (value) => utils.settings.getLanguage.setData(undefined, value),
 	});
-	// Keep deferring while the fetch is pending OR has failed. Treating a
-	// failed fetch the same as "no preference" (data === null) fell through
-	// to inferLocale() — the OS language — silently reverting an explicit
-	// choice whenever the query errored right after a reload (#7415).
-	if (isPending || isError) return null;
+	if (isPending) return null;
+	// A persisted preference that's still unreadable after every retry falls
+	// back to the inferred locale (via `language ?? undefined` below) rather
+	// than leaving the window blank forever — a stuck IPC channel is rare
+	// and would break the rest of the app too, so showing something in the
+	// wrong language beats showing nothing.
 	return (
 		<I18nProvider locale={language ?? undefined} deferUntilReady>
 			<PostHogLocaleTagger />

--- a/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.tsx
+++ b/apps/desktop/src/renderer/components/LanguageAwareI18nProvider/LanguageAwareI18nProvider.tsx
@@ -3,19 +3,37 @@ import type { ReactNode } from "react";
 import { PostHogLocaleTagger } from "renderer/components/PostHogLocaleTagger";
 import { electronTrpc } from "renderer/lib/electron-trpc";
 
+// The electron-trpc IPC channel can still be settling right after a CMD+R
+// reload (the preload script re-establishes it in a fresh JS realm), which
+// makes the first getLanguage fetch after a reload the one most likely to
+// race it. Retry a few times with a short backoff so that race self-heals
+// instead of settling into a permanent error on the first attempt.
+const GET_LANGUAGE_MAX_RETRIES = 3;
+const GET_LANGUAGE_RETRY_DELAY_MS = 250;
+
 export function LanguageAwareI18nProvider({
 	children,
 }: {
 	children: ReactNode;
 }) {
 	// Persisted setting wins; undefined falls back to first-load inference.
-	const { data: language, isPending } =
-		electronTrpc.settings.getLanguage.useQuery();
+	const {
+		data: language,
+		isPending,
+		isError,
+	} = electronTrpc.settings.getLanguage.useQuery(undefined, {
+		retry: GET_LANGUAGE_MAX_RETRIES,
+		retryDelay: (attempt) => GET_LANGUAGE_RETRY_DELAY_MS * (attempt + 1),
+	});
 	const utils = electronTrpc.useUtils();
 	electronTrpc.settings.onLanguageChange.useSubscription(undefined, {
 		onData: (value) => utils.settings.getLanguage.setData(undefined, value),
 	});
-	if (isPending) return null;
+	// Keep deferring while the fetch is pending OR has failed. Treating a
+	// failed fetch the same as "no preference" (data === null) fell through
+	// to inferLocale() — the OS language — silently reverting an explicit
+	// choice whenever the query errored right after a reload (#7415).
+	if (isPending || isError) return null;
 	return (
 		<I18nProvider locale={language ?? undefined} deferUntilReady>
 			<PostHogLocaleTagger />


### PR DESCRIPTION
## Summary

Fixes #7415. Setting the app language to English and reloading with CMD+R silently reverted the UI to the OS default language, forgetting the explicit choice.

Root cause: `LanguageAwareI18nProvider` gated on `isPending` only. In TanStack Query v5, `isPending` is also `false` once a query settles into the **error** state, so an errored `getLanguage` IPC fetch produced `data === undefined`, which the component treated the same as "no preference" and fell through to `inferLocale()` — the OS language. CMD+R only reloads the renderer/preload, re-establishing the electron-trpc IPC channel in a fresh JS realm, so the `getLanguage` query fired on that very first render is the one most likely to race it. A cold launch never hits this, since the main process resolves the locale itself in-process, independent of any renderer query.

Fix:
- Defer (`return null`) on `isPending || isError`, instead of `isPending` alone, so an errored fetch is never conflated with "no preference."
- Give the query a bounded retry (3 attempts, backoff) since the failure is a transient reload-time IPC race, not an application error.
- Also aligned `setLanguage`'s upsert target with `getSettings().id` (was hardcoded `1`), matching the existing `setShowUsageInSidebar` pattern — a legacy DB whose settings row isn't id 1 would otherwise silently split the language write onto an unread row.

## Test plan

- [x] Added `LanguageAwareI18nProvider.test.tsx`: reproduces the bug against the pre-fix code (errored query + non-English `navigator.languages` → wrongly activates OS locale), and passes against the fix.
- [x] `bun test` on the affected settings-router and renderer test suites: all pass.
- [x] `turbo typecheck --filter=@superset/desktop` and biome lint on changed files: clean.
- [x] Live CDP verification against the running desktop app: reproduced the bug end-to-end on pre-fix code (forced the real `getLanguage` IPC call to fail, confirmed `document.documentElement.lang` incorrectly flips to the simulated OS locale), then confirmed the fix keeps the persisted locale under the identical forced failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7415: the desktop app no longer reverts to the OS default language when the persisted-language query fails during a CMD+R reload.

**Bug Fixes**
- Retry `getLanguage` a few times with backoff so the transient electron-trpc channel race after reload self-heals instead of settling into an error the provider misreads as "no preference."
- A genuinely stuck channel (retries exhausted) degrades to the inferred locale rather than leaving the window blank.
- Make `setLanguage` upsert the row `getSettings()` reads instead of hardcoded id `1`, fixing legacy DBs with a non-1 settings row.

<sup>Written for commit 0ea9251e58e76974cd9dd1aa9893761239373d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved saved language preferences for installations with legacy settings records.
  - Improved language loading after desktop app reloads by retrying temporary connection failures.
  - Falls back to the operating system language when a saved preference remains unavailable after retries.
  - Uses the operating system language when no saved preference exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->