### PR TITLE
feat(desktop): Pages row in Settings > Links — external/internal + split/tab (SUPER-2315, SUPER-2192)

### DIFF
--- a/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
+++ b/apps/desktop/src/renderer/hooks/useV2UserPreferences/useV2UserPreferences.ts
@@ -20,6 +20,7 @@ export interface V2UserPreferencesApi {
 	setSidebarFileLinks: (next: LinkTierMap) => void;
 	setFolderLinks: (next: FolderTierMap) => void;
 	setPortOpenAction: (next: LinkAction) => void;
+	setPageOpenAction: (next: LinkAction) => void;
 	setRightSidebarOpen: (next: boolean | ((prev: boolean) => boolean)) => void;
 	setRightSidebarWidth: (next: number) => void;
 	setDeleteLocalBranch: (next: boolean) => void;
@@ -112,6 +113,25 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 			}
 			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
 				draft.portOpenAction = next;
+			});
+		},
+		[collections],
+	);
+
+	const setPageOpenAction = useCallback(
+		(next: LinkAction) => {
+			const existing = collections.v2UserPreferences.get(
+				V2_USER_PREFERENCES_ID,
+			);
+			if (!existing) {
+				collections.v2UserPreferences.insert({
+					...DEFAULT_V2_USER_PREFERENCES,
+					pageOpenAction: next,
+				});
+				return;
+			}
+			collections.v2UserPreferences.update(V2_USER_PREFERENCES_ID, (draft) => {
+				draft.pageOpenAction = next;
 			});
 		},
 		[collections],
@@ -315,6 +335,7 @@ export function useV2UserPreferences(): V2UserPreferencesApi {
 		setSidebarFileLinks,
 		setFolderLinks,
 		setPortOpenAction,
+		setPageOpenAction,
 		setRightSidebarOpen,
 		setRightSidebarWidth,
 		setDeleteLocalBranch,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useOpenPage/useOpenPage.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/hooks/useOpenPage/useOpenPage.ts
@@ -1,5 +1,6 @@
 import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHostWorkspaces } from "renderer/routes/_authenticated/providers/HostWorkspacesProvider";
 import { useLastActiveV2Workspace } from "renderer/stores/last-active-v2-workspace";
 import { usePagePaneIntent } from "renderer/stores/page-pane-intent";
@@ -30,6 +31,7 @@ export function useOpenPage(): OpenPage {
 	const matchRoute = useMatchRoute();
 	const { workspaces } = useHostWorkspaces();
 	const lastActiveWorkspaceId = useLastActiveV2Workspace((s) => s.workspaceId);
+	const { preferences } = useV2UserPreferences();
 
 	const routeMatch = matchRoute({
 		to: "/v2-workspace/$workspaceId",
@@ -40,7 +42,8 @@ export function useOpenPage(): OpenPage {
 
 	return useCallback(
 		(page, options) => {
-			if (options?.inPane) {
+			const inPane = options?.inPane ?? preferences.pageOpenAction === "pane";
+			if (inPane) {
 				const candidate = activeWorkspaceId ?? lastActiveWorkspaceId;
 				const targetWorkspaceId =
 					candidate && workspaces.some((w) => w.id === candidate)
@@ -62,6 +65,12 @@ export function useOpenPage(): OpenPage {
 			}
 			navigate({ to: "/pages/$slug", params: { slug: page.slug } });
 		},
-		[navigate, activeWorkspaceId, lastActiveWorkspaceId, workspaces],
+		[
+			navigate,
+			activeWorkspaceId,
+			lastActiveWorkspaceId,
+			workspaces,
+			preferences.pageOpenAction,
+		],
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/PagesView.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/pages/components/PagesView/PagesView.tsx
@@ -176,7 +176,10 @@ export function PagesView({
 							!orgEmpty && (Boolean(search.trim()) || activeScope !== "all")
 						}
 						onOpen={(page, event) =>
-							openPage(page, { inPane: isPaneModifier(event) })
+							openPage(
+								page,
+								isPaneModifier(event) ? { inPane: true } : undefined,
+							)
 						}
 						onTogglePin={toggleFavorite}
 						onDelete={async (pageId) => {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -14,6 +14,8 @@ import {
 	useState,
 	useSyncExternalStore,
 } from "react";
+import { env } from "renderer/env.renderer";
+import { useV2UserPreferences } from "renderer/hooks/useV2UserPreferences";
 import { useHotkey } from "renderer/hotkeys";
 import {
 	actionLabel,
@@ -57,6 +59,7 @@ import {
 } from "./richInputOpenStore";
 import { PasteUploadLimitError, uploadPastedFiles } from "./uploadPastedFiles";
 import { shellEscapePaths } from "./utils";
+import { parseSupersetPageUrl } from "./utils/parseSupersetPageUrl";
 import {
 	runFileLinkAction,
 	runFolderLinkAction,
@@ -82,6 +85,7 @@ export function TerminalPane({
 	const urlPolicy = useTerminalUrlPolicy();
 	const folderPolicy = useTerminalFolderPolicy();
 	const isPagesEnabled = useFeatureFlagEnabled(FEATURE_FLAGS.PAGES) ?? false;
+	const { preferences } = useV2UserPreferences();
 	const {
 		hoveredLink,
 		liveHoveredLinkRef,
@@ -339,6 +343,18 @@ export function TerminalPane({
 					);
 				},
 				onUrlClick: (event, url) => {
+					const pageSlug = isPagesEnabled
+						? parseSupersetPageUrl(url, env.NEXT_PUBLIC_WEB_URL)
+						: null;
+					if (pageSlug) {
+						event.preventDefault();
+						runUrlLinkAction(
+							linkActionDepsRef.current,
+							url,
+							preferences.pageOpenAction,
+						);
+						return;
+					}
 					const action = urlPolicy.getAction(event);
 					if (action === null) {
 						showHint(event.clientX, event.clientY);
@@ -362,6 +378,8 @@ export function TerminalPane({
 		filePolicy,
 		urlPolicy,
 		folderPolicy,
+		isPagesEnabled,
+		preferences.pageOpenAction,
 	]);
 
 	// Publish what a right-click landed on so the pane context menu (built in

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/TerminalPane.tsx
@@ -21,6 +21,7 @@ import {
 	actionLabel,
 	type FolderClickPolicy,
 	folderIntentLabel,
+	type LinkAction,
 	LinkHoverHint,
 	useTerminalFilePolicy,
 	useTerminalFolderPolicy,
@@ -671,6 +672,8 @@ export function TerminalPane({
 					urlPolicy,
 					folderPolicy,
 					worktreePath,
+					isPagesEnabled,
+					preferences.pageOpenAction,
 				)}
 				hoverPosition={hoveredLink}
 				clickHint={hint}
@@ -690,6 +693,8 @@ function resolveHoverLabel(
 	urlPolicy: ReturnType<typeof useTerminalUrlPolicy>,
 	folderPolicy: FolderClickPolicy,
 	worktreePath: string | undefined,
+	isPagesEnabled: boolean,
+	pageOpenAction: LinkAction,
 ): string | null {
 	if (!hovered) return null;
 	const event = {
@@ -698,7 +703,10 @@ function resolveHoverLabel(
 		shiftKey: hovered.shift,
 	};
 	if (hovered.info.kind === "url") {
-		const action = urlPolicy.getAction(event);
+		const pageSlug = isPagesEnabled
+			? parseSupersetPageUrl(hovered.info.url, env.NEXT_PUBLIC_WEB_URL)
+			: null;
+		const action = pageSlug ? pageOpenAction : urlPolicy.getAction(event);
 		return action ? actionLabel(action, "url") : null;
 	}
 	if (hovered.info.isDirectory) {

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/utils/runTerminalLinkAction/runTerminalLinkAction.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/TerminalPane/utils/runTerminalLinkAction/runTerminalLinkAction.ts
@@ -42,7 +42,11 @@ export function runUrlLinkAction(
 		? parseSupersetPageUrl(url, env.NEXT_PUBLIC_WEB_URL)
 		: null;
 	if (pageSlug) {
-		openPagePaneInStore(deps.store, { slug: pageSlug });
+		openPagePaneInStore(
+			deps.store,
+			{ slug: pageSlug },
+			action === "newTab" ? "tab" : "split",
+		);
 		return;
 	}
 	openUrlInV2Workspace({

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/useWorkspacePaneOpeners/useWorkspacePaneOpeners.ts
@@ -35,6 +35,7 @@ export function useWorkspacePaneOpeners({
 	newTabPresets,
 	executePreset,
 	setRightSidebarOpen,
+	pageOpenAction,
 }: {
 	store: StoreApi<WorkspaceStore<PaneViewerData>>;
 	launcher: TerminalLauncher;
@@ -44,6 +45,7 @@ export function useWorkspacePaneOpeners({
 		options?: { target?: "new-tab" | "active-tab" },
 	) => void | Promise<void>;
 	setRightSidebarOpen: V2UserPreferencesApi["setRightSidebarOpen"];
+	pageOpenAction: V2UserPreferencesApi["preferences"]["pageOpenAction"];
 }): {
 	openDiffPane: (
 		filePath: string,
@@ -238,9 +240,13 @@ export function useWorkspacePaneOpeners({
 
 	const openPagePane = useCallback(
 		(page: PagePaneData) => {
-			openPagePaneInStore(store, page);
+			openPagePaneInStore(
+				store,
+				page,
+				pageOpenAction === "newTab" ? "tab" : "split",
+			);
 		},
-		[store],
+		[store, pageOpenAction],
 	);
 
 	const openPullRequestPane = useCallback(

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/page.tsx
@@ -245,6 +245,7 @@ function V2WorkspaceContent() {
 		newTabPresets,
 		executePreset,
 		setRightSidebarOpen,
+		pageOpenAction: v2UserPreferences.pageOpenAction,
 	});
 	const paneRegistry = usePaneRegistry({
 		onOpenFile: openFilePaneFromTreeClick,

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openPagePaneInStore/openPagePaneInStore.test.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openPagePaneInStore/openPagePaneInStore.test.ts
@@ -55,10 +55,24 @@ function storeWith(pages: PagePaneData[] = []) {
 }
 
 describe("openPagePaneInStore", () => {
-	it("adds a tab when no page pane is open", () => {
+	it("splits the active pane when no page pane is open", () => {
 		const store = storeWith();
 
 		openPagePaneInStore(store, { slug: "report-a3f9k2" });
+
+		const state = store.getState();
+		expect(state.tabs).toHaveLength(1);
+		const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+		const panes = Object.values(activeTab?.panes ?? {});
+		expect(panes).toHaveLength(2);
+		const opened = panes.find((pane) => pane.kind === "page");
+		expect(opened?.data).toEqual({ slug: "report-a3f9k2" } as PaneViewerData);
+	});
+
+	it('adds a new tab when placement is "tab"', () => {
+		const store = storeWith();
+
+		openPagePaneInStore(store, { slug: "report-a3f9k2" }, "tab");
 
 		const state = store.getState();
 		expect(state.tabs).toHaveLength(2);
@@ -111,22 +125,28 @@ describe("openPagePaneInStore", () => {
 		expect(state.activeTabId).toBe("page-tab-0");
 	});
 
-	it("adds a tab for a different page", () => {
+	it("splits the active tab for a different page", () => {
 		const store = storeWith([
 			{ pageId: "page-1", slug: "report-a3f9k2", title: "Report" },
 		]);
 
 		openPagePaneInStore(store, { slug: "other-b7c1z0" });
 
-		expect(store.getState().tabs).toHaveLength(3);
+		const state = store.getState();
+		expect(state.tabs).toHaveLength(2);
+		const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+		expect(Object.values(activeTab?.panes ?? {})).toHaveLength(2);
 	});
 
-	it("ignores panes of other kinds", () => {
+	it("does not duplicate an already-open page pane", () => {
 		const store = storeWith();
 
 		openPagePaneInStore(store, { slug: "report-a3f9k2" });
 		openPagePaneInStore(store, { slug: "report-a3f9k2" });
 
-		expect(store.getState().tabs).toHaveLength(2);
+		const state = store.getState();
+		expect(state.tabs).toHaveLength(1);
+		const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+		expect(Object.values(activeTab?.panes ?? {})).toHaveLength(2);
 	});
 });

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openPagePaneInStore/openPagePaneInStore.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/utils/openPagePaneInStore/openPagePaneInStore.ts
@@ -11,12 +11,13 @@ function isSamePage(pane: PagePaneData, page: PagePaneData): boolean {
 export function openPagePaneInStore(
 	store: StoreApi<WorkspaceStore<PaneViewerData>>,
 	page: PagePaneData,
+	placement: "split" | "tab" = "split",
 ): void {
 	focusOrOpenPane<PagePaneData>(
 		store,
 		"page",
 		(pane) => isSamePage(pane, page),
 		page,
-		"tab",
+		placement,
 	);
 }

--- a/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/providers/CollectionsProvider/dashboardSidebarLocal/schema.ts
@@ -384,6 +384,8 @@ const DEFAULT_FOLDER_LINKS: FolderTierMap = {
 // in-app tab, "external" = system browser.
 const DEFAULT_PORT_OPEN_ACTION: LinkAction = "external";
 
+const DEFAULT_PAGE_OPEN_ACTION: LinkAction = "pane";
+
 function isSameLinkTierMap(a: LinkTierMap, b: LinkTierMap): boolean {
 	return (
 		a.plain === b.plain &&
@@ -428,6 +430,7 @@ export const v2UserPreferencesSchema = z.object({
 	sidebarFileLinks: linkTierMapSchema.default(DEFAULT_SIDEBAR_FILE_LINKS),
 	folderLinks: folderTierMapSchema.default(DEFAULT_FOLDER_LINKS),
 	portOpenAction: linkActionSchema.default(DEFAULT_PORT_OPEN_ACTION),
+	pageOpenAction: linkActionSchema.default(DEFAULT_PAGE_OPEN_ACTION),
 	terminalPresetsInitialized: z.boolean().default(false),
 	rightSidebarOpen: z.boolean().default(true),
 	rightSidebarTab: z.enum(["changes", "files"]).default("changes"),
@@ -467,6 +470,7 @@ export const DEFAULT_V2_USER_PREFERENCES: V2UserPreferencesRow = {
 	sidebarFileLinks: DEFAULT_SIDEBAR_FILE_LINKS,
 	folderLinks: DEFAULT_FOLDER_LINKS,
 	portOpenAction: DEFAULT_PORT_OPEN_ACTION,
+	pageOpenAction: DEFAULT_PAGE_OPEN_ACTION,
 	terminalPresetsInitialized: false,
 	rightSidebarOpen: true,
 	rightSidebarTab: "changes",

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinksSettings/LinksSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinksSettings/LinksSettings.tsx
@@ -27,7 +27,7 @@ import { FolderLinkTierMapper } from "../FolderLinkTierMapper";
 import { LinkTierMapper } from "../LinkTierMapper";
 
 const PORT_ACTIONS: LinkAction[] = ["pane", "newTab", "external"];
-const PAGE_ACTIONS: LinkAction[] = ["pane", "external"];
+const PAGE_ACTIONS: LinkAction[] = ["pane", "newTab", "external"];
 
 interface LinksSettingsProps {
 	visibleItems?: SettingItemId[] | null;
@@ -213,9 +213,7 @@ export function LinksSettings({ visibleItems }: LinksSettingsProps) {
 								<SelectContent>
 									{PAGE_ACTIONS.map((action) => (
 										<SelectItem key={action} value={action}>
-											{action === "pane"
-												? t({ message: "Open in Superset" })
-												: actionLabel(action, "url")}
+											{actionLabel(action, "url")}
 										</SelectItem>
 									))}
 								</SelectContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinksSettings/LinksSettings.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/links/components/LinksSettings/LinksSettings.tsx
@@ -27,6 +27,7 @@ import { FolderLinkTierMapper } from "../FolderLinkTierMapper";
 import { LinkTierMapper } from "../LinkTierMapper";
 
 const PORT_ACTIONS: LinkAction[] = ["pane", "newTab", "external"];
+const PAGE_ACTIONS: LinkAction[] = ["pane", "external"];
 
 interface LinksSettingsProps {
 	visibleItems?: SettingItemId[] | null;
@@ -42,6 +43,7 @@ export function LinksSettings({ visibleItems }: LinksSettingsProps) {
 		setSidebarFileLinks,
 		setFolderLinks,
 		setPortOpenAction,
+		setPageOpenAction,
 	} = useV2UserPreferences();
 
 	const showFile = isItemVisible(SETTING_ITEM_ID.LINKS_FILE, visibleItems);
@@ -52,6 +54,7 @@ export function LinksSettings({ visibleItems }: LinksSettingsProps) {
 		visibleItems,
 	);
 	const showPort = isItemVisible(SETTING_ITEM_ID.LINKS_PORT, visibleItems);
+	const showPage = isItemVisible(SETTING_ITEM_ID.LINKS_PAGE, visibleItems);
 
 	const handleFileChange = useCallback(
 		(next: LinkTierMap) => {
@@ -91,6 +94,14 @@ export function LinksSettings({ visibleItems }: LinksSettingsProps) {
 			toast.success(t({ message: "Changes saved" }));
 		},
 		[setPortOpenAction, t],
+	);
+
+	const handlePageChange = useCallback(
+		(next: LinkAction) => {
+			setPageOpenAction(next);
+			toast.success(t({ message: "Changes saved" }));
+		},
+		[setPageOpenAction, t],
 	);
 
 	return (
@@ -159,6 +170,52 @@ export function LinksSettings({ visibleItems }: LinksSettingsProps) {
 									{PORT_ACTIONS.map((action) => (
 										<SelectItem key={action} value={action}>
 											{actionLabel(action, "url")}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+				)}
+
+				{showPage && (
+					<div>
+						<h3 className="text-sm font-medium mb-1">
+							<HighlightText
+								text={t({ message: "Pages" })}
+								query={searchQuery}
+							/>
+						</h3>
+						<p className="text-xs text-muted-foreground mb-3">
+							<Trans>
+								Where Page links in terminals, chat messages, and task markdown
+								open when clicked.
+							</Trans>
+						</p>
+						<div className="flex items-center justify-between gap-4">
+							<Label
+								htmlFor="links-page-action"
+								className="text-sm font-medium"
+							>
+								<Trans>On click</Trans>
+							</Label>
+							<Select
+								value={preferences.pageOpenAction}
+								onValueChange={(v) => handlePageChange(v as LinkAction)}
+							>
+								<SelectTrigger
+									id="links-page-action"
+									size="sm"
+									className="w-44"
+								>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{PAGE_ACTIONS.map((action) => (
+										<SelectItem key={action} value={action}>
+											{action === "pane"
+												? t({ message: "Open in Superset" })
+												: actionLabel(action, "url")}
 										</SelectItem>
 									))}
 								</SelectContent>

--- a/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
+++ b/apps/desktop/src/renderer/routes/_authenticated/settings/utils/settings-search/settings-search.ts
@@ -66,6 +66,7 @@ export const SETTING_ITEM_ID = {
 	LINKS_URL: "links-url",
 	LINKS_SIDEBAR_FILE: "links-sidebar-file",
 	LINKS_PORT: "links-port",
+	LINKS_PAGE: "links-page",
 
 	EXPERIMENTAL_SUPERSET_V2: "experimental-superset-v2",
 	EXPERIMENTAL_V1_MIGRATION: "experimental-v1-migration",
@@ -216,6 +217,7 @@ export const SETTING_ITEM_VARIANT: Record<SettingItemId, SettingVariant> = {
 	[SETTING_ITEM_ID.LINKS_URL]: "v2",
 	[SETTING_ITEM_ID.LINKS_SIDEBAR_FILE]: "v2",
 	[SETTING_ITEM_ID.LINKS_PORT]: "v2",
+	[SETTING_ITEM_ID.LINKS_PAGE]: "v2",
 
 	[SETTING_ITEM_ID.EXPERIMENTAL_SUPERSET_V2]: "shared",
 	[SETTING_ITEM_ID.EXPERIMENTAL_V1_MIGRATION]: "v2",
@@ -1272,6 +1274,25 @@ export const SETTINGS_ITEMS: SettingsItem[] = [
 			"ctrl",
 			"shift",
 			"meta",
+			"browser",
+			"in-app",
+			"system",
+			"external",
+			"open",
+			"behavior",
+		],
+	},
+	{
+		id: SETTING_ITEM_ID.LINKS_PAGE,
+		section: "links",
+		title: "Pages",
+		description:
+			"Whether Page links (in terminals, chat, and task markdown) open inside Superset or the system browser",
+		keywords: [
+			"links",
+			"page",
+			"pages",
+			"click",
 			"browser",
 			"in-app",
 			"system",

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Otevřít v Scira AI"
 msgid "Open in split pane"
 msgstr "Otevřít v rozděleném panelu"
 
-msgid "Open in Superset"
-msgstr "Otevřít v Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Otevřít v T3 Chat"
 

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Otevřít v Scira AI"
 msgid "Open in split pane"
 msgstr "Otevřít v rozděleném panelu"
 
+msgid "Open in Superset"
+msgstr "Otevřít v Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Otevřít v T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Jak si stojíte?"
 
 msgid "Where does my code run?"
 msgstr "Kde běží můj kód?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Kam se po kliknutí otevřou odkazy na stránky v terminálech, chatových zprávách a markdownu úkolů."
 
 msgid "Where serious teams are"
 msgstr "Kde jsou seriózní týmy"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -10168,6 +10168,9 @@ msgstr "In Scira AI öffnen"
 msgid "Open in split pane"
 msgstr "In geteiltem Bereich öffnen"
 
+msgid "Open in Superset"
+msgstr "In Superset öffnen"
+
 msgid "Open in T3 Chat"
 msgstr "In T3 Chat öffnen"
 
@@ -16265,6 +16268,9 @@ msgstr "Auf welchem Platz stehst du?"
 
 msgid "Where does my code run?"
 msgstr "Wo läuft mein Code?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Wohin Seiten-Links in Terminals, Chatnachrichten und Aufgaben-Markdown beim Klicken geöffnet werden."
 
 msgid "Where serious teams are"
 msgstr "Wo ernsthafte Teams stehen"

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -10168,9 +10168,6 @@ msgstr "In Scira AI öffnen"
 msgid "Open in split pane"
 msgstr "In geteiltem Bereich öffnen"
 
-msgid "Open in Superset"
-msgstr "In Superset öffnen"
-
 msgid "Open in T3 Chat"
 msgstr "In T3 Chat öffnen"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Open in Scira AI"
 msgid "Open in split pane"
 msgstr "Open in split pane"
 
+msgid "Open in Superset"
+msgstr "Open in Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Open in T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Where do you rank?"
 
 msgid "Where does my code run?"
 msgstr "Where does my code run?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Where Page links in terminals, chat messages, and task markdown open when clicked."
 
 msgid "Where serious teams are"
 msgstr "Where serious teams are"

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Open in Scira AI"
 msgid "Open in split pane"
 msgstr "Open in split pane"
 
-msgid "Open in Superset"
-msgstr "Open in Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Open in T3 Chat"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Abrir en Scira AI"
 msgid "Open in split pane"
 msgstr "Abrir en un panel dividido"
 
+msgid "Open in Superset"
+msgstr "Abrir en Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Abrir en T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "¿En qué puesto estás?"
 
 msgid "Where does my code run?"
 msgstr "¿Dónde se ejecuta mi código?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Dónde se abren los enlaces a páginas en terminales, mensajes de chat y markdown de tareas al hacer clic."
 
 msgid "Where serious teams are"
 msgstr "Donde están los equipos serios"

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Abrir en Scira AI"
 msgid "Open in split pane"
 msgstr "Abrir en un panel dividido"
 
-msgid "Open in Superset"
-msgstr "Abrir en Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Abrir en T3 Chat"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Ouvrir dans Scira AI"
 msgid "Open in split pane"
 msgstr "Ouvrir dans un volet divisé"
 
-msgid "Open in Superset"
-msgstr "Ouvrir dans Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Ouvrir dans T3 Chat"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Ouvrir dans Scira AI"
 msgid "Open in split pane"
 msgstr "Ouvrir dans un volet divisé"
 
+msgid "Open in Superset"
+msgstr "Ouvrir dans Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Ouvrir dans T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Quel est votre rang ?"
 
 msgid "Where does my code run?"
 msgstr "Où mon code s'exécute-t-il ?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Où s'ouvrent les liens vers des pages dans les terminaux, les messages de chat et le markdown des tâches lorsqu'on clique dessus."
 
 msgid "Where serious teams are"
 msgstr "Là où en sont les équipes sérieuses"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Buka di Scira AI"
 msgid "Open in split pane"
 msgstr "Buka di panel terbagi"
 
+msgid "Open in Superset"
+msgstr "Buka di Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Buka di T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Di peringkat berapa Anda?"
 
 msgid "Where does my code run?"
 msgstr "Di mana kode saya berjalan?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Ke mana tautan Halaman di terminal, pesan chat, dan markdown tugas terbuka saat diklik."
 
 msgid "Where serious teams are"
 msgstr "Tempat tim serius berada"

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Buka di Scira AI"
 msgid "Open in split pane"
 msgstr "Buka di panel terbagi"
 
-msgid "Open in Superset"
-msgstr "Buka di Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Buka di T3 Chat"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Apri in Scira AI"
 msgid "Open in split pane"
 msgstr "Apri in un pannello diviso"
 
-msgid "Open in Superset"
-msgstr "Apri in Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Apri in T3 Chat"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -16270,7 +16270,7 @@ msgid "Where does my code run?"
 msgstr "Dove gira il mio codice?"
 
 msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
-msgstr "Dove si aprono i link alle Pagine nei terminali, nei messaggi di chat e nel markdown delle attività quando vengono cliccati."
+msgstr "Dove si aprono i link alle Pagine nei terminali, nei messaggi di chat e nel markdown dei task quando vengono cliccati."
 
 msgid "Where serious teams are"
 msgstr "Dove sono i team seri"

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Apri in Scira AI"
 msgid "Open in split pane"
 msgstr "Apri in un pannello diviso"
 
+msgid "Open in Superset"
+msgstr "Apri in Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Apri in T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "In che posizione sei?"
 
 msgid "Where does my code run?"
 msgstr "Dove gira il mio codice?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Dove si aprono i link alle Pagine nei terminali, nei messaggi di chat e nel markdown delle attività quando vengono cliccati."
 
 msgid "Where serious teams are"
 msgstr "Dove sono i team seri"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Scira AIで開く"
 msgid "Open in split pane"
 msgstr "分割ペインで開く"
 
+msgid "Open in Superset"
+msgstr "Supersetで開く"
+
 msgid "Open in T3 Chat"
 msgstr "T3 Chatで開く"
 
@@ -16265,6 +16268,9 @@ msgstr "あなたの順位は?"
 
 msgid "Where does my code run?"
 msgstr "コードはどこで実行されますか?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "ターミナル、チャットメッセージ、タスクの Markdown 内のページリンクをクリックしたときの開き先。"
 
 msgid "Where serious teams are"
 msgstr "本気のチームの現在地"

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Scira AIで開く"
 msgid "Open in split pane"
 msgstr "分割ペインで開く"
 
-msgid "Open in Superset"
-msgstr "Supersetで開く"
-
 msgid "Open in T3 Chat"
 msgstr "T3 Chatで開く"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Scira AI에서 열기"
 msgid "Open in split pane"
 msgstr "분할 패널에서 열기"
 
-msgid "Open in Superset"
-msgstr "Superset에서 열기"
-
 msgid "Open in T3 Chat"
 msgstr "T3 Chat에서 열기"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Scira AI에서 열기"
 msgid "Open in split pane"
 msgstr "분할 패널에서 열기"
 
+msgid "Open in Superset"
+msgstr "Superset에서 열기"
+
 msgid "Open in T3 Chat"
 msgstr "T3 Chat에서 열기"
 
@@ -16265,6 +16268,9 @@ msgstr "내 순위는 몇 위일까요?"
 
 msgid "Where does my code run?"
 msgstr "제 코드는 어디에서 실행되나요?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "터미널, 채팅 메시지, 작업 마크다운의 페이지 링크를 클릭했을 때 열리는 위치입니다."
 
 msgid "Where serious teams are"
 msgstr "진지한 팀들이 있는 곳"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Openen in Scira AI"
 msgid "Open in split pane"
 msgstr "Openen in gesplitst paneel"
 
+msgid "Open in Superset"
+msgstr "Openen in Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Openen in T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Waar sta jij?"
 
 msgid "Where does my code run?"
 msgstr "Waar draait mijn code?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Waar Pagina-links in terminals, chatberichten en taak-markdown worden geopend bij een klik."
 
 msgid "Where serious teams are"
 msgstr "Waar serieuze teams staan"

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Openen in Scira AI"
 msgid "Open in split pane"
 msgstr "Openen in gesplitst paneel"
 
-msgid "Open in Superset"
-msgstr "Openen in Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Openen in T3 Chat"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Otwórz w Scira AI"
 msgid "Open in split pane"
 msgstr "Otwórz w podzielonym panelu"
 
-msgid "Open in Superset"
-msgstr "Otwórz w Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Otwórz w T3 Chat"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Otwórz w Scira AI"
 msgid "Open in split pane"
 msgstr "Otwórz w podzielonym panelu"
 
+msgid "Open in Superset"
+msgstr "Otwórz w Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Otwórz w T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Jaka jest twoja pozycja?"
 
 msgid "Where does my code run?"
 msgstr "Gdzie działa mój kod?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Gdzie po kliknięciu otwierają się linki do stron w terminalach, wiadomościach czatu i markdownie zadań."
 
 msgid "Where serious teams are"
 msgstr "Tu są poważne zespoły"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Abrir no Scira AI"
 msgid "Open in split pane"
 msgstr "Abrir em painel dividido"
 
+msgid "Open in Superset"
+msgstr "Abrir no Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Abrir no T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Qual é a sua posição?"
 
 msgid "Where does my code run?"
 msgstr "Onde o meu código roda?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Onde os links de páginas em terminais, mensagens de chat e markdown de tarefas abrem ao serem clicados."
 
 msgid "Where serious teams are"
 msgstr "Onde os times sérios estão"

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Abrir no Scira AI"
 msgid "Open in split pane"
 msgstr "Abrir em painel dividido"
 
-msgid "Open in Superset"
-msgstr "Abrir no Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Abrir no T3 Chat"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Открыть в Scira AI"
 msgid "Open in split pane"
 msgstr "Открыть в разделённой панели"
 
+msgid "Open in Superset"
+msgstr "Открыть в Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Открыть в T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Какое у вас место?"
 
 msgid "Where does my code run?"
 msgstr "Где выполняется мой код?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Куда переходят ссылки на страницы в терминалах, сообщениях чата и markdown задач при нажатии."
 
 msgid "Where serious teams are"
 msgstr "Где сейчас серьёзные команды"

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Открыть в Scira AI"
 msgid "Open in split pane"
 msgstr "Открыть в разделённой панели"
 
-msgid "Open in Superset"
-msgstr "Открыть в Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Открыть в T3 Chat"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Scira AI'da aç"
 msgid "Open in split pane"
 msgstr "Bölünmüş bölmede aç"
 
+msgid "Open in Superset"
+msgstr "Superset'te aç"
+
 msgid "Open in T3 Chat"
 msgstr "T3 Chat'te aç"
 
@@ -16265,6 +16268,9 @@ msgstr "Kaçıncı sıradasınız?"
 
 msgid "Where does my code run?"
 msgstr "Kodum nerede çalışıyor?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Terminallerdeki, sohbet mesajlarındaki ve görev markdown'undaki Sayfa bağlantılarının tıklandığında nereye açılacağı."
 
 msgid "Where serious teams are"
 msgstr "Ciddi takımların bulunduğu yer"

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Scira AI'da aç"
 msgid "Open in split pane"
 msgstr "Bölünmüş bölmede aç"
 
-msgid "Open in Superset"
-msgstr "Superset'te aç"
-
 msgid "Open in T3 Chat"
 msgstr "T3 Chat'te aç"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -10168,6 +10168,9 @@ msgstr "Mở trong Scira AI"
 msgid "Open in split pane"
 msgstr "Mở ở khung chia đôi"
 
+msgid "Open in Superset"
+msgstr "Mở trong Superset"
+
 msgid "Open in T3 Chat"
 msgstr "Mở trong T3 Chat"
 
@@ -16265,6 +16268,9 @@ msgstr "Bạn xếp hạng bao nhiêu?"
 
 msgid "Where does my code run?"
 msgstr "Code của tôi chạy ở đâu?"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "Nơi các liên kết Trang trong terminal, tin nhắn trò chuyện và markdown tác vụ mở ra khi được nhấp."
 
 msgid "Where serious teams are"
 msgstr "Nơi các đội nghiêm túc đang đứng"

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -10168,9 +10168,6 @@ msgstr "Mở trong Scira AI"
 msgid "Open in split pane"
 msgstr "Mở ở khung chia đôi"
 
-msgid "Open in Superset"
-msgstr "Mở trong Superset"
-
 msgid "Open in T3 Chat"
 msgstr "Mở trong T3 Chat"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -10168,9 +10168,6 @@ msgstr "在Scira AI中打开"
 msgid "Open in split pane"
 msgstr "在分屏窗格中打开"
 
-msgid "Open in Superset"
-msgstr "在 Superset 中打开"
-
 msgid "Open in T3 Chat"
 msgstr "在T3 Chat中打开"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -10168,6 +10168,9 @@ msgstr "在Scira AI中打开"
 msgid "Open in split pane"
 msgstr "在分屏窗格中打开"
 
+msgid "Open in Superset"
+msgstr "在 Superset 中打开"
+
 msgid "Open in T3 Chat"
 msgstr "在T3 Chat中打开"
 
@@ -16265,6 +16268,9 @@ msgstr "你排第几？"
 
 msgid "Where does my code run?"
 msgstr "我的代码在哪里运行？"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "终端、聊天消息和任务 Markdown 中的页面链接点击后在何处打开。"
 
 msgid "Where serious teams are"
 msgstr "认真的团队都在这里"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -10168,6 +10168,9 @@ msgstr "在Scira AI中開啟"
 msgid "Open in split pane"
 msgstr "在分屏窗格中開啟"
 
+msgid "Open in Superset"
+msgstr "在 Superset 中開啟"
+
 msgid "Open in T3 Chat"
 msgstr "在T3 Chat中開啟"
 
@@ -16265,6 +16268,9 @@ msgstr "你排第幾？"
 
 msgid "Where does my code run?"
 msgstr "我的程式碼在哪裡執行？"
+
+msgid "Where Page links in terminals, chat messages, and task markdown open when clicked."
+msgstr "終端機、聊天訊息和任務 Markdown 中的頁面連結點擊後在何處開啟。"
 
 msgid "Where serious teams are"
 msgstr "認真的團隊都在這裡"

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -10168,9 +10168,6 @@ msgstr "在Scira AI中開啟"
 msgid "Open in split pane"
 msgstr "在分屏窗格中開啟"
 
-msgid "Open in Superset"
-msgstr "在 Superset 中開啟"
-
 msgid "Open in T3 Chat"
 msgstr "在T3 Chat中開啟"
 


### PR DESCRIPTION
## What

**SUPER-2315** — a dedicated "Pages" row in Settings → Links so a Page link's destination (Superset vs. system browser) is configured independently of the generic "URL links" default.

**SUPER-2192** — the placement axis on top of that: once a Page opens inside Superset, whether it splits the active pane or opens as a new tab.

## SUPER-2315 — why / fix

`runUrlLinkAction` recognized Page URLs (`parseSupersetPageUrl`), but only *after* checking whether the resolved click action was `"external"`:

```js
if (action === "external") { openExternal(url); return; }   // ← exits before the page check
const pageSlug = parseSupersetPageUrl(url, ...);
if (pageSlug) { openPagePaneInStore(...); return; }
```

Anyone whose "URL links" default click is `external` never reached the Page branch — a Page link always followed them out to the OS browser.

- New `pageOpenAction` preference, a single select (not a modifier-tiered map) mirroring `portOpenAction`.
- New "Pages" section in `LinksSettings.tsx`, same shape as "Ports".
- `TerminalPane`'s default URL click checks `parseSupersetPageUrl` before resolving the generic `urlLinks` tier, routing Page links through `pageOpenAction` instead. The right-click "Open in ..." context menu is untouched — an explicit pick always does exactly what it says.

## SUPER-2192 — why / fix

`openPagePaneInStore` always hardcoded `"tab"` placement, so there was never actually a difference between "pane" and "newTab" for pages — both landed in the same place. This closes that gap now that a placement primitive already existed (`focusOrOpenPane`'s `"split" | "tab"`, previously only ever called with `"tab"`).

- `openPagePaneInStore(store, page, placement)` — `placement` defaults to `"split"`, forwarded to `focusOrOpenPane`.
- `pageOpenAction` gets its third value back: `"newTab"` is back in the Pages Settings row, now backed by a real distinct outcome.
- `runUrlLinkAction` and the right-click "Open in ..." submenu both map their action to a placement, so picking "New Tab" on a page link actually tabs instead of always splitting/tabbing the same way.
- `useOpenPage`'s `inPane` decision falls back to `pageOpenAction === "pane"` when a caller doesn't pass an explicit override, so the Pages grid's plain click (not just terminal links) honors the setting too. Modifier-click there still forces `inPane`, unchanged.
- Dropped the "Open in Superset" placeholder label now that `"pane"` truly means a split — the existing `actionLabel` "Open in split pane" wording is accurate, so lingui correctly extracted the now-orphaned string out of every locale catalog.
- Updated `openPagePaneInStore`'s tests for the new split-by-default behavior and added coverage for explicit `"tab"` placement.

## Testing

- `bun run --filter=@superset/desktop typecheck` — pass
- `bun run check:i18n` — clean, 0 missing across all 16 locales
- `bun run --filter=@superset/desktop test` — 3752/3754 pass; the 2 failures are in `terminal-ws-transport.test.ts` (`jest.advanceTimersByTime` incompatibility), pre-existing and unrelated — reproduced identically on main before this change
- `biome check` on touched files — clean
- Addressed CodeRabbit review feedback: hover-tooltip/click-action mismatch for Page links, and an Italian translation wording fix

Closes SUPER-2315, SUPER-2192.

https://claude.ai/code/session_01V89xJG2G36ArAT9XM9WygA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Pages** link preference in Links settings.
  - Choose whether Page links open in a pane, a new tab, or the external browser.
  - Page links from terminals, chat messages, task markdown, and page views now follow the selected preference.
  - The preference defaults to opening links in a pane.
  - Page links opened in panes now split the current tab by default.

- **Localization**
  - Added translations for the Pages setting and its description across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->