### PR TITLE
fix: only ever delete a workspace's own worktree

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.test.ts
@@ -20,6 +20,7 @@ import {
 	isUnbornHeadError,
 	parsePorcelainStatusV2,
 	parsePrUrl,
+	removeWorktree,
 } from "./git";
 
 const TEST_DIR = join(
@@ -665,6 +666,84 @@ describe("createWorktree hook tolerance", () => {
 			.toString()
 			.trim();
 		expect(currentBranch).toBe("feature/new-workspace");
+	}, 10_000);
+});
+
+describe("removeWorktree", () => {
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
+
+	function listWorktrees(repoPath: string): string {
+		return execSync("git worktree list --porcelain", { cwd: repoPath })
+			.toString()
+			.trim();
+	}
+
+	test("removes a linked worktree from disk and from git", async () => {
+		const repoPath = createTestRepo("remove-linked");
+		seedCommit(repoPath);
+		const worktreePath = join(TEST_DIR, "remove-linked-worktrees", "feature");
+		await createWorktree(repoPath, "feature", worktreePath, "HEAD");
+
+		await removeWorktree(repoPath, worktreePath);
+
+		expect(existsSync(worktreePath)).toBe(false);
+		expect(listWorktrees(repoPath)).not.toContain(worktreePath);
+	}, 10_000);
+
+	test("leaves the main repository alone", async () => {
+		const repoPath = createTestRepo("remove-main");
+		seedCommit(repoPath);
+
+		await removeWorktree(repoPath, repoPath);
+
+		expect(existsSync(join(repoPath, "README.md"))).toBe(true);
+	}, 10_000);
+
+	test("leaves a directory that is not a linked worktree alone", async () => {
+		const repoPath = createTestRepo("remove-unregistered");
+		seedCommit(repoPath);
+		const strayPath = join(TEST_DIR, "remove-unregistered-stray");
+		mkdirSync(strayPath, { recursive: true });
+		writeFileSync(join(strayPath, "keep.txt"), "keep\n");
+
+		await removeWorktree(repoPath, strayPath);
+
+		expect(existsSync(join(strayPath, "keep.txt"))).toBe(true);
+	}, 10_000);
+
+	test("leaves the directory shared by the project's worktrees alone", async () => {
+		const repoPath = createTestRepo("remove-parent");
+		seedCommit(repoPath);
+		const parentPath = join(TEST_DIR, "remove-parent-worktrees");
+		const worktreePath = join(parentPath, "feature");
+		await createWorktree(repoPath, "feature", worktreePath, "HEAD");
+
+		// A workspace whose branch sanitized to "" records the parent directory
+		// as its worktree path.
+		await removeWorktree(repoPath, parentPath);
+
+		expect(existsSync(join(worktreePath, "README.md"))).toBe(true);
+		expect(listWorktrees(repoPath)).toContain(worktreePath);
+	}, 10_000);
+
+	test("prunes a registered worktree whose directory is already gone", async () => {
+		const repoPath = createTestRepo("remove-pruned");
+		seedCommit(repoPath);
+		const worktreePath = join(TEST_DIR, "remove-pruned-worktrees", "feature");
+		await createWorktree(repoPath, "feature", worktreePath, "HEAD");
+		rmSync(worktreePath, { recursive: true, force: true });
+
+		await removeWorktree(repoPath, worktreePath);
+
+		expect(listWorktrees(repoPath)).not.toContain(worktreePath);
 	}, 10_000);
 });
 

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/git.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { mkdir, rename } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -107,6 +107,27 @@ export function isUnbornHeadError(error: unknown): boolean {
 	);
 }
 
