### PR TITLE
feat(host-service): place, status and activity for subagents in the roster

### DIFF
--- a/packages/agent-setup/src/agent-wrappers.test.ts
+++ b/packages/agent-setup/src/agent-wrappers.test.ts
@@ -26,7 +26,7 @@ let mockedHomeDir = path.join(TEST_ROOT, "home");
 
 mock.module("./notify-hook", () => ({
 	NOTIFY_SCRIPT_NAME: "notify.sh",
-	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v15",
+	NOTIFY_SCRIPT_MARKER: "# Superset agent notification hook v16",
 	getNotifyScriptPath: () => path.join(TEST_HOOKS_DIR, "notify.sh"),
 	getNotifyScriptContent: () => "#!/bin/bash\nexit 0\n",
 	createNotifyScript: () => {},

--- a/packages/agent-setup/src/notify-hook.test.ts
+++ b/packages/agent-setup/src/notify-hook.test.ts
@@ -104,7 +104,7 @@ function writeHookManifest(home: string, orgId: string, endpoint: string) {
 
 describe("getNotifyScriptContent", () => {
 	it("bumps the notify hook marker when hook semantics change", () => {
-		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v15");
+		expect(NOTIFY_SCRIPT_MARKER).toBe("# Superset agent notification hook v16");
 	});
 
 	it("forwards hooks fired inside a subagent (agent_id present) to the host roster only", async () => {
@@ -132,6 +132,8 @@ describe("getNotifyScriptContent", () => {
 							sessionId: "child-thread",
 							transcriptPath: "/tmp/sessions/child-thread.jsonl",
 							agentTranscriptPath: "",
+							toolName: "",
+							toolSummary: "",
 						},
 					},
 				},
@@ -170,6 +172,8 @@ describe("getNotifyScriptContent", () => {
 							sessionId: "child-thread",
 							transcriptPath: "/tmp/sessions/parent.jsonl",
 							agentTranscriptPath: "/tmp/sessions/child.jsonl",
+							toolName: "",
+							toolSummary: "",
 						},
 					},
 				},
@@ -212,6 +216,54 @@ describe("getNotifyScriptContent", () => {
 				sessionId: "parent",
 				transcriptPath: "/tmp/sessions/parent.jsonl",
 				agentTranscriptPath: "/tmp/sessions/parent/subagents/agent-a1.jsonl",
+				toolName: "",
+				toolSummary: "",
+			});
+		} finally {
+			host.stop();
+		}
+	});
+
+	it("forwards the tool a subagent is running and the gist of its input", async () => {
+		const host = fakeHostService(false);
+		try {
+			const result = await runNotifyHookAsync(
+				{
+					hook_event_name: "PreToolUse",
+					session_id: "parent",
+					transcript_path: "/tmp/sessions/parent.jsonl",
+					agent_id: "a1",
+					agent_type: "Explore",
+					tool_name: "Bash",
+					tool_input: {
+						command: "bun test packages/host-service",
+						description: "Run host-service tests",
+					},
+				},
+				{ SUPERSET_HOST_AGENT_HOOK_URL: `${host.url}/trpc/notifications.hook` },
+			);
+			expect(result.exitCode).toBe(0);
+			expect(host.requests[0]?.json.subagent).toMatchObject({
+				id: "a1",
+				toolName: "Bash",
+				toolSummary: "bun test packages/host-service",
+			});
+
+			const readResult = await runNotifyHookAsync(
+				{
+					hook_event_name: "PostToolUse",
+					session_id: "parent",
+					agent_id: "a1",
+					tool_name: "Read",
+					tool_input: { file_path: "/repo/src/index.ts" },
+					tool_response: { file_path: "/repo/src/other.ts" },
+				},
+				{ SUPERSET_HOST_AGENT_HOOK_URL: `${host.url}/trpc/notifications.hook` },
+			);
+			expect(readResult.exitCode).toBe(0);
+			expect(host.requests[1]?.json.subagent).toMatchObject({
+				toolName: "Read",
+				toolSummary: "/repo/src/index.ts",
 			});
 		} finally {
 			host.stop();

--- a/packages/agent-setup/src/notify-hook.ts
+++ b/packages/agent-setup/src/notify-hook.ts
@@ -5,7 +5,7 @@ import { getHooksDir } from "./paths";
 import { writeFileIfChanged } from "./write-file-if-changed";
 
 export const NOTIFY_SCRIPT_NAME = "notify.sh";
-export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v15";
+export const NOTIFY_SCRIPT_MARKER = "# Superset agent notification hook v16";
 
 export function getNotifyScriptPath(): string {
 	return path.join(getHooksDir(), NOTIFY_SCRIPT_NAME);

--- a/packages/agent-setup/templates/notify-hook.template.sh
+++ b/packages/agent-setup/templates/notify-hook.template.sh
@@ -61,6 +61,10 @@ json_field() {
 }
 SUBAGENT_ID=$(json_field agent_id agentId)
 SUBAGENT_TYPE=$(json_field agent_type agentType)
+# What a subagent is doing right now, for the tree view: the tool and the
+# first argument-like field of its input.
+TOOL_NAME=$(json_field tool_name toolName)
+TOOL_SUMMARY=$(json_field command file_path path pattern query url prompt description)
 # transcript_path is the file the hook ran against (Claude: the parent
 # session; Codex: the child's own rollout); agent_transcript_path is the
 # child's transcript on SubagentStop. The host derives the child's file from
@@ -194,7 +198,7 @@ dispatch_to_host() {
 if [ -n "$SUBAGENT_ID" ]; then
   debug_log "subagent event=$EVENT_TYPE terminalId=$SUPERSET_TERMINAL_ID agentId=$AGENT_ID subagentId=$SUBAGENT_ID subagentType=$SUBAGENT_TYPE"
   [ -n "$SUPERSET_TERMINAL_ID" ] || exit 0
-  dispatch_to_host "{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"subagent\":{\"id\":\"$(json_escape "$SUBAGENT_ID")\",\"type\":\"$(json_escape "$SUBAGENT_TYPE")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\",\"transcriptPath\":\"$(json_escape "$TRANSCRIPT_PATH")\",\"agentTranscriptPath\":\"$(json_escape "$AGENT_TRANSCRIPT_PATH")\"}}}"
+  dispatch_to_host "{\"json\":{\"terminalId\":\"$(json_escape "$SUPERSET_TERMINAL_ID")\",\"eventType\":\"$(json_escape "$EVENT_TYPE")\",\"subagent\":{\"id\":\"$(json_escape "$SUBAGENT_ID")\",\"type\":\"$(json_escape "$SUBAGENT_TYPE")\",\"sessionId\":\"$(json_escape "$HOOK_SESSION_ID")\",\"transcriptPath\":\"$(json_escape "$TRANSCRIPT_PATH")\",\"agentTranscriptPath\":\"$(json_escape "$AGENT_TRANSCRIPT_PATH")\",\"toolName\":\"$(json_escape "$TOOL_NAME")\",\"toolSummary\":\"$(json_escape "$TOOL_SUMMARY")\"}}}"
   exit 0
 fi
 

--- a/packages/host-service/src/terminal-agents/index.ts
+++ b/packages/host-service/src/terminal-agents/index.ts
@@ -7,6 +7,8 @@ export { TerminalAgentStore } from "./store";
 export type {
 	ParsedSubagentTranscript,
 	SubagentHarness,
+	SubagentParentContext,
+	SubagentParentResolution,
 	SubagentTranscriptHint,
 } from "./subagent-harnesses";
 export {
@@ -24,4 +26,7 @@ export type {
 	TerminalAgentBinding,
 	TerminalAgentId,
 	TerminalSubagent,
+	TerminalSubagentActivity,
+	TerminalSubagentEndReason,
+	TerminalSubagentStatus,
 } from "./types";

--- a/packages/host-service/src/terminal-agents/store.test.ts
+++ b/packages/host-service/src/terminal-agents/store.test.ts
@@ -45,10 +45,12 @@ describe("TerminalAgentStore", () => {
 				{
 					id: "a1",
 					agentType: "Explore",
+					status: "working",
 					startedAt: NOW + 200,
 					lastEventAt: NOW + 200,
 				},
 			]);
+			expect(binding?.endedSubagents).toBeUndefined();
 			expect(store.listByWorkspace(WORKSPACE)[0]?.subagents).toHaveLength(1);
 
 			store.recordSubagentEvent({
@@ -59,6 +61,148 @@ describe("TerminalAgentStore", () => {
 				occurredAt: NOW + 300,
 			});
 			expect(store.get("t1")?.subagents).toBeUndefined();
+			expect(store.get("t1")?.endedSubagents).toEqual([
+				{
+					id: "a1",
+					agentType: "Explore",
+					status: "completed",
+					startedAt: NOW + 200,
+					lastEventAt: NOW + 300,
+					endedAt: NOW + 300,
+					endReason: "completed",
+				},
+			]);
+		});
+
+		it("derives status from each event: waiting on a permission request, working again on the next tool", () => {
+			attach();
+			const record = (eventType: string, occurredAt: number) =>
+				store.recordSubagentEvent({
+					terminalId: "t1",
+					workspaceId: WORKSPACE,
+					eventType,
+					subagentId: "a1",
+					occurredAt,
+				});
+			record("SubagentStart", NOW + 200);
+			expect(store.get("t1")?.subagents?.[0]?.status).toBe("working");
+			record("PermissionRequest", NOW + 210);
+			expect(store.get("t1")?.subagents?.[0]?.status).toBe("waiting");
+			record("PostToolUse", NOW + 220);
+			expect(store.get("t1")?.subagents?.[0]?.status).toBe("working");
+			record("Notification", NOW + 230);
+			expect(store.get("t1")?.subagents?.[0]?.status).toBe("waiting");
+			record("SubagentStop", NOW + 240);
+			expect(store.get("t1")?.subagents).toBeUndefined();
+			expect(store.get("t1")?.endedSubagents?.[0]).toMatchObject({
+				status: "completed",
+				endReason: "completed",
+				endedAt: NOW + 240,
+			});
+		});
+
+		it("records the latest tool as activity and keeps it across non-tool events", () => {
+			attach();
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "PreToolUse",
+				subagentId: "a1",
+				toolName: "Bash",
+				toolSummary: `  ${"x".repeat(200)}  `,
+				occurredAt: NOW + 200,
+			});
+			expect(store.get("t1")?.subagents?.[0]?.activity).toEqual({
+				toolName: "Bash",
+				summary: `${"x".repeat(160)}…`,
+				at: NOW + 200,
+			});
+
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "PostToolUse",
+				subagentId: "a1",
+				toolName: "Read",
+				toolSummary: "/repo/file.ts",
+				occurredAt: NOW + 210,
+			});
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "PermissionRequest",
+				subagentId: "a1",
+				occurredAt: NOW + 220,
+			});
+			expect(store.get("t1")?.subagents?.[0]?.activity).toEqual({
+				toolName: "Read",
+				summary: "/repo/file.ts",
+				at: NOW + 210,
+			});
+
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "SubagentStop",
+				subagentId: "a1",
+				occurredAt: NOW + 230,
+			});
+			expect(store.get("t1")?.endedSubagents?.[0]?.activity).toEqual({
+				toolName: "Read",
+				summary: "/repo/file.ts",
+				at: NOW + 210,
+			});
+		});
+
+		it("applies the parent placement once and never overwrites it", () => {
+			attach();
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "SubagentStart",
+				subagentId: "a1",
+				sessionId: "child-thread",
+				occurredAt: NOW + 200,
+			});
+			expect(store.get("t1")?.subagents?.[0]).toMatchObject({
+				sessionId: "child-thread",
+			});
+			expect(store.get("t1")?.subagents?.[0]?.parentUnknown).toBeUndefined();
+
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "PostToolUse",
+				subagentId: "a1",
+				parent: { parentSubagentId: "a0", known: true },
+				occurredAt: NOW + 210,
+			});
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "PostToolUse",
+				subagentId: "a1",
+				parent: { known: false },
+				occurredAt: NOW + 220,
+			});
+			expect(store.get("t1")?.subagents?.[0]).toMatchObject({
+				parentSubagentId: "a0",
+				sessionId: "child-thread",
+			});
+			expect(store.get("t1")?.subagents?.[0]?.parentUnknown).toBeUndefined();
+
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "SubagentStart",
+				subagentId: "a2",
+				parent: { known: false },
+				occurredAt: NOW + 230,
+			});
+			expect(store.get("t1")?.subagents?.[1]).toMatchObject({
+				id: "a2",
+				parentUnknown: true,
+			});
 		});
 
 		it("re-adds a child from its tool events when the start was missed and keeps the earlier type", () => {
@@ -91,12 +235,14 @@ describe("TerminalAgentStore", () => {
 				{
 					id: "a1",
 					agentType: "general-purpose",
+					status: "working",
 					startedAt: NOW + 200,
 					lastEventAt: NOW + 250,
 				},
 				{
 					id: "a2",
 					agentType: "Plan",
+					status: "working",
 					startedAt: NOW + 260,
 					lastEventAt: NOW + 260,
 				},
@@ -148,16 +294,49 @@ describe("TerminalAgentStore", () => {
 			expect(store.get("t1")?.subagents).toBeUndefined();
 		});
 
-		it("expires a child that went quiet without a stop", () => {
+		it("marks a child that went quiet without a stop as stopped", () => {
 			attach();
 			store.recordSubagentEvent({
 				terminalId: "t1",
 				workspaceId: WORKSPACE,
 				eventType: "SubagentStart",
 				subagentId: "a1",
+				agentType: "Explore",
 				occurredAt: NOW - 11 * 60_000,
 			});
 			expect(store.get("t1")?.subagents).toBeUndefined();
+			expect(store.get("t1")?.endedSubagents).toEqual([
+				{
+					id: "a1",
+					agentType: "Explore",
+					status: "stopped",
+					startedAt: NOW - 11 * 60_000,
+					lastEventAt: NOW - 11 * 60_000,
+					endedAt: NOW - 60_000,
+					endReason: "stale",
+				},
+			]);
+			expect(store.getSubagent("t1", "a1")?.status).toBe("stopped");
+		});
+
+		it("drops an ended child once its retention lapses", () => {
+			attach();
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "SubagentStart",
+				subagentId: "a1",
+				occurredAt: NOW - 3 * 60 * 60_000,
+			});
+			store.recordSubagentEvent({
+				terminalId: "t1",
+				workspaceId: WORKSPACE,
+				eventType: "SubagentStop",
+				subagentId: "a1",
+				occurredAt: NOW - 2 * 60 * 60_000,
+			});
+			expect(store.get("t1")?.endedSubagents).toBeUndefined();
+			expect(store.getSubagent("t1", "a1")).toBeUndefined();
 		});
 
 		it("caps the roster per terminal, dropping the oldest child", () => {

--- a/packages/host-service/src/terminal-agents/store.ts
+++ b/packages/host-service/src/terminal-agents/store.ts
@@ -4,8 +4,11 @@ import {
 	getSubagentHarness,
 	isTrustedTranscriptPath,
 	readSubagentTranscript,
+	type SubagentHarness,
+	type SubagentParentResolution,
 	type SubagentTranscriptHint,
 } from "./subagent-harnesses";
+import { deriveSubagentStatus } from "./subagent-status";
 import type { SubagentTranscript } from "./subagent-transcript";
 import type {
 	TerminalAgentBinding,
@@ -31,7 +34,12 @@ interface RecordSubagentEventInput {
 	eventType: string;
 	subagentId: string;
 	agentType?: string;
+	sessionId?: string;
 	transcriptPath?: string;
+	toolName?: string;
+	toolSummary?: string;
+	/** Applied only while the entry has no parent placement yet. */
+	parent?: SubagentParentResolution;
 	occurredAt: number;
 }
 
@@ -42,6 +50,8 @@ interface RecordSubagentHookInput {
 	eventType: string;
 	subagentId: string;
 	agentType?: string;
+	toolName?: string;
+	toolSummary?: string;
 	hint: SubagentTranscriptHint;
 	occurredAt: number;
 }
@@ -69,10 +79,12 @@ const END_STRAGGLER_WINDOW_MS = 30_000;
 
 /**
  * A subagent whose SubagentStop never arrived (parent interrupted, hook
- * dropped) must not sit in the roster forever. Live children re-assert on
- * every tool call, so anything quiet this long is gone.
+ * dropped) must not stay live forever. Live children re-assert on every
+ * tool call, so anything quiet this long is marked stopped.
  */
 const SUBAGENT_STALE_MS = 10 * 60_000;
+
+const MAX_ACTIVITY_SUMMARY_CHARS = 160;
 
 /**
  * Finished children stay addressable (their transcript pane may still be
@@ -234,7 +246,7 @@ export class TerminalAgentStore extends EventEmitter {
 	/**
 	 * A hook fired inside a subagent of the terminal's agent. Any event keeps
 	 * the child live (lost SubagentStarts self-heal on its next tool call);
-	 * a stop drops it. Never touches the parent binding's lifecycle state.
+	 * a stop ends it. Never touches the parent binding's lifecycle state.
 	 */
 	recordSubagentEvent(input: RecordSubagentEventInput): void {
 		const {
@@ -243,22 +255,44 @@ export class TerminalAgentStore extends EventEmitter {
 			eventType,
 			subagentId,
 			agentType,
+			sessionId,
 			transcriptPath,
+			toolName,
+			toolSummary,
+			parent,
+			occurredAt,
 		} = input;
-		const occurredAt = input.occurredAt;
 		const roster = this.subagentsByTerminal.get(terminalId);
 		const existing = roster?.get(subagentId);
 
 		const harness = getSubagentHarness(
 			this.byTerminal.get(terminalId)?.agentId,
 		);
+		const status = deriveSubagentStatus(eventType, harness);
+		const nextPath = transcriptPath ?? existing?.transcriptPath;
+		const description =
+			existing?.description ??
+			(nextPath ? harness.readDescription(nextPath) : undefined);
+		const activity =
+			toolName !== undefined
+				? {
+						toolName,
+						summary: clipActivitySummary(toolSummary ?? ""),
+						at: occurredAt,
+					}
+				: existing?.activity;
+
 		if (harness.isStopEvent(eventType)) {
 			if (!existing || existing.endedAt !== undefined) return;
 			roster?.set(subagentId, {
 				...existing,
-				...(transcriptPath ? { transcriptPath } : {}),
+				...(description ? { description } : {}),
+				...(nextPath ? { transcriptPath: nextPath } : {}),
+				...(activity ? { activity } : {}),
+				status,
 				lastEventAt: occurredAt,
 				endedAt: occurredAt,
+				endReason: "completed",
 			});
 			this.emit("change", workspaceId);
 			return;
@@ -269,17 +303,22 @@ export class TerminalAgentStore extends EventEmitter {
 		if (!this.byTerminal.has(terminalId)) return;
 
 		const nextType = agentType ?? existing?.agentType;
-		const nextPath = transcriptPath ?? existing?.transcriptPath;
+		const nextSessionId = sessionId ?? existing?.sessionId;
 		const next: TerminalSubagent = {
 			id: subagentId,
 			...(nextType ? { agentType: nextType } : {}),
-			...(nextPath ? { transcriptPath: nextPath } : {}),
+			...(description ? { description } : {}),
+			...(nextSessionId ? { sessionId: nextSessionId } : {}),
+			...placementOf(existing, parent),
+			status,
+			...(activity ? { activity } : {}),
 			// A stopped child that speaks again (Codex send_input) is live again.
 			startedAt:
 				existing && existing.endedAt === undefined
 					? existing.startedAt
 					: occurredAt,
 			lastEventAt: occurredAt,
+			...(nextPath ? { transcriptPath: nextPath } : {}),
 		};
 		if (roster) {
 			roster.set(subagentId, next);
@@ -297,9 +336,10 @@ export class TerminalAgentStore extends EventEmitter {
 	/**
 	 * A hook event that fired inside a subagent, straight from the hook
 	 * endpoint. The parent binding's harness decides whether the event
-	 * belongs to the current session and where the child's transcript
-	 * lives; the path is kept only when it passes the trust check, since the
-	 * endpoint is unauthenticated. Returns false when the event was dropped.
+	 * belongs to the current session, where the child's transcript lives,
+	 * and which roster entry spawned it; the path is kept only when it
+	 * passes the trust check, since the endpoint is unauthenticated. Returns
+	 * false when the event was dropped.
 	 */
 	recordSubagentHook(input: RecordSubagentHookInput): boolean {
 		const parent = this.byTerminal.get(input.terminalId);
@@ -315,16 +355,56 @@ export class TerminalAgentStore extends EventEmitter {
 			resolvedPath && isTrustedTranscriptPath(resolvedPath)
 				? resolvedPath
 				: undefined;
+		const placement = this.resolveSubagentParent(
+			input.terminalId,
+			input.subagentId,
+			harness,
+			input.hint,
+			transcriptPath,
+			parent?.agentSessionId,
+		);
 		this.recordSubagentEvent({
 			terminalId: input.terminalId,
 			workspaceId: input.workspaceId,
 			eventType: input.eventType,
 			subagentId: input.subagentId,
 			...(input.agentType ? { agentType: input.agentType } : {}),
+			...(input.hint.sessionId ? { sessionId: input.hint.sessionId } : {}),
 			...(transcriptPath ? { transcriptPath } : {}),
+			...(input.toolName ? { toolName: input.toolName } : {}),
+			...(input.toolSummary ? { toolSummary: input.toolSummary } : {}),
+			...(placement ? { parent: placement } : {}),
 			occurredAt: input.occurredAt,
 		});
 		return true;
+	}
+
+	/**
+	 * Ask the harness where a child sits in the tree, until it has been
+	 * placed once. The harness gets the roster as siblings so a Codex
+	 * grandchild can be matched to the sibling whose thread spawned it.
+	 */
+	private resolveSubagentParent(
+		terminalId: string,
+		subagentId: string,
+		harness: SubagentHarness,
+		hint: SubagentTranscriptHint,
+		transcriptPath: string | undefined,
+		parentSessionId: string | undefined,
+	): SubagentParentResolution | undefined {
+		const roster = this.subagentsByTerminal.get(terminalId);
+		const existing = roster?.get(subagentId);
+		if (existing && isPlaced(existing)) return undefined;
+		const siblings = roster
+			? [...roster.values()].filter((sibling) => sibling.id !== subagentId)
+			: [];
+		return harness.resolveParent(hint, {
+			...(parentSessionId ? { parentSessionId } : {}),
+			siblings,
+			...((transcriptPath ?? existing?.transcriptPath)
+				? { transcriptPath: transcriptPath ?? existing?.transcriptPath }
+				: {}),
+		});
 	}
 
 	/**
@@ -438,22 +518,31 @@ export class TerminalAgentStore extends EventEmitter {
 	}
 
 	/**
-	 * Attach the terminal's live subagents to a binding read. Stale entries
-	 * are dropped here rather than on a timer so the store stays passive.
+	 * Attach the terminal's live and recently ended subagents to a binding
+	 * read. Stale entries are settled here rather than on a timer so the
+	 * store stays passive.
 	 */
 	private withSubagents(binding: TerminalAgentBinding): TerminalAgentBinding {
 		const roster = this.pruneSubagents(binding.terminalId);
 		if (!roster) return binding;
-		const live = [...roster.values()]
-			.filter((subagent) => subagent.endedAt === undefined)
-			.sort((a, b) => a.startedAt - b.startedAt);
-		return live.length > 0 ? { ...binding, subagents: live } : binding;
+		const live: TerminalSubagent[] = [];
+		const ended: TerminalSubagent[] = [];
+		for (const subagent of roster.values()) {
+			(subagent.endedAt === undefined ? live : ended).push(subagent);
+		}
+		live.sort((a, b) => a.startedAt - b.startedAt);
+		ended.sort((a, b) => (a.endedAt ?? 0) - (b.endedAt ?? 0));
+		return {
+			...binding,
+			...(live.length > 0 ? { subagents: live } : {}),
+			...(ended.length > 0 ? { endedSubagents: ended } : {}),
+		};
 	}
 
 	/**
-	 * Drop children that went quiet without a stop, and ended children past
-	 * their retention. Runs on read rather than on a timer so the store stays
-	 * passive.
+	 * Mark children that went quiet without a stop as stopped, and drop
+	 * ended children past their retention. Runs on read rather than on a
+	 * timer so the store stays passive.
 	 */
 	private pruneSubagents(
 		terminalId: string,
@@ -462,11 +551,18 @@ export class TerminalAgentStore extends EventEmitter {
 		if (!roster) return undefined;
 		const now = Date.now();
 		for (const [id, subagent] of roster) {
-			const expired =
-				subagent.endedAt === undefined
-					? subagent.lastEventAt < now - SUBAGENT_STALE_MS
-					: subagent.endedAt < now - SUBAGENT_ENDED_RETENTION_MS;
-			if (expired) roster.delete(id);
+			if (subagent.endedAt === undefined) {
+				if (subagent.lastEventAt < now - SUBAGENT_STALE_MS) {
+					roster.set(id, {
+						...subagent,
+						status: "stopped",
+						endedAt: subagent.lastEventAt + SUBAGENT_STALE_MS,
+						endReason: "stale",
+					});
+				}
+			} else if (subagent.endedAt < now - SUBAGENT_ENDED_RETENTION_MS) {
+				roster.delete(id);
+			}
 		}
 		if (roster.size === 0) {
 			this.subagentsByTerminal.delete(terminalId);
@@ -524,4 +620,40 @@ export class TerminalAgentStore extends EventEmitter {
 		const workspaceId = marked?.workspaceId ?? existing?.workspaceId;
 		if (workspaceId) this.emit("change", workspaceId);
 	}
+}
+
+function clipActivitySummary(summary: string): string {
+	const trimmed = summary.trim();
+	return trimmed.length > MAX_ACTIVITY_SUMMARY_CHARS
+		? `${trimmed.slice(0, MAX_ACTIVITY_SUMMARY_CHARS)}…`
+		: trimmed;
+}
+
+function isPlaced(subagent: TerminalSubagent): boolean {
+	return (
+		subagent.parentSubagentId !== undefined || subagent.parentUnknown === true
+	);
+}
+
+/**
+ * The tree placement to carry on the next roster entry: an existing
+ * placement wins, otherwise the resolution from this event, if any.
+ */
+function placementOf(
+	existing: TerminalSubagent | undefined,
+	resolution: SubagentParentResolution | undefined,
+): Pick<TerminalSubagent, "parentSubagentId" | "parentUnknown"> | undefined {
+	if (existing && isPlaced(existing)) {
+		return {
+			...(existing.parentSubagentId
+				? { parentSubagentId: existing.parentSubagentId }
+				: {}),
+			...(existing.parentUnknown ? { parentUnknown: true } : {}),
+		};
+	}
+	if (!resolution) return undefined;
+	if (!resolution.known) return { parentUnknown: true };
+	return resolution.parentSubagentId
+		? { parentSubagentId: resolution.parentSubagentId }
+		: {};
 }

--- a/packages/host-service/src/terminal-agents/subagent-harnesses.test.ts
+++ b/packages/host-service/src/terminal-agents/subagent-harnesses.test.ts
@@ -173,11 +173,228 @@ describe("belongsToParentSession", () => {
 });
 
 describe("defineSubagentHarness defaults", () => {
-	it("gives an unregistered harness the shared stop events and no description", () => {
+	it("gives an unregistered harness the shared stop events, no description, and no parent evidence", () => {
 		const harness = getSubagentHarness("future-agent");
 		expect(harness.isStopEvent("SubagentStop")).toBe(true);
 		expect(harness.isStopEvent("PostToolUse")).toBe(false);
 		expect(harness.readDescription("/x.jsonl")).toBeUndefined();
+		expect(
+			harness.resolveParent({ subagentId: "c1" }, { siblings: [] }),
+		).toEqual({ known: false });
+	});
+});
+
+describe("resolveParent", () => {
+	const claude = getSubagentHarness("claude");
+	const claudeChild = (id: string, meta: Record<string, unknown> | null) => {
+		const dir = path.join(
+			mkdtempSync(path.join(tmpdir(), "claude-")),
+			"s1",
+			"subagents",
+		);
+		mkdirSync(dir, { recursive: true });
+		const transcriptPath = path.join(dir, `agent-${id}.jsonl`);
+		if (meta) {
+			writeFileSync(
+				path.join(dir, `agent-${id}.meta.json`),
+				JSON.stringify(meta),
+			);
+		}
+		return transcriptPath;
+	};
+
+	it("places a Claude child from its sidecar's parentAgentId", () => {
+		const transcriptPath = claudeChild("a2", {
+			agentType: "Explore",
+			description: "Find the socket path",
+			parentAgentId: "a1",
+			spawnDepth: 2,
+		});
+		expect(
+			claude.resolveParent(
+				{ subagentId: "a2", sessionId: "s1", transcriptPath: "/p/s1.jsonl" },
+				{ parentSessionId: "s1", siblings: [], transcriptPath },
+			),
+		).toEqual({ parentSubagentId: "a1", known: true });
+	});
+
+	it("places a Claude child with no parentAgentId directly under the agent", () => {
+		const transcriptPath = claudeChild("a1", {
+			agentType: "Explore",
+			description: "Survey the sources",
+		});
+		expect(
+			claude.resolveParent(
+				{ subagentId: "a1", sessionId: "s1", transcriptPath: "/p/s1.jsonl" },
+				{ parentSessionId: "s1", siblings: [], transcriptPath },
+			),
+		).toEqual({ known: true });
+	});
+
+	it("treats a sidecar naming the child itself as a direct child", () => {
+		const transcriptPath = claudeChild("a1", { parentAgentId: "a1" });
+		expect(
+			claude.resolveParent(
+				{ subagentId: "a1" },
+				{ siblings: [], transcriptPath },
+			),
+		).toEqual({ known: true });
+	});
+
+	it("waits for a Claude sidecar that is not written yet", () => {
+		const transcriptPath = claudeChild("a1", null);
+		expect(
+			claude.resolveParent(
+				{ subagentId: "a1" },
+				{ siblings: [], transcriptPath },
+			),
+		).toBeUndefined();
+	});
+
+	it("derives the sidecar path from the hook when the roster has no path yet", () => {
+		const transcriptPath = claudeChild("a1", { parentAgentId: "a0" });
+		const sessionPath = path.join(
+			path.dirname(path.dirname(path.dirname(transcriptPath))),
+			"s1.jsonl",
+		);
+		expect(
+			claude.resolveParent(
+				{ subagentId: "a1", sessionId: "s1", transcriptPath: sessionPath },
+				{ parentSessionId: "s1", siblings: [] },
+			),
+		).toEqual({ parentSubagentId: "a0", known: true });
+	});
+
+	it("gives up on a Claude child with no transcript evidence at all", () => {
+		expect(
+			claude.resolveParent({ subagentId: "a1" }, { siblings: [] }),
+		).toEqual({ known: false });
+	});
+
+	const codex = getSubagentHarness("codex");
+	const sessionMeta = (
+		id: string,
+		parentThreadId: string,
+		extra: Record<string, unknown> = {},
+	) =>
+		JSON.stringify({
+			timestamp: "2026-03-30T03:28:54.047Z",
+			type: "session_meta",
+			payload: {
+				id,
+				session_id: id,
+				cwd: "/repo",
+				originator: "codex_cli_rs",
+				source: {
+					subagent: {
+						thread_spawn: {
+							parent_thread_id: parentThreadId,
+							depth: 1,
+							agent_path: null,
+							agent_nickname: "Bohr",
+							agent_role: "explorer",
+						},
+					},
+				},
+				agent_nickname: "Bohr",
+				agent_role: "explorer",
+				...extra,
+			},
+		});
+	const rollout = (name: string, content: string) => {
+		const file = path.join(
+			mkdtempSync(path.join(tmpdir(), "codex-rollout-")),
+			name,
+		);
+		writeFileSync(file, content);
+		return file;
+	};
+
+	it("asks again while a Codex child's rollout has not been written", () => {
+		expect(
+			codex.resolveParent(
+				{ subagentId: "c1" },
+				{ siblings: [], transcriptPath: "/nonexistent/rollout.jsonl" },
+			),
+		).toBeUndefined();
+		expect(
+			codex.resolveParent(
+				{ subagentId: "c1" },
+				{ siblings: [], transcriptPath: rollout("empty.jsonl", "") },
+			),
+		).toBeUndefined();
+	});
+
+	it("places a Codex child spawned by the terminal's thread directly under the agent", () => {
+		const file = rollout(
+			"child.jsonl",
+			`${sessionMeta("child-thread", "root-thread")}\n${JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [] } })}\n`,
+		);
+		expect(
+			codex.resolveParent(
+				{ subagentId: "c1", sessionId: "child-thread" },
+				{ parentSessionId: "root-thread", siblings: [], transcriptPath: file },
+			),
+		).toEqual({ known: true });
+	});
+
+	it("places a Codex grandchild under the sibling whose thread spawned it", () => {
+		const file = rollout(
+			"grandchild.jsonl",
+			`${sessionMeta("grandchild-thread", "child-thread")}\n`,
+		);
+		const siblings = [
+			{
+				id: "c1",
+				sessionId: "child-thread",
+				status: "working" as const,
+				startedAt: 1,
+				lastEventAt: 1,
+			},
+		];
+		expect(
+			codex.resolveParent(
+				{ subagentId: "c2", sessionId: "grandchild-thread" },
+				{ parentSessionId: "root-thread", siblings, transcriptPath: file },
+			),
+		).toEqual({ parentSubagentId: "c1", known: true });
+	});
+
+	it("gives up on a Codex child whose spawner is in neither the binding nor the roster", () => {
+		const file = rollout(
+			"orphan.jsonl",
+			`${sessionMeta("orphan-thread", "unknown-thread")}\n`,
+		);
+		expect(
+			codex.resolveParent(
+				{ subagentId: "c3" },
+				{ parentSessionId: "root-thread", siblings: [], transcriptPath: file },
+			),
+		).toEqual({ known: false });
+		expect(
+			codex.resolveParent(
+				{ subagentId: "c4" },
+				{
+					siblings: [],
+					transcriptPath: rollout(
+						"main.jsonl",
+						`${JSON.stringify({ type: "session_meta", payload: { id: "main", source: "cli" } })}\n`,
+					),
+				},
+			),
+		).toEqual({ known: false });
+	});
+
+	it("reads a Codex child's title from the rollout's first line", () => {
+		const file = rollout(
+			"titled.jsonl",
+			`${sessionMeta("child-thread", "root-thread", { agent_path: "explorer.md" })}\n${"x".repeat(100)}\n`,
+		);
+		expect(codex.readDescription(file)).toBe("Bohr · explorer.md");
+		expect(codex.readDescription("/nonexistent/rollout.jsonl")).toBeUndefined();
+		expect(
+			codex.readDescription(rollout("plain.jsonl", "not json\n")),
+		).toBeUndefined();
 	});
 });
 

--- a/packages/host-service/src/terminal-agents/subagent-harnesses/claude.ts
+++ b/packages/host-service/src/terminal-agents/subagent-harnesses/claude.ts
@@ -107,11 +107,30 @@ export function parseClaudeSubagentTranscript(
 }
 
 /**
+ * The `agent-<id>.meta.json` sidecar Claude writes beside a child's
+ * transcript at spawn: the Task description, and for a nested child the
+ * `parentAgentId` and `spawnDepth` of the agent that spawned it. Null when
+ * the file is not there yet or unreadable.
+ */
+function readClaudeMeta(
+	transcriptPath: string,
+): Record<string, unknown> | null {
+	const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+	try {
+		const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+		return isRecord(meta) ? meta : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Claude Code. Hooks inside a child run against the parent session file
- * (`<dir>/<sessionId>.jsonl`, same session id as the parent) while the child
- * writes `<dir>/<sessionId>/subagents/agent-<id>.jsonl` with an
- * `agent-<id>.meta.json` sidecar carrying the Task description. SubagentStop
- * names the child directly as `agent_transcript_path`.
+ * (`<dir>/<sessionId>.jsonl`, same session id as the parent, at every
+ * depth) while the child writes `<dir>/<sessionId>/subagents/agent-<id>.jsonl`
+ * with an `agent-<id>.meta.json` sidecar. SubagentStop names the child
+ * directly as `agent_transcript_path`. Only the sidecar knows who spawned a
+ * nested child.
  */
 export const claudeSubagentHarness = defineSubagentHarness({
 	belongsToParentSession: (hint, parentSessionId) =>
@@ -132,14 +151,19 @@ export const claudeSubagentHarness = defineSubagentHarness({
 	},
 	parseTranscript: (text) => ({ entries: parseClaudeSubagentTranscript(text) }),
 	readDescription(transcriptPath) {
-		const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
-		try {
-			const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
-			return isRecord(meta) && typeof meta.description === "string"
-				? meta.description
-				: undefined;
-		} catch {
-			return undefined;
-		}
+		const description = readClaudeMeta(transcriptPath)?.description;
+		return typeof description === "string" ? description : undefined;
+	},
+	resolveParent(hint, context) {
+		const transcriptPath =
+			context.transcriptPath ??
+			claudeSubagentHarness.resolveTranscriptPath(hint);
+		if (!transcriptPath) return { known: false };
+		const meta = readClaudeMeta(transcriptPath);
+		if (meta === null) return undefined;
+		const parent = meta.parentAgentId;
+		return typeof parent === "string" && parent && parent !== hint.subagentId
+			? { parentSubagentId: parent, known: true }
+			: { known: true };
 	},
 });

--- a/packages/host-service/src/terminal-agents/subagent-harnesses/codex.ts
+++ b/packages/host-service/src/terminal-agents/subagent-harnesses/codex.ts
@@ -3,6 +3,7 @@ import {
 	clip,
 	isRecord,
 	parseTimestamp,
+	readTranscriptHeadRecord,
 	type SubagentTranscriptEntry,
 	summarizeToolInput,
 } from "../subagent-transcript";
@@ -18,6 +19,43 @@ function codexContentText(content: unknown): string {
 		)
 		.filter(Boolean)
 		.join("\n");
+}
+
+/** The child's title from a rollout's `session_meta` payload. */
+function sessionMetaDescription(
+	payload: Record<string, unknown>,
+): string | undefined {
+	const nickname =
+		typeof payload.agent_nickname === "string" ? payload.agent_nickname : "";
+	const agentPath =
+		typeof payload.agent_path === "string" ? payload.agent_path : "";
+	return [nickname, agentPath].filter(Boolean).join(" · ") || undefined;
+}
+
+function sessionMetaPayload(
+	record: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	return record.type === "session_meta" && isRecord(record.payload)
+		? record.payload
+		: undefined;
+}
+
+/**
+ * The thread that spawned this one, from
+ * `session_meta.payload.source.subagent.thread_spawn.parent_thread_id`
+ * (codex_cli_rs 0.117).
+ */
+function sessionMetaParentThreadId(
+	payload: Record<string, unknown>,
+): string | undefined {
+	const source = isRecord(payload.source) ? payload.source : undefined;
+	const subagent = isRecord(source?.subagent) ? source.subagent : undefined;
+	const spawn = isRecord(subagent?.thread_spawn)
+		? subagent.thread_spawn
+		: undefined;
+	return typeof spawn?.parent_thread_id === "string"
+		? spawn.parent_thread_id
+		: undefined;
 }
 
 export function parseCodexRolloutTranscript(text: string): {
@@ -43,14 +81,7 @@ export function parseCodexRolloutTranscript(text: string): {
 		const id = typeof payload.id === "string" ? payload.id : `line-${line}`;
 
 		if (record.type === "session_meta") {
-			const nickname =
-				typeof payload.agent_nickname === "string"
-					? payload.agent_nickname
-					: "";
-			const agentPath =
-				typeof payload.agent_path === "string" ? payload.agent_path : "";
-			description =
-				[nickname, agentPath].filter(Boolean).join(" · ") || undefined;
+			description = sessionMetaDescription(payload);
 			continue;
 		}
 		if (record.type !== "response_item") continue;
@@ -136,4 +167,24 @@ export function parseCodexRolloutTranscript(text: string): {
  */
 export const codexSubagentHarness = defineSubagentHarness({
 	parseTranscript: parseCodexRolloutTranscript,
+	readDescription(transcriptPath) {
+		const record = readTranscriptHeadRecord(transcriptPath);
+		const payload = record ? sessionMetaPayload(record) : undefined;
+		return payload && sessionMetaDescription(payload);
+	},
+	resolveParent(_hint, context) {
+		if (!context.transcriptPath) return { known: false };
+		const record = readTranscriptHeadRecord(context.transcriptPath);
+		if (record === null) return undefined;
+		const payload = record && sessionMetaPayload(record);
+		const parentThreadId = payload && sessionMetaParentThreadId(payload);
+		if (!parentThreadId) return { known: false };
+		if (parentThreadId === context.parentSessionId) return { known: true };
+		const spawner = context.siblings.find(
+			(sibling) => sibling.sessionId === parentThreadId,
+		);
+		return spawner
+			? { parentSubagentId: spawner.id, known: true }
+			: { known: false };
+	},
 });

--- a/packages/host-service/src/terminal-agents/subagent-harnesses/index.ts
+++ b/packages/host-service/src/terminal-agents/subagent-harnesses/index.ts
@@ -13,6 +13,8 @@ import type { SubagentHarness } from "./types";
 export type {
 	ParsedSubagentTranscript,
 	SubagentHarness,
+	SubagentParentContext,
+	SubagentParentResolution,
 	SubagentTranscriptHint,
 } from "./types";
 export { defineSubagentHarness } from "./types";

--- a/packages/host-service/src/terminal-agents/subagent-harnesses/types.ts
+++ b/packages/host-service/src/terminal-agents/subagent-harnesses/types.ts
@@ -1,4 +1,5 @@
 import type { SubagentTranscriptEntry } from "../subagent-transcript";
+import type { TerminalSubagent } from "../types";
 
 /**
  * What a hook event inside a subagent tells us about where its transcript
@@ -11,6 +12,25 @@ export interface SubagentTranscriptHint {
 	sessionId?: string;
 	transcriptPath?: string;
 	agentTranscriptPath?: string;
+}
+
+/**
+ * Where a child sits in the tree. `parentSubagentId` absent with `known`
+ * means a direct child of the terminal's agent; `known: false` means the
+ * harness had evidence to look at but it named nothing in the roster.
+ */
+export interface SubagentParentResolution {
+	parentSubagentId?: string;
+	known: boolean;
+}
+
+export interface SubagentParentContext {
+	/** The terminal agent's own session id, when the binding knows it. */
+	parentSessionId?: string;
+	/** The rest of the terminal's roster, live and ended. */
+	siblings: readonly TerminalSubagent[];
+	/** The child's transcript as the roster recorded it. */
+	transcriptPath?: string;
 }
 
 export interface ParsedSubagentTranscript {
@@ -45,6 +65,14 @@ export interface SubagentHarness {
 	parseTranscript(text: string): ParsedSubagentTranscript;
 	/** A title kept beside the transcript rather than inside it, if any. */
 	readDescription(transcriptPath: string): string | undefined;
+	/**
+	 * Which roster entry spawned this child. `undefined` means the evidence
+	 * is not on disk yet and the next event should ask again.
+	 */
+	resolveParent(
+		hint: SubagentTranscriptHint,
+		context: SubagentParentContext,
+	): SubagentParentResolution | undefined;
 }
 
 /** Hook event names that end a child's turn in the Claude schema and its forks. */
@@ -56,6 +84,7 @@ const defaults: Omit<SubagentHarness, "parseTranscript"> = {
 	resolveTranscriptPath: (hint) =>
 		hint.agentTranscriptPath || hint.transcriptPath || undefined,
 	readDescription: () => undefined,
+	resolveParent: () => ({ known: false }),
 };
 
 /**

--- a/packages/host-service/src/terminal-agents/subagent-status.test.ts
+++ b/packages/host-service/src/terminal-agents/subagent-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { getSubagentHarness } from "./subagent-harnesses";
+import { deriveSubagentStatus } from "./subagent-status";
+
+describe("deriveSubagentStatus", () => {
+	const harness = getSubagentHarness("claude");
+
+	it("maps a start or tool event to working", () => {
+		expect(deriveSubagentStatus("SubagentStart", harness)).toBe("working");
+		expect(deriveSubagentStatus("PreToolUse", harness)).toBe("working");
+		expect(deriveSubagentStatus("PostToolUse", harness)).toBe("working");
+		expect(deriveSubagentStatus("UserPromptSubmit", harness)).toBe("working");
+	});
+
+	it("maps a permission request or notification to waiting", () => {
+		expect(deriveSubagentStatus("PermissionRequest", harness)).toBe("waiting");
+		expect(deriveSubagentStatus("Notification", harness)).toBe("waiting");
+	});
+
+	it("maps the harness's stop events to completed", () => {
+		expect(deriveSubagentStatus("SubagentStop", harness)).toBe("completed");
+		expect(deriveSubagentStatus("Stop", harness)).toBe("completed");
+		expect(
+			deriveSubagentStatus("SubagentStop", {
+				isStopEvent: (eventType) => eventType === "Finished",
+			}),
+		).toBe("working");
+		expect(
+			deriveSubagentStatus("Finished", {
+				isStopEvent: (eventType) => eventType === "Finished",
+			}),
+		).toBe("completed");
+	});
+});

--- a/packages/host-service/src/terminal-agents/subagent-status.ts
+++ b/packages/host-service/src/terminal-agents/subagent-status.ts
@@ -1,0 +1,19 @@
+import type { SubagentHarness } from "./subagent-harnesses";
+import type { TerminalSubagentStatus } from "./types";
+
+/** Events where the child is blocked on the user rather than working. */
+const WAITING_EVENTS = new Set(["PermissionRequest", "Notification"]);
+
+/**
+ * The child's status after one hook event. Every event is a full statement
+ * of where the child is, so the previous status never carries over: a tool
+ * event after a permission request means the request was answered.
+ */
+export function deriveSubagentStatus(
+	eventType: string,
+	harness: Pick<SubagentHarness, "isStopEvent">,
+): TerminalSubagentStatus {
+	if (harness.isStopEvent(eventType)) return "completed";
+	if (WAITING_EVENTS.has(eventType)) return "waiting";
+	return "working";
+}

--- a/packages/host-service/src/terminal-agents/subagent-transcript.ts
+++ b/packages/host-service/src/terminal-agents/subagent-transcript.ts
@@ -24,6 +24,8 @@ export interface SubagentTranscript {
 
 /** Tail this much of a large transcript; the pane wants the recent story. */
 const MAX_READ_BYTES = 2 * 1024 * 1024;
+/** A Codex `session_meta` line carries the base instructions (~25 KB). */
+const MAX_HEAD_BYTES = 256 * 1024;
 const MAX_ENTRY_CHARS = 4000;
 
 export function clip(text: string): string {
@@ -118,4 +120,38 @@ export function readTranscriptTail(
 	}
 	if (start > 0) text = text.slice(text.indexOf("\n") + 1);
 	return { text, size: stat.size, mtimeMs: stat.mtimeMs };
+}
+
+/**
+ * The first line of a transcript, parsed as JSON. Null when the file does
+ * not exist or has nothing to read yet; undefined when the line is not JSON.
+ */
+export function readTranscriptHeadRecord(
+	transcriptPath: string,
+): Record<string, unknown> | null | undefined {
+	let fd: number;
+	try {
+		fd = fs.openSync(transcriptPath, "r");
+	} catch {
+		return null;
+	}
+	let text: string;
+	try {
+		const buffer = Buffer.alloc(MAX_HEAD_BYTES);
+		const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+		text = buffer.toString("utf8", 0, bytesRead);
+	} catch {
+		return null;
+	} finally {
+		fs.closeSync(fd);
+	}
+	const newline = text.indexOf("\n");
+	const line = (newline === -1 ? text : text.slice(0, newline)).trim();
+	if (!line) return null;
+	try {
+		const record: unknown = JSON.parse(line);
+		return isRecord(record) ? record : undefined;
+	} catch {
+		return undefined;
+	}
 }

--- a/packages/host-service/src/terminal-agents/types.ts
+++ b/packages/host-service/src/terminal-agents/types.ts
@@ -35,16 +35,43 @@ export type TerminalAgentEndReason =
  * only: it lives and dies with the parent's session, so it is never a resume
  * concern and needs no row.
  */
+export type TerminalSubagentStatus =
+	| "working"
+	| "waiting"
+	| "completed"
+	| "failed"
+	| "stopped";
+
+/** "stale" means the child went quiet without a stop and the roster gave up on it. */
+export type TerminalSubagentEndReason = "completed" | "stale";
+
+export interface TerminalSubagentActivity {
+	toolName: string;
+	summary: string;
+	at: number;
+}
+
 export interface TerminalSubagent {
 	id: string;
 	/** Harness agent type (`Explore`, `general-purpose`, a Codex role), if reported. */
 	agentType?: string;
+	/** Harness title: Claude Task description (agent-<id>.meta.json), Codex nickname/agent path (session_meta). */
+	description?: string;
+	/** The child's own hook session id (a Codex child's thread id). */
+	sessionId?: string;
+	/** Absent with parentUnknown unset = direct child of the terminal's agent. */
+	parentSubagentId?: string;
+	/** No harness evidence could place this child; the renderer roots it at level 1 with a dashed rail. */
+	parentUnknown?: boolean;
+	status: TerminalSubagentStatus;
+	activity?: TerminalSubagentActivity;
 	startedAt: number;
 	lastEventAt: number;
 	/** The child's own transcript on disk, once a hook event revealed it. */
 	transcriptPath?: string;
-	/** Set once the child reported its stop; such entries leave `subagents`. */
+	/** Set once the child ended; such entries move from `subagents` to `endedSubagents`. */
 	endedAt?: number;
+	endReason?: TerminalSubagentEndReason;
 }
 
 export interface TerminalAgentBinding {
@@ -60,4 +87,6 @@ export interface TerminalAgentBinding {
 	endReason?: TerminalAgentEndReason;
 	/** Live subagents under this agent, oldest first. Absent when none. */
 	subagents?: TerminalSubagent[];
+	/** Children with `endedAt` set, oldest-ended first. Absent when none. */
+	endedSubagents?: TerminalSubagent[];
 }

--- a/packages/host-service/src/trpc/router/notifications/notifications.test.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.test.ts
@@ -1,7 +1,8 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import path, { resolve } from "node:path";
 import type { AgentIdentity } from "@superset/shared/agent-identity";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -249,6 +250,102 @@ describe("notificationsRouter.hook", () => {
 		expect(
 			terminalAgentStore.get("terminal-codex")?.subagents?.[0]?.transcriptPath,
 		).toBe(`${homedir()}/sessions/parent.jsonl`);
+	});
+
+	it("places children with the parent binding's harness and records tool activity", async () => {
+		const { ctx, terminalAgentStore } = createContext("workspace-1");
+		const caller = notificationsRouter.createCaller(ctx);
+		await caller.hook({
+			terminalId: "terminal-claude",
+			eventType: "Start",
+			agent: { agentId: "claude", sessionId: "parent" },
+		});
+		// Claude places a child by the meta sidecar beside its transcript,
+		// which must live under the home directory to pass the trust check.
+		const sessionsDir = mkdtempSync(path.join(homedir(), ".superset-test-"));
+		const subagentsDir = path.join(sessionsDir, "parent", "subagents");
+		mkdirSync(subagentsDir, { recursive: true });
+		writeFileSync(
+			path.join(subagentsDir, "agent-child.meta.json"),
+			JSON.stringify({ agentType: "general-purpose", description: "Child" }),
+		);
+		writeFileSync(
+			path.join(subagentsDir, "agent-grandchild.meta.json"),
+			JSON.stringify({ parentAgentId: "child", spawnDepth: 2 }),
+		);
+		try {
+			await caller.hook({
+				terminalId: "terminal-claude",
+				eventType: "PreToolUse",
+				subagent: {
+					id: "child",
+					sessionId: "parent",
+					transcriptPath: path.join(sessionsDir, "parent.jsonl"),
+					toolName: " Bash ",
+					toolSummary: " bun test ",
+				},
+			});
+			await caller.hook({
+				terminalId: "terminal-claude",
+				eventType: "PreToolUse",
+				subagent: {
+					id: "grandchild",
+					sessionId: "parent",
+					transcriptPath: path.join(sessionsDir, "parent.jsonl"),
+					toolName: "Read",
+					toolSummary: "",
+				},
+			});
+		} finally {
+			rmSync(sessionsDir, { recursive: true, force: true });
+		}
+		await caller.hook({
+			terminalId: "terminal-claude",
+			eventType: "PreToolUse",
+			subagent: { id: "orphan" },
+		});
+
+		const claudeChildren = terminalAgentStore.get("terminal-claude")?.subagents;
+		expect(claudeChildren?.[0]).toMatchObject({
+			id: "child",
+			sessionId: "parent",
+			status: "working",
+			description: "Child",
+			activity: { toolName: "Bash", summary: "bun test" },
+		});
+		expect(claudeChildren?.[0]?.parentSubagentId).toBeUndefined();
+		expect(claudeChildren?.[0]?.parentUnknown).toBeUndefined();
+		expect(claudeChildren?.[1]).toMatchObject({
+			id: "grandchild",
+			parentSubagentId: "child",
+			activity: { toolName: "Read", summary: "" },
+		});
+		expect(claudeChildren?.[2]).toMatchObject({
+			id: "orphan",
+			parentUnknown: true,
+		});
+		expect(claudeChildren?.[2]?.activity).toBeUndefined();
+
+		// A Codex child's placement lives in its rollout; until that file
+		// exists the child stays unplaced rather than being rooted as unknown.
+		await caller.hook({
+			terminalId: "terminal-codex",
+			eventType: "Start",
+			agent: { agentId: "codex", sessionId: "root-thread" },
+		});
+		await caller.hook({
+			terminalId: "terminal-codex",
+			eventType: "SubagentStart",
+			subagent: {
+				id: "c1",
+				sessionId: "child-thread",
+				transcriptPath: `${homedir()}/sessions/nonexistent-rollout.jsonl`,
+			},
+		});
+		const codexChild = terminalAgentStore.get("terminal-codex")?.subagents?.[0];
+		expect(codexChild?.sessionId).toBe("child-thread");
+		expect(codexChild?.parentSubagentId).toBeUndefined();
+		expect(codexChild?.parentUnknown).toBeUndefined();
 	});
 
 	it("drops a Claude child event that names the parent's previous session", async () => {

--- a/packages/host-service/src/trpc/router/notifications/notifications.ts
+++ b/packages/host-service/src/trpc/router/notifications/notifications.ts
@@ -27,6 +27,8 @@ const subagentInput = z
 		sessionId: z.string().optional(),
 		transcriptPath: z.string().optional(),
 		agentTranscriptPath: z.string().optional(),
+		toolName: z.string().optional(),
+		toolSummary: z.string().optional(),
 	})
 	.optional();
 
@@ -126,12 +128,16 @@ export const notificationsRouter = router({
 		// out as an invalidation so the sidebar refetches bindings.
 		if (subagentId) {
 			const agentType = trimOrUndefined(input.subagent?.type);
+			const toolName = trimOrUndefined(input.subagent?.toolName);
+			const toolSummary = trimOrUndefined(input.subagent?.toolSummary);
 			const recorded = ctx.terminalAgentStore.recordSubagentHook({
 				terminalId: input.terminalId,
 				workspaceId: terminalSession.originWorkspaceId,
 				eventType: input.eventType ?? "",
 				subagentId,
 				...(agentType ? { agentType } : {}),
+				...(toolName ? { toolName } : {}),
+				...(toolSummary ? { toolSummary } : {}),
 				hint: {
 					subagentId,
 					sessionId: trimOrUndefined(input.subagent?.sessionId),


### PR DESCRIPTION
**Links**
- Issue: https://github.com/superset-sh/superset/issues/7481
- Design + live verification: https://app.superset.sh/page/tree-mode-for-the-subagents-pill-d04ka4
- Stacked on top: desktop tree UI PR (workspace-agent-tree)

## Summary
- Each roster entry (`TerminalSubagent`) now carries `parentSubagentId` / `parentUnknown`, a `status` (`working` | `waiting` | `completed` | `failed` | `stopped`), the last tool call as `activity`, the harness `description`, and the child's own `sessionId`. Bindings expose `endedSubagents` beside the live `subagents`.
- Placement comes from harness evidence: Claude's `agent-<id>.meta.json` sidecar (`parentAgentId`, `spawnDepth`), Codex's rollout `session_meta.payload.source.subagent.thread_spawn.parent_thread_id`.
- The notify hook forwards `tool_name` and a one-field input summary for subagent events (marker v16). Terminal-level status, chimes and session capture are untouched.

## Why / Context
#7481 asks for nested subagents as a visible, stateful tree. The roster was flat and only knew id, type and timestamps, so a tree could not be drawn and every child read "Running". This PR is the data half; the desktop tree that renders it is stacked on top so the two can be reviewed separately.

## How It Works
- `deriveSubagentStatus(eventType, harness)`: a stop event → `completed`; `PermissionRequest` / `Notification` → `waiting`; anything else → `working`. `failed` is in the union but no harness reports it yet.
- `recordSubagentHook` asks the harness `resolveParent(hint, { parentSessionId, siblings, transcriptPath })` until the entry is placed once. `undefined` means "evidence not written yet, try on the next event" (a Codex rollout or Claude sidecar that has not been flushed); `{ known: false }` marks `parentUnknown`.
- Claude: hooks inside a grandchild run against the top-level session file at every depth, so the sidecar beside the child's transcript is the only source. Verified live on Claude Code 2.1.270: `{"parentAgentId":"a3c70d…","spawnDepth":2}`.
- Codex: read the first line of the child's rollout; `parent_thread_id` equal to the terminal's session → direct child, equal to a sibling's `sessionId` → nested. Shape confirmed against real child rollouts under `~/.codex/sessions` (0.117).
- A live child quiet past the 10-minute stale window becomes `stopped` / `endReason: "stale"` and stays addressable for the retention hour instead of vanishing.
- Activity is clipped to 160 chars; a non-tool event keeps the previous activity. Descriptions are read from the sidecar / session_meta on each event until found.

## Manual QA Checklist
- [x] Claude Code fan-out in the dev app: four children, one of which spawned two of its own. Roster read over tRPC showed the grandchildren with `parentSubagentId` of the coordinator, `activity.toolName` = `Read`, and finished children in `endedSubagents`.
- [x] A parent that finished while its children ran (Claude backgrounds Agent-tool children) reported `completed` and came back to `working` on its next event.
- [ ] Codex `spawn_agent` end to end (unit-tested against real rollout shapes only).
- [ ] `PermissionRequest` inside a child → `waiting` (the live session ran with permissions bypassed; unit-tested).

## Testing
- `bun test` in `packages/host-service`: 1,777 pass (new: `subagent-status.test.ts`, store status/activity/stale/placement cases, Claude sidecar and Codex rollout `resolveParent` cases, notifications router placement + activity)
- `bun test` in `packages/agent-setup`: 329 pass (v16 hook fixtures, `tool_input` vs `tool_response` ordering)
- `bunx tsc --noEmit -p packages/host-service/tsconfig.json`
- `bunx biome check` on the touched directories

## Known Limitations
- The roster is still in memory; a host-service restart loses the tree (transcript panes keep reading their files). Persisting it to host.db is a follow-up.
- `failed` is never emitted.
- `json_field` in the hook takes the first `command`/`file_path`/… match in the whole payload; on `PostToolUse` that is `tool_input` only because it precedes `tool_response` in Claude's JSON. A test pins that ordering.

## Rollout
- The hook script is rewritten on next app launch (marker v15 → v16). Older hooks simply omit `toolName`/`toolSummary`; the roster then has no activity line and everything else works.

https://claude.ai/code/session_01GojHrw82odVV1wVhJQdgaM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Roster entries now track each subagent's parent, status, and last tool call so children render as a live tree; previously the roster was flat and every child showed as running. Closes #7481.

**Roster**
- Entries gain `parentSubagentId`/`parentUnknown`, `description`, `sessionId`, a `status` (`working` / `waiting` / `completed` / `failed` / `stopped`), and the latest tool as `activity`.
- Status resets on every event: any stop → `completed`, `PermissionRequest`/`Notification` → `waiting`, otherwise `working`; `failed` is in the union but no harness emits it.
- Finished children move to `endedSubagents` instead of vanishing; a child quiet past 10 minutes is marked `stopped` with `endReason: "stale"` and stays for the retention hour.

**Placement and hook**
- Claude placement reads the `agent-<id>.meta.json` sidecar (`parentAgentId`, `spawnDepth`); Codex reads the rollout's `session_meta` `parent_thread_id` against the terminal session or a sibling's.
- Missing evidence returns undefined and the next event retries; evidence that names nothing roots the child as `parentUnknown`.
- Notify hook v16 forwards the tool name and a one-field input summary; older hooks omit them and only lose the activity line.
- The tree still lives in memory — a host-service restart drops it, and `failed` is never emitted.

<sup>Written for commit 67299474bdd10c6611089b9ca291945693851e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal subagents now display live status, including working, waiting, completed, and stopped states.
  * Tool activity shows the latest tool name and a concise summary.
  * Subagent rosters now preserve recently ended agents with their completion details.
  * Nested subagents are organized under their spawning parent when available, with unknown relationships identified.
  * Agent descriptions and session information are displayed where supported.
* **Bug Fixes**
  * Quiet subagents are now marked as stale instead of disappearing immediately.
  * Tool details are consistently forwarded from notification events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->