### PR TITLE
fix(port-scanner): wait for spawned children before reading their environment in tests

### DIFF
--- a/packages/port-scanner/src/terminal-env.test.ts
+++ b/packages/port-scanner/src/terminal-env.test.ts
@@ -84,6 +84,34 @@ describe("parsePsEnvOutput", () => {
 	});
 });
 
+/**
+ * A child that is provably past exec before the test inspects it. On Linux,
+ * vfork hands control back once the new image is installed but before the
+ * kernel has recorded its environment range, so /proc/<pid>/environ reads
+ * empty for a moment after Bun.spawn returns.
+ */
+async function spawnIdle({
+	env,
+	argument,
+}: {
+	env: Record<string, string | undefined>;
+	argument?: string;
+}): Promise<Bun.Subprocess<"ignore", "pipe", "ignore">> {
+	const child = Bun.spawn(
+		[
+			process.execPath,
+			"-e",
+			"process.stdout.write('running\\n'); setTimeout(() => {}, 10000)",
+			...(argument === undefined ? [] : [argument]),
+		],
+		{ env, stdout: "pipe", stderr: "ignore" },
+	);
+	const reader = child.stdout.getReader();
+	await reader.read();
+	reader.releaseLock();
+	return child;
+}
+
 describe("readTerminalIdsFromEnv (real processes)", () => {
 	const supported = os.platform() === "darwin" || os.platform() === "linux";
 
@@ -104,32 +132,14 @@ describe("readTerminalIdsFromEnv (real processes)", () => {
 	it.skipIf(!supported)(
 		"ignores an argument-only ID in both targeted and whole-table reads",
 		async () => {
-			const fake = Bun.spawn(
-				[
-					process.execPath,
-					"-e",
-					"setTimeout(() => {}, 10000)",
-					`SUPERSET_TERMINAL_ID=${TERMINAL}`,
-				],
-				{
-					env: { SUPERSET_TERMINAL_ID: "", SUPERSET_PANE_ID: "" },
-					stdout: "ignore",
-					stderr: "ignore",
-				},
-			);
-			const real = Bun.spawn(
-				[
-					process.execPath,
-					"-e",
-					"setTimeout(() => {}, 10000)",
-					"SUPERSET_TERMINAL_ID=argument-only",
-				],
-				{
-					env: { SUPERSET_TERMINAL_ID: TERMINAL, SUPERSET_PANE_ID: "" },
-					stdout: "ignore",
-					stderr: "ignore",
-				},
-			);
+			const fake = await spawnIdle({
+				env: { SUPERSET_TERMINAL_ID: "", SUPERSET_PANE_ID: "" },
+				argument: `SUPERSET_TERMINAL_ID=${TERMINAL}`,
+			});
+			const real = await spawnIdle({
+				env: { SUPERSET_TERMINAL_ID: TERMINAL, SUPERSET_PANE_ID: "" },
+				argument: "SUPERSET_TERMINAL_ID=argument-only",
+			});
 			try {
 				for (const pids of [
 					[fake.pid, real.pid],
@@ -151,20 +161,21 @@ describe("readTerminalIdsFromEnv (real processes)", () => {
 		"reads the id from a child spawned with it and null from one without",
 		async () => {
 			const spawn = (env: Record<string, string>) =>
-				Bun.spawn([process.execPath, "-e", "setTimeout(() => {}, 5000)"], {
-					env: { ...process.env, ...env },
-				});
+				spawnIdle({ env: { ...process.env, ...env } });
 			// The test runner may itself be inside a Superset terminal, so clear
 			// the inherited ids explicitly rather than relying on their absence.
-			const withId = spawn({
+			const withId = await spawn({
 				SUPERSET_TERMINAL_ID: TERMINAL,
 				SUPERSET_PANE_ID: "",
 			});
-			const withPane = spawn({
+			const withPane = await spawn({
 				SUPERSET_TERMINAL_ID: "",
 				SUPERSET_PANE_ID: "pane-1",
 			});
-			const without = spawn({ SUPERSET_TERMINAL_ID: "", SUPERSET_PANE_ID: "" });
+			const without = await spawn({
+				SUPERSET_TERMINAL_ID: "",
+				SUPERSET_PANE_ID: "",
+			});
 			// A pid that existed and has exited: the realistic race between the
 			// table read and the environment read. (An out-of-range pid is not
 			// realistic — macOS `ps` rejects the whole batch for one.)


### PR DESCRIPTION
## Summary
- The `readTerminalIdsFromEnv (real processes)` tests inspected `/proc/<pid>/environ` immediately after `Bun.spawn` returned. On Linux, vfork hands control back to the parent once the new memory image is installed, before the kernel records the environment range, so a fast read sees an empty environment and the test fails with a null id (seen on #7476's Test job, unrelated to that change).
- Each child now writes a line to stdout once it is running and the test waits for it before reading, so both real-process tests inspect a child that is provably past exec.

## Verification
- `bun test src/terminal-env.test.ts`: 12 pass locally on macOS, three runs.
- Linux in Docker (`oven/bun:1`) with `--cpus=0.25` and two busy loops: the old test failed 1 of 40 runs with the same assertion as CI; the new test passed 40 of 40.
- Package typecheck clean for the test file.

https://claude.ai/code/session_01Q5YHeZakkyoM2GqEaYAFRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky real-process tests in `packages/port-scanner` so they wait for the spawned child to report it is running before reading its environment. On Linux, vfork returns control to the parent before the kernel records the environment range, so a fast read saw an empty `/proc/<pid>/environ` and the test failed with a null id.

<sup>Written for commit 88c0954470e1fd997c9912f5d85c96deb2d073b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved process-environment test setup for more deterministic results.
  - Added coverage for custom environment variables and optional process arguments.
  - Reduced duplicated test setup across real-process scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->