### PR TITLE
fix(desktop): stop stale repos and stale ledger rows from stranding v1 users on v1

### DIFF
--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.test.tsx
@@ -130,15 +130,37 @@ describe("useIsV1FlipLocked", () => {
 		expect(readProbe("org-mid", null)).toEqual({ locked: true, v2: false });
 	});
 
-	test("completion mid-session makes an opt-out inert", () => {
+	test("completion mid-session freezes the surface: a later opt-in does not flip forward", () => {
+		expect(readProbe("org-freeze-in", null)).toEqual({
+			locked: false,
+			v2: false,
+		});
+		markV1MigrationComplete("org-freeze-in");
+		// The completion event re-renders before anyone can toggle; that render
+		// pins the surface.
+		expect(readProbe("org-freeze-in", null)).toEqual({
+			locked: true,
+			v2: false,
+		});
+		expect(readProbe("org-freeze-in", true)).toEqual({
+			locked: true,
+			v2: false,
+		});
+	});
+
+	test("completion mid-session freezes the surface: a later opt-out does not snap back", () => {
 		createdAt = V2_ERA_CREATED_AT;
 		try {
-			expect(readProbe("org-mid-optout", false)).toEqual({
+			expect(readProbe("org-freeze-out", null)).toEqual({
 				locked: false,
-				v2: false,
+				v2: true,
 			});
-			markV1MigrationComplete("org-mid-optout");
-			expect(readProbe("org-mid-optout", false)).toEqual({
+			markV1MigrationComplete("org-freeze-out");
+			expect(readProbe("org-freeze-out", null)).toEqual({
+				locked: true,
+				v2: true,
+			});
+			expect(readProbe("org-freeze-out", false)).toEqual({
 				locked: true,
 				v2: true,
 			});

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.test.tsx
@@ -17,11 +17,14 @@ globalThis.localStorage = {
 
 // Pre-cutoff account: defaults to v1 (not in any v2-only signup cohort).
 const V1_ERA_CREATED_AT = new Date("2026-01-01T00:00:00Z");
+// Signed up after new users defaulted to v2; only an explicit opt-out
+// puts this account on v1.
+const V2_ERA_CREATED_AT = new Date("2026-08-01T00:00:00Z");
 
 // Mutable session the auth-client mock serves; tests swap the org per case
 // because isV1MigrationCompleteAtBoot caches the first read per org.
 let activeOrganizationId = "org-none";
-const createdAt: Date = V1_ERA_CREATED_AT;
+let createdAt: Date = V1_ERA_CREATED_AT;
 // renderToStaticMarkup reads zustand's initial state, not live setState, so
 // the override store is mocked with a mutable value instead.
 let optInV2: boolean | null = null;
@@ -118,6 +121,29 @@ describe("useIsV1FlipLocked", () => {
 			});
 		} finally {
 			forcedFlipActive = false;
+		}
+	});
+
+	test("completion mid-session locks the flip at once; the surface waits for the next launch", () => {
+		expect(readProbe("org-mid", null)).toEqual({ locked: false, v2: false });
+		markV1MigrationComplete("org-mid");
+		expect(readProbe("org-mid", null)).toEqual({ locked: true, v2: false });
+	});
+
+	test("completion mid-session makes an opt-out inert", () => {
+		createdAt = V2_ERA_CREATED_AT;
+		try {
+			expect(readProbe("org-mid-optout", false)).toEqual({
+				locked: false,
+				v2: false,
+			});
+			markV1MigrationComplete("org-mid-optout");
+			expect(readProbe("org-mid-optout", false)).toEqual({
+				locked: true,
+				v2: true,
+			});
+		} finally {
+			createdAt = V1_ERA_CREATED_AT;
 		}
 	});
 

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -1,11 +1,28 @@
 import { isV2OnlyUser } from "@superset/shared/v2-only-user";
+import { useSyncExternalStore } from "react";
 import { env } from "renderer/env.renderer";
 import { authClient } from "renderer/lib/auth-client";
 import {
 	isV1ForcedFlipActive,
+	isV1MigrationComplete,
 	isV1MigrationCompleteAtBoot,
+	V1_MIGRATION_COMPLETED_EVENT,
 } from "renderer/lib/v1-migration/completion";
 import { useV2LocalOverrideStore } from "renderer/stores/v2-local-override";
+
+function subscribeToMigrationCompletion(onChange: () => void): () => void {
+	window.addEventListener(V1_MIGRATION_COMPLETED_EVENT, onChange);
+	return () =>
+		window.removeEventListener(V1_MIGRATION_COMPLETED_EVENT, onChange);
+}
+
+/** Live marker read: re-renders the moment a pass completes this session. */
+function useIsV1MigrationCompleteNow(
+	organizationId: string | null | undefined,
+): boolean {
+	const read = () => isV1MigrationComplete(organizationId ?? null);
+	return useSyncExternalStore(subscribeToMigrationCompletion, read, read);
+}
 
 /**
  * True for accounts created on/after V2_ONLY_USER_CUTOFF — these users
@@ -24,8 +41,11 @@ export function useIsV2OnlyUser(): boolean {
  */
 export function useIsV1FlipLocked(): boolean {
 	const { data: session } = authClient.useSession();
+	const organizationId = session?.session?.activeOrganizationId;
+	const completedThisSession = useIsV1MigrationCompleteNow(organizationId);
 	return (
-		isV1MigrationCompleteAtBoot(session?.session?.activeOrganizationId) ||
+		isV1MigrationCompleteAtBoot(organizationId) ||
+		completedThisSession ||
 		isV1ForcedFlipActive()
 	);
 }
@@ -35,10 +55,12 @@ export function useIsV2CloudEnabled(): boolean {
 	const v2Only = useIsV2OnlyUser();
 	const optInV2 = useV2LocalOverrideStore((s) => s.optInV2);
 	const { data: session } = authClient.useSession();
+	const organizationId = session?.session?.activeOrganizationId;
+	const completedThisSession = useIsV1MigrationCompleteNow(organizationId);
 	// Migrate-then-flip: once this machine's v1 data has fully migrated for
 	// the org, v2 wins — including over an explicit opt-out (D5, sunset).
 	// Read is boot-stable, so completion mid-session flips the NEXT launch.
-	if (isV1MigrationCompleteAtBoot(session?.session?.activeOrganizationId)) {
+	if (isV1MigrationCompleteAtBoot(organizationId)) {
 		return true;
 	}
 	// Backstop: past the forced-flip version, machines whose migration never
@@ -47,6 +69,10 @@ export function useIsV2CloudEnabled(): boolean {
 	if (isV1ForcedFlipActive()) {
 		return true;
 	}
+	// Completed mid-session: the surface still flips on the next launch, but
+	// an opt-out written after completion must not drag this machine back.
+	const effectiveOptIn =
+		completedThisSession && optInV2 === false ? null : optInV2;
 	// Dev builds default to v2; an explicit opt-out (optInV2 === false) still wins.
-	return optInV2 ?? (v2Only || env.NODE_ENV === "development");
+	return effectiveOptIn ?? (v2Only || env.NODE_ENV === "development");
 }

--- a/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
+++ b/apps/desktop/src/renderer/hooks/useIsV2CloudEnabled.ts
@@ -16,6 +16,11 @@ function subscribeToMigrationCompletion(onChange: () => void): () => void {
 		window.removeEventListener(V1_MIGRATION_COMPLETED_EVENT, onChange);
 }
 
+// optInV2 as it stood when completion was first observed this session, per
+// org. The surface holds there until relaunch: no mid-session flip forward,
+// and no snap back to v1 through a late opt-out.
+const optInV2AtCompletion = new Map<string, boolean | null>();
+
 /** Live marker read: re-renders the moment a pass completes this session. */
 function useIsV1MigrationCompleteNow(
 	organizationId: string | null | undefined,
@@ -69,10 +74,13 @@ export function useIsV2CloudEnabled(): boolean {
 	if (isV1ForcedFlipActive()) {
 		return true;
 	}
-	// Completed mid-session: the surface still flips on the next launch, but
-	// an opt-out written after completion must not drag this machine back.
-	const effectiveOptIn =
-		completedThisSession && optInV2 === false ? null : optInV2;
+	let effectiveOptIn = optInV2;
+	if (completedThisSession && organizationId) {
+		if (!optInV2AtCompletion.has(organizationId)) {
+			optInV2AtCompletion.set(organizationId, optInV2);
+		}
+		effectiveOptIn = optInV2AtCompletion.get(organizationId) ?? null;
+	}
 	// Dev builds default to v2; an explicit opt-out (optInV2 === false) still wins.
 	return effectiveOptIn ?? (v2Only || env.NODE_ENV === "development");
 }

--- a/apps/desktop/src/renderer/lib/v1-migration/projects.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/projects.ts
@@ -25,23 +25,32 @@ export type ProjectImportOutcome =
 	  }
 	| { kind: "needs-relocate"; v2ProjectId: string; message: string };
 
+export type UnmigratableRepoReason = "repo-path-missing" | "not-a-git-repo";
+
 export type ProjectImportDecision =
 	| { kind: "already-imported"; v2ProjectId: string }
 	| { kind: "import" }
-	| { kind: "skip"; reason: "multiple-candidates" | "cloud-unreachable" };
+	| {
+			kind: "skip";
+			reason: "multiple-candidates" | "cloud-unreachable" | "not-a-git-repo";
+	  };
 
 /**
  * Decide what to do with a v1 project from its findByPath result. Mirrors
  * the wizard's "Import all" rules: a `local-path` candidate means the repo
  * is already a v2 project on this host; multiple cloud candidates need a
  * human to pick; cloud errors with no candidate mean we can't tell whether
- * a legacy cloud project exists, so don't risk creating a duplicate.
+ * a legacy cloud project exists, so don't risk creating a duplicate. A
+ * folder that is no longer a git repo has nothing to import headlessly.
  */
 export function decideProjectImport(
-	result: Pick<ProjectFindByPathResult, "candidates" | "cloudErrors">,
+	result: Pick<ProjectFindByPathResult, "candidates" | "cloudErrors"> & {
+		needsGitInit?: boolean;
+	},
 ): ProjectImportDecision {
 	const local = result.candidates.find((c) => c.source === "local-path");
 	if (local) return { kind: "already-imported", v2ProjectId: local.id };
+	if (result.needsGitInit) return { kind: "skip", reason: "not-a-git-repo" };
 	if (result.candidates.length > 1) {
 		return { kind: "skip", reason: "multiple-candidates" };
 	}
@@ -75,6 +84,27 @@ export function findProjectByPath(
 		walkAllRemotes: true,
 		expectedRemoteUrl: expectedRemoteUrlFor(project),
 	});
+}
+
+/**
+ * Host errors that mean the v1 project has nothing left to migrate on this
+ * machine: its repo moved, was deleted, or stopped being a git checkout.
+ * Message shapes are the host-service's (resolve-repo.ts, local-project.ts).
+ */
+export function classifyUnmigratableRepoError(
+	err: unknown,
+): UnmigratableRepoReason | null {
+	const message =
+		err instanceof Error ? err.message : typeof err === "string" ? err : "";
+	if (
+		message.startsWith("Path does not exist: ") ||
+		message.startsWith("Path is not a directory: ") ||
+		message === "Project directory is no longer a directory on disk"
+	) {
+		return "repo-path-missing";
+	}
+	if (message.startsWith("Not a git repository: ")) return "not-a-git-repo";
+	return null;
 }
 
 export function isAlreadySetUpElsewhereError(err: unknown): boolean {

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.test.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.test.ts
@@ -36,6 +36,10 @@ class FakeHost {
 	diskBranches = new Map<string, Set<string>>();
 	/** repoPath → error message create/setup should throw (broken repos). */
 	brokenRepos = new Map<string, string>();
+	/** Repo paths that no longer exist on disk (findByPath 400s). */
+	missingPaths = new Set<string>();
+	/** Existing folders that are not git repos (findByPath → needsGitInit). */
+	nonGitPaths = new Set<string>();
 	/** Throw the next N adopt calls (transient host fault). */
 	adoptFaults = 0;
 	tagFaults = 0;
@@ -58,6 +62,12 @@ class FakeHost {
 			project: {
 				findByPath: {
 					query: async ({ repoPath }: { repoPath: string }) => {
+						if (this.missingPaths.has(repoPath)) {
+							throw new Error(`Path does not exist: ${repoPath}`);
+						}
+						if (this.nonGitPaths.has(repoPath)) {
+							return { candidates: [], cloudErrors: [], needsGitInit: true };
+						}
 						const local = this.projects.find((p) => p.repoPath === repoPath);
 						return {
 							candidates: local ? [{ id: local.id, source: "local-path" }] : [],
@@ -92,6 +102,9 @@ class FakeHost {
 					}) => {
 						if (this.brokenRepos.has(mode.repoPath)) {
 							throw new Error(this.brokenRepos.get(mode.repoPath));
+						}
+						if (this.nonGitPaths.has(mode.repoPath)) {
+							throw new Error(`Not a git repository: ${mode.repoPath}`);
 						}
 						this.mutations.push({ kind: "project.create", args: name });
 						const project = { id: this.id("v2p"), repoPath: mode.repoPath };
@@ -200,6 +213,13 @@ class FakeHost {
 							this.adoptFaults--;
 							throw new Error("host transient adopt failure");
 						}
+						const owner = this.projects.find((p) => p.id === args.projectId);
+						if (!owner) throw new Error("Project is not set up on this host");
+						if (this.missingPaths.has(owner.repoPath)) {
+							throw new Error(
+								"Project directory is no longer a directory on disk",
+							);
+						}
 						this.mutations.push({ kind: "workspaceCreation.adopt", args });
 						const existing = this.workspaces.find(
 							(w) => w.projectId === args.projectId && w.branch === args.branch,
@@ -299,6 +319,14 @@ const workspace = (
 	branch: string,
 	worktreeId: string | null = null,
 ): V1WorkspaceRow => ({ id, projectId, worktreeId, name: id, branch });
+
+const runOnV1 = (ipc: FakeIpc, host: FakeHost) =>
+	runV1Migration({
+		organizationId: "org",
+		hostClient: host.client(),
+		ipc,
+		reconcileWithHost: true,
+	});
 
 const run = (ipc: FakeIpc, host: FakeHost) =>
 	runV1Migration({ organizationId: "org", hostClient: host.client(), ipc });
@@ -432,6 +460,116 @@ describe("runV1Migration scenarios", () => {
 		expect(summary.projects.migrated).toBe(1);
 		expect(summary.gateComplete).toBe(true);
 		expect(ipc.ledger.get("project\0p1")?.status).toBe("success");
+	});
+
+	test("repo whose path is gone is skipped, not failed: gate completes; restoring the path imports it later", async () => {
+		const ipc = new FakeIpc();
+		const host = new FakeHost();
+		ipc.projects = [
+			project("good", "/repo/good"),
+			project("gone", "/repo/gone"),
+		];
+		ipc.workspaces = [workspace("w-gone", "gone", "feat")];
+		host.missingPaths.add("/repo/gone");
+
+		const first = await run(ipc, host);
+		expect(first.projects.migrated).toBe(1);
+		expect(first.projects.failed).toBe(0);
+		expect(first.projects.skipped).toBe(1);
+		expect(first.workspaces.failed).toBe(0);
+		expect(first.workspaces.skipped).toBe(1);
+		expect(first.gateComplete).toBe(true);
+		expect(ipc.ledger.get("project\0gone")).toMatchObject({
+			status: "skipped",
+			reason: "repo-path-missing",
+		});
+
+		host.missingPaths.clear(); // user restored the folder
+		const second = await run(ipc, host);
+		expect(second.projects.migrated).toBe(1);
+		expect(ipc.ledger.get("project\0gone")?.status).toBe("success");
+	});
+
+	test("folder that is no longer a git repo is skipped without a create call", async () => {
+		const ipc = new FakeIpc();
+		const host = new FakeHost();
+		ipc.projects = [project("plain", "/repo/plain")];
+		host.nonGitPaths.add("/repo/plain");
+
+		const summary = await run(ipc, host);
+		expect(summary.projects.skipped).toBe(1);
+		expect(summary.projects.failed).toBe(0);
+		expect(summary.gateComplete).toBe(true);
+		expect(host.mutations).toHaveLength(0);
+		expect(ipc.ledger.get("project\0plain")).toMatchObject({
+			status: "skipped",
+			reason: "not-a-git-repo",
+		});
+	});
+
+	test("on v1, a ledger row pointing at a project the host no longer has is re-imported, not trusted", async () => {
+		const ipc = new FakeIpc();
+		const host = new FakeHost();
+		ipc.projects = [project("p1", "/repo/a")];
+		ipc.worktrees = [{ id: "wt1", path: "/trees/feat", baseBranch: "main" }];
+		ipc.workspaces = [workspace("w-feat", "p1", "feat", "wt1")];
+		host.diskBranches.set("/repo/a", new Set(["feat"]));
+
+		const first = await runOnV1(ipc, host);
+		expect(first.gateComplete).toBe(true);
+		const staleV2Id = ipc.ledger.get("project\0p1")?.v2Id;
+		expect(staleV2Id).toBeTruthy();
+
+		// host.db wiped or rebuilt: the v2 project id in the ledger is gone.
+		host.projects = [];
+		host.workspaces = [];
+
+		const second = await runOnV1(ipc, host);
+		expect(second.projects.migrated).toBe(1);
+		expect(second.workspaces.failed).toBe(0);
+		expect(second.workspaces.migrated).toBe(1);
+		expect(second.gateComplete).toBe(true);
+		expect(ipc.ledger.get("project\0p1")?.v2Id).not.toBe(staleV2Id);
+		expect(host.projects).toHaveLength(1);
+	});
+
+	test("after the flip, a project the user deleted on v2 is not re-imported", async () => {
+		const ipc = new FakeIpc();
+		const host = new FakeHost();
+		ipc.projects = [project("p1", "/repo/a")];
+		ipc.worktrees = [{ id: "wt1", path: "/trees/feat", baseBranch: "main" }];
+		ipc.workspaces = [workspace("w-feat", "p1", "feat", "wt1")];
+		host.diskBranches.set("/repo/a", new Set(["feat"]));
+		await runOnV1(ipc, host);
+
+		host.projects = [];
+		host.workspaces = [];
+
+		const followUp = await run(ipc, host); // v2 follow-up pass
+		expect(followUp.projects.migrated).toBe(0);
+		expect(followUp.workspaces.migrated).toBe(0);
+		expect(host.projects).toHaveLength(0);
+	});
+
+	test("workspace of an imported project whose directory vanished is skipped, not failed", async () => {
+		const ipc = new FakeIpc();
+		const host = new FakeHost();
+		ipc.projects = [project("p1", "/repo/a")];
+		host.diskBranches.set("/repo/a", new Set(["feat"]));
+		await runOnV1(ipc, host);
+
+		ipc.worktrees = [{ id: "wt1", path: "/trees/feat", baseBranch: "main" }];
+		ipc.workspaces = [workspace("w-feat", "p1", "feat", "wt1")];
+		host.missingPaths.add("/repo/a"); // repo deleted after the import
+
+		const summary = await runOnV1(ipc, host);
+		expect(summary.workspaces.failed).toBe(0);
+		expect(summary.workspaces.skipped).toBe(1);
+		expect(summary.gateComplete).toBe(true);
+		expect(ipc.ledger.get("workspace\0w-feat")).toMatchObject({
+			status: "skipped",
+			reason: "repo-path-missing",
+		});
 	});
 
 	test("no v1 data: gate trivially complete, zero mutations", async () => {

--- a/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/runV1Migration.ts
@@ -17,6 +17,7 @@ import {
 	type V2PresetLike,
 } from "./presets";
 import {
+	classifyUnmigratableRepoError,
 	decideProjectImport,
 	findProjectByPath,
 	importV1Project,
@@ -49,6 +50,12 @@ export interface RunV1MigrationDeps {
 	groupTarget?: V1GroupTarget;
 	organizationId: string;
 	hostClient: HostServiceClient;
+	/**
+	 * Redo done ledger rows whose v2 project/workspace no longer exists on
+	 * this host (host.db wiped or rebuilt). Only safe before the flip: on v2
+	 * a missing row is the user's own deletion and must stay deleted.
+	 */
+	reconcileWithHost?: boolean;
 	/** Electron-main reads/writes; inject fakes in tests. */
 	ipc: V1MigrationIpc;
 	/**
@@ -150,11 +157,20 @@ async function migrateProjects(
 	outcomes: V1LedgerOutcome[],
 ): Promise<KindSummary> {
 	const summary = emptySummary();
-	const v1Projects = await deps.ipc.readV1Projects();
+	const [v1Projects, hostProjects] = await Promise.all([
+		deps.ipc.readV1Projects(),
+		deps.reconcileWithHost ? deps.hostClient.project.list.query() : [],
+	]);
+	const hostProjectIds = new Set(hostProjects.map((p) => p.id));
 
 	for (const project of v1Projects) {
 		const existing = ledger.get(ledgerKey("project", project.id));
-		if (existing && isTerminalStatus(existing.status)) continue;
+		const done = !!existing && isTerminalStatus(existing.status);
+		const goneFromHost =
+			deps.reconcileWithHost &&
+			existing?.v2Id != null &&
+			!hostProjectIds.has(existing.v2Id);
+		if (done && !goneFromHost) continue;
 
 		try {
 			const findByPathResult = await findProjectByPath(deps.hostClient, {
@@ -223,6 +239,17 @@ async function migrateProjects(
 				});
 			}
 		} catch (err) {
+			const unmigratable = classifyUnmigratableRepoError(err);
+			if (unmigratable) {
+				summary.skipped++;
+				pushOutcome(ledger, outcomes, {
+					v1Id: project.id,
+					kind: "project",
+					status: "skipped",
+					reason: unmigratable,
+				});
+				continue;
+			}
 			summary.failed++;
 			pushOutcome(ledger, outcomes, {
 				v1Id: project.id,
@@ -267,9 +294,15 @@ async function migrateWorkspaces(
 		if (v2Id) v2ProjectIdByV1ProjectId.set(v1.id, v2Id);
 	}
 
+	const hostWorkspaceIds = new Set(hostWorkspaces.map((w) => w.id));
 	const pendingWorkspaces = v1Workspaces.filter((w) => {
 		const existing = ledger.get(ledgerKey("workspace", w.id));
-		return !existing || !isTerminalStatus(existing.status);
+		if (!existing || !isTerminalStatus(existing.status)) return true;
+		return (
+			!!deps.reconcileWithHost &&
+			existing.v2Id !== null &&
+			!hostWorkspaceIds.has(existing.v2Id)
+		);
 	});
 
 	const mappedV2ProjectIds = new Set(
@@ -352,6 +385,17 @@ async function migrateWorkspaces(
 				});
 			}
 		} catch (err) {
+			const unmigratable = classifyUnmigratableRepoError(err);
+			if (unmigratable) {
+				summary.skipped++;
+				pushOutcome(ledger, outcomes, {
+					v1Id: entry.v1WorkspaceId,
+					kind: "workspace",
+					status: "skipped",
+					reason: unmigratable,
+				});
+				continue;
+			}
 			summary.failed++;
 			pushOutcome(ledger, outcomes, {
 				v1Id: entry.v1WorkspaceId,

--- a/apps/desktop/src/renderer/lib/v1-migration/summary.ts
+++ b/apps/desktop/src/renderer/lib/v1-migration/summary.ts
@@ -12,8 +12,9 @@ export function emptySummary(): KindSummary {
 }
 
 /**
- * D4 flip gate. Deliberate skips (no worktree on disk, ambiguous/duplicate
- * repos, cloud unreachable) are "nothing to migrate here" classifications,
+ * D4 flip gate. Deliberate skips (no worktree on disk, repo path gone or no
+ * longer a git checkout, ambiguous/duplicate repos, cloud unreachable) are
+ * "nothing to migrate here" classifications,
  * not pending work — aged installs always have some, so they must not hold
  * the flip hostage. They stay non-terminal in the ledger and retry each
  * pass, so e.g. a restored worktree still adopts later. Only real failures

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1AutoMigration/V1AutoMigration.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1AutoMigration/V1AutoMigration.tsx
@@ -123,6 +123,7 @@ export function V1AutoMigration() {
 					organizationId,
 					hostClient: getHostServiceClientByUrl(hostUrl),
 					ipc: electronV1MigrationIpc,
+					reconcileWithHost: !isV2CloudEnabled,
 					presetTarget: {
 						agents,
 						existing: Array.from(
@@ -169,25 +170,33 @@ export function V1AutoMigration() {
 					);
 				}
 
-				// Failure reasons come from the ledger (the summary only counts)
-				// so the stuck cohort is identifiable, not just sized.
+				// Failure and skip reasons come from the ledger (the summary only
+				// counts) so the stuck cohort is identifiable, not just sized.
 				let failureReasons: string[] = [];
-				if (summary.projects.failed + summary.workspaces.failed > 0) {
+				let skipReasons: string[] = [];
+				const gating = (r: { kind: string }) =>
+					r.kind === "project" || r.kind === "workspace";
+				if (
+					summary.projects.failed +
+						summary.workspaces.failed +
+						summary.projects.skipped +
+						summary.workspaces.skipped >
+					0
+				) {
 					try {
 						const rows =
 							await electronV1MigrationIpc.ledgerList(organizationId);
-						failureReasons = [
-							...new Set(
-								rows
-									.filter(
-										(r) =>
-											r.status === "error" &&
-											(r.kind === "project" || r.kind === "workspace"),
-									)
-									.map((r) => r.reason)
-									.filter((r): r is string => !!r),
-							),
-						].slice(0, 5);
+						const reasons = (status: "error" | "skipped") =>
+							[
+								...new Set(
+									rows
+										.filter((r) => r.status === status && gating(r))
+										.map((r) => r.reason)
+										.filter((r): r is string => !!r),
+								),
+							].slice(0, 5);
+						failureReasons = reasons("error");
+						skipReasons = reasons("skipped");
 					} catch {}
 				}
 				posthog.capture("v1_auto_migration_completed", {
@@ -196,6 +205,7 @@ export function V1AutoMigration() {
 					first_completion: firstCompletion,
 					duration_ms: Date.now() - startedAt,
 					failure_reasons: failureReasons,
+					skip_reasons: skipReasons,
 				});
 			} catch (err) {
 				// Retries next boot; the ledger holds whatever progress landed.


### PR DESCRIPTION
## Why

The `v1-auto-migration` flag went to 100% on 12 Sep. What remains on v1 is mostly users the migrator can never move, per the [12 Sep status page](https://app.superset.sh/page/v1-v2-migration-where-we-stand-yxfx0w) and the [10 Sep issues tracker](https://app.superset.sh/page/v1-v2-migration-issues-9o9kbp):

| Class | People / week | Tracker |
|---|---|---|
| Repo folder gone, not a git repo, or no longer a directory | ~140 | MIGR-04, MIGR-07 |
| Ledger points at a v2 project the host no longer has | 3 | MIGR-07 |
| Switch still works after a mid-session completion | any completer | MIGR-01 (P0) |

## What changes

**Stale repos are skips, not failures.** `computeGateComplete` already says deliberate skips must not hold the flip hostage. A v1 project whose folder moved, was deleted, or stopped being a git checkout has nothing to migrate, so the three host errors for that (`Path does not exist`, `Not a git repository`, `Project directory is no longer a directory on disk`) and findByPath's `needsGitInit` now ledger as `skipped` with a reason. Skips stay non-terminal, so a restored folder still imports on a later pass. Their workspaces already fall into the unmapped-project skip path; a workspace whose project directory vanished after the import is skipped the same way.

**Stale ledger rows heal on the v1 surface.** A done row whose v2 project or workspace is gone from this host (host.db wiped or rebuilt) is redone instead of trusted, so adoption stops failing with "Project is not set up on this host" forever. Scoped to the v1 surface via `reconcileWithHost`: after the flip, a missing row is the user's own deletion and the follow-up pass keeps trusting the ledger.

**The flip lock is live, and the surface holds until relaunch.** `useIsV1FlipLocked` subscribes to the completion event through `useSyncExternalStore`, so the Experimental switch hides the moment the gate completes. `useIsV2CloudEnabled` pins the opt-in value at the first render after completion and reads that until relaunch: a later opt-in does not flip forward, a later opt-out does not snap back, and the boot marker takes over on the next launch. The second commit replaced a first cut that fell through to the account default, which the dev-app reproduction showed moving the surface mid-session.

**Telemetry.** `v1_auto_migration_completed` now carries `skip_reasons` beside `failure_reasons`, so the watch automation can keep sizing the cohort.

## Reproduced in the dev desktop app, before and after

Evidence page with screenshots and the exact pass summaries: see the PR comment below once published.

- Before: a v1 project at a missing path → pass `projects.failed=1`, `gateComplete=false`, ledger `error | Path does not exist`, no marker, user stays on v1 with the switch shown. With the gate allowed to complete on the old code, the switch stayed visible and a real click moved the surface to v2 mid-session, then back to v1.
- After: same fixture → `projects.skipped=1`, `failed=0`, `gateComplete=true`, ledger `skipped | repo-path-missing`, marker written, flip notice shown, switch gone from Experimental in the same session, an opt-in written after completion leaves the surface on v1, and the next boot lands on v2.

## Not in this PR

- Detached HEAD (8 people/week) still blocks the gate; the user can fix it and it is a real repo.
- `V1_FORCED_FLIP_VERSION` stays null. With this change the stuck cohort should drain without it.
- The API `minimumVersion` gate (PR #6704) is what reaches the 889 users below 1.19.

## Verification

- 9 new tests: stale path skipped and later restored, non-git folder skipped with no create call, vanished directory skips the workspace, v1-surface re-import after a host wipe, no re-import after the flip, mid-session completion locks the switch at once, and surface frozen against a later opt-in and a later opt-out. All failed against `main` before the fix.
- `bun test` in apps/desktop: 3765 pass, 0 fail. `tsc --noEmit` clean. Biome clean.

https://claude.ai/code/session_016NkfQLLDdHvrPS1BRJtfhj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved v1-to-v2 migration behavior so completed migrations remain stable during the current session and take effect consistently after relaunch.
  - Missing project folders and folders that are not Git repositories are now skipped instead of reported as migration failures.
  - Migration reconciliation can restore eligible projects and workspaces when host records are missing, while avoiding re-import of items removed after the v2 transition.
  - Re-imported projects now retain their worktree and branch preferences.
  - Migration completion reporting now distinguishes skipped items from actual failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->