### PR TITLE
fix(pages): comment box polish — selection lock, plain Enter to send, hide resolved pins (SUPER-2252, SUPER-2272, SUPER-2201)

### DIFF
--- a/apps/mobile/screens/(authenticated)/pages/[slug]/PageDetailScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/pages/[slug]/PageDetailScreen.tsx
@@ -108,8 +108,12 @@ export function PageDetailScreen({
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: frameEpoch is a resend trigger, not a value read here
 	useEffect(() => {
-		send({ type: "set-mode", enabled: commentMode });
-	}, [commentMode, frameEpoch, send]);
+		send({
+			type: "set-mode",
+			enabled: commentMode,
+			locked: selection !== null,
+		});
+	}, [commentMode, selection, frameEpoch, send]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: frameEpoch resends the anchor set to a runtime that just restarted
 	useEffect(() => {
@@ -151,8 +155,11 @@ export function PageDetailScreen({
 		}
 		if (message.type === "pointer-down") setSelection(null);
 		if (message.type === "pick") {
-			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-			setSelection({ anchor: message.anchor, rect: message.rect });
+			setSelection((previous) => {
+				if (previous) return previous;
+				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+				return { anchor: message.anchor, rect: message.rect };
+			});
 		}
 	}, []);
 

--- a/apps/mobile/screens/(authenticated)/pages/[slug]/PageDetailScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/pages/[slug]/PageDetailScreen.tsx
@@ -99,6 +99,10 @@ export function PageDetailScreen({
 		() => toAnchoredThreads(comments.data ?? []),
 		[comments.data],
 	);
+	const unresolvedThreads = useMemo(
+		() => threads.filter((thread) => !thread.resolved),
+		[threads],
+	);
 
 	const send = useCallback(
 		(message: Parameters<PageFrameHandle["send"]>[0]) =>
@@ -119,12 +123,12 @@ export function PageDetailScreen({
 	useEffect(() => {
 		send({
 			type: "track",
-			anchors: threads.map((thread) => ({
+			anchors: unresolvedThreads.map((thread) => ({
 				id: thread.id,
 				anchor: thread.anchor,
 			})),
 		});
-	}, [threads, frameEpoch, send]);
+	}, [unresolvedThreads, frameEpoch, send]);
 
 	useFocusEffect(
 		useCallback(() => {
@@ -165,13 +169,13 @@ export function PageDetailScreen({
 
 	const pins = useMemo(() => {
 		const out: Array<{ id: string; point: { x: number; y: number } }> = [];
-		for (const thread of threads) {
+		for (const thread of unresolvedThreads) {
 			const rect = rects[thread.id];
 			if (rect)
 				out.push({ id: thread.id, point: pinPointOf(rect, thread.anchor) });
 		}
 		return out;
-	}, [rects, threads]);
+	}, [rects, unresolvedThreads]);
 
 	const stackIndex = useMemo(() => stackPins(pins), [pins]);
 	const pinPoints = useMemo(
@@ -330,7 +334,7 @@ export function PageDetailScreen({
 						className="absolute inset-0 overflow-hidden"
 						pointerEvents="box-none"
 					>
-						{threads.map((thread) => {
+						{unresolvedThreads.map((thread) => {
 							const point = pinPoints.get(thread.id);
 							if (!point) return null;
 							return (

--- a/apps/mobile/screens/(authenticated)/pages/[slug]/PageDetailScreen.tsx
+++ b/apps/mobile/screens/(authenticated)/pages/[slug]/PageDetailScreen.tsx
@@ -79,6 +79,8 @@ export function PageDetailScreen({
 	const [commentMode, setCommentMode] = useState(false);
 	const [focused, setFocused] = useState(true);
 	const [selection, setSelection] = useState<Selection | null>(null);
+	const selectionRef = useRef(selection);
+	selectionRef.current = selection;
 	const [rects, setRects] = useState<Record<string, FrameRect>>({});
 	const [container, setContainer] = useState({ width: 0, height: 0 });
 
@@ -159,11 +161,13 @@ export function PageDetailScreen({
 		}
 		if (message.type === "pointer-down") setSelection(null);
 		if (message.type === "pick") {
-			setSelection((previous) => {
-				if (previous) return previous;
+			if (!selectionRef.current) {
 				void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-				return { anchor: message.anchor, rect: message.rect };
-			});
+			}
+			setSelection(
+				(previous) =>
+					previous ?? { anchor: message.anchor, rect: message.rect },
+			);
 		}
 	}, []);
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ kliknutí"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ odešle"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ kliknutí"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ Klick"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ zum Senden"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ Klick"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ click"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ to send"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ click"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ clic"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ para enviar"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ clic"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ clic"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ pour envoyer"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ clic"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ klik"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ untuk mengirim"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ klik"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ clic"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ per inviare"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ clic"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘クリック"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵で送信"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧クリック"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ 클릭"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵로 전송"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ 클릭"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘-klik"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ om te versturen"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧-klik"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ klik"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ aby wysłać"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ klik"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ clique"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ para enviar"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ clique"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ клик"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ — отправить"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ клик"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ tık"
 
-msgid "⌘↵ to send"
-msgstr "göndermek için ⌘↵"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ tık"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘ nhấp"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵ để gửi"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧ nhấp"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘点击"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵发送"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧点击"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -1043,9 +1043,6 @@ msgstr "~/agent $"
 msgid "⌘ click"
 msgstr "⌘點選"
 
-msgid "⌘↵ to send"
-msgstr "⌘↵傳送"
-
 msgid "⌘⇧ click"
 msgstr "⌘⇧點選"
 

--- a/packages/shared/src/page-comments-runtime.ts
+++ b/packages/shared/src/page-comments-runtime.ts
@@ -59,6 +59,7 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 
 	let enabled = false;
 	let locked = false;
+	let lockedAtPointerDown = false;
 	let tracked = [];
 	let lastHoverPath = null;
 	let frame = 0;
@@ -181,9 +182,13 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 		true,
 	);
 
+	// The host dismisses whatever is open on pointer-down and unlocks the frame
+	// before this same gesture's click arrives, so the click has to remember
+	// that it began as a dismiss or it starts a new pick.
 	document.addEventListener(
 		"mousedown",
 		() => {
+			lockedAtPointerDown = locked;
 			post({ type: "pointer-down" });
 		},
 		true,
@@ -192,10 +197,12 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 	document.addEventListener(
 		"click",
 		(event) => {
+			const dismissing = lockedAtPointerDown;
+			lockedAtPointerDown = false;
 			if (!enabled) return;
 			event.preventDefault();
 			event.stopPropagation();
-			if (locked) return;
+			if (locked || dismissing) return;
 			const el = targetAt(event.clientX, event.clientY);
 			if (!el) return;
 			const rect = rectOf(el);

--- a/packages/shared/src/page-comments-runtime.ts
+++ b/packages/shared/src/page-comments-runtime.ts
@@ -23,7 +23,7 @@ export const HOST_CHANNEL = "superset-comments/host";
 export const FRAME_CHANNEL = "superset-comments/frame";
 
 export type HostMessageBody =
-	| { type: "set-mode"; enabled: boolean }
+	| { type: "set-mode"; enabled: boolean; locked: boolean }
 	| { type: "track"; anchors: { id: string; anchor: CommentAnchor }[] }
 	| { type: "restore-scroll"; y: number };
 
@@ -58,6 +58,7 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 	const FRAME = ${JSON.stringify(FRAME_CHANNEL)};
 
 	let enabled = false;
+	let locked = false;
 	let tracked = [];
 	let lastHoverPath = null;
 	let frame = 0;
@@ -153,7 +154,7 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 	document.addEventListener(
 		"mousemove",
 		(event) => {
-			if (!enabled) return;
+			if (!enabled || locked) return;
 			const el = targetAt(event.clientX, event.clientY);
 			const path = el ? pathOf(el) : null;
 			if (path === lastHoverPath) return;
@@ -194,6 +195,7 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 			if (!enabled) return;
 			event.preventDefault();
 			event.stopPropagation();
+			if (locked) return;
 			const el = targetAt(event.clientX, event.clientY);
 			if (!el) return;
 			const rect = rectOf(el);
@@ -244,8 +246,10 @@ export const PAGE_COMMENTS_RUNTIME_SOURCE = `(() => {
 		if (!data || data.channel !== HOST) return;
 		if (data.type === "set-mode") {
 			enabled = Boolean(data.enabled);
-			document.documentElement.style.cursor = enabled ? "crosshair" : "";
-			if (!enabled) {
+			locked = Boolean(data.locked);
+			document.documentElement.style.cursor =
+				enabled && !locked ? "crosshair" : "";
+			if (!enabled || locked) {
 				lastHoverPath = null;
 				post({ type: "hover", rect: null });
 			}

--- a/packages/ui/src/components/PageComments/components/CommentComposer/CommentComposer.tsx
+++ b/packages/ui/src/components/PageComments/components/CommentComposer/CommentComposer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trans, useLingui } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react/macro";
 import { SendHorizontal } from "lucide-react";
 import { type Ref, useState } from "react";
 import { cn } from "../../../../lib/utils";
@@ -54,7 +54,7 @@ export function CommentComposer({
 				}}
 				onBlur={() => setFocused(false)}
 				onKeyDown={(event) => {
-					if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+					if (event.key === "Enter" && !event.shiftKey) {
 						event.preventDefault();
 						submit();
 					}
@@ -71,9 +71,6 @@ export function CommentComposer({
 			/>
 			{open ? (
 				<div className="flex items-center gap-2 px-3 pb-2.5">
-					<span className="text-muted-foreground text-xs">
-						<Trans>⌘↵ to send</Trans>
-					</span>
 					<Button
 						size="icon"
 						className="ml-auto size-7 rounded-md"

--- a/packages/ui/src/components/PageComments/components/CommentComposer/CommentComposer.tsx
+++ b/packages/ui/src/components/PageComments/components/CommentComposer/CommentComposer.tsx
@@ -3,6 +3,7 @@
 import { useLingui } from "@lingui/react/macro";
 import { SendHorizontal } from "lucide-react";
 import { type Ref, useState } from "react";
+import { isEnterSubmit } from "../../../../lib/keyboard";
 import { cn } from "../../../../lib/utils";
 import { Button } from "../../../ui/button";
 import { Textarea } from "../../../ui/textarea";
@@ -54,7 +55,7 @@ export function CommentComposer({
 				}}
 				onBlur={() => setFocused(false)}
 				onKeyDown={(event) => {
-					if (event.key === "Enter" && !event.shiftKey) {
+					if (isEnterSubmit(event)) {
 						event.preventDefault();
 						submit();
 					}

--- a/packages/ui/src/components/PageComments/components/PageCommentsView/PageCommentsView.tsx
+++ b/packages/ui/src/components/PageComments/components/PageCommentsView/PageCommentsView.tsx
@@ -141,6 +141,7 @@ export function PageCommentsView({
 		? null
 		: threads.find((thread) => thread.id === activeThreadId);
 	const popoverOpen = Boolean(draft || popoverThread || selection);
+	const locked = popoverOpen;
 	useEffect(() => {
 		const element = containerRef.current;
 		if (!element) return;
@@ -189,7 +190,7 @@ export function PageCommentsView({
 			}
 			if (data.type === "escape") dismiss();
 			if (data.type === "rects") setRects(data.entries);
-			if (data.type === "pick") {
+			if (data.type === "pick" && !popoverOpen) {
 				openSelection({ anchor: data.anchor, rect: data.rect });
 				setHoverRect(null);
 			}
@@ -203,6 +204,7 @@ export function PageCommentsView({
 		frameOrigin,
 		notifyFramePointerDown,
 		openSelection,
+		popoverOpen,
 		send,
 		setActiveThreadId,
 		setHoverRect,
@@ -212,8 +214,8 @@ export function PageCommentsView({
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: frameEpoch is a resend trigger, not a value read here
 	useEffect(() => {
-		send({ type: "set-mode", enabled });
-	}, [enabled, frameEpoch, send]);
+		send({ type: "set-mode", enabled, locked });
+	}, [enabled, locked, frameEpoch, send]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: frameEpoch resends the anchor set to a runtime that just restarted
 	useEffect(() => {
@@ -255,7 +257,7 @@ export function PageCommentsView({
 			/>
 
 			<div className="pointer-events-none absolute inset-0 overflow-hidden">
-				{enabled && hoverRect ? (
+				{enabled && !locked && hoverRect ? (
 					<div
 						style={{
 							transform: `translate(${hoverRect.left}px, ${hoverRect.top}px)`,

--- a/packages/ui/src/components/PageComments/components/PageCommentsView/PageCommentsView.tsx
+++ b/packages/ui/src/components/PageComments/components/PageCommentsView/PageCommentsView.tsx
@@ -217,26 +217,31 @@ export function PageCommentsView({
 		send({ type: "set-mode", enabled, locked });
 	}, [enabled, locked, frameEpoch, send]);
 
+	const unresolvedThreads = useMemo(
+		() => threads.filter((thread) => !thread.resolved),
+		[threads],
+	);
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies: frameEpoch resends the anchor set to a runtime that just restarted
 	useEffect(() => {
 		send({
 			type: "track",
-			anchors: threads.map((thread) => ({
+			anchors: unresolvedThreads.map((thread) => ({
 				id: thread.id,
 				anchor: thread.anchor,
 			})),
 		});
-	}, [frameEpoch, send, threads]);
+	}, [frameEpoch, send, unresolvedThreads]);
 
 	const pins = useMemo(() => {
 		const out: { id: string; point: PinPoint }[] = [];
-		for (const thread of threads) {
+		for (const thread of unresolvedThreads) {
 			const rect = rects[thread.id];
 			if (rect)
 				out.push({ id: thread.id, point: pinPointOf(rect, thread.anchor) });
 		}
 		return out;
-	}, [rects, threads]);
+	}, [rects, unresolvedThreads]);
 
 	const pinPoints = useMemo(
 		() => new Map(pins.map((pin) => [pin.id, pin.point])),
@@ -291,7 +296,7 @@ export function PageCommentsView({
 					</div>
 				) : null}
 
-				{threads.map((thread) => {
+				{unresolvedThreads.map((thread) => {
 					const point = pinPoints.get(thread.id);
 					if (!point) return null;
 					const first = thread.comments[0];


### PR DESCRIPTION
## What

**SUPER-2252** — while a pick's toolbar, composer, or an existing thread's popover is open, the page could show two highlighted select areas at once and a click on another part of the page would silently jump the selection instead of requiring the open one to be dismissed first.

**SUPER-2272** — the comment composer required Cmd/Ctrl+Enter to submit, with a "⌘↵ to send" hint taking up footer space. Plain Enter now submits (Shift+Enter still inserts a newline), and the hint is removed.

**SUPER-2201** — resolved comment pins stayed on the page indefinitely, cluttering content that's already been addressed. Resolved threads no longer render a pin at all (no filter toggle — they're just gone).

## Why / Fix

**2252**: the injected page runtime (`page-comments-runtime.ts`) only gated hover/click reporting on `enabled` (comment mode on/off), not on whether a pick was already open.
- `set-mode` now carries a `locked` flag (draft, selection, or an active thread popover open).
- The runtime stops emitting `hover`/`pick` while locked — clicks are still swallowed (`preventDefault`/`stopPropagation`) so the underlying page doesn't react, but they no longer start a new pick.
- Host-side (`PageCommentsView.tsx`) ignores hover updates and stray `pick` messages while locked as a second guard.
- Ported the same `locked` computation to the mobile viewer (`PageDetailScreen.tsx`), which sends `set-mode` independently.

**2272**: `CommentComposer.tsx` — swapped the `metaKey || ctrlKey` check for a plain `Enter && !shiftKey` check, and dropped the now-unused hint text and its i18n entry (`bun run check:i18n` regenerated all locale catalogs clean, 0 missing).

**2201**: both viewers (`PageCommentsView.tsx` on web, `PageDetailScreen.tsx` on mobile) filter threads to unresolved ones before computing pin positions, tracking anchors, and rendering — a resolved thread simply stops getting a pin.

## Testing

- `bun run --filter=@superset/shared --filter=@superset/ui --filter=@superset/web typecheck` — pass
- `bun run --filter=@superset/mobile typecheck` — same pre-existing failures as main (unrelated `HostWorkspaceItem`/`ChangesetFile` types), nothing new from this change
- `bun run --filter=@superset/shared test` — pass
- `bun run check:i18n` — clean, 0 missing across all locales
- `biome check` on touched files — clean

Closes SUPER-2252, SUPER-2272, SUPER-2201.

https://claude.ai/code/session_01V89xJG2G36ArAT9XM9WygA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented page selections while a comment popover is open, including hover highlights and cursor changes.
  * Resolved comment threads no longer appear as pins or bubbles or participate in page tracking.
  * Improved comment selection behavior when a popover is open.
  * Enter during IME composition no longer submits comments.

* **Improvements**
  * Comments can now be submitted by pressing Enter without Shift.
  * Removed the “⌘↵ to send” keyboard shortcut hint from supported translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->