### PR TITLE
fix(desktop): remember the sidebar Changes view mode across workspaces

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -3,6 +3,7 @@ import { useLiveQuery } from "@tanstack/react-db";
 import { useCallback } from "react";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
 import {
+	type ChangesViewMode,
 	DEFAULT_V2_USER_PREFERENCES,
 	type FolderTierMap,
 	type LinkAction,
@@ -24,6 +25,7 @@ export interface V2UserPreferencesApi {
 	setDeleteLocalBranch: (next: boolean) => void;
 	setShowPresetsBar: (next: boolean | ((prev: boolean) => boolean)) => void;
 	toggleShowPresetsBar: () => void;
+	setChangesViewMode: (next: ChangesViewMode) => void;
 	setSidebarProjectSortMode: (next: SidebarProjectSortMode) => void;
 	setBuiltinPresetHidden: (presetId: string, hidden: boolean) => void;
 	/** Hide/show a tag folder in one project without touching anyone's tags. */
@@ -204,6 +206,25 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setShowPresetsBar((prev) => !prev);
 	}, [setShowPresetsBar]);
 
+	const setChangesViewMode = useCallback(
+		(next: ChangesViewMode) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					changesViewMode: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.changesViewMode = next;
+			});
+		},
+		[collections],
+	);
+
 	const setSidebarProjectSortMode = useCallback(
 		(next: SidebarProjectSortMode) => {
 			const existing = collections.v2UserPreferences.get(
@@ -299,6 +320,7 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setDeleteLocalBranch,
 		setShowPresetsBar,
 		toggleShowPresetsBar,
+		setChangesViewMode,
 		setSidebarProjectSortMode,
 		setBuiltinPresetHidden,
 		setTagFolderHidden,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/useChangesTab.tsx
@@ -4,15 +4,13 @@ import { toast } from "@superset/ui/sonner";
 import { workspaceTrpc } from "@superset/workspace-client";
 import { useCallback, useMemo } from "react";
 import { LuGitCompareArrows } from "react-icons/lu";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useChangeset } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { useOpenInExternalEditor } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useOpenInExternalEditor";
 import { useSidebarDiffRef } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useSidebarDiffRef";
 import { useWorkspaceGitStatus } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/providers/WorkspaceGitStatusProvider";
 import { useCollections } from "renderer/routes/_authenticated/providers/CollectionsProvider";
-import type {
-	ChangesFilter,
-	ChangesViewMode,
-} from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
+import type { ChangesFilter } from "renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import type { SidebarTabDefinition } from "../../types";
 import { ChangesTabContent } from "./components/ChangesTabContent";
@@ -61,8 +59,9 @@ export function useChangesTab({
 	const filter: ChangesFilter = localState?.sidebarState?.changesFilter ?? {
 		kind: "all",
 	};
-	const viewMode: ChangesViewMode =
-		localState?.sidebarState?.changesViewMode ?? "folders";
+	const { preferences, setChangesViewMode: setViewMode } =
+		useV2UserPreferences();
+	const viewMode = preferences.changesViewMode;
 
 	const baseBranchQuery = workspaceTrpc.git.getBaseBranch.useQuery(
 		{ workspaceId },
@@ -95,16 +94,6 @@ export function useChangesTab({
 			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
 			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
 				draft.sidebarState.changesFilter = next;
-			});
-		},
-		[collections, workspaceId],
-	);
-
-	const setViewMode = useCallback(
-		(next: ChangesViewMode) => {
-			if (!collections.v2WorkspaceLocalState.get(workspaceId)) return;
-			collections.v2WorkspaceLocalState.update(workspaceId, (draft) => {
-				draft.sidebarState.changesViewMode = next;
 			});
 		},
 		[collections, workspaceId],

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.test.ts
@@ -34,6 +34,13 @@ describe("healV2UserPreferences", () => {
 		expect(healed.fileLinks).toEqual(DEFAULT_V2_USER_PREFERENCES.fileLinks);
 	});
 
+	it("keeps the user's changes view mode and defaults rows written before it existed", () => {
+		expect(
+			healV2UserPreferences({ changesViewMode: "tree" }).changesViewMode,
+		).toBe("tree");
+		expect(healV2UserPreferences({}).changesViewMode).toBe("folders");
+	});
+
 	it("preserves the terminal presets initialization sentinel", () => {
 		const healed = healV2UserPreferences({
 			terminalPresetsInitialized: true,

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -101,8 +101,6 @@ const changesFilterSchema = z.discriminatedUnion("kind", [
 
 export type ChangesFilter = z.infer<typeof changesFilterSchema>;
 
-export type ChangesViewMode = "folders" | "tree";
-
 const workspaceRunStateSchema = z.enum([
 	"running",
 	"stopped-by-user",
@@ -145,7 +143,6 @@ export const workspaceLocalStateSchema = z.object({
 		// `${projectId}:${tag}` key (written by move-into-derived-folder).
 		sectionId: z.string().min(1).nullable().default(null),
 		changesFilter: changesFilterSchema.default({ kind: "all" }),
-		changesViewMode: z.enum(["folders", "tree"]).default("folders"),
 		activeTab: WORKSPACE_SIDEBAR_TAB_SCHEMA.default("changes"),
 		isHidden: z.boolean().default(false),
 		// Epoch ms when the user pinned this workspace to the sidebar's Pinned
@@ -198,7 +195,6 @@ const SIDEBAR_STATE_DEFAULTS = {
 	tabOrder: 0,
 	sectionId: null,
 	changesFilter: { kind: "all" },
-	changesViewMode: "folders",
 	activeTab: "changes",
 	isHidden: false,
 	pinnedAt: null,
@@ -408,6 +404,10 @@ function isCompleteLinkTierMap(
 	);
 }
 
+const changesViewModeSchema = z.enum(["folders", "tree"]);
+
+export type ChangesViewMode = z.infer<typeof changesViewModeSchema>;
+
 const sidebarProjectSortModeSchema = z.enum(["manual", "active", "created"]);
 
 export type SidebarProjectSortMode = z.infer<
@@ -434,6 +434,9 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
+	// Sidebar Changes tab layout. User-scoped so a choice made in one
+	// workspace carries into every workspace opened afterwards.
+	changesViewMode: changesViewModeSchema.default("folders"),
 	// Ordering of the dashboard sidebar's Projects list; manual = drag order.
 	sidebarProjectSortMode: persistedSidebarProjectSortModeSchema,
 	// Built-in (synthetic, app-shipped) presets the user hid from the preset
@@ -472,6 +475,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	rightSidebarWidth: 340,
 	deleteLocalBranch: false,
 	showPresetsBar: true,
+	changesViewMode: "folders",
 	sidebarProjectSortMode: "manual",
 	hiddenBuiltinPresetIds: [],
 	favoritePageIds: [],

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -434,8 +434,6 @@ export const v2UserPreferencesSchema = z.object({
 	rightSidebarWidth: z.number().default(340),
 	deleteLocalBranch: z.boolean().default(false),
 	showPresetsBar: z.boolean().default(true),
-	// Sidebar Changes tab layout. User-scoped so a choice made in one
-	// workspace carries into every workspace opened afterwards.
 	changesViewMode: changesViewModeSchema.default("folders"),
 	// Ordering of the dashboard sidebar's Projects list; manual = drag order.
 	sidebarProjectSortMode: persistedSidebarProjectSortModeSchema,


### PR DESCRIPTION
## Summary

The folders/tree toggle in the sidebar Changes tab was stored in per-workspace local state, so every new workspace opened in folders view and the user had to click Tree view again each time.

- Move `changesViewMode` from `workspaceLocalStateSchema.sidebarState` to the user-scoped `v2UserPreferencesSchema` (heals to `folders` for rows written before the field existed).
- Add `setChangesViewMode` to `useV2UserPreferences`.
- `useChangesTab` reads and writes the mode through the preferences hook.

## Test plan

- [x] `bun test` on the collections provider (82 pass, includes a new heal test)
- [x] Desktop typecheck
- [x] CDP, same real-click journey on main and on this branch: choose Tree view in one workspace, open a different workspace, reload. On main the second workspace opens in folders; on this branch it opens in tree and stays tree after reload. The persisted `v2-user-preferences-<org>` row carries `"changesViewMode":"tree"`.

Evidence page with before/after screenshots and measured state per step:
https://app.superset.sh/page/tree-view-persistence-cdp-evidence-pr-7453-vx53ss

https://claude.ai/code/session_01S57Fhzi1tNy2FY9JGvDuxE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Changes view mode is now saved as a user preference, so your selected **Folders** or **Tree** view remains consistent across workspaces.
  - New users default to the **Folders** view.
  - Existing selections are preserved when preferences are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->