### PR TITLE
fix(agent-setup): provision bundled skill extras from inside app.asar

### DIFF
--- a/packages/agent-setup/src/managed-skills.ts
+++ b/packages/agent-setup/src/managed-skills.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { cp, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { writeFileIfChanged } from "./agent-wrappers-common";
@@ -321,18 +321,20 @@ function listSourceSkills(sourceDir: string): string[] | null {
 	}
 }
 
-/** Copies a bundled skill's extra files (anything besides SKILL.md) verbatim. */
+/**
+ * Copies a bundled skill's extra files (anything besides SKILL.md) verbatim.
+ * File by file rather than `fs.cp`: in a packaged app the source sits inside
+ * app.asar, whose fs shim has no `opendir`, and `cp` walks directories with it.
+ */
 async function copyBundledExtras(
 	sourceDir: string,
 	targetDir: string,
 ): Promise<void> {
-	for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
-		if (entry.name === "SKILL.md") continue;
-		await cp(
-			path.join(sourceDir, entry.name),
-			path.join(targetDir, entry.name),
-			{ recursive: true },
-		);
+	for (const file of listFilesRecursive(sourceDir)) {
+		if (file === "SKILL.md") continue;
+		const target = path.join(targetDir, file);
+		await mkdir(path.dirname(target), { recursive: true });
+		await copyFile(path.join(sourceDir, file), target);
 	}
 }
 


### PR DESCRIPTION
## Problem

Every packaged build logs, once per bundled skill at boot:

```
[agent-setup] Failed to provision skill superset-setup: Error: ENOENT, dist/main/templates/plugin/skills/setup/agents not found in …/app.asar
```

and the skill's extra files (`agents/openai.yaml`, `scripts/*.sh`) never reach the agent directories. Only `SKILL.md` is written. Development builds are unaffected because the templates are on a real filesystem there.

## Cause

`copyBundledExtras` used `fs.promises.cp({ recursive: true })`. Node's `cp` walks directories with `opendir`, which Electron's asar filesystem shim does not implement, so the walk fails with the shim's `ENOENT` for a directory that is in the archive. Reproduced inside the packaged Electron (41.10.3, Node 24.18) against `app.asar`:

| call on the `agents` directory | result |
| --- | --- |
| `readdirSync` / `promises.readdir` | ok |
| `statSync` / `promises.lstat` | ok |
| `promises.copyFile` (a file in it) | ok |
| `promises.opendir` | `ENOTDIR` |
| `promises.cp` / `cpSync` recursive | `ENOENT … not found in app.asar` |

## Fix

Copy file by file with the existing `listFilesRecursive` (readdir-based) plus `mkdir` and `copyFile`, which the shim supports. Same output layout as before.

Found while running the Linux desktop acceptance checklist (#7428, row 4.3); it is not Linux-specific, macOS builds hit the same path.

## Verification

- `bun test packages/agent-setup`: 323 pass.
- Packaged app (AppImage build of #7428 with this patch applied, run on a Linux desktop): zero `Failed to provision skill` lines at boot, and `~/.claude/skills/superset/skills/<skill>/agents/openai.yaml` plus `10x/scripts/audit.sh` are present. The same build without the patch logged the ENOENT for every skill.

https://claude.ai/code/session_01WcGbULcxE9Nw1Y8YVqe3KZ
