### PR TITLE
refactor(mobile): pull-request lane as one script job plus one comment

### DIFF
--- a/apps/mobile/.eas/workflows/build-pr.yml
+++ b/apps/mobile/.eas/workflows/build-pr.yml
@@ -1,4 +1,4 @@
-name: Build development client for pull request
+name: Mobile build
 
 on:
   pull_request:

--- a/apps/mobile/.eas/workflows/deploy.yml
+++ b/apps/mobile/.eas/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy mobile from main
+name: Deploy Mobile
 
 on:
   push:

--- a/apps/mobile/.eas/workflows/pr-cleanup.yml
+++ b/apps/mobile/.eas/workflows/pr-cleanup.yml
@@ -1,4 +1,4 @@
-name: Delete update branch for deleted git branch
+name: Mobile cleanup
 
 on:
   ref_delete: {}

--- a/apps/mobile/.eas/workflows/pr-preview.yml
+++ b/apps/mobile/.eas/workflows/pr-preview.yml
@@ -1,4 +1,4 @@
-name: Preview update for pull request
+name: Mobile preview
 
 on:
   pull_request:
@@ -13,43 +13,34 @@ on:
       - "!**/*.md"
 
 jobs:
-  fingerprint:
-    name: Fingerprint
-    type: fingerprint
-    environment: development
-
-  get_development_build:
-    name: Find development build for this fingerprint
-    needs: [fingerprint]
-    type: get-build
-    params:
-      platform: ios
-      profile: development
-      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
-      wait_for_in_progress: true
-
   publish:
-    name: Publish preview update
-    needs: [get_development_build]
-    if: ${{ needs.get_development_build.outputs.build_id }}
-    type: update
-    environment: preview
-    params:
-      platform: ios
-      branch: ${{ github.event.pull_request.head.ref }}
-      private_key_path: $UPDATES_SIGNING_KEY
-      upload_sentry_sourcemaps: true
+    name: Publish
+    environment: development
+    outputs:
+      comment: ${{ steps.publish.outputs.comment }}
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - id: publish
+        run: |
+          set -euo pipefail
+          cd "$(git rev-parse --show-toplevel)/apps/mobile"
+          json() { node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s.slice(s.search(/[\[{]/)));console.log(eval(process.argv[1])??"")})' "$1"; }
+          HASH=$(eas fingerprint:generate -p ios --build-profile development --json | json 'j.hash')
+          BUILD=$(eas build:list -p ios --build-profile development --status finished --fingerprint-hash "$HASH" --limit 1 --json --non-interactive | json 'j[0]?.id')
+          if [ -z "$BUILD" ]; then
+            set-output comment "No installed development build can load this pull request as an update: its native fingerprint is \`${HASH:0:12}\` and no development build has it. Add the \`mobile-build\` label to build one."
+            exit 0
+          fi
+          BRANCH="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          eas update -p ios --branch "$BRANCH" --message "$(git log -1 --pretty=%s)" --non-interactive --json > update.json
+          UPDATE_ID=$(json 'j[0].id' < update.json)
+          GROUP=$(json 'j[0].group' < update.json)
+          set-output comment "Preview update published for development build \`${BUILD:0:8}\` (fingerprint \`${HASH:0:12}\`). Open the build on your phone and scan:<br><img src=\"https://qr.expo.dev/eas-update?updateId=${UPDATE_ID}&appScheme=superset&host=u.expo.dev\" width=\"180\"><br>[Update group ${GROUP:0:8}](https://expo.dev/accounts/supserset-sh/projects/superset/updates/${GROUP})"
 
-  comment_with_qr:
-    name: Comment with QR code
+  comment:
+    name: Comment
     needs: [publish]
     type: github-comment
-
-  comment_needs_build:
-    name: Comment that a build is needed
-    needs: [get_development_build]
-    if: ${{ !needs.get_development_build.outputs.build_id }}
-    type: github-comment
     params:
-      payload: |
-        This pull request changes the native layer, so no installed development build can load it as an update. Add the `mobile-build` label to build one.
+      payload: ${{ needs.publish.outputs.comment }}

--- a/apps/mobile/.eas/workflows/pr-preview.yml
+++ b/apps/mobile/.eas/workflows/pr-preview.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$(git rev-parse --show-toplevel)/apps/mobile"
+          eas() { npx -y eas-cli@24.3.0 "$@"; }
           json() { node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s.slice(s.search(/[\[{]/)));console.log(eval(process.argv[1])??"")})' "$1"; }
           HASH=$(eas fingerprint:generate -p ios --build-profile development --json | json 'j.hash')
           BUILD=$(eas build:list -p ios --build-profile development --status finished --fingerprint-hash "$HASH" --limit 1 --json --non-interactive | json 'j[0]?.id')

--- a/apps/mobile/.eas/workflows/update-production.yml
+++ b/apps/mobile/.eas/workflows/update-production.yml
@@ -1,4 +1,4 @@
-name: Publish update to production
+name: Mobile production update
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Every EAS job is its own GitHub check, so the pull-request lane put five rows on every mobile PR. This PR takes it to two.

## Change

- `pr-preview.yml`: one custom job runs a script that fingerprints under the development environment, looks up a finished development build with that fingerprint (`eas build:list --fingerprint-hash`), publishes the update to the branch if one exists, and sets a single `comment` output: either a QR code plus a link to the update group, or a note that the `mobile-build` label is needed. A `github-comment` job posts it. Checks now read `Mobile preview / Publish` and `Mobile preview / Comment`.
- The lane runs entirely under the `development` environment with no signing key. Since #7451 the publish job still ran under `preview` with the key, so it would have produced signed updates whose runtime version no development build matches. That path never executed (no development build existed) so nothing shipped wrong.
- Workflow names shortened: `Deploy Mobile`, `Mobile build`.

## Verified

- `eas workflow:validate` passes on all three files.
- This PR itself triggers the new lane; its run is the test of the fingerprint, lookup, and comment path. The publish path needs a development build with a matching fingerprint; see the comments on this PR for what the run did.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the mobile pull-request lane from five GitHub checks to two by merging fingerprinting, build lookup, and update publishing into one script job that a comment job then posts.

**Details**
- The `Publish` job fingerprints under `development`, finds a finished development build with that fingerprint, and publishes an update to the branch if one exists; the `Comment` job then posts its single output: a QR code plus update group link, or a note that the `mobile-build` label is needed.
- The lane runs entirely under `development` with no signing key; the old publish step used `preview` with the key, which would have produced signed updates no development build matches, and that path never executed so nothing shipped incorrectly.
- Checks now read `Mobile preview / Publish` and `Mobile preview / Comment`.
- Workflow names standardized across all files (`Mobile build`, `Deploy Mobile`, `Mobile cleanup`, `Mobile preview`, `Mobile production update`); `eas workflow:validate` passes.

<sup>Written for commit cb1fd94f45c9fb3939c253d8cc3d94a82a0beb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mobile pull request previews now publish updates and provide a QR code for easier access when a matching build is available.
  - When no compatible build is found, preview results include guidance on the next steps.

- **Chores**
  - Simplified and standardized the names of mobile build, deployment, preview, cleanup, and production update workflows.
  - Improved preview workflow handling to clearly report whether an update was published successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->