### PR TITLE
fix(desktop): reject diff hydration when the loaded contents don't match the patch

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/DiffPane.tsx
@@ -475,12 +475,13 @@ export function DiffPane({
 					? { oldFile: null, newFile }
 					: { oldFile, newFile };
 			if (isDiffContentStale(fileDiff, loaded)) {
-				// The file moved on after its patch was cached, so these lines
-				// don't line up with the hunks they'd be hydrated into.
-				// Staying partial keeps the patch's hunks on screen instead of
-				// tearing the pane down; the `git:changed` that follows the
-				// write refetches the patch, and expanding works again.
-				throw new Error(`${file.path} changed since its diff was loaded`);
+				// The file moved on after its patch was cached, or a side
+				// couldn't be read at the patch's ref, so these lines don't
+				// line up with the hunks they'd be hydrated into. Staying
+				// partial keeps the patch's hunks on screen instead of tearing
+				// the pane down; the `git:changed` that follows the write
+				// refetches the patch, and expanding works again.
+				throw new Error(`${file.path} no longer matches its diff`);
 			}
 			return loaded;
 		},

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.test.ts
@@ -169,6 +169,50 @@ describe("diff loading guards", () => {
 		).toBe(true);
 	});
 
+	test("rejects contents the host could not read at the patch's ref", () => {
+		// loadFileDiffContent answers a failed `git show` with "" instead of an
+		// error; hydrated from nothing, every hunk line is one @pierre/diffs
+		// walks straight off the end of.
+		const unreadable: FileContents = { name: FILE_PATH, contents: "" };
+		expect(
+			isDiffContentStale(REWRITES_MIDDLE, {
+				oldFile: unreadable,
+				newFile: unreadable,
+			}),
+		).toBe(true);
+		expect(
+			isDiffContentStale(REWRITES_MIDDLE, {
+				oldFile: fileContents(COMMITTED_LINES),
+				newFile: unreadable,
+			}),
+		).toBe(true);
+	});
+
+	test("rejects contents shorter than the patch's hunks", () => {
+		expect(
+			isDiffContentStale(REWRITES_MIDDLE, {
+				oldFile: fileContents(COMMITTED_LINES.slice(0, 5)),
+				newFile: fileContents(MIDDLE_REWRITTEN_LINES.slice(0, 5)),
+			}),
+		).toBe(true);
+	});
+
+	test("rejects contents whose lines moved under the patch", () => {
+		// Two lines inserted at the top and two dropped at the bottom: same
+		// length and the same trailing count, but the hunk's rows would show
+		// lines the patch never described.
+		expect(
+			isDiffContentStale(REWRITES_MIDDLE, {
+				oldFile: fileContents(COMMITTED_LINES),
+				newFile: fileContents([
+					"written_after_the_patch_1",
+					"written_after_the_patch_2",
+					...MIDDLE_REWRITTEN_LINES.slice(0, -2),
+				]),
+			}),
+		).toBe(true);
+	});
+
 	test("rejects contents missing a side the diff needs", () => {
 		expect(
 			isDiffContentStale(REWRITES_TO_END_OF_FILE, {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/utils/diffLoadingGuards/diffLoadingGuards.ts
@@ -51,12 +51,13 @@ export function isDiffContentTooLarge(
 
 /** Whether `files` was read at a different revision than the patch `fileDiff`
  * was parsed from. Hydration keeps the patch's hunks and swaps in whole-file
- * line arrays, so contents fetched after the file moved on leave the lines past
- * the last hunk uneven between the two sides. @pierre/diffs asserts they match
- * while it measures layout, and throws from a layout effect — which no boundary
- * inside the pane can catch, so the whole view goes down. Measured on a
- * throwaway clone: rejecting the load leaves the real metadata partial, still
- * rendering the hunks the patch already gave us. */
+ * line arrays, so the hunks must find their own lines at their own positions
+ * in those contents, and contents fetched after the file moved on leave the
+ * lines past the last hunk uneven between the two sides. @pierre/diffs walks
+ * lines that exist on neither side while it measures layout, and throws from a
+ * layout effect — which no boundary inside the pane can catch, so the whole
+ * view goes down. Measured on a throwaway clone: rejecting the load leaves the
+ * real metadata partial, still rendering the hunks the patch already gave us. */
 export function isDiffContentStale(
 	fileDiff: FileDiffMetadata,
 	files: FileDiffLoadedFiles,
@@ -70,6 +71,7 @@ export function isDiffContentStale(
 		// its change type — are just as unusable as mismatched ones.
 		return true;
 	}
+	if (!hunkLinesMatchContents(fileDiff, hydrated)) return true;
 	const lastHunk = hydrated.hunks.at(-1);
 	// Mirrors the cases @pierre/diffs itself skips before comparing.
 	if (
@@ -87,6 +89,62 @@ export function isDiffContentStale(
 		getHunkSideEndBoundary(lastHunk.deletionStart, lastHunk.deletionCount);
 	if (additionRemaining <= 0 && deletionRemaining <= 0) return false;
 	return additionRemaining !== deletionRemaining;
+}
+
+/** Every line the patch carries, read back from the loaded contents at the
+ * position its hunk header claims. The host answers a `git show` it can't
+ * satisfy with empty contents rather than an error, and a file edited in place
+ * keeps its length while its lines move — neither changes the trailing-context
+ * count, and both leave hunks pointing at lines that aren't there. */
+function hunkLinesMatchContents(
+	fileDiff: FileDiffMetadata,
+	hydrated: FileDiffMetadata,
+): boolean {
+	return fileDiff.hunks.every(
+		(hunk) =>
+			sideLinesMatch(
+				fileDiff.deletionLines,
+				hunk.deletionLineIndex,
+				hydrated.deletionLines,
+				hunk.deletionStart,
+				hunk.deletionCount,
+			) &&
+			sideLinesMatch(
+				fileDiff.additionLines,
+				hunk.additionLineIndex,
+				hydrated.additionLines,
+				hunk.additionStart,
+				hunk.additionCount,
+			),
+	);
+}
+
+function sideLinesMatch(
+	patchLines: string[],
+	patchOffset: number,
+	fileLines: string[],
+	fileStart: number,
+	count: number,
+): boolean {
+	for (let index = 0; index < count; index++) {
+		const patchLine = patchLines[patchOffset + index];
+		// A patch whose trailing blank context was trimmed away carries fewer
+		// lines than its header counts; the lines it does carry still decide.
+		if (patchLine == null) return true;
+		const fileLine = fileLines[fileStart - 1 + index];
+		if (
+			fileLine == null ||
+			withoutNewline(patchLine) !== withoutNewline(fileLine)
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/** The patch's final line is the only one parsed without its newline. */
+function withoutNewline(line: string): string {
+	return line.endsWith("\n") ? line.slice(0, -1) : line;
 }
 
 /** @pierre/diffs' own unified-hunk boundary math, which it doesn't export: a


### PR DESCRIPTION
## Summary
- The Changes pane no longer crashes with `DiffHunksRenderer.processDiffResult: deletionLine and additionLine are null` when it expands context on a file whose loaded contents don't match its cached patch.
- `isDiffContentStale` now verifies every line the patch carries against the hydrated contents, on both sides, instead of only comparing trailing line counts.

## Why / Context
Expanding context (or editing) in the Changes pane asks the host for both sides of the file and splices them under the patch's hunks. The host answers any failed `git show` with an empty string rather than an error, and a file can be rewritten after its patch was cached. The existing guard only compared the line counts after the last hunk, so empty, truncated, or shifted contents passed as fresh. @pierre/diffs then walked rows that exist on neither side and threw from a layout effect, which no error boundary inside the pane can catch, so the whole pane went down (the stack trace in the report ends in `walkContextLines`).

## How It Works
- After the trial `hydratePartialDiff("clone")`, `hunkLinesMatchContents` walks each hunk and compares the patch's compact line arrays (offset by `hunk.deletionLineIndex` / `additionLineIndex`) with the hydrated file lines at `hunk.deletionStart` / `additionStart`. Any missing or different line marks the contents stale, and the diff stays partial with its hunks still rendered.
- Lines the patch doesn't carry (a trailing blank context line trimmed off) are skipped rather than failed; the patch's final line is compared without its newline since the parser drops it.
- The trailing-count check is kept for the append-after-patch case, where hunk lines still match but the sides end unevenly.
- The Changes pane's rejection message now covers unreadable contents as well as files that moved on.

## Manual QA Checklist
Verified over CDP in this worktree's dev desktop, same journey on both builds: unstaged edit on a file's last line (hunk reaches EOF on both sides, the shape the old guard could not see), Changes pane in unified view, working-tree file truncated from a script, expand chevron clicked within ~20ms.
- [x] Before the fix: `deletionLine and additionLine are null` thrown twice from the pane's layout effect
- [x] After the fix: one `story.txt no longer matches its diff` console line, no library error, hunks still rendered
- [x] Correct contents still hydrate: guard sweep over every file in five real commits (680 checks across raw/trimmed patches and empty/short/grown content variants) reports no missed crash and no correct file rejected; the only rejections are new files, which the library itself refuses to hydrate, unchanged from before

## Testing
- `bun test .../diffLoadingGuards.test.ts` (11 pass; three new cases: empty contents, contents shorter than the hunks, lines moved under the patch)
- `bun run typecheck` in `apps/desktop`
- `bunx biome check` on the changed files

## Known Limitations
- The PR Code tab is unaffected: it never hydrates files, so it cannot reach this path.

## Follow-ups
- The diff card header keeps stale +/- counts after the patch refetches (a plain edit the sidebar reports as +2 −2 leaves the header at −1 +1). Present with or without this change.
- A renamed-and-edited file renders as a full new-file addition in the Changes pane because the per-file patch is pathspec-limited, so git cannot see the rename.

https://claude.ai/code/session_01MHDxzd3qBph1BQwhkmjpkP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Changes pane crash when expanding context on a file whose loaded contents don't match its cached patch. The old staleness guard only compared trailing line counts, so empty, truncated, or shifted contents passed as fresh, and `@pierre/diffs` threw `deletionLine and additionLine are null` from a layout effect, taking down the whole pane.

The guard now reads every line the patch carries back from the hydrated contents at the position its hunk header claims, on both sides. Any missing or different line keeps the diff partial, so hunks stay rendered. The trailing-count check remains for the append-after-patch case.

<sup>Written for commit ad3d6bbaaf0137ec1110dcff5bab28f0474ac0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diff validation to detect when displayed file contents no longer match the associated patch.
  - Prevented stale or incomplete diff content from being shown, including cases involving missing lines, shifted lines, or unreadable file content.
  - Updated error messaging to clarify when file content no longer matches its diff.

- **Tests**
  - Added coverage for malformed and stale diff content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->