+/**
+ * Paths from `git worktree list --porcelain`, main worktree first, then the
+ * linked worktrees (including prunable ones whose directory is gone).
+ */
+async function listRegisteredWorktreePaths(
+	mainRepoPath: string,
+): Promise<string[]> {
+	const { stdout } = await execGitWithShellPath(
+		["-C", mainRepoPath, "worktree", "list", "--porcelain"],
+		{ timeout: 10_000 },
+	);
+
+	const paths: string[] = [];
+	for (const line of stdout.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			paths.push(line.slice("worktree ".length).trim());
+		}
+	}
+	return paths;
+}
+
 async function isWorktreeRegistered({
 	mainRepoPath,
 	worktreePath,
@@ -115,26 +136,26 @@ async function isWorktreeRegistered({
 	worktreePath: string;
 }): Promise<boolean> {
 	try {
-		const { stdout } = await execGitWithShellPath(
-			["-C", mainRepoPath, "worktree", "list", "--porcelain"],
-			{ timeout: 10_000 },
-		);
-
 		const expectedPath = resolve(worktreePath);
-		for (const line of stdout.split("\n")) {
-			if (!line.startsWith("worktree ")) {
-				continue;
-			}
-
-			const listedPath = line.slice("worktree ".length).trim();
-			if (resolve(listedPath) === expectedPath) {
-				return true;
-			}
-		}
-
-		return false;
+		const registered = await listRegisteredWorktreePaths(mainRepoPath);
+		return registered.some(
+			(listedPath) => resolve(listedPath) === expectedPath,
+		);
 	} catch {
 		return false;
+	}
+}
+
+/**
+ * Resolves symlinks (e.g. /tmp -> /private/tmp) without folding case, so two
+ * spellings that only differ in case stay distinct on a case-insensitive
+ * filesystem: git registers exactly one of them and only that one is ours.
+ */
+function resolveWorktreeIdentity(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
 	}
 }
 
@@ -814,10 +835,58 @@ export async function deleteLocalBranch({
 	}
 }
 
+/**
+ * Removes a linked worktree from disk and from git's metadata.
+ *
+ * Only a path git itself lists as a linked worktree of `mainRepoPath` is
+ * deleted. A DB row can point elsewhere — at the main checkout, at the
+ * parent directory shared by every worktree of the project, or at a
+ * sibling whose name differs only in case — and none of those are ours to
+ * delete, so they are left on disk and only the metadata is pruned.
+ */
 export async function removeWorktree(
 	mainRepoPath: string,
 	worktreePath: string,
 ): Promise<void> {
+	const prune = () =>
+		execGitWithShellPath(["-C", mainRepoPath, "worktree", "prune"], {
+			timeout: 10_000,
+		});
+
+	let registered: string[];
+	try {
+		registered = await listRegisteredWorktreePaths(mainRepoPath);
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		console.error(`Failed to remove worktree: ${errorMessage}`);
+		throw new Error(`Failed to remove worktree: ${errorMessage}`);
+	}
+
+	const target = resolveWorktreeIdentity(worktreePath);
+	const [mainWorktreePath, ...linkedWorktreePaths] = registered.map(
+		resolveWorktreeIdentity,
+	);
+	if (
+		target === mainWorktreePath ||
+		target === resolveWorktreeIdentity(mainRepoPath)
+	) {
+		console.error(
+			`[removeWorktree] Refusing to delete ${worktreePath}: it is the main repository`,
+		);
+		return;
+	}
+	if (!linkedWorktreePaths.includes(target)) {
+		if (existsSync(worktreePath)) {
+			console.warn(
+				`[removeWorktree] ${worktreePath} is not a linked worktree of ${mainRepoPath}; leaving it on disk`,
+			);
+		}
+		try {
+			await prune();
+		} catch {}
+		return;
+	}
+
 	try {
 		// Rename the worktree to a sibling temp dir (same filesystem to avoid EXDEV),
 		// then `git worktree prune` to clean metadata, then delete in background.
@@ -827,9 +896,7 @@ export async function removeWorktree(
 		);
 		await rename(worktreePath, tempPath);
 
-		await execGitWithShellPath(["-C", mainRepoPath, "worktree", "prune"], {
-			timeout: 10_000,
-		});
+		await prune();
 
 		// Delete the moved directory in the background — don't block the caller.
 		// Use spawned `rm -rf` instead of Node's fs.rm which can hang on macOS
@@ -857,9 +924,7 @@ export async function removeWorktree(
 		// If the worktree directory is already gone, just prune metadata
 		if (code === "ENOENT") {
 			try {
-				await execGitWithShellPath(["-C", mainRepoPath, "worktree", "prune"], {
-					timeout: 10_000,
-				});
+				await prune();
 			} catch {}
 			return;
 		}

--- a/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspaces/utils/workspace-creation.ts
@@ -15,6 +15,7 @@ import {
 } from "./db-helpers";
 import { getWorktreeCreatedAt, listExternalWorktrees } from "./git";
 import { resolveWorktreePath } from "./resolve-worktree-path";
+import { selectExternalWorktreesForImport } from "./select-external-worktrees-for-import";
 import { copySupersetConfigToWorktree, loadSetupConfig } from "./setup";
 
 interface CreateWorkspaceFromWorktreeParams {
@@ -347,10 +348,13 @@ export async function openExternalWorktree({
 			cause: { kind: "WORKTREE_MISSING", worktreePath },
 		});
 	}
-	if (liveWorktree.isBare || liveWorktree.isDetached || !liveWorktree.branch) {
+	const [importable] = selectExternalWorktreesForImport([liveWorktree], {
+		mainRepoPath: project.mainRepoPath,
+	});
+	if (!importable?.branch) {
 		throw new Error("Worktree is not importable");
 	}
-	const branch = liveWorktree.branch;
+	const branch = importable.branch;
 	const worktreeCreatedAt = getWorktreeCreatedAt(worktreePath);
 
 	let existingWorktree = localDb

--- a/packages/host-service/src/trpc/router/project/project.ts
+++ b/packages/host-service/src/trpc/router/project/project.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../tag-folders";
 import { emitLocalWorkspaceDeleted } from "../../../workspaces/local-workspace-store";
 import { machineOnlyProcedure, protectedProcedure, router } from "../../index";
+import { findProjectByRepoPath } from "../workspace-cleanup/is-main-workspace";
 import {
 	normalizeSparseCheckoutPaths,
 	parseSparseCheckoutPaths,
@@ -870,7 +871,9 @@ export const projectRouter = router({
 				.filter((ws) => ws.archivedAt == null || existsSync(ws.worktreePath));
 
 			for (const ws of localWorkspaces) {
-				if (ws.worktreePath === localProject.repoPath) continue;
+				// Skips this project's own checkout and any other project whose
+				// git root is one of these worktrees (see isMainWorkspace).
+				if (findProjectByRepoPath(ctx, ws.worktreePath)) continue;
 				try {
 					const git = await ctx.git(localProject.repoPath);
 					await git.raw(["worktree", "remove", ws.worktreePath]);

--- a/packages/host-service/src/trpc/router/workspace-cleanup/is-main-workspace.ts
+++ b/packages/host-service/src/trpc/router/workspace-cleanup/is-main-workspace.ts
@@ -15,6 +15,9 @@ export type IsMainWorkspaceResult = {
 export const MAIN_WORKSPACE_REASON =
 	"Main workspaces cannot be deleted. Remove them from the sidebar or remove the project from this host instead.";
 
+export const OTHER_PROJECT_CHECKOUT_REASON =
+	"This worktree is the main checkout of another project on this host. Remove that project instead.";
+
 /**
  * Authoritative "is this a main workspace?" check for the cleanup router.
  *
@@ -57,7 +60,33 @@ export async function isMainWorkspace(
 		return { isMain: true, reason: MAIN_WORKSPACE_REASON, local, project };
 	}
 
+	// A linked worktree can be imported as its own project (its git root is
+	// the worktree path). Destroying the workspace row that adopted it here
+	// would `worktree remove --force --force` that project's checkout.
+	if (local && findProjectByRepoPath(ctx, local.worktreePath)) {
+		return {
+			isMain: true,
+			reason: OTHER_PROJECT_CHECKOUT_REASON,
+			local,
+			project,
+		};
+	}
+
 	return { isMain: false, reason: null, local, project };
+}
+
+/** The project whose checkout lives at `path`, compared after realpath
+ * normalization like the main-workspace check above. */
+export function findProjectByRepoPath(
+	ctx: Pick<HostServiceContext, "db">,
+	path: string,
+): ProjectRow | undefined {
+	const target = normalizePath(path);
+	return ctx.db
+		.select()
+		.from(projects)
+		.all()
+		.find((row) => normalizePath(row.repoPath) === target);
 }
 
 function normalizePath(p: string): string {

--- a/packages/host-service/test/workspace-cleanup.test.ts
+++ b/packages/host-service/test/workspace-cleanup.test.ts
@@ -32,12 +32,16 @@ type WorkspaceRow = {
 	archivedAt?: number | null;
 };
 type ProjectRow = { id: string; repoPath: string; worktreeBaseDir?: string };
+type OtherProjectRow = { id: string; repoPath: string };
 
 type WorktreeState = { hasChanges: boolean; hasUnpushedCommits: boolean };
 
 interface ContextSpec {
 	workspace?: WorkspaceRow;
 	project?: ProjectRow;
+	// Every project row on the host (the other-project checkout guard
+	// scans them); defaults to just `project`.
+	allProjects?: OtherProjectRow[];
 	// git-ops behavior for this test; the ops are patched below so the
 	// saga's git work never spawns anything. Task-internal behaviors
 	// (rev-list swallow, `--force --force` semantics, registry verification)
@@ -140,6 +144,12 @@ function makeCtx(spec: ContextSpec): HostServiceContext & {
 					// getHostWorktreeBaseDir when a spec sets no per-project
 					// worktreeBaseDir ("no host settings row" shape).
 					where: () => ({ all: terminalSelectAll, get: () => undefined }),
+					// Unfiltered `.all` serves findProjectByRepoPath's scan.
+					all: () =>
+						spec.allProjects ??
+						(spec.project
+							? [{ id: spec.project.id, repoPath: spec.project.repoPath }]
+							: []),
 				}),
 			}),
 			update: () => ({
@@ -226,6 +236,30 @@ describe("isMainWorkspace", () => {
 		});
 		const result = await isMainWorkspace(ctx, "ws-1");
 		expect(result.isMain).toBe(true);
+	});
+
+	test("returns isMain: true when the worktree is another project's checkout", async () => {
+		const tmp = mkdtempSync(join(tmpdir(), "superset-other-project-"));
+		try {
+			const ctx = makeCtx({
+				workspace: {
+					id: "ws-1",
+					projectId: "p-1",
+					worktreePath: tmp,
+					branch: "feature",
+				},
+				project: { id: "p-1", repoPath: "/repo" },
+				allProjects: [
+					{ id: "p-1", repoPath: "/repo" },
+					{ id: "p-2", repoPath: tmp },
+				],
+			});
+			const result = await isMainWorkspace(ctx, "ws-1");
+			expect(result.isMain).toBe(true);
+			expect(result.reason).toContain("another project");
+		} finally {
+			rmSync(tmp, { recursive: true, force: true });
+		}
 	});
 
 	test("returns isMain: false when neither path equality nor local type fires", async () => {


### PR DESCRIPTION
Deleting a workspace could remove a directory that was not that workspace's own worktree. Three paths led there:

1. **`openExternalWorktree` accepted the main checkout.** It only checked that the path was listed by `git worktree list` and was neither bare nor detached — all true for the main repository. Importing it created a workspace row whose path is the main checkout, and deleting that workspace ran teardown in it. Now it applies the same filter the import list uses, which excludes the main worktree.

2. **`removeWorktree` trusted the stored path.** It renamed and `rm -rf`'d whatever the row pointed at, which could be the directory shared by every worktree of a project (a branch name that sanitizes to `""`) or a sibling worktree whose branch differs only in case on APFS. It now removes only a path git itself lists as a linked worktree of that repo, comparing after symlink resolution and without folding case; anything else is left on disk and only the metadata is pruned.

3. **A worktree imported as its own project.** Such a project's `repoPath` *is* a worktree path, and `workspaceCleanup.destroy` (plus the startup reconciler and `project.remove`'s sweep) only guarded the owning project's main checkout — so deleting the workspace that adopted it ran `git worktree remove --force` on another project's checkout. `isMainWorkspace` now also refuses when any project's `repoPath` resolves to that path.

Tests cover each refusal plus the normal remove path.

Part of an audit pass over the v2 stack on macOS.

https://claude.ai/code/session_01HmVz1yzkCEfnfDYDQxjN8u


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace deletion so it only ever removes the workspace's own linked worktree, not the main checkout, a shared parent directory, or another project's checkout.

**Bug Fixes**
- `openExternalWorktree` now rejects the main checkout, matching the import list filter.
- `removeWorktree` only deletes paths git lists as linked worktrees, comparing after symlink resolution without case folding; anything else is pruned from metadata but left on disk.
- `isMainWorkspace` and `project.remove` now refuse when any project's `repoPath` resolves to the worktree path.

<sup>Written for commit 6387c2908bc8eb594915cf04ce4ba055f96745ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree removal safeguards to prevent deleting main repositories or directories used by other projects.
  * Preserved unregistered and shared worktree directories while cleaning up stale Git metadata.
  * Improved validation when importing external worktrees.
  * Workspace cleanup now correctly recognizes repositories belonging to other projects and protects them from deletion.

* **Tests**
  * Added coverage for safe worktree removal, stale registrations, protected repositories, and cross-project workspace detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->