### PR TITLE
fix(cli): format HTTP 401 responses as expired sessions

### DIFF
--- a/packages/cli-framework/src/runner.ts
+++ b/packages/cli-framework/src/runner.ts
@@ -82,9 +82,13 @@ export function formatError(
 		const trpcError = error as Error & {
 			code?: string;
 			data?: { code?: string; requiredPlan?: string | null };
+			meta?: { response?: { status?: number } };
+			cause?: { status?: number };
 		};
 		const code = trpcError.data?.code ?? trpcError.code;
-		if (code === "UNAUTHORIZED") {
+		const httpStatus =
+			trpcError.meta?.response?.status ?? trpcError.cause?.status;
+		if (code === "UNAUTHORIZED" || (!code && httpStatus === 401)) {
 			return {
 				message: "Session expired",
 				hint: `Run: ${cliName} auth login`,

--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -1,5 +1,13 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { ApiHttpError, fetchRejectingNonJsonErrors } from "./api-client";
+import type { AppRouter } from "@superset/trpc";
+import { TRPCClientError } from "@trpc/client";
+import { formatError } from "../../../cli-framework/src/runner";
+import {
+	ApiHttpError,
+	createApiClient,
+	fetchRejectingNonJsonErrors,
+} from "./api-client";
+import { env } from "./env";
 
 let respond: () => Response = () => new Response("");
 const server = Bun.serve({ port: 0, fetch: () => respond() });
@@ -49,5 +57,110 @@ describe("fetchRejectingNonJsonErrors", () => {
 		const response = await fetchRejectingNonJsonErrors(url);
 
 		expect(await response.text()).toBe("ok");
+	});
+});
+
+const originalApiUrl = env.SUPERSET_API_URL;
+afterAll(() => {
+	env.SUPERSET_API_URL = originalApiUrl;
+});
+
+async function queryError(): Promise<TRPCClientError<AppRouter>> {
+	env.SUPERSET_API_URL = `http://localhost:${server.port}`;
+	const api = createApiClient({ bearer: "fake-stale-token" });
+	const error: unknown = await api.user.me
+		.query()
+		.catch((error: unknown) => error);
+	expect(error).toBeInstanceOf(TRPCClientError);
+	return error as TRPCClientError<AppRouter>;
+}
+
+function nativeError(code: string, httpStatus: number, message: string) {
+	return Response.json(
+		[
+			{
+				error: {
+					json: {
+						code: code === "FORBIDDEN" ? -32003 : -32001,
+						message,
+						data: { code, httpStatus, path: "user.me" },
+					},
+				},
+			},
+		],
+		{ status: httpStatus },
+	);
+}
+
+describe("API HTTP errors through the CLI formatter", () => {
+	test.each([
+		[
+			"plain JSON",
+			() => Response.json({ error: "Unauthorized" }, { status: 401 }),
+		],
+		["non-JSON", () => new Response("Unauthorized", { status: 401 })],
+	] as const)("formats a %s 401 as an expired session", async (_, response) => {
+		respond = response;
+		expect(formatError(await queryError(), "superset")).toEqual({
+			message: "Session expired",
+			hint: "Run: superset auth login",
+		});
+	});
+
+	test("preserves native tRPC unauthorized errors", async () => {
+		respond = () => nativeError("UNAUTHORIZED", 401, "Token revoked");
+		const error = await queryError();
+		expect(error.message).toBe("Token revoked");
+		expect(error.data).toMatchObject({
+			code: "UNAUTHORIZED",
+			httpStatus: 401,
+			path: "user.me",
+		});
+		expect(formatError(error, "superset")).toEqual({
+			message: "Session expired",
+			hint: "Run: superset auth login",
+		});
+	});
+
+	test("preserves native tRPC non-auth errors", async () => {
+		respond = () => nativeError("FORBIDDEN", 403, "Not a member");
+		const error = await queryError();
+		expect(error.data?.code).toBe("FORBIDDEN");
+		expect(formatError(error, "superset")).toEqual({ message: "Not a member" });
+	});
+
+	test("prefers native tRPC codes over the HTTP status", async () => {
+		respond = () => nativeError("FORBIDDEN", 401, "Not a member");
+		expect(formatError(await queryError(), "superset")).toEqual({
+			message: "Not a member",
+		});
+	});
+
+	test("preserves non-401 JSON transformation errors", async () => {
+		respond = () => Response.json({ error: "Bad gateway" }, { status: 502 });
+		expect(formatError(await queryError(), "superset")).toEqual({
+			message: "Unable to transform response from server",
+		});
+	});
+
+	test("preserves non-401 HTTP status and body", async () => {
+		respond = () =>
+			new Response("Gateway unavailable", {
+				status: 502,
+				statusText: "Bad Gateway",
+			});
+		const error = await queryError();
+		expect(error.cause).toBeInstanceOf(ApiHttpError);
+		expect(formatError(error, "superset")).toEqual({
+			message: "HTTP 502 Bad Gateway: Gateway unavailable",
+		});
+	});
+
+	test("deserializes successful tRPC responses", async () => {
+		respond = () =>
+			Response.json([{ result: { data: { json: { id: "test-user" } } } }]);
+		env.SUPERSET_API_URL = `http://localhost:${server.port}`;
+		const api = createApiClient({ bearer: "fake-stale-token" });
+		expect((await api.user.me.query()).id).toBe("test-user");
 	});
 });


### PR DESCRIPTION
## What & why

After #7095, an unauthenticated request through the web origin returns HTTP 401 with `{"error":"Unauthorized"}`. With a stale but unexpired bearer token, `superset auth whoami` still reports `Unable to transform response from server` because that body is not a tRPC error envelope.

The CLI error formatter now falls back to the HTTP status carried by tRPC's response metadata or the existing `ApiHttpError` cause. A 401 without a native error code uses the existing output:

```text
Error: Session expired
Hint: Run: superset auth login
```

Native tRPC codes retain precedence. The API client, refresh policy, web proxy, and host service are unchanged; no user-facing copy or catalogs changed.

Follow-up to #7095 and related to #7072. This branch includes the #7095 squash commit `0bc709300bf2c4985aa6bf3134aacbdaf33cefda` (verified after fetching `origin main`). Prior proxy verification: https://app.superset.sh/page/pr-7095-verified-json-401-for-unauthenticated-api-n6dihr

## How I tested it

- Added real localhost HTTP tests through `createApiClient` → tRPC batching/SuperJSON → `formatError`, without mocked fetch or manufactured client errors. Before implementation, the JSON and text 401 regressions failed (8 pass, 2 fail).
- Coverage includes JSON 401, text 401, native tRPC unauthorized and forbidden errors, native-code precedence over HTTP status, non-401 JSON transformation errors, non-401 HTTP status/body preservation, and successful responses.
- `bun run --cwd packages/cli test`: **245 pass**.
- `bun test packages/cli-framework/src`: **25 pass**.
- CLI and CLI-framework package typechecks: **pass**.
- `bun run typecheck`: **39 tasks successful**.
- `bun run lint`: **pass**, 7,750 files checked. Biome write/check also passed on the changed files.
- `bun run check:plugins` and `git diff --check`: **pass**.
- Repository-wide `bun run test`: **blocked by missing environment variables in `@superset/trpc`**, including `OPENAI_API_KEY` and OAuth configuration. The CLI and framework suites pass independently.

### Actual compiled CLI, before and after

Built the native arm64 executable before and after with:

```sh
SUPERSET_API_URL=http://127.0.0.1:18795 bun run --cwd packages/cli build
```

Ran `packages/cli/dist/superset auth whoami --json` against a controlled Bun HTTP server bound to `127.0.0.1:18795`, using an isolated temporary `SUPERSET_HOME_DIR`. The config contained only fake access/refresh tokens, with access-token expiry one hour in the future. Child-process environment excluded real credentials and API-key overrides. The endpoint is baked into the compiled CLI at build time.

| HTTP response / scenario | Before | After |
| --- | --- | --- |
| 401 application/json `{"error":"Unauthorized"}` | `Error: Unable to transform response from server` | `Error: Session expired` + login hint; exit 1 |
| 401 text `Unauthorized` | `Error: HTTP 401 Unauthorized: Unauthorized` | `Error: Session expired` + login hint; exit 1 |
| Native tRPC 401 | Session expired + login hint; exit 1 | Same |
| 502 text `Gateway unavailable` | `Error: HTTP 502 Bad Gateway: Gateway unavailable`; exit 1 | Same |
| Successful user + organization responses | OAuth identity JSON; exit 0 | Same |
| Expired token + successful refresh | Token POST, then user/organization queries; exit 0 | Same |

The unexpired-token 401 runs reached `GET /api/trpc/user.me` without a token refresh request. A separate expired-token run reached `POST /api/auth/oauth2/token` before the user and organization queries.

This verifies the real compiled CLI against a controlled endpoint, **not a dev-web end-to-end flow**. Local setup completed dependency installation and local database migrations, but dev-account seeding failed because `babel-plugin-macros` was missing. No real credentials were used in the verification evidence.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — same-repository branch; not applicable


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI error formatter so a stale bearer token returning a non-tRPC HTTP 401 from the web origin is reported as `Session expired` with the login hint instead of `Unable to transform response from server`. Native tRPC error codes keep precedence, and non-401 responses retain their existing output.

- Falls back to the HTTP status from tRPC response metadata or `ApiHttpError` cause when no native tRPC error code is present.
- Adds real localhost HTTP tests through `createApiClient` covering JSON/text 401s, native tRPC codes, precedence, non-401 responses, and successful responses.
- Leaves the API client, refresh policy, web proxy, host service, and user-facing copy unchanged.

<sup>Written for commit fb5939bea3efce27433741ec5eb5f9904a5fbe4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI error messages for API failures, including clearer handling of expired sessions and unauthorized responses.
  - Preserved specific tRPC error details when available while correctly formatting other HTTP errors.

- **Tests**
  - Added coverage for authentication failures, non-authentication errors, HTTP status handling, and successful API response deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->