### PR TITLE
fix(auth): always show the Google account picker on sign-in

### DIFF
--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -251,6 +251,7 @@ export const auth = betterAuth({
 		google: {
 			clientId: env.GOOGLE_CLIENT_ID,
 			clientSecret: env.GOOGLE_CLIENT_SECRET,
+			prompt: "select_account",
 		},
 		apple: {
 			clientId: env.APPLE_CLIENT_ID,


### PR DESCRIPTION
## Why

Google's OAuth auto-completes when the browser holds exactly one signed-in Google session. In Slack's in-app browser that session is often a different account from the one with access, so opening a pages link silently signs you in as the wrong user and the page 404s as no-access.

## What

Pass `prompt: "select_account"` on the Google social provider. better-auth forwards it onto the authorization URL, so Google shows the account chooser on every sign-in instead of silently picking the only session. Covers web, desktop, and the mobile Google button since they share the server config; native ID-token flows are untouched.

Cost: users with a single Google account get one extra click at sign-in.

https://claude.ai/code/session_01XX782bbZtXYkzAy7JUMmSq

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google OAuth silently signing users into the wrong account when the browser holds a single Google session. The Google provider now passes `prompt: "select_account"`, so Google shows the account chooser on every sign-in instead of auto-completing with the session Slack's in-app browser happens to have.

Users with a single Google account get one extra click at sign-in. This covers web, desktop, and the mobile Google button since they share the server config; native ID-token flows are unchanged.

<sup>Written for commit 7b1a6692aab2990fd60d608c73611622488d45b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Google sign-in now displays the account-selection screen each time, allowing users to choose a different Google account instead of automatically reusing the previously selected account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->