### PR TITLE
feat(mobile): terminal PR links open the in-app pull request screen

### DIFF
--- a/apps/mobile/hooks/useOpenLink/useOpenLink.ts
+++ b/apps/mobile/hooks/useOpenLink/useOpenLink.ts
@@ -3,22 +3,41 @@ import { useCallback } from "react";
 import { env } from "@/lib/env";
 import { openUrl } from "@/lib/open-url";
 import { pageSlugFromUrl } from "@/lib/page-links";
+import { pullRequestFromUrl } from "@/lib/pull-request-links";
 
-export function useOpenLink(): (url: string) => void {
+/** Pull request links only open in-app with a workspace: its host is what answers for the PR. */
+export function useOpenLink({
+	workspaceId,
+}: {
+	workspaceId?: string;
+} = {}): (url: string) => void {
 	const router = useRouter();
 
 	return useCallback(
 		(url: string) => {
 			const slug = pageSlugFromUrl(url, env.EXPO_PUBLIC_WEB_URL);
-			if (slug === null) {
-				openUrl(url);
+			if (slug !== null) {
+				router.push({
+					pathname: "/(authenticated)/pages/[slug]/preview",
+					params: { slug },
+				});
 				return;
 			}
-			router.push({
-				pathname: "/(authenticated)/pages/[slug]/preview",
-				params: { slug },
-			});
+			const pullRequest = pullRequestFromUrl(url);
+			if (pullRequest !== null && workspaceId) {
+				router.push({
+					pathname: "/workspace/[id]/pull-request/[pullRequestId]",
+					params: {
+						id: workspaceId,
+						pullRequestId: String(pullRequest.pullNumber),
+						owner: pullRequest.owner,
+						repo: pullRequest.repo,
+					},
+				});
+				return;
+			}
+			openUrl(url);
 		},
-		[router],
+		[router, workspaceId],
 	);
 }

--- a/apps/mobile/lib/pull-request-links/index.ts
+++ b/apps/mobile/lib/pull-request-links/index.ts
@@ -1,0 +1,1 @@
+export { type PullRequestLink, pullRequestFromUrl } from "./pullRequestLinks";

--- a/apps/mobile/lib/pull-request-links/pullRequestLinks.test.ts
+++ b/apps/mobile/lib/pull-request-links/pullRequestLinks.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { pullRequestFromUrl } from "./pullRequestLinks";
+
+describe("pullRequestFromUrl", () => {
+	test("reads owner, repo and number from a pull request link", () => {
+		expect(
+			pullRequestFromUrl("https://github.com/superset-sh/superset/pull/7463"),
+		).toEqual({ owner: "superset-sh", repo: "superset", pullNumber: 7463 });
+	});
+
+	test("keeps the pull request behind its tabs, comments and threads", () => {
+		const expected = { owner: "o", repo: "r", pullNumber: 12 };
+		expect(pullRequestFromUrl("https://github.com/o/r/pull/12/")).toEqual(
+			expected,
+		);
+		expect(pullRequestFromUrl("https://github.com/o/r/pull/12/files")).toEqual(
+			expected,
+		);
+		expect(
+			pullRequestFromUrl("https://github.com/o/r/pull/12#issuecomment-9"),
+		).toEqual(expected);
+		expect(
+			pullRequestFromUrl("https://github.com/o/r/pull/12?diff=split"),
+		).toEqual(expected);
+	});
+
+	test("refuses github links that are not one pull request", () => {
+		expect(pullRequestFromUrl("https://github.com/o/r/pulls")).toBe(null);
+		expect(pullRequestFromUrl("https://github.com/o/r/pull")).toBe(null);
+		expect(pullRequestFromUrl("https://github.com/o/r/pull/new")).toBe(null);
+		expect(pullRequestFromUrl("https://github.com/o/r/pull/12a")).toBe(null);
+		expect(pullRequestFromUrl("https://github.com/o/r/issues/12")).toBe(null);
+		expect(pullRequestFromUrl("https://github.com/o/r")).toBe(null);
+	});
+
+	test("refuses other hosts, however similar", () => {
+		expect(pullRequestFromUrl("https://gitlab.com/o/r/pull/12")).toBe(null);
+		expect(
+			pullRequestFromUrl("https://github.com.evil.example/o/r/pull/1"),
+		).toBe(null);
+		expect(pullRequestFromUrl("http://github.com/o/r/pull/12")).toBe(null);
+	});
+
+	test("refuses anything that is not a url", () => {
+		expect(pullRequestFromUrl("o/r/pull/12")).toBe(null);
+		expect(pullRequestFromUrl("")).toBe(null);
+	});
+});

--- a/apps/mobile/lib/pull-request-links/pullRequestLinks.ts
+++ b/apps/mobile/lib/pull-request-links/pullRequestLinks.ts
@@ -1,0 +1,29 @@
+export interface PullRequestLink {
+	owner: string;
+	repo: string;
+	pullNumber: number;
+}
+
+/**
+ * The pull request a github.com link points at: the PR itself or any of its
+ * tabs, comments and review threads (they all belong to that one PR).
+ */
+export function pullRequestFromUrl(url: string): PullRequestLink | null {
+	let target: URL;
+	try {
+		target = new URL(url);
+	} catch {
+		return null;
+	}
+	if (target.protocol !== "https:" || target.hostname !== "github.com") {
+		return null;
+	}
+
+	const [owner, repo, kind, number] = target.pathname
+		.split("/")
+		.filter(Boolean);
+	if (!owner || !repo || kind !== "pull" || !number || !/^\d+$/.test(number)) {
+		return null;
+	}
+	return { owner, repo, pullNumber: Number.parseInt(number, 10) };
+}

--- a/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalWebView/TerminalWebView.tsx
+++ b/apps/mobile/screens/(authenticated)/workspace/[id]/components/TerminalWebView/TerminalWebView.tsx
@@ -141,7 +141,7 @@ export const TerminalWebView = forwardRef<
 	onTapRef.current = onTap;
 	const onScrollChangeRef = useRef(onScrollChange);
 	onScrollChangeRef.current = onScrollChange;
-	const openLink = useOpenLink();
+	const openLink = useOpenLink({ workspaceId });
 	const openLinkRef = useRef(openLink);
 	openLinkRef.current = openLink;
 


### PR DESCRIPTION
## Summary
- A github.com pull request link tapped in the mobile terminal now opens the in-app pull request screen for that PR instead of leaving for Safari.
- `useOpenLink` takes the terminal's workspace id; `pullRequestFromUrl` reads owner, repo and number from the link (PR tabs, comment and review-thread anchors all resolve to the PR). Owner and repo are passed explicitly so a PR on another repository still resolves through the workspace's host.
- Page links keep the preview route; any other link still opens in the browser. The page frame passes no workspace, so its PR links keep opening externally.

## Verification
- `bun test` on the new parser (5 tests). Mobile typecheck shows the same 11 pre-existing timer-type errors in shared packages with and without this change.
- In the iPhone 17 Pro Max simulator against prod: printed `https://github.com/superset-sh/superset/pull/7463` into a fixture terminal, tapped it, and the in-app PR screen for #7463 opened (Merged, +115 −12, 3 files).

https://claude.ai/code/session_01Q5YHeZakkyoM2GqEaYAFRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tapping a github.com pull request link in the mobile terminal now opens the in-app pull request screen for that PR instead of leaving for Safari.

- `useOpenLink` now takes the terminal's workspace ID, and a new parser reads owner, repo, and PR number from the link.
- PR tabs, comment anchors, and review-thread anchors all resolve to the same PR.
- Owner and repo are passed explicitly so a PR on another repository still resolves through the workspace's host.
- Page links keep the preview route; any other link still opens in the browser, and page-frame PR links keep opening externally since they pass no workspace.

<sup>Written for commit 4bec7cd1fae4bf42fd38d513a8e897d6e25e07dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull-request links from GitHub now open directly within the mobile app when a workspace is available.
  * Pull-request links without an associated workspace, along with other external links, continue opening externally.

* **Bug Fixes**
  * Improved recognition of GitHub pull-request URLs, including links with trailing slashes, query parameters, or fragments.

* **Tests**
  * Added coverage for valid and invalid pull-request URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->