### PR TITLE
chore(desktop): bump version to 1.29.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "@superset/desktop",
 	"productName": "Superset",
 	"description": "The last developer tool you'll ever need",
-	"version": "1.28.0",
+	"version": "1.29.0",
 	"main": "./dist/main/index.js",
 	"resources": "src/resources",
 	"repository": {

--- a/bun.lock
+++ b/bun.lock
@@ -122,7 +122,7 @@
     },
     "apps/desktop": {
       "name": "@superset/desktop",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "dependencies": {
         "@ast-grep/napi": "0.41.1",
         "@better-auth/api-key": "1.6.22",
@@ -878,7 +878,7 @@
     },
     "packages/cli": {
       "name": "@superset/cli",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "dependencies": {
         "@clack/prompts": "0.10.1",
         "@superset/agent-setup": "workspace:*",
@@ -978,7 +978,7 @@
     },
     "packages/host-service": {
       "name": "@superset/host-service",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "dependencies": {
         "@hono/node-server": "2.0.10",
         "@hono/node-ws": "1.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/cli",
-	"version": "1.28.0",
+	"version": "1.29.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/host-service/package.json
+++ b/packages/host-service/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@superset/host-service",
-	"version": "1.28.0",
+	"version": "1.29.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
Prepare the 1.29.0 desktop draft release from main at c3c6717bb7. Bump desktop, host-service, and CLI together from 1.28.0 to 1.29.0 and refresh the lockfile. The pty-daemon version remains current.

Validation: bun run check:versions and bun run check:plugins pass. Release builds: https://github.com/superset-sh/superset/actions/runs/34743484897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application and related packages to version 1.29.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->