### PR TITLE
feat(billing): gate automations behind the Pro plan

### DIFF
--- a/apps/api/src/app/api/automations/evaluate/route.ts
+++ b/apps/api/src/app/api/automations/evaluate/route.ts
@@ -2,11 +2,18 @@ import { db } from "@superset/db/client";
 import {
 	automations,
 	automationTriggers,
+	subscriptions,
 	type TriggerConfig,
 } from "@superset/db/schema";
+import {
+	ACTIVE_SUBSCRIPTION_STATUSES,
+	type PlanTier,
+	planAllowsTriggerKind,
+	planTierFromSubscription,
+} from "@superset/shared/billing";
 import { nextOccurrenceAfter } from "@superset/shared/rrule";
 import { Client } from "@upstash/qstash";
-import { and, eq, lte } from "drizzle-orm";
+import { and, desc, eq, inArray, lte } from "drizzle-orm";
 import { env } from "@/env";
 import { redispatchUndispatched } from "@/lib/automations/redispatchUndispatched";
 import { singleFlight } from "@/lib/singleFlight";
@@ -41,6 +48,38 @@ function scheduleFromConfig(
 }
 
 /**
+ * The plan of each organization, for the tier gate. One query for the whole
+ * batch rather than one per row; the newest paying subscription wins, as it
+ * does everywhere else the plan is read.
+ */
+async function organizationPlans(
+	organizationIds: string[],
+): Promise<Map<string, PlanTier>> {
+	const plans = new Map<string, PlanTier>();
+	if (organizationIds.length === 0) return plans;
+	const rows = await db
+		.select({
+			organizationId: subscriptions.referenceId,
+			plan: subscriptions.plan,
+			status: subscriptions.status,
+		})
+		.from(subscriptions)
+		.where(
+			and(
+				inArray(subscriptions.referenceId, organizationIds),
+				inArray(subscriptions.status, [...ACTIVE_SUBSCRIPTION_STATUSES]),
+			),
+		)
+		.orderBy(desc(subscriptions.createdAt));
+	for (const row of rows) {
+		if (!plans.has(row.organizationId)) {
+			plans.set(row.organizationId, planTierFromSubscription(row));
+		}
+	}
+	return plans;
+}
+
+/**
  * One sweep at a time. Ticks arrive every minute whether or not the previous
  * sweep finished, and a sweep that is still going is not worth joining.
  */
@@ -65,6 +104,7 @@ export async function POST(request: Request): Promise<Response> {
 	const rows = await db
 		.select({
 			automationId: automations.id,
+			organizationId: automations.organizationId,
 			triggerId: automationTriggers.id,
 			nextRunAt: automationTriggers.nextRunAt,
 			config: automationTriggers.config,
@@ -87,6 +127,16 @@ export async function POST(request: Request): Promise<Response> {
 			row.nextRunAt !== null,
 	);
 
+	// Tier gate, same map the editor badges from: a downgraded org's schedules
+	// stay configured and keep advancing, they just never fire. Advancing keeps
+	// the row current, so an upgrade resumes at the next occurrence instead of
+	// replaying a backlog of missed ones.
+	const plans = await organizationPlans([
+		...new Set(due.map((row) => row.organizationId)),
+	]);
+	const belowPlan = (organizationId: string) =>
+		!planAllowsTriggerKind(plans.get(organizationId) ?? "free", "schedule");
+
 	// Work out the next occurrence before dispatching anything: a trigger we
 	// can't advance must not be enqueued, or it would fire on every tick forever
 	// while its next_run_at stayed put.
@@ -95,6 +145,7 @@ export async function POST(request: Request): Promise<Response> {
 		triggerId: string;
 		scheduledFor: Date;
 		next: Date | null;
+		enqueue: boolean;
 	}> = [];
 	const unusable: Array<{ automationId: string; reason: string }> = [];
 
@@ -113,11 +164,14 @@ export async function POST(request: Request): Promise<Response> {
 				triggerId: row.triggerId,
 				scheduledFor: bucketToMinute(row.nextRunAt),
 				next: nextOccurrenceAfter({ ...schedule, after: row.nextRunAt }),
+				enqueue: !belowPlan(row.organizationId),
 			});
 		} catch (error) {
 			unusable.push({ automationId: row.automationId, reason: String(error) });
 		}
 	}
+	const toEnqueue = planned.filter((entry) => entry.enqueue);
+	const skippedByPlan = planned.length - toEnqueue.length;
 
 	// Should be empty. These automations are stalled until someone fixes the
 	// config, so they need to be loud rather than silently skipped.
@@ -138,19 +192,21 @@ export async function POST(request: Request): Promise<Response> {
 		});
 	}
 
