### PR TITLE
fix(mobile): let deploy's build lookups wait for a build already in progress

### DIFF
--- a/apps/mobile/.eas/workflows/deploy.yml
+++ b/apps/mobile/.eas/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
       platform: ios
       profile: preview
       fingerprint_hash: ${{ needs.fingerprint_preview.outputs.ios_fingerprint_hash }}
+      wait_for_in_progress: true
 
   build_internal:
     name: Build internal
@@ -49,6 +50,7 @@ jobs:
       platform: ios
       profile: production
       fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      wait_for_in_progress: true
 
   build_production:
     name: Build production


### PR DESCRIPTION
Seen on the first afternoon of the deploy lane: three production builds (35, 36, 37) with the identical fingerprint `3658c7e2…`, each uploaded to App Store Connect, because #7408 and #7428 merged while the previous build was still running and the `get-build` lookup only matches finished builds.

`wait_for_in_progress: true` on both lookups in `deploy.yml`, matching `pr-preview.yml`. A merge that lands mid-build now waits for that build and skips its own; the run that started the build is the one that uploads it.

Validated with `eas workflow:validate`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate production and internal builds in the mobile deploy lane when a merge lands while a build with the same fingerprint is already running. The lookups now wait for in-progress builds, matching the pull-request lane, so a second merge reuses the running build instead of starting and uploading another.

- Both `build_internal` and `build_production` lookups set `wait_for_in_progress: true`.
- The run that starts a build is the one that uploads it.

<sup>Written for commit 95d0b1b513540b541b52f23cd257ee92e736ecff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile builds now wait for an in-progress matching build instead of failing when one is already running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->