### PR TITLE
fix(panes): activate a pane on any press, including header controls

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserPaneToolbar/BrowserPaneToolbar.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/BrowserPane/components/BrowserPaneToolbar/BrowserPaneToolbar.tsx
@@ -50,7 +50,6 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 	);
 
 	const isBlankPage = !state.currentUrl || state.currentUrl === "about:blank";
-	const PaneHeaderActions = ctx.components.PaneHeaderActions;
 
 	return (
 		<div className="flex h-full w-full min-w-0 items-center justify-between">
@@ -111,7 +110,7 @@ export function BrowserPaneToolbar({ ctx }: BrowserPaneToolbarProps) {
 					onOpenFindBar={() => findBarStore.open(paneId)}
 					onNavigateToUrl={handleNavigate}
 				/>
-				<PaneHeaderActions />
+				{ctx.headerActions}
 			</div>
 		</div>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/PagePaneTitle/PagePaneTitle.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/PagePaneTitle/PagePaneTitle.tsx
@@ -29,11 +29,7 @@ export function PagePaneTitle({ data, paneId, onClose }: PagePaneTitleProps) {
 	}
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: keeps the pane drag from starting on the menu trigger
-		<span
-			className="flex min-w-0 items-center"
-			onMouseDown={(event) => event.stopPropagation()}
-		>
+		<span className="flex min-w-0 items-center">
 			<PageTitleMenu
 				page={page}
 				versions={versions}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/components/TerminalSessionDropdown/TerminalSessionDropdown.tsx
@@ -363,7 +363,6 @@ export function TerminalSessionDropdown({
 						})}
 						title={triggerTitle}
 						className="flex min-w-0 max-w-96 items-center gap-1.5 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-						onMouseDown={(event) => event.stopPropagation()}
 						onClick={(event) => event.stopPropagation()}
 					>
 						<TerminalPaneIcon

--- a/packages/panes/src/react/components/PaneHeaderActions/PaneHeaderActions.tsx
+++ b/packages/panes/src/react/components/PaneHeaderActions/PaneHeaderActions.tsx
@@ -10,11 +10,7 @@ export function PaneHeaderActions<TData>({
 	context: RendererContext<TData>;
 }) {
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: stop mousedown from triggering pane focus re-render before click fires
-		<div
-			className="flex shrink-0 items-center gap-1"
-			onMouseDown={(e) => e.stopPropagation()}
-		>
+		<div className="flex shrink-0 items-center gap-1">
 			{actions.map((action, _index) => {
 				const icon =
 					typeof action.icon === "function"

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/Pane.tsx
@@ -119,7 +119,7 @@ export function Pane<TData>({
 						newPane,
 					}),
 			},
-			components: { PaneHeaderActions: () => null },
+			headerActions: null,
 		};
 
 		// Resolve workspace-level actions (or empty if not provided)
@@ -135,7 +135,7 @@ export function Pane<TData>({
 			workspaceResolved,
 		);
 
-		ctx.components.PaneHeaderActions = () => (
+		ctx.headerActions = (
 			<PaneHeaderActions actions={finalActions} context={ctx} />
 		);
 
@@ -243,7 +243,6 @@ export function Pane<TData>({
 
 	return (
 		<PaneContextMenu actions={resolvedContextMenuActions} context={context}>
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: clicking anywhere in a pane focuses it (standard IDE behavior) */}
 			<div
 				ref={setRefs}
 				// @container/pane-header: header pieces collapse by the pane's own
@@ -255,7 +254,7 @@ export function Pane<TData>({
 						? "border-primary/15"
 						: "border-transparent"
 				}`}
-				onMouseDown={context.actions.focus}
+				onPointerDownCapture={context.actions.focus}
 			>
 				<PaneHeader
 					title={title}
@@ -264,7 +263,7 @@ export function Pane<TData>({
 					titleContent={titleContent}
 					headerExtras={headerExtras}
 					toolbar={toolbar}
-					actionsContent={<context.components.PaneHeaderActions />}
+					actionsContent={context.headerActions}
 					paneId={pane.id}
 					onClick={
 						definition?.onHeaderClick

--- a/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
+++ b/packages/panes/src/react/components/Workspace/components/Tab/components/Pane/components/PaneHeader/components/DefaultHeaderContent/DefaultHeaderContent.tsx
@@ -54,11 +54,7 @@ export function DefaultHeaderContent({
 			    the split/close actions on the right are the last thing to go.
 			    Holds for any icon size; components lower their own priority via
 			    the @container/pane-header queries. */}
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: stop drag from starting on action buttons */}
-			<div
-				className="flex min-w-0 items-center justify-end gap-0.5 overflow-hidden"
-				onMouseDown={(e) => e.stopPropagation()}
-			>
+			<div className="flex min-w-0 items-center justify-end gap-0.5 overflow-hidden">
 				{headerExtras}
 				{actionsContent}
 			</div>

--- a/packages/panes/src/react/types.ts
+++ b/packages/panes/src/react/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from "react";
+import type { ReactNode } from "react";
 import type { StoreApi } from "zustand/vanilla";
 import type { CreatePaneInput, WorkspaceStore } from "../core/store";
 import type { Pane, Tab } from "../types";
@@ -57,9 +57,7 @@ export interface RendererContext<TData> {
 		) => void;
 	};
 
-	components: {
-		PaneHeaderActions: ComponentType;
-	};
+	headerActions: ReactNode;
 }
 
 export interface PaneTitleSource {


### PR DESCRIPTION
## Problem

Clicking a header control on an inactive pane never activated that pane. The terminal session dropdown, Copy terminal ID, Rich input, and the split/close icons all stop mousedown propagation, and pane activation lived on the same bubbling mousedown handler at the pane root. The control still worked and the inactive header brightens on hover and focus-within, so the pane looked selected while the store kept the previous pane active. Cmd+W then closed the previous pane, which is what "it looks highlighted but Cmd+W deletes the wrong pane" was.

## Fix

- Pane root activates on `onPointerDownCapture` instead of bubbling `onMouseDown`. No descendant can swallow it, and pointerdown also covers Radix triggers, which cancel the compat mousedown entirely.
- `RendererContext.components.PaneHeaderActions` (a fresh component type on every render) becomes `RendererContext.headerActions`, a stable element. The per-render component remounted the buttons whenever `isActive` flipped, which is why the stopPropagation calls were added: activating on mousedown destroyed the button before mouseup and ate the click. `BrowserPaneToolbar` is the only external consumer.
- The four `onMouseDown={stopPropagation}` handlers in `PaneHeaderActions`, `DefaultHeaderContent`, `TerminalSessionDropdown`, and `PagePaneTitle` go. Their comments cite preventing pane drags, but react-dnd's HTML5 backend listens to `dragstart`, not mousedown, so their only effect was blocking activation.

## Verification

Driven over CDP against the dev app on this branch, real pointer input.

- Before: clicking the inactive terminal's title, Copy terminal ID, or Rich input left the browser pane active in the store while the terminal header read as active (opacity 1, focus inside it).
- After: each of those spots activates the terminal and the control still works (menu opens, rich input focuses). Browser active → click terminal Rich input → Cmd+W closes the terminal.
- Split and close icons on an inactive pane still fire their click after activation; event tracing shows pointerdown through click reaching the button, no exceptions.
- `packages/panes` 110 tests pass, `apps/desktop` 3756 tests pass, biome and tsc clean.

https://claude.ai/code/session_01QyArMFaaqAS3TePiW2wPVZ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pane activation so pressing any header control — split/close icons, the terminal session dropdown, Copy terminal ID, Rich input — on an inactive pane now activates that pane. Previously those controls stopped mousedown propagation while activation lived on the bubbling mousedown at the pane root, so the store kept the previous pane active even though the header looked selected; Cmd+W then closed the wrong pane.

- Pane activation now fires on `onPointerDownCapture`, which no descendant can swallow, and the control's own click still fires afterward.
- Header actions are exposed as a stable `headerActions` element instead of a per-render component type; the old component remounted the buttons whenever `isActive` changed, which is why the `stopPropagation` handlers existed.
- Removed the four `onMouseDown={stopPropagation}` handlers; their stated purpose of preventing pane drags never held because `react-dnd` listens to `dragstart`, not mousedown.

<sup>Written for commit a59f0431c7d339cdedc7ea0bdb6aea3f7ad7dbe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Interaction Updates**
  * Pane header actions and terminal session controls now allow mouse-down events to propagate normally.
  * Pane focus is triggered when pointer interaction begins, improving consistency across mouse and pointer inputs.
  * Header actions are rendered consistently across workspace panes.
* **Refactor**
  * Simplified how pane header actions are provided and displayed without changing their visible controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->