### PR TITLE
refactor(trpc,desktop,mobile): fold the v2Host router into host

### DIFF
--- a/apps/desktop/src/renderer/hooks/host-service/useHostServiceUpdate/useHostServiceUpdate.ts
+++ b/apps/desktop/src/renderer/hooks/host-service/useHostServiceUpdate/useHostServiceUpdate.ts
@@ -74,7 +74,7 @@ export function useHostServiceUpdate(options: {
 			void queryClient.invalidateQueries({
 				queryKey: hostServiceInfoQueryKey(hostUrl),
 			});
-			void cloudUtils.v2Host.list.invalidate();
+			void cloudUtils.host.roster.invalidate();
 			update({ stage: "updated", error: null });
 		};
 		const fail = (error: string) => update({ stage: "failed", error });

--- a/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
+++ b/apps/desktop/src/renderer/hooks/known-hosts/useKnownHosts/useKnownHosts.ts
@@ -6,7 +6,7 @@ import { useRelayUrl } from "renderer/hooks/useRelayUrl";
 import { cloudTrpc } from "renderer/lib/cloud-trpc";
 import { getHostEventBus } from "renderer/lib/host-event-bus";
 
-type HostRow = RouterOutputs["v2Host"]["list"][number];
+type HostRow = RouterOutputs["host"]["roster"][number];
 
 export type KnownHostRow = HostRow & { isOnline: boolean };
 
@@ -40,7 +40,7 @@ export function useKnownHosts(): {
 } {
 	const organizationId = useActiveOrganizationId();
 	const relayUrl = useRelayUrl();
-	const hostsQuery = cloudTrpc.v2Host.list.useQuery(
+	const hostsQuery = cloudTrpc.host.roster.useQuery(
 		{ organizationId: organizationId ?? "" },
 		{
 			enabled: organizationId !== null,

--- a/apps/desktop/src/renderer/lib/cloud-trpc.ts
+++ b/apps/desktop/src/renderer/lib/cloud-trpc.ts
@@ -48,7 +48,6 @@ export const CLOUD_TRPC_ROUTER_ROOTS = [
 	"task",
 	"team",
 	"user",
-	"v2Host",
 	"v2Project",
 ] as const;
 

--- a/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
+++ b/apps/desktop/src/renderer/providers/ElectronTRPCProvider/ElectronTRPCProvider.tsx
@@ -87,7 +87,7 @@ const PERSIST_KEY_PREFIXES = new Set([
 ]);
 // tRPC queries persisted by procedure path: the host roster, so the sidebar
 // fans out to remote hosts on a cold or offline boot before the cloud answers.
-const PERSIST_TRPC_PATHS = new Set(["v2Host.list"]);
+const PERSIST_TRPC_PATHS = new Set(["host.roster"]);
 
 export function ElectronTRPCProvider({
 	children,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/components/WorkspaceHostIncompatibleState/WorkspaceHostIncompatibleState.tsx
@@ -37,8 +37,7 @@ export function WorkspaceHostIncompatibleState({
 		update.progress.stage !== "updated" &&
 		update.progress.stage !== "failed";
 	const { data: session } = authClient.useSession();
-	const { data: members = [] } =
-		cloudTrpc.v2Host.listMembers.useQuery(undefined);
+	const { data: members = [] } = cloudTrpc.host.listMembers.useQuery(undefined);
 	const { data: info } = useHostServiceInfo(hostUrl);
 	const isOwner = members.some(
 		(member) =>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspaces/hooks/useAccessibleV2Workspaces/useAccessibleV2Workspaces.ts
@@ -290,7 +290,7 @@ export function useAccessibleV2Workspaces(
 
 	const { hosts: hostRows } = useKnownHosts();
 
-	const { data: hostMemberRows = [] } = cloudTrpc.v2Host.listMembers.useQuery(
+	const { data: hostMemberRows = [] } = cloudTrpc.host.listMembers.useQuery(
 		undefined,
 		{},
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceWorktreesInSidebar/selectWorktreesToPlace.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/AgentHooks/hooks/usePlaceWorktreesInSidebar/selectWorktreesToPlace.ts
@@ -48,7 +48,7 @@ export type PlacementContext = {
  * purpose: a row nobody can open is sidebar noise (#7100).
  *
  * Creator gate: a remote workspace is placed only when the signed-in user
- * created it. Hosts are shared (`v2Host.list` is "hosts you can access", not
+ * created it. Hosts are shared (`host.roster` is "hosts you can access", not
  * "hosts you own"), so anything wider pins teammates' work — and a placed row
  * is sticky, so interim clutter would outlive a later fix. A null creator
  * (host predating the `x-superset-user-id` stamp) is not placed; those rows

--- a/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/DashboardNewWorkspaceModal/components/DashboardNewWorkspaceForm/components/DevicePicker/hooks/useWorkspaceHostOptions/useWorkspaceHostOptions.ts
@@ -45,7 +45,7 @@ export function useWorkspaceHostOptions(): UseWorkspaceHostOptionsResult {
 	const { hosts: hostRows } = useKnownHosts();
 
 	const { data: hostMemberRows = [] } =
-		cloudTrpc.v2Host.listMembers.useQuery(undefined);
+		cloudTrpc.host.listMembers.useQuery(undefined);
 
 	const accessibleHosts = useMemo(() => {
 		const accessibleHostIds = new Set(

--- a/apps/desktop/src/renderer/routes/_authenticated/components/RealtimeNudges/RealtimeNudges.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/RealtimeNudges/RealtimeNudges.tsx
@@ -34,7 +34,7 @@ export function RealtimeNudges() {
 			for (const kind of kinds) {
 				switch (kind) {
 					case "hosts":
-						void utils.v2Host.list.invalidate(undefined, options);
+						void utils.host.roster.invalidate(undefined, options);
 						break;
 					case "cloud_workspaces":
 						void utils.cloudWorkspace.list.invalidate(undefined, options);

--- a/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticActions/useOptimisticActions.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/hooks/useOptimisticActions/useOptimisticActions.ts
@@ -449,8 +449,8 @@ export function useOptimisticActions() {
 					runHostsMutation("Failed to delete host", () =>
 						makeTransaction(
 							"delete",
-							apiTrpcClient.v2Host.delete.mutate({ hostId }).finally(() => {
-								void utils.v2Host.invalidate();
+							apiTrpcClient.host.delete.mutate({ hostId }).finally(() => {
+								void utils.host.invalidate();
 							}),
 						),
 					),
@@ -458,11 +458,9 @@ export function useOptimisticActions() {
 					runHostsMutation("Failed to rename host", () =>
 						makeTransaction(
 							"update",
-							apiTrpcClient.v2Host.rename
-								.mutate({ hostId, name })
-								.finally(() => {
-									void utils.v2Host.invalidate();
-								}),
+							apiTrpcClient.host.rename.mutate({ hostId, name }).finally(() => {
+								void utils.host.invalidate();
+							}),
 						),
 					),
 			},
@@ -476,14 +474,14 @@ export function useOptimisticActions() {
 					runUsersHostsMutation("Failed to add member", () =>
 						makeTransaction(
 							"insert",
-							apiTrpcClient.v2Host.addMember
+							apiTrpcClient.host.addMember
 								.mutate({
 									hostId: input.hostId,
 									userId: input.userId,
 									role: input.role ?? "member",
 								})
 								.finally(() => {
-									void utils.v2Host.invalidate();
+									void utils.host.invalidate();
 								}),
 						),
 					),
@@ -492,10 +490,10 @@ export function useOptimisticActions() {
 						const { userId, hostId } = parseUsersHostsKey(rowKey);
 						return makeTransaction(
 							"delete",
-							apiTrpcClient.v2Host.removeMember
+							apiTrpcClient.host.removeMember
 								.mutate({ hostId, userId })
 								.finally(() => {
-									void utils.v2Host.invalidate();
+									void utils.host.invalidate();
 								}),
 						);
 					}),
@@ -504,10 +502,10 @@ export function useOptimisticActions() {
 						const { userId, hostId } = parseUsersHostsKey(rowKey);
 						return makeTransaction(
 							"update",
-							apiTrpcClient.v2Host.setMemberRole
+							apiTrpcClient.host.setMemberRole
 								.mutate({ hostId, userId, role })
 								.finally(() => {
-									void utils.v2Host.invalidate();
+									void utils.host.invalidate();
 								}),
 						);
 					}),

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/hosts/$hostId/components/HostSettings/HostSettings.tsx
@@ -59,7 +59,7 @@ export function HostSettings({ hostId }: HostSettingsProps) {
 	);
 
 	const { data: allHostMembers = [] } =
-		cloudTrpc.v2Host.listMembers.useQuery(undefined);
+		cloudTrpc.host.listMembers.useQuery(undefined);
 	const hostUserRows = useMemo(
 		() => allHostMembers.filter((row) => row.hostId === hostId),
 		[allHostMembers, hostId],

--- a/apps/mobile/hooks/useOrgHosts/useOrgHosts.ts
+++ b/apps/mobile/hooks/useOrgHosts/useOrgHosts.ts
@@ -5,7 +5,7 @@ import { useHostsPresence } from "@/hooks/useHostsPresence";
 import { useSession } from "@/lib/auth/client";
 import { apiClient } from "@/lib/trpc/client";
 
-export type OrgHostRow = RouterOutputs["v2Host"]["list"][number];
+export type OrgHostRow = RouterOutputs["host"]["roster"][number];
 export type OrgHost = OrgHostRow & { isOnline: boolean };
 
 export const NO_HOSTS: OrgHost[] = [];
@@ -16,10 +16,10 @@ function useOrgHostsQuery(): UseQueryResult<OrgHostRow[]> {
 	const organizationId = session?.session?.activeOrganizationId ?? null;
 
 	return useQuery({
-		queryKey: ["cloud", "v2Host", "list", organizationId],
+		queryKey: ["cloud", "host", "roster", organizationId],
 		enabled: organizationId !== null,
 		queryFn: () =>
-			apiClient.v2Host.list.query({ organizationId: organizationId ?? "" }),
+			apiClient.host.roster.query({ organizationId: organizationId ?? "" }),
 		staleTime: 30_000,
 	});
 }

--- a/apps/mobile/screens/RootLayout/RootLayout.tsx
+++ b/apps/mobile/screens/RootLayout/RootLayout.tsx
@@ -32,7 +32,7 @@ import { PostHogProvider } from "./providers/PostHogProvider";
 // credential and must not reach disk. Decoration and terminal lists are live.
 const PERSISTED_QUERY_PREFIXES = [
 	["cloud", "user", "myOrganizations"],
-	["cloud", "v2Host", "list"],
+	["cloud", "host", "roster"],
 	["cloud", "cloudWorkspace", "list"],
 	["host-service", "workspaces", "list"],
 	["host-service", "projects", "list"],

--- a/packages/i18n/src/server-errors.ts
+++ b/packages/i18n/src/server-errors.ts
@@ -739,63 +739,57 @@ export const serverErrorMessages: Record<
 					"You are the only owner of an organization that has other members. Transfer ownership or delete the organization first.",
 			}),
 		),
-	"serverError.v2Host.aHostMustHaveAtLeast": () =>
+	"serverError.host.aHostMustHaveAtLeast": () =>
 		i18n._(
 			msg({
 				message: "A host must have at least one owner.",
 			}),
 		),
-	"serverError.v2Host.hostNotFoundInThisOrganization": () =>
+	"serverError.host.hostNotFoundInThisOrganization": () =>
 		i18n._(
 			msg({
 				message: "Host not found in this organization",
 			}),
 		),
-	"serverError.v2Host.notAMemberOfThisOrganization": () =>
-		i18n._(
-			msg({
-				message: "Not a member of this organization",
-			}),
-		),
-	"serverError.v2Host.onlyHostOwnersCanChangeMembership": () =>
+	"serverError.host.onlyHostOwnersCanChangeMembership": () =>
 		i18n._(
 			msg({
 				message: "Only host owners can change membership",
 			}),
 		),
-	"serverError.v2Host.onlyHostOwnersCanDelete": () =>
+	"serverError.host.onlyHostOwnersCanDelete": () =>
 		i18n._(
 			msg({
 				message: "Only host owners can delete this host",
 			}),
 		),
-	"serverError.v2Host.thisUserRunsTheHostService": () =>
+	"serverError.host.thisUserRunsTheHostService": () =>
 		i18n._(
 			msg({
 				message:
 					"This user runs the host service for this device and can't be removed.",
 			}),
 		),
-	"serverError.v2Host.thisUserRunsTheHostService2": () =>
+	"serverError.host.thisUserRunsTheHostService2": () =>
 		i18n._(
 			msg({
 				message:
 					"This user runs the host service for this device and must remain an owner.",
 			}),
 		),
-	"serverError.v2Host.userAlreadyHasAccess": () =>
+	"serverError.host.userAlreadyHasAccess": () =>
 		i18n._(
 			msg({
 				message: "User already has access to this host",
 			}),
 		),
-	"serverError.v2Host.userIsNotAMember": () =>
+	"serverError.host.userIsNotAMember": () =>
 		i18n._(
 			msg({
 				message: "User is not a member of this organization",
 			}),
 		),
-	"serverError.v2Host.userIsNotAMemberOf2": () =>
+	"serverError.host.userIsNotAMemberOf2": () =>
 		i18n._(
 			msg({
 				message: "User is not a member of this host",

--- a/packages/trpc/src/root.ts
+++ b/packages/trpc/src/root.ts
@@ -12,7 +12,7 @@ import { billingRouter } from "./router/billing";
 import { chatRouter } from "./router/chat";
 import { cloudWorkspaceRouter } from "./router/cloud-workspace";
 import { environmentRouter } from "./router/environment";
-import { hostRouter } from "./router/host";
+import { hostManagementRouter, hostRouter } from "./router/host";
 import { integrationRouter } from "./router/integration";
 import { leaderboardRouter } from "./router/leaderboard";
 import { organizationRouter } from "./router/organization";
@@ -23,7 +23,6 @@ import { supportRouter } from "./router/support/support";
 import { taskRouter } from "./router/task";
 import { teamRouter } from "./router/team";
 import { userRouter } from "./router/user";
-import { v2HostRouter } from "./router/v2-host";
 import { v2ProjectRouter } from "./router/v2-project";
 import { v2WorkspaceRouter } from "./router/v2-workspace";
 import { createCallerFactory, createTRPCRouter } from "./trpc";
@@ -40,7 +39,7 @@ export const appRouter = createTRPCRouter({
 	cloudWorkspace: cloudWorkspaceRouter,
 	environment: environmentRouter,
 	growth: growthRouter,
-	host: hostRouter,
+	host: { ...hostRouter, ...hostManagementRouter },
 	integration: integrationRouter,
 	leaderboard: leaderboardRouter,
 	organization: organizationRouter,
@@ -52,7 +51,16 @@ export const appRouter = createTRPCRouter({
 	team: teamRouter,
 	agentCredential: agentCredentialRouter,
 	user: userRouter,
-	v2Host: v2HostRouter,
+	// TODO(2026-10-11): drop; desktops and phones before 1.29 call these names.
+	v2Host: {
+		list: hostManagementRouter.roster,
+		listMembers: hostManagementRouter.listMembers,
+		rename: hostManagementRouter.rename,
+		delete: hostManagementRouter.delete,
+		addMember: hostManagementRouter.addMember,
+		removeMember: hostManagementRouter.removeMember,
+		setMemberRole: hostManagementRouter.setMemberRole,
+	},
 	v2Project: v2ProjectRouter,
 	v2Workspace: v2WorkspaceRouter,
 });

--- a/packages/trpc/src/router/host/index.ts
+++ b/packages/trpc/src/router/host/index.ts
@@ -1,1 +1,2 @@
 export { hostRouter } from "./host";
+export { hostManagementRouter } from "./management";

--- a/packages/trpc/src/router/host/management.ts
+++ b/packages/trpc/src/router/host/management.ts
@@ -29,7 +29,7 @@ async function requireHostOwner(
 		throw userError({
 			code: "NOT_FOUND",
 			message: "Host not found in this organization",
-			i18nKey: "serverError.v2Host.hostNotFoundInThisOrganization",
+			i18nKey: "serverError.host.hostNotFoundInThisOrganization",
 		});
 	}
 
@@ -46,7 +46,7 @@ async function requireHostOwner(
 		throw userError({
 			code: "FORBIDDEN",
 			message: "Only host owners can change membership",
-			i18nKey: "serverError.v2Host.onlyHostOwnersCanChangeMembership",
+			i18nKey: "serverError.host.onlyHostOwnersCanChangeMembership",
 		});
 	}
 
@@ -66,12 +66,12 @@ async function requireOrgMember(userId: string, organizationId: string) {
 		throw userError({
 			code: "BAD_REQUEST",
 			message: "User is not a member of this organization",
-			i18nKey: "serverError.v2Host.userIsNotAMember",
+			i18nKey: "serverError.host.userIsNotAMember",
 		});
 	}
 }
 
-export const v2HostRouter = {
+export const hostManagementRouter = {
 	/**
 	 * The roster: which hosts this user may reach in the organization, and
 	 * what they are called. Membership only; liveness is the relay's and
@@ -79,10 +79,11 @@ export const v2HostRouter = {
 	 * phones from before it existed, which scope by the active-org header,
 	 * keep their host list until they update.
 	 *
-	 * TODO(2026-10-11): make the input required and drop the header fallback;
-	 * by then auto-update has moved the fleet past 1.28.
+	 * TODO(2026-10-11): make the input required, drop the header fallback and
+	 * the v2Host alias in root.ts; by then auto-update has moved the fleet
+	 * past 1.28.
 	 */
-	list: protectedProcedure
+	roster: protectedProcedure
 		.input(z.object({ organizationId: z.string().uuid() }).optional())
 		.query(async ({ ctx, input }) => {
 			const organizationId = input?.organizationId ?? requireActiveOrgId(ctx);
@@ -155,7 +156,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "NOT_FOUND",
 						message: "Host not found in this organization",
-						i18nKey: "serverError.v2Host.hostNotFoundInThisOrganization",
+						i18nKey: "serverError.host.hostNotFoundInThisOrganization",
 					});
 				}
 				return await getCurrentTxid(tx);
@@ -187,7 +188,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "FORBIDDEN",
 						message: "Not a member of this organization",
-						i18nKey: "serverError.v2Host.notAMemberOfThisOrganization",
+						i18nKey: "serverError.host.notAMemberOfThisOrganization",
 					});
 				}
 
@@ -207,7 +208,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "NOT_FOUND",
 						message: "Host not found in this organization",
-						i18nKey: "serverError.v2Host.hostNotFoundInThisOrganization",
+						i18nKey: "serverError.host.hostNotFoundInThisOrganization",
 					});
 				}
 
@@ -228,7 +229,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "FORBIDDEN",
 						message: "Only host owners can delete this host",
-						i18nKey: "serverError.v2Host.onlyHostOwnersCanDelete",
+						i18nKey: "serverError.host.onlyHostOwnersCanDelete",
 					});
 				}
 
@@ -246,7 +247,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "NOT_FOUND",
 						message: "Host not found in this organization",
-						i18nKey: "serverError.v2Host.hostNotFoundInThisOrganization",
+						i18nKey: "serverError.host.hostNotFoundInThisOrganization",
 					});
 				}
 
@@ -295,7 +296,7 @@ export const v2HostRouter = {
 				throw userError({
 					code: "CONFLICT",
 					message: "User already has access to this host",
-					i18nKey: "serverError.v2Host.userAlreadyHasAccess",
+					i18nKey: "serverError.host.userAlreadyHasAccess",
 				});
 			}
 
@@ -323,7 +324,7 @@ export const v2HostRouter = {
 					code: "BAD_REQUEST",
 					message:
 						"This user runs the host service for this device and can't be removed.",
-					i18nKey: "serverError.v2Host.thisUserRunsTheHostService",
+					i18nKey: "serverError.host.thisUserRunsTheHostService",
 				});
 			}
 
@@ -358,7 +359,7 @@ export const v2HostRouter = {
 						throw userError({
 							code: "BAD_REQUEST",
 							message: "A host must have at least one owner.",
-							i18nKey: "serverError.v2Host.aHostMustHaveAtLeast",
+							i18nKey: "serverError.host.aHostMustHaveAtLeast",
 						});
 					}
 				}
@@ -404,7 +405,7 @@ export const v2HostRouter = {
 					code: "BAD_REQUEST",
 					message:
 						"This user runs the host service for this device and must remain an owner.",
-					i18nKey: "serverError.v2Host.thisUserRunsTheHostService2",
+					i18nKey: "serverError.host.thisUserRunsTheHostService2",
 				});
 			}
 
@@ -422,7 +423,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "NOT_FOUND",
 						message: "User is not a member of this host",
-						i18nKey: "serverError.v2Host.userIsNotAMemberOf2",
+						i18nKey: "serverError.host.userIsNotAMemberOf2",
 					});
 				}
 
@@ -443,7 +444,7 @@ export const v2HostRouter = {
 						throw userError({
 							code: "BAD_REQUEST",
 							message: "A host must have at least one owner.",
-							i18nKey: "serverError.v2Host.aHostMustHaveAtLeast",
+							i18nKey: "serverError.host.aHostMustHaveAtLeast",
 						});
 					}
 				}
@@ -463,7 +464,7 @@ export const v2HostRouter = {
 					throw userError({
 						code: "NOT_FOUND",
 						message: "User is not a member of this host",
-						i18nKey: "serverError.v2Host.userIsNotAMemberOf2",
+						i18nKey: "serverError.host.userIsNotAMemberOf2",
 					});
 				}
 				return await getCurrentTxid(tx);

--- a/packages/trpc/src/router/v2-host/index.ts
+++ b/packages/trpc/src/router/v2-host/index.ts
@@ -1,1 +1,0 @@
-export { v2HostRouter } from "./v2-host";


### PR DESCRIPTION
Follow-up to #7442 and #7443.

The session-side host procedures lived under a `v2Host` key from the v1-to-v2 port; there is no v1 host any more. They now sit in `router/host/management.ts` and are exposed under `host` alongside the JWT procedures the host-service, CLI and relay use. `host.list` already belongs to the CLI, so the roster is `host.roster`. Error keys follow the router name, and the one duplicate message shares the existing `host` key.

Installed desktops and phones still call `v2Host.*`, so `root.ts` keeps that key as an alias to the same procedures until 2026-10-11, the same date the roster's optional input goes; both carry the dated TODO.

Checks: lint, `check:i18n` (no catalog change, the English text is unchanged), typecheck across trpc, i18n, api, desktop, mobile, cli and sdk; i18n 157 pass, desktop 3753 pass, trpc 255 pass with the same 4 pre-existing `sitemap.test.ts` env failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds the session-side `v2Host` router into `host`: the host-management procedures now live under the `host` key next to the JWT ones, with `list` renamed to `roster` and i18n error keys aligned. Desktop and mobile callers move to the new names; `v2Host` remains as a temporary alias until 2026-10-11.

**Notes**
- `host.list` already belongs to the CLI, so the roster is `host.roster`.
- Keeps `v2Host.*` aliased in `root.ts` with a dated TODO until 2026-10-11, matching the roster's optional-input deprecation.
- Renames `serverError.v2Host.*` i18n keys to `serverError.host.*`; English strings unchanged, so no catalog update needed.

<sup>Written for commit 45ce0a68b09d869b83458305a2c677d5937e4092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when viewing and managing hosts across desktop and mobile.
  - Host rosters and membership details now refresh correctly after updates, real-time notifications, and management actions.
  - Host data can be restored reliably across sessions.
  - Updated host-related error messages for clearer, consistent feedback.

- **Refactor**
  - Consolidated host management and roster functionality under the current host service, while maintaining compatibility with existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->