### PR TITLE
feat(desktop): per-file Stage / Unstage in the v2 Changes sidebar

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/ChangesTreeView.tsx
@@ -43,9 +43,14 @@ import {
 } from "shared/absolute-paths";
 import type { FoldSignal } from "../../ChangesFileList";
 import { setFileDragData } from "../../hooks/useFileDrag";
+import { useStagingMutations } from "../../hooks/useStagingMutations";
+import { StageToggleButton } from "../StageToggleButton";
 import { FileRowContextMenuItems } from "./components/FileRowContextMenuItems";
 import { FolderContextMenuItems } from "./components/FolderContextMenuItems";
-import { ShadowRowHoverActions } from "./components/ShadowRowHoverActions";
+import {
+	HOVER_ACTIONS_ROW_CSS,
+	ShadowRowHoverActions,
+} from "./components/ShadowRowHoverActions";
 import { useMeasuredTreeHeight } from "./hooks/useMeasuredTreeHeight";
 import { buildTreeShape } from "./utils/buildTreeShape";
 
@@ -92,7 +97,8 @@ interface ChangesTreeViewProps {
  *  - `renderRowDecoration`: `+N/−N` on files, file count on directories
  *  - `renderContextMenu`: file-row actions matching `FileRow`; folder-row
  *    actions (open in editor, copy path)
- *  - hover actions overlay (Discard on unstaged + more-actions ⌄ dropdown)
+ *  - hover actions overlay (Discard + Stage on unstaged, Unstage on staged,
+ *    plus the more-actions ⌄ dropdown)
  *  - `useChangesSidebarFilePolicy` for settings-driven click routing
  *  - selection echo: when the diff pane's file is in this section, focus it
  *
@@ -152,7 +158,7 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		paths: treePaths,
 		initialExpansion: "open",
 		search: false,
-		unsafeCSS: PIERRE_TREE_UNSAFE_CSS,
+		unsafeCSS: PIERRE_TREE_UNSAFE_CSS + HOVER_ACTIONS_ROW_CSS,
 		gitStatus: initialGitStatusEntriesRef.current,
 		icons: { set: "complete", colored: true },
 		itemHeight: ITEM_HEIGHT,
@@ -351,6 +357,8 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 		},
 	});
 
+	const { stageFile, unstageFile } = useStagingMutations(workspaceId);
+
 	const fileMenuItems = (file: ChangesetFile) => (
 		<FileRowContextMenuItems
 			file={file}
@@ -360,6 +368,8 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 			onOpenFile={onOpenFile}
 			onOpenInEditor={onOpenInEditor}
 			onRequestDiscard={setDiscardTarget}
+			onStageFile={stageFile}
+			onUnstageFile={unstageFile}
 		/>
 	);
 
