### PR TITLE
feat(mobile): expand a production rollout on a schedule

### DIFF
--- a/apps/mobile/.eas/workflows/expand-production-rollout.yml
+++ b/apps/mobile/.eas/workflows/expand-production-rollout.yml
@@ -1,0 +1,48 @@
+name: Mobile production rollout
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  expand:
+    name: Expand
+    environment: production
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - run: |
+          set -euo pipefail
+          cd "$(git rev-parse --show-toplevel)/apps/mobile"
+          eas() { npx -y eas-cli@24.3.0 "$@"; }
+          json() { node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s.slice(s.search(/[\[{]/)));console.log(eval(process.argv[1])??"")})' "$1"; }
+          LATEST=$(eas update:list --branch production --limit 1 --json --non-interactive)
+          GROUP=$(echo "$LATEST" | json '(j.currentPage??j)[0]?.group')
+          PERCENT=$(echo "$LATEST" | json '(j.currentPage??j)[0]?.rolloutPercentage')
+          if [ -z "$GROUP" ] || [ -z "$PERCENT" ] || [ "$PERCENT" = "100" ]; then
+            echo "No production rollout in progress."
+            exit 0
+          fi
+          VIEW=$(eas update:view "$GROUP" --json --insights --days 7)
+          AGE_HOURS=$(echo "$VIEW" | json 'Math.floor((Date.now()-Date.parse(j.updates[0].createdAt))/36e5)')
+          INSTALLS=$(echo "$VIEW" | json 'j.insights.platforms[0].totals.installs')
+          FAILED_INSTALLS=$(echo "$VIEW" | json 'j.insights.platforms[0].totals.failedInstalls')
+          CRASH_RATE=$(echo "$VIEW" | json 'j.insights.platforms[0].totals.crashRatePercent')
+          echo "Rollout ${GROUP:0:8} at ${PERCENT}% for ${AGE_HOURS}h: ${INSTALLS} installs, ${FAILED_INSTALLS} failed, crash rate ${CRASH_RATE}%."
+          NEXT=""
+          if [ "$AGE_HOURS" -ge 48 ]; then NEXT=100; elif [ "$AGE_HOURS" -ge 24 ]; then NEXT=50; fi
+          if [ -z "$NEXT" ] || [ "$NEXT" -le "$PERCENT" ]; then
+            echo "Holding at ${PERCENT}%: not old enough for the next step."
+            exit 0
+          fi
+          if [ "$INSTALLS" -lt 20 ]; then
+            echo "Only ${INSTALLS} installs after ${AGE_HOURS}h: too little data to expand. Expand by hand with eas update:edit if the telemetry is known to be missing."
+            exit 1
+          fi
+          if node -e "process.exit(($CRASH_RATE) > 1 || ($FAILED_INSTALLS) / ($INSTALLS) > 0.05 ? 0 : 1)"; then
+            echo "Unhealthy rollout: holding at ${PERCENT}%. Revert with eas update:revert-update-rollout, or expand by hand once understood."
+            exit 1
+          fi
+          eas update:edit --branch production --rollout-percentage "$NEXT" --non-interactive
+          echo "Expanded to ${NEXT}%."

--- a/apps/mobile/RELEASE.md
+++ b/apps/mobile/RELEASE.md
@@ -92,11 +92,16 @@ Channels: `preview` for internal builds, `production` for the store build.
 
 ### Production
 
-Never automatic. Dispatch `update-production.yml`, approve it in the run, and it
-publishes at 10%. Adoption ramps on cold start, so judge it over days.
+Publishing is never automatic. Dispatch `update-production.yml`, approve it in
+the run, and it publishes at 10%. Expansion is: every four hours
+`expand-production-rollout.yml` looks at the rollout and moves it to 50% after
+24 hours and to 100% after 48, as long as EAS insights show at least 20
+installs, a crash rate at or under 1%, and failed installs at or under 5%.
+Below those it holds and the run fails, so a stuck rollout is visible. Nothing
+ever lowers a percentage automatically.
 
 ```bash
-# Expand.
+# Expand by hand, ahead of the schedule or when insights are known to be missing.
 eas update:edit --branch production --rollout-percentage 50 --non-interactive
 eas update:edit --branch production --rollout-percentage 100 --non-interactive
 


### PR DESCRIPTION
Answers "will the 10% not auto-expand?" It did not; EAS has no built-in staged rollout schedule. Now it does here.

## Change

`expand-production-rollout.yml`, an EAS scheduled workflow (`0 */4 * * *`, also dispatchable). Each run:

- Reads the latest update on the `production` branch. No rollout in progress (no `rolloutPercentage`, or already 100) means exit quietly.
- After 24 hours moves it to 50%, after 48 hours to 100%, using `eas update:edit`, which refuses to lower a percentage.
- Before expanding, requires EAS update insights for the group to show at least 20 installs, a crash rate at or under 1%, and failed installs at or under 5%. Otherwise it holds and the run fails, so a stuck rollout is visible. Reverting stays manual (`eas update:revert-update-rollout`).

RELEASE.md documents the policy. `update-production.yml` is unchanged: publishing still needs a dispatch and an approval.

## Verified

- `eas workflow:validate` passes.
- A manual run of the workflow on this branch exercises the plumbing on the runner (checkout, install, eas-cli through npx, JSON parsing) and exits on "no production rollout in progress", since nothing has been published to production yet. The expand branch of the script runs for the first time on the first real rollout; the thresholds are the ones to watch then.

## Not verified

Whether EAS insights populate for this app: the latest preview update shows zero installs so far, which may just be nobody having launched it. If insights stay empty, the 20-install gate holds forever and the run goes red after 24 hours, which is the intended signal; expand by hand and check the telemetry.

https://claude.ai/code/session_01UPGxecZoDbCa6iNrJoUZ8n


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled EAS workflow that automatically expands the production rollout from 10% to 50% after 24 hours and to 100% after 48 hours, provided EAS insights show at least 20 installs, a crash rate at or under 1%, and failed installs at or under 5%. Previously, expansion required manual `eas update:edit` runs.

- The workflow runs every four hours and exits quietly when no rollout is in progress.
- It holds and fails the run when the health thresholds aren't met, so a stuck rollout stays visible.
- Publishing remains manual; only expansion is automated.
- It never lowers a rollout percentage; that stays manual.
- `RELEASE.md` now documents the policy and the manual override for when insights are missing.

<sup>Written for commit ae668d457f5218246f997e2e9f92fa1fa0a328b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mobile app production updates now expand gradually from 10% to 50% after 24 hours, then to 100% after 48 hours when minimum install and stability thresholds are met.
  - Rollout expansion is automatically paused when crash rates or failed installations exceed safe limits.
  - Scheduled and manual rollout advancement are supported.

- **Documentation**
  - Updated release guidance explains rollout timing, eligibility checks, pauses, and manual advancement procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->