### PR TITLE
fix(workspace-fs): cap the filename search index at 200k entries

### DIFF
--- a/packages/workspace-fs/src/search-index-bounds.test.ts
+++ b/packages/workspace-fs/src/search-index-bounds.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+	collectSearchIndexPaths,
 	getSearchIndex,
 	invalidateAllSearchIndexes,
 	patchSearchIndexesForRoot,
@@ -66,6 +67,38 @@ describe("index walk depth", () => {
 
 		expect(names).toContain("shallow.ts");
 		expect(names).not.toContain("deep.ts");
+	});
+});
+
+describe("index entry cap", () => {
+	it("stops the walk at the cap and reports truncation", async () => {
+		const root = await makeRepoRoot();
+		for (let i = 0; i < 12; i++) {
+			await fs.writeFile(path.join(root, `file-${i}.txt`), "x");
+		}
+
+		const capped = await collectSearchIndexPaths(root, {
+			includeHidden: false,
+			maxEntries: 5,
+		});
+
+		expect(capped.paths).toHaveLength(5);
+		expect(capped.truncated).toBe(true);
+	});
+
+	it("keeps the whole tree when it fits under the cap", async () => {
+		const root = await makeRepoRoot();
+		for (let i = 0; i < 12; i++) {
+			await fs.writeFile(path.join(root, `file-${i}.txt`), "x");
+		}
+
+		const full = await collectSearchIndexPaths(root, {
+			includeHidden: false,
+			maxEntries: 12,
+		});
+
+		expect(full.paths).toHaveLength(12);
+		expect(full.truncated).toBe(false);
 	});
 });
 

--- a/packages/workspace-fs/src/search.ts
+++ b/packages/workspace-fs/src/search.ts
@@ -149,6 +149,12 @@ const SEARCH_INDEX_CACHE_TTL_MS = 30 * 60_000;
 
 const UNTRACKED_ROOT_SCAN_DEPTH = 8;
 const MAX_SEARCH_INDEX_BUILD_RESTARTS = 3;
