### PR TITLE
fix(desktop): validate values crossing into the main process

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/projects/utils/favicon-discovery.ts
+++ b/apps/desktop/src/lib/trpc/routers/projects/utils/favicon-discovery.ts
@@ -1,5 +1,5 @@
-import { readFile, stat } from "node:fs/promises";
-import { extname } from "node:path";
+import { readFile, realpath, stat } from "node:fs/promises";
+import { extname, isAbsolute, relative, sep } from "node:path";
 import fg from "fast-glob";
 import {
 	saveProjectIconFromBuffer,
@@ -57,8 +57,24 @@ export async function discoverAndSaveProjectIcon({
 		// Use the first match (ordered by FAVICON_PATTERNS priority)
 		const iconPath = matches[0];
 
+		// A repo can symlink favicon.png (or a parent dir) at a file outside the
+		// checkout; don't copy that into the icon store.
+		const [repoReal, iconReal] = await Promise.all([
+			realpath(repoPath),
+			realpath(iconPath),
+		]);
+		const relativeIconPath = relative(repoReal, iconReal);
+		if (
+			relativeIconPath === "" ||
+			relativeIconPath === ".." ||
+			relativeIconPath.startsWith(`..${sep}`) ||
+			isAbsolute(relativeIconPath)
+		) {
+			return null;
+		}
+
 		// Check file size
-		const fileStat = await stat(iconPath);
+		const fileStat = await stat(iconReal);
 		if (fileStat.size > MAX_FAVICON_SIZE) {
 			console.log(
 				`[favicon-discovery] Icon too large (${Math.round(fileStat.size / 1024)}KB): ${iconPath}`,
@@ -70,7 +86,7 @@ export async function discoverAndSaveProjectIcon({
 
 		// For .ico files, read as buffer since they may need special handling
 		if (ext === "ico") {
-			const buffer = await readFile(iconPath);
+			const buffer = await readFile(iconReal);
 			return await saveProjectIconFromBuffer({
 				projectId,
 				buffer: Buffer.from(buffer),
@@ -78,7 +94,10 @@ export async function discoverAndSaveProjectIcon({
 			});
 		}
 
-		return await saveProjectIconFromFile({ projectId, sourcePath: iconPath });
+		return await saveProjectIconFromFile({
+			projectId,
+			sourcePath: iconReal,
+		});
 	} catch (error) {
 		console.error("[favicon-discovery] Error discovering icon:", error);
 		return null;

--- a/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
+++ b/apps/desktop/src/lib/trpc/routers/terminal/terminal.ts
@@ -242,7 +242,7 @@ export const createTerminalRouter = () => {
 		write: terminalProcedure
 			.input(
 				z.object({
-					paneId: z.string(),
+					paneId: SAFE_ID,
 					data: z.string(),
 					throwOnError: z.boolean().optional(),
 				}),
@@ -281,7 +281,7 @@ export const createTerminalRouter = () => {
 			}),
 
 		ackColdRestore: terminalProcedure
-			.input(z.object({ paneId: z.string() }))
+			.input(z.object({ paneId: SAFE_ID }))
 			.mutation(({ input }) => {
 				terminal.ackColdRestore(input.paneId);
 			}),
@@ -289,7 +289,7 @@ export const createTerminalRouter = () => {
 		resize: terminalProcedure
 			.input(
 				z.object({
-					paneId: z.string(),
+					paneId: SAFE_ID,
 					cols: z.number(),
 					rows: z.number(),
 					seq: z.number().optional(),
@@ -302,7 +302,7 @@ export const createTerminalRouter = () => {
 		signal: terminalProcedure
 			.input(
 				z.object({
-					paneId: z.string(),
+					paneId: SAFE_ID,
 					signal: z.string().optional(),
 				}),
 			)
@@ -313,7 +313,7 @@ export const createTerminalRouter = () => {
 		kill: terminalProcedure
 			.input(
 				z.object({
-					paneId: z.string(),
+					paneId: SAFE_ID,
 				}),
 			)
 			.mutation(async ({ input }) => {
@@ -323,7 +323,7 @@ export const createTerminalRouter = () => {
 		detach: terminalProcedure
 			.input(
 				z.object({
-					paneId: z.string(),
+					paneId: SAFE_ID,
 				}),
 			)
 			.mutation(async ({ input }) => {
@@ -333,7 +333,7 @@ export const createTerminalRouter = () => {
 		clearScrollback: terminalProcedure
 			.input(
 				z.object({
-					paneId: z.string(),
+					paneId: SAFE_ID,
 				}),
 			)
 			.mutation(async ({ input }) => {
@@ -451,7 +451,7 @@ export const createTerminalRouter = () => {
 		}),
 
 		getSession: terminalProcedure
-			.input(z.string())
+			.input(SAFE_ID)
 			.query(async ({ input: paneId }) => {
 				return terminal.getSession(paneId);
 			}),
@@ -481,7 +481,7 @@ export const createTerminalRouter = () => {
 			}),
 
 		stream: terminalProcedure
-			.input(z.string())
+			.input(SAFE_ID)
 			.subscription(({ input: paneId }) => {
 				return observable<
 					| { type: "data"; data: string }

--- a/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
+++ b/apps/desktop/src/lib/trpc/routers/workspace-fs-service.ts
@@ -6,6 +6,7 @@ import {
 } from "@superset/workspace-fs/host";
 import { TRPCError } from "@trpc/server";
 import { shell } from "electron";
+import { assertRegisteredWorktree } from "./changes/security/path-validation";
 import { getWorkspace } from "./workspaces/utils/db-helpers";
 import { execWithShellEnv } from "./workspaces/utils/shell-env";
 import { getWorkspacePath } from "./workspaces/utils/worktree";
@@ -74,6 +75,7 @@ export function toRegisteredWorktreeRelativePath(
 	worktreePath: string,
 	absolutePath: string,
 ): string {
+	assertRegisteredWorktree(worktreePath);
 	const normalizedWorktreePath = path.resolve(worktreePath);
 	const normalizedAbsolutePath = path.resolve(absolutePath);
 	const relativePath = path.relative(

--- a/apps/desktop/src/main/lib/notifications/query-string.test.ts
+++ b/apps/desktop/src/main/lib/notifications/query-string.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { queryString } from "./query-string";
+
+describe("queryString", () => {
+	it("keeps a plain string value", () => {
+		expect(queryString("pane-1")).toBe("pane-1");
+		expect(queryString("")).toBe("");
+	});
+
+	it("drops the array express builds from repeated keys", () => {
+		expect(queryString(["pane-1", "pane-2"])).toBeUndefined();
+	});
+
+	it("drops the object express builds from bracket syntax", () => {
+		expect(queryString({ x: "1" })).toBeUndefined();
+	});
+
+	it("drops absent values", () => {
+		expect(queryString(undefined)).toBeUndefined();
+		expect(queryString(null)).toBeUndefined();
+	});
+});

--- a/apps/desktop/src/main/lib/notifications/query-string.ts
+++ b/apps/desktop/src/main/lib/notifications/query-string.ts
@@ -1,0 +1,7 @@
+/**
+ * Query values arrive as string | string[] | object (express parses
+ * `?a[b]=1` and repeated keys); the hook protocol only ever sends strings.
+ */
+export function queryString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}

--- a/apps/desktop/src/main/lib/notifications/server.ts
+++ b/apps/desktop/src/main/lib/notifications/server.ts
@@ -50,22 +50,28 @@ app.use((req, res, next) => {
 	next();
 });
 
+/**
+ * Query values arrive as string | string[] | object (express parses
+ * `?a[b]=1` and repeated keys); the hook protocol only ever sends strings.
+ */
+function queryString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
 // Agent lifecycle hook
 app.get("/hook/complete", (req, res) => {
-	const {
-		paneId,
-		tabId,
-		workspaceId,
-		sessionId,
-		terminalId,
-		hookSessionId,
-		resourceId,
-		eventType,
-		rawEventType,
-		agentId,
-		env: clientEnv,
-		version,
-	} = req.query;
+	const paneId = queryString(req.query.paneId);
+	const tabId = queryString(req.query.tabId);
+	const workspaceId = queryString(req.query.workspaceId);
+	const sessionId = queryString(req.query.sessionId);
+	const terminalId = queryString(req.query.terminalId);
+	const hookSessionId = queryString(req.query.hookSessionId);
+	const resourceId = queryString(req.query.resourceId);
+	const eventType = queryString(req.query.eventType);
+	const rawEventType = queryString(req.query.rawEventType);
+	const agentId = queryString(req.query.agentId);
+	const clientEnv = queryString(req.query.env);
+	const version = queryString(req.query.version);
 
 	// Environment validation: detect dev/prod cross-talk
 	// We still return success to not block the agent, but log a warning
@@ -84,7 +90,7 @@ app.get("/hook/complete", (req, res) => {
 		);
 	}
 
-	const mappedEventType = mapEventType(eventType as string | undefined);
+	const mappedEventType = mapEventType(eventType);
 
 	// Unknown or missing eventType: return success but don't process
 	// This ensures forward compatibility and doesn't block the agent
@@ -95,37 +101,25 @@ app.get("/hook/complete", (req, res) => {
 		return res.json({ success: true, ignored: true });
 	}
 
-	const resolvedPaneId = resolvePaneId(
-		paneId as string | undefined,
-		tabId as string | undefined,
-		workspaceId as string | undefined,
-	);
+	const resolvedPaneId = resolvePaneId(paneId, tabId, workspaceId);
 
 	// v1 pane agent-session capture for the v1→v2 migration's resume seeding.
 	// Needs the un-collapsed event (SessionEnd vs Stop) — only v7+ hook
 	// scripts send it, so absence just means no capture.
-	if (
-		resolvedPaneId &&
-		typeof rawEventType === "string" &&
-		rawEventType.length > 0 &&
-		typeof agentId === "string" &&
-		agentId.length > 0
-	) {
+	if (resolvedPaneId && rawEventType && agentId) {
 		recordV1AgentHookEvent(resolvedPaneId, {
 			rawEventType,
 			agentId,
-			...(typeof sessionId === "string" && sessionId.length > 0
-				? { agentSessionId: sessionId }
-				: {}),
+			...(sessionId ? { agentSessionId: sessionId } : {}),
 			at: Date.now(),
 		});
 	}
 
 	const event: AgentLifecycleEvent = {
 		paneId: resolvedPaneId,
-		tabId: tabId as string | undefined,
-		workspaceId: workspaceId as string | undefined,
-		terminalId: terminalId as string | undefined,
+		tabId,
+		workspaceId,
+		terminalId,
 		eventType: mappedEventType,
 	};
 
@@ -133,13 +127,13 @@ app.get("/hook/complete", (req, res) => {
 		console.log("[notifications] hook event received", {
 			eventType,
 			mappedEventType,
-			paneId: paneId as string | undefined,
-			tabId: tabId as string | undefined,
-			workspaceId: workspaceId as string | undefined,
-			sessionId: sessionId as string | undefined,
-			terminalId: terminalId as string | undefined,
-			hookSessionId: hookSessionId as string | undefined,
-			resourceId: resourceId as string | undefined,
+			paneId,
+			tabId,
+			workspaceId,
+			sessionId,
+			terminalId,
+			hookSessionId,
+			resourceId,
 			resolvedPaneId,
 		});
 	}

--- a/apps/desktop/src/main/lib/notifications/server.ts
+++ b/apps/desktop/src/main/lib/notifications/server.ts
@@ -8,6 +8,7 @@ import { env } from "shared/env.shared";
 import type { AgentLifecycleEvent } from "shared/notification-types";
 import { HOOK_PROTOCOL_VERSION } from "../terminal/env";
 import { mapEventType } from "./map-event-type";
+import { queryString } from "./query-string";
 import { resolvePaneId } from "./resolve-pane-id";
 import { recordV1AgentHookEvent } from "./v1-agent-sessions";
 
@@ -49,14 +50,6 @@ app.use((req, res, next) => {
 	}
 	next();
 });
-
-/**
- * Query values arrive as string | string[] | object (express parses
- * `?a[b]=1` and repeated keys); the hook protocol only ever sends strings.
- */
-function queryString(value: unknown): string | undefined {
-	return typeof value === "string" ? value : undefined;
-}
 
 // Agent lifecycle hook
 app.get("/hook/complete", (req, res) => {

--- a/apps/desktop/src/main/lib/project-icon-files.test.ts
+++ b/apps/desktop/src/main/lib/project-icon-files.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rmSync } from "node:fs";
+
+// project-icons resolves its store from SUPERSET_HOME_DIR at import time, so the
+// env has to be set before the module is loaded — hence the dynamic import.
+let home: string;
+let sources: string;
+let icons: typeof import("./project-icons");
+
+beforeAll(async () => {
+	home = await mkdtemp(join(tmpdir(), "superset-icon-home-"));
+	sources = await mkdtemp(join(tmpdir(), "superset-icon-src-"));
+	process.env.SUPERSET_HOME_DIR = home;
+	icons = await import("./project-icons");
+});
+
+afterAll(() => {
+	rmSync(home, { recursive: true, force: true });
+	rmSync(sources, { recursive: true, force: true });
+});
+
+async function writeSource(name: string, contents: string): Promise<string> {
+	const sourcePath = join(sources, name);
+	await writeFile(sourcePath, contents);
+	return sourcePath;
+}
+
+describe("saveProjectIconFromFile", () => {
+	test("copies a supported icon into the store", async () => {
+		const sourcePath = await writeSource("logo.png", "icon-bytes");
+
+		const url = await icons.saveProjectIconFromFile({
+			projectId: "project-1",
+			sourcePath,
+		});
+
+		expect(url).toContain("project-1");
+		expect(await readdir(icons.PROJECT_ICONS_DIR)).toContain("project-1.png");
+	});
+
+	test("rejects an unsupported extension", async () => {
+		const sourcePath = await writeSource("logo.webp", "icon-bytes");
+
+		expect(
+			icons.saveProjectIconFromFile({ projectId: "project-2", sourcePath }),
+		).rejects.toThrow("Unsupported icon format");
+	});
+
+	test("rejects a source larger than the icon size cap", async () => {
+		const sourcePath = await writeSource(
+			"huge.png",
+			"x".repeat(512 * 1024 + 1),
+		);
+
+		expect(
+			icons.saveProjectIconFromFile({ projectId: "project-3", sourcePath }),
+		).rejects.toThrow("too large");
+	});
+
+	test("rejects a directory dressed up as an icon", async () => {
+		expect(
+			icons.saveProjectIconFromFile({
+				projectId: "project-4",
+				sourcePath: sources,
+			}),
+		).rejects.toThrow("not a file");
+	});
+
+	test("checks the symlink target, not the link", async () => {
+		const target = await writeSource("big-target.png", "x".repeat(512 * 1024 + 1));
+		const linkPath = join(sources, "link.png");
+		await symlink(target, linkPath);
+
+		expect(
+			icons.saveProjectIconFromFile({ projectId: "project-5", sourcePath: linkPath }),
+		).rejects.toThrow("too large");
+	});
+
+	test("refuses a project id that is not a single path segment", async () => {
+		const sourcePath = await writeSource("ok.png", "icon-bytes");
+
+		for (const projectId of ["../escape", "nested/id", "..", ""]) {
+			expect(
+				icons.saveProjectIconFromFile({ projectId, sourcePath }),
+			).rejects.toThrow("Invalid project id");
+		}
+	});
+});

--- a/apps/desktop/src/main/lib/project-icons.ts
+++ b/apps/desktop/src/main/lib/project-icons.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, unlinkSync } from "node:fs";
-import { copyFile, writeFile } from "node:fs/promises";
+import { copyFile, realpath, stat, writeFile } from "node:fs/promises";
 import { extname, join } from "node:path";
 import {
 	getImageExtensionFromMimeType,
@@ -13,6 +13,19 @@ export const PROJECT_ICONS_DIR = join(SUPERSET_HOME_DIR, "project-icons");
 /** Max icon file size: 512KB */
 const MAX_ICON_SIZE = 512 * 1024;
 const PROJECT_ICON_EXTENSIONS = new Set(["png", "jpg", "svg", "ico"]);
+
+/** The icon store is flat; an id with a separator would write outside it. */
+function iconDestination(projectId: string, ext: string): string {
+	if (
+		!projectId ||
+		projectId === "." ||
+		projectId === ".." ||
+		/[\\/]/.test(projectId)
+	) {
+		throw new Error("Invalid project id");
+	}
+	return join(PROJECT_ICONS_DIR, `${projectId}.${ext}`);
+}
 
 /**
  * Ensures the project icons directory exists.
@@ -88,12 +101,29 @@ export async function saveProjectIconFromFile({
 	projectId: string;
 	sourcePath: string;
 }): Promise<string> {
+	const ext = extname(sourcePath).slice(1).toLowerCase() || "png";
+	if (!PROJECT_ICON_EXTENSIONS.has(ext)) {
+		throw new Error(
+			"Unsupported icon format. Supported formats are PNG, JPEG, SVG, and ICO.",
+		);
+	}
+	const destPath = iconDestination(projectId, ext);
+
+	// Resolve symlinks before checking, so what is copied is what was checked.
+	const sourceReal = await realpath(sourcePath);
+	const sourceStat = await stat(sourceReal);
+	if (!sourceStat.isFile()) {
+		throw new Error("Icon source is not a file");
+	}
+	if (sourceStat.size > MAX_ICON_SIZE) {
+		throw new Error(
+			`Icon file too large (${Math.round(sourceStat.size / 1024)}KB). Maximum is ${MAX_ICON_SIZE / 1024}KB.`,
+		);
+	}
+
 	ensureProjectIconsDir();
 	removeExistingIcon(projectId);
-
-	const ext = extname(sourcePath) || ".png";
-	const destPath = join(PROJECT_ICONS_DIR, `${projectId}${ext}`);
-	await copyFile(sourcePath, destPath);
+	await copyFile(sourceReal, destPath);
 
 	return getProjectIconProtocolUrl(projectId);
 }
@@ -110,10 +140,8 @@ export async function saveProjectIconFromDataUrl({
 	projectId: string;
 	dataUrl: string;
 }): Promise<string> {
-	ensureProjectIconsDir();
-	removeExistingIcon(projectId);
-
 	const { buffer, ext } = parseProjectIconDataUrl(dataUrl);
+	const destPath = iconDestination(projectId, ext);
 
 	if (buffer.length > MAX_ICON_SIZE) {
 		throw new Error(
@@ -121,7 +149,8 @@ export async function saveProjectIconFromDataUrl({
 		);
 	}
 
-	const destPath = join(PROJECT_ICONS_DIR, `${projectId}.${ext}`);
+	ensureProjectIconsDir();
+	removeExistingIcon(projectId);
 	await writeFile(destPath, buffer);
 
 	return getProjectIconProtocolUrl(projectId);
@@ -140,8 +169,7 @@ export async function saveProjectIconFromBuffer({
 	buffer: Buffer;
 	ext: string;
 }): Promise<string> {
-	ensureProjectIconsDir();
-	removeExistingIcon(projectId);
+	const destPath = iconDestination(projectId, ext);
 
 	if (buffer.length > MAX_ICON_SIZE) {
 		throw new Error(
@@ -149,7 +177,8 @@ export async function saveProjectIconFromBuffer({
 		);
 	}
 
-	const destPath = join(PROJECT_ICONS_DIR, `${projectId}.${ext}`);
+	ensureProjectIconsDir();
+	removeExistingIcon(projectId);
 	await writeFile(destPath, buffer);
 
 	return getProjectIconProtocolUrl(projectId);


### PR DESCRIPTION
Five boundaries where a value from the renderer, from a repo, or from any local process reached something with more authority than it should have. Each is small and independent:

- **Terminal procedures** — pane ids are validated on every procedure, not just some of them.
- **`/hook/complete`** — the endpoint cast every `req.query` value to a string, but express parses repeated keys and `?a[b]=1` into arrays and objects, so a non-string `paneId` flowed into the lifecycle event, the renderer focus handler, and `app-state.json` (as an `"[object Object]"` key). Non-string values are now treated as absent. The endpoint is reachable by any local process.
- **Project icon store** — `saveProjectIconFromFile` copied any path into `~/.superset/project-icons`, which `superset-icon://` serves to the renderer, with no size, type or file check, and built the destination from the project id without rejecting separators. It now resolves symlinks first (so what is copied is what was checked), requires a regular file within the size cap and a supported extension, and refuses an id that isn't a single path segment. Today's only caller already validates; this closes it for the next one.
- **Favicon discovery** — a repo's favicon path is resolved before it is copied, so a symlink in the repo can't pull an unrelated host file into the icon store.
- **`toRegisteredWorktreeRelativePath`** — actually checks registration, which the name promised.

The last commit adds the tests those first two lacked: `queryString` moved into its own module so it can be imported without booting the express app, and `saveProjectIconFromFile` driven against a temporary `SUPERSET_HOME_DIR`. Verified they fail against the code before the fix.

Part of an audit pass over the v2 stack on macOS.

https://claude.ai/code/session_01HmVz1yzkCEfnfDYDQxjN8u


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens validation at five boundaries in the desktop app where values from the renderer, a repo, or a local process reached sensitive code paths.

**Bug Fixes**
- Terminal pane IDs now use the same validation as createOrAttach.
- `/hook/complete` treats non-string query values as absent instead of casting them to strings.
- Project icon sources must be regular files within the size cap and a supported extension; symlinks are resolved before checking.
- Project IDs must be a single path segment for all icon save paths.
- Favicon discovery only copies icons that resolve inside the repo.
- `toRegisteredWorktreeRelativePath` now checks registration as its name promised.
- Tests cover the query-string helper and icon store guards.

<sup>Written for commit d16ca50bf78ac22e7c55430c2ec2bb7dabb250c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project icon handling by validating file types, sizes, paths, and symbolic links before saving.
  - Added safeguards to prevent invalid project identifiers and unregistered worktree paths from being used.
  - Strengthened terminal session input validation to reject unsafe pane and session identifiers.
  - Improved notification query handling for consistent string values and safer session updates.

- **Tests**
  - Added coverage for project icon validation and notification query parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->