### PR TITLE
feat(billing): request Pro cancellation feedback after 45 minutes

### DIFF
--- a/apps/api/src/app/api/integrations/stripe/jobs/cancellation-feedback/eligibility.test.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/cancellation-feedback/eligibility.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { emitFeedbackOnce, isFeedbackEligible } from "./eligibility";
+
+const cancellation = {
+	status: "active" as const,
+	cancel_at_period_end: true,
+	cancel_at: null,
+	canceled_at: 100,
+	cancellation_details: {
+		reason: "cancellation_requested" as const,
+		comment: null,
+		feedback: null,
+	},
+};
+
+describe("cancellation feedback eligibility", () => {
+	test("accepts voluntary Pro cancellation at the end of the wait", () => {
+		expect(isFeedbackEligible(cancellation, 100)).toBe(true);
+		expect(
+			isFeedbackEligible({ ...cancellation, status: "canceled" }, 100),
+		).toBe(true);
+	});
+	test("skips resumed subscriptions and superseded cancellation jobs", () => {
+		expect(
+			isFeedbackEligible({ ...cancellation, cancel_at_period_end: false }, 100),
+		).toBe(false);
+		expect(isFeedbackEligible({ ...cancellation, canceled_at: 200 }, 100)).toBe(
+			false,
+		);
+	});
+	test("skips payment failures, disputed payments, and existing written feedback", () => {
+		for (const reason of ["payment_failed", "payment_disputed"] as const) {
+			expect(
+				isFeedbackEligible(
+					{
+						...cancellation,
+						cancellation_details: {
+							...cancellation.cancellation_details,
+							reason,
+						},
+					},
+					100,
+				),
+			).toBe(false);
+		}
+		expect(
+			isFeedbackEligible(
+				{
+					...cancellation,
+					cancellation_details: {
+						...cancellation.cancellation_details,
+						comment: "The terminal kept crashing",
+					},
+				},
+				100,
+			),
+		).toBe(false);
+	});
+	test("accepts a scheduled cancel_at, but excludes past-due subscriptions", () => {
+		expect(
+			isFeedbackEligible(
+				{ ...cancellation, cancel_at_period_end: false, cancel_at: 200 },
+				100,
+			),
+		).toBe(true);
+		expect(
+			isFeedbackEligible({ ...cancellation, status: "past_due" }, 100),
+		).toBe(false);
+	});
+});
+
+describe("at-most-once campaign enrollment", () => {
+	test("concurrent deliveries start only one email run", async () => {
+		let claimed = false;
+		let events = 0;
+		const claim = async () => {
+			if (claimed) return null;
+			claimed = true;
+			return "OK";
+		};
+		const emit = async () => {
+			events++;
+		};
+		await Promise.all([
+			emitFeedbackOnce({ claim, emit }),
+			emitFeedbackOnce({ claim, emit }),
+		]);
+		expect(events).toBe(1);
+	});
+	test("an ambiguous Resend failure must not create a duplicate on retry", async () => {
+		let claimed = false;
+		let events = 0;
+		const claim = async () => {
+			if (claimed) return null;
+			claimed = true;
+			return "OK";
+		};
+		const emit = async () => {
+			events++;
+			throw new Error("response timed out");
+		};
+		await expect(emitFeedbackOnce({ claim, emit })).rejects.toThrow(
+			"response timed out",
+		);
+		expect(await emitFeedbackOnce({ claim, emit })).toBe(false);
+		expect(events).toBe(1);
+	});
+});

--- a/apps/api/src/app/api/integrations/stripe/jobs/cancellation-feedback/eligibility.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/cancellation-feedback/eligibility.ts
@@ -1,0 +1,38 @@
+import type Stripe from "stripe";
+
+type CancellationState = Pick<
+	Stripe.Subscription,
+	| "status"
+	| "cancel_at_period_end"
+	| "cancel_at"
+	| "canceled_at"
+	| "cancellation_details"
+>;
+
+export function isFeedbackEligible(
+	subscription: CancellationState,
+	canceledAt: number,
+) {
+	return (
+		subscription.canceled_at === canceledAt &&
+		subscription.cancellation_details?.reason === "cancellation_requested" &&
+		!subscription.cancellation_details.comment?.trim() &&
+		(subscription.status === "canceled" ||
+			(subscription.status === "active" &&
+				(subscription.cancel_at_period_end || subscription.cancel_at !== null)))
+	);
+}
+
+export async function emitFeedbackOnce({
+	claim,
+	emit,
+}: {
+	claim: () => Promise<unknown>;
+	emit: () => Promise<void>;
+}) {
+	if (!(await claim())) return false;
+	// Resend events have no idempotency key. Keep the claim even if a send
+	// times out: retrying an accepted event would start a second email run.
+	await emit();
+	return true;
+}