+/**
+ * Entries kept per index. One uncapped walk of a home-sized tree is enough to
+ * push host-service into V8's heap limit; past this the walk is destroyed and
+ * search answers for the files it saw.
+ */
+export const MAX_SEARCH_INDEX_ENTRIES = 200_000;
 
 export class SearchIndexBuildAborted extends Error {
 	constructor() {
@@ -338,24 +344,26 @@ export async function isGitRepositoryRoot(rootPath: string): Promise<boolean> {
 	}
 }
 
-async function buildSearchIndex(
-	{ rootPath, includeHidden }: SearchIndexKeyOptions,
-	signal?: AbortSignal,
-): Promise<SearchIndexEntry[]> {
-	const normalizedRootPath = normalizeAbsolutePath(rootPath);
-	const deep = (await isGitRepositoryRoot(normalizedRootPath))
-		? Number.POSITIVE_INFINITY
-		: UNTRACKED_ROOT_SCAN_DEPTH;
-
+export async function collectSearchIndexPaths(
+	rootPath: string,
+	options: {
+		includeHidden: boolean;
+		deep?: number;
+		signal?: AbortSignal;
+		maxEntries?: number;
+	},
+): Promise<{ paths: string[]; truncated: boolean }> {
+	const { includeHidden, signal } = options;
+	const maxEntries = options.maxEntries ?? MAX_SEARCH_INDEX_ENTRIES;
 	const stream = fg.stream("**/*", {
-		cwd: normalizedRootPath,
+		cwd: rootPath,
 		onlyFiles: true,
 		dot: includeHidden,
 		followSymbolicLinks: false,
 		unique: true,
 		suppressErrors: true,
 		ignore: DEFAULT_IGNORE_PATTERNS,
-		deep,
+		deep: options.deep ?? Number.POSITIVE_INFINITY,
 	});
 
 	const onAbort = () => {
@@ -363,11 +371,18 @@ async function buildSearchIndex(
 	};
 	signal?.addEventListener("abort", onAbort, { once: true });
 
-	const items: SearchIndexEntry[] = [];
+	const paths: string[] = [];
+	let truncated = false;
 	try {
+		// Breaking out of for-await returns the stream, which destroys the
+		// underlying directory walk instead of letting it run to completion.
 		for await (const entry of stream) {
 			if (signal?.aborted) throw new SearchIndexBuildAborted();
-			items.push(createSearchIndexEntry(normalizedRootPath, String(entry)));
+			if (paths.length >= maxEntries) {
+				truncated = true;
+				break;
+			}
+			paths.push(String(entry));
 		}
 	} catch (error) {
 		if (signal?.aborted) throw new SearchIndexBuildAborted();
@@ -377,7 +392,32 @@ async function buildSearchIndex(
 	}
 
 	if (signal?.aborted) throw new SearchIndexBuildAborted();
-	return items;
+	return { paths, truncated };
+}
+
+async function buildSearchIndex(
+	{ rootPath, includeHidden }: SearchIndexKeyOptions,
+	signal?: AbortSignal,
+): Promise<SearchIndexEntry[]> {
+	const normalizedRootPath = normalizeAbsolutePath(rootPath);
+	const deep = (await isGitRepositoryRoot(normalizedRootPath))
+		? Number.POSITIVE_INFINITY
+		: UNTRACKED_ROOT_SCAN_DEPTH;
+
+	const { paths, truncated } = await collectSearchIndexPaths(
+		normalizedRootPath,
+		{ includeHidden, deep, signal },
+	);
+	if (truncated) {
+		console.warn("[workspace-fs/search] index truncated at the entry cap", {
+			rootPath: normalizedRootPath,
+			maxEntries: MAX_SEARCH_INDEX_ENTRIES,
+		});
+	}
+
+	return paths.map((relativePath) =>
+		createSearchIndexEntry(normalizedRootPath, relativePath),
+	);
 }
 
 export async function getSearchIndex(
@@ -797,9 +837,9 @@ function applySearchPatchEvent({
 			return;
 		}
 
-		const nextAbsolutePath = normalizeAbsolutePath(event.absolutePath);
-		itemsByPath.set(
-			nextAbsolutePath,
+		setIndexedEntry(
+			itemsByPath,
+			normalizeAbsolutePath(event.absolutePath),
 			createSearchIndexEntry(rootPath, nextRelativePath),
 		);
 		return;
@@ -817,7 +857,25 @@ function applySearchPatchEvent({
 		return;
 	}
 
-	itemsByPath.set(absolutePath, createSearchIndexEntry(rootPath, relativePath));
+	setIndexedEntry(
+		itemsByPath,
+		absolutePath,
+		createSearchIndexEntry(rootPath, relativePath),
+	);
+}
+
+function setIndexedEntry(
+	itemsByPath: Map<string, SearchIndexEntry>,
+	absolutePath: string,
+	entry: SearchIndexEntry,
+): void {
+	if (
+		!itemsByPath.has(absolutePath) &&
+		itemsByPath.size >= MAX_SEARCH_INDEX_ENTRIES
+	) {
+		return;
+	}
+	itemsByPath.set(absolutePath, entry);
 }
 
 export function invalidateSearchIndex(options: SearchIndexKeyOptions): void {
@@ -885,7 +943,8 @@ function applyDirectoryPatchEvent({
 		const nextAbsolutePath = `${to}${absolutePath.slice(from.length)}`;
 		const nextRelativePath = toRelativePath(rootPath, nextAbsolutePath);
 		if (!shouldIndexRelativePath(nextRelativePath, includeHidden)) continue;
-		itemsByPath.set(
+		setIndexedEntry(
+			itemsByPath,
 			nextAbsolutePath,
 			createSearchIndexEntry(rootPath, nextRelativePath),
 		);


### PR DESCRIPTION
Stacked on #7420. Merge that first; this diff is one commit on top of its head.

## Why

#7420 removes the boot-time search-index pre-warm, which is what runs host-service into V8's heap limit on the machine in #7469 (about twenty worktrees of one project, each too large for the nested-repo scan budget, all walked at boot on 1.26.0). After #7420 the walk streams and is abortable, but every entry still lands in one array, and the new depth bound only applies outside a git repository. Every one of those worktrees is a git repository. So a single filename search inside one of them still builds an index of the whole tree.

That is a one-root, user-triggered spike rather than a crash loop, but on a tree this size it is still enough to abort the process.

## What

- `collectSearchIndexPaths` walks with `fast-glob` and stops at `MAX_SEARCH_INDEX_ENTRIES` (200,000). Breaking out of the `for await` returns the stream, which destroys the directory walk instead of letting it finish.
- `buildSearchIndex` logs the root once when the walk was truncated so the cap is diagnosable from host-service.log.
- Patch-time adds from the watcher go through `setIndexedEntry`, which refuses a new key once the index is at the cap. Existing keys still update, and deletes and renames still apply, so a watched tree cannot grow a truncated index back over the limit.

The cap value and the streaming approach are the same as the one in #7247. This is the minimal piece of that PR that stands on its own.

## Tests

Two new tests in `search-index-bounds.test.ts`: a 12-file root with `maxEntries: 5` returns 5 paths and `truncated: true`; the same root with the cap at 12 returns everything with `truncated: false`.

```
packages/workspace-fs: 111 pass, 0 fail (17 files)
tsc --noEmit: clean for workspace-fs
biome check: clean
```

The host-service typecheck in this worktree reports a missing `@blaxel/core` module in `packages/trpc`; that package is declared but not installed here and is unrelated to this change.

https://claude.ai/code/session_01R9k7AWsjnQr1J7TmkgXDg4


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the filename search index at 200,000 entries so a single search in a very large worktree no longer pushes host-service into V8's heap limit. Previously the walk streamed but kept every entry, so an uncapped index could still be built; now the walk stops at the cap, with a one-time log for truncated roots, and patch-time watcher adds refuse new keys past the cap while updates, deletes, and renames still apply.

**Details**
- Breaks out of the stream walk and destroys the directory walk at the cap.
- Logs a warning with the root path when the index is truncated.
- Watcher adds go through `setIndexedEntry` to respect the cap without blocking existing key updates.
- Adds tests covering both truncated and full index walks.

<sup>Written for commit 354bea33e06855b38537ccb8743880fea21096b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

