### PR TITLE
feat(shared,plugins): allow the Google Fonts stylesheet in the page CSP (SUPER-1995)

### DIFF
--- a/packages/shared/src/usercontent/csp.test.ts
+++ b/packages/shared/src/usercontent/csp.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { pageContentSecurityPolicy } from "./csp";
+
+describe("pageContentSecurityPolicy", () => {
+	it("allows the Google Fonts stylesheet host, and nothing else, in style-src", () => {
+		const policy = pageContentSecurityPolicy(["'none'"]);
+		const styleSrc = policy
+			.split("; ")
+			.find((directive) => directive.startsWith("style-src"));
+		expect(styleSrc).toBe(
+			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+		);
+	});
+
+	it("keeps script-src closed to remote hosts", () => {
+		const policy = pageContentSecurityPolicy(["'none'"]);
+		const scriptSrc = policy
+			.split("; ")
+			.find((directive) => directive.startsWith("script-src"));
+		expect(scriptSrc).toBe("script-src 'self' 'unsafe-inline'");
+	});
+
+	it("already allows any https font file", () => {
+		const policy = pageContentSecurityPolicy(["'none'"]);
+		expect(policy).toContain("font-src 'self' data: https:");
+	});
+
+	it("joins the given frame-ancestors", () => {
+		const policy = pageContentSecurityPolicy([
+			"https://a.example",
+			"https://b.example",
+		]);
+		expect(policy).toContain(
+			"frame-ancestors https://a.example https://b.example",
+		);
+	});
+});

