### PR TITLE
fix(mobile): embed the update-signing certificate only in preview and production builds

### DIFF
--- a/apps/mobile/.eas/workflows/pr-preview.yml
+++ b/apps/mobile/.eas/workflows/pr-preview.yml
@@ -16,7 +16,7 @@ jobs:
   fingerprint:
     name: Fingerprint
     type: fingerprint
-    environment: preview
+    environment: development
 
   get_development_build:
     name: Find development build for this fingerprint

--- a/apps/mobile/RELEASE.md
+++ b/apps/mobile/RELEASE.md
@@ -127,11 +127,13 @@ server and compute nothing.
 Signed publishing needs the EAS Production plan or above; on a lower plan the
 publish is rejected at its final step, after the bundle has already uploaded.
 
-Code signing reaches local development too: a development build embeds the
-certificate and asks Metro for a signed manifest, so `expo start` refuses to
-serve it without the key. Run it as
-`expo start --dev-client --private-key-path ~/.superset/keys/mobile-updates/private-key.pem`
-(the key is in 1Password) or the app sits on the dev launcher forever.
+A build carries the certificate only when `MOBILE_SIGNED_UPDATES=1` is in its
+EAS environment, which is `preview` and `production`. Development builds and
+anything built on a laptop have no certificate, so `expo start` serves them
+without the key; a build that embeds the certificate would refuse Metro until
+`--private-key-path` is passed. `app.config.ts` refuses to build a preview or
+production binary without the variable, so deleting it breaks the build
+instead of shipping an unsigned store app.
 
 ### Retiring old builds
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -11,6 +11,17 @@ config({
 	quiet: true,
 });
 
+const SIGNED_BUILD_PROFILES = ["preview", "production"];
+const signedUpdates = process.env.MOBILE_SIGNED_UPDATES === "1";
+if (
+	!signedUpdates &&
+	SIGNED_BUILD_PROFILES.includes(process.env.EAS_BUILD_PROFILE ?? "")
+) {
+	throw new Error(
+		`MOBILE_SIGNED_UPDATES=1 is missing from the ${process.env.EAS_BUILD_PROFILE} EAS environment; refusing to build an unsigned ${process.env.EAS_BUILD_PROFILE} binary`,
+	);
+}
+
 export default ({ config }: ConfigContext) => ({
 	...config,
 	name: "Superset",
@@ -26,8 +37,10 @@ export default ({ config }: ConfigContext) => ({
 	runtimeVersion: { policy: "fingerprint" as const },
 	updates: {
 		url: "https://u.expo.dev/fa9332a8-896a-4d2a-be5b-d82469b46e5d",
-		codeSigningCertificate: "./certs/certificate.pem",
-		codeSigningMetadata: { keyid: "main", alg: "rsa-v1_5-sha256" as const },
+		...(signedUpdates && {
+			codeSigningCertificate: "./certs/certificate.pem",
+			codeSigningMetadata: { keyid: "main", alg: "rsa-v1_5-sha256" as const },
+		}),
 	},
 	ios: {
 		supportsTablet: false,

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -7,6 +7,7 @@
 		"development": {
 			"developmentClient": true,
 			"distribution": "internal",
+			"environment": "development",
 			"channel": "development"
 		},
 		"preview": {


### PR DESCRIPTION
Follow-up to #7439. Rendering #7445 on a simulator hit this: a dev client built from main embeds the update-signing certificate, so it sends `expo-expect-signature` to Metro, and `expo start` refuses to serve it without `--private-key-path`. Every developer needed the private key on their laptop to run the app.

## Change

- `app.config.ts` includes `codeSigningCertificate` and `codeSigningMetadata` only when `MOBILE_SIGNED_UPDATES=1`. That variable is set in the `preview` and `production` EAS environments (done) and nowhere else. Development builds and anything built on a laptop have no certificate, so Metro serves them with no key.
- The config throws when `EAS_BUILD_PROFILE` is `preview` or `production` and the variable is missing, so deleting it breaks the build instead of shipping an unsigned store app.
- The `development` build profile now declares `environment: development`, and the pull-request lane fingerprints under that environment, so its `get-build` lookup matches the unsigned development builds.
- RELEASE.md updated.

## Verified

- `expo prebuild` with the variable unset writes no `EXUpdatesCodeSigning*` keys to Expo.plist; with it set, both keys are present.
- The guard fires: evaluating the config with `EAS_BUILD_PROFILE=production` and no variable throws `MOBILE_SIGNED_UPDATES=1 is missing from the production EAS environment`.
- `eas fingerprint:generate` per profile: preview and production still hash identically to each other; development now differs from them. Comparing the production hash before and after this change, the only source that moved is `eas.json` itself (the evaluated config is byte-identical).
- `workflow:validate` passes on the edited lane. Root typecheck 38/38.

## Not verified

No EAS build has run with this config yet. The next preview or production build proves the guard passes on the builder; the next development build proves Metro serves it unsigned.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the update-signing certificate to preview and production builds so development builds no longer require the private key to run on a simulator.

**Bug Fixes**
- `app.config.ts` only embeds the certificate when `MOBILE_SIGNED_UPDATES=1` is set, which is only in preview and production EAS environments.
- The config now throws if a preview or production build runs without that variable, so a missing certificate fails the build instead of shipping an unsigned store app.
- The development build profile and PR preview lane now fingerprint under the `development` environment, keeping the build lookup aligned with unsigned development builds.

<sup>Written for commit cd512e72436d5c82ed50d58159345834b6bf0546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Mobile development builds now use the development environment consistently.
  - Code signing is enabled only for preview and production builds when explicitly configured.
  - Development builds and locally created binaries remain unsigned and can be launched without signing credentials.
  - Preview and production builds now prevent creation when required signing configuration is missing.

- **Documentation**
  - Updated the mobile release runbook with the current code-signing and local development requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->