### PR TITLE
fix(auth): validate the desktop sign-in callback target

### DIFF
--- a/apps/api/src/app/api/auth/desktop/connect/desktopProtocol.test.ts
+++ b/apps/api/src/app/api/auth/desktop/connect/desktopProtocol.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { isDesktopProtocol } from "./desktopProtocol";
+
+describe("isDesktopProtocol", () => {
+	test("accepts the schemes the desktop registers", () => {
+		expect(isDesktopProtocol("superset")).toBe(true);
+		expect(isDesktopProtocol("superset-dev")).toBe(true);
+		expect(isDesktopProtocol("superset-my-worktree2")).toBe(true);
+		expect(isDesktopProtocol("Superset")).toBe(true);
+	});
+
+	test("rejects anything that could redirect the token elsewhere", () => {
+		expect(isDesktopProtocol("https")).toBe(false);
+		expect(isDesktopProtocol("https://attacker.example/?x=")).toBe(false);
+		expect(isDesktopProtocol("superset://evil")).toBe(false);
+		expect(isDesktopProtocol("superset-")).toBe(false);
+		expect(isDesktopProtocol("supersets")).toBe(false);
+		expect(isDesktopProtocol("javascript")).toBe(false);
+		expect(isDesktopProtocol("")).toBe(false);
+	});
+});

--- a/apps/api/src/app/api/auth/desktop/connect/desktopProtocol.ts
+++ b/apps/api/src/app/api/auth/desktop/connect/desktopProtocol.ts
@@ -1,0 +1,17 @@
+import { PROTOCOL_SCHEMES } from "@superset/shared/constants";
+
+/**
+ * The desktop registers `superset` (release), `superset-dev`, or
+ * `superset-<workspace>` for a dev instance. Anything else is not a scheme
+ * the app answers, and since the success page pastes this straight into
+ * `${protocol}://auth/callback?token=...`, an unconstrained value would turn
+ * the freshly minted session token into an open redirect.
+ */
+const DESKTOP_PROTOCOL = new RegExp(
+	`^${PROTOCOL_SCHEMES.PROD}(?:-[a-z0-9][a-z0-9-]*)?$`,
+	"i",
+);
+
+export function isDesktopProtocol(protocol: string): boolean {
+	return DESKTOP_PROTOCOL.test(protocol);
+}

--- a/apps/api/src/app/api/auth/desktop/connect/route.ts
+++ b/apps/api/src/app/api/auth/desktop/connect/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@superset/auth/server";
 import { NextResponse } from "next/server";
 
 import { env } from "@/env";
