### PR TITLE
fix(mobile): "+N more" outranks "Not updating" in the Lock Screen card

### DIFF
--- a/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
+++ b/apps/mobile/targets/agentactivity/AgentActivityWidget.swift
@@ -130,10 +130,11 @@ private struct Row: View {
 private struct CardBody: View {
 	let context: ActivityViewContext<AgentActivityAttributes>
 
-	/// The footer is the one line where the card can admit it has stopped
-	/// hearing anything.
+	/// A hidden agent outranks the stale notice: the dimmed card already says
+	/// it stopped hearing anything, so "Not updating" only takes the footer
+	/// when there is nothing dropped to count.
 	private var footer: String? {
-		context.isStale ? context.state.staleDetail : context.state.more
+		context.state.more ?? (context.isStale ? context.state.staleDetail : nil)
 	}
 
 	var body: some View {


### PR DESCRIPTION
## Why

#7460 gave the stale notice the footer slot. Once the app leaves the foreground for two minutes the activity goes stale, and the card swaps the "+N more" count for "Not updating". The count is the line we actually want on the Lock Screen.

## What

Footer priority flipped in the widget: `more` wins; `staleDetail` only shows when nothing was dropped. The card still dims to 55% when stale, so staleness is still visible without spending the footer on it.

## Verification

One-line Swift change in the widget target; no JS change. Not sim-verified (native widget change needs an EAS/`expo run:ios` build).

https://claude.ai/code/session_019R4jiQ8STC4BY594f4jjPc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Lock Screen widget footer priority so the "+N more" count shows instead of the "Not updating" stale notice.

- When the activity goes stale, the card now keeps the dropped-count line; "Not updating" appears only when nothing was dropped.
- Staleness remains visible through the existing 55% card dim.

<sup>Written for commit 2945a43c11d1be95e40b713b47b9e1ed6908fff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated activity cards to display the latest additional message before showing stale-state details.
  * Stale-state messaging now appears only when no additional message is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->