### PR TITLE
fix(desktop): widen sidebar group stripes without shifting content

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SidebarDragOverlay/SidebarDragOverlay.tsx
@@ -29,7 +29,7 @@ export function SidebarDragOverlay({
 		return (
 			<div
 				style={{
-					borderLeft: accentColor ? `2px solid ${accentColor}` : undefined,
+					boxShadow: accentColor ? `inset 3px 0 ${accentColor}` : undefined,
 				}}
 			>
 				<DashboardSidebarWorkspaceItem workspace={activeItem.workspace} />
@@ -44,9 +44,9 @@ export function SidebarDragOverlay({
 	return (
 		<div
 			style={{
-				borderLeft: hasColor
-					? `2px solid ${section.color}`
-					: "2px solid var(--color-border)",
+				boxShadow: hasColor
+					? `inset 3px 0 ${section.color}`
+					: "inset 2px 0 var(--color-border)",
 			}}
 		>
 			<div className="flex min-h-8 w-full items-center gap-1.5 pl-0.5 pr-2 py-1.5 text-[11px] font-medium text-muted-foreground">

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableSectionHeader/SortableSectionHeader.tsx
@@ -92,9 +92,9 @@ export function SortableSectionHeader({
 				transform: CSS.Translate.toString(transform),
 				transition,
 				opacity: isDragging ? 0.5 : undefined,
-				borderLeft: hasColor
-					? `2px solid ${section.color}`
-					: "2px solid var(--color-border)",
+				boxShadow: hasColor
+					? `inset 3px 0 ${section.color}`
+					: "inset 2px 0 var(--color-border)",
 			}}
 		>
 			<DashboardSidebarSectionContextMenu

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/components/DashboardSidebar/components/SortableWorkspaceItem/SortableWorkspaceItem.tsx
@@ -100,7 +100,7 @@ export function SortableWorkspaceItem({
 				transform: CSS.Translate.toString(transform),
 				transition,
 				opacity: isDragging || isDragPlaceholder ? 0.5 : undefined,
-				borderLeft: accentColor ? `2px solid ${accentColor}` : undefined,
+				boxShadow: accentColor ? `inset 3px 0 ${accentColor}` : undefined,
 			}}
 			{...attributes}
 			{...listeners}
@@ -113,9 +113,6 @@ export function SortableWorkspaceItem({
 			<div
 				className={cn(
 					"grid transition-[grid-template-rows,opacity] duration-150 ease-out",
-					// Pull the row back over the accent border so grouped rows keep
-					// the same left edge whether or not their folder has a color.
-					accentColor && "-ml-0.5",
 					collapsed
 						? "grid-rows-[0fr] opacity-0"
 						: "grid-rows-[1fr] opacity-100",


### PR DESCRIPTION
## What & why

Widen sidebar group color stripes from 2px to 3px to improve visibility. Render them as inset shadows so the entire stripe takes up zero layout space, including group headers and drag previews. Remove the workspace row margin that compensated for the former border.

## How I tested it

- Repository lint and plugin validation passed.
- Dev app started successfully for user review.
- Full repository typecheck passed (39 tasks).
- Desktop tests passed: 3,847 tests, 0 failures.
- Full repository tests blocked in the unchanged `@superset/trpc` package by missing environment variables, including after explicitly loading the workspace `.env`.
- No automated visual verification or screenshots captured.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (same-repository branch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated sidebar workspace and section color indicators to use inset highlights instead of left borders.
  - Adjusted accent widths and fallback colors for improved visual consistency.
  - Refined sortable workspace row spacing alongside the updated indicator styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->