### PR TITLE
fix(mobile): keep the session readable when a push wakes the app on a locked phone

### DIFF
--- a/apps/mobile/lib/auth/client.ts
+++ b/apps/mobile/lib/auth/client.ts
@@ -6,9 +6,9 @@ import {
 	organizationClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
-import * as SecureStore from "expo-secure-store";
 import { env } from "../env";
 import { transportFetch } from "../errors";
+import { sessionStorage } from "./sessionStorage";
 
 let jwt: string | null = null;
 
@@ -26,7 +26,7 @@ export const authClient = createAuthClient({
 		expoClient({
 			scheme: "superset",
 			storagePrefix: "superset",
-			storage: SecureStore,
+			storage: sessionStorage,
 		}),
 		organizationClient({
 			teams: { enabled: true },

--- a/apps/mobile/lib/auth/sessionStorage/index.ts
+++ b/apps/mobile/lib/auth/sessionStorage/index.ts
@@ -1,0 +1,1 @@
+export { sessionStorage } from "./sessionStorage";

--- a/apps/mobile/lib/auth/sessionStorage/sessionStorage.test.ts
+++ b/apps/mobile/lib/auth/sessionStorage/sessionStorage.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const AFTER_FIRST_UNLOCK = "afterFirstUnlock";
+const NEW = {
+	keychainService: "superset-auth",
+	keychainAccessible: AFTER_FIRST_UNLOCK,
+};
+
+const getItem = mock((_key: string, _options?: object): string | null => null);
+const setItem = mock((_key: string, _value: string, _options?: object) => true);
+const deleteItemAsync = mock(async (_key: string, _options?: object) => {});
+
+mock.module("expo-secure-store", () => ({
+	AFTER_FIRST_UNLOCK,
+	getItem,
+	setItem,
+	deleteItemAsync,
+}));
+
+const { sessionStorage } = await import("./sessionStorage");
+
+beforeEach(() => {
+	getItem.mockReset();
+	setItem.mockReset();
+	deleteItemAsync.mockReset();
+	getItem.mockImplementation(() => null);
+});
+
+describe("sessionStorage", () => {
+	test("reads the background-readable item without touching the legacy one", () => {
+		getItem.mockImplementation((_key, options) =>
+			options ? "new-value" : "legacy-value",
+		);
+
+		expect(sessionStorage.getItem("superset_cookie")).toBe("new-value");
+		expect(getItem).toHaveBeenCalledTimes(1);
+		expect(getItem).toHaveBeenCalledWith("superset_cookie", NEW);
+		expect(setItem).not.toHaveBeenCalled();
+	});
+
+	test("moves a legacy item into the background-readable service on read", () => {
+		getItem.mockImplementation((_key, options) =>
+			options ? null : "legacy-value",
+		);
+
+		expect(sessionStorage.getItem("superset_cookie")).toBe("legacy-value");
+		expect(setItem).toHaveBeenCalledWith(
+			"superset_cookie",
+			"legacy-value",
+			NEW,
+		);
+		expect(deleteItemAsync).toHaveBeenCalledWith("superset_cookie");
+	});
+
+	test("a missing key is null and writes nothing", () => {
+		expect(sessionStorage.getItem("superset_session_data")).toBeNull();
+		expect(getItem).toHaveBeenCalledTimes(2);
+		expect(setItem).not.toHaveBeenCalled();
+		expect(deleteItemAsync).not.toHaveBeenCalled();
+	});
+
+	test("writes only to the background-readable service and drops the legacy copy", () => {
+		sessionStorage.setItem("superset_cookie", "{}");
+
+		expect(setItem).toHaveBeenCalledTimes(1);
+		expect(setItem).toHaveBeenCalledWith("superset_cookie", "{}", NEW);
+		expect(deleteItemAsync).toHaveBeenCalledTimes(1);
+		expect(deleteItemAsync).toHaveBeenCalledWith("superset_cookie");
+	});
+});

--- a/apps/mobile/lib/auth/sessionStorage/sessionStorage.ts
+++ b/apps/mobile/lib/auth/sessionStorage/sessionStorage.ts
@@ -1,0 +1,26 @@
+import * as SecureStore from "expo-secure-store";
+
+// A Live Activity push-to-start wakes the app while the phone is locked, and
+// better-auth reads the session from here as its module loads. Keychain items
+// default to WHEN_UNLOCKED, which throws in that launch, so the session lives
+// in its own service under the class Apple prescribes for background reads.
+// Updating an item never changes its class, so the legacy copy is re-added
+// here rather than overwritten.
+const BACKGROUND_READABLE: SecureStore.SecureStoreOptions = {
+	keychainService: "superset-auth",
+	keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+};
+
+export const sessionStorage = {
+	getItem(key: string): string | null {
+		const value = SecureStore.getItem(key, BACKGROUND_READABLE);
+		if (value != null) return value;
+		const legacy = SecureStore.getItem(key);
+		if (legacy != null) sessionStorage.setItem(key, legacy);
+		return legacy;
+	},
+	setItem(key: string, value: string): void {
+		SecureStore.setItem(key, value, BACKGROUND_READABLE);
+		void SecureStore.deleteItemAsync(key);
+	},
+};


### PR DESCRIPTION
## Problem

A TestFlight phone on build 1.1.0 (39) crashed at launch with a fatal keychain read (`errSecInteractionNotAllowed`) thrown from module scope in `apps/mobile/lib/auth/client.ts`. The event was recorded with the app in the background and the app start time equal to the crash time: the app was woken by the system while the phone was locked and died before it rendered anything.

## Root cause

better-auth's Expo client reads the cached session from `expo-secure-store` synchronously while `createAuthClient` runs, i.e. as the module loads. Those keychain items were stored with SecureStore's default class, `WHEN_UNLOCKED`, which the keychain refuses to decrypt while the phone is locked.

Nothing launched the app in the background until the Live Activity push work. Build 39 was cut from #7482 (merged then reverted by #7489, reopened as #7491), which observes ActivityKit push-to-start tokens; Apple documents that a push-to-start notification wakes the app with background runtime. That launch reads the keychain on a locked phone and throws. The same launch is also where #7491 registers the new activity's update token, so on a locked phone the card would start and then never update.

## Fix

The session items now live in their own keychain service stored with `AFTER_FIRST_UNLOCK`, the class Apple recommends for items background launches need. `SecItemUpdate` never changes an existing item's class (expo-secure-store's `update` only sends `kSecValueData`), so an item written before this change is re-added into the new service the first time it is read, and the old copy deleted afterwards. Reads prefer the new service, so no request ever observes a gap. JS-only; ships over the air.

This is a change to the protection class of the session token, so it should have a human look before it lands. #7491 depends on it to work on a locked phone.

## Verification

```
$ bunx biome check apps/mobile/lib/auth
Checked 4 files in 4ms. No fixes applied.

$ cd apps/mobile && bun test lib/auth
 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [35.00ms]

$ cd apps/mobile && bun run typecheck
157 pre-existing errors, all in screens/** files this PR does not touch; 0 mention lib/auth.
```

Known residual: a phone that receives a push-to-start before its first foreground open on this build still has only the legacy item, so that one launch crashes as before; the next foreground open migrates it. A reboot before first unlock also refuses `AFTER_FIRST_UNLOCK` reads, which is the boundary Apple prescribes for background apps.

Not verified on a device: a background push-to-start launch on a locked phone with a migrated session. That needs #7491's server side and a native build.

Refs MOBILE-7

https://claude.ai/code/session_01KJbaszyuM6twhif6orRSQe


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile app crash in MOBILE-7 when a Live Activity push wakes it on a locked phone. The session token now lives in a dedicated keychain service using `AFTER_FIRST_UNLOCK` instead of `expo-secure-store`'s default `WHEN_UNLOCKED`, so the synchronous session read at startup no longer throws `errSecInteractionNotAllowed`.

- Existing `WHEN_UNLOCKED` sessions migrate to the new service on the first read, and the old copy is deleted afterward.
- Reads prefer the new service, so a legacy session never appears missing while it's being moved.
- The token is now readable while the device is locked after the first unlock; that's a deliberate change to its protection class.
- JS-only, so it ships without a native build.

<sup>Written for commit e51ca40d45417d4b9b982a51d7ad145c91af4f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/superset-sh/superset/pull/7505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mobile authentication session persistence so sessions remain available when the device is locked, including during background activity startup.
  - Added automatic migration of existing sessions to the updated secure storage, helping preserve active sign-ins.
- **Bug Fixes**
  - Resolved inconsistencies when reading and updating authentication sessions across device lock states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
