### PR TITLE
fix(desktop): don't let the browser pane or Open in Finder act with the app's authority

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/browser/browser.ts
+++ b/apps/desktop/src/lib/trpc/routers/browser/browser.ts
@@ -340,30 +340,23 @@ export const createBrowserRouter = () => {
 				};
 			}),
 
+		// Guest pages share the app renderer's partition, so clearing local
+		// storage / IndexedDB there would also wipe the app's own persisted
+		// state (layouts, hotkeys, theme). Only cookies and the HTTP cache —
+		// which the app itself doesn't use — can be cleared through here.
 		clearBrowsingData: publicProcedure
 			.input(
 				z.object({
-					type: z.enum(["cookies", "cache", "storage", "all"]),
+					type: z.enum(["cookies", "cache", "all"]),
 				}),
 			)
 			.mutation(async ({ input }) => {
 				const ses = session.fromPartition("persist:superset");
-				switch (input.type) {
-					case "cookies":
-						await ses.clearStorageData({ storages: ["cookies"] });
-						break;
-					case "cache":
-						await ses.clearCache();
-						break;
-					case "storage":
-						await ses.clearStorageData({
-							storages: ["localstorage", "indexdb"],
-						});
-						break;
-					case "all":
-						await ses.clearStorageData();
-						await ses.clearCache();
-						break;
+				if (input.type === "cookies" || input.type === "all") {
+					await ses.clearStorageData({ storages: ["cookies"] });
+				}
+				if (input.type === "cache" || input.type === "all") {
+					await ses.clearCache();
 				}
 				return { success: true };
 			}),

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import {
 	getAppCommand,
+	isMacOsBundlePath,
+	openFolderInFileBrowser,
 	pathIsMissing,
 	RelativePathWithoutCwdError,
 	resolvePath,
@@ -796,5 +798,84 @@ describe("pathIsMissing", () => {
 		// ENAMETOOLONG: we cannot tell whether the path is there, so the app
 		// still gets to try and its failure still reports.
 		expect(await pathIsMissing(`/${"a".repeat(5000)}`)).toBe(false);
+	});
+});
+
+describe("isMacOsBundlePath", () => {
+	test("recognizes app and plugin bundles regardless of case", () => {
+		expect(isMacOsBundlePath("/Applications/Evil.app")).toBe(true);
+		expect(isMacOsBundlePath("/tmp/Evil.APP")).toBe(true);
+		expect(isMacOsBundlePath("/tmp/thing.prefPane")).toBe(true);
+		expect(isMacOsBundlePath("/tmp/run.workflow")).toBe(true);
+	});
+
+	test("leaves ordinary folders alone", () => {
+		expect(isMacOsBundlePath("/tmp/project")).toBe(false);
+		expect(isMacOsBundlePath("/tmp/app")).toBe(false);
+		expect(isMacOsBundlePath("/tmp/my.folder")).toBe(false);
+	});
+});
+
+describe("openFolderInFileBrowser", () => {
+	let tmpDir: string;
+	const originalPlatform = process.platform;
+	const opened: string[] = [];
+	const openPath = async (path: string) => {
+		opened.push(path);
+		return "";
+	};
+
+	beforeEach(async () => {
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		opened.length = 0;
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "open-folder-"));
+	});
+
+	afterEach(async () => {
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	test("opens a plain folder", async () => {
+		const folder = path.join(tmpDir, "project");
+		await fs.mkdir(folder);
+		await openFolderInFileBrowser(folder, openPath);
+		expect(opened).toEqual([folder]);
+	});
+
+	test("refuses an app bundle even though it stats as a directory", async () => {
+		const bundle = path.join(tmpDir, "Evil.app");
+		await fs.mkdir(bundle);
+		await expect(openFolderInFileBrowser(bundle, openPath)).rejects.toThrow(
+			/application bundle/,
+		);
+		expect(opened).toEqual([]);
+	});
+
+	test("refuses a symlink that resolves to an app bundle", async () => {
+		const bundle = path.join(tmpDir, "Evil.app");
+		await fs.mkdir(bundle);
+		const link = path.join(tmpDir, "innocent");
+		await fs.symlink(bundle, link);
+		await expect(openFolderInFileBrowser(link, openPath)).rejects.toThrow(
+			/application bundle/,
+		);
+		expect(opened).toEqual([]);
+	});
+
+	test("refuses a file, which would open in its default handler", async () => {
+		const script = path.join(tmpDir, "run.command");
+		await fs.writeFile(script, "#!/bin/sh\necho hi\n", { mode: 0o755 });
+		await expect(openFolderInFileBrowser(script, openPath)).rejects.toThrow(
+			/Not a folder/,
+		);
+		expect(opened).toEqual([]);
+	});
+
+	test("reports a missing path as not found", async () => {
+		await expect(
+			openFolderInFileBrowser(path.join(tmpDir, "gone"), openPath),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+		expect(opened).toEqual([]);
 	});
 });

--- a/apps/desktop/src/lib/trpc/routers/external/helpers.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/helpers.ts
@@ -390,6 +390,89 @@ export async function pathIsMissing(filePath: string): Promise<boolean> {
 }
 
 /**
+ * Directory extensions macOS Launch Services treats as a package to *run or
+ * install* rather than a folder to browse. `shell.openPath("/x/Evil.app")`
+ * launches Evil, and a `.app` stats as a plain directory, so "is a directory"
+ * alone does not make a path safe to hand to `open`. Matched
+ * case-insensitively, the way the filesystem and Launch Services do.
+ */
+const MACOS_BUNDLE_EXTENSIONS = new Set([
+	".app",
+	".appex",
+	".bundle",
+	".framework",
+	".plugin",
+	".kext",
+	".prefpane",
+	".qlgenerator",
+	".xpc",
+	".osax",
+	".mdimporter",
+	".component",
+	".wdgt",
+	".saver",
+	".action",
+	".workflow",
+	".mpkg",
+	".pkg",
+	".scptd",
+]);
+
+export function isMacOsBundlePath(filePath: string): boolean {
+	return MACOS_BUNDLE_EXTENSIONS.has(nodePath.extname(filePath).toLowerCase());
+}
+
+/**
+ * Opens a folder in the OS file browser (Finder), refusing anything that would
+ * launch instead. The path may come from untrusted text (a terminal link, a
+ * repo path), so a `.app` bundle — or a symlink to one, hence `realpath` —
+ * must not reach `shell.openPath`, and neither may a file, which would open
+ * in its default handler (Terminal for `.command`/`.sh`).
+ */
+export async function openFolderInFileBrowser(
+	filePath: string,
+	openPath: (path: string) => Promise<string>,
+): Promise<void> {
+	let realPath: string;
+	let isDirectory: boolean;
+	try {
+		realPath = await fs.realpath(filePath);
+		isDirectory = (await fs.stat(realPath)).isDirectory();
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "This folder no longer exists.",
+			});
+		}
+		throw error;
+	}
+	if (!isDirectory) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Not a folder.",
+		});
+	}
+	if (
+		process.platform === "darwin" &&
+		(isMacOsBundlePath(realPath) || isMacOsBundlePath(filePath))
+	) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Refusing to open an application bundle.",
+		});
+	}
+	const errorMessage = await openPath(filePath);
+	if (errorMessage) {
+		throw new TRPCError({
+			code: "INTERNAL_SERVER_ERROR",
+			message: errorMessage,
+		});
+	}
+}
+
+/**
  * Spawns a process and waits for it to complete.
  * @throws Error if the process exits with non-zero code or fails to spawn
  */

