### PR TITLE
fix(integrations): refresh Sentry tokens with the jwt-bearer grant

### DIFF
--- a/packages/trpc/src/router/integration/sentry/utils.ts
+++ b/packages/trpc/src/router/integration/sentry/utils.ts
@@ -1,3 +1,4 @@
+import { createHmac, randomUUID } from "node:crypto";
 import type { SentryConfig } from "@superset/db/schema";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -136,18 +137,47 @@ export async function verifySentryInstall(
 }
 
 /**
+ * Sentry's `jwt-bearer` grant: a one-minute HS256 assertion signed with the
+ * app's client secret, which refreshes an installation's token without a
+ * refresh token. Sentry recommends it over `refresh_token` because that grant
+ * is single-use — a rotation Sentry commits but whose response never reaches
+ * us leaves the stored refresh token dead, and the connection with it.
+ */
+function clientSecretAssertion(clientId: string, clientSecret: string) {
+	const now = Math.floor(Date.now() / 1000);
+	const encode = (value: object) =>
+		Buffer.from(JSON.stringify(value)).toString("base64url");
+	const unsigned = `${encode({ alg: "HS256", typ: "JWT" })}.${encode({
+		iss: clientId,
+		sub: clientId,
+		iat: now,
+		exp: now + 60,
+		jti: randomUUID(),
+	})}`;
+	const signature = createHmac("sha256", clientSecret)
+		.update(unsigned)
+		.digest("base64url");
+	return `${unsigned}.${signature}`;
+}
+
+/**
  * A usable access token for a connection, refreshing it first when it is within
  * the buffer of expiry. Public-app tokens live ~8h, so anything cached longer
  * than a session needs this.
+ *
+ * A failed refresh throws rather than disconnecting: the assertion needs only
+ * the app's own credentials, so a rejection is a transient fault or a
+ * misconfiguration, not a lost grant. An uninstall arrives on the webhook as
+ * `installation.deleted`, which is what disconnects.
  */
 export async function getSentryAccessToken(
 	connectionId: string,
 ): Promise<RefreshedToken> {
 	return withRefreshedToken(connectionId, {
 		exchange: async (connection) => {
-			if (!connection.refreshToken || !env.SENTRY_CLIENT_ID) {
-				return { keep: true };
-			}
+			const clientId = env.SENTRY_CLIENT_ID;
+			const clientSecret = env.SENTRY_CLIENT_SECRET;
+			if (!clientId || !clientSecret) return { keep: true };
 
 			// The install uuid is the token endpoint's path segment; without it
 			// there is nothing to refresh against, so the current token is all
@@ -158,12 +188,12 @@ export async function getSentryAccessToken(
 
 			const response = await fetch(authorizationsUrl(installationUuid), {
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${clientSecretAssertion(clientId, clientSecret)}`,
+				},
 				body: JSON.stringify({
-					grant_type: "refresh_token",
-					refresh_token: connection.refreshToken,
-					client_id: env.SENTRY_CLIENT_ID,
-					client_secret: env.SENTRY_CLIENT_SECRET,
+					grant_type: "urn:sentry:params:oauth:grant-type:jwt-bearer",
 				}),
 			});
 			if (!response.ok) {
@@ -179,17 +209,6 @@ export async function getSentryAccessToken(
 				refreshToken: data.refreshToken,
 				tokenExpiresAt: new Date(data.expiresAt),
 			};
-		},
-		// A revoked or already-used refresh token comes back as 400 invalid_grant.
-		revokedWhen: (error) => {
-			if (!(error instanceof TokenRefreshError)) return null;
-			const invalidGrant =
-				(error.body as { error?: unknown } | null)?.error === "invalid_grant";
-			return error.status === 401 ||
-				error.status === 403 ||
-				(error.status === 400 && invalidGrant)
-				? "invalid_grant"
-				: null;
 		},
 	});
 }


### PR DESCRIPTION
## Why

The Sentry issue-triage automation went dark at 2026-09-11 03:39 UTC. The `integration_connections` row for the Superset org was marked disconnected with reason `invalid_grant`, and from then on the issue webhook answered "No connection" and recorded nothing — 8 new Sentry issues arrived with no `automation_events` row.

Sentry's `refresh_token` grant is single-use: the server looks the refresh token up by exact value and deletes it on every rotation (`sentry_apps/token_exchange/refresher.py`). A rotation Sentry commits but whose response never reaches us leaves our stored refresh token dead, and the next refresh answers 401. `getSentryAccessToken` treated any 401 as a revoked grant and disconnected the connection. Sentry's own docs now call the refresh-token method "not recommended" for exactly this reason.

## What

- `getSentryAccessToken` uses the `jwt-bearer` grant Sentry recommends: a one-minute HS256 assertion signed with the app's client secret (`iss`/`sub` = client id, `iat`, `exp` = iat + 60, fresh `jti`), sent as `Authorization: Bearer` to the same authorizations endpoint. No refresh token is involved, so there is no single-use state to lose.
- A failed refresh throws instead of disconnecting. The assertion needs only the app's own credentials, so a rejection is transient or a misconfiguration. An uninstall arrives as the `installation.deleted` webhook, which already disconnects. The trigger-options router catches the throw and returns an empty project list.
- No new dependency: the assertion is built with `node:crypto`.

No background refresh job is needed (unlike Linear): the client secret never rotates, so any request can refresh at any time.

## Verification

- `tsc --noEmit` and `biome check` clean on `packages/trpc`.
- `SKIP_ENV_VALIDATION=1 bun test` in `packages/trpc`: 276 pass, 0 fail (without the flag, 4 growth tests fail on env loading; unrelated).
- The generated assertion decodes with PyJWT using the exact call Sentry makes (`jwt.decode(token, secret, options={}, algorithms=["HS256"])`); a wrong secret is rejected with `InvalidSignatureError`.
- **Not exercised against the production installation:** the local `.env` credentials belong to the `superset-dev` app, not the app that owns the production install, so a live call from a dev machine returns 401 "Could not validate JWT" (the wrong-secret case). The first live exercise is the first automation-editor load after deploy.

## After merge

The production connection row is still flagged disconnected and the refresh path returns early on that flag. It needs either a reconnect from Settings → Integrations or clearing `disconnected_at` / `disconnect_reason` on that row.

https://claude.ai/code/session_0184Rtw1Xtaf9CPDcQqQFFBd


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Sentry token refresh to the `jwt-bearer` grant so refresh failures no longer disconnect the integration.

- Sentry's `refresh_token` grant is single-use; a rotation whose response never arrives leaves the stored token dead, and the next refresh returns 401, which previously disconnected the connection.
- The new grant uses a one-minute HS256 assertion signed with the client secret, so there is no single-use state to lose.
- A failed refresh now throws instead of disconnecting; an uninstall still arrives via the `installation.deleted` webhook.
- The production connection row is still flagged disconnected and needs a manual reconnect after deploy.

<sup>Written for commit ebf8b4c59d94d4d697dfeca56c4afba498ba6053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry integration token renewal by updating the authentication flow.
  * Reduced reliance on stored refresh credentials during token renewal.
  * Improved handling of authentication failures during the renewal process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->