### PR TITLE
fix(desktop): keep diff controls usable in narrow panes

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/DiffPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/DiffPaneHeaderExtras.tsx
@@ -27,14 +27,14 @@ export function DiffPaneHeaderExtras({
 
 	const buttonClass = (active: boolean) =>
 		cn(
-			"flex size-5 items-center justify-center transition-colors",
+			"flex size-5 shrink-0 items-center justify-center transition-colors",
 			active
 				? "bg-secondary text-foreground"
 				: "text-muted-foreground hover:text-foreground",
 		);
 
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex shrink-0 items-center gap-1">
 			<DiffPanePRLink workspaceId={workspaceId} store={store} />
 			<Tooltip>
 				<TooltipTrigger asChild>
@@ -101,7 +101,7 @@ export function DiffPaneHeaderExtras({
 				</TooltipContent>
 			</Tooltip>
 			<div
-				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
+				className="mx-1 h-3.5 w-px shrink-0 bg-muted-foreground/30"
 				aria-hidden="true"
 			/>
 		</div>

--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/components/DiffPanePRLink/DiffPanePRLink.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/DiffPane/components/DiffPaneHeaderExtras/components/DiffPanePRLink/DiffPanePRLink.tsx
@@ -55,17 +55,17 @@ export function DiffPanePRLink({ workspaceId, store }: DiffPanePRLinkProps) {
 						aria-label={t({
 							message: `Open pull request #${pr.number}`,
 						})}
-						className="group flex h-5 items-center gap-1.5 rounded-md border border-border/60 bg-muted/30 px-1.5 transition-colors hover:bg-accent/60"
+						className="group flex h-5 shrink-0 items-center whitespace-nowrap gap-1.5 rounded-md border border-border/60 bg-muted/30 px-1.5 transition-colors hover:bg-accent/60"
 					>
-						<PRIcon state={state} className="size-3.5" />
+						<PRIcon state={state} className="size-3.5 shrink-0" />
 						{/* Verb-first label: the bare number read as a badge, not as
 						    an action that opens the PR. */}
-						<span className="font-medium text-[11px] text-foreground tabular-nums">
+						<span className="hidden max-w-48 truncate font-medium text-[11px] text-foreground tabular-nums @min-[360px]/pane-header:inline">
 							{t({
 								message: `Open PR #${pr.number}`,
 							})}
 						</span>
-						<LuArrowRight className="size-3 text-muted-foreground transition-transform group-hover:translate-x-px" />
+						<LuArrowRight className="hidden size-3 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-px @min-[360px]/pane-header:block" />
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom">
@@ -75,7 +75,7 @@ export function DiffPanePRLink({ workspaceId, store }: DiffPanePRLinkProps) {
 			{/* Rendered here, not by the parent, so no stray divider shows when
 			    the link is hidden (no PR / session workspace). */}
 			<div
-				className="mx-1 h-3.5 w-px bg-muted-foreground/30"
+				className="mx-1 h-3.5 w-px shrink-0 bg-muted-foreground/30"
 				aria-hidden="true"
 			/>
 		</>

--- a/apps/desktop/src/renderer/screens/main/components/DiffViewToolbar/DiffViewToolbar.tsx
+++ b/apps/desktop/src/renderer/screens/main/components/DiffViewToolbar/DiffViewToolbar.tsx
@@ -73,8 +73,8 @@ export function DiffViewToolbar({
 		);
 
 	return (
-		<div className="flex shrink-0 items-center justify-between gap-1 border-b border-border/20 px-2 py-1.5">
-			<div className="flex items-center gap-1">
+		<div className="flex shrink-0 flex-wrap items-center justify-between gap-1 border-b border-border/20 px-2 py-1.5">
+			<div className="flex shrink-0 items-center gap-1 whitespace-nowrap">
 				{tree != null && (
 					<button
 						type="button"
@@ -150,7 +150,7 @@ export function DiffViewToolbar({
 					</>
 				)}
 			</div>
-			<div className="flex items-center gap-1">
+			<div className="flex shrink-0 items-center gap-1 whitespace-nowrap">
 				{commentNav != null && commentNav.total > 0 && (
 					<>
 						<div className="flex items-center gap-0.5 rounded-md bg-muted/50 px-1.5 py-0.5">


### PR DESCRIPTION
## What & why

Narrow diff panes let the “Open PR” label wrap outside the fixed-height header and push comment navigation past the pane edge. Keep header controls from shrinking, show the PR action as an icon below 360px container width, and allow diff toolbar groups to wrap onto a second row. Wider panes retain the full PR label.

## How I tested it

- `bun run lint` — passed.
- `bun run typecheck` — passed (39 tasks).
- `git diff --check` — passed.
- `bun run test` — blocked by invalid environment variables in `@superset/trpc` (273 passed, 1 failure/error).
- Rendered the actual modified React components with mocked PR/settings data in an isolated browser preview at 270px, 360px, and 640px outer widths. Measured `scrollWidth === clientWidth` for all three panes and inspected the screenshot below. This is component layout evidence, not end-to-end desktop verification; local setup failed at dev-account seeding.

![Isolated diff component preview at three pane widths](https://raw.githubusercontent.com/superset-sh/superset/66c28069d38eba31ba6439c05b199751c6760cb5/diff-responsiveness.png)

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs — same-repository branch


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes diff controls overflowing in narrow panes. The "Open PR" label used to wrap outside the fixed-height header and push comment navigation past the pane edge; now it collapses to an icon button below 360px container width, header controls keep their size, and toolbar groups wrap onto a second row. Wider panes still show the full PR label.

<sup>Written for commit 055120442eed97ac229d8b761434ab16fa91b174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved diff toolbar layout so controls maintain their size and remain readable when space is limited.
  * Enabled toolbar wrapping for narrower window and pane widths.
  * Updated pull request link presentation to keep icons and dividers stable, constrain longer labels, and show a more compact layout below narrow pane widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->