### PR TITLE
fix(setup): seed every API env key a worktree .env lacks

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,6 +5,10 @@
 # `./.superset/setup.local.sh` copies this to .env (and overrides ports/URLs
 # with a per-workspace allocation). Or just `cp .env.local.example .env`.
 #
+# Both setup scripts also append every key that has a value here but none in
+# the worktree's .env, so this file is the one list of keys the API requires
+# and the placeholder each gets. A key left empty here is never seeded.
+#
 # Third-party credentials here are FAKE placeholders so env validation passes
 # and the app boots with no real accounts. The services they point at are never
 # reached on the core local path, or fail gracefully if they are. Sign in with

--- a/.superset/lib/common.sh
+++ b/.superset/lib/common.sh
@@ -142,3 +142,72 @@ print_summary() {
   # Return non-zero if any steps failed
   [ ${#FAILED_STEPS[@]} -eq 0 ]
 }
+
+# Returns 0 when env_file has a line `key=<non-empty value>`; `key=`, `key=""`
+# and `key=''` count as unset because the schemas read an empty string as
+# undefined (emptyStringAsUndefined).
+env_file_has_value() {
+  local env_file="$1"
+  local key="$2"
+  awk -v key="$key" -v dq='""' -v sq="''" '
+    index($0, key "=") == 1 {
+      value = substr($0, length(key) + 2)
+      sub(/[[:space:]]+$/, "", value)
+      if (value != "" && value != dq && value != sq) { found = 1; exit }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$env_file"
+}
+
+# Appends to env_file every key that has a value in template but none in
+# env_file. .env.local.example is the template: a fake value for every key
+# packages/trpc/src/env.ts and apps/api/src/env.ts require, an empty value for
+# every key that must stay unset, so it is the one list of required keys and
+# their placeholder shapes.
+seed_missing_env_placeholders() {
+  local template="$1"
+  local env_file="$2"
+
+  if [ ! -f "$template" ]; then
+    error "Template not found: $template"
+    return 1
+  fi
+  if [ ! -f "$env_file" ]; then
+    error "Env file not found: $env_file"
+    return 1
+  fi
+
+  local key_line='^([A-Za-z_][A-Za-z0-9_]*)=(.*)$'
+  local line key value
+  local missing_lines=()
+  local missing_keys=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    [[ "$line" =~ $key_line ]] || continue
+    key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+    case "$value" in
+      ""|'""'|"''") continue ;;
+    esac
+    if env_file_has_value "$env_file" "$key"; then
+      continue
+    fi
+    missing_lines+=("$line")
+    missing_keys="${missing_keys:+$missing_keys }$key"
+  done < "$template"
+
+  if [ ${#missing_lines[@]} -eq 0 ]; then
+    success "Every key with a value in $template already has one in $env_file"
+    return 0
+  fi
+
+  {
+    echo ""
+    echo "# ===== Placeholders seeded by setup from $template ====="
+    echo "# Each key below was missing or empty. The values are fakes that satisfy"
+    echo "# the API env schemas; replace one with a real value when a feature needs it."
+    printf '%s\n' "${missing_lines[@]}"
+  } >> "$env_file"
+
+  success "Seeded ${#missing_lines[@]} placeholder(s) into $env_file: $missing_keys"
+  return 0
+}

--- a/.superset/lib/setup/main.sh
+++ b/.superset/lib/setup/main.sh
@@ -61,7 +61,17 @@ setup_main() {
     step_failed "Write .env file"
   fi
 
-  # Step 9: Setup local MCP in .mcp.json (opt-in)
+  # Step 9: Fill keys the root .env lacks with fakes from .env.local.example
+  if ! step_seed_env_placeholders; then
+    step_failed "Seed .env placeholders"
+  fi
+
+  # Step 10: Prove the API can load this .env
+  if ! step_validate_env; then
+    step_failed "Validate .env"
+  fi
+
+  # Step 11: Setup local MCP in .mcp.json (opt-in)
   if [ "$SETUP_LOCAL_MCP" = "1" ]; then
     if ! step_setup_local_mcp; then
       step_failed "Setup local MCP"

--- a/.superset/lib/setup/steps.sh
+++ b/.superset/lib/setup/steps.sh
@@ -607,3 +607,33 @@ step_seed_local_db() {
   success "Local DB seeded from $source_db"
   return 0
 }
+
+step_seed_env_placeholders() {
+  echo "🧩 Seeding placeholders for keys missing from .env..."
+  seed_missing_env_placeholders ".env.local.example" ".env"
+}
+
+# The API validates its env with zod at module load; a missing key turns every
+# /api/trpc response into Next's HTML 500 and the desktop renders blank. Catch
+# that here, where the zod issues name the keys, instead of at first boot.
+step_validate_env() {
+  echo "🔎 Validating .env against the API env schemas..."
+
+  if ! command -v bun &> /dev/null; then
+    error "bun not available"
+    return 1
+  fi
+  if [ ! -f .env ]; then
+    error ".env not found"
+    return 1
+  fi
+
+  if ! env -u SKIP_ENV_VALIDATION bun --env-file=.env -e \
+      'await import("./packages/trpc/src/env.ts"); await import("./apps/api/src/env.ts");'; then
+    error ".env is missing a key the API requires (issues above). Give it a fake value in .env.local.example and re-run setup, which seeds it."
+    return 1
+  fi
+
+  success ".env satisfies packages/trpc/src/env.ts and apps/api/src/env.ts"
+  return 0
+}

--- a/.superset/setup.local.sh
+++ b/.superset/setup.local.sh
@@ -40,7 +40,7 @@ local_ensure_env() {
     cp .env.local.example .env
     success "Created .env from .env.local.example"
   else
-    success ".env already exists — leaving as-is"
+    success ".env already exists — keeping its values; keys it lacks are seeded below"
   fi
   return 0
 }
@@ -304,6 +304,8 @@ local_setup_main() {
   step_install_dependencies || step_failed "Install dependencies"
   local_allocate_ports || step_failed "Allocate ports"
   local_write_env || step_failed "Write workspace .env"
+  step_seed_env_placeholders || step_failed "Seed .env placeholders"
+  step_validate_env || step_failed "Validate .env"
   local_db_up || step_failed "Start local DB stack"
   local_migrate || step_failed "Apply migrations"
   local_seed_dev_account || step_failed "Seed dev account"

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -39,14 +39,28 @@ pair `.optional()` with an `if (!env.X) throw`: that is required in disguise.
 - `.env.local.example` — fake working value (`fake-r2-access-key-id`,
   `superset-private-dev`). Local should boot with no real credentials.
 
+The fake value must satisfy the schema: a URL for `z.string().url()`, 32+
+characters for `.min(32)`. Setup copies it into any worktree `.env` that lacks
+the key (see 4), and then loads both schemas against the result, so a value
+that fails validation fails setup.
+
+Leave the value **empty** only for a key that should stay unset locally
+(`CLOUDFLARE_BROWSER_RENDERING_TOKEN`, the APNs keys). Setup never seeds an
+empty value.
+
 ## 4. The root `.env`
 
-`setup.local.sh` seeds `.env` from `.env.local.example` **only if `.env` does
-not exist**, and `setup.sh` copies the **root checkout's** `.env` into every new
-worktree. So the root `.env` (`~/code/superset/.env`) is the source of truth for
-local dev, and a template-only change reaches nobody already set up.
+`setup.local.sh` seeds `.env` from `.env.local.example` only if `.env` does not
+exist, and `setup.sh` copies the **root checkout's** `.env` into every new
+worktree. Either way, setup then appends every key that has a value in
+`.env.local.example` but none in the worktree's `.env`, right after it writes
+the port block, and re-running setup without `--force` fills the gaps in an
+existing worktree. Existing values are never overwritten; an empty `KEY=`
+counts as missing.
 
-Add the key there, and tell the team to do the same.
+So a worktree boots with the fake value until the root `.env`
+(`~/code/superset/.env`) carries a real one. Add the key there when the feature
+needs the real service locally, and tell the team to do the same.
 
 ## 5. Both deploy workflows
 
@@ -70,8 +84,8 @@ or the value arrives empty.
 
 - [ ] `gh secret set`
 - [ ] Schema, required unless it has a real fallback
-- [ ] `.env.example` empty, `.env.local.example` fake
-- [ ] Root `.env`, and the team told
+- [ ] `.env.example` empty, `.env.local.example` fake and schema-valid
+- [ ] Root `.env` when the feature needs the real value locally, and the team told
 - [ ] `deploy-production.yml`: `env:` block **and** `--env`
 - [ ] `deploy-preview.yml`: same two
 


### PR DESCRIPTION
## Problem

`packages/trpc/src/env.ts` and `apps/api/src/env.ts` validate the API env with zod at module load. `setup.sh` copies the root checkout's `.env` into a new worktree, and `setup.local.sh` leaves an existing `.env` untouched, so any required key added to the schema after that file was written is simply absent. The API then answers every `/api/trpc/*` request with Next's HTML 500 (`❌ Invalid environment variables` in the api dev log), `CollectionsProvider` never resolves, and the desktop renders an empty `<app>` after the first reload. This has bitten six sessions; today's miss was the four Vercel sandbox keys, earlier ones the R2 / `STATIC_URL` / `USERCONTENT_TOKEN_SECRET` group.

## Fix

Both setup scripts run two new steps right after they write the port block:

1. **Seed placeholders** (`seed_missing_env_placeholders` in `.superset/lib/common.sh`): appends every key that has a value in `.env.local.example` but none in the worktree `.env`. `.env.local.example` is already the one place `docs/environment-variables.md` requires a schema-valid fake for every key (URL-shaped where the schema wants a URL, 32+ chars for the usercontent secret) and an empty value for every key that must stay unset, so it is the single source of truth: the next new key added there is seeded everywhere with no script change. Existing values are never touched, an empty `KEY=` / `KEY=""` counts as missing, and a second run appends nothing, so re-running setup without `--force` repairs an existing worktree.
2. **Validate** (`step_validate_env`): imports both env modules with `bun --env-file=.env`, so a missing key fails setup with the zod issue list naming the keys instead of surfacing as a blank renderer on first boot.

Also updates `docs/environment-variables.md` (sections 3 and 4 plus the checklist) and the `.env.local.example` header to describe the seeding contract.

## Keys now seeded

Anything with a value in `.env.local.example` that the worktree `.env` lacks. Against the current root `.env` on this machine that is exactly:

`VERCEL_SANDBOX_TOKEN`, `VERCEL_SANDBOX_TEAM_ID`, `VERCEL_SANDBOX_PROJECT_ID`, `VERCEL_SANDBOX_REGION`, `SANDBOX_ACCESS_SIGNING_KEY`, `REALTIME_URL`, `REALTIME_NUDGE_SECRET`, `EXPO_PUBLIC_RELAY_URL`, `LEADERBOARD_INTERNAL_TOKEN`, `SUPERSET_MCP_API_KEY`

The earlier misses (`CLOUDFLARE_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_PRIVATE_BUCKET`, `R2_PUBLIC_BUCKET`, `R2_ENDPOINT`, `STATIC_URL`, `USERCONTENT_TOKEN_SECRET`) are covered by the same rule whenever a `.env` lacks them.

## Verification

- `bash -n` on `setup.sh`, `setup.local.sh`, `lib/common.sh`, `lib/setup/steps.sh`, `lib/setup/main.sh`: clean.
- Copied the root `.env` (which lacks the sandbox keys) into a scratch dir. Before seeding, `bun --env-file … -e 'import trpc env; import api env'` failed with the 5 zod issues (4 sandbox keys + `REALTIME_NUDGE_SECRET`). After `seed_missing_env_placeholders`, both schemas passed. A second run left the file byte-identical (shasum) and reported nothing to seed.
- Edge cases on a hand-written file: `KEY=`, `KEY=""`, `KEY=''` each got a placeholder; a key with a real value was not duplicated. Both Bun's `--env-file` and `dotenv-cli` (what `apps/api dev` uses) resolve the appended line as the effective value.
- Ran `step_seed_env_placeholders` and `step_validate_env` as the scripts call them (cwd with `.env`, `.env.local.example`, `packages/`, `apps/`, `node_modules/`): validate fails with the issue list before seeding, seeds 10 keys, validate passes, re-seed is a no-op.
- Started `apps/api` with `dotenv -e <seeded .env> -- next dev --port 39871` and curled `/api/trpc/organization.list?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%7D%7D`: `401 application/json` with the tRPC `UNAUTHORIZED` body, not `500 text/html`.
- There are no existing tests for the setup scripts. `setup.sh --force` was not run in this worktree.

https://claude.ai/code/session_01L1pkcXniaZNxL1EQSWzs4U


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, an API env key added after a worktree `.env` was written stayed missing, so `/api/trpc/*` requests returned Next's HTML 500 and the desktop rendered blank after reload. Both setup scripts now seed missing keys from `.env.local.example` and validate the `.env` before finishing.

**Bug Fixes**
- Appends placeholder values only for keys that are missing or empty in `.env`; existing values are never overwritten, and empty values (`KEY=`, `KEY=""`, `KEY=''`) count as missing, so re-running setup without `--force` repairs an existing worktree.
- Validates the seeded `.env` by loading `packages/trpc/src/env.ts` and `apps/api/src/env.ts` with `bun`, so a missing key fails setup with the zod issue list; setup now requires `bun`.
- `.env.local.example` is the single source of required keys; a schema-valid fake added there is seeded into every worktree with no script change.

**Docs**
- Updates `docs/environment-variables.md` and the `.env.local.example` header to describe the seeding contract.

<sup>Written for commit c7fd4f7634942ac766520c032568fc987871909c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local setup now fills missing environment variables with schema-valid placeholder values without overwriting existing values.
  - Setup validates the resulting environment and reports configuration errors before continuing.
  - Empty values remain unset and are not populated automatically.

- **Documentation**
  - Updated environment setup guidance to explain placeholder values, validation, reruns, and when real credentials are required.
  - Clarified environment template behavior and setup messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->