### PR TITLE
fix(mobile): home composer asks "What do you want to do?"

### DIFF
--- a/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
+++ b/apps/mobile/screens/(authenticated)/(home)/home/components/NewChatWidget/NewChatWidget.tsx
@@ -323,7 +323,7 @@ export function NewChatWidget({
 		<Composer
 			ref={composerRef}
 			placeholder={t({
-				message: "Plan, ask, build...",
+				message: "What do you want to do?",
 			})}
 			initialDraft={initialDraft}
 			isSending={isSending}

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Tarif"
 msgid "Plan restored"
 msgstr "Tarif obnoven"
 
-msgid "Plan, ask, build..."
-msgstr "Plánujte, ptejte se, tvořte..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Plánuji refaktor tooltipů"
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Tarif"
 msgid "Plan restored"
 msgstr "Tarif wiederhergestellt"
 
-msgid "Plan, ask, build..."
-msgstr "Planen, fragen, bauen..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Das Tooltip-Refactoring planen"
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Plan"
 msgid "Plan restored"
 msgstr "Plan restored"
 
-msgid "Plan, ask, build..."
-msgstr "Plan, ask, build..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Planning the tooltip refactor"
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Plan"
 msgid "Plan restored"
 msgstr "Plan restaurado"
 
-msgid "Plan, ask, build..."
-msgstr "Planifica, pregunta, construye..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Planificando la refactorización de los tooltips"
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Forfait"
 msgid "Plan restored"
 msgstr "Forfait rétabli"
 
-msgid "Plan, ask, build..."
-msgstr "Planifier, demander, construire..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Planification du refactor du tooltip"
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Paket"
 msgid "Plan restored"
 msgstr "Paket dipulihkan"
 
-msgid "Plan, ask, build..."
-msgstr "Rencanakan, tanya, bangun..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Merencanakan refactor tooltip"
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Piano"
 msgid "Plan restored"
 msgstr "Piano ripristinato"
 
-msgid "Plan, ask, build..."
-msgstr "Pianifica, chiedi, costruisci..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Pianificazione del refactor dei tooltip"
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -10855,9 +10855,6 @@ msgstr "プラン"
 msgid "Plan restored"
 msgstr "プランを復元しました"
 
-msgid "Plan, ask, build..."
-msgstr "計画、質問、構築..."
-
 msgid "Planning the tooltip refactor"
 msgstr "tooltipのリファクタリングを計画中"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -10855,9 +10855,6 @@ msgstr "플랜"
 msgid "Plan restored"
 msgstr "플랜이 복원되었습니다"
 
-msgid "Plan, ask, build..."
-msgstr "계획, 질문, 개발..."
-
 msgid "Planning the tooltip refactor"
 msgstr "툴팁 리팩터링 계획 중"
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Plan"
 msgid "Plan restored"
 msgstr "Plan hersteld"
 
-msgid "Plan, ask, build..."
-msgstr "Plannen, vragen, bouwen..."
-
 msgid "Planning the tooltip refactor"
 msgstr "De tooltip-refactor plannen"
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Plan"
 msgid "Plan restored"
 msgstr "Plan przywrócony"
 
-msgid "Plan, ask, build..."
-msgstr "Planuj, pytaj, buduj..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Planowanie refaktoryzacji tooltipów"
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Plano"
 msgid "Plan restored"
 msgstr "Plano restaurado"
 
-msgid "Plan, ask, build..."
-msgstr "Planeje, pergunte, construa..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Planejando a refatoração dos tooltips"
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Тариф"
 msgid "Plan restored"
 msgstr "Тариф восстановлен"
 
-msgid "Plan, ask, build..."
-msgstr "Планируйте, спрашивайте, стройте..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Планируем рефакторинг tooltip"
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Plan"
 msgid "Plan restored"
 msgstr "Plan geri yüklendi"
 
-msgid "Plan, ask, build..."
-msgstr "Planlayın, sorun, geliştirin..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Tooltip yeniden düzenlemesi planlanıyor"
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -10855,9 +10855,6 @@ msgstr "Gói"
 msgid "Plan restored"
 msgstr "Đã khôi phục gói"
 
-msgid "Plan, ask, build..."
-msgstr "Lên kế hoạch, hỏi, xây dựng..."
-
 msgid "Planning the tooltip refactor"
 msgstr "Lên kế hoạch refactor tooltip"
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -10855,9 +10855,6 @@ msgstr "方案"
 msgid "Plan restored"
 msgstr "方案已恢复"
 
-msgid "Plan, ask, build..."
-msgstr "规划、提问、构建..."
-
 msgid "Planning the tooltip refactor"
 msgstr "正在规划tooltip重构"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -10855,9 +10855,6 @@ msgstr "方案"
 msgid "Plan restored"
 msgstr "方案已恢復"
 
-msgid "Plan, ask, build..."
-msgstr "規劃、提問、構建..."
-
 msgid "Planning the tooltip refactor"
 msgstr "正在規劃tooltip重構"
 


### PR DESCRIPTION
## Summary
- The home composer placeholder changes from "Plan, ask, build..." to "What do you want to do?", matching the desktop new-workspace prompt.
- The session composer keeps "Type a message...".
- Catalogs drop the old entry; the new string was already translated in every locale, so `check:i18n` passes with zero missing.

## Verification
`bun run check:i18n` clean. Not run on a simulator; the string is one character longer than before.

https://claude.ai/code/session_01T4LfyHyHKgV7VGsJRuk3dX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the home composer placeholder on mobile from "Plan, ask, build..." to "What do you want to do?" to match the desktop new-workspace prompt. The session composer keeps "Type a message...". The old placeholder string is removed from all locale catalogs; the new string was already translated, so `check:i18n` passes cleanly.

<sup>Written for commit eb1685d7799f67addfde1bff542312f1743dedc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the new-chat composer placeholder to “What do you want to do?”.
  * Applied the new placeholder consistently across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->