### PR TITLE
fix: narrow where short-lived secrets and sign-in states stay valid

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/auth/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/index.ts
@@ -10,6 +10,7 @@ import { env as sharedEnv } from "shared/env.shared";
 import { z } from "zod";
 import { publicProcedure, router } from "../..";
 import {
+	AUTH_STATE_TTL_MS,
 	authEvents,
 	clearToken,
 	loadToken,
@@ -90,8 +91,8 @@ export const createAuthRouter = () => {
 					const state = crypto.randomBytes(32).toString("base64url");
 					stateStore.set(state, Date.now());
 
-					// Clean up expired states (10 minutes)
-					const cutoff = Date.now() - 10 * 60 * 1000;
+					// Clean up expired states
+					const cutoff = Date.now() - AUTH_STATE_TTL_MS;
 					for (const [s, ts] of stateStore) {
 						if (ts < cutoff) stateStore.delete(s);
 					}

--- a/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.test.ts
@@ -26,6 +26,7 @@ mock.module("./crypto-storage", () => ({
 }));
 
 const {
+	AUTH_STATE_TTL_MS,
 	authEvents,
 	clearToken,
 	handleAuthCallback,
@@ -186,6 +187,21 @@ describe("auth token storage", () => {
 
 		expect(retriedResult).toEqual({ success: true });
 		expect(stateStore.has(state)).toBe(false);
+	});
+
+	test("rejects a sign-in state older than its TTL", async () => {
+		const state = "stale-state";
+		stateStore.set(state, Date.now() - AUTH_STATE_TTL_MS - 1);
+
+		const result = await handleAuthCallback({
+			token: "token",
+			expiresAt: "2099-01-01",
+			state,
+		});
+
+		expect(result.success).toBe(false);
+		expect(stateStore.has(state)).toBe(false);
+		expect(fs.existsSync(tokenFile)).toBe(false);
 	});
 
 	test("sign-out clears unusable storage from the token path before reporting success", async () => {

--- a/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts
+++ b/apps/desktop/src/lib/trpc/routers/auth/utils/auth-functions.ts
@@ -202,6 +202,8 @@ async function writeStoredAuth(storedAuth: StoredAuth): Promise<void> {
 }
 
 export const stateStore = new Map<string, number>();
+/** How long a sign-in started with `signIn` may take to come back. */
+export const AUTH_STATE_TTL_MS = 10 * 60 * 1000;
 let authWriteQueue: Promise<unknown> = Promise.resolve();
 
 function serializeAuthWrite<Result>(
@@ -342,6 +344,11 @@ export async function handleAuthCallback(params: {
 		return { success: false, error: "Invalid or expired auth session" };
 	}
 	stateStore.delete(params.state);
+	// signIn only sweeps expired states when the next sign-in starts, so
+	// without this check a state stays valid until the app restarts.
+	if (Date.now() - stateIssuedAt > AUTH_STATE_TTL_MS) {
+		return { success: false, error: "Invalid or expired auth session" };
+	}
 
 	try {
 		await saveToken({ token: params.token, expiresAt: params.expiresAt });

--- a/packages/host-service/src/providers/git/askpass.test.ts
+++ b/packages/host-service/src/providers/git/askpass.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile, rm, stat } from "node:fs/promises";
+import { writeTempAskpass } from "./askpass";
+
+const written: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		written.splice(0).map((filePath) => rm(filePath, { force: true })),
+	);
+});
+
+describe("writeTempAskpass", () => {
+	test("never exposes the token to other users, even before chmod", async () => {
+		const filePath = await writeTempAskpass("ghp_secret");
+		written.push(filePath);
+
+		const { mode } = await stat(filePath);
+		expect(mode & 0o077).toBe(0);
+		expect(mode & 0o700).toBe(0o700);
+		expect(await readFile(filePath, "utf8")).toContain('echo "ghp_secret"');
+	});
+});

--- a/packages/host-service/src/providers/git/askpass.ts
+++ b/packages/host-service/src/providers/git/askpass.ts
@@ -11,7 +11,7 @@ case "$1" in
   *) echo "${token}" ;;
 esac
 `;
-	await writeFile(filePath, script);
+	await writeFile(filePath, script, { mode: 0o700 });
 	await chmod(filePath, 0o700);
 	return filePath;
 }

--- a/packages/host-service/src/terminal/env-strip.ts
+++ b/packages/host-service/src/terminal/env-strip.ts
@@ -34,6 +34,9 @@ const STRIP_PREFIXES = [
 	"NEXT_PUBLIC_",
 	"TURBO_",
 	"HOST_",
+	// Loopback control surface for the desktop's in-app browser panes; the
+	// secret authorizes CDP-level control and belongs to host-service only.
+	"BROWSER_BRIDGE_",
 ];
 
 const SUPERSET_KEEP_KEYS = new Set([

--- a/packages/host-service/src/terminal/env.test.ts
+++ b/packages/host-service/src/terminal/env.test.ts
@@ -119,6 +119,9 @@ describe("stripTerminalRuntimeEnv", () => {
 		// Auth refresh tokens inherited from parent (CLI/desktop) env
 		OAUTH_REFRESH_TOKEN: "oauth-refresh-secret",
 		SUPERSET_REFRESH_TOKEN: "superset-refresh-secret",
+		// Desktop browser-bridge control surface handed to host-service at spawn
+		BROWSER_BRIDGE_URL: "http://127.0.0.1:51799",
+		BROWSER_BRIDGE_SECRET: "bridge-secret",
 		// Keys that SHOULD survive
 		HOME: "/Users/test",
 		PATH: "/usr/bin:/usr/local/bin",
@@ -170,6 +173,12 @@ describe("stripTerminalRuntimeEnv", () => {
 		const result = stripTerminalRuntimeEnv(secretsEnv);
 		expect(result.OAUTH_REFRESH_TOKEN).toBeUndefined();
 		expect(result.SUPERSET_REFRESH_TOKEN).toBeUndefined();
+	});
+
+	test("browser bridge secret and endpoint do not reach PTY env", () => {
+		const result = stripTerminalRuntimeEnv(secretsEnv);
+		expect(result.BROWSER_BRIDGE_SECRET).toBeUndefined();
+		expect(result.BROWSER_BRIDGE_URL).toBeUndefined();
 	});
 
 	test("HOST_* prefix is stripped, DESKTOP_* exact keys only", () => {


### PR DESCRIPTION
Three places where a short-lived secret was kept around more loosely than it needs to be:

- **Terminal env (`host-service`)** — `stripTerminalRuntimeEnv` didn't strip `BROWSER_BRIDGE_URL` / `BROWSER_BRIDGE_SECRET`. They only matter to the desktop process that spawns host-service, but when the login-shell probe times out (8s on a slow rc file) the PTY env falls back to a `process.env` snapshot, so every terminal — and every agent started in one — inherited them. Added to the stripped prefixes.
- **Git askpass helper** — the token-bearing script was written with the default mode and `chmod`'ed to `0700` afterwards, so it was briefly readable by anyone in the temp dir. The mode is now passed at creation.
- **Desktop OAuth callback** — `handleAuthCallback` accepted any state still in `stateStore`, and expired entries were only swept when the *next* sign-in began, so a state from an abandoned sign-in stayed usable until the app restarted. The callback now applies the same 10-minute TTL `signIn` already uses.

Tests cover all three.

Part of an audit pass over the v2 stack on macOS.

https://claude.ai/code/session_01HmVz1yzkCEfnfDYDQxjN8u


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes three places where short-lived secrets and sign-in states stayed valid longer than needed: the browser-bridge secret leaked into terminal env, the git askpass token was briefly world-readable, and an abandoned OAuth sign-in state stayed usable until app restart.

**Bug Fixes**
- `stripTerminalRuntimeEnv` now strips `BROWSER_BRIDGE_URL` and `BROWSER_BRIDGE_SECRET`, which previously reached every terminal and agent when a login-shell probe timed out.
- `writeTempAskpass` now creates the token-bearing script with mode `0o700`, closing the window where the token was world-readable before the `chmod`.
- `handleAuthCallback` now rejects sign-in states older than 10 minutes; previously they were only swept when the next sign-in began, so a state from an abandoned sign-in stayed valid until app restart.
- Tests cover all three fixes.

<sup>Written for commit 8b177abbb1763c65167d2fcd31b59d3ab7e4662a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth sign-in callbacks now reject expired authentication states after 10 minutes.
  - Browser bridge credentials are no longer passed to terminal sessions.
  - Temporary Git authentication files are created with owner-only permissions.

- **Tests**
  - Added coverage for expired authentication states, protected temporary files, and removal of browser bridge variables from terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->