### PR TITLE
feat(desktop): "Relaunch now" on the v1→v2 flip notice

### DIFF
--- a/apps/desktop/src/lib/trpc/routers/settings/index.ts
+++ b/apps/desktop/src/lib/trpc/routers/settings/index.ts
@@ -44,7 +44,7 @@ import { TRPCError } from "@trpc/server";
 import { observable } from "@trpc/server/observable";
 import { app } from "electron";
 import { env } from "main/env.main";
-import { exitImmediately } from "main/index";
+import { exitImmediately, quitApp } from "main/index";
 import { hasCustomRingtone } from "main/lib/custom-ringtones";
 import { getHostServiceCoordinator } from "main/lib/host-service-coordinator";
 import { applyAppLanguage, languageEvents } from "main/lib/language";
@@ -898,6 +898,13 @@ export const createSettingsRouter = () => {
 		restartApp: publicProcedure.mutation(() => {
 			app.relaunch();
 			exitImmediately();
+			return { success: true };
+		}),
+
+		/** Relaunch through the normal quit path so cleanup and DB flushes run. */
+		relaunchApp: publicProcedure.mutation(() => {
+			app.relaunch();
+			quitApp();
 			return { success: true };
 		}),
 

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1FlipNotice/V1FlipNotice.test.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1FlipNotice/V1FlipNotice.test.tsx
@@ -1,0 +1,99 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// happy-dom for real clicks; unregister in afterAll so the shared mock
+// document used by the other renderer suites is restored (see Redirect.test).
+const alreadyRegistered = GlobalRegistrator.isRegistered;
+if (!alreadyRegistered) GlobalRegistrator.register();
+(
+	globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ORG = "org-flip-notice";
+const tracked: string[] = [];
+let relaunchCalls = 0;
+
+mock.module("renderer/lib/analytics", () => ({
+	track: (event: string) => {
+		tracked.push(event);
+	},
+}));
+mock.module("renderer/lib/trpc-client", () => ({
+	electronTrpcClient: {
+		settings: {
+			relaunchApp: {
+				mutate: async () => {
+					relaunchCalls++;
+					return { success: true };
+				},
+			},
+		},
+	},
+}));
+const realAuthClient = await import("renderer/lib/auth-client");
+mock.module("renderer/lib/auth-client", () => ({
+	...realAuthClient,
+	authClient: {
+		...realAuthClient.authClient,
+		useSession: () => ({
+			data: { session: { activeOrganizationId: ORG }, user: {} },
+		}),
+	},
+}));
+// The card's cover shader needs WebGL; the notice's behaviour does not.
+mock.module("@paper-design/shaders-react", () => ({
+	Dithering: () => null,
+}));
+
+// Queries come from render(): the module-level `screen` binds document.body
+// at first import, which an earlier suite may have done against the shared
+// mock document rather than happy-dom.
+const { act, cleanup, fireEvent, render } = await import(
+	"@testing-library/react"
+);
+const { markV1MigrationComplete } = await import(
+	"renderer/lib/v1-migration/completion"
+);
+const { V1FlipNotice } = await import("./V1FlipNotice");
+
+afterEach(() => {
+	cleanup();
+	tracked.length = 0;
+	relaunchCalls = 0;
+});
+afterAll(async () => {
+	if (!alreadyRegistered) await GlobalRegistrator.unregister();
+});
+
+describe("V1FlipNotice", () => {
+	test("renders nothing until the org's migration completes", () => {
+		const { queryByText } = render(<V1FlipNotice />);
+		expect(queryByText("A better Superset is ready")).toBeNull();
+	});
+
+	test("shows once complete; Relaunch now tracks and relaunches", async () => {
+		const { getByRole, getByText } = render(<V1FlipNotice />);
+		await act(async () => {
+			markV1MigrationComplete(ORG);
+		});
+		expect(getByText("A better Superset is ready")).toBeTruthy();
+		expect(tracked).toContain("v1_flip_notice_shown");
+
+		fireEvent.click(getByRole("button", { name: "Relaunch now" }));
+		await act(async () => {});
+		expect(relaunchCalls).toBe(1);
+		expect(tracked).toContain("v1_flip_notice_relaunch");
+		expect(tracked).not.toContain("v1_flip_notice_dismissed");
+	});
+
+	test("Later dismisses without relaunching", async () => {
+		const { getByRole, queryByText } = render(<V1FlipNotice />);
+		await act(async () => {
+			markV1MigrationComplete(ORG);
+		});
+		fireEvent.click(getByRole("button", { name: "Later" }));
+		expect(queryByText("A better Superset is ready")).toBeNull();
+		expect(tracked).toContain("v1_flip_notice_dismissed");
+		expect(relaunchCalls).toBe(0);
+	});
+});

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1FlipNotice/V1FlipNotice.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1FlipNotice/V1FlipNotice.tsx
@@ -3,6 +3,7 @@ import { useLingui as useTranslation } from "@lingui/react";
 import { useEffect, useRef, useState } from "react";
 import { track } from "renderer/lib/analytics";
 import { authClient } from "renderer/lib/auth-client";
+import { electronTrpcClient } from "renderer/lib/trpc-client";
 import {
 	isV1MigrationComplete,
 	V1_MIGRATION_COMPLETED_EVENT,
@@ -53,12 +54,23 @@ export function V1FlipNotice() {
 		setDismissed(true);
 	};
 
+	const relaunch = () => {
+		track("v1_flip_notice_relaunch");
+		electronTrpcClient.settings.relaunchApp.mutate().catch((err) => {
+			console.error("[v1-migration] relaunch failed", err);
+		});
+	};
+
 	return (
 		<FlipNoticeCard
 			title={translate(msg({ message: "A better Superset is ready" }))}
 			body="Superset has been upgraded: faster, cleaner, and built around your projects. Everything comes along on your next launch."
 			warning="Running terminal sessions won't carry over."
-			ctaLabel="Got it"
+			action={{
+				label: translate(msg({ message: "Relaunch now" })),
+				onClick: relaunch,
+			}}
+			ctaLabel={translate(msg({ message: "Later" }))}
 			onDismiss={dismiss}
 		/>
 	);

--- a/apps/desktop/src/renderer/routes/_authenticated/components/V1FlipNotice/components/FlipNoticeCard/FlipNoticeCard.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/components/V1FlipNotice/components/FlipNoticeCard/FlipNoticeCard.tsx
@@ -18,6 +18,8 @@ interface FlipNoticeCardProps {
 	body: string;
 	/** Rendered as an amber callout row (WorkspaceHoverCard idiom). */
 	warning?: string;
+	/** Primary button; when present the dismiss cta renders as secondary. */
+	action?: { label: string; onClick: () => void };
 	ctaLabel: string;
 	onDismiss: () => void;
 }
@@ -32,6 +34,7 @@ export function FlipNoticeCard({
 	title,
 	body,
 	warning,
+	action,
 	ctaLabel,
 	onDismiss,
 }: FlipNoticeCardProps) {
@@ -74,9 +77,20 @@ export function FlipNoticeCard({
 						<p className="text-sm">{warning}</p>
 					</div>
 				) : null}
-				<Button size="sm" onClick={onDismiss}>
-					{ctaLabel}
-				</Button>
+				<div className="flex gap-2">
+					{action ? (
+						<Button size="sm" onClick={action.onClick}>
+							{action.label}
+						</Button>
+					) : null}
+					<Button
+						size="sm"
+						variant={action ? "outline" : "default"}
+						onClick={onDismiss}
+					>
+						{ctaLabel}
+					</Button>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/i18n/locales/cs/messages.po
+++ b/packages/i18n/locales/cs/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Související články"
 msgid "Relative path copied"
 msgstr "Relativní cesta zkopírována"
 
+msgid "Relaunch now"
+msgstr "Restartovat nyní"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Běžící agenty přepnete jejich novým spuštěním."
 

--- a/packages/i18n/locales/de/messages.po
+++ b/packages/i18n/locales/de/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Verwandte Beiträge"
 msgid "Relative path copied"
 msgstr "Relativer Pfad kopiert"
 
+msgid "Relaunch now"
+msgstr "Jetzt neu starten"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Starte laufende Agenten neu, um sie umzustellen."
 

--- a/packages/i18n/locales/en/messages.po
+++ b/packages/i18n/locales/en/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Related Posts"
 msgid "Relative path copied"
 msgstr "Relative path copied"
 
+msgid "Relaunch now"
+msgstr "Relaunch now"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Relaunch running agents to switch them."
 

--- a/packages/i18n/locales/es/messages.po
+++ b/packages/i18n/locales/es/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Publicaciones relacionadas"
 msgid "Relative path copied"
 msgstr "Ruta relativa copiada"
 
+msgid "Relaunch now"
+msgstr "Reiniciar ahora"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Vuelve a lanzar los agentes en marcha para cambiarlos."
 

--- a/packages/i18n/locales/fr/messages.po
+++ b/packages/i18n/locales/fr/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Articles liés"
 msgid "Relative path copied"
 msgstr "Chemin relatif copié"
 
+msgid "Relaunch now"
+msgstr "Redémarrer maintenant"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Relancez les agents en cours pour les basculer."
 

--- a/packages/i18n/locales/id/messages.po
+++ b/packages/i18n/locales/id/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Tulisan Terkait"
 msgid "Relative path copied"
 msgstr "Path relatif disalin"
 
+msgid "Relaunch now"
+msgstr "Mulai ulang sekarang"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Jalankan ulang agen yang sedang berjalan untuk menggantinya."
 

--- a/packages/i18n/locales/it/messages.po
+++ b/packages/i18n/locales/it/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Post correlati"
 msgid "Relative path copied"
 msgstr "Percorso relativo copiato"
 
+msgid "Relaunch now"
+msgstr "Riavvia ora"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Riavvia gli agenti in esecuzione per cambiarli."
 

--- a/packages/i18n/locales/ja/messages.po
+++ b/packages/i18n/locales/ja/messages.po
@@ -11632,6 +11632,9 @@ msgstr "関連記事"
 msgid "Relative path copied"
 msgstr "相対パスをコピーしました"
 
+msgid "Relaunch now"
+msgstr "今すぐ再起動"
+
 msgid "Relaunch running agents to switch them."
 msgstr "実行中のエージェントを切り替えるには再起動してください。"
 

--- a/packages/i18n/locales/ko/messages.po
+++ b/packages/i18n/locales/ko/messages.po
@@ -11632,6 +11632,9 @@ msgstr "관련 게시물"
 msgid "Relative path copied"
 msgstr "상대 경로 복사됨"
 
+msgid "Relaunch now"
+msgstr "지금 다시 시작"
+
 msgid "Relaunch running agents to switch them."
 msgstr "실행 중인 에이전트는 다시 실행해야 바뀝니다."
 

--- a/packages/i18n/locales/nl/messages.po
+++ b/packages/i18n/locales/nl/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Gerelateerde berichten"
 msgid "Relative path copied"
 msgstr "Relatief pad gekopieerd"
 
+msgid "Relaunch now"
+msgstr "Nu opnieuw starten"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Herstart draaiende agents om ze te wisselen."
 

--- a/packages/i18n/locales/pl/messages.po
+++ b/packages/i18n/locales/pl/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Powiązane wpisy"
 msgid "Relative path copied"
 msgstr "Skopiowano ścieżkę względną"
 
+msgid "Relaunch now"
+msgstr "Uruchom ponownie teraz"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Uruchom ponownie działających agentów, aby ich przełączyć."
 

--- a/packages/i18n/locales/pt-BR/messages.po
+++ b/packages/i18n/locales/pt-BR/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Posts relacionados"
 msgid "Relative path copied"
 msgstr "Caminho relativo copiado"
 
+msgid "Relaunch now"
+msgstr "Reiniciar agora"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Reinicie os agentes em execução para trocar a conta deles."
 

--- a/packages/i18n/locales/ru/messages.po
+++ b/packages/i18n/locales/ru/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Похожие посты"
 msgid "Relative path copied"
 msgstr "Относительный путь скопирован"
 
+msgid "Relaunch now"
+msgstr "Перезапустить сейчас"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Перезапустите работающих агентов, чтобы переключить их."
 

--- a/packages/i18n/locales/tr/messages.po
+++ b/packages/i18n/locales/tr/messages.po
@@ -11632,6 +11632,9 @@ msgstr "İlgili yazılar"
 msgid "Relative path copied"
 msgstr "Göreli yol kopyalandı"
 
+msgid "Relaunch now"
+msgstr "Şimdi yeniden başlat"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Değiştirmek için çalışan ajanları yeniden başlatın."
 

--- a/packages/i18n/locales/vi/messages.po
+++ b/packages/i18n/locales/vi/messages.po
@@ -11632,6 +11632,9 @@ msgstr "Bài viết liên quan"
 msgid "Relative path copied"
 msgstr "Đã sao chép đường dẫn tương đối"
 
+msgid "Relaunch now"
+msgstr "Khởi động lại ngay"
+
 msgid "Relaunch running agents to switch them."
 msgstr "Hãy khởi chạy lại các agent đang chạy để đổi sang tài khoản này."
 

--- a/packages/i18n/locales/zh-CN/messages.po
+++ b/packages/i18n/locales/zh-CN/messages.po
@@ -11632,6 +11632,9 @@ msgstr "相关文章"
 msgid "Relative path copied"
 msgstr "已复制相对路径"
 
+msgid "Relaunch now"
+msgstr "立即重启"
+
 msgid "Relaunch running agents to switch them."
 msgstr "重新启动运行中的智能体才能切换。"
 

--- a/packages/i18n/locales/zh-TW/messages.po
+++ b/packages/i18n/locales/zh-TW/messages.po
@@ -11632,6 +11632,9 @@ msgstr "相關文章"
 msgid "Relative path copied"
 msgstr "已複製相對路徑"
 
+msgid "Relaunch now"
+msgstr "立即重啟"
+
 msgid "Relaunch running agents to switch them."
 msgstr "重新啟動執行中的代理程式才能切換。"
 


### PR DESCRIPTION
## Why

The auto-migration flips a machine to v2 on its **next launch**. As of 12 Sep, 227 people have completed the gate and are still on v1 because they have not relaunched; some run the app for days. The notice already tells them "Everything comes along on your next launch" and then gives them nothing to click. See the [status page](https://app.superset.sh/page/v1-v2-migration-where-we-stand-yxfx0w), decision 1.

## What changes

- `FlipNoticeCard` takes an optional primary `action`; when present the dismiss cta renders as the secondary button. The post-flip welcome card is unchanged.
- `V1FlipNotice` offers **Relaunch now** (primary) and **Later** (dismiss). Relaunch tracks `v1_flip_notice_relaunch`, then calls a new `settings.relaunchApp` procedure.
- `relaunchApp` is `app.relaunch()` + `quitApp()`, the normal quit path with cleanup, not the existing unused `restartApp`, which bypasses `before-quit` via `app.exit(0)`.
- "Relaunch now" added to the catalogs and translated in all 16 locales, matching each locale's existing "Restart" wording. "Later" already existed. `bun run check:i18n` passes.

## Verification

- New `V1FlipNotice.test.tsx` (happy-dom + testing-library, real clicks): hidden until completion; shows on completion and tracks `shown`; Relaunch calls the procedure once and tracks `relaunch`; Later dismisses without relaunching. Queries are render-bound because the module-level `screen` can be bound to the shared mock document by an earlier suite.
- `bun test` in apps/desktop: 3768 pass, 0 fail. `tsc --noEmit` clean. Biome clean.

Independent of #7480 (no overlapping files).

https://claude.ai/code/session_016NkfQLLDdHvrPS1BRJtfhj


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Relaunch now" action to the v1→v2 flip notice so users who completed the migration gate can relaunch immediately instead of waiting for their next app launch.

- Relaunching calls the new `relaunchApp` tRPC procedure (`app.relaunch()` + `quitApp()`), so cleanup and DB flushes run; the unused `restartApp` bypasses `before-quit` via `app.exit(0)`.
- The notice tracks `v1_flip_notice_relaunch`; the dismiss button is relabeled "Later" and keeps the existing `v1_flip_notice_dismissed` tracking.
- `FlipNoticeCard` accepts an optional primary `action`; when present the dismiss CTA renders as secondary. The post-flip welcome card is unchanged, and "Relaunch now" is translated in all 16 locales.
- Adds `V1FlipNotice.test.tsx` covering hidden-until-complete, tracking, relaunch, and dismiss behavior.

<sup>Written for commit 07ac09d2bc5df6ddbc420edb6ba57a6ee7320054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Relaunch now” option to the migration notice, allowing the app to restart immediately.
  - Added a “Later” option to dismiss the notice without restarting.
  - Relaunches now follow the standard shutdown process to preserve pending changes.

- **Localization**
  - Added translations for the relaunch action across supported languages.

- **Tests**
  - Added coverage for migration notice visibility, relaunch behavior, dismissal, and analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->