--- a/apps/desktop/src/lib/trpc/routers/external/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/external/index.ts
@@ -18,6 +18,7 @@ import { getWorkspacePath } from "../workspaces/utils/worktree";
 import {
 	type ExternalApp,
 	getAppCommand,
+	openFolderInFileBrowser,
 	pathIsMissing,
 	RelativePathWithoutCwdError,
 	resolvePath,
@@ -121,6 +122,38 @@ async function openPathInApp(
 }
 
 /**
+ * Fallback for openFileInEditor when no editor is configured. The path may be
+ * untrusted (a Cmd+clicked terminal link), so it must open as a *document*:
+ * `shell.openPath` hands it to the OS default handler, which for `.command`,
+ * `.sh`, an executable, or an app bundle means running it. macOS `open -t`
+ * asks the default text editor instead; folders go through the bundle guard.
+ */
+async function openInDefaultEditor(filePath: string): Promise<void> {
+	let isDirectory: boolean;
+	try {
+		isDirectory = (await fs.promises.stat(filePath)).isDirectory();
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ENOENT" || code === "ENOTDIR") {
+			throw new TRPCError({
+				code: "NOT_FOUND",
+				message: "This file no longer exists.",
+			});
+		}
+		throw error;
+	}
+	if (isDirectory) {
+		await openFolderInFileBrowser(filePath, (path) => shell.openPath(path));
+		return;
+	}
+	if (process.platform === "darwin") {
+		await spawnAsync("open", ["-t", filePath]);
+		return;
+	}
+	await shell.openPath(filePath);
+}
+
+/**
  * External operations router.
  * Handles opening URLs and files in external applications.
  */