--- a/packages/shared/src/usercontent/csp.ts
+++ b/packages/shared/src/usercontent/csp.ts
@@ -12,7 +12,7 @@ export function pageContentSecurityPolicy(
 	return [
 		"default-src 'none'",
 		"script-src 'self' 'unsafe-inline'",
-		"style-src 'self' 'unsafe-inline'",
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 		// `'self'` is what lets a directory publish's own assets load. The
 		// scheme sources cover remote media; without `'self'` a page's own
 		// image only loads because production happens to be https, and the

--- a/plugins/superset/skills/page/SKILL.md
+++ b/plugins/superset/skills/page/SKILL.md
@@ -61,11 +61,11 @@ enforced identically in the desktop pane and the web viewer:
   nothing and gives no visible reason why.
 - **No scripts or stylesheets from a remote host, with one exception.**
   `<script src="https://…">` is always blocked. `<link rel="stylesheet"
-  href="https://…">` is blocked too, except from `fonts.googleapis.com` — a
-  Google Fonts `<link>` tag works as-is. A directory publish's own files load
-  fine (relative `src`/`href`), and any remote font *file* is allowed, so an
-  inline `@font-face { src: url(https://…) }` also works for fonts from
-  elsewhere.
+  href="https://…">` is blocked too, except from `fonts.googleapis.com`, so
+  a Google Fonts `<link>` tag works as-is. A directory publish's own files
+  load fine (relative `src`/`href`), and any remote font *file* is allowed,
+  so an inline `@font-face { src: url(https://…) }` also works for fonts
+  from elsewhere.
 - **Images, video and audio may be remote** (`https:`, `data:` or `blob:`),
   but prefer `data:` URIs for anything the page cannot do without: a reader
   with the network off sees nothing, and a remote image makes every reader's

--- a/plugins/superset/skills/page/SKILL.md
+++ b/plugins/superset/skills/page/SKILL.md
@@ -59,11 +59,13 @@ enforced identically in the desktop pane and the web viewer:
   several chart and templating libraries and a number of date and expression
   helpers. Check for it before you reach for a dependency: the page renders
   nothing and gives no visible reason why.
-- **No scripts or stylesheets from a remote host.** `<script
-  src="https://…">` and `<link rel="stylesheet" href="https://…">` are
-  blocked, Google Fonts `<link>` tags included. A directory publish's own
-  files load fine (relative `src`/`href`), and a remote font *file* is
-  allowed, so an inline `@font-face { src: url(https://…) }` works.
+- **No scripts or stylesheets from a remote host, with one exception.**
+  `<script src="https://…">` is always blocked. `<link rel="stylesheet"
+  href="https://…">` is blocked too, except from `fonts.googleapis.com` — a
+  Google Fonts `<link>` tag works as-is. A directory publish's own files load
+  fine (relative `src`/`href`), and any remote font *file* is allowed, so an
+  inline `@font-face { src: url(https://…) }` also works for fonts from
+  elsewhere.
 - **Images, video and audio may be remote** (`https:`, `data:` or `blob:`),
   but prefer `data:` URIs for anything the page cannot do without: a reader
   with the network off sees nothing, and a remote image makes every reader's
@@ -355,7 +357,7 @@ Reopen with `superset pages comments resolve --thread <id> --reopen`.
 | Reader gets a 404 | Page is `just_me`, either set that way or created before `org` became the default; widen it with `--visibility org` |
 | Page is blank once published, fine locally | A script threw, or the page loads a script or stylesheet from a remote host |
 | A chart or widget renders nothing and logs no error | The library compiles code with `new Function` or `eval`, which the policy refuses; pick one that does not |
-| Fonts missing when published | A Google Fonts `<link>`; inline the `@font-face` instead, or use `--sp-font-sans` |
+| Fonts missing when published | A stylesheet `<link>` from a host other than `fonts.googleapis.com`; inline the `@font-face` instead, or use `--sp-font-sans` |
 | Page ignores `class="dark"` | The class belongs on `<body>`, not on `<html>` or a wrapper |
 | A theme token has no effect | It was redefined on `body`; move the override to `:root` |
 | Images missing when published | `http://` URLs, or the reader is offline; embed as `data:` URIs |


### PR DESCRIPTION
## What

"No remote fonts. My CSP carves out exactly one exception for Google Fonts; yours blocks everything, so system stack is the ceiling on typography." — feedback from an agent comparing Superset's page CSP against Claude's own artifact CSP.

## Why

`pageContentSecurityPolicy` (`packages/shared/src/usercontent/csp.ts`):
- `font-src 'self' data: https:` already allows any https font **file** — this part was never the problem.
- `style-src 'self' 'unsafe-inline'` had **zero** remote allowance — so the standard `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=...">` snippet everyone copies straight off Google Fonts' own picker was silently dropped. The `page` skill's own docs already knew this and told people to hand-inline `@font-face` instead.

## Fix

- `style-src` now allows `https://fonts.googleapis.com` specifically — nothing broader. That host only ever serves `@font-face` CSS; the actual font files it points at still go through the existing (already-permissive) `font-src`.
- Updated the `page` skill's content-policy bullet and failure-table row to describe the new behavior instead of the old workaround.
- Added `csp.test.ts` — `pageContentSecurityPolicy` had no direct test coverage before this.

## Testing

- `bun run --filter=@superset/shared typecheck` — pass
- `bun run --filter=@superset/shared test` — 1023/1023 pass (including the new 4)
- `bun run check:plugins` — passes
- `biome check` on touched files — clean

Closes SUPER-1995.

https://claude.ai/code/session_01V89xJG2G36ArAT9XM9WygA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the Google Fonts stylesheet host in the page CSP so standard Google Fonts `<link>` tags load instead of being silently dropped. `style-src` now allows only `https://fonts.googleapis.com`; other remote stylesheets and scripts remain blocked, and remote font files still go through the existing `font-src` rule. Updates the `page` skill docs to match and adds `pageContentSecurityPolicy` tests. Closes SUPER-1995.

<sup>Written for commit 298be3903927bebca409f1b8d54cf1f214d8d77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Superset Pages can now load stylesheets from Google Fonts.
  * Inline font files loaded through `@font-face` remain supported.
  * Remote stylesheets from other hosts continue to be blocked.

* **Documentation**
  * Updated content-policy guidance and troubleshooting information to reflect Google Fonts stylesheet support and restrictions on other remote stylesheet links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->