+import { isDesktopProtocol } from "./desktopProtocol";
 
 export async function GET(request: Request) {
 	const url = new URL(request.url);
@@ -16,6 +17,10 @@ export async function GET(request: Request) {
 
 	if (provider !== "google" && provider !== "github") {
 		return new Response("Invalid provider", { status: 400 });
+	}
+
+	if (protocol && !isDesktopProtocol(protocol)) {
+		return new Response("Invalid protocol", { status: 400 });
 	}
 
 	const successUrl = new URL(`${env.NEXT_PUBLIC_WEB_URL}/auth/desktop/success`);

--- a/apps/web/src/app/auth/desktop/success/page.tsx
+++ b/apps/web/src/app/auth/desktop/success/page.tsx
@@ -5,6 +5,10 @@ import { sessions } from "@superset/db/schema/auth";
 import { headers } from "next/headers";
 import { initServerI18n } from "@/lib/i18n-server";
 import { DesktopRedirect } from "./components/DesktopRedirect";
+import {
+	isDesktopProtocol,
+	parseLoopbackCallback,
+} from "./utils/desktopCallbackTarget";
 
 export default async function DesktopSuccessPage({
 	searchParams,
@@ -90,6 +94,35 @@ export default async function DesktopSuccessPage({
 		);
 	}
 
+	// The token below goes wherever these point, so refuse anything that is
+	// not the desktop app before minting it.
+	const localCallback = localCallbackBase
+		? parseLoopbackCallback(localCallbackBase)
+		: undefined;
+	if (
+		!isDesktopProtocol(desktop_protocol) ||
+		(localCallbackBase && !localCallback)
+	) {
+		return (
+			<div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
+				<p className="text-xl text-muted-foreground">
+					{i18n._(
+						msg({
+							message: "Authentication failed",
+						}),
+					)}
+				</p>
+				<p className="text-muted-foreground/70">
+					{i18n._(
+						msg({
+							message: "Please try signing in again from the desktop app.",
+						}),
+					)}
+				</p>
+			</div>
+		);
+	}
+
 	// Desktop and web need independent sessions with separate activeOrganizationId
 	const headersObj = await headers();
 	const userAgent = headersObj.get("user-agent") || "Superset Desktop App";
@@ -113,9 +146,13 @@ export default async function DesktopSuccessPage({
 		updatedAt: now,
 	});
 	const desktopUrl = `${desktop_protocol}://auth/callback?token=${encodeURIComponent(token)}&expiresAt=${encodeURIComponent(expiresAt.toISOString())}&state=${encodeURIComponent(state)}`;
-	const localCallbackUrl = localCallbackBase
-		? `${localCallbackBase}?token=${encodeURIComponent(token)}&expiresAt=${encodeURIComponent(expiresAt.toISOString())}&state=${encodeURIComponent(state)}`
-		: undefined;
+	let localCallbackUrl: string | undefined;
+	if (localCallback) {
+		localCallback.searchParams.set("token", token);
+		localCallback.searchParams.set("expiresAt", expiresAt.toISOString());
+		localCallback.searchParams.set("state", state);
+		localCallbackUrl = localCallback.toString();
+	}
 
 	return (
 		<div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">

--- a/apps/web/src/app/auth/desktop/success/utils/desktopCallbackTarget/desktopCallbackTarget.test.ts
+++ b/apps/web/src/app/auth/desktop/success/utils/desktopCallbackTarget/desktopCallbackTarget.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	isDesktopProtocol,
+	parseLoopbackCallback,
+} from "./desktopCallbackTarget";
+
+describe("isDesktopProtocol", () => {
+	test("accepts the schemes the desktop registers", () => {
+		expect(isDesktopProtocol("superset")).toBe(true);
+		expect(isDesktopProtocol("superset-dev")).toBe(true);
+		expect(isDesktopProtocol("superset-my-worktree2")).toBe(true);
+		expect(isDesktopProtocol("Superset")).toBe(true);
+	});
+
+	test("rejects anything that could redirect the token elsewhere", () => {
+		expect(isDesktopProtocol("https")).toBe(false);
+		expect(isDesktopProtocol("https://attacker.example/?x=")).toBe(false);
+		expect(isDesktopProtocol("superset://evil")).toBe(false);
+		expect(isDesktopProtocol("superset-")).toBe(false);
+		expect(isDesktopProtocol("supersets")).toBe(false);
+		expect(isDesktopProtocol("javascript")).toBe(false);
+		expect(isDesktopProtocol("")).toBe(false);
+	});
+});
+
+describe("parseLoopbackCallback", () => {
+	test("accepts the desktop's loopback callback", () => {
+		expect(
+			parseLoopbackCallback("http://127.0.0.1:41893/auth/callback")?.href,
+		).toBe("http://127.0.0.1:41893/auth/callback");
+		expect(
+			parseLoopbackCallback("http://localhost:3000/auth/callback")?.href,
+		).toBe("http://localhost:3000/auth/callback");
+	});
+
+	test("rejects other hosts and schemes", () => {
+		expect(
+			parseLoopbackCallback("https://attacker.example/auth/callback"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://attacker.example/auth/callback"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://127.0.0.1.attacker.example/auth/callback"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://[::1]:3000/auth/callback"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("https://127.0.0.1/auth/callback"),
+		).toBeUndefined();
+		expect(parseLoopbackCallback("superset://auth/callback")).toBeUndefined();
+		expect(parseLoopbackCallback("javascript:alert(1)")).toBeUndefined();
+		expect(parseLoopbackCallback("//127.0.0.1/auth/callback")).toBeUndefined();
+		expect(parseLoopbackCallback("not a url")).toBeUndefined();
+		expect(parseLoopbackCallback("")).toBeUndefined();
+	});
+
+	test("rejects credentials, other paths, queries, and fragments", () => {
+		expect(
+			parseLoopbackCallback("http://user:pw@127.0.0.1/auth/callback"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://127.0.0.1@attacker.example/auth/callback"),
+		).toBeUndefined();
+		expect(parseLoopbackCallback("http://127.0.0.1/")).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://127.0.0.1/auth/callback/../other"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://127.0.0.1/auth/callback?x=1"),
+		).toBeUndefined();
+		expect(
+			parseLoopbackCallback("http://127.0.0.1/auth/callback#frag"),
+		).toBeUndefined();
+	});
+});

--- a/apps/web/src/app/auth/desktop/success/utils/desktopCallbackTarget/desktopCallbackTarget.ts
+++ b/apps/web/src/app/auth/desktop/success/utils/desktopCallbackTarget/desktopCallbackTarget.ts
@@ -1,0 +1,39 @@
+import { PROTOCOL_SCHEMES } from "@superset/shared/constants";
+
+/**
+ * The desktop registers `superset` (release), `superset-dev`, or
+ * `superset-<workspace>` for a dev instance. The success page pastes the
+ * scheme straight into `${protocol}://auth/callback?token=...`, so anything
+ * else would send the freshly minted session token to an attacker's URL.
+ * Mirrors the allowlist in apps/api `auth/desktop/connect`.
+ */
+const DESKTOP_PROTOCOL = new RegExp(
+	`^${PROTOCOL_SCHEMES.PROD}(?:-[a-z0-9][a-z0-9-]*)?$`,
+	"i",
+);
+
+export function isDesktopProtocol(protocol: string): boolean {
+	return DESKTOP_PROTOCOL.test(protocol);
+}
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost"]);
+
+/**
+ * The desktop's local fallback listens on plain http at a loopback address
+ * under `/auth/callback`. Returns the parsed URL when the value is exactly
+ * that shape (no credentials, query, or fragment), otherwise `undefined`.
+ */
+export function parseLoopbackCallback(value: string): URL | undefined {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return undefined;
+	}
+	if (url.protocol !== "http:") return undefined;
+	if (!LOOPBACK_HOSTS.has(url.hostname)) return undefined;
+	if (url.username || url.password) return undefined;
+	if (url.pathname !== "/auth/callback") return undefined;
+	if (url.search || url.hash) return undefined;
+	return url;
+}

--- a/apps/web/src/app/auth/desktop/success/utils/desktopCallbackTarget/index.ts
+++ b/apps/web/src/app/auth/desktop/success/utils/desktopCallbackTarget/index.ts
@@ -1,0 +1,4 @@
+export {
+	isDesktopProtocol,
+	parseLoopbackCallback,
+} from "./desktopCallbackTarget";


### PR DESCRIPTION
The desktop sign-in handoff builds its redirect out of query params — `protocol` on `GET /api/auth/desktop/connect`, and `desktop_protocol` / `desktop_local_callback` on the web success page — and used them as given, so the redirect target was not necessarily the desktop app.

Both ends now validate before the redirect is built:

- **apps/api** — `protocol` has to be a scheme the desktop registers (`superset`, `superset-dev`, `superset-<workspace>`). Anything else answers 400.
- **apps/web** — same scheme allowlist, and the local callback has to be `http://127.0.0.1|localhost/auth/callback` with no credentials, query or fragment. Rejected values render the error page the route already has.

Unit tests cover the accepted and rejected shapes on both sides.

Part of an audit pass over the v2 stack on macOS.

https://claude.ai/code/session_01HmVz1yzkCEfnfDYDQxjN8u


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop sign-in handoff so the session token can only be redirected to the desktop app, not an attacker-controlled URL.

- API now requires `protocol` to be `superset`, `superset-dev`, or `superset-<workspace>`; anything else answers 400.
- Web applies the same scheme allowlist to `desktop_protocol`, and `desktop_local_callback` must be `http://127.0.0.1|localhost/auth/callback` with no credentials, query, or fragment; rejected values render the existing error page.
- Unit tests cover accepted and rejected shapes on both sides.

<sup>Written for commit f63bc0c3acbad77106e89401a5dfde68ff3c5fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop sign-in security by accepting only supported desktop protocol schemes.
  - Added validation for local authentication callback URLs, blocking malformed, external, or unsafe destinations.
  - Authentication now reports a clear failure instead of proceeding when protocol or callback details are invalid.
  - Callback tokens are handled through validated URL parameters, reducing the risk of unintended redirects.

- **Tests**
  - Added coverage for supported protocols and invalid callback targets, including external hosts, unsafe schemes, credentials, and malformed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->