@@ -171,13 +204,7 @@ export const createExternalRouter = () => {
 						message: `openFolderInFinder requires an absolute path (got ${JSON.stringify(input)}).`,
 					});
 				}
-				const errorMessage = await shell.openPath(input);
-				if (errorMessage) {
-					throw new TRPCError({
-						code: "INTERNAL_SERVER_ERROR",
-						message: errorMessage,
-					});
-				}
+				await openFolderInFileBrowser(input, (path) => shell.openPath(path));
 			}),
 
 		saveToDownloads: publicProcedure
@@ -323,10 +350,10 @@ export const createExternalRouter = () => {
 					const app = input.app ?? resolveDefaultEditor(input.projectId);
 
 					if (!app) {
-						// No preferred editor configured yet.
-						// Fall back to OS default file handler so Cmd/Ctrl+click still works
-						// even when Cursor (or any specific editor) isn't installed.
-						await shell.openPath(filePath);
+						// No preferred editor configured yet: fall back to the OS
+						// default text editor so Cmd/Ctrl+click still works even when
+						// Cursor (or any specific editor) isn't installed.
+						await openInDefaultEditor(filePath);
 						return;
 					}
 

--- a/apps/desktop/src/main/lib/browser/browser-manager.test.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.test.ts
@@ -32,13 +32,22 @@ type WindowOpenHandler = (
 	details: Electron.HandlerDetails,
 ) => Electron.WindowOpenHandlerResponse;
 
+interface FakeSession {
+	setPermissionRequestHandler: ReturnType<typeof mock>;
+	setPermissionCheckHandler: ReturnType<typeof mock>;
+}
+
+type Listener = (...args: unknown[]) => void;
+
 interface FakeWebContents {
 	throttlingCalls: boolean[];
+	session: FakeSession;
+	listeners: Map<string, Listener>;
 	isDestroyed: () => boolean;
 	setBackgroundThrottling: (allowed: boolean) => void;
 	setWindowOpenHandler: (handler: WindowOpenHandler) => void;
 	windowOpen: WindowOpenHandler | null;
-	on: () => void;
+	on: (event: string, listener: Listener) => void;
 	off: () => void;
 	getURL: () => string;
 	getTitle: () => string;
@@ -55,10 +64,23 @@ interface FakeWebContents {
 
 let nextId = 1;
 
-function makeWc(): { wc: FakeWebContents; id: number } {
+function makeSession(): FakeSession {
+	return {
+		setPermissionRequestHandler: mock(() => {}),
+		setPermissionCheckHandler: mock(() => {}),
+	};
+}
+
+function makeWc(session: FakeSession = makeSession()): {
+	wc: FakeWebContents;
+	id: number;
+} {
 	const throttlingCalls: boolean[] = [];
+	const listeners = new Map<string, Listener>();
 	const wc: FakeWebContents = {
 		throttlingCalls,
+		session,
+		listeners,
 		isDestroyed: () => false,
 		setBackgroundThrottling: (allowed: boolean) => {
 			throttlingCalls.push(allowed);
@@ -67,7 +89,9 @@ function makeWc(): { wc: FakeWebContents; id: number } {
 			wc.windowOpen = handler;
 		},
 		windowOpen: null,
-		on: () => {},
+		on: (event, listener) => {
+			listeners.set(event, listener);
+		},
 		off: () => {},
 		getURL: () => "https://example.com",
 		getTitle: () => "Example",
@@ -374,6 +398,19 @@ describe("forced CDP detach", () => {
 	});
 });
 
+describe("guest permission policy", () => {
+	test("register installs the permission handlers on the guest's session, once", () => {
+		const session = makeSession();
+		const a = makeWc(session);
+		const b = makeWc(session);
+		browserManager.register("pane-perm-a", a.id, "ws-1");
+		browserManager.register("pane-perm-b", b.id, "ws-1");
+		registered.push("pane-perm-a", "pane-perm-b");
+		expect(session.setPermissionRequestHandler).toHaveBeenCalledTimes(1);
+		expect(session.setPermissionCheckHandler).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("host window key forwarding", () => {
 	type BeforeInput = (
 		event: { preventDefault: () => void },
@@ -385,6 +422,7 @@ describe("host window key forwarding", () => {
 		const wc = {
 			id: 4242,
 			focusedFrame,
+			session: makeSession(),
 			on: (event: string, listener: BeforeInput) => {
 				if (event === "before-input-event") handler = listener;
 			},

--- a/apps/desktop/src/main/lib/browser/browser-manager.ts
+++ b/apps/desktop/src/main/lib/browser/browser-manager.ts
@@ -18,6 +18,7 @@ import {
 import { DesignModeController } from "./design-mode-controller";
 import { captureDesignModeScreenshot } from "./design-mode-screenshot";
 import { buildDesignModeScript } from "./design-mode-script";
+import { installGuestPermissionPolicy } from "./guest-permissions";
 import { markBrowserPanePopup, shouldOpenAsPopup } from "./popup-window";
 
 interface ConsoleEntry {
@@ -257,6 +258,10 @@ class BrowserManager extends EventEmitter {
 		});
 		const wc = webContents.fromId(webContentsId);
 		if (wc) {
+			// Electron grants every permission (camera, mic, geolocation, screen
+			// capture, openExternal, …) to a page unless the session has a
+			// handler; the guest is hostile content, so it gets an allowlist.
+			installGuestPermissionPolicy(wc.session);
 			// Throttling stays enabled by default so parked/offscreen persistent
 			// webviews don't run at full speed in the background — except while
 			// agent work is in flight on the pane (see acquireAgentWake), where a
@@ -359,6 +364,9 @@ class BrowserManager extends EventEmitter {
 	 * top frame is left alone so the renderer handles the real event.
 	 */
 	registerHostWindow(wc: Electron.WebContents): void {
+		// The host window's subframes load web content too; the policy is
+		// per-session, so this also covers a pane that registers later.
+		installGuestPermissionPolicy(wc.session);
 		wc.on("before-input-event", (event, input) => {
 			if (input.type !== "keyDown") return;
 			if (!wc.focusedFrame?.parent) return;

--- a/apps/desktop/src/main/lib/browser/guest-permissions.test.ts
+++ b/apps/desktop/src/main/lib/browser/guest-permissions.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import {
+	installGuestPermissionPolicy,
+	isGuestSubject,
+	shouldGrantPermission,
+} from "./guest-permissions";
+import { markBrowserPanePopup } from "./popup-window";
+
+function contentsOf(type: "window" | "webview") {
+	return { getType: () => type } as Electron.WebContents;
+}
+
+describe("isGuestSubject", () => {
+	test("the app's own top-level document is not a guest", () => {
+		expect(
+			isGuestSubject({ contents: contentsOf("window"), isMainFrame: true }),
+		).toBe(false);
+	});
+
+	test("a webview guest, a pane popup, a subframe, and a worker are guests", () => {
+		expect(
+			isGuestSubject({ contents: contentsOf("webview"), isMainFrame: true }),
+		).toBe(true);
+		const popup = contentsOf("window");
+		markBrowserPanePopup(popup);
+		expect(isGuestSubject({ contents: popup, isMainFrame: true })).toBe(true);
+		expect(
+			isGuestSubject({ contents: contentsOf("window"), isMainFrame: false }),
+		).toBe(true);
+		expect(isGuestSubject({ contents: null, isMainFrame: true })).toBe(true);
+	});
+
+	test("a destroyed webContents counts as a guest", () => {
+		const destroyed = {
+			getType: () => {
+				throw new Error("Object has been destroyed");
+			},
+		} as unknown as Electron.WebContents;
+		expect(isGuestSubject({ contents: destroyed, isMainFrame: true })).toBe(
+			true,
+		);
+	});
+});
+
+describe("shouldGrantPermission", () => {
+	const guest = { contents: contentsOf("webview"), isMainFrame: true };
+	const app = { contents: contentsOf("window"), isMainFrame: true };
+
+	test("denies privacy- and hardware-sensitive permissions to a guest", () => {
+		for (const permission of [
+			"media",
+			"geolocation",
+			"notifications",
+			"display-capture",
+			"clipboard-read",
+			"openExternal",
+			"pointerLock",
+			"midiSysex",
+			"fileSystem",
+			"unknown",
+		]) {
+			expect(shouldGrantPermission(guest, permission)).toBe(false);
+		}
+	});
+
+	test("lets a guest use the benign browsing permissions", () => {
+		expect(shouldGrantPermission(guest, "fullscreen")).toBe(true);
+		expect(shouldGrantPermission(guest, "clipboard-sanitized-write")).toBe(
+			true,
+		);
+	});
+
+	test("keeps the app document on Electron's default: everything granted", () => {
+		expect(shouldGrantPermission(app, "media")).toBe(true);
+		expect(shouldGrantPermission(app, "clipboard-read")).toBe(true);
+	});
+});
+
+describe("installGuestPermissionPolicy", () => {
+	test("installs both handlers once per session and they agree", () => {
+		type RequestHandler = NonNullable<
+			Parameters<Electron.Session["setPermissionRequestHandler"]>[0]
+		>;
+		type CheckHandler = NonNullable<
+			Parameters<Electron.Session["setPermissionCheckHandler"]>[0]
+		>;
+		const handlers: { request?: RequestHandler; check?: CheckHandler } = {};
+		let installs = 0;
+		const ses = {
+			setPermissionRequestHandler: (handler: RequestHandler) => {
+				handlers.request = handler;
+				installs++;
+			},
+			setPermissionCheckHandler: (handler: CheckHandler) => {
+				handlers.check = handler;
+				installs++;
+			},
+		} as unknown as Electron.Session;
+
+		installGuestPermissionPolicy(ses);
+		installGuestPermissionPolicy(ses);
+		expect(installs).toBe(2);
+		const requestHandler = handlers.request as RequestHandler;
+		const checkHandler = handlers.check as CheckHandler;
+
+		const granted: boolean[] = [];
+		requestHandler(
+			contentsOf("webview"),
+			"media",
+			(ok: boolean) => granted.push(ok),
+			{
+				isMainFrame: true,
+				requestingUrl: "https://example.com",
+			},
+		);
+		requestHandler(
+			contentsOf("window"),
+			"media",
+			(ok: boolean) => granted.push(ok),
+			{
+				isMainFrame: true,
+				requestingUrl: "file:///app/index.html",
+			},
+		);
+		expect(granted).toEqual([false, true]);
+
+		expect(
+			checkHandler(contentsOf("webview"), "geolocation", "https://x", {
+				isMainFrame: true,
+			}),
+		).toBe(false);
+		expect(
+			checkHandler(null, "notifications", "https://x", {
+				isMainFrame: true,
+			}),
+		).toBe(false);
+		expect(
+			checkHandler(contentsOf("window"), "geolocation", "file://", {
+				isMainFrame: true,
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/desktop/src/main/lib/browser/guest-permissions.ts
+++ b/apps/desktop/src/main/lib/browser/guest-permissions.ts
@@ -1,0 +1,84 @@
+/**
+ * Permission policy for untrusted web content: a browser pane's guest, the
+ * popups it opens, workers, and any subframe of the host window.
+ *
+ * Electron grants every permission request when no handler is installed on a
+ * session — so, without this, a page loaded in the browser pane could turn on
+ * the camera or microphone, read geolocation or the clipboard, start screen
+ * capture, post OS notifications under the app's name, or launch an external
+ * URL-scheme handler (`ssh:`, `tel:`, `x-apple.systempreferences:`) from a
+ * subframe, all without any prompt. The app's own document keeps Electron's
+ * default (grant); guests only get the permissions listed here.
+ *
+ * Kept free of Electron imports so the decision is unit-testable; the live
+ * wiring is `installGuestPermissionPolicy`, called by the browser manager.
+ */
+
+import { isBrowserPanePopup } from "./popup-window";
+
+const GUEST_ALLOWED_PERMISSIONS = new Set<string>([
+	// HTML fullscreen (video players); stays inside the pane's webview.
+	"fullscreen",
+	// navigator.clipboard.writeText — "copy" buttons; write-only.
+	"clipboard-sanitized-write",
+	// Encrypted Media Extensions; no privacy surface.
+	"mediaKeySystem",
+]);
+
+export function isGuestPermissionAllowed(permission: string): boolean {
+	return GUEST_ALLOWED_PERMISSIONS.has(permission);
+}
+
+export interface PermissionSubject {
+	/** Null when the request comes from a service or shared worker. */
+	contents: Pick<Electron.WebContents, "getType"> | null;
+	isMainFrame: boolean;
+}
+
+/**
+ * Whether the requester is untrusted web content rather than the app's own
+ * top-level document: a webview guest, a pane popup, a worker (no
+ * webContents), or a subframe of any window (the PDF viewer, an embedded
+ * page).
+ */
+export function isGuestSubject(subject: PermissionSubject): boolean {
+	const { contents } = subject;
+	if (!contents) return true;
+	if (!subject.isMainFrame) return true;
+	try {
+		if (contents.getType() === "webview") return true;
+	} catch {
+		// Destroyed webContents: nothing legitimate is asking.
+		return true;
+	}
+	return isBrowserPanePopup(contents as Electron.WebContents);
+}
+
+export function shouldGrantPermission(
+	subject: PermissionSubject,
+	permission: string,
+): boolean {
+	return !isGuestSubject(subject) || isGuestPermissionAllowed(permission);
+}
+
+const installedSessions = new WeakSet<Electron.Session>();
+
+/** Idempotent per session; the pane, its popups, and the host window share one. */
+export function installGuestPermissionPolicy(ses: Electron.Session): void {
+	if (installedSessions.has(ses)) return;
+	installedSessions.add(ses);
+	ses.setPermissionRequestHandler((contents, permission, callback, details) => {
+		callback(
+			shouldGrantPermission(
+				{ contents, isMainFrame: details.isMainFrame },
+				permission,
+			),
+		);
+	});
+	ses.setPermissionCheckHandler((contents, permission, _origin, details) =>
+		shouldGrantPermission(
+			{ contents, isMainFrame: details.isMainFrame },
+			permission,
+		),
+	);
+}


### PR DESCRIPTION
Three fixes around the in-app browser pane and opening things from the app.

**Guest permissions.** Electron grants every permission request when a session has no handler, and `persist:superset` — browser-pane webviews, their sign-in popups, the host window — had none. So a page loaded in the in-app browser could take camera/microphone, geolocation, clipboard read, screen capture, OS notifications under Superset's name, or hand a subframe URL to an external scheme handler (`ssh:`, `tel:`, `x-apple.systempreferences:`) with no prompt. A request + check handler is now installed on the session: the app's own top-level document keeps the default behavior, and untrusted content (webview guests, pane popups, workers, subframes) gets an allowlist of fullscreen, clipboard write and EME.

**Open in Finder / editor fallback.** `external.openFolderInFinder` passed any absolute path to `shell.openPath`. A `.app` bundle stats as a directory, so a path printed in a terminal (or a symlink to one) would *launch* it rather than reveal it, and a file path went to its default handler, which runs `.command` / `.sh`. Folders are now realpath'd, must actually be directories, and macOS bundle extensions are refused; when no editor is configured, files open with `open -t` instead.

**Clear browsing data.** `browser.clearBrowsingData` accepted `storage` / `all`, which calls `session.clearStorageData()` on `persist:superset`. Guest pages share that partition with the app renderer, so "clear all browsing data" also erased the app's own localStorage/IndexedDB — layouts, hotkeys, theme. Only cookies and the HTTP cache can be cleared through it now.

Tests cover the permission matrix, the refused paths, and the clear-data scopes.

Part of an audit pass over the v2 stack on macOS.

https://claude.ai/code/session_01HmVz1yzkCEfnfDYDQxjN8u


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three desktop security gaps where untrusted content could act with the app's authority: browser-pane pages silently received every Electron permission, "Open in Finder" could launch app bundles or run scripts, and clearing browsing data wiped the app's own persisted state.

**Guest permissions**
- Pages in the in-app browser previously got every permission Electron can grant — camera, mic, geolocation, clipboard, screen capture, notifications, external URL schemes — with no prompt.
- Untrusted content (webview guests, pane popups, workers, subframes) now only gets fullscreen, clipboard write, and EME; the app's own window keeps Electron's default grants.

**External file handling**
- "Open in Finder" previously launched `.app` bundles and ran `.command`/`.sh` files; it now requires a real directory and refuses macOS bundle extensions.
- Opening a file with no editor configured previously used the OS default handler (which runs scripts); it now opens in the default text editor via `open -t`.
- "Clear all browsing data" previously also cleared the app's own persisted state; it now only clears cookies and the HTTP cache.

<sup>Written for commit 83392b4c1860d2b796c789bfcaa3c67644d6e629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer permission handling for embedded and untrusted web content, limiting access to sensitive capabilities.
  * Improved opening folders and files in the default system applications across platforms.
  * Prevented macOS application bundles from being opened as ordinary folders.

* **Bug Fixes**
  * Opening missing paths or files as folders now reports clearer errors.
  * “Clear all browsing data” now clears cookies and HTTP cache only; storage data is no longer included.
  * Removed the browsing-data “storage” option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->