@@ -393,30 +403,38 @@ export const ChangesTreeView = memo(function ChangesTreeView({
 	};
 
 	const renderHoverInlineActions = (treePath: string) => {
-		if (sectionKind !== "unstaged") return null;
 		const file = fileByTreePath.get(treePath);
 		if (!file) return null;
+		if (sectionKind === "staged") {
+			return (
+				<StageToggleButton action="unstage" onClick={() => unstageFile(file)} />
+			);
+		}
+		if (sectionKind !== "unstaged") return null;
 		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<button
-						type="button"
-						aria-label={t({
-							message: "Discard changes",
-						})}
-						className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive"
-						onClick={(e) => {
-							e.stopPropagation();
-							setDiscardTarget(file);
-						}}
-					>
-						<Undo2 className="size-3.5" />
-					</button>
-				</TooltipTrigger>
-				<TooltipContent side="top">
-					<Trans>Discard changes</Trans>
-				</TooltipContent>
-			</Tooltip>
+			<>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							aria-label={t({
+								message: "Discard changes",
+							})}
+							className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive"
+							onClick={(e) => {
+								e.stopPropagation();
+								setDiscardTarget(file);
+							}}
+						>
+							<Undo2 className="size-3.5" />
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="top">
+						<Trans>Discard changes</Trans>
+					</TooltipContent>
+				</Tooltip>
+				<StageToggleButton action="stage" onClick={() => stageFile(file)} />
+			</>
 		);
 	};
 

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/FileRowContextMenuItems/FileRowContextMenuItems.tsx
@@ -8,6 +8,8 @@ import {
 	ExternalLink,
 	FileText,
 	GitCompare,
+	Minus,
+	Plus,
 	SquarePlus,
 	Trash2,
 	Undo2,
@@ -41,6 +43,8 @@ interface FileRowContextMenuItemsProps {
 	 * inside it before the user could confirm.
 	 */
 	onRequestDiscard?: (file: ChangesetFile) => void;
+	onStageFile?: (file: ChangesetFile) => void;
+	onUnstageFile?: (file: ChangesetFile) => void;
 }
 
 /**
@@ -56,12 +60,16 @@ export function FileRowContextMenuItems({
 	onOpenFile,
 	onOpenInEditor,
 	onRequestDiscard,
+	onStageFile,
+	onUnstageFile,
 }: FileRowContextMenuItemsProps) {
 	const { t } = useLingui();
 	const absolutePath = worktreePath
 		? toAbsoluteWorkspacePath(worktreePath, file.path)
 		: undefined;
-	const canDiscard = sectionKind === "unstaged";
+	const canDiscard = sectionKind === "unstaged" && onRequestDiscard;
+	const canStage = sectionKind === "unstaged" && onStageFile;
+	const canUnstage = sectionKind === "staged" && onUnstageFile;
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
 	const changeKey = getChangesetFileKey(file);
 
@@ -128,23 +136,33 @@ export function FileRowContextMenuItems({
 					/>
 				</>
 			)}
-			{canDiscard && onRequestDiscard && (
-				<>
-					<DropdownMenuSeparator />
-					<DropdownMenuItem
-						variant="destructive"
-						onSelect={() => onRequestDiscard(file)}
-					>
-						{isDeleteAction ? <Trash2 /> : <Undo2 />}
-						{isDeleteAction
-							? t({
-									message: "Delete",
-								})
-							: t({
-									message: "Discard changes",
-								})}
-					</DropdownMenuItem>
-				</>
+			{(canStage || canUnstage || canDiscard) && <DropdownMenuSeparator />}
+			{canStage && (
+				<DropdownMenuItem onSelect={() => onStageFile(file)}>
+					<Plus />
+					<Trans>Stage file</Trans>
+				</DropdownMenuItem>
+			)}
+			{canUnstage && (
+				<DropdownMenuItem onSelect={() => onUnstageFile(file)}>
+					<Minus />
+					<Trans>Unstage file</Trans>
+				</DropdownMenuItem>
+			)}
+			{canDiscard && (
+				<DropdownMenuItem
+					variant="destructive"
+					onSelect={() => onRequestDiscard(file)}
+				>
+					{isDeleteAction ? <Trash2 /> : <Undo2 />}
+					{isDeleteAction
+						? t({
+								message: "Delete",
+							})
+						: t({
+								message: "Discard changes",
+							})}
+				</DropdownMenuItem>
 			)}
 		</>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/ShadowRowHoverActions/ShadowRowHoverActions.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/ShadowRowHoverActions/ShadowRowHoverActions.tsx
@@ -5,7 +5,27 @@ import {
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
-import { type ReactNode, useCallback, useRef, useState } from "react";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+
+const HOVER_ACTIONS_ROW_ATTR = "data-hover-actions";
+
+/**
+ * Pierre paints the `+N/−N` and status letter inside its shadow root, where
+ * the overlay would draw on top of them; hide them on the row the overlay is
+ * anchored to. Append to the tree's `unsafeCSS`.
+ */
+export const HOVER_ACTIONS_ROW_CSS = `
+	[${HOVER_ACTIONS_ROW_ATTR}] [data-item-section="decoration"],
+	[${HOVER_ACTIONS_ROW_ATTR}] [data-item-section="git"] {
+		visibility: hidden;
+	}
+`;
 
 interface ShadowRowHoverActionsProps {
 	/**
@@ -41,10 +61,21 @@ export function ShadowRowHoverActions({
 	} | null>(null);
 	const [menuOpen, setMenuOpen] = useState(false);
 	const hoverRowRef = useRef<HTMLElement | null>(null);
+	const overlayRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const row = hoverRowRef.current;
+		if (!hover || !row) return;
+		row.setAttribute(HOVER_ACTIONS_ROW_ATTR, "");
+		return () => row.removeAttribute(HOVER_ACTIONS_ROW_ATTR);
+	}, [hover]);
 
 	const handleMouseOver = useCallback(
 		(e: React.MouseEvent<HTMLDivElement>) => {
 			if (menuOpen) return;
+			// The overlay sits over the row it belongs to; entering one of its
+			// buttons must not read as leaving the row.
+			if (overlayRef.current?.contains(e.target as Node)) return;
 			const row = findFileRow(e);
 			if (!row) {
 				if (hoverRowRef.current) {
@@ -99,7 +130,10 @@ export function ShadowRowHoverActions({
 						pointerEvents: "none",
 					}}
 				>
-					<div className="pointer-events-auto absolute inset-y-0 right-2 flex items-center gap-0.5">
+					<div
+						ref={overlayRef}
+						className="pointer-events-auto absolute inset-y-0 right-2 flex items-center gap-0.5"
+					>
 						{renderInlineActions?.(hover.treePath)}
 						<DropdownMenu
 							open={menuOpen}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/ShadowRowHoverActions/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/ChangesTreeView/components/ShadowRowHoverActions/index.ts
@@ -1,1 +1,4 @@
-export { ShadowRowHoverActions } from "./ShadowRowHoverActions";
+export {
+	HOVER_ACTIONS_ROW_CSS,
+	ShadowRowHoverActions,
+} from "./ShadowRowHoverActions";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/FileRow/FileRow.tsx
@@ -12,6 +12,7 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuSeparator,
 	DropdownMenuShortcut,
 	DropdownMenuTrigger,
 } from "@superset/ui/dropdown-menu";
@@ -24,6 +25,8 @@ import {
 	ExternalLink,
 	FileText,
 	GitCompare,
+	Minus,
+	Plus,
 	SquarePlus,
 	Trash2,
 	Undo2,
@@ -42,8 +45,10 @@ import {
 } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
 import { toAbsoluteWorkspacePath } from "shared/absolute-paths";
 import { useFileDrag } from "../../hooks/useFileDrag";
+import { useStagingMutations } from "../../hooks/useStagingMutations";
 import { DiffStatText } from "../DiffStatText";
 import { PathActionsMenuItems } from "../PathActionsMenuItems";
+import { StageToggleButton } from "../StageToggleButton";
 
 function splitPath(path: string): { dir: string; basename: string } {
 	const lastSlash = path.lastIndexOf("/");
@@ -88,7 +93,9 @@ export const FileRow = memo(function FileRow({
 		? toAbsoluteWorkspacePath(worktreePath, file.path)
 		: undefined;
 	const changeKey = getChangesetFileKey(file);
-	const canDiscard = file.source.kind === "unstaged";
+	const canStage = file.source.kind === "unstaged";
+	const canUnstage = file.source.kind === "staged";
+	const canDiscard = canStage;
 	const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 	const isDeleteAction = file.status === "untracked" || file.status === "added";
 	const utils = workspaceTrpc.useUtils();
@@ -112,6 +119,7 @@ export const FileRow = memo(function FileRow({
 		setShowDiscardConfirm(false);
 		discardMutation.mutate({ workspaceId, filePath: file.path });
 	};
+	const { stageFile, unstageFile } = useStagingMutations(workspaceId);
 
 	const policy = useChangesSidebarFilePolicy();
 	const diffNewTabTier = policy.tierForIntent("diffNewTab");
@@ -151,7 +159,7 @@ export const FileRow = memo(function FileRow({
 						{basename}
 					</span>
 				</span>
-				<span className="ml-auto flex shrink-0 items-center gap-1.5 group-hover:invisible">
+				<span className="ml-auto flex shrink-0 items-center gap-1.5 group-hover:invisible group-has-[[data-state=open]]:invisible">
 					{(file.additions > 0 || file.deletions > 0) && (
 						<span className="text-[10px] text-muted-foreground">
 							<DiffStatText
@@ -185,6 +193,15 @@ export const FileRow = memo(function FileRow({
 							<Trans>Discard changes</Trans>
 						</TooltipContent>
 					</Tooltip>
+				)}
+				{canStage && (
+					<StageToggleButton action="stage" onClick={() => stageFile(file)} />
+				)}
+				{canUnstage && (
+					<StageToggleButton
+						action="unstage"
+						onClick={() => unstageFile(file)}
+					/>
 				)}
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>
@@ -248,6 +265,24 @@ export const FileRow = memo(function FileRow({
 								</DropdownMenuShortcut>
 							)}
 						</DropdownMenuItem>
+						{canStage && (
+							<>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem onSelect={() => stageFile(file)}>
+									<Plus />
+									<Trans>Stage file</Trans>
+								</DropdownMenuItem>
+							</>
+						)}
+						{canUnstage && (
+							<>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem onSelect={() => unstageFile(file)}>
+									<Minus />
+									<Trans>Unstage file</Trans>
+								</DropdownMenuItem>
+							</>
+						)}
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</div>
@@ -318,21 +353,31 @@ export const FileRow = memo(function FileRow({
 						/>
 					</>
 				)}
+				{(canStage || canUnstage) && <ContextMenuSeparator />}
+				{canStage && (
+					<ContextMenuItem onSelect={() => stageFile(file)}>
+						<Plus />
+						<Trans>Stage file</Trans>
+					</ContextMenuItem>
+				)}
+				{canUnstage && (
+					<ContextMenuItem onSelect={() => unstageFile(file)}>
+						<Minus />
+						<Trans>Unstage file</Trans>
+					</ContextMenuItem>
+				)}
 				{canDiscard && (
-					<>
-						<ContextMenuSeparator />
-						<ContextMenuItem
-							variant="destructive"
-							onSelect={() => setShowDiscardConfirm(true)}
-						>
-							{isDeleteAction ? <Trash2 /> : <Undo2 />}
-							{isDeleteAction
-								? t({ message: "Delete" })
-								: t({
-										message: "Discard changes",
-									})}
-						</ContextMenuItem>
-					</>
+					<ContextMenuItem
+						variant="destructive"
+						onSelect={() => setShowDiscardConfirm(true)}
+					>
+						{isDeleteAction ? <Trash2 /> : <Undo2 />}
+						{isDeleteAction
+							? t({ message: "Delete" })
+							: t({
+									message: "Discard changes",
+								})}
+					</ContextMenuItem>
 				)}
 			</ContextMenuContent>
 			<DiscardConfirmDialog

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/StageToggleButton/StageToggleButton.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/StageToggleButton/StageToggleButton.tsx
@@ -1,0 +1,35 @@
+import { useLingui } from "@lingui/react/macro";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
+import { Minus, Plus } from "lucide-react";
+
+interface StageToggleButtonProps {
+	action: "stage" | "unstage";
+	onClick: () => void;
+}
+
+export function StageToggleButton({ action, onClick }: StageToggleButtonProps) {
+	const { t } = useLingui();
+	const label =
+		action === "stage"
+			? t({ message: "Stage file" })
+			: t({ message: "Unstage file" });
+	const Icon = action === "stage" ? Plus : Minus;
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					aria-label={label}
+					className="flex size-5 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+					onClick={(e) => {
+						e.stopPropagation();
+						onClick();
+					}}
+				>
+					<Icon className="size-3.5" />
+				</button>
+			</TooltipTrigger>
+			<TooltipContent side="top">{label}</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/StageToggleButton/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/components/StageToggleButton/index.ts
@@ -1,0 +1,1 @@
+export { StageToggleButton } from "./StageToggleButton";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useStagingMutations/index.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useStagingMutations/index.ts
@@ -1,0 +1,1 @@
+export { useStagingMutations } from "./useStagingMutations";

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useStagingMutations/useStagingMutations.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/components/WorkspaceSidebar/hooks/useChangesTab/components/ChangesFileList/hooks/useStagingMutations/useStagingMutations.ts
@@ -1,0 +1,44 @@
+import { useLingui } from "@lingui/react/macro";
+import { errorMessage } from "@superset/i18n/errors";
+import { toast } from "@superset/ui/sonner";
+import { workspaceTrpc } from "@superset/workspace-client";
+import { useCallback } from "react";
+import type { ChangesetFile } from "renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useChangeset";
+
+export function useStagingMutations(workspaceId: string) {
+	const { t } = useLingui();
+	const utils = workspaceTrpc.useUtils();
+	const invalidate = () => {
+		void utils.git.getStatus.invalidate({ workspaceId });
+		void utils.git.getDiff.invalidate({ workspaceId });
+	};
+	const { mutate: stage } = workspaceTrpc.git.stageFile.useMutation({
+		onSuccess: invalidate,
+		onError: (err) => {
+			toast.error(t({ message: "Couldn't stage file" }), {
+				description: errorMessage(err),
+			});
+		},
+	});
+	const { mutate: unstage } = workspaceTrpc.git.unstageFile.useMutation({
+		onSuccess: invalidate,
+		onError: (err) => {
+			toast.error(t({ message: "Couldn't unstage file" }), {
+				description: errorMessage(err),
+			});
+		},
+	});
+
+	const stageFile = useCallback(
+		(file: ChangesetFile) =>
+			stage({ workspaceId, filePath: file.path, oldPath: file.oldPath }),
+		[stage, workspaceId],
+	);
+	const unstageFile = useCallback(
+		(file: ChangesetFile) =>
+			unstage({ workspaceId, filePath: file.path, oldPath: file.oldPath }),
+		[unstage, workspaceId],
+	);
+
+	return { stageFile, unstageFile };
+}

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -197,6 +197,25 @@ const getDiffInputShape = z.object({
 const MAX_DIFF_BULK_PATHS = 2000;
 const DIFF_SIDE_FILE_MAX_BYTES = 10 * 1024 * 1024;
 
+// A rename is two index entries (delete of `oldPath`, add of `filePath`);
+// staging or unstaging only one end would split it into a delete plus an add.
+const stagingTargetInput = z.object({
+	workspaceId: z.string(),
+	filePath: z.string(),
+	oldPath: z.string().optional(),
+});
+
+function resolveStagingTargetPaths(
+	input: z.infer<typeof stagingTargetInput>,
+): string[] {
+	assertSafeRelativePath(input.filePath);
+	if (input.oldPath == null || input.oldPath === input.filePath) {
+		return [input.filePath];
+	}
+	assertSafeRelativePath(input.oldPath);
+	return [input.filePath, input.oldPath];
+}
+
 export const gitRouter = router({
 	listBranches: queryProcedure
 		.input(z.object({ workspaceId: z.string() }))
@@ -552,6 +571,26 @@ export const gitRouter = router({
 			for (const filePath of deletePaths) {
 				await removeFromWorktree(worktreePath, filePath);
 			}
+			return { success: true };
+		}),
+
+	stageFile: protectedProcedure
+		.input(stagingTargetInput)
+		.mutation(async ({ ctx, input }) => {
+			const paths = resolveStagingTargetPaths(input);
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			await git.raw(["add", "-A", "--", ...paths]);
+			return { success: true };
+		}),
+
+	unstageFile: protectedProcedure
+		.input(stagingTargetInput)
+		.mutation(async ({ ctx, input }) => {
+			const paths = resolveStagingTargetPaths(input);
+			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
+			const git = await ctx.git(worktreePath);
+			await git.raw(["reset", "HEAD", "--", ...paths]);
 			return { success: true };
 		}),
 

--- a/packages/host-service/src/trpc/router/git/git.ts
+++ b/packages/host-service/src/trpc/router/git/git.ts
@@ -16,6 +16,7 @@ import {
 	gitDiffSideBlobTask,
 	gitFetchBaseRefTask,
 	gitPushTask,
+	gitStagePathsTask,
 	gitStatusSnapshotTask,
 } from "../../../workers/tasks/git";
 import { protectedProcedure, queryProcedure, router } from "../../index";
@@ -579,9 +580,13 @@ export const gitRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const paths = resolveStagingTargetPaths(input);
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
-			const git = await ctx.git(worktreePath);
-			await git.raw(["add", "-A", "--", ...paths]);
-			return { success: true };
+			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
+			return getHostWorkerPool().run(gitStagePathsTask, {
+				worktreePath,
+				paths,
+				action: "stage",
+				gitEnv,
+			});
 		}),
 
 	unstageFile: protectedProcedure
@@ -589,9 +594,13 @@ export const gitRouter = router({
 		.mutation(async ({ ctx, input }) => {
 			const paths = resolveStagingTargetPaths(input);
 			const worktreePath = resolveWorktreePath(ctx, input.workspaceId);
-			const git = await ctx.git(worktreePath);
-			await git.raw(["reset", "HEAD", "--", ...paths]);
-			return { success: true };
+			const gitEnv = await resolveGitTaskEnv(ctx, worktreePath);
+			return getHostWorkerPool().run(gitStagePathsTask, {
+				worktreePath,
+				paths,
+				action: "unstage",
+				gitEnv,
+			});
 		}),
 
 	stageAll: protectedProcedure

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -390,6 +390,24 @@ export const gitDeleteBranchTask = defineWorkerTask<
 	},
 });
 
+export const gitStagePathsTask = defineWorkerTask<
+	{
+		worktreePath: string;
+		paths: string[];
+		action: "stage" | "unstage";
+		gitEnv: GitTaskEnv;
+	},
+	{ success: true }
+>({
+	type: "git/stagePaths",
+	handler: async ({ worktreePath, paths, action, gitEnv }) => {
+		const git = createUserSimpleGit(worktreePath).env(gitEnv);
+		if (action === "stage") await git.raw(["add", "-A", "--", ...paths]);
+		else await git.raw(["reset", "HEAD", "--", ...paths]);
+		return { success: true };
+	},
+});
+
 export const gitCommitTask = defineWorkerTask<
 	{
 		worktreePath: string;

--- a/packages/host-service/src/workers/tasks/git.ts
+++ b/packages/host-service/src/workers/tasks/git.ts
@@ -402,8 +402,10 @@ export const gitStagePathsTask = defineWorkerTask<
 	type: "git/stagePaths",
 	handler: async ({ worktreePath, paths, action, gitEnv }) => {
 		const git = createUserSimpleGit(worktreePath).env(gitEnv);
-		if (action === "stage") await git.raw(["add", "-A", "--", ...paths]);
-		else await git.raw(["reset", "HEAD", "--", ...paths]);
+		// Paths come from status output, not from a pathspec the user typed;
+		// without this, a name like `:(glob)**` would match the whole tree.
+		const command = action === "stage" ? ["add", "-A"] : ["reset", "HEAD"];
+		await git.raw(["--literal-pathspecs", ...command, "--", ...paths]);
 		return { success: true };
 	},
 });

--- a/packages/host-service/test/integration/git.integration.test.ts
+++ b/packages/host-service/test/integration/git.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { writeFileSync } from "node:fs";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { TRPCClientError } from "@trpc/client";
 import { eq } from "drizzle-orm";
@@ -92,6 +92,143 @@ describe("git router integration", () => {
 			workspaceId: scenario.workspaceId,
 		});
 		expect(result.baseBranch).toBeNull();
+	});
+
+	test("stageFile stages one modified file and leaves the rest unstaged", async () => {
+		await scenario.repo.commit("seed", {
+			"a.txt": "original-a",
+			"b.txt": "original-b",
+		});
+		writeFileSync(join(scenario.repo.repoPath, "a.txt"), "modified-a");
+		writeFileSync(join(scenario.repo.repoPath, "b.txt"), "modified-b");
+
+		await scenario.host.trpc.git.stageFile.mutate({
+			workspaceId: scenario.workspaceId,
+			filePath: "a.txt",
+		});
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.staged.map((f) => f.path)).toEqual(["a.txt"]);
+		expect(status.unstaged.map((f) => f.path)).toEqual(["b.txt"]);
+	});
+
+	test("stageFile stages an untracked file", async () => {
+		writeFileSync(join(scenario.repo.repoPath, "new.txt"), "new file");
+
+		await scenario.host.trpc.git.stageFile.mutate({
+			workspaceId: scenario.workspaceId,
+			filePath: "new.txt",
+		});
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.staged.find((f) => f.path === "new.txt")?.status).toBe(
+			"added",
+		);
+		expect(status.unstaged.map((f) => f.path)).not.toContain("new.txt");
+	});
+
+	test("stageFile stages a working-tree deletion as a deletion", async () => {
+		await scenario.repo.commit("seed", { "gone.txt": "bye" });
+		rmSync(join(scenario.repo.repoPath, "gone.txt"));
+
+		await scenario.host.trpc.git.stageFile.mutate({
+			workspaceId: scenario.workspaceId,
+			filePath: "gone.txt",
+		});
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.staged.find((f) => f.path === "gone.txt")?.status).toBe(
+			"deleted",
+		);
+		expect(status.unstaged).toEqual([]);
+	});
+
+	test("unstageFile unstages one staged file and leaves the rest staged", async () => {
+		await scenario.repo.commit("seed", {
+			"a.txt": "original-a",
+			"b.txt": "original-b",
+		});
+		writeFileSync(join(scenario.repo.repoPath, "a.txt"), "modified-a");
+		writeFileSync(join(scenario.repo.repoPath, "b.txt"), "modified-b");
+		await scenario.repo.git.add(["a.txt", "b.txt"]);
+
+		await scenario.host.trpc.git.unstageFile.mutate({
+			workspaceId: scenario.workspaceId,
+			filePath: "a.txt",
+		});
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.staged.map((f) => f.path)).toEqual(["b.txt"]);
+		expect(status.unstaged.map((f) => f.path)).toEqual(["a.txt"]);
+	});
+
+	test("unstageFile on a staged rename unstages both ends", async () => {
+		await scenario.repo.commit("seed", { "old.txt": "same content" });
+		await scenario.repo.git.mv("old.txt", "new.txt");
+
+		await scenario.host.trpc.git.unstageFile.mutate({
+			workspaceId: scenario.workspaceId,
+			filePath: "new.txt",
+			oldPath: "old.txt",
+		});
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.staged).toEqual([]);
+		expect(status.unstaged).toMatchObject([
+			{ path: "new.txt", oldPath: "old.txt", status: "renamed" },
+		]);
+	});
+
+	test("stageFile on an unstaged rename stages both ends", async () => {
+		await scenario.repo.commit("seed", { "old.txt": "same content" });
+		await scenario.repo.git.mv("old.txt", "new.txt");
+		await scenario.repo.git.raw(["reset", "HEAD", "--", "old.txt", "new.txt"]);
+
+		await scenario.host.trpc.git.stageFile.mutate({
+			workspaceId: scenario.workspaceId,
+			filePath: "new.txt",
+			oldPath: "old.txt",
+		});
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.unstaged).toEqual([]);
+		expect(status.staged).toMatchObject([
+			{ path: "new.txt", oldPath: "old.txt", status: "renamed" },
+		]);
+	});
+
+	test("stageFile and unstageFile reject paths outside the worktree", async () => {
+		const unsafe = ["/etc/passwd", "../escape.txt"];
+		const inputs = [
+			...unsafe.map((filePath) => ({ filePath })),
+			...unsafe.map((oldPath) => ({ filePath: "ok.txt", oldPath })),
+		];
+		for (const input of inputs) {
+			await expect(
+				scenario.host.trpc.git.stageFile.mutate({
+					workspaceId: scenario.workspaceId,
+					...input,
+				}),
+			).rejects.toBeInstanceOf(TRPCClientError);
+			await expect(
+				scenario.host.trpc.git.unstageFile.mutate({
+					workspaceId: scenario.workspaceId,
+					...input,
+				}),
+			).rejects.toBeInstanceOf(TRPCClientError);
+		}
 	});
 
 	test("renameBranch renames an unpushed branch", async () => {

--- a/packages/host-service/test/integration/git.integration.test.ts
+++ b/packages/host-service/test/integration/git.integration.test.ts
@@ -209,6 +209,24 @@ describe("git router integration", () => {
 		]);
 	});
 
+	test("stageFile treats pathspec magic as a literal file name", async () => {
+		await scenario.repo.commit("seed", { "ordinary.txt": "base" });
+		writeFileSync(join(scenario.repo.repoPath, "ordinary.txt"), "changed");
+
+		await expect(
+			scenario.host.trpc.git.stageFile.mutate({
+				workspaceId: scenario.workspaceId,
+				filePath: ":(glob)**",
+			}),
+		).rejects.toBeInstanceOf(TRPCClientError);
+
+		const status = await scenario.host.trpc.git.getStatus.query({
+			workspaceId: scenario.workspaceId,
+		});
+		expect(status.staged).toEqual([]);
+		expect(status.unstaged.map((f) => f.path)).toEqual(["ordinary.txt"]);
+	});
+
 	test("stageFile and unstageFile reject paths outside the worktree", async () => {
 		const unsafe = ["/etc/passwd", "../escape.txt"];
 		const inputs = [

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Nepodařilo se připravit změny"
 msgid "Couldn't stage design feedback"
 msgstr "Nepodařilo se připravit designovou zpětnou vazbu"
 
+msgid "Couldn't stage file"
+msgstr "Nepodařilo se připravit soubor"
+
 msgid "Couldn't start a new agent session"
 msgstr "Nepodařilo se spustit novou relaci agenta"
 
@@ -4356,6 +4359,9 @@ msgstr "Pracovní prostor se nepodařilo spustit"
 
 msgid "Couldn't unstage changes"
 msgstr "Nepodařilo se zrušit přípravu změn"
+
+msgid "Couldn't unstage file"
+msgstr "Nepodařilo se zrušit přípravu souboru"
 
 msgid "Couldn't update pull request"
 msgstr "Pull request se nepodařilo aktualizovat"
@@ -13609,6 +13615,9 @@ msgstr "Nad sebou"
 msgid "Stage all"
 msgstr "Připravit vše"
 
+msgid "Stage file"
+msgstr "Připravit soubor"
+
 msgid "Staged"
 msgstr "Připravené"
 
@@ -15515,6 +15524,9 @@ msgstr "Neuložené změny"
 
 msgid "Unstage all"
 msgstr "Zrušit přípravu u všech"
+
+msgid "Unstage file"
+msgstr "Zrušit přípravu souboru"
 
 msgid "Unstaged"
 msgstr "Nepřipravené"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -4361,7 +4361,7 @@ msgid "Couldn't unstage changes"
 msgstr "Stagen konnte nicht aufgehoben werden"
 
 msgid "Couldn't unstage file"
-msgstr "Stagen der Datei konnte nicht aufgehoben werden"
+msgstr "Datei konnte nicht unstaged werden"
 
 msgid "Couldn't update pull request"
 msgstr "Pull Request konnte nicht aktualisiert werden"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Änderungen konnten nicht gestaged werden"
 msgid "Couldn't stage design feedback"
 msgstr "Design-Feedback konnte nicht vorbereitet werden"
 
+msgid "Couldn't stage file"
+msgstr "Datei konnte nicht gestaged werden"
+
 msgid "Couldn't start a new agent session"
 msgstr "Es konnte keine neue Agenten-Sitzung gestartet werden"
 
@@ -4356,6 +4359,9 @@ msgstr "Arbeitsbereich konnte nicht gestartet werden"
 
 msgid "Couldn't unstage changes"
 msgstr "Stagen konnte nicht aufgehoben werden"
+
+msgid "Couldn't unstage file"
+msgstr "Stagen der Datei konnte nicht aufgehoben werden"
 
 msgid "Couldn't update pull request"
 msgstr "Pull Request konnte nicht aktualisiert werden"
@@ -13609,6 +13615,9 @@ msgstr "Gestapelt"
 msgid "Stage all"
 msgstr "Alles stagen"
 
+msgid "Stage file"
+msgstr "Datei stagen"
+
 msgid "Staged"
 msgstr "Gestaged"
 
@@ -15515,6 +15524,9 @@ msgstr "Nicht gespeicherte Änderungen"
 
 msgid "Unstage all"
 msgstr "Alles unstagen"
+
+msgid "Unstage file"
+msgstr "Datei unstagen"
 
 msgid "Unstaged"
 msgstr "Nicht gestaged"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Couldn't stage changes"
 msgid "Couldn't stage design feedback"
 msgstr "Couldn't stage design feedback"
 
+msgid "Couldn't stage file"
+msgstr "Couldn't stage file"
+
 msgid "Couldn't start a new agent session"
 msgstr "Couldn't start a new agent session"
 
@@ -4356,6 +4359,9 @@ msgstr "Couldn't start workspace"
 
 msgid "Couldn't unstage changes"
 msgstr "Couldn't unstage changes"
+
+msgid "Couldn't unstage file"
+msgstr "Couldn't unstage file"
 
 msgid "Couldn't update pull request"
 msgstr "Couldn't update pull request"
@@ -13609,6 +13615,9 @@ msgstr "Stacked"
 msgid "Stage all"
 msgstr "Stage all"
 
+msgid "Stage file"
+msgstr "Stage file"
+
 msgid "Staged"
 msgstr "Staged"
 
@@ -15515,6 +15524,9 @@ msgstr "Unsaved changes"
 
 msgid "Unstage all"
 msgstr "Unstage all"
+
+msgid "Unstage file"
+msgstr "Unstage file"
 
 msgid "Unstaged"
 msgstr "Unstaged"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -4339,6 +4339,9 @@ msgstr "No se pudieron preparar los cambios"
 msgid "Couldn't stage design feedback"
 msgstr "No se pudo preparar el feedback de diseño"
 
+msgid "Couldn't stage file"
+msgstr "No se pudo preparar el archivo"
+
 msgid "Couldn't start a new agent session"
 msgstr "No se pudo iniciar una sesión de agente nueva"
 
@@ -4356,6 +4359,9 @@ msgstr "No se pudo iniciar el espacio de trabajo"
 
 msgid "Couldn't unstage changes"
 msgstr "No se pudieron quitar los cambios de preparados"
+
+msgid "Couldn't unstage file"
+msgstr "No se pudo quitar el archivo de preparados"
 
 msgid "Couldn't update pull request"
 msgstr "No se pudo actualizar la pull request"
@@ -13609,6 +13615,9 @@ msgstr "Apilado"
 msgid "Stage all"
 msgstr "Preparar todo"
 
+msgid "Stage file"
+msgstr "Preparar archivo"
+
 msgid "Staged"
 msgstr "Preparados"
 
@@ -15515,6 +15524,9 @@ msgstr "Cambios sin guardar"
 
 msgid "Unstage all"
 msgstr "Quitar todo de preparados"
+
+msgid "Unstage file"
+msgstr "Quitar archivo de preparados"
 
 msgid "Unstaged"
 msgstr "Sin preparar"

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Impossible d'indexer les modifications"
 msgid "Couldn't stage design feedback"
 msgstr "Impossible de préparer le retour de design"
 
+msgid "Couldn't stage file"
+msgstr "Impossible d'indexer le fichier"
+
 msgid "Couldn't start a new agent session"
 msgstr "Impossible de démarrer une nouvelle session d'agent"
 
@@ -4356,6 +4359,9 @@ msgstr "Impossible de démarrer l'espace de travail"
 
 msgid "Couldn't unstage changes"
 msgstr "Impossible de désindexer les modifications"
+
+msgid "Couldn't unstage file"
+msgstr "Impossible de désindexer le fichier"
 
 msgid "Couldn't update pull request"
 msgstr "Impossible de mettre à jour la pull request"
@@ -13609,6 +13615,9 @@ msgstr "Empilé"
 msgid "Stage all"
 msgstr "Tout indexer"
 
+msgid "Stage file"
+msgstr "Indexer le fichier"
+
 msgid "Staged"
 msgstr "Indexés"
 
@@ -15515,6 +15524,9 @@ msgstr "Modifications non enregistrées"
 
 msgid "Unstage all"
 msgstr "Tout désindexer"
+
+msgid "Unstage file"
+msgstr "Désindexer le fichier"
 
 msgid "Unstaged"
 msgstr "Non indexés"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Tidak bisa men-stage perubahan"
 msgid "Couldn't stage design feedback"
 msgstr "Tidak bisa menyiapkan masukan desain"
 
+msgid "Couldn't stage file"
+msgstr "Tidak bisa men-stage file"
+
 msgid "Couldn't start a new agent session"
 msgstr "Tidak bisa memulai sesi agen baru"
 
@@ -4356,6 +4359,9 @@ msgstr "Tidak bisa memulai workspace"
 
 msgid "Couldn't unstage changes"
 msgstr "Tidak bisa meng-unstage perubahan"
+
+msgid "Couldn't unstage file"
+msgstr "Tidak bisa meng-unstage file"
 
 msgid "Couldn't update pull request"
 msgstr "Tidak bisa memperbarui pull request"
@@ -13609,6 +13615,9 @@ msgstr "Bertumpuk"
 msgid "Stage all"
 msgstr "Stage semua"
 
+msgid "Stage file"
+msgstr "Stage file"
+
 msgid "Staged"
 msgstr "Sudah di-stage"
 
@@ -15515,6 +15524,9 @@ msgstr "Perubahan belum disimpan"
 
 msgid "Unstage all"
 msgstr "Unstage semua"
+
+msgid "Unstage file"
+msgstr "Unstage file"
 
 msgid "Unstaged"
 msgstr "Belum di-stage"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Impossibile aggiungere le modifiche allo stage"
 msgid "Couldn't stage design feedback"
 msgstr "Impossibile preparare il feedback di design"
 
+msgid "Couldn't stage file"
+msgstr "Impossibile aggiungere il file allo stage"
+
 msgid "Couldn't start a new agent session"
 msgstr "Impossibile avviare una nuova sessione dell'agente"
 
@@ -4356,6 +4359,9 @@ msgstr "Impossibile avviare il workspace"
 
 msgid "Couldn't unstage changes"
 msgstr "Impossibile togliere le modifiche dallo stage"
+
+msgid "Couldn't unstage file"
+msgstr "Impossibile togliere il file dallo stage"
 
 msgid "Couldn't update pull request"
 msgstr "Impossibile aggiornare la pull request"
@@ -13609,6 +13615,9 @@ msgstr "Impilato"
 msgid "Stage all"
 msgstr "Aggiungi tutto allo stage"
 
+msgid "Stage file"
+msgstr "Aggiungi il file allo stage"
+
 msgid "Staged"
 msgstr "In stage"
 
@@ -15515,6 +15524,9 @@ msgstr "Modifiche non salvate"
 
 msgid "Unstage all"
 msgstr "Togli tutto dallo stage"
+
+msgid "Unstage file"
+msgstr "Togli il file dallo stage"
 
 msgid "Unstaged"
 msgstr "Non in stage"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -4339,6 +4339,9 @@ msgstr "変更をステージできませんでした"
 msgid "Couldn't stage design feedback"
 msgstr "デザインフィードバックを準備できませんでした"
 
+msgid "Couldn't stage file"
+msgstr "ファイルをステージできませんでした"
+
 msgid "Couldn't start a new agent session"
 msgstr "新しいエージェントセッションを開始できませんでした"
 
@@ -4356,6 +4359,9 @@ msgstr "ワークスペースを開始できませんでした"
 
 msgid "Couldn't unstage changes"
 msgstr "変更をステージ解除できませんでした"
+
+msgid "Couldn't unstage file"
+msgstr "ファイルをステージ解除できませんでした"
 
 msgid "Couldn't update pull request"
 msgstr "プルリクエストを更新できませんでした"
@@ -13609,6 +13615,9 @@ msgstr "積み重ね"
 msgid "Stage all"
 msgstr "すべてステージ"
 
+msgid "Stage file"
+msgstr "ファイルをステージ"
+
 msgid "Staged"
 msgstr "ステージ済み"
 
@@ -15515,6 +15524,9 @@ msgstr "未保存の変更"
 
 msgid "Unstage all"
 msgstr "すべてステージ解除"
+
+msgid "Unstage file"
+msgstr "ファイルをステージ解除"
 
 msgid "Unstaged"
 msgstr "未ステージ"

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -4339,6 +4339,9 @@ msgstr "변경 사항을 스테이징하지 못했습니다"
 msgid "Couldn't stage design feedback"
 msgstr "디자인 피드백을 준비하지 못했습니다"
 
+msgid "Couldn't stage file"
+msgstr "파일을 스테이징하지 못했습니다"
+
 msgid "Couldn't start a new agent session"
 msgstr "새 에이전트 세션을 시작할 수 없습니다"
 
@@ -4356,6 +4359,9 @@ msgstr "워크스페이스를 시작하지 못했습니다"
 
 msgid "Couldn't unstage changes"
 msgstr "스테이징을 해제하지 못했습니다"
+
+msgid "Couldn't unstage file"
+msgstr "파일 스테이징을 해제하지 못했습니다"
 
 msgid "Couldn't update pull request"
 msgstr "풀 리퀘스트를 업데이트하지 못했습니다"
@@ -13609,6 +13615,9 @@ msgstr "스택"
 msgid "Stage all"
 msgstr "모두 스테이징"
 
+msgid "Stage file"
+msgstr "파일 스테이징"
+
 msgid "Staged"
 msgstr "스테이징됨"
 
@@ -15515,6 +15524,9 @@ msgstr "저장하지 않은 변경 사항"
 
 msgid "Unstage all"
 msgstr "스테이징 모두 해제"
+
+msgid "Unstage file"
+msgstr "파일 스테이징 해제"
 
 msgid "Unstaged"
 msgstr "스테이징 안 됨"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Kan wijzigingen niet stagen"
 msgid "Couldn't stage design feedback"
 msgstr "Kan designfeedback niet klaarzetten"
 
+msgid "Couldn't stage file"
+msgstr "Kan bestand niet stagen"
+
 msgid "Couldn't start a new agent session"
 msgstr "Kan geen nieuwe agentsessie starten"
 
@@ -4356,6 +4359,9 @@ msgstr "Kan werkruimte niet starten"
 
 msgid "Couldn't unstage changes"
 msgstr "Kan wijzigingen niet unstagen"
+
+msgid "Couldn't unstage file"
+msgstr "Kan bestand niet unstagen"
 
 msgid "Couldn't update pull request"
 msgstr "Kan pull request niet bijwerken"
@@ -13609,6 +13615,9 @@ msgstr "Gestapeld"
 msgid "Stage all"
 msgstr "Alles stagen"
 
+msgid "Stage file"
+msgstr "Bestand stagen"
+
 msgid "Staged"
 msgstr "Gestaged"
 
@@ -15515,6 +15524,9 @@ msgstr "Niet-opgeslagen wijzigingen"
 
 msgid "Unstage all"
 msgstr "Alles unstagen"
+
+msgid "Unstage file"
+msgstr "Bestand unstagen"
 
 msgid "Unstaged"
 msgstr "Niet gestaged"

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Nie udało się dodać zmian do indeksu"
 msgid "Couldn't stage design feedback"
 msgstr "Nie udało się przygotować uwag projektowych"
 
+msgid "Couldn't stage file"
+msgstr "Nie udało się dodać pliku do indeksu"
+
 msgid "Couldn't start a new agent session"
 msgstr "Nie udało się uruchomić nowej sesji agenta"
 
@@ -4356,6 +4359,9 @@ msgstr "Nie udało się uruchomić obszaru roboczego"
 
 msgid "Couldn't unstage changes"
 msgstr "Nie udało się usunąć zmian z indeksu"
+
+msgid "Couldn't unstage file"
+msgstr "Nie udało się usunąć pliku z indeksu"
 
 msgid "Couldn't update pull request"
 msgstr "Nie udało się zaktualizować pull requesta"
@@ -13609,6 +13615,9 @@ msgstr "Ułożone w stos"
 msgid "Stage all"
 msgstr "Dodaj wszystko do indeksu"
 
+msgid "Stage file"
+msgstr "Dodaj plik do indeksu"
+
 msgid "Staged"
 msgstr "Zaindeksowane"
 
@@ -15515,6 +15524,9 @@ msgstr "Niezapisane zmiany"
 
 msgid "Unstage all"
 msgstr "Usuń wszystko z indeksu"
+
+msgid "Unstage file"
+msgstr "Usuń plik z indeksu"
 
 msgid "Unstaged"
 msgstr "Niezaindeksowane"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Não foi possível adicionar as alterações ao stage"
 msgid "Couldn't stage design feedback"
 msgstr "Não foi possível preparar o feedback de design"
 
+msgid "Couldn't stage file"
+msgstr "Não foi possível adicionar o arquivo ao stage"
+
 msgid "Couldn't start a new agent session"
 msgstr "Não foi possível iniciar uma nova sessão de agente"
 
@@ -4356,6 +4359,9 @@ msgstr "Não foi possível iniciar a área de trabalho"
 
 msgid "Couldn't unstage changes"
 msgstr "Não foi possível remover as alterações do stage"
+
+msgid "Couldn't unstage file"
+msgstr "Não foi possível remover o arquivo do stage"
 
 msgid "Couldn't update pull request"
 msgstr "Não foi possível atualizar o pull request"
@@ -13609,6 +13615,9 @@ msgstr "Empilhado"
 msgid "Stage all"
 msgstr "Adicionar tudo ao stage"
 
+msgid "Stage file"
+msgstr "Adicionar arquivo ao stage"
+
 msgid "Staged"
 msgstr "No stage"
 
@@ -15515,6 +15524,9 @@ msgstr "Alterações não salvas"
 
 msgid "Unstage all"
 msgstr "Remover tudo do stage"
+
+msgid "Unstage file"
+msgstr "Remover arquivo do stage"
 
 msgid "Unstaged"
 msgstr "Fora do stage"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Не удалось проиндексировать изменения"
 msgid "Couldn't stage design feedback"
 msgstr "Не удалось подготовить отзыв по дизайну"
 
+msgid "Couldn't stage file"
+msgstr "Не удалось проиндексировать файл"
+
 msgid "Couldn't start a new agent session"
 msgstr "Не удалось запустить новую сессию агента"
 
@@ -4356,6 +4359,9 @@ msgstr "Не удалось запустить рабочую область"
 
 msgid "Couldn't unstage changes"
 msgstr "Не удалось снять индексацию"
+
+msgid "Couldn't unstage file"
+msgstr "Не удалось снять индексацию с файла"
 
 msgid "Couldn't update pull request"
 msgstr "Не удалось обновить пул-реквест"
@@ -13609,6 +13615,9 @@ msgstr "Стопкой"
 msgid "Stage all"
 msgstr "Проиндексировать всё"
 
+msgid "Stage file"
+msgstr "Проиндексировать файл"
+
 msgid "Staged"
 msgstr "Проиндексировано"
 
@@ -15515,6 +15524,9 @@ msgstr "Несохранённые изменения"
 
 msgid "Unstage all"
 msgstr "Снять индексацию со всего"
+
+msgid "Unstage file"
+msgstr "Снять индексацию с файла"
 
 msgid "Unstaged"
 msgstr "Не проиндексировано"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Değişiklikler hazırlanamadı"
 msgid "Couldn't stage design feedback"
 msgstr "Tasarım geri bildirimi hazırlanamadı"
 
+msgid "Couldn't stage file"
+msgstr "Dosya hazırlanamadı"
+
 msgid "Couldn't start a new agent session"
 msgstr "Yeni bir ajan oturumu başlatılamadı"
 
@@ -4356,6 +4359,9 @@ msgstr "Çalışma alanı başlatılamadı"
 
 msgid "Couldn't unstage changes"
 msgstr "Değişiklikler hazırlıktan çıkarılamadı"
+
+msgid "Couldn't unstage file"
+msgstr "Dosya hazırlıktan çıkarılamadı"
 
 msgid "Couldn't update pull request"
 msgstr "Pull request güncellenemedi"
@@ -13609,6 +13615,9 @@ msgstr "Üst üste"
 msgid "Stage all"
 msgstr "Tümünü hazırla"
 
+msgid "Stage file"
+msgstr "Dosyayı hazırla"
+
 msgid "Staged"
 msgstr "Hazırlanmış"
 
@@ -15515,6 +15524,9 @@ msgstr "Kaydedilmemiş değişiklikler"
 
 msgid "Unstage all"
 msgstr "Tümünü hazırlıktan çıkar"
+
+msgid "Unstage file"
+msgstr "Dosyayı hazırlıktan çıkar"
 
 msgid "Unstaged"
 msgstr "Hazırlanmamış"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -4339,6 +4339,9 @@ msgstr "Không thể stage các thay đổi"
 msgid "Couldn't stage design feedback"
 msgstr "Không thể chuẩn bị góp ý thiết kế"
 
+msgid "Couldn't stage file"
+msgstr "Không thể stage tệp"
+
 msgid "Couldn't start a new agent session"
 msgstr "Không thể bắt đầu phiên agent mới"
 
@@ -4356,6 +4359,9 @@ msgstr "Không khởi động được workspace"
 
 msgid "Couldn't unstage changes"
 msgstr "Không thể bỏ stage các thay đổi"
+
+msgid "Couldn't unstage file"
+msgstr "Không thể bỏ stage tệp"
 
 msgid "Couldn't update pull request"
 msgstr "Không thể cập nhật pull request"
@@ -13609,6 +13615,9 @@ msgstr "Xếp chồng"
 msgid "Stage all"
 msgstr "Stage tất cả"
 
+msgid "Stage file"
+msgstr "Stage tệp"
+
 msgid "Staged"
 msgstr "Đã stage"
 
@@ -15515,6 +15524,9 @@ msgstr "Thay đổi chưa lưu"
 
 msgid "Unstage all"
 msgstr "Bỏ stage tất cả"
+
+msgid "Unstage file"
+msgstr "Bỏ stage tệp"
 
 msgid "Unstaged"
 msgstr "Chưa stage"

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -4339,6 +4339,9 @@ msgstr "无法暂存更改"
 msgid "Couldn't stage design feedback"
 msgstr "无法暂存设计反馈"
 
+msgid "Couldn't stage file"
+msgstr "无法暂存文件"
+
 msgid "Couldn't start a new agent session"
 msgstr "无法启动新的智能体会话"
 
@@ -4356,6 +4359,9 @@ msgstr "无法启动工作区"
 
 msgid "Couldn't unstage changes"
 msgstr "无法取消暂存更改"
+
+msgid "Couldn't unstage file"
+msgstr "无法取消暂存文件"
 
 msgid "Couldn't update pull request"
 msgstr "无法更新拉取请求"
@@ -13609,6 +13615,9 @@ msgstr "堆叠"
 msgid "Stage all"
 msgstr "全部暂存"
 
+msgid "Stage file"
+msgstr "暂存文件"
+
 msgid "Staged"
 msgstr "已暂存"
 
@@ -15515,6 +15524,9 @@ msgstr "未保存的更改"
 
 msgid "Unstage all"
 msgstr "全部取消暂存"
+
+msgid "Unstage file"
+msgstr "取消暂存文件"
 
 msgid "Unstaged"
 msgstr "未暂存"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -4339,6 +4339,9 @@ msgstr "無法暫存更改"
 msgid "Couldn't stage design feedback"
 msgstr "無法暫存設計回饋"
 
+msgid "Couldn't stage file"
+msgstr "無法暫存檔案"
+
 msgid "Couldn't start a new agent session"
 msgstr "無法啟動新的代理程式會話"
 
@@ -4356,6 +4359,9 @@ msgstr "無法啟動工作區"
 
 msgid "Couldn't unstage changes"
 msgstr "無法取消暫存更改"
+
+msgid "Couldn't unstage file"
+msgstr "無法取消暫存檔案"
 
 msgid "Couldn't update pull request"
 msgstr "無法更新拉取請求"
@@ -13609,6 +13615,9 @@ msgstr "堆疊"
 msgid "Stage all"
 msgstr "全部暫存"
 
+msgid "Stage file"
+msgstr "暫存檔案"
+
 msgid "Staged"
 msgstr "已暫存"
 
@@ -15515,6 +15524,9 @@ msgstr "未儲存的更改"
 
 msgid "Unstage all"
 msgstr "全部取消暫存"
+
+msgid "Unstage file"
+msgstr "取消暫存檔案"
 
 msgid "Unstaged"
 msgstr "未暫存"


### PR DESCRIPTION
**Links**
- Issue: #4511 (closed in the July stale sweep, still reproduces; also tracked on #5594)
- Supersedes: #4512 (triage-bot PR with the original implementation, closed unmerged)

## Summary
- File rows in the v2 Changes sidebar get a hover `+` (unstaged) / `−` (staged) and "Stage file" / "Unstage file" in the row dropdown and context menu, in both the folders view and the tree view.
- Host-service gains `git.stageFile` / `git.unstageFile`, which take the path plus an optional old path so a rename stages or unstages as one unit.
- Two adjacent fixes in the tree view's hover overlay: entering one of its buttons no longer clears it (and can no longer wedge the dropdown flag), and Pierre's `+N/−N` / status letter hide under the overlay instead of showing through it.

## Why / Context
v1 let you stage a single file from the row. In v2 the only staging path was the section header's Stage all / Unstage all; rows exposed Discard plus an open-in dropdown. #4512 had the right shape but was closed unmerged; this PR takes its approach and adjusts the rename handling and the overlay behaviour it would have made worse.

## How It Works
- `useStagingMutations(workspaceId)` (shared by `FileRow` and `ChangesTreeView`) wraps the two mutations, invalidates `git.getStatus` / `git.getDiff`, and toasts on error. It passes `ChangesetFile.oldPath` so both ends of a rename move together.
- Server side, `resolveStagingTargetPaths` validates both paths with `assertSafeRelativePath` and runs `git add -A -- <paths>` / `git reset HEAD -- <paths>`. `-A` so a working-tree deletion stages as a deletion.
- `StageToggleButton` is the shared hover `+` / `−`; `FileRowContextMenuItems` takes `onStageFile` / `onUnstageFile` so the tree's dropdown and context menu match `FileRow`'s.
- `ShadowRowHoverActions` ignores mouseover events whose target is inside the overlay, and stamps `data-hover-actions` on the anchored Pierre row; `HOVER_ACTIONS_ROW_CSS` (appended to the tree's `unsafeCSS`) hides the row's `decoration` and `git` sections while stamped. `FileRow` gets the folders-view equivalent (`group-has-[[data-state=open]]:invisible` on the stats) for while its menu is open.

## Manual QA Checklist
Driven end to end over CDP against a scratch repo with a modified file, an untracked file, a working-tree deletion, and a rename; every action checked against `git status` in the repo, with screenshots of each state and an empty `console.error` hook afterwards.

### Folders view
- [x] Hover unstaged row shows Discard, `+`, ⌄; click `+` moves the file to Staged (`M ` in git)
- [x] Hover staged row shows `−`, ⌄ (no Discard); click `−` moves it back (` M`)
- [x] `+` on an untracked file stages it as added (`A `)
- [x] `+` on the `old-name.ts → renamed.ts` row stages as a single rename (`R  old -> new`), `−` on the staged rename splits it back to ` D` + `??` which the status query folds into one unstaged rename row
- [x] Row dropdown and right-click menu show "Stage file" (unstaged) / "Unstage file" (staged), grouped with Discard
- [x] While the dropdown is open the `+1 −1` stats stay hidden behind the overlay

### Tree view
- [x] Same hover buttons, dropdown items, and git outcomes as above
- [x] Moving the pointer from the filename onto Discard / `+` / ⌄ keeps the overlay mounted (before: it cleared and re-appeared, and a click could leave the overlay wedged closed)
- [x] Hovered row hides Pierre's `+N/−N` and status letter under the overlay; both come back when the pointer leaves or the menu closes

## Testing
- `bun test packages/host-service/test/integration/git.integration.test.ts` — 7 new cases: single modified file, untracked, working-tree deletion, single staged file, rename stage / unstage (both ends), absolute and traversal paths rejected on both mutations and on `oldPath`
- `bun test` on the changes-tab dir, `bun run typecheck` (desktop, host-service), `bun run lint`, `bun run check:i18n` (four new strings translated in all 16 catalogs), `packages/i18n` tests

## Design Decisions
- **Client supplies `oldPath` rather than the server detecting renames**: unstaged rename detection is a temp-dir `git diff -M` in `getStatus`; re-running it per click is wasteful and the client already has the pair.
- **Shared hook + button instead of duplicating the mutation setup per component**: #4512 copied the discard-mutation boilerplate into both `FileRow` and `ChangesTreeView`.

## Known Limitations
- The diff pane shows "Unable to load diff" for an unstaged rename whose content is unchanged. Pre-existing, not touched here.

https://claude.ai/code/session_01YZSuBcHjnwW4gfdEtVcX9x

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-file Stage/Unstage to the v2 Changes sidebar: file rows in both the folders and tree views get a hover `+` (unstaged) / `−` (staged) button and "Stage file" / "Unstage file" items in the row dropdown and context menu. Before, only the section header could stage everything; now individual files can be staged, and renames stage as a single unit.

**New Features**
- Adds `git.stageFile` / `git.unstageFile` to the `host-service` git router; both validate paths with `assertSafeRelativePath` and run the git work in a worker task.
- `useStagingMutations` wraps both mutations, invalidates `git.getStatus` and `git.getDiff`, and toasts failures.

**Bug Fixes**
- Tree-view hover overlay no longer clears (or wedges the menu) when the pointer enters one of its buttons.
- The overlay now hides the row's `+N/−N` and status letter instead of showing through it.
- Staged paths run with `--literal-pathspecs` so a name like `:(glob)**` can no longer stage the whole tree.

<sup>Written for commit f0843fd608ce27879c395182b2a617ce0c668d65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stage or unstage individual files from hover actions, dropdowns, and context menus.
  - Handle renamed files correctly when staging or unstaging.
  - Added localized labels and error messages for file-level staging actions.

- **Bug Fixes**
  - Improved hover-action behavior while interacting with file rows.
  - Added validation for unsafe file paths during staging operations.
  - Treat file paths literally to prevent unintended path matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->