--- a/apps/api/src/app/api/integrations/stripe/jobs/cancellation-feedback/route.ts
+++ b/apps/api/src/app/api/integrations/stripe/jobs/cancellation-feedback/route.ts
@@ -1,0 +1,132 @@
+import { db } from "@superset/db/client";
+import {
+	members,
+	organizations,
+	subscriptions,
+	users,
+} from "@superset/db/schema";
+import { ACTIVE_SUBSCRIPTION_STATUSES } from "@superset/shared/billing";
+import { Redis } from "@upstash/redis";
+import { and, eq, isNull } from "drizzle-orm";
+import { Resend } from "resend";
+import Stripe from "stripe";
+import { z } from "zod";
+import { env } from "@/env";
+import { verifyQstashRequest } from "@/lib/verifyQstash";
+import { emitFeedbackOnce, isFeedbackEligible } from "./eligibility";
+
+const stripe = new Stripe(env.STRIPE_SECRET_KEY);
+const resend = new Resend(env.RESEND_API_KEY);
+const redis = new Redis({
+	url: env.KV_REST_API_URL,
+	token: env.KV_REST_API_TOKEN,
+});
+const path = "/api/integrations/stripe/jobs/cancellation-feedback";
+const payloadSchema = z.object({
+	stripeSubscriptionId: z.string().min(1),
+	canceledAt: z.number().int().positive(),
+});
+
+export async function POST(request: Request) {
+	const body = await request.text();
+	const rejected = await verifyQstashRequest(request, body, path);
+	if (rejected) return rejected;
+	let payload: z.infer<typeof payloadSchema>;
+	try {
+		payload = payloadSchema.parse(JSON.parse(body));
+	} catch {
+		return Response.json({ error: "Invalid payload" }, { status: 400 });
+	}
+
+	try {
+		const subscription = await stripe.subscriptions.retrieve(
+			payload.stripeSubscriptionId,
+		);
+		if (!isFeedbackEligible(subscription, payload.canceledAt)) {
+			return Response.json({ skipped: "cancellation no longer eligible" });
+		}
+		if (
+			!subscription.items.data.some(
+				({ price }) =>
+					price.id === env.STRIPE_PRO_MONTHLY_PRICE_ID ||
+					price.id === env.STRIPE_PRO_YEARLY_PRICE_ID,
+			)
+		)
+			return Response.json({ skipped: "not a Pro price" });
+		const localSubscription = await db.query.subscriptions.findFirst({
+			where: and(
+				eq(subscriptions.stripeSubscriptionId, subscription.id),
+				eq(subscriptions.plan, "pro"),
+			),
+		});
+		if (!localSubscription) return Response.json({ skipped: "not Pro" });
+		const customerId =
+			typeof subscription.customer === "string"
+				? subscription.customer
+				: subscription.customer.id;
+		const organization = await db.query.organizations.findFirst({
+			where: and(
+				eq(organizations.id, localSubscription.referenceId),
+				eq(organizations.stripeCustomerId, customerId),
+			),
+		});
+		if (!organization)
+			return Response.json({ skipped: "organization missing" });
+		for await (const other of stripe.subscriptions.list({
+			customer: customerId,
+			status: "all",
+			limit: 100,
+		})) {
+			if (
+				other.id !== subscription.id &&
+				ACTIVE_SUBSCRIPTION_STATUSES.some((status) => status === other.status)
+			) {
+				return Response.json({ skipped: "resubscribed" });
+			}
+		}
+		const recipients = await db
+			.select({ id: users.id, email: users.email })
+			.from(members)
+			.innerJoin(users, eq(members.userId, users.id))
+			.where(
+				and(
+					eq(members.organizationId, organization.id),
+					eq(members.role, "owner"),
+					isNull(users.deletionRequestedAt),
+				),
+			);
+		let enrolled = 0;
+		for (const recipient of recipients) {
+			const contact = await resend.contacts.get({ email: recipient.email });
+			if (contact.error?.name === "not_found") continue;
+			if (contact.error) throw new Error(contact.error.message);
+			if (!contact.data || contact.data.unsubscribed) continue;
+			const sent = await emitFeedbackOnce({
+				claim: () =>
+					redis.set(
+						`pro-cancellation-feedback:${subscription.id}:${recipient.id}`,
+						"claimed",
+						{ nx: true },
+					),
+				emit: async () => {
+					const result = await resend.events.send({
+						event: "pro.cancellation_feedback_due",
+						contactId: contact.data.id,
+					});
+					if (result.error) throw new Error(result.error.message);
+				},
+			});
+			if (sent) enrolled++;
+		}
+		return Response.json({ enrolled });
+	} catch (error) {
+		console.error(
+			"[stripe/cancellation-feedback] Failed to process feedback:",
+			error,
+		);
+		return Response.json(
+			{ error: "Failed to process feedback" },
+			{ status: 500 },
+		);
+	}
+}

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -1268,6 +1268,30 @@ export const auth = betterAuth({
 						(cancellationDetails ?? stripeSubscription.cancellation_details)
 							?.reason === "payment_failed";
 
+					if (
+						subscription.plan === "pro" &&
+						!dueToPaymentFailure &&
+						stripeSubscription.canceled_at
+					) {
+						try {
+							await qstash.publishJSON({
+								url: `${env.NEXT_PUBLIC_API_URL}/api/integrations/stripe/jobs/cancellation-feedback`,
+								body: {
+									stripeSubscriptionId: stripeSubscription.id,
+									canceledAt: stripeSubscription.canceled_at,
+								},
+								delay: 2700,
+								retries: 3,
+								deduplicationId: `pro-cancellation-feedback-${stripeSubscription.id}-${stripeSubscription.canceled_at}`,
+							});
+						} catch (error) {
+							console.error(
+								"[stripe/cancellation-feedback] Failed to queue feedback:",
+								error,
+							);
+						}
+					}
+
 					await resend.batch.send(
 						recipients.map((recipient) => ({
 							from: "Superset <noreply@superset.sh>",

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -221,3 +221,32 @@ Then:
 4. Send test emails before production use
 
 React Email components are tested across major email clients (Gmail, Outlook, Apple Mail, etc.).
+
+## Pro cancellation feedback
+
+[Resend automation](https://resend.com/automations/01a0983b-d36f-731b-af0e-a6bf972e9d19/editor)
+uses the published [pro-cancellation-feedback template](https://resend.com/templates/23458b3f-39fb-4465-a3f8-431b73d51aa4/editor).
+The graph is included in `scripts/sync-automations.ts`.
+
+The billing cancellation callback schedules a QStash job with a **45-minute (2,700-second) delay**.
+The `/api/integrations/stripe/jobs/cancellation-feedback` job checks Stripe again
+before emitting `pro.cancellation_feedback_due`; the Resend automation then sends
+one email immediately. Do not add another delay in Resend.
+
+Only new Pro cancellation requests schedule jobs. There is no historical backfill.
+The job targets organization owners who are existing, subscribed Resend contacts.
+It skips reversed or superseded cancellations, payment failures, replacement active
+subscriptions, pending account deletions, and cancellations with written feedback.
+
+A persistent Redis claim permits at most one enrollment per subscription and owner.
+Because Resend events do not offer idempotency keys, a failed or ambiguous event
+request keeps its claim: delivery can be missed, but retrying the QStash job cannot
+send a duplicate. Investigate `[stripe/cancellation-feedback]` errors and Resend run
+history before manually recovering a missed enrollment. Do not delete claims or
+replay campaign events in bulk.
+
+The API deployment must include both the cancellation callback and the job route.
+Until that deployment, the enabled Resend automation receives no events from this
+code. Stop the automation in Resend to disable campaign sending. Never test by
+emitting an event for a customer; local eligibility and deduplication tests live
+beside the job route.

--- a/packages/email/scripts/sync-automations.ts
+++ b/packages/email/scripts/sync-automations.ts
@@ -7,8 +7,10 @@
  *   RESEND_API_KEY=... bun scripts/sync-automations.ts [--apply] [--force]
  *
  * Four hard-won rules this script encodes:
- * - ONLY `user.signed_up` is safe as a trigger: it fires once per user, from
- *   better-auth's `user.create.after` hook. `user.activated` fires on every
+ * - Triggers must be deduplicated: `user.signed_up` fires once per user, from
+ *   better-auth's `user.create.after` hook; `pro.cancellation_feedback_due`
+ *   claims a Redis key per subscription and recipient before emission.
+ *   `user.activated` fires on every
  *   workspace create and `app.first_opened` on every first-host/onboarding
  *   path, so triggering on either enrols a user once per occurrence. Pointing
  *   habit-drip's trigger at `user.activated` sent 1,487 copies of one email to
@@ -18,7 +20,7 @@
  * - GATING an emitter is the mirror of that rule: it hits every consumer. The
  *   signup hook withholds `user.signed_up` from the activation A/B's control
  *   arm, so a second automation triggering on it would silently lose that arm
- *   too. That is why only activation-drip is defined here. Before adding
+ *   too. Only activation-drip uses that trigger here. Before adding
  *   another `user.signed_up` trigger, split enrolment into its own event.
  * - NEVER update an enabled automation's steps: despite the API's wording,
  *   doing so cancelled every in-flight run (2026-08-20, ~324 users dropped
@@ -68,6 +70,33 @@ function template(alias: string, variables?: Record<string, unknown>) {
 }
 
 const desired: DesiredAutomation[] = [
+	{
+		name: "pro-cancellation-feedback",
+		steps: [
+			{
+				key: "trigger",
+				type: "trigger",
+				config: { eventName: "pro.cancellation_feedback_due" },
+			},
+			{
+				key: "send_email-7961cf59-b3a1-4af6-b167-e675656fd80a",
+				type: "send_email",
+				config: {
+					template: { id: "23458b3f-39fb-4465-a3f8-431b73d51aa4" },
+					subject: "",
+					from: "Kiet <kiet@hey.superset.sh>",
+					replyTo: "kiet@superset.sh",
+				},
+			},
+		],
+		connections: [
+			{
+				from: "trigger",
+				to: "send_email-7961cf59-b3a1-4af6-b167-e675656fd80a",
+				type: "default",
+			},
+		],
+	},
 	{
 		// Signup drip. Listens for first-open from minute zero; a user with no
 		// first-open event by day 1 cannot have activated (onboarding precedes
@@ -152,7 +181,8 @@ function canonDuration(v: string): string {
 function canonConfig(c: Record<string, unknown>): Record<string, unknown> {
 	const out: Record<string, unknown> = {};
 	for (const [k, v] of Object.entries(c)) {
-		const key = k === "event_name" ? "eventName" : k;
+		const key =
+			k === "event_name" ? "eventName" : k === "reply_to" ? "replyTo" : k;
 		out[key] =
 			(key === "timeout" || key === "duration") && typeof v === "string"
 				? canonDuration(v)


### PR DESCRIPTION
## What & why

Schedule a personal feedback email 45 minutes after an organization requests cancellation of Pro. The delayed job rechecks Stripe before enrolling owners in the published Resend campaign, so a reversed cancellation does not result in an email asking why they left.

Exclude payment failures, replacement active subscriptions, deleted/pending-deletion accounts, unsubscribed or missing Resend contacts, and cancellations that already include written feedback. A persistent Redis claim limits enrollment to once per subscription and owner. Claims survive ambiguous Resend failures because the events API has no idempotency key; a missed send is preferable to duplicate campaign runs.

The Resend automation and template are already published and enabled. Deploying this API change starts enrollment for future cancellation requests; no historical backfill runs. The 45-minute delay is in QStash, so the Resend graph sends immediately on `pro.cancellation_feedback_due`.

- [Resend automation](https://resend.com/automations/01a0983b-d36f-731b-af0e-a6bf972e9d19/editor)
- [Published email template](https://resend.com/templates/23458b3f-39fb-4465-a3f8-431b73d51aa4/editor)

## How I tested it

- `bun run lint` passed.
- `bun run typecheck` passed: all 39 tasks.
- `bun run --cwd apps/api test` passed: all 77 tests, including six cancellation eligibility/deduplication tests covering concurrent delivery and an ambiguous Resend timeout.
- Verified the published template's sender, reply-to, subject and body, and the enabled automation's trigger/template connection in the signed-in Resend UI. No test events were sent to customers.
- Full `bun run test` was attempted: it hit a filesystem-watcher timeout in `packages/workspace-fs` and missing environment variables in `packages/trpc`; these files are unchanged by this PR.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass
- [x] "Allow edits from maintainers" is checked on fork PRs (same-repository branch)
