### PR TITLE
chore(mobile): publish production updates to everyone, no staged rollout

### DIFF
--- a/apps/mobile/.eas/workflows/update-production.yml
+++ b/apps/mobile/.eas/workflows/update-production.yml
@@ -13,7 +13,7 @@ jobs:
     type: require-approval
 
   publish:
-    name: Publish to production at 10%
+    name: Publish to production
     needs: [approve]
     type: update
     environment: production
@@ -21,6 +21,5 @@ jobs:
       platform: ios
       channel: production
       message: ${{ inputs.message }}
-      rollout_percentage: 10
       private_key_path: $UPDATES_SIGNING_KEY
       upload_sentry_sourcemaps: true

--- a/apps/mobile/RELEASE.md
+++ b/apps/mobile/RELEASE.md
@@ -93,25 +93,16 @@ Channels: `preview` for internal builds, `production` for the store build.
 ### Production
 
 Never automatic. Dispatch `update-production.yml`, approve it in the run, and it
-publishes at 10%. Adoption ramps on cold start, so judge it over days.
+publishes to everyone on the production channel. No staged rollout: a small
+team with few users learns more from a fast rollback than a slow ramp.
 
 ```bash
-# Expand.
-eas update:edit --branch production --rollout-percentage 50 --non-interactive
-eas update:edit --branch production --rollout-percentage 100 --non-interactive
-
-# Back out during a rollout. Republishes the previous update to everyone,
-# including users who already took the bad one.
-eas update:revert-update-rollout --branch production --non-interactive \
-  --private-key-path ~/.superset/keys/mobile-updates/private-key.pem
-
-# Back out after a rollout completed.
+# Back out. Republishes the previous update to everyone, including users who
+# already took the bad one.
 eas update:rollback --private-key-path ~/.superset/keys/mobile-updates/private-key.pem
 ```
 
-One rollout per branch at a time, and it must reach 100 or be reverted before
-the next production update can publish. An update that migrates persisted state
-is not rollback-safe; fix forward.
+An update that migrates persisted state is not rollback-safe; fix forward.
 
 The private key lives in 1Password and nowhere in this repository. EAS holds a
 copy it will never show you, so 1Password is the only backup.


### PR DESCRIPTION
Replaces #7465 (closed). The production lane published at 10% and left expansion to two manual `update:edit` calls or a scheduler; neither is worth carrying at this size. `update-production.yml` now publishes to the whole production channel after the dispatch and approval, and RELEASE.md says how to back out with `eas update:rollback`.

Validated with `eas workflow:validate`. No behaviour on main changes until someone dispatches the lane; production has had no update yet.

https://claude.ai/code/session_01UPGxecZoDbCa6iNrJoUZ8n


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the staged rollout for production mobile updates. The production lane now publishes to the whole `production` channel after approval, and the runbook's only back-out path is `eas update:rollback`.

**Rollout actions**
- No behavior changes on `main` until someone dispatches the lane; production has had no update yet.
- `eas update:rollback` republishes the previous update, including to users who already took the bad one.
- Updates that migrate persisted state are not rollback-safe; fix forward.

<sup>Written for commit 44e132f2bc474deb4fb35fe5d082687d73177d03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Production updates are now published to all production users at once rather than through a staged 10% → 50% → 100% rollout.
  - The staged rollout expansion and rollout-revert procedures have been removed.
  - Production updates remain reversible through the standard rollback process, though fixes may require a follow-up update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->