### PR TITLE
fix(desktop): constrain what app windows can load and open

### DIFF
--- a/apps/desktop/src/lib/electron-app/factories/app/setup.ts
+++ b/apps/desktop/src/lib/electron-app/factories/app/setup.ts
@@ -1,10 +1,12 @@
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow } from "electron";
 import { env } from "main/env.main";
 import { isBrowserPanePopup } from "main/lib/browser/popup-window";
 import { loadReactDevToolsExtension } from "main/lib/extensions";
+import { safeOpenExternal } from "main/lib/safe-url";
 import { PLATFORM } from "shared/constants";
 import { makeAppId } from "shared/utils";
 import { ignoreConsoleWarnings } from "../../utils/ignore-console-warnings";
+import { isSameAppDocument } from "../../utils/same-app-document";
 
 ignoreConsoleWarnings(["Manifest version 2 is deprecated"]);
 
@@ -44,6 +46,28 @@ export async function makeAppSetup(
 
 	app.on("web-contents-created", (_, contents) => {
 		if (contents.getType() === "webview") return;
+		// A <webview> attribute can ask for a preload script or Node access for
+		// the guest; the browser pane sets neither, and guest content must never
+		// get them. Pin the guest's preferences regardless of what the tag says.
+		contents.on("will-attach-webview", (_event, webPreferences) => {
+			delete webPreferences.preload;
+			delete (webPreferences as { preloadURL?: string }).preloadURL;
+			webPreferences.nodeIntegration = false;
+			webPreferences.nodeIntegrationInSubFrames = false;
+			webPreferences.nodeIntegrationInWorker = false;
+			webPreferences.contextIsolation = true;
+			webPreferences.webSecurity = true;
+			webPreferences.allowRunningInsecureContent = false;
+		});
+		// `window.open` / target="_blank" from an app window: with no handler
+		// Electron would create a child window that inherits the preload bridge,
+		// so a `file:` link in rendered repo content would run local HTML with
+		// the whole tRPC surface. Deny every window; web links go to the system
+		// browser. Browser-pane popups get their own handler once created.
+		contents.setWindowOpenHandler(({ url }) => {
+			void safeOpenExternal(url);
+			return { action: "deny" };
+		});
 		contents.on("will-navigate", (event, url) => {
 			// A popup a browser pane opened navigates in place: it is a real
 			// `window.open` window (an OAuth sign-in, typically) that has to stay
@@ -52,11 +76,12 @@ export async function makeAppSetup(
 			// (SUPER-1272). Checked here rather than above because the popup is
 			// marked on `did-create-window`, after this listener is attached.
 			if (isBrowserPanePopup(contents)) return;
-			// Always prevent in-app navigation for external URLs
-			if (url.startsWith("http://") || url.startsWith("https://")) {
-				event.preventDefault();
-				shell.openExternal(url);
-			}
+			// Reloads and re-routes of the app document stay in-app. Anything
+			// else would replace the UI with a page that still has the preload
+			// bridge — `file:` and custom schemes included, not only http(s).
+			if (isSameAppDocument(contents.getURL(), url)) return;
+			event.preventDefault();
+			void safeOpenExternal(url);
 		});
 	});
 

--- a/apps/desktop/src/lib/electron-app/utils/same-app-document.test.ts
+++ b/apps/desktop/src/lib/electron-app/utils/same-app-document.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { isSameAppDocument } from "./same-app-document";
+
+const PROD =
+	"file:///Applications/Superset.app/Contents/Resources/app/renderer/index.html#/workspace/1";
+const DEV = "http://localhost:5173/#/workspace/1";
+
+describe("isSameAppDocument", () => {
+	test("allows reloading and re-routing the app's own document", () => {
+		expect(isSameAppDocument(PROD, PROD)).toBe(true);
+		expect(
+			isSameAppDocument(
+				PROD,
+				"file:///Applications/Superset.app/Contents/Resources/app/renderer/index.html#/settings",
+			),
+		).toBe(true);
+		expect(isSameAppDocument(DEV, "http://localhost:5173/")).toBe(true);
+		expect(isSameAppDocument(DEV, "http://localhost:5173/?x=1#/y")).toBe(true);
+	});
+
+	test("refuses another local file, which would load with the preload bridge", () => {
+		expect(isSameAppDocument(PROD, "file:///tmp/evil.html")).toBe(false);
+		expect(
+			isSameAppDocument(
+				PROD,
+				"file:///Applications/Superset.app/Contents/Resources/app/renderer/other.html",
+			),
+		).toBe(false);
+		expect(isSameAppDocument(DEV, "file:///tmp/evil.html")).toBe(false);
+	});
+
+	test("refuses other schemes and origins", () => {
+		expect(isSameAppDocument(PROD, "javascript:alert(1)")).toBe(false);
+		expect(isSameAppDocument(PROD, "superset://auth/callback")).toBe(false);
+		expect(isSameAppDocument(DEV, "http://localhost:5174/")).toBe(false);
+		expect(isSameAppDocument(DEV, "https://localhost:5173/")).toBe(false);
+		expect(isSameAppDocument(DEV, "http://evil.test/")).toBe(false);
+	});
+
+	test("refuses when either URL is unparseable", () => {
+		expect(isSameAppDocument("", "file:///tmp/evil.html")).toBe(false);
+		expect(isSameAppDocument(PROD, "not a url")).toBe(false);
+	});
+});

--- a/apps/desktop/src/lib/electron-app/utils/same-app-document.ts
+++ b/apps/desktop/src/lib/electron-app/utils/same-app-document.ts
@@ -1,0 +1,27 @@
+/**
+ * Whether a top-level navigation stays on the document an app window already
+ * shows — a reload, or a search/hash change of the same page. Anything else
+ * (another `file:` path, `javascript:`, a custom scheme, a different origin)
+ * must not replace the app UI: the new page would run with the app's
+ * preload bridge, and with it the whole tRPC surface.
+ */
+export function isSameAppDocument(
+	currentUrl: string,
+	targetUrl: string,
+): boolean {
+	let current: URL;
+	let target: URL;
+	try {
+		current = new URL(currentUrl);
+		target = new URL(targetUrl);
+	} catch {
+		return false;
+	}
+	if (current.protocol !== target.protocol) return false;
+	if (target.protocol === "file:") {
+		return current.pathname === target.pathname;
+	}
+	return (
+		current.origin === target.origin && current.pathname === target.pathname
+	);
+}


### PR DESCRIPTION
Two gaps in how the main process constrains what an app window is allowed to load:

- `will-navigate` was only diverted for `http(s)`, so a `file:`, `javascript:` or custom-scheme top-level navigation could replace the app document with one that still has the preload bridge attached.
- App windows had no `setWindowOpenHandler`, so a `target="_blank"` link in rendered content could open a child window that inherits the same preload.

Both paths now allow only the app's own document and send web links through `safeOpenExternal`. Webview attachment additionally strips `preload`/`nodeIntegration` and pins `contextIsolation` on every guest.

`same-app-document` is a small helper with unit tests for the dev-server, packaged-app and rejected cases.

Part of an audit pass over the v2 stack on macOS.

https://claude.ai/code/session_01HmVz1yzkCEfnfDYDQxjN8u


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two gaps in how the main process constrains app window navigation: `will-navigate` now only allows the app's own document, and `window.open`/`target="_blank"` links are denied and routed to the system browser.

- `will-navigate` denies all non-app-document navigations, including `file:`, `javascript:`, and custom schemes.
- Added `setWindowOpenHandler` to deny popups and route web links through `safeOpenExternal`.
- `webview` attachment now strips `preload`/`nodeIntegration` and pins `contextIsolation` on every guest.

<sup>Written for commit d497c7a6a1369d857b1c79e43341e439c0571a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Hardened guest web content by disabling unsafe capabilities and enforcing stronger isolation.
  - Prevented external pages from loading inside the app.
  - Redirected pop-up and external navigation requests to the system browser.
- **Bug Fixes**
  - Improved handling of same-app navigation across production and development environments.
  - Added coverage for invalid URLs, differing schemes, origins, and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->