-	await qstash.batchJSON(
-		planned.map(({ automationId, triggerId, scheduledFor }) => ({
-			url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${automationId}`,
-			body: {
-				automationId,
-				triggerId,
-				scheduledFor: scheduledFor.toISOString(),
-			},
-			deduplicationId: `${automationId}_${scheduledFor.getTime()}`,
-			retries: 2,
-			failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
-		})),
-	);
+	if (toEnqueue.length > 0) {
+		await qstash.batchJSON(
+			toEnqueue.map(({ automationId, triggerId, scheduledFor }) => ({
+				url: `${env.NEXT_PUBLIC_API_URL}/api/automations/dispatch/${automationId}`,
+				body: {
+					automationId,
+					triggerId,
+					scheduledFor: scheduledFor.toISOString(),
+				},
+				deduplicationId: `${automationId}_${scheduledFor.getTime()}`,
+				retries: 2,
+				failureCallback: `${env.NEXT_PUBLIC_API_URL}/api/automations/run-failed`,
+			})),
+		);
+	}
 
 	const advanceResults = await Promise.allSettled(
 		planned.map(async ({ triggerId, next }) => {
@@ -188,7 +244,8 @@ export async function POST(request: Request): Promise<Response> {
 	const redispatched = await sweepUndispatched();
 
 	return Response.json({
-		enqueued: planned.length,
+		enqueued: toEnqueue.length,
+		skippedByPlan,
 		advanceFailed: advanceFailures.length,
 		unusable: unusable.length,
 		redispatched,

--- a/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
+++ b/apps/api/src/lib/automations/dispatchMatchingTriggers.ts
@@ -16,6 +16,7 @@ import {
 	ACTIVE_SUBSCRIPTION_STATUSES,
 	type PlanTier,
 	planAllowsTriggerKind,
+	planTierFromSubscription,
 	requiredPlanForTriggerKind,
 } from "@superset/shared/billing";
 import { Client } from "@upstash/qstash";
@@ -174,7 +175,7 @@ export async function dispatchMatchingTriggers(params: {
  */
 async function organizationPlan(organizationId: string): Promise<PlanTier> {
 	const [subscription] = await db
-		.select({ plan: subscriptions.plan })
+		.select({ plan: subscriptions.plan, status: subscriptions.status })
 		.from(subscriptions)
 		.where(
 			and(
@@ -184,8 +185,7 @@ async function organizationPlan(organizationId: string): Promise<PlanTier> {
 		)
 		.orderBy(desc(subscriptions.createdAt))
 		.limit(1);
-	const plan = subscription?.plan;
-	return plan === "pro" || plan === "enterprise" ? plan : "free";
+	return planTierFromSubscription(subscription);
 }
 
 /**

--- a/apps/desktop/src/renderer/components/Paywall/components/FeaturePreview/FeaturePreview.tsx
+++ b/apps/desktop/src/renderer/components/Paywall/components/FeaturePreview/FeaturePreview.tsx
@@ -4,6 +4,7 @@ import { cn } from "@superset/ui/utils";
 import type { ComponentType } from "react";
 import type { ProFeature } from "../../constants";
 import { PRO_FEATURES } from "../../constants";
+import { AutomationsDemo } from "./components/AutomationsDemo";
 import { DitheredBackground } from "./components/DitheredBackground";
 import { MobileAppDemo } from "./components/MobileAppDemo";
 import { RemoteAccessDemo } from "./components/RemoteAccessDemo";
@@ -12,6 +13,7 @@ import { TasksDemo } from "./components/TasksDemo";
 import { TeamCollaborationDemo } from "./components/TeamCollaborationDemo";
 
 const DEMO_COMPONENTS: Record<string, ComponentType> = {
+	automations: AutomationsDemo,
 	"team-collaboration": TeamCollaborationDemo,
 	tasks: TasksDemo,
 	"slack-integration": SlackIntegrationDemo,

--- a/apps/desktop/src/renderer/components/Paywall/components/FeaturePreview/components/AutomationsDemo/AutomationsDemo.tsx
+++ b/apps/desktop/src/renderer/components/Paywall/components/FeaturePreview/components/AutomationsDemo/AutomationsDemo.tsx
@@ -1,0 +1,76 @@
+import { Trans } from "@lingui/react/macro";
+import { HiCheck, HiOutlineClock } from "react-icons/hi2";
+
+// Sample rows, deliberately untranslated like the other demos' fixtures.
+const AUTOMATIONS = [
+	{
+		id: "1",
+		name: "Morning standup digest",
+		cadence: "Weekdays 9:00",
+		ran: true,
+	},
+	{
+		id: "2",
+		name: "Nightly dependency sweep",
+		cadence: "Daily 3:00",
+		ran: true,
+	},
+	{
+		id: "3",
+		name: "Weekly changelog draft",
+		cadence: "Fridays 17:00",
+		ran: false,
+	},
+	{ id: "4", name: "Triage new Sentry issues", cadence: "Hourly", ran: false },
+];
+
+export function AutomationsDemo() {
+	return (
+		<div className="w-full h-full flex items-center justify-center">
+			<div className="w-[300px] bg-card/90 backdrop-blur-sm rounded-lg border border-border shadow-2xl overflow-hidden">
+				<div className="flex items-center justify-between px-4 py-3 bg-muted/80 border-b border-border/50">
+					<div className="flex items-center gap-2">
+						<div className="flex gap-1.5">
+							<div className="w-2.5 h-2.5 rounded-full bg-[#ff5f57]" />
+							<div className="w-2.5 h-2.5 rounded-full bg-[#febc2e]" />
+							<div className="w-2.5 h-2.5 rounded-full bg-[#28c840]" />
+						</div>
+						<span className="text-xs text-muted-foreground ml-1">
+							<Trans>Automations</Trans>
+						</span>
+					</div>
+					<span className="text-xs text-muted-foreground/70 bg-foreground/10 px-2 py-0.5 rounded">
+						<Trans>Up next</Trans>
+					</span>
+				</div>
+
+				<div className="p-2">
+					{AUTOMATIONS.map((automation) => (
+						<div
+							key={automation.id}
+							className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-foreground/5 transition-colors cursor-pointer group"
+						>
+							{automation.ran ? (
+								<div className="w-5 h-5 rounded-full bg-emerald-500/20 flex items-center justify-center shrink-0">
+									<HiCheck className="w-3 h-3 text-emerald-400" />
+								</div>
+							) : (
+								<div className="w-5 h-5 rounded-full bg-amber-500/15 flex items-center justify-center shrink-0">
+									<HiOutlineClock className="w-3 h-3 text-amber-400" />
+								</div>
+							)}
+							<div className="flex-1 min-w-0">
+								<span className="text-xs block truncate text-foreground">
+									{automation.name}
+								</span>
+							</div>
+							<span className="text-[10px] tabular-nums text-muted-foreground shrink-0">
+								{automation.cadence}
+							</span>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/src/renderer/components/Paywall/components/FeaturePreview/components/AutomationsDemo/index.ts
+++ b/apps/desktop/src/renderer/components/Paywall/components/FeaturePreview/components/AutomationsDemo/index.ts
@@ -1,0 +1,1 @@
+export { AutomationsDemo } from "./AutomationsDemo";

--- a/apps/desktop/src/renderer/components/Paywall/components/FeatureSidebar/FeatureSidebar.tsx
+++ b/apps/desktop/src/renderer/components/Paywall/components/FeatureSidebar/FeatureSidebar.tsx
@@ -28,14 +28,14 @@ export function FeatureSidebar({
 	}, [highlightedFeatureId]);
 
 	return (
-		<div className="flex flex-col border-r bg-card">
+		<div className="flex w-[249px] shrink-0 flex-col border-r bg-card">
 			<div className="px-5 pt-5 pb-2.5">
 				<h1 className="mb-0 text-lg font-bold text-foreground">
 					<Trans>Pro Features</Trans>
 				</h1>
 			</div>
 
-			<div className="flex flex-col gap-2.5 px-5 py-2.5">
+			<div className="flex flex-col gap-2 py-2.5">
 				{orderedFeatures.map((proFeature) => (
 					<FeatureButton
 						key={proFeature.id}
@@ -64,7 +64,7 @@ function FeatureButton({ feature, isSelected, onSelect }: FeatureButtonProps) {
 			type="button"
 			onClick={onSelect}
 			className={cn(
-				"group flex w-[209px] h-16 items-center gap-3 px-4 py-3.5 transition-all duration-200 ease-out",
+				"group flex h-14 w-full items-center gap-3 px-5 py-2.5 transition-all duration-200 ease-out",
 				"cursor-pointer text-left",
 				isSelected
 					? "bg-muted text-foreground"

--- a/apps/desktop/src/renderer/components/Paywall/constants.ts
+++ b/apps/desktop/src/renderer/components/Paywall/constants.ts
@@ -5,6 +5,7 @@ import { FaSlack } from "react-icons/fa";
 import {
 	HiDevicePhoneMobile,
 	HiOutlineClipboardDocumentList,
+	HiOutlineClock,
 	HiOutlineSignal,
 	HiUsers,
 } from "react-icons/hi2";
@@ -14,6 +15,7 @@ export const GATED_FEATURES = {
 	TASKS: "tasks",
 	REMOTE_ACCESS: "remote-access",
 	MOBILE_APP: "mobile-app",
+	AUTOMATIONS: "automations",
 } as const;
 
 export type GatedFeature = (typeof GATED_FEATURES)[keyof typeof GATED_FEATURES];
@@ -41,6 +43,19 @@ export const PRO_FEATURES: ProFeature[] = [
 		icon: HiOutlineSignal,
 		iconColor: "text-pink-500",
 		gradientColors: ["#be185d", "#9d174d", "#831843", "#1a1a2e"],
+	},
+	{
+		id: "automations",
+		title: msg({
+			message: "Automations",
+		}),
+		description: msg({
+			message:
+				"Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review.",
+		}),
+		icon: HiOutlineClock,
+		iconColor: "text-amber-500",
+		gradientColors: ["#b45309", "#92400e", "#78350f", "#1a1a2e"],
 	},
 	{
 		id: "team-collaboration",
@@ -103,4 +118,5 @@ export const FEATURE_ID_MAP: Record<GatedFeature, string> = {
 	[GATED_FEATURES.TASKS]: "tasks",
 	[GATED_FEATURES.REMOTE_ACCESS]: "remote-access",
 	[GATED_FEATURES.MOBILE_APP]: "mobile-app",
+	[GATED_FEATURES.AUTOMATIONS]: "automations",
 };

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.test.tsx
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.test.tsx
@@ -1,0 +1,105 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// A plan fetch the test resolves by hand, so two clicks can land while the
+// gate is still waiting on it.
+let resolvePlan: (plan: { plan: string } | null) => void = () => {};
+const ensureData = mock(
+	() =>
+		new Promise<{ plan: string } | null>((resolve) => {
+			resolvePlan = resolve;
+		}),
+);
+const paywall = mock(() => {});
+
+mock.module("renderer/lib/auth-client", () => ({
+	authClient: { useSession: () => ({ data: { session: { plan: null } } }) },
+}));
+mock.module("renderer/lib/cloud-trpc", () => ({
+	cloudTrpc: {
+		useUtils: () => ({ billing: { activePlan: { ensureData } } }),
+		billing: { activePlan: { useQuery: () => ({ data: undefined }) } },
+	},
+}));
+mock.module("renderer/hooks/useActiveOrganizationId", () => ({
+	useActiveOrganizationId: () => "org-1",
+}));
+mock.module("./Paywall", () => ({ paywall }));
+
+const { act, cleanup, renderHook } = await import("@testing-library/react");
+const { usePaywall } = await import("./usePaywall");
+
+afterEach(() => {
+	cleanup();
+	ensureData.mockClear();
+	paywall.mockClear();
+});
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+const settle = () => act(async () => {});
+
+describe("gateFeature while the plan is still resolving", () => {
+	// The caller's own pending flag only flips once its callback has started,
+	// so the gate itself has to drop the second click.
+	test("runs the callback once for two immediate clicks", async () => {
+		const { result } = renderHook(() => usePaywall());
+		const callback = mock(() => {});
+
+		act(() => {
+			result.current.gateFeature("automations", callback);
+			result.current.gateFeature("automations", callback);
+		});
+		expect(ensureData).toHaveBeenCalledTimes(1);
+
+		resolvePlan({ plan: "pro" });
+		await settle();
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	test("accepts a new click once the first has settled", async () => {
+		const { result } = renderHook(() => usePaywall());
+		const callback = mock(() => {});
+
+		act(() => result.current.gateFeature("automations", callback));
+		resolvePlan({ plan: "pro" });
+		await settle();
+
+		act(() => result.current.gateFeature("automations", callback));
+		resolvePlan({ plan: "pro" });
+		await settle();
+		expect(callback).toHaveBeenCalledTimes(2);
+	});
+
+	test("shows the paywall once, not per click, on a free plan", async () => {
+		const { result } = renderHook(() => usePaywall());
+		const callback = mock(() => {});
+
+		act(() => {
+			result.current.gateFeature("automations", callback);
+			result.current.gateFeature("automations", callback);
+		});
+		resolvePlan(null);
+		await settle();
+		expect(callback).not.toHaveBeenCalled();
+		expect(paywall).toHaveBeenCalledTimes(1);
+	});
+
+	test("gates different features independently", async () => {
+		const { result } = renderHook(() => usePaywall());
+		const callback = mock(() => {});
+
+		act(() => {
+			result.current.gateFeature("automations", callback);
+			result.current.gateFeature("tasks", callback);
+		});
+		expect(ensureData).toHaveBeenCalledTimes(2);
+	});
+});

--- a/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
+++ b/apps/desktop/src/renderer/components/Paywall/usePaywall.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useActiveOrganizationId } from "renderer/hooks/useActiveOrganizationId";
 import {
 	isPaidPlanTier,
@@ -19,6 +20,12 @@ export function usePaywall() {
 	// from a callback, and the paywall must be attributed to the org THIS
 	// window is showing.
 	const organizationId = useActiveOrganizationId();
+	// Features whose gate is still resolving the plan. A second click during
+	// that window is dropped rather than queued: the caller's own pending
+	// state only flips once its callback has started, so without this a
+	// double-click on a cold start could create two automations or dispatch
+	// two runs.
+	const resolving = useRef(new Set<GatedFeature>());
 
 	const userPlan = resolveCurrentPlan({
 		subscriptionPlan: activePlan?.plan,
@@ -61,21 +68,27 @@ export function usePaywall() {
 		callback: () => void | Promise<void>,
 		context?: Record<string, unknown>,
 	): void {
+		if (resolving.current.has(feature)) return;
+		resolving.current.add(feature);
 		void (async () => {
-			const plan = await resolvePlanWhenKnown();
-			if (isPaidPlanTier(plan)) {
-				try {
-					await callback();
-				} catch (error) {
-					console.error(`[paywall] Callback error for ${feature}:`, error);
+			try {
+				const plan = await resolvePlanWhenKnown();
+				if (isPaidPlanTier(plan)) {
+					try {
+						await callback();
+					} catch (error) {
+						console.error(`[paywall] Callback error for ${feature}:`, error);
+					}
+					return;
 				}
-				return;
+				paywall(feature, {
+					organizationId,
+					userPlan: plan,
+					...context,
+				});
+			} finally {
+				resolving.current.delete(feature);
 			}
-			paywall(feature, {
-				organizationId,
-				userPlan: plan,
-				...context,
-			});
 		})();
 	}
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/$automationId/page.tsx
@@ -7,6 +7,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { TRPCClientError } from "@trpc/client";
 import { useMemo, useState } from "react";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { apiTrpcClient } from "renderer/lib/api-trpc-client";
 import { authClient } from "renderer/lib/auth-client";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
@@ -93,6 +94,9 @@ function AutomationDetailPage() {
 	const ownerName = owner?.name ?? owner?.email ?? null;
 
 	const utils = cloudTrpc.useUtils();
+	// Running and resuming are Pro (the server refuses them too); pausing,
+	// editing, and deleting stay open to a downgraded org.
+	const { gateFeature } = usePaywall();
 
 	const setEnabledMutation = useMutation({
 		mutationFn: (enabled: boolean) =>
@@ -243,7 +247,11 @@ function AutomationDetailPage() {
 							],
 						});
 					}}
-					onRunNow={() => runNowMutation.mutate()}
+					onRunNow={() =>
+						gateFeature(GATED_FEATURES.AUTOMATIONS, () =>
+							runNowMutation.mutate(),
+						)
+					}
 					onOpenHistory={() => setHistoryOpen(true)}
 					deleteDisabled={deleteMutation.isPending}
 					runNowDisabled={runNowMutation.isPending}
@@ -255,7 +263,15 @@ function AutomationDetailPage() {
 					automation={automation}
 					recentRuns={recentRuns}
 					ownerName={ownerName}
-					onToggleEnabled={(enabled) => setEnabledMutation.mutate(enabled)}
+					onToggleEnabled={(enabled) => {
+						if (!enabled) {
+							setEnabledMutation.mutate(false);
+							return;
+						}
+						gateFeature(GATED_FEATURES.AUTOMATIONS, () =>
+							setEnabledMutation.mutate(true),
+						);
+					}}
 					toggleDisabled={setEnabledMutation.isPending}
 					readOnly={readOnly}
 				/>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationsEmptyState/AutomationsEmptyState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/AutomationsEmptyState/AutomationsEmptyState.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import { Badge } from "@superset/ui/badge";
 import { Button } from "@superset/ui/button";
 import { LuPlus, LuTimer } from "react-icons/lu";
 import {
@@ -13,6 +14,8 @@ interface AutomationsEmptyStateProps {
 	isCreating: boolean;
 	onCreateManually: () => void;
 	isCreatingManually: boolean;
+	/** The viewer's plan can't create one; the buttons open the paywall. */
+	showProBadge?: boolean;
 }
 export function AutomationsEmptyState({
 	onSelectTemplate,
@@ -20,6 +23,7 @@ export function AutomationsEmptyState({
 	isCreating,
 	onCreateManually,
 	isCreatingManually,
+	showProBadge = false,
 }: AutomationsEmptyStateProps) {
 	return (
 		<div className="mx-auto flex w-full max-w-xl flex-1 flex-col justify-center gap-10 py-12">
@@ -28,8 +32,13 @@ export function AutomationsEmptyState({
 					<LuTimer className="size-5" />
 				</div>
 				<div className="space-y-2">
-					<h2 className="font-semibold text-lg tracking-tight">
+					<h2 className="flex items-center gap-2 font-semibold text-lg tracking-tight">
 						<Trans>What should run on a schedule?</Trans>
+						{showProBadge && (
+							<Badge variant="default">
+								<Trans>PRO</Trans>
+							</Badge>
+						)}
 					</h2>
 					<p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
 						<Trans>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/runtimeWarnings.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/components/TriggersEditor/runtimeWarnings.test.ts
@@ -63,8 +63,8 @@ describe("a row nothing is wrong with", () => {
 		).toEqual([]);
 	});
 
-	test("a schedule needs no plan at all", () => {
-		expect(collectRuntimeWarnings([scheduleRow] as never, {}, "free")).toEqual(
+	test("a schedule on a paid plan", () => {
+		expect(collectRuntimeWarnings([scheduleRow] as never, {}, "pro")).toEqual(
 			[],
 		);
 	});
@@ -77,6 +77,13 @@ describe("a row the plan will not run", () => {
 		expect(
 			collectRuntimeWarnings([slackRow(["C1"])] as never, CHANNELS, "free"),
 		).toEqual(["Slack triggers require the Pro plan."]);
+	});
+
+	// Automations are Pro as a whole, so a downgraded org's schedules stop too.
+	test("names Pro for a schedule on a free plan", () => {
+		expect(collectRuntimeWarnings([scheduleRow] as never, {}, "free")).toEqual([
+			"Scheduled triggers require the Pro plan.",
+		]);
 	});
 
 	test("names Enterprise for a Teams trigger", () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/automations/page.tsx
@@ -48,6 +48,7 @@ import {
 	LuTriangleAlert,
 	LuX,
 } from "react-icons/lu";
+import { GATED_FEATURES, usePaywall } from "renderer/components/Paywall";
 import { useRecentProjects } from "renderer/hooks/host-projects/useRecentProjects";
 import { useNow } from "renderer/hooks/useNow";
 import { useV2AgentChoices } from "renderer/hooks/useV2AgentChoices";
@@ -457,6 +458,12 @@ function AutomationsPage() {
 	const { machineId, activeHostUrl } = useLocalHostService();
 	const { agents: agentChoices } = useV2AgentChoices(activeHostUrl);
 	const { submit: submitWorkspaceCreate } = useWorkspaceCreates();
+	// Automations are Pro. Creating, running, and resuming go through the
+	// paywall; the server refuses the same three, so this is the friendly
+	// front of one gate. Pausing, editing, and deleting stay open so a
+	// downgraded org keeps control of what it has.
+	const { gateFeature, hasAccess, isReady: planReady } = usePaywall();
+	const showProBadge = planReady && !hasAccess(GATED_FEATURES.AUTOMATIONS);
 
 	// Cursor-style creation: no dialog. "New automation" writes an untitled
 	// automation with no triggers and opens its detail page, which is the
@@ -513,7 +520,14 @@ function AutomationsPage() {
 
 	const handleSelectTemplate = (template: AutomationTemplate) => {
 		if (createMutation.isPending) return;
-		createMutation.mutate(template);
+		gateFeature(GATED_FEATURES.AUTOMATIONS, () =>
+			createMutation.mutate(template),
+		);
+	};
+
+	const handleCreateManually = () => {
+		if (createMutation.isPending) return;
+		gateFeature(GATED_FEATURES.AUTOMATIONS, () => createMutation.mutate(null));
 	};
 
 	// Opens a project-less agent session seeded with automation-creation
@@ -522,6 +536,9 @@ function AutomationsPage() {
 	const [creatingWithAgent, setCreatingWithAgent] = useState(false);
 	const handleCreateWithAgent = () => {
 		if (creatingWithAgent) return;
+		gateFeature(GATED_FEATURES.AUTOMATIONS, startCreateWithAgent);
+	};
+	const startCreateWithAgent = () => {
 		if (!machineId) {
 			toast.error(
 				t({
@@ -593,19 +610,24 @@ function AutomationsPage() {
 			isOwner={automation.ownerUserId === currentUserId}
 			isRetrying={retryingIds.has(automation.id)}
 			onRunNow={(a) =>
-				runNowMutation.mutate({
-					id: a.id,
-					name: a.name,
-					targetHostId: a.targetHostId,
-				})
+				gateFeature(GATED_FEATURES.AUTOMATIONS, () =>
+					runNowMutation.mutate({
+						id: a.id,
+						name: a.name,
+						targetHostId: a.targetHostId,
+					}),
+				)
 			}
-			onToggleEnabled={(a) =>
-				setEnabledMutation.mutate({
-					id: a.id,
-					enabled: !a.enabled,
-					name: a.name,
-				})
-			}
+			onToggleEnabled={(a) => {
+				const toggle = () =>
+					setEnabledMutation.mutate({
+						id: a.id,
+						enabled: !a.enabled,
+						name: a.name,
+					});
+				if (a.enabled) toggle();
+				else gateFeature(GATED_FEATURES.AUTOMATIONS, toggle);
+			}}
 			onDelete={setPendingDelete}
 		/>
 	);
@@ -639,7 +661,7 @@ function AutomationsPage() {
 						showCreate={!orgEmpty}
 						secondaryAction={{
 							label: <Trans>New automation</Trans>,
-							onSelect: () => createMutation.mutate(null),
+							onSelect: handleCreateManually,
 							disabled: createMutation.isPending,
 						}}
 					/>
@@ -706,7 +728,11 @@ function AutomationsPage() {
 													size="sm"
 													className="h-8 gap-1.5 px-3"
 													disabled={retryAllMutation.isPending}
-													onClick={() => retryAllMutation.mutate(failedMine)}
+													onClick={() =>
+														gateFeature(GATED_FEATURES.AUTOMATIONS, () =>
+															retryAllMutation.mutate(failedMine),
+														)
+													}
 												>
 													<LuRotateCw
 														className={cn(
@@ -794,8 +820,9 @@ function AutomationsPage() {
 									onSelectTemplate={handleSelectTemplate}
 									onCreateWithAgent={handleCreateWithAgent}
 									isCreating={creatingWithAgent}
-									onCreateManually={() => createMutation.mutate(null)}
+									onCreateManually={handleCreateManually}
 									isCreatingManually={createMutation.isPending}
+									showProBadge={showProBadge}
 								/>
 							</div>
 						) : showTeamEmptyState ? (

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -163,7 +163,7 @@ export function DashboardSidebarHeader({
 	const isPluginsEnabled =
 		(useFeatureFlagEnabled(FEATURE_FLAGS.PLUGINS) ?? false) ||
 		env.NODE_ENV === "development";
-	const { myFailedCount } = useFailedAutomations();
+	const { myFailedCount, hasAutomations } = useFailedAutomations();
 
 	const {
 		tab: lastTab,
@@ -187,8 +187,17 @@ export function DashboardSidebarHeader({
 		navigate({ to: "/v2-workspaces" });
 	};
 
+	// Automations are Pro, but an org that already has some (a downgrade) can
+	// still reach the list to pause, edit, or delete them; the page gates the
+	// actions that need the plan. A Free org with none meets the paywall here.
 	const handleAutomationsClick = () => {
-		navigate({ to: "/automations" });
+		if (hasAutomations) {
+			navigate({ to: "/automations" });
+			return;
+		}
+		gateFeature(GATED_FEATURES.AUTOMATIONS, () => {
+			navigate({ to: "/automations" });
+		});
 	};
 
 	const handleTasksClick = () => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/DashboardSidebarHeader/DashboardSidebarHeader.tsx
@@ -163,7 +163,8 @@ export function DashboardSidebarHeader({
 	const isPluginsEnabled =
 		(useFeatureFlagEnabled(FEATURE_FLAGS.PLUGINS) ?? false) ||
 		env.NODE_ENV === "development";
-	const { myFailedCount, hasAutomations } = useFailedAutomations();
+	const { myFailedCount, hasAutomations, automationsPending } =
+		useFailedAutomations();
 
 	const {
 		tab: lastTab,
@@ -190,8 +191,11 @@ export function DashboardSidebarHeader({
 	// Automations are Pro, but an org that already has some (a downgrade) can
 	// still reach the list to pause, edit, or delete them; the page gates the
 	// actions that need the plan. A Free org with none meets the paywall here.
+	// While the list is still loading the answer is unknown, so let the click
+	// through: an empty list page gates every action itself, and a wrong
+	// paywall on a downgraded org would be the worse mistake.
 	const handleAutomationsClick = () => {
-		if (hasAutomations) {
+		if (hasAutomations || automationsPending) {
 			navigate({ to: "/automations" });
 			return;
 		}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
@@ -27,6 +27,8 @@ interface FailedAutomations {
 	failedIds: Set<string>;
 	/** How many of the current user's failures the user hasn't seen yet. */
 	myFailedCount: number;
+	/** The org has at least one automation, so the list is worth reaching. */
+	hasAutomations: boolean;
 	/** Clear the failure badge by acknowledging the user's current failures. */
 	markMyFailuresSeen: () => void;
 }
@@ -105,6 +107,7 @@ export function useFailedAutomations(): FailedAutomations {
 		lastRunById,
 		failedIds,
 		myFailedCount,
+		hasAutomations: automationRows.length > 0,
 		markMyFailuresSeen,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useFailedAutomations/useFailedAutomations.ts
@@ -29,6 +29,8 @@ interface FailedAutomations {
 	myFailedCount: number;
 	/** The org has at least one automation, so the list is worth reaching. */
 	hasAutomations: boolean;
+	/** The list has not loaded yet, so `hasAutomations` is not yet known. */
+	automationsPending: boolean;
 	/** Clear the failure badge by acknowledging the user's current failures. */
 	markMyFailuresSeen: () => void;
 }
@@ -47,10 +49,11 @@ export function useFailedAutomations(): FailedAutomations {
 		undefined,
 		{ refetchInterval: 30_000, staleTime: 30_000 },
 	);
-	const { data: automationRows = [] } = cloudTrpc.automation.list.useQuery(
-		undefined,
-		{ refetchInterval: 30_000, staleTime: 30_000 },
-	);
+	const { data: automationRows = [], isPending: automationsPending } =
+		cloudTrpc.automation.list.useQuery(undefined, {
+			refetchInterval: 30_000,
+			staleTime: 30_000,
+		});
 
 	const { lastRunStatusById, lastRunById, failedIds, myFailureTimes } =
 		useMemo(() => {
@@ -108,6 +111,7 @@ export function useFailedAutomations(): FailedAutomations {
 		failedIds,
 		myFailedCount,
 		hasAutomations: automationRows.length > 0,
+		automationsPending,
 		markMyFailuresSeen,
 	};
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/billing/plans/page.tsx
@@ -196,21 +196,21 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
 			},
 			{
 				label: msg({
+					message: "GitHub integration",
+				}),
+				values: [true, true, true],
+			},
+			{
+				label: msg({
 					message: "Remote access",
 				}),
 				values: [null, true, true],
-				badge: {
-					label: msg({
-						message: "Beta",
-					}),
-					variant: "default",
-				},
 			},
 			{
 				label: msg({
 					message: "Automations",
 				}),
-				values: [true, true, true],
+				values: [null, true, true],
 			},
 			{
 				label: msg({
@@ -223,12 +223,6 @@ const COMPARISON_SECTIONS: ComparisonSection[] = [
 					}),
 					variant: "secondary",
 				},
-			},
-			{
-				label: msg({
-					message: "GitHub integration",
-				}),
-				values: [true, true, true],
 			},
 			{
 				label: msg({

--- a/apps/docs/content/docs/automations.mdx
+++ b/apps/docs/content/docs/automations.mdx
@@ -1,6 +1,7 @@
 ---
 title: Automations
 description: Schedule agent sessions to run on a recurring basis
+pro: true
 ---
 
 ## Overview
@@ -20,6 +21,7 @@ The list shows 7-day health stats (Active, Created, Failed), groups enabled auto
 
 ## Requirements
 
+- **A Pro plan**: Automations are a [Pro feature](https://superset.sh/pricing). Creating, running, and resuming an automation needs a Pro or Enterprise subscription on the organization, from the app, the CLI, or the SDK alike. An organization that downgrades keeps its automations and can still edit, pause, or delete them, but they stop firing until it upgrades again.
 - **A project, or session mode**: automations usually run against a v2 project linked to a GitHub repo. Pick **No project** and each run creates a [session workspace](/workspaces#sessions) instead.
 - **A target device**: The run fires on the device you pick when creating the automation.
 

--- a/apps/docs/content/docs/cli/cli-reference.mdx
+++ b/apps/docs/content/docs/cli/cli-reference.mdx
@@ -1392,8 +1392,10 @@ Use [`automations logs`](#superset-automations-logs-id) for run history.
 	]}
 	output="Automation"
 >
-Create an automation. Provide `--prompt` or `--prompt-file`; if both are
-present, the inline `--prompt` value is used. A `--project` or `--workspace`
+Create an automation. Automations are a Pro feature: `create`, `run`, and
+`resume` need a Pro or Enterprise subscription on the active organization and
+fail with `Automations require the Pro plan.` otherwise. Provide `--prompt` or
+`--prompt-file`; if both are present, the inline `--prompt` value is used. A `--project` or `--workspace`
 must exist on the target host; the CLI verifies this before creating the
 automation. Omit both for **session mode**: each run creates a project-less
 session workspace on the target host.

--- a/apps/docs/content/docs/sdk/reference.mdx
+++ b/apps/docs/content/docs/sdk/reference.mdx
@@ -275,7 +275,7 @@ const { terminalId } = await client.terminals.create({
 
 ## automations
 
-Recurring agent runs scheduled by RRULE. Requires a Pro subscription on the org for `create` / `update` / `delete`.
+Recurring agent runs scheduled by RRULE. Automations are a Pro feature: `create`, `run`, and `resume` are refused with `FORBIDDEN` unless the org has a Pro or Enterprise subscription. Reading, `update`, `pause`, and `delete` stay available so a downgraded org keeps control of what it has.
 
 ### `automations.list(params?)`
 

--- a/apps/marketing/src/app/[lang]/pricing/constants.ts
+++ b/apps/marketing/src/app/[lang]/pricing/constants.ts
@@ -147,6 +147,12 @@ export const PRICING_TIERS: PricingTier[] = [
 				}),
 			},
 			{
+				id: "automations",
+				label: msg({
+					message: "Automations",
+				}),
+			},
+			{
 				id: "linearIntegration",
 				label: msg({
 					message: "Linear integration",
@@ -323,24 +329,25 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
 				values: [true, true, true],
 			},
 			{
+				id: "githubIntegration",
+				label: msg({
+					message: "GitHub integration",
+				}),
+				values: [true, true, true],
+			},
+			{
 				id: "remoteAccess",
 				label: msg({
 					message: "Remote access",
 				}),
 				values: [null, true, true],
-				badge: {
-					label: msg({
-						message: "Beta",
-					}),
-					variant: "default",
-				},
 			},
 			{
 				id: "automations",
 				label: msg({
 					message: "Automations",
 				}),
-				values: [true, true, true],
+				values: [null, true, true],
 			},
 			{
 				id: "mobileApp",
@@ -354,13 +361,6 @@ export const COMPARISON_SECTIONS: ComparisonSection[] = [
 					}),
 					variant: "secondary",
 				},
-			},
-			{
-				id: "githubIntegration",
-				label: msg({
-					message: "GitHub integration",
-				}),
-				values: [true, true, true],
 			},
 			{
 				id: "linearIntegration",

--- a/apps/marketing/src/app/agents.md/route.ts
+++ b/apps/marketing/src/app/agents.md/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
 		"- **Workspaces**: create a branch- or PR-scoped Git worktree on a registered host, list, rename, and delete workspaces.",
 		"- **Agents**: launch a coding-agent session with a prompt inside a workspace; list the agent presets installed on a host.",
 		"- **Terminals**: open a PTY in a workspace, optionally running a one-off command.",
-		"- **Automations**: schedule recurring agent runs (RFC 5545 RRULE), pause/resume/run them, and read run logs.",
+		"- **Automations** (Pro plan): schedule recurring agent runs (RFC 5545 RRULE), pause/resume/run them, and read run logs.",
 		"- **Hosts and projects**: enumerate the machines and checked-out repositories available to the user.",
 		"",
 		"## Endpoints",

--- a/apps/marketing/src/app/agents.md/route.ts
+++ b/apps/marketing/src/app/agents.md/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
 		"- **Workspaces**: create a branch- or PR-scoped Git worktree on a registered host, list, rename, and delete workspaces.",
 		"- **Agents**: launch a coding-agent session with a prompt inside a workspace; list the agent presets installed on a host.",
 		"- **Terminals**: open a PTY in a workspace, optionally running a one-off command.",
-		"- **Automations** (Pro plan): schedule recurring agent runs (RFC 5545 RRULE), pause/resume/run them, and read run logs.",
+		"- **Automations**: schedule recurring agent runs (RFC 5545 RRULE), pause/resume/run them, and read run logs. Creating, running, and resuming need the Pro plan; listing, pausing, editing, and deleting do not.",
 		"- **Hosts and projects**: enumerate the machines and checked-out repositories available to the user.",
 		"",
 		"## Endpoints",

--- a/apps/marketing/src/app/index.md/route.ts
+++ b/apps/marketing/src/app/index.md/route.ts
@@ -42,7 +42,7 @@ export async function GET() {
 		"- **Any CLI agent**: Claude Code, OpenAI Codex, OpenCode, and anything else that runs in a terminal.",
 		"- **Diff review**: review every change from one dashboard before merging.",
 		"- **Persistent terminals**: sessions survive app restarts.",
-		"- **Automations**: schedule recurring agent runs with a prompt.",
+		"- **Automations** (Pro): schedule recurring agent runs with a prompt.",
 		"- **MCP server**: drive Superset from other AI agents over the Model Context Protocol.",
 		"",
 		"## Get started",

--- a/packages/cli-framework/src/runner.test.ts
+++ b/packages/cli-framework/src/runner.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from "bun:test";
 import { CLIError } from "./errors";
 import { formatError } from "./runner";
 
-function trpcError(code: string, message: string): Error {
-	const error = new Error(message) as Error & { data?: { code?: string } };
-	error.data = { code };
+function trpcError(
+	code: string,
+	message: string,
+	data: Record<string, unknown> = {},
+): Error {
+	const error = new Error(message) as Error & {
+		data?: { code?: string } & Record<string, unknown>;
+	};
+	error.data = { code, ...data };
 	return error;
 }
 
@@ -31,6 +37,37 @@ describe("formatError", () => {
 		const result = formatError(trpcError("UNAUTHORIZED", "nope"), "superset");
 		expect(result.message).toBe("Session expired");
 		expect(result.hint).toBe("Run: superset auth login");
+	});
+
+	it("adds an upgrade hint when the server names a required plan", () => {
+		const result = formatError(
+			trpcError("FORBIDDEN", "Automations require the Pro plan.", {
+				requiredPlan: "pro",
+			}),
+			"superset",
+		);
+		expect(result.message).toBe("Automations require the Pro plan.");
+		expect(result.hint).toContain("Needs the Pro plan");
+		expect(result.hint).toContain("superset.sh/pricing");
+	});
+
+	it("names Enterprise when that is the tier", () => {
+		const result = formatError(
+			trpcError("FORBIDDEN", "SSO requires the Enterprise plan.", {
+				requiredPlan: "enterprise",
+			}),
+			"superset",
+		);
+		expect(result.hint).toContain("Needs the Enterprise plan");
+	});
+
+	it("leaves other FORBIDDEN errors without a hint", () => {
+		const result = formatError(
+			trpcError("FORBIDDEN", "Not a member of this organization"),
+			"superset",
+		);
+		expect(result.message).toBe("Not a member of this organization");
+		expect(result.hint).toBeUndefined();
 	});
 
 	it("passes CLIError message and suggestion through", () => {

--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -81,13 +81,23 @@ export function formatError(
 	if (error instanceof Error) {
 		const trpcError = error as Error & {
 			code?: string;
-			data?: { code?: string };
+			data?: { code?: string; requiredPlan?: string | null };
 		};
 		const code = trpcError.data?.code ?? trpcError.code;
 		if (code === "UNAUTHORIZED") {
 			return {
 				message: "Session expired",
 				hint: `Run: ${cliName} auth login`,
+			};
+		}
+		// A plan gate: the server sets data.requiredPlan on every such refusal
+		// (planRequiredError in @superset/trpc), so no matching on message text.
+		const requiredPlan = trpcError.data?.requiredPlan;
+		if (requiredPlan) {
+			const tier = requiredPlan === "enterprise" ? "Enterprise" : "Pro";
+			return {
+				message: error.message,
+				hint: `Needs the ${tier} plan. Upgrade at https://superset.sh/pricing, or in the app under Settings → Billing.`,
 			};
 		}
 		if (code === "NOT_FOUND") {

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -2275,7 +2275,7 @@ msgid "Automations & event triggers"
 msgstr "Automatizace a spouštěče událostí"
 
 msgid "Automations require the Pro plan."
-msgstr "Automatizace vyžadují plán Pro."
+msgstr "Automatizace vyžadují tarif Pro."
 
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatizace, selhává: {myFailedCount}"

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automatizace (selhává: {myFailedCount})"
 msgid "Automations & event triggers"
 msgstr "Automatizace a spouštěče událostí"
 
+msgid "Automations require the Pro plan."
+msgstr "Automatizace vyžadují plán Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatizace, selhává: {myFailedCount}"
 
@@ -2422,9 +2425,6 @@ msgstr "Zaostává za main o ? commitů, je potřeba rebase"
 
 msgid "Being built right now."
 msgstr "Právě se staví."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Za obzorem: F5 není tvrzení o blízké budoucnosti"
@@ -11242,6 +11242,9 @@ msgstr "Pushování…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Naplánujte opakovanou práci"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Naplánujte opakující se práci podle rozvrhu nebo události. Agenti běží sami a výsledek skončí v pracovním prostoru, kde ho zkontrolujete."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automatisierungen ({myFailedCount} fehlgeschlagen)"
 msgid "Automations & event triggers"
 msgstr "Automatisierungen & Ereignis-Trigger"
 
+msgid "Automations require the Pro plan."
+msgstr "Automatisierungen erfordern den Pro-Plan."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatisierungen, {myFailedCount} fehlgeschlagen"
 
@@ -2422,9 +2425,6 @@ msgstr "? Commits hinter main, Rebase nötig"
 
 msgid "Being built right now."
 msgstr "Wird gerade gebaut."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Ausblick: F5 ist keine kurzfristige Behauptung"
@@ -11242,6 +11242,9 @@ msgstr "Wird gepusht…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Wiederkehrende Arbeit auf einen Zeitplan setzen"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Lege wiederkehrende Arbeit auf einen Zeitplan oder ein Ereignis. Agenten laufen von selbst und landen in einem Arbeitsbereich, den du prüfst."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -11244,7 +11244,7 @@ msgid "Put recurring work on a schedule"
 msgstr "Wiederkehrende Arbeit auf einen Zeitplan setzen"
 
 msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
-msgstr "Lege wiederkehrende Arbeit auf einen Zeitplan oder ein Ereignis. Agenten laufen von selbst und landen in einem Arbeitsbereich, den du prüfst."
+msgstr "Plane wiederkehrende Arbeit nach einem Zeitplan oder löse sie durch ein Ereignis aus. Agenten laufen von selbst und landen in einem Arbeitsbereich, den du prüfst."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automations ({myFailedCount} failing)"
 msgid "Automations & event triggers"
 msgstr "Automations & event triggers"
 
+msgid "Automations require the Pro plan."
+msgstr "Automations require the Pro plan."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automations, {myFailedCount} failing"
 
@@ -2422,9 +2425,6 @@ msgstr "Behind main by ? commits, needs rebase"
 
 msgid "Being built right now."
 msgstr "Being built right now."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Beyond: F5 is not a near-term claim"
@@ -11242,6 +11242,9 @@ msgstr "Pushing..."
 
 msgid "Put recurring work on a schedule"
 msgstr "Put recurring work on a schedule"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automatizaciones ({myFailedCount} con errores)"
 msgid "Automations & event triggers"
 msgstr "Automatizaciones y disparadores por eventos"
 
+msgid "Automations require the Pro plan."
+msgstr "Las automatizaciones requieren el plan Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatizaciones, {myFailedCount} con errores"
 
@@ -2422,9 +2425,6 @@ msgstr "? commits por detrás de main, necesita rebase"
 
 msgid "Being built right now."
 msgstr "Se está construyendo ahora mismo."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Más allá: F5 no es una afirmación a corto plazo"
@@ -11242,6 +11242,9 @@ msgstr "Haciendo push…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Pon el trabajo recurrente en un horario"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Programa el trabajo recurrente según un horario o un evento. Los agentes se ejecutan solos y el resultado llega a un espacio de trabajo para que lo revises."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automatisations ({myFailedCount} en échec)"
 msgid "Automations & event triggers"
 msgstr "Automatisations et déclencheurs d'événements"
 
+msgid "Automations require the Pro plan."
+msgstr "Les automatisations nécessitent le forfait Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatisations, {myFailedCount} en échec"
 
@@ -2422,9 +2425,6 @@ msgstr "En retard de ? commits sur main, rebase nécessaire"
 
 msgid "Being built right now."
 msgstr "En cours de construction en ce moment."
-
-msgid "Beta"
-msgstr "Bêta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Au-delà : F5 n'est pas une promesse à court terme"
@@ -11242,6 +11242,9 @@ msgstr "Push en cours…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Mettez le travail récurrent sur un calendrier"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Planifiez le travail récurrent selon un horaire ou un événement. Les agents s'exécutent seuls et le résultat arrive dans un espace de travail à passer en revue."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -11244,7 +11244,7 @@ msgid "Put recurring work on a schedule"
 msgstr "Jadwalkan pekerjaan yang berulang"
 
 msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
-msgstr "Jadwalkan pekerjaan berulang berdasarkan waktu atau event. Agent berjalan sendiri dan hasilnya mendarat di sebuah workspace untuk kamu review."
+msgstr "Jadwalkan pekerjaan berulang berdasarkan waktu atau picu lewat event. Agen berjalan sendiri dan hasilnya mendarat di sebuah workspace untuk Anda tinjau."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Otomatisasi ({myFailedCount} gagal)"
 msgid "Automations & event triggers"
 msgstr "Otomatisasi & pemicu event"
 
+msgid "Automations require the Pro plan."
+msgstr "Otomatisasi memerlukan paket Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Otomatisasi, {myFailedCount} gagal"
 
@@ -2422,9 +2425,6 @@ msgstr "Tertinggal ? commit dari main, perlu rebase"
 
 msgid "Being built right now."
 msgstr "Sedang dibangun sekarang."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Di luar itu: F5 bukan klaim jangka dekat"
@@ -11242,6 +11242,9 @@ msgstr "Melakukan push…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Jadwalkan pekerjaan yang berulang"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Jadwalkan pekerjaan berulang berdasarkan waktu atau event. Agent berjalan sendiri dan hasilnya mendarat di sebuah workspace untuk kamu review."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automazioni ({myFailedCount} in errore)"
 msgid "Automations & event triggers"
 msgstr "Automazioni e trigger da eventi"
 
+msgid "Automations require the Pro plan."
+msgstr "Le automazioni richiedono il piano Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automazioni, {myFailedCount} in errore"
 
@@ -2422,9 +2425,6 @@ msgstr "Indietro di ? commit rispetto a main, serve un rebase"
 
 msgid "Being built right now."
 msgstr "In costruzione proprio ora."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Oltre: F5 non è una previsione a breve termine"
@@ -11242,6 +11242,9 @@ msgstr "Push in corso…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Metti il lavoro ricorrente in agenda"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Metti il lavoro ricorrente su una pianificazione o un evento. Gli agenti girano da soli e il risultato arriva in un workspace da rivedere."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -2274,6 +2274,9 @@ msgstr "オートメーション({myFailedCount}件失敗中)"
 msgid "Automations & event triggers"
 msgstr "オートメーションとイベントトリガー"
 
+msgid "Automations require the Pro plan."
+msgstr "オートメーションにはProプランが必要です。"
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "オートメーション、{myFailedCount}件が失敗中"
 
@@ -2422,9 +2425,6 @@ msgstr "mainより?コミット遅れています。リベースが必要です"
 
 msgid "Being built right now."
 msgstr "いま作っています。"
-
-msgid "Beta"
-msgstr "ベータ"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "その先:F5は近い将来の主張ではない"
@@ -11242,6 +11242,9 @@ msgstr "プッシュ中…"
 
 msgid "Put recurring work on a schedule"
 msgstr "繰り返しの作業をスケジュールに載せる"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "繰り返しの作業をスケジュールやイベントで実行しましょう。エージェントは自動で動き、結果はレビュー用のワークスペースに入ります。"
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -2274,6 +2274,9 @@ msgstr "자동화 ({myFailedCount}개 실패)"
 msgid "Automations & event triggers"
 msgstr "자동화 및 이벤트 트리거"
 
+msgid "Automations require the Pro plan."
+msgstr "자동화에는 Pro 플랜이 필요합니다."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "자동화, {myFailedCount}개 실패"
 
@@ -2422,9 +2425,6 @@ msgstr "main보다 커밋 ?개 뒤처짐, 리베이스 필요"
 
 msgid "Being built right now."
 msgstr "지금 만들고 있습니다."
-
-msgid "Beta"
-msgstr "베타"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "그 너머: F5는 단기 전망이 아닙니다"
@@ -11242,6 +11242,9 @@ msgstr "푸시 중…"
 
 msgid "Put recurring work on a schedule"
 msgstr "반복 업무를 일정에 올리세요"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "반복되는 작업을 일정이나 이벤트에 맡기세요. 에이전트가 알아서 실행되고 결과는 검토할 수 있도록 워크스페이스에 도착합니다."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -11244,7 +11244,7 @@ msgid "Put recurring work on a schedule"
 msgstr "Zet terugkerend werk op een schema"
 
 msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
-msgstr "Zet terugkerend werk op een schema of een gebeurtenis. Agents draaien vanzelf en komen in een werkruimte terecht die jij beoordeelt."
+msgstr "Zet terugkerend werk op een schema of laat het starten door een gebeurtenis. Agents draaien vanzelf en zetten het resultaat klaar in een werkruimte om te beoordelen."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automatiseringen ({myFailedCount} mislukt)"
 msgid "Automations & event triggers"
 msgstr "Automatiseringen en event-triggers"
 
+msgid "Automations require the Pro plan."
+msgstr "Automatiseringen vereisen het Pro-abonnement."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatiseringen, {myFailedCount} mislukt"
 
@@ -2422,9 +2425,6 @@ msgstr "? commits achter op main, rebase nodig"
 
 msgid "Being built right now."
 msgstr "Wordt nu gebouwd."
-
-msgid "Beta"
-msgstr "Bèta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Verder: F5 is geen claim voor de korte termijn"
@@ -11242,6 +11242,9 @@ msgstr "Bezig met pushen…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Zet terugkerend werk op een schema"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Zet terugkerend werk op een schema of een gebeurtenis. Agents draaien vanzelf en komen in een werkruimte terecht die jij beoordeelt."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -11244,7 +11244,7 @@ msgid "Put recurring work on a schedule"
 msgstr "Ustaw powtarzalną pracę na harmonogram"
 
 msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
-msgstr "Ustaw powtarzalną pracę według harmonogramu lub zdarzenia. Agenci działają sami, a wynik ląduje w obszarze roboczym do Twojego przeglądu."
+msgstr "Ustaw powtarzalną pracę według harmonogramu lub po wystąpieniu zdarzenia. Agenci działają sami, a wynik ląduje w obszarze roboczym do Twojego przeglądu."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automatyzacje ({myFailedCount} nieudanych)"
 msgid "Automations & event triggers"
 msgstr "Automatyzacje i wyzwalacze zdarzeń"
 
+msgid "Automations require the Pro plan."
+msgstr "Automatyzacje wymagają planu Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automatyzacje, {myFailedCount} nieudanych"
 
@@ -2422,9 +2425,6 @@ msgstr "Za main o ? commitów, wymaga rebase"
 
 msgid "Being built right now."
 msgstr "Budowane właśnie teraz."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Dalej: F5 to nie zapowiedź na najbliższy czas"
@@ -11242,6 +11242,9 @@ msgstr "Wykonywanie push…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Ustaw powtarzalną pracę na harmonogram"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Ustaw powtarzalną pracę według harmonogramu lub zdarzenia. Agenci działają sami, a wynik ląduje w obszarze roboczym do Twojego przeglądu."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Automações ({myFailedCount} falhando)"
 msgid "Automations & event triggers"
 msgstr "Automações e gatilhos de evento"
 
+msgid "Automations require the Pro plan."
+msgstr "As automações exigem o plano Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Automações, {myFailedCount} falhando"
 
@@ -2422,9 +2425,6 @@ msgstr "? commits atrás da main, precisa de rebase"
 
 msgid "Being built right now."
 msgstr "Em construção agora."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Além disso: o F5 não é uma promessa de curto prazo"
@@ -11242,6 +11242,9 @@ msgstr "Fazendo push…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Coloque o trabalho recorrente em uma agenda"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Coloque o trabalho recorrente em um agendamento ou evento. Os agentes rodam sozinhos e o resultado chega em uma área de trabalho para você revisar."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Автоматизации (с ошибкой: {myFailedCount})"
 msgid "Automations & event triggers"
 msgstr "Автоматизации и триггеры по событиям"
 
+msgid "Automations require the Pro plan."
+msgstr "Для автоматизаций нужен план Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Автоматизации, с ошибкой: {myFailedCount}"
 
@@ -2422,9 +2425,6 @@ msgstr "Отстаёт от main на ? коммитов, нужен rebase"
 
 msgid "Being built right now."
 msgstr "Делается прямо сейчас."
-
-msgid "Beta"
-msgstr "Бета"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Дальше: F5 — не заявка на ближайшее будущее"
@@ -11242,6 +11242,9 @@ msgstr "Отправка…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Поставьте повторяющуюся работу на расписание"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Поставьте повторяющуюся работу на расписание или событие. Агенты работают сами, а результат приземляется в рабочую область для проверки."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Otomasyonlar ({myFailedCount} başarısız)"
 msgid "Automations & event triggers"
 msgstr "Otomasyonlar ve olay tetikleyicileri"
 
+msgid "Automations require the Pro plan."
+msgstr "Otomasyonlar Pro planı gerektirir."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Otomasyonlar, {myFailedCount} başarısız"
 
@@ -2422,9 +2425,6 @@ msgstr "main dalının ? commit gerisinde, rebase gerekiyor"
 
 msgid "Being built right now."
 msgstr "Şu anda geliştiriliyor."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Ötesi: F5 yakın vadeli bir iddia değil"
@@ -11242,6 +11242,9 @@ msgstr "Push ediliyor…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Tekrarlayan işleri zamanlamaya alın"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Tekrarlayan işleri bir zamanlamaya veya olaya bağlayın. Ajanlar kendi başına çalışır ve sonuç, incelemeniz için bir çalışma alanına düşer."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -2274,6 +2274,9 @@ msgstr "Tự động hóa ({myFailedCount} đang lỗi)"
 msgid "Automations & event triggers"
 msgstr "Tự động hóa & trigger sự kiện"
 
+msgid "Automations require the Pro plan."
+msgstr "Tự động hóa yêu cầu gói Pro."
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "Tự động hóa, {myFailedCount} đang lỗi"
 
@@ -2422,9 +2425,6 @@ msgstr "Chậm hơn main ? commit, cần rebase"
 
 msgid "Being built right now."
 msgstr "Đang được xây ngay lúc này."
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "Xa hơn: F5 không phải tuyên bố cho tương lai gần"
@@ -11242,6 +11242,9 @@ msgstr "Đang push…"
 
 msgid "Put recurring work on a schedule"
 msgstr "Đưa việc lặp lại vào lịch"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "Đặt công việc lặp lại theo lịch hoặc sự kiện. Agent tự chạy và kết quả nằm trong một workspace để bạn xem lại."
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -2274,6 +2274,9 @@ msgstr "自动化（{myFailedCount}个失败）"
 msgid "Automations & event triggers"
 msgstr "自动化与事件触发"
 
+msgid "Automations require the Pro plan."
+msgstr "自动化需要Pro套餐。"
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "自动化，{myFailedCount}个失败"
 
@@ -2422,9 +2425,6 @@ msgstr "落后main ?个提交，需要变基"
 
 msgid "Being built right now."
 msgstr "正在构建中。"
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "再往后：F5不是近期的主张"
@@ -11242,6 +11242,9 @@ msgstr "正在推送…"
 
 msgid "Put recurring work on a schedule"
 msgstr "把重复的活儿排进日程"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "把重复性工作放到计划或事件上。代理会自行运行，结果会落在一个工作区里供你审查。"
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -11244,7 +11244,7 @@ msgid "Put recurring work on a schedule"
 msgstr "把重复的活儿排进日程"
 
 msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
-msgstr "把重复性工作放到计划或事件上。代理会自行运行，结果会落在一个工作区里供你审查。"
+msgstr "按计划或事件触发重复性工作。智能体会自行运行，结果会落在一个工作区里供你审查。"
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -11244,7 +11244,7 @@ msgid "Put recurring work on a schedule"
 msgstr "把重複的活兒排進日程"
 
 msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
-msgstr "把重複性工作放到排程或事件上。代理會自行執行，結果會落在一個工作區裡供你審查。"
+msgstr "將重複性工作排入排程，或設定為由事件觸發。代理程式會自行執行，並將結果放入工作區供你審查。"
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -2274,6 +2274,9 @@ msgstr "自動化（{myFailedCount}個失敗）"
 msgid "Automations & event triggers"
 msgstr "自動化與事件觸發"
 
+msgid "Automations require the Pro plan."
+msgstr "自動化需要Pro方案。"
+
 msgid "Automations, {myFailedCount} failing"
 msgstr "自動化，{myFailedCount}個失敗"
 
@@ -2422,9 +2425,6 @@ msgstr "落後main ?個提交，需要變基"
 
 msgid "Being built right now."
 msgstr "正在構建中。"
-
-msgid "Beta"
-msgstr "Beta"
 
 msgid "Beyond: F5 is not a near-term claim"
 msgstr "再往後：F5不是近期的主張"
@@ -11242,6 +11242,9 @@ msgstr "正在推送…"
 
 msgid "Put recurring work on a schedule"
 msgstr "把重複的活兒排進日程"
+
+msgid "Put recurring work on a schedule or an event. Agents run on their own and land in a workspace for you to review."
+msgstr "把重複性工作放到排程或事件上。代理會自行執行，結果會落在一個工作區裡供你審查。"
 
 msgid "px"
 msgstr "px"

--- a/packages/i18n/src/server-errors.ts
+++ b/packages/i18n/src/server-errors.ts
@@ -49,6 +49,12 @@ export const serverErrorMessages: Record<
 				message: `This automation belongs to ${params?.organizationName}. Switch to that organization to open it.`,
 			}),
 		),
