### PR TITLE
feat(admin): net revenue retention tile from Stripe Sigma

### DIFF
--- a/apps/admin/src/app/(dashboard)/components/BurnByVendorTile/BurnByVendorTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/BurnByVendorTile/BurnByVendorTile.tsx
@@ -43,7 +43,7 @@ export function BurnByVendorTile() {
 					: undefined
 			}
 		>
-			<div className="space-y-2">
+			<div className="flex h-full flex-col justify-center gap-2">
 				{vendors.map((vendor) => (
 					<div key={vendor.name} className="flex items-center gap-2 text-xs">
 						<span className="w-40 shrink-0 truncate" title={vendor.name}>

--- a/apps/admin/src/app/(dashboard)/components/EnterpriseArrTile/EnterpriseArrTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/EnterpriseArrTile/EnterpriseArrTile.tsx
@@ -58,7 +58,7 @@ export function EnterpriseArrTile() {
 				message: "No active enterprise accounts",
 			})}
 		>
-			<div className="space-y-3">
+			<div className="flex h-full flex-col justify-center gap-3">
 				{accounts.map((account) => (
 					<div key={account.name} className="flex items-center gap-3">
 						{account.logo ? (

--- a/apps/admin/src/app/(dashboard)/components/MrrTile/MrrTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/MrrTile/MrrTile.tsx
@@ -15,27 +15,18 @@ import {
 	SelectValue,
 } from "@superset/ui/select";
 import { cn } from "@superset/ui/utils";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Area, AreaChart, XAxis, YAxis } from "recharts";
 
 import { useTRPC } from "@/trpc/react";
 
+import { useSigmaMetric } from "../../hooks/useSigmaMetric";
 import { makeDateAxis } from "../../utils/chartAxis";
 import { InsightTileFrame } from "../InsightTileFrame";
 import { type MrrDatum, MrrTooltip } from "./MrrTooltip";
 
 const RANGE_DAYS = { "7d": 7, "35d": 35, "180d": 180 } as const;
 type RangeKey = keyof typeof RANGE_DAYS;
-
-/** Matches the server's reason for "a Sigma run is in flight". */
-const COMPUTING_REASON = "computing";
-
-interface MrrSeries {
-	points: { date: string; mrrUsd: number }[];
-	dataLoadTime: string | null;
-	dataThrough: string | null;
-}
 
 // Matches the timestamp InsightTileFrame renders in the header, so the two
 // read as the same kind of fact.
@@ -78,40 +69,18 @@ export function MrrTile() {
 		},
 	} satisfies ChartConfig;
 	const [range, setRange] = useState<RangeKey>("7d");
-	const queryClient = useQueryClient();
-	const query = useQuery(
-		trpc.business.getMrr.queryOptions(undefined, {
-			refetchInterval: (q) =>
-				q.state.data && !q.state.data.available ? 10_000 : false,
-		}),
-	);
-	const refresh = useMutation(
-		trpc.business.refreshMrr.mutationOptions({
-			// Settled rather than success: the mutation reports the run it
-			// kicked, and the poll below is what lands it either way.
-			onSettled: () =>
-				queryClient.invalidateQueries({
-					queryKey: trpc.business.getMrr.queryKey(),
-				}),
-		}),
-	);
-
-	const unavailableReason =
-		query.data && !query.data.available ? query.data.reason : null;
-	const isComputing = unavailableReason === COMPUTING_REASON;
-	// Refreshing drops the cached figure, so the server answers "computing"
-	// for the ~minute Sigma takes. Hold the series already on screen through
-	// that rather than blanking the tile the moment someone asks to refresh
-	// it. Only across "computing" — a real failure should still surface.
-	const [lastSeries, setLastSeries] = useState<MrrSeries | null>(null);
-	if (query.data?.available && query.data.points !== lastSeries?.points) {
-		setLastSeries({
-			points: query.data.points,
-			dataLoadTime: query.data.dataLoadTime,
-			dataThrough: query.data.dataThrough,
-		});
-	}
-	const series = query.data?.available || isComputing ? lastSeries : null;
+	const {
+		data: series,
+		isLoading,
+		error,
+		unavailableReason,
+		isComputing,
+		refresh,
+		isRefreshing,
+	} = useSigmaMetric({
+		query: trpc.business.getMrr.queryOptions(),
+		refresh: trpc.business.refreshMrr.mutationOptions(),
+	});
 
 	// Server returns 180 daily points; range switches filter client-side.
 	const days = RANGE_DAYS[range];
@@ -143,10 +112,10 @@ export function MrrTile() {
 			})}
 			lastRefresh={series?.dataLoadTime ?? null}
 			fill
-			isLoading={query.isLoading}
-			onRefresh={() => refresh.mutate()}
-			isRefreshing={refresh.isPending || isComputing}
-			error={query.error}
+			isLoading={isLoading}
+			onRefresh={refresh}
+			isRefreshing={isRefreshing}
+			error={error}
 			empty={points.length === 0}
 			emptyLabel={
 				isComputing

--- a/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTile.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useLingui } from "@lingui/react/macro";
+import { useFormat } from "@superset/i18n/react";
+import {
+	type ChartConfig,
+	ChartContainer,
+	ChartTooltip,
+} from "@superset/ui/chart";
+import { cn } from "@superset/ui/utils";
+import { Line, LineChart, ReferenceLine, XAxis, YAxis } from "recharts";
+
+import { useTRPC } from "@/trpc/react";
+
+import { useSigmaMetric } from "../../hooks/useSigmaMetric";
+import { formatMonth, makeDateAxis } from "../../utils/chartAxis";
+import { InsightTileFrame } from "../InsightTileFrame";
+import { NrrTooltip } from "./NrrTooltip";
+
+// Matches the timestamp InsightTileFrame renders in the header, so the two
+// read as the same kind of fact.
+const TIMESTAMP_FORMAT: Intl.DateTimeFormatOptions = {
+	month: "short",
+	day: "numeric",
+	hour: "numeric",
+	minute: "2-digit",
+};
+
+export function NrrTile() {
+	const { formatDateTime, formatNumber } = useFormat();
+	const { t } = useLingui();
+	const trpc = useTRPC();
+	const chartConfig = {
+		nrrPct: {
+			label: t({ message: "NRR" }),
+			color: "var(--chart-1)",
+		},
+		nrrPctPartial: {
+			label: t({ message: "NRR (month so far)" }),
+			color: "var(--chart-1)",
+		},
+	} satisfies ChartConfig;
+	const {
+		data: series,
+		isLoading,
+		error,
+		unavailableReason,
+		isComputing,
+		refresh,
+		isRefreshing,
+	} = useSigmaMetric({
+		query: trpc.business.getNrr.queryOptions(),
+		refresh: trpc.business.refreshNrr.mutationOptions(),
+	});
+
+	// The last row is the current month: the cohort's MRR today against what
+	// it paid at the end of last month. Drawn dashed, like the partial week on
+	// the trend tiles, and kept out of the headline.
+	const currentMonth = new Date().toISOString().slice(0, 7);
+	const months = series?.months ?? [];
+	const lastIndex = months.length - 1;
+	const lastIsPartial = months[lastIndex]?.month.slice(0, 7) === currentMonth;
+	const points = months.map((m, i) => ({
+		...m,
+		partial: lastIsPartial && i === lastIndex,
+		nrrPctSolid: lastIsPartial && i === lastIndex ? null : m.nrrPct,
+		nrrPctPartial: lastIsPartial && i >= lastIndex - 1 ? m.nrrPct : null,
+	}));
+	const xAxis = makeDateAxis(points.map((point) => point.month));
+	const latest = [...points].reverse().find((point) => !point.partial);
+
+	return (
+		<InsightTileFrame
+			title={t({ message: "Net revenue retention — monthly (Stripe)" })}
+			description={t({
+				message:
+					"MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded",
+			})}
+			lastRefresh={series?.dataLoadTime ?? null}
+			fill
+			isLoading={isLoading}
+			onRefresh={refresh}
+			isRefreshing={isRefreshing}
+			error={error}
+			empty={points.length === 0}
+			emptyLabel={
+				isComputing
+					? t({
+							message: "Computing in Stripe — up to a minute on first load",
+						})
+					: unavailableReason
+						? t({
+								message: `Unavailable: ${unavailableReason}`,
+							})
+						: undefined
+			}
+		>
+			<div className="flex h-full flex-col gap-4">
+				{latest ? (
+					<div className="shrink-0">
+						<div className="flex items-baseline gap-2">
+							<span
+								className={cn(
+									"text-3xl font-bold",
+									latest.nrrPct >= 100 ? "text-green-500" : undefined,
+								)}
+							>
+								{latest.nrrPct.toFixed(1)}%
+							</span>
+							<span className="text-muted-foreground text-sm">
+								{formatMonth(latest.month)}
+							</span>
+						</div>
+						<p className="text-muted-foreground text-sm">
+							{t({
+								message: `$${formatNumber(latest.startMrrUsd, undefined)} from ${latest.customers} customers became $${formatNumber(latest.retainedMrrUsd, undefined)}`,
+							})}
+						</p>
+						{series?.dataThrough ? (
+							<p className="text-muted-foreground text-xs">
+								{t({
+									message: `Stripe data through ${formatDateTime(new Date(series.dataThrough), TIMESTAMP_FORMAT)}`,
+								})}
+							</p>
+						) : null}
+					</div>
+				) : null}
+				<ChartContainer
+					config={chartConfig}
+					className="aspect-auto w-full flex-1 min-h-[160px]"
+				>
+					<LineChart data={points}>
+						<XAxis
+							dataKey="month"
+							tickLine={false}
+							axisLine={false}
+							fontSize={11}
+							ticks={xAxis.ticks}
+							tickFormatter={xAxis.tickFormatter}
+						/>
+						<YAxis
+							tickLine={false}
+							axisLine={false}
+							width={44}
+							domain={["auto", "auto"]}
+							tickFormatter={(v: number) => `${v}%`}
+						/>
+						<ReferenceLine
+							y={100}
+							stroke="var(--muted-foreground)"
+							strokeDasharray="3 3"
+						/>
+						<ChartTooltip content={<NrrTooltip />} />
+						<Line
+							dataKey="nrrPctSolid"
+							stroke="var(--color-nrrPct)"
+							strokeWidth={2}
+							dot={false}
+							type="monotone"
+						/>
+						<Line
+							dataKey="nrrPctPartial"
+							stroke="var(--color-nrrPctPartial)"
+							strokeWidth={2}
+							strokeDasharray="5 5"
+							dot={false}
+							type="monotone"
+							tooltipType="none"
+						/>
+					</LineChart>
+				</ChartContainer>
+			</div>
+		</InsightTileFrame>
+	);
+}

--- a/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTile.tsx
@@ -17,8 +17,6 @@ import { formatMonth, makeDateAxis } from "../../utils/chartAxis";
 import { InsightTileFrame } from "../InsightTileFrame";
 import { NrrTooltip } from "./NrrTooltip";
 
-// Matches the timestamp InsightTileFrame renders in the header, so the two
-// read as the same kind of fact.
 const TIMESTAMP_FORMAT: Intl.DateTimeFormatOptions = {
 	month: "short",
 	day: "numeric",
@@ -53,9 +51,6 @@ export function NrrTile() {
 		refresh: trpc.business.refreshNrr.mutationOptions(),
 	});
 
-	// The last row is the current month: the cohort's MRR today against what
-	// it paid at the end of last month. Drawn dashed, like the partial week on
-	// the trend tiles, and kept out of the headline.
 	const currentMonth = new Date().toISOString().slice(0, 7);
 	const months = series?.months ?? [];
 	const lastIndex = months.length - 1;

--- a/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTile.tsx
+++ b/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTile.tsx
@@ -30,11 +30,11 @@ export function NrrTile() {
 	const trpc = useTRPC();
 	const chartConfig = {
 		nrrPct: {
-			label: t({ message: "NRR" }),
+			label: t({ message: "monthly NRR" }),
 			color: "var(--chart-1)",
 		},
 		nrrPctPartial: {
-			label: t({ message: "NRR (month so far)" }),
+			label: t({ message: "monthly NRR (month so far)" }),
 			color: "var(--chart-1)",
 		},
 	} satisfies ChartConfig;
@@ -137,13 +137,20 @@ export function NrrTile() {
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							domain={["auto", "auto"]}
+							domain={[0, "auto"]}
 							tickFormatter={(v: number) => `${v}%`}
 						/>
 						<ReferenceLine
 							y={100}
 							stroke="var(--muted-foreground)"
 							strokeDasharray="3 3"
+							label={{
+								value: t({ message: "100% (retain everything)" }),
+								position: "insideBottomRight",
+								offset: 8,
+								fill: "var(--muted-foreground)",
+								fontSize: 11,
+							}}
 						/>
 						<ChartTooltip content={<NrrTooltip />} />
 						<Line

--- a/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTooltip.tsx
+++ b/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTooltip.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { useFormat } from "@superset/i18n/react";
+
+import { formatMonth } from "../../utils/chartAxis";
+
+export interface NrrDatum {
+	month: string;
+	customers: number;
+	startMrrUsd: number;
+	retainedMrrUsd: number;
+	expansionUsd: number;
+	contractionUsd: number;
+	churnUsd: number;
+	nrrPct: number;
+	partial: boolean;
+}
+
+interface NrrTooltipProps {
+	active?: boolean;
+	payload?: { payload: NrrDatum }[];
+}
+
+export function NrrTooltip({ active, payload }: NrrTooltipProps) {
+	const { formatNumber } = useFormat();
+
+	const datum = payload?.[0]?.payload;
+	if (!active || !datum) return null;
+
+	const usd = (value: number) =>
+		`${value < 0 ? "-" : ""}$${formatNumber(Math.abs(value), undefined)}`;
+
+	return (
+		<div className="border-border/50 bg-background min-w-[13rem] rounded-lg border px-3 py-2 text-xs shadow-xl">
+			<div className="flex items-center justify-between gap-4 pb-1">
+				<span className="font-medium">
+					{formatMonth(datum.month)}
+					{datum.partial ? (
+						<span className="text-muted-foreground">
+							{" "}
+							<Trans>(so far)</Trans>
+						</span>
+					) : null}
+				</span>
+				<span className="font-medium tabular-nums">
+					{datum.nrrPct.toFixed(1)}%
+				</span>
+			</div>
+			<div className="flex items-center justify-between gap-4">
+				<span>
+					<Trans>Start MRR ({datum.customers} customers)</Trans>
+				</span>
+				<span className="tabular-nums">{usd(datum.startMrrUsd)}</span>
+			</div>
+			<div className="text-muted-foreground flex items-center justify-between gap-4">
+				<span>
+					<Trans>Expansion</Trans>
+				</span>
+				<span className="tabular-nums">{usd(datum.expansionUsd)}</span>
+			</div>
+			<div className="text-muted-foreground flex items-center justify-between gap-4">
+				<span>
+					<Trans>Contraction</Trans>
+				</span>
+				<span className="tabular-nums">{usd(datum.contractionUsd)}</span>
+			</div>
+			<div className="text-muted-foreground flex items-center justify-between gap-4">
+				<span>
+					<Trans>Churn</Trans>
+				</span>
+				<span className="tabular-nums">{usd(datum.churnUsd)}</span>
+			</div>
+			<div className="flex items-center justify-between gap-4">
+				<span>
+					<Trans>Retained MRR</Trans>
+				</span>
+				<span className="font-medium tabular-nums">
+					{usd(datum.retainedMrrUsd)}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTooltip.tsx
+++ b/apps/admin/src/app/(dashboard)/components/NrrTile/NrrTooltip.tsx
@@ -3,8 +3,6 @@
 import { Trans } from "@lingui/react/macro";
 import { useFormat } from "@superset/i18n/react";
 
-import { formatMonth } from "../../utils/chartAxis";
-
 export interface NrrDatum {
 	month: string;
 	customers: number;
@@ -23,7 +21,7 @@ interface NrrTooltipProps {
 }
 
 export function NrrTooltip({ active, payload }: NrrTooltipProps) {
-	const { formatNumber } = useFormat();
+	const { formatDate, formatNumber } = useFormat();
 
 	const datum = payload?.[0]?.payload;
 	if (!active || !datum) return null;
@@ -33,17 +31,26 @@ export function NrrTooltip({ active, payload }: NrrTooltipProps) {
 
 	return (
 		<div className="border-border/50 bg-background min-w-[13rem] rounded-lg border px-3 py-2 text-xs shadow-xl">
+			<div className="text-muted-foreground pb-1">
+				{formatDate(new Date(`${datum.month}T00:00:00Z`), {
+					month: "short",
+					day: "numeric",
+					year: "numeric",
+					timeZone: "UTC",
+				})}
+				{datum.partial ? (
+					<>
+						{" "}
+						<Trans>(so far)</Trans>
+					</>
+				) : null}
+			</div>
 			<div className="flex items-center justify-between gap-4 pb-1">
-				<span className="font-medium">
-					{formatMonth(datum.month)}
-					{datum.partial ? (
-						<span className="text-muted-foreground">
-							{" "}
-							<Trans>(so far)</Trans>
-						</span>
-					) : null}
+				<span className="flex items-center gap-1.5">
+					<span className="size-2 rounded-full bg-[var(--chart-1)]" />
+					<Trans>monthly NRR</Trans>
 				</span>
-				<span className="font-medium tabular-nums">
+				<span className="font-semibold tabular-nums">
 					{datum.nrrPct.toFixed(1)}%
 				</span>
 			</div>

--- a/apps/admin/src/app/(dashboard)/components/NrrTile/index.ts
+++ b/apps/admin/src/app/(dashboard)/components/NrrTile/index.ts
@@ -1,0 +1,1 @@
+export { NrrTile } from "./NrrTile";

--- a/apps/admin/src/app/(dashboard)/hooks/useSigmaMetric/index.ts
+++ b/apps/admin/src/app/(dashboard)/hooks/useSigmaMetric/index.ts
@@ -1,0 +1,1 @@
+export { useSigmaMetric } from "./useSigmaMetric";

--- a/apps/admin/src/app/(dashboard)/hooks/useSigmaMetric/useSigmaMetric.ts
+++ b/apps/admin/src/app/(dashboard)/hooks/useSigmaMetric/useSigmaMetric.ts
@@ -18,10 +18,8 @@ type SigmaResult =
 	| { available: true; dataLoadTime: string | null; dataThrough: string | null }
 	| { available: false; reason: string };
 
-// A Stripe Sigma metric: the server answers "computing" for the ~minute a run
-// takes, so poll it down, and hold the figure already on screen through a
-// refresh rather than blanking the tile the moment someone asks for a newer
-// one. Only across "computing" — a real failure should still surface.
+// Holds the last landed result only across "computing": a refresh should not
+// blank the tile, but a real failure should still surface.
 export function useSigmaMetric<
 	R extends SigmaResult,
 	E extends { message: string },
@@ -45,8 +43,6 @@ export function useSigmaMetric<
 	});
 	const mutation = useMutation({
 		...refresh,
-		// Settled rather than success: the mutation reports the run it kicked,
-		// and the poll above is what lands it either way.
 		onSettled: () =>
 			queryClient.invalidateQueries({ queryKey: query.queryKey }),
 	});

--- a/apps/admin/src/app/(dashboard)/hooks/useSigmaMetric/useSigmaMetric.ts
+++ b/apps/admin/src/app/(dashboard)/hooks/useSigmaMetric/useSigmaMetric.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+	type QueryKey,
+	type UseMutationOptions,
+	type UseQueryOptions,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useState } from "react";
+
+/** Matches the server's reason for "a Sigma run is in flight". */
+const COMPUTING_REASON = "computing";
+const COMPUTING_POLL_MS = 10 * 1000;
+
+type SigmaResult =
+	| { available: true; dataLoadTime: string | null; dataThrough: string | null }
+	| { available: false; reason: string };
+
+// A Stripe Sigma metric: the server answers "computing" for the ~minute a run
+// takes, so poll it down, and hold the figure already on screen through a
+// refresh rather than blanking the tile the moment someone asks for a newer
+// one. Only across "computing" — a real failure should still surface.
+export function useSigmaMetric<
+	R extends SigmaResult,
+	E extends { message: string },
+	K extends QueryKey,
+>({
+	query,
+	refresh,
+}: {
+	query: UseQueryOptions<R, E, R, K>;
+	refresh: UseMutationOptions<R, E, void>;
+}) {
+	const queryClient = useQueryClient();
+	const result = useQuery({
+		...query,
+		refetchInterval: (q) =>
+			q.state.data && !q.state.data.available
+				? q.state.data.reason === COMPUTING_REASON
+					? COMPUTING_POLL_MS
+					: false
+				: false,
+	});
+	const mutation = useMutation({
+		...refresh,
+		// Settled rather than success: the mutation reports the run it kicked,
+		// and the poll above is what lands it either way.
+		onSettled: () =>
+			queryClient.invalidateQueries({ queryKey: query.queryKey }),
+	});
+
+	const unavailableReason =
+		result.data && !result.data.available ? result.data.reason : null;
+	const isComputing = unavailableReason === COMPUTING_REASON;
+
+	type Landed = Extract<R, { available: true }>;
+	const [last, setLast] = useState<Landed | null>(null);
+	if (result.data?.available && result.data !== last) {
+		setLast(result.data as Landed);
+	}
+
+	return {
+		data: result.data?.available || isComputing ? last : null,
+		isLoading: result.isLoading,
+		error: result.error,
+		unavailableReason,
+		isComputing,
+		refresh: () => mutation.mutate(),
+		isRefreshing: mutation.isPending || isComputing,
+	};
+}

--- a/apps/admin/src/app/(dashboard)/page.tsx
+++ b/apps/admin/src/app/(dashboard)/page.tsx
@@ -37,7 +37,6 @@ import { TileLayoutProvider } from "./providers/TileLayoutProvider";
 // tall one leaves a hole under it.
 const CHART_H = 4;
 const TALL_CHART_H = 6;
-const LIST_H = 3;
 const TABLE_H = 6;
 const FUNNEL_H = 4;
 const STAR_H = 6;
@@ -140,7 +139,6 @@ export default function DashboardPage() {
 							}
 							tiles={[
 								{ key: "mrr", node: <MrrTile />, w: FULL_W, h: CHART_H },
-								{ key: "nrr", node: <NrrTile />, w: FULL_W, h: TALL_CHART_H },
 								{
 									key: "dau",
 									node: <TrendSeriesTile {...DAU_PROPS} />,
@@ -162,20 +160,26 @@ export default function DashboardPage() {
 								{
 									key: "net-burn",
 									node: <NetBurnTile />,
-									w: FULL_W,
+									w: HALF_W,
 									h: CHART_H,
 								},
 								{
 									key: "burn-by-vendor",
 									node: <BurnByVendorTile />,
 									w: HALF_W,
-									h: LIST_H,
+									h: CHART_H,
 								},
 								{
 									key: "enterprise-arr",
 									node: <EnterpriseArrTile />,
 									w: HALF_W,
-									h: LIST_H,
+									h: TALL_CHART_H,
+								},
+								{
+									key: "nrr",
+									node: <NrrTile />,
+									w: HALF_W,
+									h: TALL_CHART_H,
 								},
 								{
 									key: "star-history",

--- a/apps/admin/src/app/(dashboard)/page.tsx
+++ b/apps/admin/src/app/(dashboard)/page.tsx
@@ -36,6 +36,7 @@ import { TileLayoutProvider } from "./providers/TileLayoutProvider";
 // height — a row is as tall as its tallest tile, so a short tile beside a
 // tall one leaves a hole under it.
 const CHART_H = 4;
+const TALL_CHART_H = 6;
 const LIST_H = 3;
 const TABLE_H = 6;
 const FUNNEL_H = 4;
@@ -139,7 +140,7 @@ export default function DashboardPage() {
 							}
 							tiles={[
 								{ key: "mrr", node: <MrrTile />, w: FULL_W, h: CHART_H },
-								{ key: "nrr", node: <NrrTile />, w: FULL_W, h: CHART_H },
+								{ key: "nrr", node: <NrrTile />, w: FULL_W, h: TALL_CHART_H },
 								{
 									key: "dau",
 									node: <TrendSeriesTile {...DAU_PROPS} />,

--- a/apps/admin/src/app/(dashboard)/page.tsx
+++ b/apps/admin/src/app/(dashboard)/page.tsx
@@ -10,6 +10,7 @@ import { EnterpriseArrTile } from "./components/EnterpriseArrTile";
 import { HogQLLineTile } from "./components/HogQLLineTile";
 import { MrrTile } from "./components/MrrTile";
 import { NetBurnTile } from "./components/NetBurnTile";
+import { NrrTile } from "./components/NrrTile";
 import { OrgAdoptionTile } from "./components/OrgAdoptionTile";
 import { PostHogFunnelTile } from "./components/PostHogFunnelTile";
 import { ResetLayoutButton } from "./components/ResetLayoutButton";
@@ -138,6 +139,7 @@ export default function DashboardPage() {
 							}
 							tiles={[
 								{ key: "mrr", node: <MrrTile />, w: FULL_W, h: CHART_H },
+								{ key: "nrr", node: <NrrTile />, w: FULL_W, h: CHART_H },
 								{
 									key: "dau",
 									node: <TrendSeriesTile {...DAU_PROPS} />,

--- a/apps/api/src/app/api/analytics/jobs/refresh-mrr/route.ts
+++ b/apps/api/src/app/api/analytics/jobs/refresh-mrr/route.ts
@@ -1,4 +1,7 @@
-import { refreshSigmaMrr } from "@superset/trpc/business-metrics";
+import {
+	refreshSigmaMrr,
+	refreshSigmaNrr,
+} from "@superset/trpc/business-metrics";
 
 import { verifyQstashRequest } from "@/lib/verifyQstash";
 
@@ -6,13 +9,13 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
 /**
- * Keeps the admin dashboard's MRR tile warm.
+ * Keeps the admin dashboard's Stripe Sigma tiles (MRR, NRR) warm.
  *
- * The Sigma query takes ~30-60s, so whoever triggers it first eats the wait.
+ * A Sigma query takes ~20-60s, so whoever triggers it first eats the wait.
  * Left to dashboard traffic that was always a person looking at the tile —
  * admin gets a few dozen loads a day, so the cache had usually expired by the
- * time anyone looked. Running hourly against a 12h entry means the tile only
- * ever reads a landed result.
+ * time anyone looked. Running hourly against a 12h entry means the tiles only
+ * ever read a landed result.
  */
 export async function POST(request: Request): Promise<Response> {
 	const body = await request.text();
@@ -23,11 +26,20 @@ export async function POST(request: Request): Promise<Response> {
 	);
 	if (rejected) return rejected;
 
-	const result = await refreshSigmaMrr();
-	if (!result.available) {
-		console.error("[refresh-mrr] refresh did not land:", result.reason);
-		return Response.json({ refreshed: false, reason: result.reason });
+	const [mrr, nrr] = await Promise.all([refreshSigmaMrr(), refreshSigmaNrr()]);
+	if (!mrr.available) {
+		console.error("[refresh-mrr] MRR refresh did not land:", mrr.reason);
+	}
+	if (!nrr.available) {
+		console.error("[refresh-mrr] NRR refresh did not land:", nrr.reason);
 	}
 
-	return Response.json({ refreshed: true, points: result.points.length });
+	return Response.json({
+		mrr: mrr.available
+			? { refreshed: true, points: mrr.points.length }
+			: { refreshed: false, reason: mrr.reason },
+		nrr: nrr.available
+			? { refreshed: true, months: nrr.months.length }
+			: { refreshed: false, reason: nrr.reason },
+	});
 }

--- a/apps/api/src/app/api/analytics/jobs/refresh-mrr/route.ts
+++ b/apps/api/src/app/api/analytics/jobs/refresh-mrr/route.ts
@@ -26,7 +26,12 @@ export async function POST(request: Request): Promise<Response> {
 	);
 	if (rejected) return rejected;
 
-	const [mrr, nrr] = await Promise.all([refreshSigmaMrr(), refreshSigmaNrr()]);
+	const [mrrRun, nrrRun] = await Promise.allSettled([
+		refreshSigmaMrr(),
+		refreshSigmaNrr(),
+	]);
+	const mrr = settled(mrrRun);
+	const nrr = settled(nrrRun);
 	if (!mrr.available) {
 		console.error("[refresh-mrr] MRR refresh did not land:", mrr.reason);
 	}
@@ -42,4 +47,17 @@ export async function POST(request: Request): Promise<Response> {
 			? { refreshed: true, months: nrr.months.length }
 			: { refreshed: false, reason: nrr.reason },
 	});
+}
+
+function settled<T>(
+	result: PromiseSettledResult<T>,
+): T | { available: false; reason: string } {
+	if (result.status === "fulfilled") return result.value;
+	return {
+		available: false,
+		reason:
+			result.reason instanceof Error
+				? result.reason.message
+				: String(result.reason),
+	};
 }

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -93,6 +93,9 @@ msgstr "(externí)"
 msgid "(no output)"
 msgstr "(žádný výstup)"
 
+msgid "(so far)"
+msgstr "(zatím)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# aktivní port — skrýt podrobnosti} few {# aktivní porty — skrýt podrobnosti} many {# aktivního portu — skrýt podrobnosti} other {# aktivních portů — skrýt podrobnosti}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ před 2 h"
 
 msgid "✓ 3d ago"
 msgstr "✓ před 3 d"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR {1} zákazníků se změnilo z ${0} na ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Zvolte, kdy vás Superset upozorní."
 msgid "Choose which agent watches this page for comments"
 msgstr "Vyberte, který agent sleduje komentáře na této stránce"
 
+msgid "Churn"
+msgstr "Odchody"
+
 msgid "CI failed"
 msgstr "CI selhalo"
 
@@ -3823,6 +3835,9 @@ msgstr "Pokračování v relaci agenta vyžaduje připnutý pracovní prostor"
 
 msgid "continuing the last session"
 msgstr "pokračováním v poslední relaci"
+
+msgid "Contraction"
+msgstr "Pokles"
 
 msgid "Contributions"
 msgstr "Příspěvky"
@@ -5740,6 +5755,9 @@ msgstr "Rozbalit vlákno"
 
 msgid "Expand workspace"
 msgstr "Rozbalit pracovní prostor"
+
+msgid "Expansion"
+msgstr "Růst"
 
 msgid "Experimental"
 msgstr "Experimentální"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — denně (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR zákazníků platících na konci předchozího měsíce jako podíl toho, co tehdy platili: růst a pokles po odečtení odchodů, bez nových zákazníků"
+
 msgid "Multi-select"
 msgstr "Výběr více možností"
 
@@ -8825,6 +8846,9 @@ msgstr "čistý burn"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Čistý burn — měsíčně (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Čisté udržení tržeb — měsíčně (Stripe)"
 
 msgid "Network Changed"
 msgstr "Síť se změnila"
@@ -9688,6 +9712,12 @@ msgstr "Teď běží {0} (dříve {1}). Všechny relace byly zavřeny."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Teď jsme získali <0>11 milionů dolarů</0> od nejlepších investorů v Silicon Valley, abychom postavili platformu pro softwarové továrny."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (zatím tento měsíc)"
 
 msgid "Numbered list"
 msgstr "Číslovaný seznam"
@@ -12023,6 +12053,9 @@ msgstr "Pokračovat v automatizaci"
 msgid "Resuming {0}…"
 msgstr "Obnovuji {0}…"
 
+msgid "Retained MRR"
+msgstr "Udržené MRR"
+
 msgid "Retention and revenue"
 msgstr "Udržení a tržby"
 
@@ -13647,6 +13680,10 @@ msgstr "Začněte zdarma. Až vám to jako týmu přestane stačit, přejděte v
 
 msgid "Start from a template"
 msgstr "Začít ze šablony"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Počáteční MRR ({0} zákazníků)"
 
 msgid "Start new session"
 msgstr "Spustit novou relaci"

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minut"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ souběžných proudů práce bez ztráty přehledu"
 
+msgid "100% (retain everything)"
+msgstr "100 % (udržet vše)"
+
 msgid "15 minutes"
 msgstr "15 minut"
 
@@ -8683,6 +8686,12 @@ msgstr "Měsíčně"
 msgid "Monthly at {time}"
 msgstr "Měsíčně v {time}"
 
+msgid "monthly NRR"
+msgstr "měsíční NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "měsíční NRR (zatím tento měsíc)"
+
 msgid "Monthly on {day}"
 msgstr "Měsíčně {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Teď běží {0} (dříve {1}). Všechny relace byly zavřeny."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Teď jsme získali <0>11 milionů dolarů</0> od nejlepších investorů v Silicon Valley, abychom postavili platformu pro softwarové továrny."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (zatím tento měsíc)"
 
 msgid "Numbered list"
 msgstr "Číslovaný seznam"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -93,6 +93,9 @@ msgstr "(extern)"
 msgid "(no output)"
 msgstr "(keine Ausgabe)"
 
+msgid "(so far)"
+msgstr "(bisher)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# aktiver Port — Details ausblenden} other {# aktive Ports — Details ausblenden}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ vor 2 Std."
 
 msgid "✓ 3d ago"
 msgstr "✓ vor 3 Tagen"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR von {1} Kunden: ${0} → ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Wähle, wann Superset dich anstupst."
 msgid "Choose which agent watches this page for comments"
 msgstr "Wähle, welcher Agent diese Seite auf Kommentare beobachtet"
 
+msgid "Churn"
+msgstr "Abwanderung"
+
 msgid "CI failed"
 msgstr "CI fehlgeschlagen"
 
@@ -3823,6 +3835,9 @@ msgstr "Das Fortsetzen einer Agent-Sitzung erfordert einen angehefteten Workspac
 
 msgid "continuing the last session"
 msgstr "Fortsetzung der letzten Sitzung"
+
+msgid "Contraction"
+msgstr "Kontraktion"
 
 msgid "Contributions"
 msgstr "Beiträge"
@@ -5740,6 +5755,9 @@ msgstr "Thread ausklappen"
 
 msgid "Expand workspace"
 msgstr "Arbeitsbereich ausklappen"
+
+msgid "Expansion"
+msgstr "Expansion"
 
 msgid "Experimental"
 msgstr "Experimentell"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — täglich (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR der Kunden, die Ende des Vormonats zahlten, als Anteil dessen, was sie damals zahlten: Expansion und Kontraktion abzüglich Abwanderung, ohne Neukunden"
+
 msgid "Multi-select"
 msgstr "Mehrfachauswahl"
 
@@ -8825,6 +8846,9 @@ msgstr "Net Burn"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Net Burn — monatlich (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Net Revenue Retention — monatlich (Stripe)"
 
 msgid "Network Changed"
 msgstr "Netzwerk gewechselt"
@@ -9688,6 +9712,12 @@ msgstr "Es läuft jetzt {0} (vorher {1}). Alle Sitzungen wurden geschlossen."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Jetzt haben wir <0>11 Mio. $</0> von den besten Investoren im Silicon Valley eingesammelt, um die Plattform für Softwarefabriken zu bauen."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (laufender Monat bisher)"
 
 msgid "Numbered list"
 msgstr "Nummerierte Liste"
@@ -12023,6 +12053,9 @@ msgstr "Automatisierung fortsetzen"
 msgid "Resuming {0}…"
 msgstr "{0} wird fortgesetzt…"
 
+msgid "Retained MRR"
+msgstr "Verbleibender MRR"
+
 msgid "Retention and revenue"
 msgstr "Bindung und Umsatz"
 
@@ -13647,6 +13680,10 @@ msgstr "Starte kostenlos. Upgrade, wenn dein Team herauswächst. Enterprise-Tari
 
 msgid "Start from a template"
 msgstr "Mit einer Vorlage starten"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Start-MRR ({0} Kunden)"
 
 msgid "Start new session"
 msgstr "Neue Sitzung starten"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 Minuten"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ parallele Arbeitsstränge ohne Kontrollverlust"
 
+msgid "100% (retain everything)"
+msgstr "100 % (alles behalten)"
+
 msgid "15 minutes"
 msgstr "15 Minuten"
 
@@ -8683,6 +8686,12 @@ msgstr "Monatlich"
 msgid "Monthly at {time}"
 msgstr "Monatlich um {time}"
 
+msgid "monthly NRR"
+msgstr "monatliche NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "monatliche NRR (laufender Monat bisher)"
+
 msgid "Monthly on {day}"
 msgstr "Monatlich am {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Es läuft jetzt {0} (vorher {1}). Alle Sitzungen wurden geschlossen."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Jetzt haben wir <0>11 Mio. $</0> von den besten Investoren im Silicon Valley eingesammelt, um die Plattform für Softwarefabriken zu bauen."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (laufender Monat bisher)"
 
 msgid "Numbered list"
 msgstr "Nummerierte Liste"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minutes"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ concurrent workstreams without dropped state"
 
+msgid "100% (retain everything)"
+msgstr "100% (retain everything)"
+
 msgid "15 minutes"
 msgstr "15 minutes"
 
@@ -8683,6 +8686,12 @@ msgstr "Monthly"
 msgid "Monthly at {time}"
 msgstr "Monthly at {time}"
 
+msgid "monthly NRR"
+msgstr "monthly NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "monthly NRR (month so far)"
+
 msgid "Monthly on {day}"
 msgstr "Monthly on {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Now running {0} (was {1}). All sessions were closed."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (month so far)"
 
 msgid "Numbered list"
 msgstr "Numbered list"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -93,6 +93,9 @@ msgstr "(external)"
 msgid "(no output)"
 msgstr "(no output)"
 
+msgid "(so far)"
+msgstr "(so far)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2h ago"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3d ago"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "${0} from {1} customers became ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Choose when Superset pings you."
 msgid "Choose which agent watches this page for comments"
 msgstr "Choose which agent watches this page for comments"
 
+msgid "Churn"
+msgstr "Churn"
+
 msgid "CI failed"
 msgstr "CI failed"
 
@@ -3823,6 +3835,9 @@ msgstr "Continuing an agent session requires a pinned workspace"
 
 msgid "continuing the last session"
 msgstr "continuing the last session"
+
+msgid "Contraction"
+msgstr "Contraction"
 
 msgid "Contributions"
 msgstr "Contributions"
@@ -5740,6 +5755,9 @@ msgstr "Expand thread"
 
 msgid "Expand workspace"
 msgstr "Expand workspace"
+
+msgid "Expansion"
+msgstr "Expansion"
 
 msgid "Experimental"
 msgstr "Experimental"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — daily (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+
 msgid "Multi-select"
 msgstr "Multi-select"
 
@@ -8825,6 +8846,9 @@ msgstr "net burn"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Net burn — monthly (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Net revenue retention — monthly (Stripe)"
 
 msgid "Network Changed"
 msgstr "Network Changed"
@@ -9688,6 +9712,12 @@ msgstr "Now running {0} (was {1}). All sessions were closed."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (month so far)"
 
 msgid "Numbered list"
 msgstr "Numbered list"
@@ -12023,6 +12053,9 @@ msgstr "Resume automation"
 msgid "Resuming {0}…"
 msgstr "Resuming {0}…"
 
+msgid "Retained MRR"
+msgstr "Retained MRR"
+
 msgid "Retention and revenue"
 msgstr "Retention and revenue"
 
@@ -13647,6 +13680,10 @@ msgstr "Start free. Upgrade when your team outgrows it. Enterprise plans for org
 
 msgid "Start from a template"
 msgstr "Start from a template"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Start MRR ({0} customers)"
 
 msgid "Start new session"
 msgstr "Start new session"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -93,6 +93,9 @@ msgstr "(externo)"
 msgid "(no output)"
 msgstr "(sin salida)"
 
+msgid "(so far)"
+msgstr "(hasta ahora)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# puerto activo: ocultar detalles} other {# puertos activos: ocultar detalles}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ hace 2 h"
 
 msgid "✓ 3d ago"
 msgstr "✓ hace 3 d"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "El MRR de {1} clientes pasó de ${0} a ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Elige cuándo te avisa Superset."
 msgid "Choose which agent watches this page for comments"
 msgstr "Elige qué agente observa los comentarios de esta página"
 
+msgid "Churn"
+msgstr "Abandono"
+
 msgid "CI failed"
 msgstr "CI falló"
 
@@ -3823,6 +3835,9 @@ msgstr "Continuar una sesión de agente requiere un espacio de trabajo fijado"
 
 msgid "continuing the last session"
 msgstr "continuando la última sesión"
+
+msgid "Contraction"
+msgstr "Contracción"
 
 msgid "Contributions"
 msgstr "Contribuciones"
@@ -5740,6 +5755,9 @@ msgstr "Expandir el hilo"
 
 msgid "Expand workspace"
 msgstr "Expandir el espacio de trabajo"
+
+msgid "Expansion"
+msgstr "Expansión"
 
 msgid "Experimental"
 msgstr "Experimental"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — diario (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR de los clientes que pagaban al final del mes anterior, como proporción de lo que pagaban entonces: expansión y contracción, descontando el abandono, sin clientes nuevos"
+
 msgid "Multi-select"
 msgstr "Selección múltiple"
 
@@ -8825,6 +8846,9 @@ msgstr "gasto neto"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Gasto neto — mensual (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Retención neta de ingresos — mensual (Stripe)"
 
 msgid "Network Changed"
 msgstr "La red cambió"
@@ -9688,6 +9712,12 @@ msgstr "Ahora se ejecuta {0} (antes {1}). Se cerraron todas las sesiones."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Ahora hemos levantado <0>$11M</0> de los mejores inversores de Silicon Valley para construir la plataforma de las fábricas de software."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (mes en curso hasta ahora)"
 
 msgid "Numbered list"
 msgstr "Lista numerada"
@@ -12023,6 +12053,9 @@ msgstr "Reanudar la automatización"
 msgid "Resuming {0}…"
 msgstr "Retomando {0}…"
 
+msgid "Retained MRR"
+msgstr "MRR retenido"
+
 msgid "Retention and revenue"
 msgstr "Retención e ingresos"
 
@@ -13647,6 +13680,10 @@ msgstr "Empieza gratis. Sube de plan cuando tu equipo se quede corto. Planes Ent
 
 msgid "Start from a template"
 msgstr "Empezar desde una plantilla"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "MRR inicial ({0} clientes)"
 
 msgid "Start new session"
 msgstr "Iniciar una sesión nueva"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minutos"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10 o más líneas de trabajo simultáneas sin perder el hilo"
 
+msgid "100% (retain everything)"
+msgstr "100 % (retener todo)"
+
 msgid "15 minutes"
 msgstr "15 minutos"
 
@@ -8683,6 +8686,12 @@ msgstr "Mensual"
 msgid "Monthly at {time}"
 msgstr "Mensualmente a las {time}"
 
+msgid "monthly NRR"
+msgstr "NRR mensual"
+
+msgid "monthly NRR (month so far)"
+msgstr "NRR mensual (mes en curso hasta ahora)"
+
 msgid "Monthly on {day}"
 msgstr "Mensualmente el {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Ahora se ejecuta {0} (antes {1}). Se cerraron todas las sesiones."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Ahora hemos levantado <0>$11M</0> de los mejores inversores de Silicon Valley para construir la plataforma de las fábricas de software."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (mes en curso hasta ahora)"
 
 msgid "Numbered list"
 msgstr "Lista numerada"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -93,6 +93,9 @@ msgstr "(externe)"
 msgid "(no output)"
 msgstr "(aucune sortie)"
 
+msgid "(so far)"
+msgstr "(jusqu'ici)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# port actif — masquer les détails} other {# ports actifs — masquer les détails}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ il y a 2 h"
 
 msgid "✓ 3d ago"
 msgstr "✓ il y a 3 j"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "Le MRR de {1} clients est passé de ${0} à ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Choisissez quand Superset vous notifie."
 msgid "Choose which agent watches this page for comments"
 msgstr "Choisir l'agent qui surveille les commentaires de cette page"
 
+msgid "Churn"
+msgstr "Attrition"
+
 msgid "CI failed"
 msgstr "CI en échec"
 
@@ -3823,6 +3835,9 @@ msgstr "Continuer une session d'agent nécessite un espace de travail épinglé"
 
 msgid "continuing the last session"
 msgstr "en continuant la dernière session"
+
+msgid "Contraction"
+msgstr "Contraction"
 
 msgid "Contributions"
 msgstr "Contributions"
@@ -5740,6 +5755,9 @@ msgstr "Développer le fil"
 
 msgid "Expand workspace"
 msgstr "Développer l'espace de travail"
+
+msgid "Expansion"
+msgstr "Expansion"
 
 msgid "Experimental"
 msgstr "Expérimental"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — quotidien (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR des clients payants à la fin du mois précédent, en part de ce qu'ils payaient alors : expansion et contraction nettes de l'attrition, nouveaux clients exclus"
+
 msgid "Multi-select"
 msgstr "Sélection multiple"
 
@@ -8825,6 +8846,9 @@ msgstr "burn net"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Burn net — mensuel (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Rétention nette du revenu — mensuelle (Stripe)"
 
 msgid "Network Changed"
 msgstr "Réseau modifié"
@@ -9688,6 +9712,12 @@ msgstr "Exécute désormais {0} (auparavant {1}). Toutes les sessions ont été 
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Aujourd'hui, nous avons levé <0>11 M$</0> auprès des meilleurs investisseurs de la Silicon Valley pour construire la plateforme des usines logicielles."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (mois en cours jusqu'ici)"
 
 msgid "Numbered list"
 msgstr "Liste numérotée"
@@ -12023,6 +12053,9 @@ msgstr "Reprendre l'automatisation"
 msgid "Resuming {0}…"
 msgstr "Reprise de {0}…"
 
+msgid "Retained MRR"
+msgstr "MRR conservé"
+
 msgid "Retention and revenue"
 msgstr "Rétention et revenus"
 
@@ -13647,6 +13680,10 @@ msgstr "Commencez gratuitement. Passez à l'offre supérieure quand votre équip
 
 msgid "Start from a template"
 msgstr "Partir d'un modèle"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "MRR initial ({0} clients)"
 
 msgid "Start new session"
 msgstr "Démarrer une nouvelle session"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minutes"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10 chantiers simultanés ou plus sans perte d'état"
 
+msgid "100% (retain everything)"
+msgstr "100 % (tout conserver)"
+
 msgid "15 minutes"
 msgstr "15 minutes"
 
@@ -8683,6 +8686,12 @@ msgstr "Mensuel"
 msgid "Monthly at {time}"
 msgstr "Mensuelle à {time}"
 
+msgid "monthly NRR"
+msgstr "NRR mensuel"
+
+msgid "monthly NRR (month so far)"
+msgstr "NRR mensuel (mois en cours jusqu'ici)"
+
 msgid "Monthly on {day}"
 msgstr "Mensuelle le {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Exécute désormais {0} (auparavant {1}). Toutes les sessions ont été 
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Aujourd'hui, nous avons levé <0>11 M$</0> auprès des meilleurs investisseurs de la Silicon Valley pour construire la plateforme des usines logicielles."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (mois en cours jusqu'ici)"
 
 msgid "Numbered list"
 msgstr "Liste numérotée"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -93,6 +93,9 @@ msgstr "(eksternal)"
 msgid "(no output)"
 msgstr "(tidak ada keluaran)"
 
+msgid "(so far)"
+msgstr "(sejauh ini)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# port aktif — sembunyikan detail} other {# port aktif — sembunyikan detail}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2j lalu"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3h lalu"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR dari {1} pelanggan berubah dari ${0} menjadi ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Pilih kapan Superset memberi tahu Anda."
 msgid "Choose which agent watches this page for comments"
 msgstr "Pilih agen yang memantau komentar di halaman ini"
 
+msgid "Churn"
+msgstr "Churn"
+
 msgid "CI failed"
 msgstr "CI gagal"
 
@@ -3823,6 +3835,9 @@ msgstr "Melanjutkan sesi agen memerlukan ruang kerja yang disematkan"
 
 msgid "continuing the last session"
 msgstr "melanjutkan sesi terakhir"
+
+msgid "Contraction"
+msgstr "Kontraksi"
 
 msgid "Contributions"
 msgstr "Kontribusi"
@@ -5740,6 +5755,9 @@ msgstr "Bentangkan thread"
 
 msgid "Expand workspace"
 msgstr "Bentangkan workspace"
+
+msgid "Expansion"
+msgstr "Ekspansi"
 
 msgid "Experimental"
 msgstr "Eksperimental"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — harian (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR dari pelanggan yang membayar pada akhir bulan sebelumnya, sebagai proporsi dari yang mereka bayar saat itu: ekspansi dan kontraksi setelah dikurangi churn, tanpa pelanggan baru"
+
 msgid "Multi-select"
 msgstr "Pilih banyak"
 
@@ -8825,6 +8846,9 @@ msgstr "net burn"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Net burn — bulanan (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Retensi pendapatan bersih — bulanan (Stripe)"
 
 msgid "Network Changed"
 msgstr "Jaringan Berubah"
@@ -9688,6 +9712,12 @@ msgstr "Kini menjalankan {0} (sebelumnya {1}). Semua sesi ditutup."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Kini, kami telah menggalang <0>$11 juta</0> dari investor terbaik di Silicon Valley untuk membangun platform bagi pabrik perangkat lunak."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (bulan ini sejauh ini)"
 
 msgid "Numbered list"
 msgstr "Daftar bernomor"
@@ -12023,6 +12053,9 @@ msgstr "Lanjutkan otomatisasi"
 msgid "Resuming {0}…"
 msgstr "Melanjutkan {0}…"
 
+msgid "Retained MRR"
+msgstr "MRR yang dipertahankan"
+
 msgid "Retention and revenue"
 msgstr "Retensi dan pendapatan"
 
@@ -13647,6 +13680,10 @@ msgstr "Mulai gratis. Upgrade saat tim Anda membutuhkan lebih. Paket enterprise 
 
 msgid "Start from a template"
 msgstr "Mulai dari templat"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "MRR awal ({0} pelanggan)"
 
 msgid "Start new session"
 msgstr "Mulai sesi baru"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 menit"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ alur kerja bersamaan tanpa kehilangan konteks"
 
+msgid "100% (retain everything)"
+msgstr "100% (mempertahankan semua)"
+
 msgid "15 minutes"
 msgstr "15 menit"
 
@@ -8683,6 +8686,12 @@ msgstr "Bulanan"
 msgid "Monthly at {time}"
 msgstr "Bulanan pukul {time}"
 
+msgid "monthly NRR"
+msgstr "NRR bulanan"
+
+msgid "monthly NRR (month so far)"
+msgstr "NRR bulanan (bulan ini sejauh ini)"
+
 msgid "Monthly on {day}"
 msgstr "Bulanan pada tanggal {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Kini menjalankan {0} (sebelumnya {1}). Semua sesi ditutup."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Kini, kami telah menggalang <0>$11 juta</0> dari investor terbaik di Silicon Valley untuk membangun platform bagi pabrik perangkat lunak."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (bulan ini sejauh ini)"
 
 msgid "Numbered list"
 msgstr "Daftar bernomor"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -93,6 +93,9 @@ msgstr "(esterno)"
 msgid "(no output)"
 msgstr "(nessun output)"
 
+msgid "(so far)"
+msgstr "(finora)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# porta attiva — nascondi i dettagli} other {# porte attive — nascondi i dettagli}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2h fa"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3g fa"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "Il MRR di {1} clienti è passato da ${0} a ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Scegli quando Superset ti avvisa."
 msgid "Choose which agent watches this page for comments"
 msgstr "Scegli quale agente osserva i commenti di questa pagina"
 
+msgid "Churn"
+msgstr "Abbandono"
+
 msgid "CI failed"
 msgstr "CI fallita"
 
@@ -3823,6 +3835,9 @@ msgstr "Continuare una sessione dell'agente richiede un workspace fissato"
 
 msgid "continuing the last session"
 msgstr "continuando l'ultima sessione"
+
+msgid "Contraction"
+msgstr "Contrazione"
 
 msgid "Contributions"
 msgstr "Contributi"
@@ -5740,6 +5755,9 @@ msgstr "Espandi il thread"
 
 msgid "Expand workspace"
 msgstr "Espandi il workspace"
+
+msgid "Expansion"
+msgstr "Espansione"
 
 msgid "Experimental"
 msgstr "Sperimentale"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — giornaliero (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR dei clienti paganti a fine del mese precedente, in rapporto a quanto pagavano allora: espansione e contrazione al netto dell'abbandono, nuovi clienti esclusi"
+
 msgid "Multi-select"
 msgstr "Selezione multipla"
 
@@ -8825,6 +8846,9 @@ msgstr "burn netto"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Burn netto — mensile (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Net revenue retention — mensile (Stripe)"
 
 msgid "Network Changed"
 msgstr "Rete cambiata"
@@ -9688,6 +9712,12 @@ msgstr "Ora è in esecuzione {0} (prima {1}). Tutte le sessioni sono state chius
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Ora abbiamo raccolto <0>11 milioni di dollari</0> dai migliori investitori della Silicon Valley per costruire la piattaforma per le fabbriche di software."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (mese in corso finora)"
 
 msgid "Numbered list"
 msgstr "Elenco numerato"
@@ -12023,6 +12053,9 @@ msgstr "Riprendi l'automazione"
 msgid "Resuming {0}…"
 msgstr "Ripresa di {0}…"
 
+msgid "Retained MRR"
+msgstr "MRR trattenuto"
+
 msgid "Retention and revenue"
 msgstr "Retention e ricavi"
 
@@ -13647,6 +13680,10 @@ msgstr "Inizia gratis. Passa a un piano superiore quando il tuo team cresce. Pia
 
 msgid "Start from a template"
 msgstr "Parti da un modello"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "MRR iniziale ({0} clienti)"
 
 msgid "Start new session"
 msgstr "Avvia una nuova sessione"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minuti"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ flussi di lavoro simultanei senza perdere il filo"
 
+msgid "100% (retain everything)"
+msgstr "100% (trattenere tutto)"
+
 msgid "15 minutes"
 msgstr "15 minuti"
 
@@ -8683,6 +8686,12 @@ msgstr "Mensile"
 msgid "Monthly at {time}"
 msgstr "Ogni mese alle {time}"
 
+msgid "monthly NRR"
+msgstr "NRR mensile"
+
+msgid "monthly NRR (month so far)"
+msgstr "NRR mensile (mese in corso finora)"
+
 msgid "Monthly on {day}"
 msgstr "Ogni mese il {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Ora è in esecuzione {0} (prima {1}). Tutte le sessioni sono state chius
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Ora abbiamo raccolto <0>11 milioni di dollari</0> dai migliori investitori della Silicon Valley per costruire la piattaforma per le fabbriche di software."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (mese in corso finora)"
 
 msgid "Numbered list"
 msgstr "Elenco numerato"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10分"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "状態を取りこぼさない10以上の並行ワークストリーム"
 
+msgid "100% (retain everything)"
+msgstr "100%（全て維持）"
+
 msgid "15 minutes"
 msgstr "15分"
 
@@ -8683,6 +8686,12 @@ msgstr "月払い"
 msgid "Monthly at {time}"
 msgstr "毎月 {time}"
 
+msgid "monthly NRR"
+msgstr "月次NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "月次NRR（今月の途中経過）"
+
 msgid "Monthly on {day}"
 msgstr "毎月{day}"
 
@@ -9712,12 +9721,6 @@ msgstr "現在{0}が動作しています(以前は{1})。すべてのセッシ�
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "そしていま、ソフトウェア工場のためのプラットフォームを作るべく、シリコンバレーの一流投資家から<0>1,100万ドル</0>を調達しました。"
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR（今月の途中経過）"
 
 msgid "Numbered list"
 msgstr "番号付きリスト"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -93,6 +93,9 @@ msgstr "(外部)"
 msgid "(no output)"
 msgstr "（出力なし）"
 
+msgid "(so far)"
+msgstr "（現時点）"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {#個のアクティブなポート — 詳細を隠す} other {#個のアクティブなポート — 詳細を隠す}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2時間前"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3日前"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "顧客{1}社の${0}が${2}になりました"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Supersetから通知するタイミングを選びます。"
 msgid "Choose which agent watches this page for comments"
 msgstr "このページのコメントを監視するエージェントを選択"
 
+msgid "Churn"
+msgstr "解約"
+
 msgid "CI failed"
 msgstr "CIが失敗しました"
 
@@ -3823,6 +3835,9 @@ msgstr "エージェントセッションを継続するには、ワークスペ
 
 msgid "continuing the last session"
 msgstr "前回のセッションを継続"
+
+msgid "Contraction"
+msgstr "縮小"
 
 msgid "Contributions"
 msgstr "コントリビューション"
@@ -5740,6 +5755,9 @@ msgstr "スレッドを展開"
 
 msgid "Expand workspace"
 msgstr "ワークスペースを展開"
+
+msgid "Expansion"
+msgstr "拡大"
 
 msgid "Experimental"
 msgstr "実験的機能"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — 日次(Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "前月末時点で支払っていた顧客のMRRを、当時の支払額に対する割合で示したもの。拡大と縮小から解約を差し引き、新規顧客は除外"
+
 msgid "Multi-select"
 msgstr "複数選択"
 
@@ -8825,6 +8846,9 @@ msgstr "ネットバーン"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "ネットバーン — 月次(Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "純収益維持率 — 月次（Stripe）"
 
 msgid "Network Changed"
 msgstr "ネットワークが変更されました"
@@ -9688,6 +9712,12 @@ msgstr "現在{0}が動作しています(以前は{1})。すべてのセッシ�
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "そしていま、ソフトウェア工場のためのプラットフォームを作るべく、シリコンバレーの一流投資家から<0>1,100万ドル</0>を調達しました。"
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR（今月の途中経過）"
 
 msgid "Numbered list"
 msgstr "番号付きリスト"
@@ -12023,6 +12053,9 @@ msgstr "オートメーションを再開"
 msgid "Resuming {0}…"
 msgstr "{0}を再開中…"
 
+msgid "Retained MRR"
+msgstr "維持されたMRR"
+
 msgid "Retention and revenue"
 msgstr "定着と収益"
 
@@ -13647,6 +13680,10 @@ msgstr "無料で始められます。チームの規模に合わなくなった
 
 msgid "Start from a template"
 msgstr "テンプレートから開始"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "開始時MRR（顧客{0}社）"
 
 msgid "Start new session"
 msgstr "新しいセッションを開始"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10분"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "상태 유실 없이 동시 작업 흐름 10개 이상"
 
+msgid "100% (retain everything)"
+msgstr "100% (전부 유지)"
+
 msgid "15 minutes"
 msgstr "15분"
 
@@ -8683,6 +8686,12 @@ msgstr "월간"
 msgid "Monthly at {time}"
 msgstr "매월 {time}"
 
+msgid "monthly NRR"
+msgstr "월간 NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "월간 NRR (이번 달 현재까지)"
+
 msgid "Monthly on {day}"
 msgstr "매월 {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "이제 {0}을(를) 실행합니다(이전 {1}). 모든 세션이 닫혔�
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "이제 소프트웨어 공장을 위한 플랫폼을 만들기 위해 실리콘밸리 최고의 투자자들로부터 <0>1,100만 달러</0>를 투자받았습니다."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (이번 달 현재까지)"
 
 msgid "Numbered list"
 msgstr "번호 매기기 목록"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -93,6 +93,9 @@ msgstr "(외부)"
 msgid "(no output)"
 msgstr "(출력 없음)"
 
+msgid "(so far)"
+msgstr "(현재까지)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {활성 포트 #개 — 세부 정보 숨기기} other {활성 포트 #개 — 세부 정보 숨기기}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2시간 전"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3일 전"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "고객 {1}명의 MRR이 ${0}에서 ${2}(으)로 변경됨"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Superset이 언제 알릴지 선택하세요."
 msgid "Choose which agent watches this page for comments"
 msgstr "이 페이지의 댓글을 감시할 에이전트 선택"
 
+msgid "Churn"
+msgstr "이탈"
+
 msgid "CI failed"
 msgstr "CI 실패"
 
@@ -3823,6 +3835,9 @@ msgstr "에이전트 세션을 계속하려면 고정된 워크스페이스가 �
 
 msgid "continuing the last session"
 msgstr "마지막 세션을 계속"
+
+msgid "Contraction"
+msgstr "축소"
 
 msgid "Contributions"
 msgstr "기여"
@@ -5740,6 +5755,9 @@ msgstr "스레드 펼치기"
 
 msgid "Expand workspace"
 msgstr "워크스페이스 펼치기"
+
+msgid "Expansion"
+msgstr "확장"
 
 msgid "Experimental"
 msgstr "실험실"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — 일별 (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "전월 말에 결제 중이던 고객의 MRR을 당시 결제액 대비 비율로 표시: 확장과 축소에서 이탈을 뺀 값, 신규 고객 제외"
+
 msgid "Multi-select"
 msgstr "다중 선택"
 
@@ -8825,6 +8846,9 @@ msgstr "순 소진액"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "순 소진액 — 월별 (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "순매출 유지율 — 월별 (Stripe)"
 
 msgid "Network Changed"
 msgstr "네트워크 변경됨"
@@ -9688,6 +9712,12 @@ msgstr "이제 {0}을(를) 실행합니다(이전 {1}). 모든 세션이 닫혔�
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "이제 소프트웨어 공장을 위한 플랫폼을 만들기 위해 실리콘밸리 최고의 투자자들로부터 <0>1,100만 달러</0>를 투자받았습니다."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (이번 달 현재까지)"
 
 msgid "Numbered list"
 msgstr "번호 매기기 목록"
@@ -12023,6 +12053,9 @@ msgstr "자동화 재개"
 msgid "Resuming {0}…"
 msgstr "{0}을(를) 재개하는 중…"
 
+msgid "Retained MRR"
+msgstr "유지된 MRR"
+
 msgid "Retention and revenue"
 msgstr "유지와 수익"
 
@@ -13647,6 +13680,10 @@ msgstr "무료로 시작하세요. 팀이 커지면 업그레이드하세요. �
 
 msgid "Start from a template"
 msgstr "템플릿으로 시작"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "시작 MRR (고객 {0}명)"
 
 msgid "Start new session"
 msgstr "새 세션 시작"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -93,6 +93,9 @@ msgstr "(extern)"
 msgid "(no output)"
 msgstr "(geen uitvoer)"
 
+msgid "(so far)"
+msgstr "(tot nu toe)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# actieve poort — details verbergen} other {# actieve poorten — details verbergen}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2u geleden"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3d geleden"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR van {1} klanten ging van ${0} naar ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Kies wanneer Superset je een seintje geeft."
 msgid "Choose which agent watches this page for comments"
 msgstr "Kies welke agent deze pagina volgt voor reacties"
 
+msgid "Churn"
+msgstr "Opzeggingen"
+
 msgid "CI failed"
 msgstr "CI mislukt"
 
@@ -3823,6 +3835,9 @@ msgstr "Een agentsessie voortzetten vereist een vastgezette workspace"
 
 msgid "continuing the last session"
 msgstr "de laatste sessie voortzetten"
+
+msgid "Contraction"
+msgstr "Krimp"
 
 msgid "Contributions"
 msgstr "Bijdragen"
@@ -5740,6 +5755,9 @@ msgstr "Thread uitklappen"
 
 msgid "Expand workspace"
 msgstr "Werkruimte uitklappen"
+
+msgid "Expansion"
+msgstr "Uitbreiding"
 
 msgid "Experimental"
 msgstr "Experimenteel"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — dagelijks (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR van klanten die eind vorige maand betaalden, als aandeel van wat ze toen betaalden: uitbreiding en krimp na aftrek van opzeggingen, zonder nieuwe klanten"
+
 msgid "Multi-select"
 msgstr "Meerdere keuzes"
 
@@ -8825,6 +8846,9 @@ msgstr "netto burn"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Netto burn — maandelijks (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Netto-omzetbehoud — maandelijks (Stripe)"
 
 msgid "Network Changed"
 msgstr "Netwerk gewijzigd"
@@ -9688,6 +9712,12 @@ msgstr "Nu draait {0} (was {1}). Alle sessies zijn gesloten."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Inmiddels hebben we <0>$11M</0> opgehaald bij de beste investeerders in Silicon Valley om het platform voor softwarefabrieken te bouwen."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (deze maand tot nu toe)"
 
 msgid "Numbered list"
 msgstr "Genummerde lijst"
@@ -12023,6 +12053,9 @@ msgstr "Automatisering hervatten"
 msgid "Resuming {0}…"
 msgstr "{0} hervatten…"
 
+msgid "Retained MRR"
+msgstr "Behouden MRR"
+
 msgid "Retention and revenue"
 msgstr "Retentie en omzet"
 
@@ -13647,6 +13680,10 @@ msgstr "Begin gratis. Upgrade wanneer je team eruit groeit. Enterprise-plannen v
 
 msgid "Start from a template"
 msgstr "Beginnen met een sjabloon"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Start-MRR ({0} klanten)"
 
 msgid "Start new session"
 msgstr "Nieuwe sessie starten"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minuten"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ gelijktijdige werkstromen zonder verlies van context"
 
+msgid "100% (retain everything)"
+msgstr "100% (alles behouden)"
+
 msgid "15 minutes"
 msgstr "15 minuten"
 
@@ -8683,6 +8686,12 @@ msgstr "Maandelijks"
 msgid "Monthly at {time}"
 msgstr "Maandelijks om {time}"
 
+msgid "monthly NRR"
+msgstr "maandelijkse NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "maandelijkse NRR (deze maand tot nu toe)"
+
 msgid "Monthly on {day}"
 msgstr "Maandelijks op {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Nu draait {0} (was {1}). Alle sessies zijn gesloten."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Inmiddels hebben we <0>$11M</0> opgehaald bij de beste investeerders in Silicon Valley om het platform voor softwarefabrieken te bouwen."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (deze maand tot nu toe)"
 
 msgid "Numbered list"
 msgstr "Genummerde lijst"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -93,6 +93,9 @@ msgstr "(zewnętrzny)"
 msgid "(no output)"
 msgstr "(brak wyniku)"
 
+msgid "(so far)"
+msgstr "(do tej pory)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# aktywny port — ukryj szczegóły} few {# aktywne porty — ukryj szczegóły} many {# aktywnych portów — ukryj szczegóły} other {# aktywnego portu — ukryj szczegóły}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2 godz. temu"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3 dni temu"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR {1} klientów zmienił się z ${0} na ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Wybierz, kiedy Superset ma Cię powiadamiać."
 msgid "Choose which agent watches this page for comments"
 msgstr "Wybierz, który agent obserwuje komentarze na tej stronie"
 
+msgid "Churn"
+msgstr "Odejścia"
+
 msgid "CI failed"
 msgstr "CI nie przeszło"
 
@@ -3823,6 +3835,9 @@ msgstr "Kontynuowanie sesji agenta wymaga przypiętego obszaru roboczego"
 
 msgid "continuing the last session"
 msgstr "kontynuując ostatnią sesję"
+
+msgid "Contraction"
+msgstr "Spadek"
 
 msgid "Contributions"
 msgstr "Wkład"
@@ -5740,6 +5755,9 @@ msgstr "Rozwiń wątek"
 
 msgid "Expand workspace"
 msgstr "Rozwiń obszar roboczy"
+
+msgid "Expansion"
+msgstr "Wzrost"
 
 msgid "Experimental"
 msgstr "Eksperymentalne"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — dziennie (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR klientów płacących na koniec poprzedniego miesiąca jako udział tego, co wtedy płacili: wzrost i spadek pomniejszone o odejścia, bez nowych klientów"
+
 msgid "Multi-select"
 msgstr "Wielokrotny wybór"
 
@@ -8825,6 +8846,9 @@ msgstr "wypływ netto"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Wypływ netto — miesięcznie (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Retencja przychodów netto — miesięcznie (Stripe)"
 
 msgid "Network Changed"
 msgstr "Sieć się zmieniła"
@@ -9688,6 +9712,12 @@ msgstr "Działa teraz {0} (wcześniej {1}). Wszystkie sesje zamknięto."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Teraz pozyskaliśmy <0>11 mln USD</0> od najlepszych inwestorów w Dolinie Krzemowej, aby zbudować platformę dla fabryk oprogramowania."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (od początku miesiąca)"
 
 msgid "Numbered list"
 msgstr "Lista numerowana"
@@ -12023,6 +12053,9 @@ msgstr "Wznów automatyzację"
 msgid "Resuming {0}…"
 msgstr "Wznawianie {0}…"
 
+msgid "Retained MRR"
+msgstr "Zachowany MRR"
+
 msgid "Retention and revenue"
 msgstr "Utrzymanie i przychody"
 
@@ -13647,6 +13680,10 @@ msgstr "Zacznij za darmo. Podnieś plan, gdy zespół z niego wyrośnie. Plany E
 
 msgid "Start from a template"
 msgstr "Zacznij od szablonu"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Początkowy MRR ({0} klientów)"
 
 msgid "Start new session"
 msgstr "Uruchom nową sesję"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minut"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ równoległych nurtów pracy bez gubienia stanu"
 
+msgid "100% (retain everything)"
+msgstr "100% (zachowanie wszystkiego)"
+
 msgid "15 minutes"
 msgstr "15 minut"
 
@@ -8683,6 +8686,12 @@ msgstr "Miesięcznie"
 msgid "Monthly at {time}"
 msgstr "Co miesiąc o {time}"
 
+msgid "monthly NRR"
+msgstr "miesięczny NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "miesięczny NRR (od początku miesiąca)"
+
 msgid "Monthly on {day}"
 msgstr "Co miesiąc {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Działa teraz {0} (wcześniej {1}). Wszystkie sesje zamknięto."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Teraz pozyskaliśmy <0>11 mln USD</0> od najlepszych inwestorów w Dolinie Krzemowej, aby zbudować platformę dla fabryk oprogramowania."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (od początku miesiąca)"
 
 msgid "Numbered list"
 msgstr "Lista numerowana"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -93,6 +93,9 @@ msgstr "(externo)"
 msgid "(no output)"
 msgstr "(sem saída)"
 
+msgid "(so far)"
+msgstr "(até agora)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# porta ativa — ocultar detalhes} other {# portas ativas — ocultar detalhes}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ há 2h"
 
 msgid "✓ 3d ago"
 msgstr "✓ há 3d"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "O MRR de {1} clientes passou de ${0} para ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Escolha quando o Superset te avisa."
 msgid "Choose which agent watches this page for comments"
 msgstr "Escolha qual agente observa os comentários desta página"
 
+msgid "Churn"
+msgstr "Cancelamentos"
+
 msgid "CI failed"
 msgstr "CI falhou"
 
@@ -3823,6 +3835,9 @@ msgstr "Continuar uma sessão de agente exige uma área de trabalho fixada"
 
 msgid "continuing the last session"
 msgstr "continuando a última sessão"
+
+msgid "Contraction"
+msgstr "Contração"
 
 msgid "Contributions"
 msgstr "Contribuições"
@@ -5740,6 +5755,9 @@ msgstr "Expandir a thread"
 
 msgid "Expand workspace"
 msgstr "Expandir área de trabalho"
+
+msgid "Expansion"
+msgstr "Expansão"
 
 msgid "Experimental"
 msgstr "Experimental"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — diário (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR dos clientes que pagavam no fim do mês anterior, como proporção do que pagavam então: expansão e contração líquidas de cancelamentos, sem clientes novos"
+
 msgid "Multi-select"
 msgstr "Múltipla escolha"
 
@@ -8825,6 +8846,9 @@ msgstr "queima líquida"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Queima líquida — mensal (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Retenção líquida de receita — mensal (Stripe)"
 
 msgid "Network Changed"
 msgstr "A rede mudou"
@@ -9688,6 +9712,12 @@ msgstr "Rodando {0} agora (era {1}). Todas as sessões foram fechadas."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Agora, captamos <0>US$ 11 milhões</0> com os melhores investidores do Vale do Silício para construir a plataforma das fábricas de software."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (mês em andamento até agora)"
 
 msgid "Numbered list"
 msgstr "Lista numerada"
@@ -12023,6 +12053,9 @@ msgstr "Retomar automação"
 msgid "Resuming {0}…"
 msgstr "Retomando {0}…"
 
+msgid "Retained MRR"
+msgstr "MRR retido"
+
 msgid "Retention and revenue"
 msgstr "Retenção e receita"
 
@@ -13647,6 +13680,10 @@ msgstr "Comece de graça. Faça upgrade quando o time crescer. Planos Enterprise
 
 msgid "Start from a template"
 msgstr "Começar por um modelo"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "MRR inicial ({0} clientes)"
 
 msgid "Start new session"
 msgstr "Iniciar nova sessão"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 minutos"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10 ou mais frentes simultâneas sem perder o fio"
 
+msgid "100% (retain everything)"
+msgstr "100% (reter tudo)"
+
 msgid "15 minutes"
 msgstr "15 minutos"
 
@@ -8683,6 +8686,12 @@ msgstr "Mensal"
 msgid "Monthly at {time}"
 msgstr "Mensalmente às {time}"
 
+msgid "monthly NRR"
+msgstr "NRR mensal"
+
+msgid "monthly NRR (month so far)"
+msgstr "NRR mensal (mês em andamento até agora)"
+
 msgid "Monthly on {day}"
 msgstr "Mensalmente no dia {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Rodando {0} agora (era {1}). Todas as sessões foram fechadas."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Agora, captamos <0>US$ 11 milhões</0> com os melhores investidores do Vale do Silício para construir a plataforma das fábricas de software."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (mês em andamento até agora)"
 
 msgid "Numbered list"
 msgstr "Lista numerada"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 минут"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ параллельных потоков работы без потери состояния"
 
+msgid "100% (retain everything)"
+msgstr "100% (всё удержано)"
+
 msgid "15 minutes"
 msgstr "15 минут"
 
@@ -8683,6 +8686,12 @@ msgstr "Ежемесячно"
 msgid "Monthly at {time}"
 msgstr "Ежемесячно в {time}"
 
+msgid "monthly NRR"
+msgstr "месячный NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "месячный NRR (с начала текущего месяца)"
+
 msgid "Monthly on {day}"
 msgstr "Ежемесячно {day} числа"
 
@@ -9712,12 +9721,6 @@ msgstr "Сейчас работает {0} (было {1}). Все сессии з
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Сейчас мы привлекли <0>$11 млн</0> от лучших инвесторов Кремниевой долины, чтобы построить платформу для софтверных фабрик."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (с начала текущего месяца)"
 
 msgid "Numbered list"
 msgstr "Нумерованный список"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -93,6 +93,9 @@ msgstr "(внешний)"
 msgid "(no output)"
 msgstr "(нет вывода)"
 
+msgid "(so far)"
+msgstr "(пока)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# активный порт — скрыть детали} few {# активных порта — скрыть детали} many {# активных портов — скрыть детали} other {# активных портов — скрыть детали}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2 ч. назад"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3 д. назад"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR клиентов ({1}): с ${0} до ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Выберите, когда Superset вас уведомляет."
 msgid "Choose which agent watches this page for comments"
 msgstr "Выберите, какой агент отслеживает комментарии на этой странице"
 
+msgid "Churn"
+msgstr "Отток"
+
 msgid "CI failed"
 msgstr "CI упал"
 
@@ -3823,6 +3835,9 @@ msgstr "Для продолжения сессии агента нужно за�
 
 msgid "continuing the last session"
 msgstr "продолжая последнюю сессию"
+
+msgid "Contraction"
+msgstr "Сокращение"
 
 msgid "Contributions"
 msgstr "Вклад"
@@ -5740,6 +5755,9 @@ msgstr "Развернуть ветку"
 
 msgid "Expand workspace"
 msgstr "Развернуть рабочую область"
+
+msgid "Expansion"
+msgstr "Расширение"
 
 msgid "Experimental"
 msgstr "Экспериментальные"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — по дням (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR клиентов, плативших на конец прошлого месяца, как доля того, что они платили тогда: расширение и сокращение за вычетом оттока, без новых клиентов"
+
 msgid "Multi-select"
 msgstr "Множественный выбор"
 
@@ -8825,6 +8846,9 @@ msgstr "чистый расход"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Чистый расход — по месяцам (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Чистое удержание выручки — помесячно (Stripe)"
 
 msgid "Network Changed"
 msgstr "Сеть изменилась"
@@ -9688,6 +9712,12 @@ msgstr "Сейчас работает {0} (было {1}). Все сессии з
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Сейчас мы привлекли <0>$11 млн</0> от лучших инвесторов Кремниевой долины, чтобы построить платформу для софтверных фабрик."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (с начала текущего месяца)"
 
 msgid "Numbered list"
 msgstr "Нумерованный список"
@@ -12023,6 +12053,9 @@ msgstr "Возобновить автоматизацию"
 msgid "Resuming {0}…"
 msgstr "Возобновление {0}…"
 
+msgid "Retained MRR"
+msgstr "Удержанный MRR"
+
 msgid "Retention and revenue"
 msgstr "Удержание и выручка"
 
@@ -13647,6 +13680,10 @@ msgstr "Начните бесплатно. Переходите на платн�
 
 msgid "Start from a template"
 msgstr "Начать с шаблона"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Начальный MRR (клиентов: {0})"
 
 msgid "Start new session"
 msgstr "Начать новую сессию"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 dakika"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "Durum kaybı olmadan 10+ eşzamanlı iş akışı"
 
+msgid "100% (retain everything)"
+msgstr "%100 (her şeyi elde tutma)"
+
 msgid "15 minutes"
 msgstr "15 dakika"
 
@@ -8683,6 +8686,12 @@ msgstr "Aylık"
 msgid "Monthly at {time}"
 msgstr "Her ay saat {time}"
 
+msgid "monthly NRR"
+msgstr "aylık NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "aylık NRR (bu ay şimdiye kadar)"
+
 msgid "Monthly on {day}"
 msgstr "Her ay {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Şimdi {0} çalışıyor (önceki: {1}). Tüm oturumlar kapatıldı."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Şimdi, yazılım fabrikaları için platformu kurmak üzere Silikon Vadisi'nin en iyi yatırımcılarından <0>11 milyon dolar</0> topladık."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (bu ay şimdiye kadar)"
 
 msgid "Numbered list"
 msgstr "Numaralı liste"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -93,6 +93,9 @@ msgstr "(harici)"
 msgid "(no output)"
 msgstr "(çıktı yok)"
 
+msgid "(so far)"
+msgstr "(şimdiye kadar)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# etkin port — ayrıntıları gizle} other {# etkin port — ayrıntıları gizle}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2sa önce"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3g önce"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "{1} müşterinin MRR'si ${0} iken ${2} oldu"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Superset'in sizi ne zaman uyaracağını seçin."
 msgid "Choose which agent watches this page for comments"
 msgstr "Bu sayfanın yorumlarını hangi ajanın izleyeceğini seç"
 
+msgid "Churn"
+msgstr "Kayıp"
+
 msgid "CI failed"
 msgstr "CI başarısız"
 
@@ -3823,6 +3835,9 @@ msgstr "Bir aracı oturumunu sürdürmek için sabitlenmiş bir çalışma alan�
 
 msgid "continuing the last session"
 msgstr "son oturumu sürdürerek"
+
+msgid "Contraction"
+msgstr "Daralma"
 
 msgid "Contributions"
 msgstr "Katkılar"
@@ -5740,6 +5755,9 @@ msgstr "Konuyu genişlet"
 
 msgid "Expand workspace"
 msgstr "Çalışma alanını genişlet"
+
+msgid "Expansion"
+msgstr "Genişleme"
 
 msgid "Experimental"
 msgstr "Deneysel"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — günlük (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "Önceki ay sonunda ödeme yapan müşterilerin MRR'si, o zaman ödediklerine oranla: kayıp düşüldükten sonra genişleme ve daralma, yeni müşteriler hariç"
+
 msgid "Multi-select"
 msgstr "Çoklu seçim"
 
@@ -8825,6 +8846,9 @@ msgstr "net harcama"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Net harcama — aylık (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Net gelir elde tutma — aylık (Stripe)"
 
 msgid "Network Changed"
 msgstr "Ağ değişti"
@@ -9688,6 +9712,12 @@ msgstr "Şimdi {0} çalışıyor (önceki: {1}). Tüm oturumlar kapatıldı."
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Şimdi, yazılım fabrikaları için platformu kurmak üzere Silikon Vadisi'nin en iyi yatırımcılarından <0>11 milyon dolar</0> topladık."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (bu ay şimdiye kadar)"
 
 msgid "Numbered list"
 msgstr "Numaralı liste"
@@ -12023,6 +12053,9 @@ msgstr "Otomasyonu sürdür"
 msgid "Resuming {0}…"
 msgstr "{0} sürdürülüyor…"
 
+msgid "Retained MRR"
+msgstr "Elde tutulan MRR"
+
 msgid "Retention and revenue"
 msgstr "Elde tutma ve gelir"
 
@@ -13647,6 +13680,10 @@ msgstr "Ücretsiz başlayın. Takımınız büyüdüğünde yükseltin. Gelişmi
 
 msgid "Start from a template"
 msgstr "Şablondan başla"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "Başlangıç MRR'si ({0} müşteri)"
 
 msgid "Start new session"
 msgstr "Yeni oturum başlat"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -93,6 +93,9 @@ msgstr "(bên ngoài)"
 msgid "(no output)"
 msgstr "(không có đầu ra)"
 
+msgid "(so far)"
+msgstr "(đến nay)"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {# cổng đang hoạt động — ẩn chi tiết} other {# cổng đang hoạt động — ẩn chi tiết}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2 giờ trước"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3 ngày trước"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "MRR của {1} khách hàng từ ${0} thành ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "Chọn khi nào Superset báo cho bạn."
 msgid "Choose which agent watches this page for comments"
 msgstr "Chọn agent theo dõi bình luận của trang này"
 
+msgid "Churn"
+msgstr "Rời bỏ"
+
 msgid "CI failed"
 msgstr "CI thất bại"
 
@@ -3823,6 +3835,9 @@ msgstr "Để tiếp tục phiên agent, cần ghim một workspace"
 
 msgid "continuing the last session"
 msgstr "tiếp tục phiên gần nhất"
+
+msgid "Contraction"
+msgstr "Thu hẹp"
 
 msgid "Contributions"
 msgstr "Đóng góp"
@@ -5740,6 +5755,9 @@ msgstr "Mở rộng luồng"
 
 msgid "Expand workspace"
 msgstr "Mở rộng workspace"
+
+msgid "Expansion"
+msgstr "Mở rộng"
 
 msgid "Experimental"
 msgstr "Thử nghiệm"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — theo ngày (Stripe)"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "MRR từ các khách hàng đang trả phí vào cuối tháng trước, tính theo tỷ lệ so với số họ trả khi đó: mở rộng và thu hẹp trừ đi rời bỏ, không tính khách hàng mới"
+
 msgid "Multi-select"
 msgstr "Chọn nhiều"
 
@@ -8825,6 +8846,9 @@ msgstr "đốt tiền ròng"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "Đốt tiền ròng — theo tháng (Mercury)"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "Tỷ lệ giữ chân doanh thu ròng — hàng tháng (Stripe)"
 
 msgid "Network Changed"
 msgstr "Mạng đã thay đổi"
@@ -9688,6 +9712,12 @@ msgstr "Hiện đang chạy {0} (trước là {1}). Mọi phiên đã bị đón
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Giờ đây, chúng tôi đã gọi được <0>11 triệu USD</0> từ những nhà đầu tư tốt nhất Thung lũng Silicon để xây nền tảng cho các nhà máy phần mềm."
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR (tháng này đến nay)"
 
 msgid "Numbered list"
 msgstr "Danh sách đánh số"
@@ -12023,6 +12053,9 @@ msgstr "Tiếp tục tự động hóa"
 msgid "Resuming {0}…"
 msgstr "Đang resume {0}…"
 
+msgid "Retained MRR"
+msgstr "MRR giữ lại"
+
 msgid "Retention and revenue"
 msgstr "Giữ chân và doanh thu"
 
@@ -13647,6 +13680,10 @@ msgstr "Bắt đầu miễn phí. Nâng cấp khi đội của bạn lớn hơn.
 
 msgid "Start from a template"
 msgstr "Bắt đầu từ mẫu"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "MRR ban đầu ({0} khách hàng)"
 
 msgid "Start new session"
 msgstr "Bắt đầu phiên mới"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10 phút"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10+ luồng công việc đồng thời mà không rớt trạng thái"
 
+msgid "100% (retain everything)"
+msgstr "100% (giữ toàn bộ)"
+
 msgid "15 minutes"
 msgstr "15 phút"
 
@@ -8683,6 +8686,12 @@ msgstr "Hằng tháng"
 msgid "Monthly at {time}"
 msgstr "Hằng tháng lúc {time}"
 
+msgid "monthly NRR"
+msgstr "NRR hàng tháng"
+
+msgid "monthly NRR (month so far)"
+msgstr "NRR hàng tháng (tháng này đến nay)"
+
 msgid "Monthly on {day}"
 msgstr "Hằng tháng vào {day}"
 
@@ -9712,12 +9721,6 @@ msgstr "Hiện đang chạy {0} (trước là {1}). Mọi phiên đã bị đón
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "Giờ đây, chúng tôi đã gọi được <0>11 triệu USD</0> từ những nhà đầu tư tốt nhất Thung lũng Silicon để xây nền tảng cho các nhà máy phần mềm."
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR (tháng này đến nay)"
 
 msgid "Numbered list"
 msgstr "Danh sách đánh số"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -93,6 +93,9 @@ msgstr "（外部）"
 msgid "(no output)"
 msgstr "（无输出）"
 
+msgid "(so far)"
+msgstr "（截至目前）"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {#个活动端口 — 隐藏详情} other {#个活动端口 — 隐藏详情}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2小时前"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3天前"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "{1} 位客户的 MRR 从 ${0} 变为 ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "选择Superset在什么时候通知你。"
 msgid "Choose which agent watches this page for comments"
 msgstr "选择由哪个智能体关注此页面的评论"
 
+msgid "Churn"
+msgstr "流失"
+
 msgid "CI failed"
 msgstr "CI失败"
 
@@ -3823,6 +3835,9 @@ msgstr "继续智能体会话需要固定的工作区"
 
 msgid "continuing the last session"
 msgstr "继续上一个会话"
+
+msgid "Contraction"
+msgstr "收缩"
 
 msgid "Contributions"
 msgstr "贡献"
@@ -5740,6 +5755,9 @@ msgstr "展开讨论"
 
 msgid "Expand workspace"
 msgstr "展开工作区"
+
+msgid "Expansion"
+msgstr "扩张"
 
 msgid "Experimental"
 msgstr "实验功能"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — 按日（Stripe）"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "上月末付费客户的 MRR 占其当时付费额的比例：扩张与收缩扣除流失后的净值，不含新客户"
+
 msgid "Multi-select"
 msgstr "多选"
 
@@ -8825,6 +8846,9 @@ msgstr "净支出"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "净支出 — 按月（Mercury）"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "净收入留存率 — 每月（Stripe）"
 
 msgid "Network Changed"
 msgstr "网络已变更"
@@ -9688,6 +9712,12 @@ msgstr "当前运行{0}（之前是{1}）。所有会话已关闭。"
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "如今，我们已从硅谷最好的投资人那里融资<0>1100万美元</0>，用来打造软件工厂的平台。"
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR（本月至今）"
 
 msgid "Numbered list"
 msgstr "编号列表"
@@ -12023,6 +12053,9 @@ msgstr "恢复自动化"
 msgid "Resuming {0}…"
 msgstr "正在恢复{0}…"
 
+msgid "Retained MRR"
+msgstr "留存 MRR"
+
 msgid "Retention and revenue"
 msgstr "留存与收入"
 
@@ -13647,6 +13680,10 @@ msgstr "免费开始。团队用不够时再升级。企业方案面向有进阶
 
 msgid "Start from a template"
 msgstr "从模板开始"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "起始 MRR（{0} 位客户）"
 
 msgid "Start new session"
 msgstr "开始新会话"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10分钟"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10条以上并行工作流且不丢状态"
 
+msgid "100% (retain everything)"
+msgstr "100%（全部留存）"
+
 msgid "15 minutes"
 msgstr "15分钟"
 
@@ -8683,6 +8686,12 @@ msgstr "按月"
 msgid "Monthly at {time}"
 msgstr "每月{time}"
 
+msgid "monthly NRR"
+msgstr "月度 NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "月度 NRR（本月至今）"
+
 msgid "Monthly on {day}"
 msgstr "每月{day}"
 
@@ -9712,12 +9721,6 @@ msgstr "当前运行{0}（之前是{1}）。所有会话已关闭。"
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "如今，我们已从硅谷最好的投资人那里融资<0>1100万美元</0>，用来打造软件工厂的平台。"
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR（本月至今）"
 
 msgid "Numbered list"
 msgstr "编号列表"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -93,6 +93,9 @@ msgstr "（外部）"
 msgid "(no output)"
 msgstr "（無輸出）"
 
+msgid "(so far)"
+msgstr "（截至目前）"
+
 #. placeholder {0}: ports.length
 msgid "{0, plural, one {# active port — hide details} other {# active ports — hide details}}"
 msgstr "{0, plural, one {#個活動埠 — 隱藏詳情} other {#個活動埠 — 隱藏詳情}}"
@@ -1047,6 +1050,12 @@ msgstr "✓ 2小時前"
 
 msgid "✓ 3d ago"
 msgstr "✓ 3天前"
+
+#. placeholder {0}: formatNumber(latest.startMrrUsd, undefined)
+#. placeholder {1}: latest.customers
+#. placeholder {2}: formatNumber(latest.retainedMrrUsd, undefined)
+msgid "${0} from {1} customers became ${2}"
+msgstr "{1} 位客戶的 MRR 從 ${0} 變為 ${2}"
 
 #. placeholder {0}: formatNumber(latest.prevUsd, undefined)
 #. placeholder {1}: latest.prevDate
@@ -3042,6 +3051,9 @@ msgstr "選擇Superset在什麼時候通知你。"
 msgid "Choose which agent watches this page for comments"
 msgstr "選擇由哪個代理程式關注此頁面的評論"
 
+msgid "Churn"
+msgstr "流失"
+
 msgid "CI failed"
 msgstr "CI失敗"
 
@@ -3823,6 +3835,9 @@ msgstr "繼續代理程式工作階段需要已釘選的工作區"
 
 msgid "continuing the last session"
 msgstr "繼續上一個工作階段"
+
+msgid "Contraction"
+msgstr "縮減"
 
 msgid "Contributions"
 msgstr "貢獻"
@@ -5740,6 +5755,9 @@ msgstr "展開討論"
 
 msgid "Expand workspace"
 msgstr "展開工作區"
+
+msgid "Expansion"
+msgstr "擴張"
 
 msgid "Experimental"
 msgstr "實驗功能"
@@ -8719,6 +8737,9 @@ msgstr "MRR"
 msgid "MRR — daily (Stripe)"
 msgstr "MRR — 按日（Stripe）"
 
+msgid "MRR from customers paying at the end of the prior month, as a share of what they paid then: expansion and contraction net of churn, new customers excluded"
+msgstr "上月底付費客戶的 MRR 佔其當時付費額的比例：擴張與縮減扣除流失後的淨值，不含新客戶"
+
 msgid "Multi-select"
 msgstr "多選"
 
@@ -8825,6 +8846,9 @@ msgstr "淨支出"
 
 msgid "Net burn — monthly (Mercury)"
 msgstr "淨支出 — 按月（Mercury）"
+
+msgid "Net revenue retention — monthly (Stripe)"
+msgstr "淨收入留存率 — 每月（Stripe）"
 
 msgid "Network Changed"
 msgstr "網路已變更"
@@ -9688,6 +9712,12 @@ msgstr "目前執行{0}（之前是{1}）。所有會話已關閉。"
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "如今，我們已從矽谷最好的投資人那裡融資<0>1100萬美元</0>，用來打造軟體工廠的平臺。"
+
+msgid "NRR"
+msgstr "NRR"
+
+msgid "NRR (month so far)"
+msgstr "NRR（本月至今）"
 
 msgid "Numbered list"
 msgstr "編號列表"
@@ -12023,6 +12053,9 @@ msgstr "恢復自動化"
 msgid "Resuming {0}…"
 msgstr "正在恢復{0}…"
 
+msgid "Retained MRR"
+msgstr "留存 MRR"
+
 msgid "Retention and revenue"
 msgstr "留存與營收"
 
@@ -13647,6 +13680,10 @@ msgstr "免費開始。團隊用不夠時再升級。企業方案面向有進階
 
 msgid "Start from a template"
 msgstr "從模板開始"
+
+#. placeholder {0}: datum.customers
+msgid "Start MRR ({0} customers)"
+msgstr "起始 MRR（{0} 位客戶）"
 
 msgid "Start new session"
 msgstr "開始新會話"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -1103,6 +1103,9 @@ msgstr "10分鐘"
 msgid "10+ concurrent workstreams without dropped state"
 msgstr "10條以上並行工作流且不丟狀態"
 
+msgid "100% (retain everything)"
+msgstr "100%（全部留存）"
+
 msgid "15 minutes"
 msgstr "15分鐘"
 
@@ -8683,6 +8686,12 @@ msgstr "按月"
 msgid "Monthly at {time}"
 msgstr "每月{time}"
 
+msgid "monthly NRR"
+msgstr "月度 NRR"
+
+msgid "monthly NRR (month so far)"
+msgstr "月度 NRR（本月至今）"
+
 msgid "Monthly on {day}"
 msgstr "每月{day}"
 
@@ -9712,12 +9721,6 @@ msgstr "目前執行{0}（之前是{1}）。所有會話已關閉。"
 
 msgid "Now, we've raised <0>$11M</0> from the best investors in Silicon Valley to build the platform for software factories."
 msgstr "如今，我們已從矽谷最好的投資人那裡融資<0>1100萬美元</0>，用來打造軟體工廠的平臺。"
-
-msgid "NRR"
-msgstr "NRR"
-
-msgid "NRR (month so far)"
-msgstr "NRR（本月至今）"
 
 msgid "Numbered list"
 msgstr "編號列表"

--- a/packages/trpc/src/router/analytics/business.ts
+++ b/packages/trpc/src/router/analytics/business.ts
@@ -127,21 +127,128 @@ data_freshness AS (
 SELECT daily_mrr_series.*, data_freshness.data_through
 FROM daily_mrr_series CROSS JOIN data_freshness`;
 
+// Net revenue retention, month over month: of the customers paying at the end
+// of one month, what they pay at the end of the next, as a share of what they
+// paid before — expansion and contraction net of churn, new customers excluded.
+// Same events table as MRR above, rolled up per customer at month ends. A
+// customer's MRR at a month end is the running sum of their changes, so the
+// per-customer spine walks every month from the first change to today: a month
+// with no events still has to carry the balance forward. A single latest FX
+// rate converts every currency: the figure is a ratio of the same customers'
+// MRR one month apart, so a rate that is a few days stale moves it by nothing
+// worth a daily FX join. Current month's row is what the cohort pays today.
+const NRR_SQL = `WITH fx AS (
+  SELECT CAST(JSON_PARSE(buy_currency_exchange_rates) AS MAP(VARCHAR, DOUBLE)) AS rate_per_usd
+  FROM exchange_rates_from_usd
+  ORDER BY date DESC
+  LIMIT 1
+),
+monthly_changes AS (
+  SELECT
+    customer_id,
+    DATE_TRUNC('month', DATE(local_event_timestamp)) AS month,
+    SUM(mrr_change / fx.rate_per_usd[currency] * fx.rate_per_usd['usd']) AS mrr_change_usd
+  FROM subscription_item_change_events_v2_beta
+  CROSS JOIN fx
+  GROUP BY 1, 2
+),
+months AS (
+  SELECT month
+  FROM UNNEST(SEQUENCE(
+    (SELECT MIN(month) FROM monthly_changes),
+    DATE_TRUNC('month', CURRENT_DATE),
+    INTERVAL '1' MONTH
+  )) AS t(month)
+),
+customer_months AS (
+  SELECT c.customer_id, m.month
+  FROM (SELECT DISTINCT customer_id FROM monthly_changes) c
+  CROSS JOIN months m
+),
+month_end_mrr AS (
+  SELECT
+    cm.customer_id,
+    cm.month,
+    SUM(COALESCE(mc.mrr_change_usd, 0)) OVER (
+      PARTITION BY cm.customer_id ORDER BY cm.month
+    ) AS mrr_usd
+  FROM customer_months cm
+  LEFT JOIN monthly_changes mc
+    ON mc.customer_id = cm.customer_id AND mc.month = cm.month
+),
+cohort AS (
+  SELECT cur.month, prev.mrr_usd AS start_mrr, cur.mrr_usd AS end_mrr
+  FROM month_end_mrr cur
+  JOIN month_end_mrr prev
+    ON prev.customer_id = cur.customer_id
+    AND prev.month = cur.month - INTERVAL '1' MONTH
+  WHERE prev.mrr_usd > 0
+),
+nrr AS (
+  SELECT
+    month,
+    COUNT(*) AS customers,
+    SUM(start_mrr) AS start_minor,
+    SUM(end_mrr) AS retained_minor,
+    SUM(GREATEST(end_mrr - start_mrr, 0)) AS expansion_minor,
+    SUM(CASE WHEN end_mrr > 0 THEN LEAST(end_mrr - start_mrr, 0) ELSE 0 END) AS contraction_minor,
+    SUM(CASE WHEN end_mrr <= 0 THEN end_mrr - start_mrr ELSE 0 END) AS churn_minor
+  FROM cohort
+  GROUP BY month
+),
+data_freshness AS (
+  SELECT TO_ISO8601(MAX(event_timestamp)) AS data_through
+  FROM subscription_item_change_events_v2_beta
+)
+SELECT
+  CAST(nrr.month AS VARCHAR) AS month,
+  nrr.customers,
+  ROUND(nrr.start_minor / 100, 2) AS start_mrr_usd,
+  ROUND(nrr.retained_minor / 100, 2) AS retained_mrr_usd,
+  ROUND(nrr.expansion_minor / 100, 2) AS expansion_usd,
+  ROUND(nrr.contraction_minor / 100, 2) AS contraction_usd,
+  ROUND(nrr.churn_minor / 100, 2) AS churn_usd,
+  data_freshness.data_through
+FROM nrr CROSS JOIN data_freshness
+WHERE nrr.month >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '12' MONTH
+ORDER BY nrr.month`;
+
 interface MrrPoint {
 	date: string;
 	mrrUsd: number;
 }
 
-type MrrResult =
-	| {
+interface NrrMonth {
+	/** First day of the month. */
+	month: string;
+	customers: number;
+	startMrrUsd: number;
+	retainedMrrUsd: number;
+	expansionUsd: number;
+	contractionUsd: number;
+	churnUsd: number;
+	nrrPct: number;
+}
+
+type SigmaResult<T extends object> =
+	| ({
 			available: true;
 			/** When we ran the query. */
 			dataLoadTime: string | null;
 			/** When Sigma's data actually ends — hours behind dataLoadTime. */
 			dataThrough: string | null;
-			points: MrrPoint[];
-	  }
+	  } & T)
 	| { available: false; reason: string };
+
+type MrrResult = SigmaResult<{ points: MrrPoint[] }>;
+type NrrResult = SigmaResult<{ months: NrrMonth[] }>;
+
+interface SigmaQuery<T extends object> {
+	cacheKey: string;
+	sql: string;
+	/** Null when the CSV does not have the columns the query promised. */
+	parse: (rows: Record<string, string>[]) => T | null;
+}
 
 interface QueryRun {
 	id: string;
@@ -157,37 +264,65 @@ function stripeHeaders() {
 	};
 }
 
-function parseMrrCsv(csv: string): {
-	points: MrrPoint[];
-	dataThrough: string | null;
-} {
+function parseSigmaCsv(csv: string): Record<string, string>[] {
 	const [header, ...rows] = csv.trim().split("\n");
 	const columns = (header ?? "").split(",").map((c) => c.replaceAll('"', ""));
-	const dayIndex = columns.indexOf("day");
-	const mrrIndex = columns.indexOf("total_mrr_in_usd");
-	const throughIndex = columns.indexOf("data_through");
-	if (dayIndex === -1 || mrrIndex === -1) {
-		return { points: [], dataThrough: null };
-	}
-	// One value for the whole run, repeated on every row by the CROSS JOIN.
-	// event_timestamp is UTC and TO_ISO8601 leaves the offset off, so pin it
-	// rather than let the reader guess a zone.
-	const through = (rows[0]?.split(",")[throughIndex] ?? "").replaceAll('"', "");
-	const points = rows
-		.map((row) => {
-			const cells = row.split(",").map((c) => c.replaceAll('"', ""));
-			return {
-				// Sigma emits "2026-08-04 00:00:00.000"; keep the date only
-				date: (cells[dayIndex] ?? "").slice(0, 10),
-				mrrUsd: Number(cells[mrrIndex] ?? Number.NaN),
-			};
-		})
-		.filter((p) => p.date && Number.isFinite(p.mrrUsd))
-		.sort((a, b) => a.date.localeCompare(b.date));
-	return { points, dataThrough: through ? `${through}Z` : null };
+	return rows.map((row) =>
+		Object.fromEntries(
+			row
+				.split(",")
+				.map((cell, index) => [columns[index] ?? "", cell.replaceAll('"', "")]),
+		),
+	);
 }
 
-// Sigma data refreshes ~daily and the query takes ~30-60s, so results are
+const MRR_QUERY: SigmaQuery<{ points: MrrPoint[] }> = {
+	cacheKey: "mrr",
+	sql: MRR_SQL,
+	parse: (rows) => {
+		const points = rows
+			.map((row) => ({
+				// Sigma emits "2026-08-04 00:00:00.000"; keep the date only
+				date: (row.day ?? "").slice(0, 10),
+				mrrUsd: Number(row.total_mrr_in_usd ?? Number.NaN),
+			}))
+			.filter((p) => p.date && Number.isFinite(p.mrrUsd))
+			.sort((a, b) => a.date.localeCompare(b.date));
+		return points.length ? { points } : null;
+	},
+};
+
+const NRR_QUERY: SigmaQuery<{ months: NrrMonth[] }> = {
+	cacheKey: "nrr",
+	sql: NRR_SQL,
+	parse: (rows) => {
+		const months = rows
+			.map((row) => {
+				const startMrrUsd = Number(row.start_mrr_usd ?? Number.NaN);
+				const retainedMrrUsd = Number(row.retained_mrr_usd ?? Number.NaN);
+				return {
+					month: (row.month ?? "").slice(0, 10),
+					customers: Number(row.customers ?? Number.NaN),
+					startMrrUsd,
+					retainedMrrUsd,
+					expansionUsd: Number(row.expansion_usd ?? Number.NaN),
+					contractionUsd: Number(row.contraction_usd ?? Number.NaN),
+					churnUsd: Number(row.churn_usd ?? Number.NaN),
+					nrrPct: (retainedMrrUsd / startMrrUsd) * 100,
+				};
+			})
+			.filter(
+				(m) =>
+					m.month &&
+					Number.isFinite(m.startMrrUsd) &&
+					Number.isFinite(m.nrrPct),
+			)
+			.sort((a, b) => a.month.localeCompare(b.month));
+		return months.length ? { months } : null;
+	},
+};
+
+// Sigma data refreshes ~daily and a query takes ~20-60s, so results are
 // cached for 12h. Requests never block on a running query: the first caller
 // kicks off a run and gets { available: false } immediately; later calls (the
 // tile re-polls, or the refresh job) check the same pending run until it lands.
@@ -196,22 +331,26 @@ function parseMrrCsv(csv: string): {
 // instance, so a poll rarely found the run its predecessor started and kicked
 // off a fresh one instead — the tile sat on "computing" indefinitely while
 // burning a Sigma run per dashboard load.
-const MRR_CACHE_KEY = "mrr";
-const MRR_PENDING_KEY = "mrr:pending";
-const MRR_CACHE_TTL_SECONDS = 12 * 60 * 60;
+const SIGMA_CACHE_TTL_SECONDS = 12 * 60 * 60;
 /** A run that has not landed by now is never landing; let the next caller retry. */
-const MRR_PENDING_TTL_SECONDS = 10 * 60;
+const SIGMA_PENDING_TTL_SECONDS = 10 * 60;
 /** Held between claiming the right to start a run and having its id. */
-const MRR_CLAIMING = "claiming";
-const MRR_COMPUTING_REASON = "computing";
+const SIGMA_CLAIMING = "claiming";
+const SIGMA_COMPUTING_REASON = "computing";
 
-async function createMrrRun(): Promise<MrrResult | { runId: string }> {
+function pendingKey(query: SigmaQuery<object>): string {
+	return `${query.cacheKey}:pending`;
+}
+
+async function createSigmaRun(
+	sql: string,
+): Promise<{ available: false; reason: string } | { runId: string }> {
 	const createResponse = await fetch(
 		"https://api.stripe.com/v2/data/reporting/query_runs",
 		{
 			method: "POST",
 			headers: { ...stripeHeaders(), "Content-Type": "application/json" },
-			body: JSON.stringify({ sql: MRR_SQL }),
+			body: JSON.stringify({ sql }),
 		},
 	);
 	const created = (await createResponse.json()) as QueryRun;
@@ -226,7 +365,10 @@ async function createMrrRun(): Promise<MrrResult | { runId: string }> {
 	return { runId: created.id };
 }
 
-async function collectMrrRun(runId: string): Promise<MrrResult | null> {
+async function collectSigmaRun<T extends object>(
+	query: SigmaQuery<T>,
+	runId: string,
+): Promise<SigmaResult<T> | null> {
 	const response = await fetch(
 		`https://api.stripe.com/v2/data/reporting/query_runs/${runId}`,
 		{ headers: stripeHeaders() },
@@ -238,29 +380,32 @@ async function collectMrrRun(runId: string): Promise<MrrResult | null> {
 	if (run.status !== "succeeded" || !downloadUrl) {
 		return { available: false, reason: `Sigma query ${run.status}` };
 	}
-	const csv = await (await fetch(downloadUrl)).text();
-	const { points, dataThrough } = parseMrrCsv(csv);
-	if (!points.length) {
+	const rows = parseSigmaCsv(await (await fetch(downloadUrl)).text());
+	const parsed = query.parse(rows);
+	if (!parsed) {
 		return { available: false, reason: "unexpected Sigma CSV columns" };
 	}
+	// One value for the whole run, repeated on every row by the CROSS JOIN.
+	// event_timestamp is UTC and TO_ISO8601 leaves the offset off, so pin it
+	// rather than let the reader guess a zone.
+	const through = rows[0]?.data_through ?? "";
 	return {
 		available: true,
 		dataLoadTime: new Date().toISOString(),
-		dataThrough,
-		points,
+		dataThrough: through ? `${through}Z` : null,
+		...parsed,
 	};
 }
 
 /**
- * Advance the MRR query by one step: serve the cache, else collect the run in
+ * Advance a Sigma query by one step: serve the cache, else collect the run in
  * flight, else start one. Never blocks on Stripe finishing — callers that want
  * a landed result call this until it stops saying "computing".
  */
-async function advanceSigmaMrr({
-	ignoreCache = false,
-}: {
-	ignoreCache?: boolean;
-} = {}): Promise<MrrResult> {
+async function advanceSigmaQuery<T extends object>(
+	query: SigmaQuery<T>,
+	{ ignoreCache = false }: { ignoreCache?: boolean } = {},
+): Promise<SigmaResult<T>> {
 	if (!env.STRIPE_SECRET_KEY) {
 		return { available: false, reason: "STRIPE_SECRET_KEY not configured" };
 	}
@@ -272,79 +417,106 @@ async function advanceSigmaMrr({
 	}
 
 	if (!ignoreCache) {
-		const cached = await readMetricCache<MrrResult>(MRR_CACHE_KEY);
+		const cached = await readMetricCache<SigmaResult<T>>(query.cacheKey);
 		if (cached?.available) return cached;
 	}
 
-	const pending = await readMetricCache<string>(MRR_PENDING_KEY);
-	if (pending && pending !== MRR_CLAIMING) {
-		const finished = await collectMrrRun(pending);
+	const pending = await readMetricCache<string>(pendingKey(query));
+	if (pending && pending !== SIGMA_CLAIMING) {
+		const finished = await collectSigmaRun(query, pending);
 		if (!finished) {
-			return { available: false, reason: MRR_COMPUTING_REASON };
+			return { available: false, reason: SIGMA_COMPUTING_REASON };
 		}
-		await writeMetricCache(MRR_CACHE_KEY, finished, MRR_CACHE_TTL_SECONDS);
-		await clearMetricCache(MRR_PENDING_KEY);
+		await writeMetricCache(query.cacheKey, finished, SIGMA_CACHE_TTL_SECONDS);
+		await clearMetricCache(pendingKey(query));
 		return finished;
 	}
-	if (pending === MRR_CLAIMING) {
-		return { available: false, reason: MRR_COMPUTING_REASON };
+	if (pending === SIGMA_CLAIMING) {
+		return { available: false, reason: SIGMA_COMPUTING_REASON };
 	}
 
 	// Whoever claims the key owns starting the run; everyone else waits for it
 	// rather than paying Stripe for a duplicate.
 	const claimed = await claimMetricCache(
-		MRR_PENDING_KEY,
-		MRR_CLAIMING,
-		MRR_PENDING_TTL_SECONDS,
+		pendingKey(query),
+		SIGMA_CLAIMING,
+		SIGMA_PENDING_TTL_SECONDS,
 	);
 	if (!claimed) {
-		return { available: false, reason: MRR_COMPUTING_REASON };
+		return { available: false, reason: SIGMA_COMPUTING_REASON };
 	}
 
-	const kicked = await createMrrRun();
+	const kicked = await createSigmaRun(query.sql);
 	if (!("runId" in kicked)) {
-		await clearMetricCache(MRR_PENDING_KEY);
+		await clearMetricCache(pendingKey(query));
 		return kicked;
 	}
 	await writeMetricCache(
-		MRR_PENDING_KEY,
+		pendingKey(query),
 		kicked.runId,
-		MRR_PENDING_TTL_SECONDS,
+		SIGMA_PENDING_TTL_SECONDS,
 	);
-	return { available: false, reason: MRR_COMPUTING_REASON };
+	return { available: false, reason: SIGMA_COMPUTING_REASON };
 }
 
 /**
- * Drive the query to completion. Used by the refresh job, which has the time
- * budget to wait and exists so the tile only ever reads a landed result.
+ * Drive a query to completion. Used by the refresh job, which has the time
+ * budget to wait and exists so the tiles only ever read a landed result.
  */
-export async function refreshSigmaMrr({
-	timeBudgetMs = 120_000,
-	pollIntervalMs = 5_000,
-}: {
-	timeBudgetMs?: number;
-	pollIntervalMs?: number;
-} = {}): Promise<MrrResult> {
+async function refreshSigmaQuery<T extends object>(
+	query: SigmaQuery<T>,
+	{
+		timeBudgetMs = 120_000,
+		pollIntervalMs = 5_000,
+	}: { timeBudgetMs?: number; pollIntervalMs?: number } = {},
+): Promise<SigmaResult<T>> {
 	const startedAt = Date.now();
 	// Ignore the cache on every step. The job runs more often than the entry
 	// expires, so honouring it would hand back the previous result before the
 	// pending run is ever collected — the tile would then only move when the
 	// entry lapsed, with a Sigma run burnt every hour for nothing. The finished
 	// run is returned straight from the pending branch, not via the cache.
-	let last = await advanceSigmaMrr({ ignoreCache: true });
+	let last = await advanceSigmaQuery(query, { ignoreCache: true });
 	while (
 		!last.available &&
-		last.reason === MRR_COMPUTING_REASON &&
+		last.reason === SIGMA_COMPUTING_REASON &&
 		Date.now() - startedAt < timeBudgetMs
 	) {
 		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-		last = await advanceSigmaMrr({ ignoreCache: true });
+		last = await advanceSigmaQuery(query, { ignoreCache: true });
 	}
 	return last;
 }
 
-async function fetchLatestSigmaMrr(): Promise<MrrResult> {
-	return advanceSigmaMrr();
+export function refreshSigmaMrr(): Promise<MrrResult> {
+	return refreshSigmaQuery(MRR_QUERY);
+}
+
+export function refreshSigmaNrr(): Promise<NrrResult> {
+	return refreshSigmaQuery(NRR_QUERY);
+}
+
+// A tile's refresh button. The hourly job already keeps the entry warm, so the
+// only reason to press this is to get past the cached figure — hence dropping
+// the entry rather than just re-reading it. Dropping it is also what makes the
+// tile's poll follow the new run: the getter serves the cache before it ever
+// looks at a pending run, so an entry left in place would leave this run
+// uncollected until the next hourly job.
+//
+// Kicking the run is all this does. Sigma takes 20-60s and the tRPC route
+// caps at 60s, so driving it to completion here would be a coin flip against
+// the function timeout; the tile polls it down instead.
+async function kickSigmaRefresh<T extends object>(
+	query: SigmaQuery<T>,
+): Promise<SigmaResult<T>> {
+	const result = await advanceSigmaQuery(query, { ignoreCache: true });
+	// Only drop the cached figure once there is a run to replace it with, so a
+	// Stripe blip leaves the last good number on screen rather than trading it
+	// for an error.
+	if (!result.available && result.reason === SIGMA_COMPUTING_REASON) {
+		await clearMetricCache(query.cacheKey);
+	}
+	return result;
 }
 
 interface MercuryAccount {
@@ -609,28 +781,11 @@ async function fetchMercuryCashFlow(): Promise<CashFlowResult> {
 }
 
 export const businessRouter = {
-	getMrr: adminProcedure.query(() => fetchLatestSigmaMrr()),
+	getMrr: adminProcedure.query(() => advanceSigmaQuery(MRR_QUERY)),
+	refreshMrr: adminProcedure.mutation(() => kickSigmaRefresh(MRR_QUERY)),
 
-	// The tile's refresh button. The hourly job already keeps the entry warm,
-	// so the only reason to press this is to get past the cached figure —
-	// hence dropping the entry rather than just re-reading it. Dropping it is
-	// also what makes the tile's poll follow the new run: getMrr serves the
-	// cache before it ever looks at a pending run, so an entry left in place
-	// would leave this run uncollected until the next hourly job.
-	//
-	// Kicking the run is all this does. Sigma takes 30-60s and the tRPC route
-	// caps at 60s, so driving it to completion here would be a coin flip
-	// against the function timeout; the tile polls it down instead.
-	refreshMrr: adminProcedure.mutation(async () => {
-		const result = await advanceSigmaMrr({ ignoreCache: true });
-		// Only drop the cached figure once there is a run to replace it with,
-		// so a Stripe blip leaves the last good number on screen rather than
-		// trading it for an error.
-		if (!result.available && result.reason === MRR_COMPUTING_REASON) {
-			await clearMetricCache(MRR_CACHE_KEY);
-		}
-		return result;
-	}),
+	getNrr: adminProcedure.query(() => advanceSigmaQuery(NRR_QUERY)),
+	refreshNrr: adminProcedure.mutation(() => kickSigmaRefresh(NRR_QUERY)),
 
 	// Cohort survival: % of subscriptions started in a month still active k
 	// months later. Neon is authoritative for subscription state (D-10).
@@ -717,8 +872,7 @@ export const businessRouter = {
 		}),
 
 	// Logo retention: % of orgs subscribed at the end of month m still
-	// subscribed at the end of m+1. Count-based — dollar NRR needs a second
-	// Sigma query and is intentionally out of scope here.
+	// subscribed at the end of m+1. Count-based; the dollar view is getNrr.
 	getLogoRetention: adminProcedure
 		.input(z.object({ months: z.number().min(3).max(24).default(8) }))
 		.query(async ({ input }) => {

--- a/packages/trpc/src/router/analytics/business.ts
+++ b/packages/trpc/src/router/analytics/business.ts
@@ -297,26 +297,23 @@ const NRR_QUERY: SigmaQuery<{ months: NrrMonth[] }> = {
 	sql: NRR_SQL,
 	parse: (rows) => {
 		const months = rows
-			.map((row) => {
-				const startMrrUsd = Number(row.start_mrr_usd ?? Number.NaN);
-				const retainedMrrUsd = Number(row.retained_mrr_usd ?? Number.NaN);
-				return {
-					month: (row.month ?? "").slice(0, 10),
+			.flatMap((row) => {
+				const numbers = {
 					customers: Number(row.customers ?? Number.NaN),
-					startMrrUsd,
-					retainedMrrUsd,
+					startMrrUsd: Number(row.start_mrr_usd ?? Number.NaN),
+					retainedMrrUsd: Number(row.retained_mrr_usd ?? Number.NaN),
 					expansionUsd: Number(row.expansion_usd ?? Number.NaN),
 					contractionUsd: Number(row.contraction_usd ?? Number.NaN),
 					churnUsd: Number(row.churn_usd ?? Number.NaN),
-					nrrPct: (retainedMrrUsd / startMrrUsd) * 100,
 				};
+				const month = (row.month ?? "").slice(0, 10);
+				const nrrPct = (numbers.retainedMrrUsd / numbers.startMrrUsd) * 100;
+				const valid =
+					month &&
+					Number.isFinite(nrrPct) &&
+					Object.values(numbers).every(Number.isFinite);
+				return valid ? [{ month, ...numbers, nrrPct }] : [];
 			})
-			.filter(
-				(m) =>
-					m.month &&
-					Number.isFinite(m.startMrrUsd) &&
-					Number.isFinite(m.nrrPct),
-			)
 			.sort((a, b) => a.month.localeCompare(b.month));
 		return months.length ? { months } : null;
 	},


### PR DESCRIPTION
## What

A **Net revenue retention — monthly (Stripe)** tile on the admin Company tab, full width under MRR.

For each month the cohort is every customer paying at the end of the prior month; the figure is what they pay at the end of this month as a share of what they paid then — expansion and contraction net of churn, new customers excluded. Headline is the last complete month, the current month is drawn dashed, and the tooltip breaks the movement into start MRR, expansion, contraction, churn, and retained MRR.

## How

- A second Stripe Sigma query on `subscription_item_change_events_v2_beta`: per-customer MRR at each month end is the running sum of `mrr_change` over a customer × month spine, converted with one latest FX rate. Enterprise is included, matching the MRR tile.
- The Sigma run/cache plumbing in `business.ts` is now generic over a `SigmaQuery { cacheKey, sql, parse }` descriptor, so NRR reuses the claim → run → collect → cache flow. `getNrr` / `refreshNrr` sit beside `getMrr` / `refreshMrr`.
- The hourly `refresh-mrr` job warms both queries; the route path is unchanged so the QStash schedule keeps working.
- `useSigmaMetric` hook in admin carries the "computing" poll and hold-last-landed-result behaviour; `MrrTile` moved onto it, `NrrTile` uses it.
- 11 new strings translated in all 16 locales; `check:i18n` passes.

## Verified

- Query run live against Stripe: every row reconciles (start + expansion + contraction + churn = retained); ~20s per run.
- Admin app driven headless with a minted company-domain session: tile goes from "Computing in Stripe" to the landed chart, the cache sees exactly one run per query, tooltip renders the breakdown. August: $14,510 from 541 customers → $12,875, 88.7%.
- `bun test` in `packages/trpc` (276 pass with the root `.env` loaded) and `apps/api`; typecheck and biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a monthly net revenue retention (NRR) tile to the admin Company tab, showing what customers paying at the end of one month pay at the end of the next, net of churn and excluding new customers. The current month is drawn dashed and kept out of the headline; the tooltip breaks the movement into start MRR, expansion, contraction, churn, and retained MRR. The chart reads like the PostHog insight: Y axis from zero, a 100% goal line labelled "retain everything", and a taller default cell so the axis stays in view.

**Refactors**
- Generalizes the Sigma run/cache plumbing in `business.ts` over a `SigmaQuery` descriptor so NRR reuses the claim → run → collect → cache flow; unparseable NRR rows are dropped before they reach the tile.
- Adds a `useSigmaMetric` hook for the computing poll and hold-last-landed-result behavior; `MrrTile` moved onto it and `NrrTile` uses it.
- Warms both queries from the hourly `refresh-mrr` job, settling each independently so one failure doesn't block the other; the route path is unchanged so the QStash schedule keeps working.
- Reflows the dashboard: NRR sits beside enterprise ARR (half width, tall) and burn by vendor beside net burn (half width, chart height), with the vendor and enterprise ARR lists vertically centred in their taller cells.

<sup>Written for commit b4bfd822888fb8bbf488a8941aa79a4174876459. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a monthly Net Revenue Retention (NRR) tile to the company dashboard.
  * NRR includes headline retention, customer and MRR details, trend charts, partial-month status, and metric breakdowns.
  * MRR and NRR support refresh, loading, computing, unavailable, and error states.
  * Dashboard refreshes report MRR and NRR results independently.
  * Updated dashboard tile layout and sizing for improved presentation.

* **Localization**
  * Added translations for NRR, MRR retention, churn, contraction, expansion, and related labels across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->