### PR TITLE
feat(desktop): copy GitHub URL from pull request pane header

### DIFF
--- a/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/PullRequestPane/components/PullRequestPaneHeaderExtras/PullRequestPaneHeaderExtras.tsx
+++ b/apps/desktop/src/renderer/routes/_authenticated/_dashboard/v2-workspace/$workspaceId/hooks/usePaneRegistry/components/PullRequestPane/components/PullRequestPaneHeaderExtras/PullRequestPaneHeaderExtras.tsx
@@ -1,7 +1,10 @@
 import { Trans, useLingui } from "@lingui/react/macro";
+import { toast } from "@superset/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@superset/ui/tooltip";
 import { useNavigate } from "@tanstack/react-router";
-import { LuMaximize2 } from "react-icons/lu";
+import { LuCheck, LuCopy, LuMaximize2 } from "react-icons/lu";
+import { useCopyToClipboard } from "renderer/hooks/useCopyToClipboard";
+import { usePullRequestDetail } from "renderer/routes/_authenticated/_dashboard/pull-requests/hooks/usePullRequestDetail";
 import { usePullRequestsSplitViewStore } from "renderer/routes/_authenticated/_dashboard/pull-requests/stores/pullRequestsSplitViewStore";
 import { useWorkspace } from "renderer/routes/_authenticated/_dashboard/v2-workspace/providers/WorkspaceProvider";
 import type { PullRequestPaneData } from "../../../../../../types";
@@ -20,36 +23,71 @@ export function PullRequestPaneHeaderExtras({
 }: PullRequestPaneHeaderExtrasProps) {
 	const { t } = useLingui();
 	const navigate = useNavigate();
-	const { workspace } = useWorkspace();
+	const { workspace, hostUrl } = useWorkspace();
+	const { copyToClipboard, copied } = useCopyToClipboard();
 	const projectId = workspace.projectId;
+	const detail = usePullRequestDetail({
+		projectId,
+		hostUrl,
+		prNumber: data.prNumber,
+	});
+	const url = detail.data?.url;
+	const copyLabel = copied
+		? t({ message: "Copied" })
+		: t({ message: "Copy link to pull request" });
 	if (projectId == null) return null;
 
 	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					onClick={() => {
-						// Same pair the PR list's own row click performs — the detail
-						// pane may have been collapsed the last time the view was open.
-						usePullRequestsSplitViewStore.getState().expandDetail();
-						void navigate({
-							to: "/pull-requests/$prNumber",
-							params: { prNumber: String(data.prNumber) },
-							search: { project: projectId },
-						});
-					}}
-					aria-label={t({
-						message: "Open in Pull Requests",
-					})}
-					className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
-				>
-					<LuMaximize2 className="size-3.5" />
-				</button>
-			</TooltipTrigger>
-			<TooltipContent side="bottom">
-				<Trans>Open in Pull Requests</Trans>
-			</TooltipContent>
-		</Tooltip>
+		<>
+			{url && (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button
+							type="button"
+							onClick={() => {
+								void copyToClipboard(url).catch(() => {
+									toast.error(t({ message: "Failed to copy to clipboard" }));
+								});
+							}}
+							aria-label={copyLabel}
+							className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+						>
+							{copied ? (
+								<LuCheck className="size-3.5" />
+							) : (
+								<LuCopy className="size-3.5" />
+							)}
+						</button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">{copyLabel}</TooltipContent>
+				</Tooltip>
+			)}
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						onClick={() => {
+							// Same pair the PR list's own row click performs — the detail
+							// pane may have been collapsed the last time the view was open.
+							usePullRequestsSplitViewStore.getState().expandDetail();
+							void navigate({
+								to: "/pull-requests/$prNumber",
+								params: { prNumber: String(data.prNumber) },
+								search: { project: projectId },
+							});
+						}}
+						aria-label={t({
+							message: "Open in Pull Requests",
+						})}
+						className="rounded p-1 text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					>
+						<LuMaximize2 className="size-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">
+					<Trans>Open in Pull Requests</Trans>
+				</TooltipContent>
+			</Tooltip>
+		</>
 	);
 }


### PR DESCRIPTION
## What & why

Add a copy button beside the expand control in the pull request pane header, so users can copy the PR's GitHub URL without opening GitHub. The button uses the cached PR URL, briefly shows a checkmark after copying, and reports clipboard failures.

## How I tested it

- In this branch's signed-in Electron renderer at localhost:4245, opened workspace PR #7485 through the sidebar and clicked the new copy button. Confirmed the Copied state and clipboard value `https://github.com/superset-sh/superset/pull/7485`.
- Captured and reviewed a pane-header screenshot locally.
- `bun run lint`, `bun run typecheck` (39 packages), `bun run check:i18n`, and `bun run check:plugins` pass.
- `bun run test` stopped in `@superset/trpc` on environment-variable validation during module loading (273 pass, 1 fail, 1 error). The full suite did not complete.

## Checklist

- [x] PR title follows conventional commits (`type(scope): subject`)
- [x] `bun run lint` and `bun run typecheck` pass (CI fails on lint warnings too)
- [x] "Allow edits from maintainers" is checked on fork PRs (not a fork PR)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copy button beside the expand control in the pull request pane header, so users can copy the PR's GitHub URL without opening GitHub. The button only renders once the URL is loaded, shows a checkmark after copying, and reports clipboard failures with an error toast.

<sup>Written for commit a20530e79396eda6998ca3af62c9950ec0a477bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a copy-to-clipboard button for pull request URLs when available.
  - The button provides visual confirmation after copying and displays an error notification if copying fails.
  - Retained the option to open the pull request in the Pull Requests view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->