+	"serverError.automation.automationsRequireThePro": () =>
+		i18n._(
+			msg({
+				message: "Automations require the Pro plan.",
+			}),
+		),
 	"serverError.automation.automationNotFound": () =>
 		i18n._(
 			msg({

--- a/packages/shared/src/billing.test.ts
+++ b/packages/shared/src/billing.test.ts
@@ -1,18 +1,58 @@
 import { describe, expect, test } from "bun:test";
-import { planAllowsTriggerKind, requiredPlanForTriggerKind } from "./billing";
+import {
+	planAllowsAutomations,
+	planAllowsTriggerKind,
+	planTierFromSubscription,
+	requiredPlanForTriggerKind,
+} from "./billing";
 import { LAUNCHED_TRIGGER_KINDS } from "./constants";
 
-/** The one kind every plan gets. Everything else is a paid provider. */
-const FREE_KINDS = new Set<string>(["schedule"]);
+describe("planAllowsAutomations", () => {
+	test("free cannot, paid plans can", () => {
+		expect(planAllowsAutomations("free")).toBe(false);
+		expect(planAllowsAutomations("pro")).toBe(true);
+		expect(planAllowsAutomations("enterprise")).toBe(true);
+	});
+});
+
+describe("planTierFromSubscription", () => {
+	test("no subscription is free", () => {
+		expect(planTierFromSubscription(null)).toBe("free");
+		expect(planTierFromSubscription(undefined)).toBe("free");
+	});
+
+	test("a paying subscription resolves to its plan", () => {
+		expect(planTierFromSubscription({ plan: "pro", status: "active" })).toBe(
+			"pro",
+		);
+		expect(
+			planTierFromSubscription({ plan: "enterprise", status: "trialing" }),
+		).toBe("enterprise");
+		// Stripe is still retrying; access continues through its dunning window.
+		expect(planTierFromSubscription({ plan: "pro", status: "past_due" })).toBe(
+			"pro",
+		);
+	});
+
+	test("a lapsed subscription is free again", () => {
+		expect(planTierFromSubscription({ plan: "pro", status: "canceled" })).toBe(
+			"free",
+		);
+		expect(planTierFromSubscription({ plan: "free", status: "active" })).toBe(
+			"free",
+		);
+	});
+});
 
 describe("planAllowsTriggerKind", () => {
-	test("free plans get schedules and nothing else", () => {
-		expect(planAllowsTriggerKind("free", "schedule")).toBe(true);
+	test("free plans get no trigger kinds at all", () => {
+		expect(planAllowsTriggerKind("free", "schedule")).toBe(false);
 		expect(planAllowsTriggerKind("free", "slack")).toBe(false);
 		expect(planAllowsTriggerKind("free", "microsoft_teams")).toBe(false);
 	});
 
-	test("pro gets the pro providers but not the enterprise ones", () => {
+	test("pro gets schedules and the pro providers but not the enterprise ones", () => {
+		expect(planAllowsTriggerKind("pro", "schedule")).toBe(true);
 		expect(planAllowsTriggerKind("pro", "slack")).toBe(true);
 		expect(planAllowsTriggerKind("pro", "linear")).toBe(true);
 		expect(planAllowsTriggerKind("pro", "microsoft_teams")).toBe(false);
@@ -37,15 +77,12 @@ describe("planAllowsTriggerKind", () => {
  *
  * Adding a provider is a code-only change everywhere else, so nothing forces
  * whoever adds one to think about billing — and a kind missing from the map is
- * silently free for everybody. This fails the moment that happens.
+ * silently free for everybody, when automations as a whole are Pro. This
+ * fails the moment that happens.
  */
 describe("every launched provider is priced", () => {
 	for (const kind of LAUNCHED_TRIGGER_KINDS) {
 		test(`${kind}`, () => {
-			if (FREE_KINDS.has(kind)) {
-				expect(requiredPlanForTriggerKind(kind)).toBeUndefined();
-				return;
-			}
 			expect(requiredPlanForTriggerKind(kind)).toBeDefined();
 			expect(planAllowsTriggerKind("free", kind)).toBe(false);
 		});

--- a/packages/shared/src/billing.ts
+++ b/packages/shared/src/billing.ts
@@ -44,16 +44,44 @@ export const PLAN_RANK: Record<PlanTier, number> = {
 	enterprise: 2,
 };
 
+/** The tier an org needs to create, run, or resume an automation. */
+export const AUTOMATIONS_REQUIRED_PLAN: Exclude<PlanTier, "free"> = "pro";
+
 /**
- * The billing tier each trigger kind needs; kinds absent here are free
- * (schedule). One map for both sides of the product: the desktop Add Trigger
- * menu locks and badges off it, and the event dispatcher skips triggers above
- * the org's plan. Editing a saved above-tier trigger is deliberately still
- * allowed — a downgraded org maintains its automations, they just don't fire.
+ * The plan tier a subscription row resolves to: its plan while the
+ * subscription is still paying, `free` otherwise (or when there is no row).
+ */
+export function planTierFromSubscription(
+	subscription:
+		| { plan: string | null | undefined; status: string | null | undefined }
+		| null
+		| undefined,
+): PlanTier {
+	if (!subscription || !isActiveSubscriptionStatus(subscription.status)) {
+		return "free";
+	}
+	const plan = subscription.plan;
+	return plan === "pro" || plan === "enterprise" ? plan : "free";
+}
+
+/** Whether an org on this plan may create, run, or resume automations. */
+export function planAllowsAutomations(plan: PlanTier): boolean {
+	return PLAN_RANK[plan] >= PLAN_RANK[AUTOMATIONS_REQUIRED_PLAN];
+}
+
+/**
+ * The billing tier each trigger kind needs. Automations are a Pro feature,
+ * so every kind is at least Pro; a kind absent here would be free, which is
+ * what the billing test guards against. One map for both sides of the
+ * product: the desktop Add Trigger menu locks and badges off it, and the
+ * dispatchers skip triggers above the org's plan. Editing a saved above-tier
+ * trigger is deliberately still allowed — a downgraded org maintains its
+ * automations, they just don't fire.
  */
 const TRIGGER_KIND_REQUIRED_PLAN: Partial<
 	Record<string, Exclude<PlanTier, "free">>
 > = {
+	schedule: AUTOMATIONS_REQUIRED_PLAN,
 	github: "pro",
 	slack: "pro",
 	linear: "pro",

--- a/packages/trpc/src/i18n-error.test.ts
+++ b/packages/trpc/src/i18n-error.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { formatError, isI18nErrorCause, userError } from "./i18n-error";
+import { TRPCError } from "@trpc/server";
+import {
+	formatError,
+	isI18nErrorCause,
+	planRequiredError,
+	userError,
+} from "./i18n-error";
 
 // Round trip: userError() → errorFormatter → the client-visible shape.data.
 // TRPCError.cause is NOT serialized by tRPC, so this is the contract that
@@ -32,6 +38,31 @@ describe("i18n error contract", () => {
 			i18nKey: "serverError.workspace.notFound",
 			i18nParams: { name: "api" },
 		});
+	});
+
+	test("planRequiredError is FORBIDDEN and forwards requiredPlan", () => {
+		const error = planRequiredError({
+			message: "Automations require the Pro plan.",
+			i18nKey: "serverError.automation.automationsRequireThePro",
+			requiredPlan: "pro",
+		});
+		expect(error.code).toBe("FORBIDDEN");
+		const shape = formatError({ shape: { data: {} }, error });
+		expect(shape.data.requiredPlan).toBe("pro");
+		expect(shape.data.i18nKey).toBe(
+			"serverError.automation.automationsRequireThePro",
+		);
+	});
+
+	test("an unknown requiredPlan is rejected with the rest of the cause", () => {
+		const error = new TRPCError({
+			code: "FORBIDDEN",
+			message: "x",
+			cause: { i18nKey: "k", requiredPlan: "platinum" },
+		});
+		const shape = formatError({ shape: { data: {} }, error });
+		expect(shape.data.i18nKey).toBeNull();
+		expect(shape.data.requiredPlan).toBeNull();
 	});
 
 	test("malformed i18nParams are rejected, not forwarded to clients", () => {

--- a/packages/trpc/src/i18n-error.ts
+++ b/packages/trpc/src/i18n-error.ts
@@ -8,9 +8,23 @@ import { ZodError } from "zod";
 // entries for every key live in packages/i18n/src/server-errors.ts.
 // Strategy: plans/20260826-i18n-strategy.md.
 
+/** The paid tiers a gate can name. Mirrors PlanTier minus "free". */
+export type RequiredPlan = "pro" | "enterprise";
+
 export interface I18nErrorCause {
 	i18nKey: string;
 	i18nParams?: Record<string, string | number>;
+	/**
+	 * Set when the error is a plan gate: the tier the caller's org needs.
+	 * Travels to clients as `data.requiredPlan`, so the CLI can print an
+	 * upgrade hint and the desktop can open the paywall without matching on
+	 * message text.
+	 */
+	requiredPlan?: RequiredPlan;
+}
+
+function isRequiredPlan(value: unknown): value is RequiredPlan | undefined {
+	return value === undefined || value === "pro" || value === "enterprise";
 }
 
 function isValidParams(
@@ -30,7 +44,8 @@ export function isI18nErrorCause(cause: unknown): cause is I18nErrorCause {
 		typeof cause === "object" &&
 		cause !== null &&
 		typeof (cause as { i18nKey?: unknown }).i18nKey === "string" &&
-		isValidParams((cause as { i18nParams?: unknown }).i18nParams)
+		isValidParams((cause as { i18nParams?: unknown }).i18nParams) &&
+		isRequiredPlan((cause as { requiredPlan?: unknown }).requiredPlan)
 	);
 }
 
@@ -54,6 +69,7 @@ export function formatError<TShape extends { data: object }>({
 			zodError: error.cause instanceof ZodError ? error.cause.flatten() : null,
 			i18nKey: i18nCause?.i18nKey ?? null,
 			i18nParams: i18nCause?.i18nParams ?? null,
+			requiredPlan: i18nCause?.requiredPlan ?? null,
 		},
 	};
 }
@@ -63,6 +79,7 @@ export function userError(opts: {
 	message: string;
 	i18nKey: string;
 	params?: Record<string, string | number>;
+	requiredPlan?: RequiredPlan;
 }): TRPCError {
 	return new TRPCError({
 		code: opts.code,
@@ -70,6 +87,20 @@ export function userError(opts: {
 		cause: {
 			i18nKey: opts.i18nKey,
 			i18nParams: opts.params,
+			requiredPlan: opts.requiredPlan,
 		} satisfies I18nErrorCause,
 	});
+}
+
+/**
+ * The one way to refuse a request on plan. Every gate throws through here so
+ * the refusal is FORBIDDEN, names the tier in the message, and carries
+ * `requiredPlan` for clients to act on.
+ */
+export function planRequiredError(opts: {
+	message: string;
+	i18nKey: string;
+	requiredPlan: RequiredPlan;
+}): TRPCError {
+	return userError({ code: "FORBIDDEN", ...opts });
 }

--- a/packages/trpc/src/router/automation/automation.ts
+++ b/packages/trpc/src/router/automation/automation.ts
@@ -9,6 +9,11 @@ import {
 } from "@superset/db/schema";
 import type { DraftTrigger } from "@superset/shared/automation-triggers";
 import {
+	AUTOMATIONS_REQUIRED_PLAN,
+	planAllowsAutomations,
+	planTierFromSubscription,
+} from "@superset/shared/billing";
+import {
 	describeSchedule,
 	nextOccurrenceAfter,
 	nextOccurrences,
@@ -18,9 +23,12 @@ import { TRPCError, type TRPCRouterRecord } from "@trpc/server";
 import { and, asc, desc, eq, ilike } from "drizzle-orm";
 import { z } from "zod";
 import { env } from "../../env";
-import { protectedProcedure, userError } from "../../trpc";
+import { planRequiredError, protectedProcedure, userError } from "../../trpc";
 import { joinSlackTriggerChannels } from "../integration/slack/joinChannels";
-import { requireActiveOrgMembership } from "../utils/active-org";
+import {
+	requireActiveOrgMembership,
+	requireActiveOrgMembershipWithSubscription,
+} from "../utils/active-org";
 import { dispatchAutomation } from "./dispatch";
 import {
 	automationBaseColumns,
@@ -44,6 +52,27 @@ import {
 import { saveTriggerSet } from "./triggerSet";
 import { automationVersionsRouter } from "./versions";
 import { generateWebhookToken, hashWebhookToken } from "./webhookSecret";
+
+/**
+ * Membership plus the Pro gate. Automations are a Pro feature: creating,
+ * running, and resuming one needs a paying org. Reading, editing, pausing,
+ * and deleting stay open so a downgraded org keeps control of what it has —
+ * those rows simply stop firing (the dispatchers apply the same tier map).
+ */
+async function requireAutomationsPlan(
+	ctx: Parameters<typeof requireActiveOrgMembershipWithSubscription>[0],
+): Promise<string> {
+	const { organizationId, subscription } =
+		await requireActiveOrgMembershipWithSubscription(ctx);
+	if (!planAllowsAutomations(planTierFromSubscription(subscription))) {
+		throw planRequiredError({
+			message: "Automations require the Pro plan.",
+			i18nKey: "serverError.automation.automationsRequireThePro",
+			requiredPlan: AUTOMATIONS_REQUIRED_PLAN,
+		});
+	}
+	return organizationId;
+}
 
 function escapeLikePattern(value: string): string {
 	return value.replace(/[\\%_]/g, (match) => `\\${match}`);
@@ -286,7 +315,7 @@ export const automationRouter = {
 	create: protectedProcedure
 		.input(createAutomationSchema)
 		.mutation(async ({ ctx, input }) => {
-			const organizationId = await requireActiveOrgMembership(ctx);
+			const organizationId = await requireAutomationsPlan(ctx);
 
 			if (input.targetHostId) {
 				await verifyHostAccess(
@@ -700,7 +729,10 @@ export const automationRouter = {
 	setEnabled: protectedProcedure
 		.input(z.object({ id: z.string().uuid(), enabled: z.boolean() }))
 		.mutation(async ({ ctx, input }) => {
-			const organizationId = await requireActiveOrgMembership(ctx);
+			// Pausing is always allowed; resuming is what needs the plan.
+			const organizationId = input.enabled
+				? await requireAutomationsPlan(ctx)
+				: await requireActiveOrgMembership(ctx);
 			const existing = await getAutomationForUser(
 				ctx.session.user.id,
 				organizationId,
@@ -746,7 +778,7 @@ export const automationRouter = {
 	runNow: protectedProcedure
 		.input(z.object({ id: z.string().uuid() }))
 		.mutation(async ({ ctx, input }) => {
-			const organizationId = await requireActiveOrgMembership(ctx);
+			const organizationId = await requireAutomationsPlan(ctx);
 			const automation = await getAutomationForUser(
 				ctx.session.user.id,
 				organizationId,

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -8,8 +8,8 @@ import superjson from "superjson";
 import { formatError, userError } from "./i18n-error";
 import { posthog } from "./lib/analytics";
 
-export type { I18nErrorCause } from "./i18n-error";
-export { isI18nErrorCause, userError } from "./i18n-error";
+export type { I18nErrorCause, RequiredPlan } from "./i18n-error";
+export { isI18nErrorCause, planRequiredError, userError } from "./i18n-error";
 
 export interface ApiClientInfo {
 	product: "desktop" | "mobile" | "cli" | "sdk";


### PR DESCRIPTION
## Summary

Automations become a Pro feature, gated from one tier map so the desktop, the API, and the dispatchers agree.

**Server**
- `automation.create`, `runNow`, and `setEnabled(true)` refuse Free orgs with FORBIDDEN "Automations require the Pro plan." Reading, editing, pausing, and deleting stay open so a downgraded org keeps control of what it has.
- `schedule` joins `TRIGGER_KIND_REQUIRED_PLAN`; the evaluate sweep skips due schedules for Free orgs but still advances `next_run_at`, so an upgrade resumes at the next occurrence with no backlog. Event triggers were already gated by the same map.
- Plan-gate errors carry a structured `data.requiredPlan` via `planRequiredError` in `@superset/trpc`. The CLI prints an upgrade hint for any such refusal instead of matching message text. SDK and MCP callers get the same FORBIDDEN with the field.

**Desktop**
- Automations joins the Pro Features dialog with its own preview. Create with AI, New automation, templates, Run now, Retry all, and resume open the paywall on Free.
- The sidebar entry opens the paywall for a Free org with no automations and passes through for an org that already has some (a downgrade).
- The trigger editor warns "Scheduled triggers require the Pro plan" and locks the kind in Add Trigger.
- Dialog rows tightened to 56px, edge to edge, so six entries no longer stretch the preview column.

**Marketing and docs**
- Pricing card and comparison table list Automations under Pro; Beta tag removed from Remote access; GitHub integration grouped with the other every-plan rows. The in-app plan comparison matches.
- Automations doc gets the Pro badge and a plan requirement; SDK and CLI references say which calls need Pro. `index.md` and `agents.md` mark it Pro.
- Two new strings translated into all 16 locales; `check:i18n` reports none missing.

## Evidence

Film and stills of the desktop on a Free plan hitting every gate, plus the updated pages: https://app.superset.sh/page/automations-pro-gate-2cr3dt

## Tests

Billing, paywall, automations, sidebar, error-contract, and CLI formatter suites pass. Typecheck, lint, and `check:i18n` clean.

https://claude.ai/code/session_013vQd5zL3XWkTBMKgsQv1oH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automations are now a Pro feature: creating, running, or resuming one requires a Pro or Enterprise subscription, enforced by the same tier map across the API, the desktop, and the dispatchers. Reading, editing, pausing, and deleting stay open so a downgraded org keeps control of what it has.

**Server**
- `automation.create`, `runNow`, and `setEnabled(true)` refuse Free orgs with FORBIDDEN "Automations require the Pro plan."
- The evaluate sweep skips due schedules for Free orgs but still advances `next_run_at`, so an upgrade resumes at the next occurrence with no backlog.
- Plan-gate errors carry `data.requiredPlan` via `planRequiredError` in `@superset/trpc`; the CLI prints an upgrade hint for any such refusal.

**Desktop, docs, and marketing**
- Create, Run now, Retry all, and resume open the paywall on Free; the gate drops a duplicate click while the plan is resolving, and the sidebar passes through for orgs that already have automations or are still loading.
- The trigger editor warns "Scheduled triggers require the Pro plan" and locks the kind in Add Trigger.
- Pricing and comparison pages list Automations under Pro; the Beta tag is removed from Remote access and GitHub integration moves to the every-plan rows.
- Docs mark Automations as Pro, and the two new strings are translated into all 16 locales.

<sup>Written for commit f75c483bae65cf39b6580c5c673ed25c0b81c5df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automations now require a Pro or Enterprise plan to create, run, or resume.
  * Existing automations remain available for viewing, editing, pausing, and deleting after downgrade.
  * Scheduled triggers are skipped for ineligible plans while their next run times continue advancing.
  * Added an Automations paywall preview, Pro badges, and clearer upgrade guidance.

* **Documentation**
  * Updated automation, CLI, SDK, pricing, and capability documentation.
  * Added translations for plan restrictions and scheduling descriptions.

* **UI Updates**
  * Refined paywall sidebar layout and pricing comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->