### PR TITLE
fix(mobile): stop a dismissed form sheet from clipping the screen that replaces it

### DIFF
--- a/apps/mobile/react-native-screens-sheet-patch.test.ts
+++ b/apps/mobile/react-native-screens-sheet-patch.test.ts
@@ -35,9 +35,9 @@ describe("react-native-screens form sheet scroll view observer patch", () => {
 			.map(([, file]) => file)) {
 			const patch = readFileSync(join(repoRoot, path), "utf8");
 			expect(patch).toContain("ios/RNSScreen.mm");
-			expect(patch).toMatch(/\+\s*BOOL _invalidated;/);
+			// 4.27+ declares `invalidated` itself, so a regenerated patch adds only
+			// the early return; the assignment line is upstream's from then on.
 			expect(patch).toMatch(/\+\s*if \(_invalidated\) \{/);
-			expect(patch).toMatch(/\+\s*_invalidated = YES;/);
 		}
 	});
 

--- a/apps/mobile/react-native-screens-sheet-patch.test.ts
+++ b/apps/mobile/react-native-screens-sheet-patch.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Guards the bun patch on react-native-screens (patches/README.md). Without
+// it, a screen pushed after a form sheet has been shown can come up with its
+// ScrollView sized to the sheet (half the screen): everything below is
+// neither painted nor tappable. patchedDependencies is keyed to an exact
+// version, so bumping react-native-screens (an Expo SDK bump will) silently
+// drops the patch. If this fails after a bump, check upstream for the fix
+// before re-applying the patch; do NOT delete the test.
+const repoRoot = join(import.meta.dir, "../..");
+const patched: Record<string, string> =
+	JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"))
+		.patchedDependencies ?? {};
+const lockfile = readFileSync(join(repoRoot, "bun.lock"), "utf8");
+
+describe("react-native-screens form sheet scroll view observer patch", () => {
+	test("every resolved react-native-screens version is patched", () => {
+		const resolved = [
+			...lockfile.matchAll(
+				/"react-native-screens": \["react-native-screens@([^"]+)"/g,
+			),
+		].map((match) => `react-native-screens@${match[1]}`);
+
+		expect(resolved.length).toBeGreaterThan(0);
+		for (const version of resolved) {
+			expect(patched[version]).toBeString();
+		}
+	});
+
+	test("the patch stops an invalidated sheet from resizing its scroll view", () => {
+		for (const path of Object.entries(patched)
+			.filter(([name]) => name.startsWith("react-native-screens@"))
+			.map(([, file]) => file)) {
+			const patch = readFileSync(join(repoRoot, path), "utf8");
+			expect(patch).toContain("ios/RNSScreen.mm");
+			expect(patch).toMatch(/\+\s*BOOL _invalidated;/);
+			expect(patch).toMatch(/\+\s*if \(_invalidated\) \{/);
+			expect(patch).toMatch(/\+\s*_invalidated = YES;/);
+		}
+	});
+
+	test("the installed package carries the patch", () => {
+		const source = readFileSync(
+			join(
+				import.meta.dir,
+				"node_modules/react-native-screens/ios/RNSScreen.mm",
+			),
+			"utf8",
+		);
+		expect(source).toContain("if (_invalidated) {");
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1358,6 +1358,7 @@
     "trpc-electron@0.1.2": "patches/trpc-electron@0.1.2.patch",
     "node-pty@1.2.0-beta.14": "patches/node-pty@1.2.0-beta.14.patch",
     "@xterm/xterm@6.1.0-beta.302": "patches/@xterm%2Fxterm@6.1.0-beta.302.patch",
+    "react-native-screens@4.26.0": "patches/react-native-screens@4.26.0.patch",
   },
   "overrides": {
     "@tiptap/extension-dropcursor": "3.30.5",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"metro@0.84.4": "patches/metro@0.84.4.patch",
 		"node-pty@1.2.0-beta.14": "patches/node-pty@1.2.0-beta.14.patch",
 		"@xterm/xterm@6.1.0-beta.302": "patches/@xterm%2Fxterm@6.1.0-beta.302.patch",
-		"trpc-electron@0.1.2": "patches/trpc-electron@0.1.2.patch"
+		"trpc-electron@0.1.2": "patches/trpc-electron@0.1.2.patch",
+		"react-native-screens@4.26.0": "patches/react-native-screens@4.26.0.patch"
 	}
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -310,10 +310,11 @@ must not add the ivar again — only the early return is needed.
 
 ```bash
 bun patch react-native-screens@<new-version>
-# in node_modules/react-native-screens/ios/RNSScreen.mm:
-#   add `BOOL _invalidated;` to the RNSScreenView ivar block,
-#   set `_invalidated = YES;` first thing in invalidateImpl,
-#   and return early from applyFrameCorrectionForDescendantScrollView when it is set
+# in node_modules/react-native-screens/ios/RNSScreen.mm, return early from
+# applyFrameCorrectionForDescendantScrollView when `_invalidated` is set.
+# Before 4.27.0 only: also add `BOOL _invalidated;` to the RNSScreenView ivar
+# block and set `_invalidated = YES;` first thing in invalidateImpl (4.27.0+
+# already has both; adding the ivar again fails to compile).
 bun patch --commit 'node_modules/react-native-screens'
 bun test apps/mobile/react-native-screens-sheet-patch.test.ts
 ```

--- a/patches/README.md
+++ b/patches/README.md
@@ -277,3 +277,47 @@ ports on the spawn attributes it already builds in `pty_posix_spawn`
 (`posix_spawnattr_setexceptionports_np`). If node-pty ships that, the pty side
 no longer needs the patch, but `host-service-coordinator.ts` still needs a
 port-clearing exec trampoline; keep the patched helper (or ship our own) for it.
+
+## react-native-screens (`react-native-screens@<version>.patch`)
+
+**Why:** on iOS, a form sheet screen (`presentation: "formSheet"`) finds the
+`ScrollView` in its content on every layout pass and sizes it to the sheet's
+frame. When a sheet is replaced by a pushed screen (`router.replace` from the
+pull-requests sheet), Fabric recycles the sheet's `UIScrollView` into the new
+screen, and the dismissed sheet still gets one more layout pass *after* it has
+been invalidated: it finds that recycled scroll view down its old subview chain
+and sizes it to the sheet again. The PR screen came up with its scroll view at
+464pt (the `[0.5]` detent), everything below the fold unpainted and untappable,
+and every later screen that reused that scroll view instance did the same.
+Upstream #4091 (in 4.26.0) only removes the KVO observer in `invalidate`; the
+layout-pass path is untouched and still present on `4.28-stable` as of
+2026-09-12. Diagnosed with `NSLog` in `correctScrollViewFrame:` and
+`invalidateImpl`: the correction to 464pt logs 4ms after the sheet's
+invalidate, on the same scroll view pointer the new screen had just laid out at
+956pt.
+
+**What it changes** (`ios/RNSScreen.mm`): an `_invalidated` flag set in
+`invalidateImpl`; `applyFrameCorrectionForDescendantScrollView` returns early
+once it is set. Reproduced unpatched on 4.27.0 (latest stable, 2026-09-12) in
+the same flow, so bumping alone does not fix it. 4.27.0 already declares an
+`invalidated` property on `RNSScreenView` (set in `invalidateImpl`, used only
+for transition progress and header config), so a regenerated patch for 4.27+
+must not add the ivar again — only the early return is needed.
+
+**Guard test:** `apps/mobile/react-native-screens-sheet-patch.test.ts`.
+
+**Regenerating after a version bump** (~2 min, plus a native rebuild to verify):
+
+```bash
+bun patch react-native-screens@<new-version>
+# in node_modules/react-native-screens/ios/RNSScreen.mm:
+#   add `BOOL _invalidated;` to the RNSScreenView ivar block,
+#   set `_invalidated = YES;` first thing in invalidateImpl,
+#   and return early from applyFrameCorrectionForDescendantScrollView when it is set
+bun patch --commit 'node_modules/react-native-screens'
+bun test apps/mobile/react-native-screens-sheet-patch.test.ts
+```
+
+Verify in the simulator: open a workspace with two PRs, tap the PR chip, tap a
+row, go back, reopen the sheet, tap the other row. The second PR must show its
+description and the Files row without scrolling.

--- a/patches/react-native-screens@4.26.0.patch
+++ b/patches/react-native-screens@4.26.0.patch
@@ -1,0 +1,33 @@
+diff --git a/ios/RNSScreen.mm b/ios/RNSScreen.mm
+index 9b66012dc8db1e3af0cb5457f8dad86e7f2fe5e3..b8e075934de53bee9326affb1d2d4a64550d30e3 100644
+--- a/ios/RNSScreen.mm
++++ b/ios/RNSScreen.mm
+@@ -53,6 +53,7 @@ @interface RNSScreenView () <UIAdaptivePresentationControllerDelegate,
+ 
+ @implementation RNSScreenView {
+   __weak RCTScrollViewComponentView *_sheetsScrollView;
++  BOOL _invalidated;
+ 
+   /// Up-to-date only when sheet is in `fitToContents` mode.
+   CGFloat _sheetContentHeight;
+@@ -177,6 +178,12 @@ - (void)updateBounds
+ 
+ - (void)applyFrameCorrectionForDescendantScrollView
+ {
++  // A dismissed sheet still gets a layout pass after it has been invalidated,
++  // by which time Fabric may have recycled its scroll view into the screen
++  // that replaced it; sizing that to the sheet clips the new screen.
++  if (_invalidated) {
++    return;
++  }
+   RCTScrollViewComponentView *scrollView = [self tryFindDescendantScrollView];
+   if (_sheetsScrollView != scrollView) {
+     [_sheetsScrollView removeObserver:self forKeyPath:@"bounds" context:nil];
+@@ -769,6 +776,7 @@ - (BOOL)isTransparentModal
+ 
+ - (void)invalidateImpl
+ {
++  _invalidated = YES;
+   // Since the scroll view might get immediately recycled we remove ourselves
+   // immediately.
+   if (_sheetsScrollView != nil) {


### PR DESCRIPTION
## Why

Satya reported that PR rows in the mobile pull-requests sheet "all open the same PR", with no description and no Files link. The rows were fine; the screen they opened was not. After the sheet had been used once, any PR screen mounted with cached data came up with its native `UIScrollView` frozen at **464pt** (the sheet's `[0.5]` detent on an iPhone 17 Pro Max). Everything below was laid out but neither painted nor tappable, so the description looked empty and the Files row vanished. A PR's first visit starts on a spinner and re-lays out after the sheet is gone, which is why it looked like a "second visit" bug.

## Root cause

react-native-screens: a `formSheet` `RNSScreenView` sizes the `ScrollView` in its content to the sheet on every layout pass. When the sheet is replaced by the pushed PR screen, Fabric recycles the sheet's `UIScrollView` into the new screen, and the dismissed sheet still gets one more layout pass **after** it has been invalidated. `NSLog` on 4.26.0:

```
17:10:32.309  invalidate screen=0x37b0ba200 pres=6 sv=0x155a6c380
17:10:32.313  correct    screen=0x37b0ba200 pres=6 frame={{0, 0}, {440, 464}} sv=0x155a6c380 svframe={{0, 0}, {440, 956}}
```

Upstream #4091 (already in 4.26.0) only removes the KVO observer in `invalidate`; this layout-pass path is untouched. Reproduced unpatched on 4.27.0 (latest) and in a stock `create-expo-app` with three routes, so it is not something in this app. Same symptom as software-mansion/react-native-screens#4090. Filed upstream as software-mansion/react-native-screens#4651 with a bare repro (https://github.com/saddlepaddle/rns-formsheet-clips-pushed-screen); fix proposed in software-mansion/react-native-screens#4652 with `Test4651` reproducing it in their FabricExample on `main` (their `Test4090` does not trip it because its pushed screen wraps the ScrollView in a View). Drop this patch once a release carries that fix.

## What changes

- `patches/react-native-screens@4.26.0.patch`: `_invalidated` flag set in `invalidateImpl`; `applyFrameCorrectionForDescendantScrollView` returns early once set.
- `apps/mobile/react-native-screens-sheet-patch.test.ts`: guard test so a version bump cannot silently drop the patch (per `patches/README.md`).
- `patches/README.md`: why, what, regeneration recipe. Note for 4.27+: upstream already declares an `invalidated` property, so only the early return is needed there.

No app code changes. Wrapping the ScrollView, `router.back()`+`push` from the sheet, and a KVO-side guard were all tried and do not fix it.

## Verification

Rebuilt the iOS dev client (`expo run:ios`) on the iPhone 17 Pro Max simulator against prod and drove it with Maestro, measuring native frames from the accessibility tree:

- Before: chip → row → back → chip → other row: second and later PR screens at `[0,0]-[440,464]`; cached deep links the same.
- After: four consecutive sheet-row round trips across both PRs and a cached deep link all at full height; "See More" expands; the Files row opens the Files changed screen.
- Unpatched 4.27.0, same flow: clipped again (control).
- Bare expo-router app, pristine 4.26.0: clipped on the first sheet → row transition; direct push full height.

## Shipping

Native change: needs an EAS/TestFlight build, not an OTA update.

https://claude.ai/code/session_011PZUSeDASNWgF56PEP3d4M


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an iOS issue where dismissing a form sheet could cause recycled scroll views on the next screen to be sized incorrectly, leaving content unpainted.
  - Subsequent screens now retain correct layout and display their content reliably after a sheet is dismissed.

- **Documentation**
  - Added documentation covering the fix, verification steps, and patch regeneration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->