### PR TITLE
fix(desktop): don't double the sidebar divider beside the active first tab

### DIFF
--- a/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/TabBar.tsx
@@ -203,6 +203,7 @@ export function TabBar<TData>({
 								registry={registry}
 								index={i}
 								isActive={tab.id === activeTabId}
+								flushLeft={i === 0 && !renderTabBarLeading}
 								onSelect={() => onSelectTab(tab.id)}
 								onClose={() => onCloseTab(tab.id)}
 								onCloseOthers={() => onCloseOtherTabs(tab.id)}

--- a/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
+++ b/packages/panes/src/react/components/Workspace/components/TabBar/components/TabItem/TabItem.tsx
@@ -27,6 +27,7 @@ interface TabItemProps<TData> {
 	registry: PaneRegistry<TData>;
 	index: number;
 	isActive: boolean;
+	flushLeft: boolean;
 	onSelect: () => void;
 	onClose: () => void;
 	onCloseOthers: () => void;
@@ -42,6 +43,7 @@ export function TabItem<TData>({
 	registry,
 	index,
 	isActive,
+	flushLeft,
 	onSelect,
 	onClose,
 	onCloseOthers,
@@ -128,6 +130,7 @@ export function TabItem<TData>({
 						isActive
 							? "border border-border border-b-transparent bg-background text-foreground"
 							: "border border-transparent border-b-border text-muted-foreground/70 hover:bg-border/20 hover:text-muted-foreground",
+						flushLeft && "border-l-transparent",
 						isPaneOver && "bg-primary/5",
 						isDragging && "opacity-30",
 					)}


### PR DESCRIPTION
## Why

With the dashboard sidebar expanded, the divider between it and the pane tab bar is one line thicker along the tab row whenever the first tab is active. The active tab outlines its left, right, and top edges, and its left edge sits directly on the sidebar's divider.

## What

The tab bar tells the first tab it is flush left when nothing renders ahead of it, and that tab drops its left border (`border-l-transparent`), the same treatment the workspace sidebar header gives its first tab. With the collapsed rail the tab bar hosts the traffic-light inset and nav controls ahead of the tabs, so the first tab keeps its outline there.

## Verification

Driven over CDP in this worktree's dev app: opened a v2 workspace, added a terminal tab via the plus menu. The active first tab's computed left border is transparent and the divider measures the same width at the tab row and below it (was 3 px at the tab row, 2 px below).

Not changed: the divider itself is still two coincident 1 px lines (resizable panel + sidebar inner container). That predates this branch and the collapsed rail relies on the inner one.

https://claude.ai/code/session_015pogMW2rmrXaSNATckMFmM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the divider between the expanded sidebar and tab bar being one line thicker along the tab row whenever the first tab is active. The active first tab now drops its left border when nothing renders ahead of it, keeping the divider a consistent width.

- `TabBar` passes `flushLeft` to the first tab only when no leading content renders ahead of it.
- `TabItem` applies `border-l-transparent` when `flushLeft` is set.
- The collapsed rail still renders traffic-light inset and nav controls ahead of the tabs, so the first tab keeps its outline there.

<sup>Written for commit 990b918020fc1eed1dbbe2b0b90dc45953ac3062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab bar alignment by removing the visible left border from the first tab when no leading content is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->